### PR TITLE
[codex] Add structured ignore suppressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
+ "ignore",
  "nose-detect",
  "nose-eval",
  "nose-frontend",

--- a/crates/nose-cli/Cargo.toml
+++ b/crates/nose-cli/Cargo.toml
@@ -24,6 +24,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 rayon = { workspace = true }
+ignore = { workspace = true }
 
 [dev-dependencies]
 nose-il = { workspace = true }

--- a/crates/nose-cli/src/baseline.rs
+++ b/crates/nose-cli/src/baseline.rs
@@ -28,6 +28,19 @@ pub(crate) fn family_key(f: &RefactorFamily) -> u64 {
     h
 }
 
+pub(crate) fn family_id(f: &RefactorFamily) -> String {
+    format_key(family_key(f))
+}
+
+pub(crate) fn format_key(key: u64) -> String {
+    format!("{key:016x}")
+}
+
+pub(crate) fn parse_key(s: &str) -> Option<u64> {
+    let s = s.strip_prefix("0x").unwrap_or(s);
+    u64::from_str_radix(s, 16).ok()
+}
+
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) struct MemberKey {
     pub file: String,
@@ -83,7 +96,7 @@ pub(crate) fn load(path: &Path) -> Baseline {
     let entries: Vec<BaselineEntry> = entries
         .iter()
         .filter_map(|e| {
-            let key = u64::from_str_radix(&e.key, 16).ok()?;
+            let key = parse_key(&e.key)?;
             let members = e
                 .members
                 .iter()
@@ -108,7 +121,7 @@ pub(crate) fn write(
     let mut entries: Vec<Entry> = families
         .iter()
         .map(|f| Entry {
-            key: format!("{:016x}", family_key(f)),
+            key: family_id(f),
             note: note_of(f),
             members: member_keys(f)
                 .into_iter()

--- a/crates/nose-cli/src/config.rs
+++ b/crates/nose-cli/src/config.rs
@@ -12,6 +12,7 @@
 //! # threshold = 0.70 # only valid when mode includes "near"
 //! min-lines = 8
 //! min-tokens = 30
+//! ignore-file = "nose.ignore.json"
 //! ```
 
 use serde::Deserialize;
@@ -31,6 +32,7 @@ pub(crate) struct ScanConfig {
     pub min_lines: Option<u32>,
     pub min_tokens: Option<usize>,
     pub top: Option<usize>,
+    pub ignore_file: Option<PathBuf>,
 }
 
 #[derive(Deserialize, Default)]

--- a/crates/nose-cli/src/ignores.rs
+++ b/crates/nose-cli/src/ignores.rs
@@ -1,0 +1,441 @@
+//! Structured suppressions for scan findings.
+//!
+//! Inline `nose-ignore` removes a unit before detection. This module handles the
+//! later, auditable case: a family was found, reviewed, and intentionally hidden
+//! with a reason, owner, and optional expiry.
+
+use crate::baseline;
+use anyhow::{Context, Result};
+use ignore::overrides::Override;
+use nose_detect::RefactorFamily;
+use serde::Deserialize;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+pub(crate) const DEFAULT_IGNORE_FILE: &str = "nose.ignore.json";
+
+pub(crate) struct IgnoreSet {
+    path: PathBuf,
+    entries: Vec<Entry>,
+    expired: Vec<ExpiredEntry>,
+}
+
+#[derive(Clone, serde::Serialize)]
+pub(crate) struct IgnoreSelectors {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    family_id: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    paths: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    languages: Vec<String>,
+}
+
+#[derive(Clone, serde::Serialize)]
+pub(crate) struct IgnoreMatch {
+    entry: usize,
+    reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    owner: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<String>,
+    selectors: IgnoreSelectors,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    matched_paths: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    matched_languages: Vec<String>,
+}
+
+#[derive(Clone, serde::Serialize)]
+pub(crate) struct ExpiredEntry {
+    entry: usize,
+    reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    owner: Option<String>,
+    expires_at: String,
+}
+
+#[derive(serde::Serialize)]
+pub(crate) struct IgnoreSummary<'a> {
+    path: String,
+    active_entries: usize,
+    expired_entries: usize,
+    ignored_families: usize,
+    expired: &'a [ExpiredEntry],
+}
+
+impl<'a> IgnoreSummary<'a> {
+    pub(crate) fn line(&self) -> String {
+        format!(
+            "structured ignores: {} ignored {} · {} active {} · {} expired {} ({})",
+            self.ignored_families,
+            plural(self.ignored_families, "family", "families"),
+            self.active_entries,
+            plural(self.active_entries, "entry", "entries"),
+            self.expired_entries,
+            plural(self.expired_entries, "entry", "entries"),
+            self.path
+        )
+    }
+}
+
+struct Entry {
+    index: usize,
+    family_id: Option<u64>,
+    path_matcher: Option<Override>,
+    language_set: BTreeSet<String>,
+    selectors: IgnoreSelectors,
+    reason: String,
+    note: Option<String>,
+    owner: Option<String>,
+    expires_at: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum Document {
+    Object(DocumentObject),
+    Entries(Vec<RawEntry>),
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DocumentObject {
+    ignores: Vec<RawEntry>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawEntry {
+    family_id: Option<String>,
+    #[serde(default)]
+    paths: Vec<String>,
+    #[serde(default)]
+    languages: Vec<String>,
+    reason: String,
+    note: Option<String>,
+    owner: Option<String>,
+    expires_at: Option<String>,
+}
+
+pub(crate) fn load_for_scan(path: Option<&Path>) -> Result<Option<IgnoreSet>> {
+    let path = match path {
+        Some(path) => Some(path.to_path_buf()),
+        None => {
+            let default = PathBuf::from(DEFAULT_IGNORE_FILE);
+            default.is_file().then_some(default)
+        }
+    };
+    path.map(|path| load(&path)).transpose()
+}
+
+pub(crate) fn load(path: &Path) -> Result<IgnoreSet> {
+    let bytes =
+        std::fs::read(path).with_context(|| format!("reading ignore file {}", path.display()))?;
+    let document: Document = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing ignore file {}", path.display()))?;
+    let raw_entries = match document {
+        Document::Object(document) => document.ignores,
+        Document::Entries(entries) => entries,
+    };
+
+    let today = Date::today();
+    let mut entries = Vec::new();
+    let mut expired = Vec::new();
+    for (index, raw) in raw_entries.into_iter().enumerate() {
+        let entry = Entry::from_raw(index, raw)
+            .with_context(|| format!("validating ignore file {}", path.display()))?;
+        if entry.is_expired(today) {
+            expired.push(ExpiredEntry {
+                entry: index,
+                reason: entry.reason,
+                owner: entry.owner,
+                expires_at: entry.expires_at.expect("expired entries have expires_at"),
+            });
+        } else {
+            entries.push(entry);
+        }
+    }
+    Ok(IgnoreSet {
+        path: path.to_path_buf(),
+        entries,
+        expired,
+    })
+}
+
+impl IgnoreSet {
+    pub(crate) fn match_family(&self, family: &RefactorFamily) -> Option<IgnoreMatch> {
+        self.entries
+            .iter()
+            .find_map(|entry| entry.match_family(family))
+    }
+
+    pub(crate) fn summary(&self, ignored_families: usize) -> IgnoreSummary<'_> {
+        IgnoreSummary {
+            path: self.path.display().to_string(),
+            active_entries: self.entries.len(),
+            expired_entries: self.expired.len(),
+            ignored_families,
+            expired: &self.expired,
+        }
+    }
+
+    pub(crate) fn warn_expired(&self) {
+        for entry in &self.expired {
+            eprintln!(
+                "warning: ignore file {} entry ignores[{}] expired on {} and was not applied ({})",
+                self.path.display(),
+                entry.entry,
+                entry.expires_at,
+                entry.reason
+            );
+        }
+    }
+}
+
+impl Entry {
+    fn from_raw(index: usize, raw: RawEntry) -> Result<Self> {
+        if raw.reason.trim().is_empty() {
+            anyhow::bail!("ignores[{index}].reason must be a non-empty string");
+        }
+        let family_id = raw
+            .family_id
+            .as_deref()
+            .map(parse_family_id)
+            .transpose()
+            .with_context(|| format!("ignores[{index}].family_id is not a hex family id"))?;
+        let path_matcher = build_path_matcher(index, &raw.paths)?;
+        let language_set = raw
+            .languages
+            .iter()
+            .map(|language| {
+                let language = language.trim().to_ascii_lowercase();
+                if language.is_empty() {
+                    anyhow::bail!("ignores[{index}].languages contains an empty language");
+                }
+                Ok(language)
+            })
+            .collect::<Result<BTreeSet<_>>>()?;
+        if family_id.is_none() && raw.paths.is_empty() && language_set.is_empty() {
+            anyhow::bail!(
+                "ignores[{index}] must set at least one selector: family_id, paths, or languages"
+            );
+        }
+        let expires_at = raw
+            .expires_at
+            .as_deref()
+            .map(parse_date_for_entry(index))
+            .transpose()?
+            .map(|date| date.to_string());
+
+        Ok(Entry {
+            index,
+            family_id,
+            path_matcher,
+            language_set,
+            selectors: IgnoreSelectors {
+                family_id: raw.family_id,
+                paths: raw.paths,
+                languages: raw.languages,
+            },
+            reason: raw.reason,
+            note: raw.note,
+            owner: raw.owner,
+            expires_at,
+        })
+    }
+
+    fn is_expired(&self, today: Date) -> bool {
+        self.expires_at
+            .as_deref()
+            .and_then(|date| Date::parse(date).ok())
+            .is_some_and(|date| date < today)
+    }
+
+    fn match_family(&self, family: &RefactorFamily) -> Option<IgnoreMatch> {
+        if self
+            .family_id
+            .is_some_and(|family_id| family_id != baseline::family_key(family))
+        {
+            return None;
+        }
+
+        let matched_paths = match &self.path_matcher {
+            Some(matcher) => {
+                let paths = family
+                    .locations
+                    .iter()
+                    .filter(|location| matcher.matched(&location.file, false).is_whitelist())
+                    .map(|location| location.file.clone())
+                    .collect::<BTreeSet<_>>();
+                if paths.is_empty() {
+                    return None;
+                }
+                paths.into_iter().collect()
+            }
+            None => Vec::new(),
+        };
+
+        let matched_languages = if self.language_set.is_empty() {
+            Vec::new()
+        } else {
+            let languages = family
+                .locations
+                .iter()
+                .filter_map(|location| {
+                    let language = location.lang.to_ascii_lowercase();
+                    self.language_set.contains(&language).then_some(language)
+                })
+                .collect::<BTreeSet<_>>();
+            if languages.is_empty() {
+                return None;
+            }
+            languages.into_iter().collect()
+        };
+
+        Some(IgnoreMatch {
+            entry: self.index,
+            reason: self.reason.clone(),
+            note: self.note.clone(),
+            owner: self.owner.clone(),
+            expires_at: self.expires_at.clone(),
+            selectors: self.selectors.clone(),
+            matched_paths,
+            matched_languages,
+        })
+    }
+}
+
+fn build_path_matcher(index: usize, paths: &[String]) -> Result<Option<Override>> {
+    if paths.is_empty() {
+        return Ok(None);
+    }
+    let mut builder = ignore::overrides::OverrideBuilder::new(".");
+    for pattern in paths {
+        let pattern = pattern.trim();
+        if pattern.is_empty() {
+            anyhow::bail!("ignores[{index}].paths contains an empty pattern");
+        }
+        if pattern.starts_with('!') {
+            anyhow::bail!("ignores[{index}].paths does not support negative pattern {pattern:?}");
+        }
+        builder
+            .add(pattern)
+            .with_context(|| format!("ignores[{index}].paths has invalid glob {pattern:?}"))?;
+    }
+    builder
+        .build()
+        .with_context(|| format!("building path matcher for ignores[{index}]"))
+        .map(Some)
+}
+
+fn parse_family_id(s: &str) -> Result<u64> {
+    let s = s.trim();
+    let hex = s.strip_prefix("0x").unwrap_or(s);
+    if hex.len() != 16 {
+        anyhow::bail!("family ids must be 16 hex digits, optionally prefixed with 0x");
+    }
+    baseline::parse_key(s).ok_or_else(|| {
+        anyhow::anyhow!("family ids must be 16 hex digits, optionally prefixed with 0x")
+    })
+}
+
+fn parse_date_for_entry(index: usize) -> impl FnOnce(&str) -> Result<Date> {
+    move |date| {
+        Date::parse(date).with_context(|| format!("ignores[{index}].expires_at must be YYYY-MM-DD"))
+    }
+}
+
+fn plural<'a>(n: usize, singular: &'a str, plural: &'a str) -> &'a str {
+    if n == 1 {
+        singular
+    } else {
+        plural
+    }
+}
+
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+struct Date {
+    year: i32,
+    month: u32,
+    day: u32,
+}
+
+impl Date {
+    fn parse(s: &str) -> Result<Self> {
+        let bytes = s.as_bytes();
+        if bytes.len() != 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+            anyhow::bail!("expected YYYY-MM-DD");
+        }
+        let year = parse_digits(&bytes[0..4]).context("invalid year")? as i32;
+        let month = parse_digits(&bytes[5..7]).context("invalid month")?;
+        let day = parse_digits(&bytes[8..10]).context("invalid day")?;
+        if !(1..=12).contains(&month) {
+            anyhow::bail!("month must be 01 through 12");
+        }
+        let max_day = days_in_month(year, month);
+        if day == 0 || day > max_day {
+            anyhow::bail!("day must be valid for the month");
+        }
+        Ok(Date { year, month, day })
+    }
+
+    fn today() -> Self {
+        let days = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            / 86_400;
+        civil_from_days(days as i64)
+    }
+}
+
+impl std::fmt::Display for Date {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:04}-{:02}-{:02}", self.year, self.month, self.day)
+    }
+}
+
+fn parse_digits(bytes: &[u8]) -> Result<u32> {
+    let mut value = 0u32;
+    for &byte in bytes {
+        if !byte.is_ascii_digit() {
+            anyhow::bail!("not a decimal digit");
+        }
+        value = value * 10 + u32::from(byte - b'0');
+    }
+    Ok(value)
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+fn civil_from_days(days_since_epoch: i64) -> Date {
+    let z = days_since_epoch + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = mp + if mp < 10 { 3 } else { -9 };
+    let year = y + i64::from(month <= 2);
+    Date {
+        year: year as i32,
+        month: month as u32,
+        day: day as u32,
+    }
+}

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3,6 +3,7 @@
 mod baseline;
 mod cache;
 mod config;
+mod ignores;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -154,6 +155,10 @@ enum Cmd {
         /// duplication — the way to adopt on a codebase that already has clones.
         #[arg(long, value_name = "FILE")]
         baseline: Option<PathBuf>,
+        /// Structured ignore file for intentionally suppressed families. Defaults
+        /// to `nose.ignore.json` when that file exists.
+        #[arg(long, value_name = "FILE")]
+        ignore_file: Option<PathBuf>,
         /// Explicitly report only families that are new or changed compared with
         /// `--baseline`. This is the default behavior when `--baseline` is present;
         /// the flag makes CI intent readable in scripts.
@@ -474,7 +479,11 @@ struct ScanJsonReport<'a> {
     ranking: ScanJsonRanking,
     #[serde(skip_serializing_if = "Option::is_none")]
     baseline: Option<&'a BaselineSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ignore: Option<ignores::IgnoreSummary<'a>>,
     families: Vec<ScanJsonFamily<'a>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    ignored_families: Vec<ScanJsonIgnoredFamily<'a>>,
 }
 
 #[derive(serde::Serialize)]
@@ -499,28 +508,44 @@ struct ScanJsonRanking {
 
 #[derive(serde::Serialize)]
 struct ScanJsonFamily<'a> {
+    family_id: String,
     #[serde(flatten)]
     family: &'a nose_detect::RefactorFamily,
     #[serde(skip_serializing_if = "Option::is_none")]
     baseline_status: Option<&'static str>,
 }
 
+#[derive(serde::Serialize)]
+struct ScanJsonIgnoredFamily<'a> {
+    family_id: String,
+    #[serde(flatten)]
+    family: &'a nose_detect::RefactorFamily,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    baseline_status: Option<&'static str>,
+    ignore: &'a ignores::IgnoreMatch,
+}
+
+struct ScanJsonInput<'a> {
+    scope: &'a ScanScope,
+    sort: SortKey,
+    top: usize,
+    families: &'a [nose_detect::RefactorFamily],
+    shown: &'a [&'a nose_detect::RefactorFamily],
+    baseline: Option<&'a BaselineComparison>,
+    ignore_set: Option<&'a ignores::IgnoreSet>,
+    ignored_families: &'a [IgnoredFamily],
+}
+
 impl<'a> ScanJsonReport<'a> {
-    fn new(
-        scope: &'a ScanScope,
-        sort: SortKey,
-        top: usize,
-        families: &[nose_detect::RefactorFamily],
-        shown: &'a [&'a nose_detect::RefactorFamily],
-        baseline: Option<&'a BaselineComparison>,
-    ) -> Self {
-        let statuses = baseline.map(|b| &b.statuses);
+    fn new(input: ScanJsonInput<'a>) -> Self {
+        let statuses = input.baseline.map(|b| &b.statuses);
         ScanJsonReport {
             schema_version: SCAN_JSON_SCHEMA_VERSION,
             tool_version: env!("CARGO_PKG_VERSION"),
             scope: ScanJsonScope {
-                files: scope.files,
-                languages: scope
+                files: input.scope.files,
+                languages: input
+                    .scope
                     .langs
                     .iter()
                     .map(|(language, files)| ScanJsonLanguage {
@@ -530,23 +555,45 @@ impl<'a> ScanJsonReport<'a> {
                     .collect(),
             },
             ranking: ScanJsonRanking {
-                sort: sort.json_name(),
-                total_families: families.len(),
-                shown_families: shown.len(),
-                limit: (top != 0).then_some(top),
+                sort: input.sort.json_name(),
+                total_families: input.families.len(),
+                shown_families: input.shown.len(),
+                limit: (input.top != 0).then_some(input.top),
             },
-            baseline: baseline.map(|b| &b.summary),
-            families: shown
+            baseline: input.baseline.map(|b| &b.summary),
+            ignore: input
+                .ignore_set
+                .map(|set| set.summary(input.ignored_families.len())),
+            families: input
+                .shown
                 .iter()
                 .map(|family| ScanJsonFamily {
+                    family_id: baseline::family_id(family),
                     family,
                     baseline_status: statuses
                         .and_then(|s| s.get(&baseline::family_key(family)))
                         .map(BaselineStatus::as_str),
                 })
                 .collect(),
+            ignored_families: input
+                .ignored_families
+                .iter()
+                .map(|ignored| ScanJsonIgnoredFamily {
+                    family_id: baseline::family_id(&ignored.family),
+                    family: &ignored.family,
+                    baseline_status: statuses
+                        .and_then(|s| s.get(&baseline::family_key(&ignored.family)))
+                        .map(BaselineStatus::as_str),
+                    ignore: &ignored.ignore,
+                })
+                .collect(),
         }
     }
+}
+
+struct IgnoredFamily {
+    family: nose_detect::RefactorFamily,
+    ignore: ignores::IgnoreMatch,
 }
 
 #[derive(serde::Serialize)]
@@ -569,10 +616,6 @@ impl BaselineSummary {
             self.unchanged_families,
             self.resolved_families
         )
-    }
-
-    fn reportable_families(&self) -> usize {
-        self.new_families + self.changed_families
     }
 }
 
@@ -862,6 +905,7 @@ fn run() -> Result<()> {
             cache_dir,
             fail,
             baseline,
+            ignore_file,
             new_only: _,
             fail_on_new,
             write_baseline,
@@ -884,6 +928,7 @@ fn run() -> Result<()> {
             cache_dir,
             fail,
             baseline,
+            ignore_file,
             fail_on_new,
             write_baseline,
             threshold,
@@ -1556,6 +1601,7 @@ struct ScanArgs {
     cache_dir: Option<PathBuf>,
     fail: bool,
     baseline: Option<PathBuf>,
+    ignore_file: Option<PathBuf>,
     fail_on_new: bool,
     write_baseline: bool,
     threshold: Option<f64>,
@@ -1667,9 +1713,14 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
     };
     let min_lines = args.min_lines.or(cfg.min_lines).unwrap_or(5);
     let min_tokens = args.min_tokens.or(cfg.min_tokens).unwrap_or(24);
+    let ignore_file = args.ignore_file.or(cfg.ignore_file);
     // Excludes are additive: config patterns plus any given on the command line.
     let mut exclude = cfg.exclude;
     exclude.extend(args.exclude.iter().cloned());
+    let ignore_set = ignores::load_for_scan(ignore_file.as_deref())?;
+    if let Some(ignore_set) = &ignore_set {
+        ignore_set.warn_expired();
+    }
 
     let opts = nose_detect::DetectOptions {
         threshold,
@@ -1789,6 +1840,18 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
         families.retain(|f| !accepted.keys.contains(&baseline::family_key(f)));
         comparison
     });
+    let mut ignored_families = Vec::new();
+    if let Some(ignore_set) = &ignore_set {
+        let mut active = Vec::with_capacity(families.len());
+        for family in families {
+            if let Some(ignore) = ignore_set.match_family(&family) {
+                ignored_families.push(IgnoredFamily { family, ignore });
+            } else {
+                active.push(family);
+            }
+        }
+        families = active;
+    }
 
     // `--top 0` means "no limit": show every family (documented in docs/usage.md).
     let limit = if top == 0 { usize::MAX } else { top };
@@ -1796,26 +1859,38 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
 
     match args.format {
         ReportFormat::Json => {
-            let json = ScanJsonReport::new(
-                &scope,
+            let json = ScanJsonReport::new(ScanJsonInput {
+                scope: &scope,
                 sort,
                 top,
-                &families,
-                &shown,
-                baseline_comparison.as_ref(),
-            );
+                families: &families,
+                shown: &shown,
+                baseline: baseline_comparison.as_ref(),
+                ignore_set: ignore_set.as_ref(),
+                ignored_families: &ignored_families,
+            });
             println!("{}", serde_json::to_string_pretty(&json)?);
         }
         ReportFormat::Markdown => {
             // Scope line first — tells the reader what was actually scanned (so a small
             // count from `.gitignore`/`--exclude` pruning is visible, not a silent gap).
             println!("{}\n", scope.summary());
-            print_refactor_markdown(&families, &shown, channels, baseline_comparison.as_ref());
+            print_refactor_markdown(
+                &families,
+                &shown,
+                channels,
+                baseline_comparison.as_ref(),
+                ignore_set.as_ref(),
+                ignored_families.len(),
+            );
         }
         ReportFormat::Human => {
             println!("{}", scope.summary());
             if let Some(comparison) = &baseline_comparison {
                 println!("{}", comparison.summary.line());
+            }
+            if let Some(ignore_set) = &ignore_set {
+                println!("{}", ignore_set.summary(ignored_families.len()).line());
             }
             print_refactor_human(&families, &shown, sort, channels, args.diff, args.proposal)
         }
@@ -1826,19 +1901,25 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
     }
     // CI gate: report is already printed; a non-empty (filtered) family set is a
     // failure when --fail is set.
-    if args.fail_on_new
-        && baseline_comparison
-            .as_ref()
-            .is_some_and(|comparison| comparison.summary.reportable_families() > 0)
-    {
-        let comparison = baseline_comparison
-            .as_ref()
-            .expect("--fail-on-new requires --baseline");
+    if let (true, Some(comparison)) = (
+        args.fail_on_new && !families.is_empty(),
+        baseline_comparison.as_ref(),
+    ) {
+        let mut new_families = 0usize;
+        let mut changed_families = 0usize;
+        for family in &families {
+            match comparison.statuses.get(&baseline::family_key(family)) {
+                Some(BaselineStatus::Changed) => changed_families += 1,
+                Some(BaselineStatus::New) => new_families += 1,
+                None => {}
+            }
+        }
+        let reportable_families = new_families + changed_families;
         eprintln!(
             "\nnose: {} new and {} changed {} found (--fail-on-new)",
-            comparison.summary.new_families,
-            comparison.summary.changed_families,
-            channels.report_label(comparison.summary.reportable_families())
+            new_families,
+            changed_families,
+            channels.report_label(reportable_families)
         );
         std::process::exit(1);
     }
@@ -1941,6 +2022,7 @@ fn refactor_sarif(families: &[&nose_detect::RefactorFamily]) -> Result<String> {
                 "message": { "text": msg },
                 "locations": f.locations.first().map(phys).into_iter().collect::<Vec<_>>(),
                 "relatedLocations": f.locations.iter().skip(1).map(phys).collect::<Vec<_>>(),
+                "properties": { "family_id": baseline::family_id(f) },
             })
         })
         .collect();
@@ -2044,7 +2126,12 @@ fn print_refactor_human(
     // fanout is capped, with a pointer to the full machine-readable list.
     const SITE_CAP: usize = 30;
     for (i, f) in shown.iter().enumerate() {
-        println!("\n#{}  {}", i + 1, family_summary(f));
+        println!(
+            "\n#{}  id {} · {}",
+            i + 1,
+            baseline::family_id(f),
+            family_summary(f)
+        );
         println!("    → {}", family_hint(f));
         for l in f.locations.iter().take(SITE_CAP) {
             let name = l
@@ -2393,6 +2480,8 @@ fn print_refactor_markdown(
     shown: &[&nose_detect::RefactorFamily],
     mode: ScanChannels,
     baseline: Option<&BaselineComparison>,
+    ignore_set: Option<&ignores::IgnoreSet>,
+    ignored_families: usize,
 ) {
     println!("# {}\n", mode.markdown_title());
     println!(
@@ -2404,14 +2493,18 @@ fn print_refactor_markdown(
     if let Some(comparison) = baseline {
         println!("{}\n", comparison.summary.line());
     }
+    if let Some(ignore_set) = ignore_set {
+        println!("{}\n", ignore_set.summary(ignored_families).line());
+    }
     for (i, f) in shown.iter().enumerate() {
         let xlang = match family_langs(f) {
             s if s.is_empty() => String::new(),
             s => format!(" · cross-language: {s}"),
         };
         println!(
-            "## {}. {} sites, {} files, {} modules — ~{} dup lines ({}){}",
+            "## {}. `{}` — {} sites, {} files, {} modules — ~{} dup lines ({}){}",
             i + 1,
+            baseline::family_id(f),
             f.members,
             f.files,
             f.modules,

--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -126,6 +126,7 @@ fn assert_scan_json_v1_contract(json: &serde_json::Value) {
         .expect("fixture should include a family");
     let family = family.as_object().expect("family object");
     for key in [
+        "family_id",
         "value",
         "members",
         "files",
@@ -1546,6 +1547,194 @@ fn inline_nose_ignore_suppresses_a_site() {
     assert!(
         run(&["scan", p, "--min-tokens", "12"]).contains("0 clone"),
         "the marked copy must be suppressed, leaving no family"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn structured_ignore_suppresses_family_id_with_metadata() {
+    let dir = make_project("structured_ignore_id");
+    let p = dir.to_str().unwrap();
+    let before = run(&[
+        "scan",
+        p,
+        "--mode",
+        "semantic",
+        "--min-tokens",
+        "12",
+        "--format",
+        "json",
+        "--top",
+        "0",
+    ]);
+    let before_json = scan_json(&before);
+    let family_id = scan_families(&before_json)[0]["family_id"]
+        .as_str()
+        .expect("family_id should be exposed")
+        .to_string();
+    let ignore_file = std::env::temp_dir().join(format!(
+        "nose_structured_ignore_{}.json",
+        std::process::id()
+    ));
+    fs::write(
+        &ignore_file,
+        format!(
+            "{{\"ignores\":[{{\"family_id\":\"{family_id}\",\"reason\":\"generated-code\",\"note\":\"Generated from the same template.\",\"owner\":\"platform\",\"expires_at\":\"2099-01-01\"}}]}}\n"
+        ),
+    )
+    .unwrap();
+
+    let after = run(&[
+        "scan",
+        p,
+        "--mode",
+        "semantic",
+        "--min-tokens",
+        "12",
+        "--format",
+        "json",
+        "--top",
+        "0",
+        "--ignore-file",
+        ignore_file.to_str().unwrap(),
+    ]);
+    let after_json = scan_json(&after);
+    assert!(
+        scan_families(&after_json).is_empty(),
+        "the ignored family should be absent from active findings: {after}"
+    );
+    assert_eq!(after_json["ignore"]["active_entries"], 1);
+    assert_eq!(after_json["ignore"]["ignored_families"], 1);
+    assert_eq!(after_json["ignored_families"][0]["family_id"], family_id);
+    assert_eq!(
+        after_json["ignored_families"][0]["ignore"]["reason"],
+        "generated-code"
+    );
+    assert_eq!(
+        after_json["ignored_families"][0]["ignore"]["owner"],
+        "platform"
+    );
+
+    let _ = fs::remove_file(&ignore_file);
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn default_structured_ignore_file_matches_paths() {
+    let dir = make_project("structured_ignore_paths");
+    fs::write(
+        dir.join("nose.ignore.json"),
+        "{\"ignores\":[{\"paths\":[\"a/**\"],\"reason\":\"template-copy\",\"note\":\"a/ is generated.\"}]}\n",
+    )
+    .unwrap();
+    let out = Command::new(bin())
+        .args([
+            "scan",
+            ".",
+            "--mode",
+            "semantic",
+            "--min-tokens",
+            "12",
+            "--format",
+            "json",
+            "--top",
+            "0",
+        ])
+        .current_dir(&dir)
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "scan should succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let json = scan_json(&stdout);
+    assert!(
+        scan_families(&json).is_empty(),
+        "path ignore should suppress the family: {stdout}"
+    );
+    assert_eq!(json["ignore"]["active_entries"], 1);
+    assert_eq!(json["ignore"]["ignored_families"], 1);
+    assert_eq!(
+        json["ignored_families"][0]["ignore"]["matched_paths"][0],
+        "./a/f.py"
+    );
+    assert_eq!(
+        json["ignored_families"][0]["ignore"]["selectors"]["paths"][0],
+        "a/**"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn expired_structured_ignore_is_reported_but_not_applied() {
+    let dir = make_project("structured_ignore_expired");
+    fs::write(
+        dir.join("nose.ignore.json"),
+        "{\"ignores\":[{\"paths\":[\"a/**\"],\"reason\":\"temporary-waiver\",\"owner\":\"platform\",\"expires_at\":\"2000-01-01\"}]}\n",
+    )
+    .unwrap();
+    let out = Command::new(bin())
+        .args([
+            "scan",
+            ".",
+            "--mode",
+            "semantic",
+            "--min-tokens",
+            "12",
+            "--format",
+            "json",
+            "--top",
+            "0",
+        ])
+        .current_dir(&dir)
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    let json = scan_json(&stdout);
+    assert!(
+        !scan_families(&json).is_empty(),
+        "expired ignore must not suppress the family: {stdout}"
+    );
+    assert_eq!(json["ignore"]["active_entries"], 0);
+    assert_eq!(json["ignore"]["expired_entries"], 1);
+    assert_eq!(json["ignore"]["ignored_families"], 0);
+    assert_eq!(json["ignore"]["expired"][0]["reason"], "temporary-waiver");
+    assert!(
+        stderr.contains("expired on 2000-01-01") && stderr.contains("not applied"),
+        "stderr should explain the expired entry: {stderr}"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn malformed_structured_ignore_file_fails_clearly() {
+    let dir = make_project("structured_ignore_bad");
+    let ignore_file = dir.join("bad-ignore.json");
+    fs::write(
+        &ignore_file,
+        "{\"ignores\":[{\"paths\":[\"a/**\"],\"note\":\"missing reason\"}]}\n",
+    )
+    .unwrap();
+    let out = Command::new(bin())
+        .args([
+            "scan",
+            dir.to_str().unwrap(),
+            "--min-tokens",
+            "12",
+            "--ignore-file",
+            ignore_file.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "malformed ignore files must fail");
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("parsing ignore file") || stderr.contains("validating ignore file"),
+        "error should name the ignore file problem: {stderr}"
     );
     let _ = fs::remove_dir_all(&dir);
 }

--- a/crates/nose-cli/tests/fixtures/scan-json-v1.json
+++ b/crates/nose-cli/tests/fixtures/scan-json-v1.json
@@ -18,6 +18,7 @@
   },
   "families": [
     {
+      "family_id": "479389f590c1234a",
       "value": 5.0,
       "members": 2,
       "files": 2,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ min-value   = 200
 min-members = 3
 min-tokens  = 30
 top         = 50
+ignore-file = "nose.ignore.json"
 ```
 
 Pass an alternate file with `--config <file>`. A malformed config is a **hard
@@ -37,6 +38,7 @@ the built-in default". Keys are kebab-case and live under the `[scan]` table.
 | `min-tokens` | int | `24` | `--min-tokens` |
 | `min-lines` | int | `5` | `--min-lines` |
 | `top` | int | `30` | `--top` |
+| `ignore-file` | string path | auto-read `nose.ignore.json` when present | `--ignore-file` |
 
 `mode` is a TOML array, even for one channel:
 
@@ -72,6 +74,24 @@ excluded directory is pruned, not just filtered out afterward.
 `.gitignore` is always respected automatically, so vendored dependencies, build
 output, and the like are skipped without any configuration.
 
+## Structured ignores
+
+`ignore-file` points to a structured suppression file for reviewed findings:
+
+```toml
+[scan]
+ignore-file = "nose.ignore.json"
+```
+
+When unset, nose automatically reads `nose.ignore.json` in the current working
+directory if it exists. Pass `--ignore-file <file>` to override the config for one
+run. Ignored families are hidden from the active report and from `--fail` /
+`--fail-on-new`, while `--format json` still includes them with their reason,
+owner, note, and expiry metadata.
+
+The file format, selector semantics, and expiry behavior are documented in
+[structured-ignores](structured-ignores.md).
+
 ## Inline suppression
 
 To mark one specific clone as intentionally kept, put `// nose-ignore` on or
@@ -79,6 +99,7 @@ just above the unit (function/class/block). nose drops that unit from
 detection, so it never shows up as a family. Use this for a duplicate you've
 consciously decided to live with, rather than excluding the whole file.
 
-For accepting *all* of today's existing duplication at once — so only *new*
-duplication is reported — use a baseline instead; see
+For a finding that should stay visible to audit tooling, prefer a structured
+ignore entry. For accepting *all* of today's existing duplication at once — so
+only *new* duplication is reported — use a baseline instead; see
 [continuous-integration](continuous-integration.md).

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -70,6 +70,27 @@ and want the lower bar locked in — it's a ratchet.
 With `--format json`, the top-level `baseline` object carries those counts and each
 reported family gets `baseline_status: "new"` or `"changed"`.
 
+## Structured ignores — audited suppressions
+
+Baselines accept the current state in bulk. Structured ignores are for individual
+families that were reviewed and intentionally kept. Commit `nose.ignore.json`
+next to the code, or point to another file with `--ignore-file` / `ignore-file`
+in [configuration](configuration.md):
+
+```sh
+nose scan src --ignore-file nose.ignore.json --fail
+```
+
+Ignored families are removed from the active report, so they do not fail `--fail`
+or `--fail-on-new`. They are still present in `--format json` under
+`ignored_families`, with the ignore entry's reason, note, owner, expiry, matched
+selectors, and matched paths.
+
+Malformed ignore files fail the run. Expired entries are reported as warnings and
+listed in `ignore.expired`, but are not applied. That makes stale waivers visible
+instead of silently hiding duplication. See [structured-ignores](structured-ignores.md)
+for the file format and selector semantics.
+
 ## SARIF for code scanning
 
 `--format sarif` emits SARIF 2.1.0, which GitHub code-scanning ingests to render

--- a/docs/home.md
+++ b/docs/home.md
@@ -17,6 +17,7 @@ Start here if you want to *run* nose on a codebase.
 - [scan-json](scan-json.md) — the versioned `nose scan --format json` contract for downstream tooling.
 - [clone-types](clone-types.md) — what nose covers across the standard Type-1/2/3/4 taxonomy, with its honest limits.
 - [configuration](configuration.md) — the `nose.toml` file: excludes, thresholds, baselines, caching, inline `// nose-ignore`.
+- [structured-ignores](structured-ignores.md) — suppress reviewed findings with reason, owner, expiry, and machine-readable ignored-family output.
 - [continuous-integration](continuous-integration.md) — the `--fail` gate, baseline-driven incremental adoption, SARIF, and fast re-runs.
 - [languages](languages.md) — the supported languages and the embedded `<script>` extraction for Vue/Svelte/HTML.
 

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -25,6 +25,13 @@ The top-level value is always an object:
     "shown_families": 10,
     "limit": 10
   },
+  "ignore": {
+    "path": "nose.ignore.json",
+    "active_entries": 2,
+    "expired_entries": 0,
+    "ignored_families": 0,
+    "expired": []
+  },
   "families": []
 }
 ```
@@ -42,16 +49,22 @@ and is read by the CLI test suite.
 | `scope.files` | integer | Number of supported source files scanned after ignores and excludes. |
 | `scope.languages` | array | Per-language file counts, largest first. |
 | `ranking.sort` | string | Sort key used for `families`: `extractability`, `value`, or `sites`. |
-| `ranking.total_families` | integer | Families remaining after filters and baseline suppression, before `--top`. |
+| `ranking.total_families` | integer | Active families remaining after filters, baseline suppression, and structured ignores, before `--top`. |
 | `ranking.shown_families` | integer | Families present in `families`. |
 | `ranking.limit` | integer or null | The `--top` limit; `null` means `--top 0` showed every family. |
 | `baseline` | object, optional | Baseline comparison summary when `--baseline` is active. |
-| `families` | array | Ranked clone families in display order. Empty means no family survived the filters. |
+| `ignore` | object, optional | Structured ignore summary when an ignore file was read. |
+| `families` | array | Active ranked clone families in display order. Empty means no family survived the filters, baseline, and structured ignores. |
+| `ignored_families` | array, optional | Suppressed families with the same family fields plus nested ignore metadata. Present when at least one current family was ignored. |
 
 When `--baseline` is active, `families` contains only reportable current families:
 new families and changed families. Exact baseline matches are counted in
 `baseline.unchanged_families`; accepted families no longer present are counted in
 `baseline.resolved_families`.
+
+When structured ignores are active, `families` contains only active findings.
+Ignored current families are omitted from `ranking.total_families` and appear in
+`ignored_families` instead.
 
 ## Baseline fields
 
@@ -67,6 +80,33 @@ The optional `baseline` object has:
 | `unchanged_families` | integer | Current families whose key exactly matches the baseline. |
 | `resolved_families` | integer | Baseline families that are no longer present in the current scan. |
 
+## Ignore fields
+
+The optional `ignore` object has:
+
+| field | type | meaning |
+|---|---|---|
+| `path` | string | Ignore file path used for the scan. |
+| `active_entries` | integer | Non-expired entries available for matching. |
+| `expired_entries` | integer | Valid entries whose `expires_at` date has passed. |
+| `ignored_families` | integer | Current families suppressed by active entries. |
+| `expired` | array | Expired entry metadata: `entry`, `reason`, optional `owner`, and `expires_at`. |
+
+Each `ignored_families[]` item has the same fields as a normal family, plus:
+
+| field | type | meaning |
+|---|---|---|
+| `ignore.entry` | integer | Zero-based index in the ignore file's `ignores` array. |
+| `ignore.reason` | string | Required structured rationale. |
+| `ignore.note` | string, optional | Human context for the decision. |
+| `ignore.owner` | string, optional | Team or person responsible for the ignore. |
+| `ignore.expires_at` | string, optional | `YYYY-MM-DD` expiry date. Expired entries are not applied. |
+| `ignore.selectors` | object | Original selectors from the entry: `family_id`, `paths`, and/or `languages`. |
+| `ignore.matched_paths` | array, optional | Family member paths that matched `paths`. |
+| `ignore.matched_languages` | array, optional | Family member languages that matched `languages`. |
+
+The ignore file format is documented in [structured-ignores](structured-ignores.md).
+
 ## Family fields
 
 Each `families[]` item is one refactoring candidate. Field names are stable within
@@ -74,6 +114,7 @@ schema version 1:
 
 | field | type | meaning |
 |---|---|---|
+| `family_id` | string | Stable family key used by baselines and structured ignores. |
 | `value` | number | Raw refactoring value: duplicated volume scaled by similarity and spread. |
 | `members` | integer | Number of duplicated sites. |
 | `files` | integer | Distinct files spanned by the family. |

--- a/docs/structured-ignores.md
+++ b/docs/structured-ignores.md
@@ -1,0 +1,114 @@
+# Structured ignores
+
+Structured ignores suppress reviewed clone families without losing the decision
+context. Use them when a finding is intentional, generated, framework-imposed, or
+owned by a team that is not ready to refactor it yet. For command basics see
+[usage](usage.md); for CI gates see [continuous-integration](continuous-integration.md).
+Back to [home](home.md).
+
+## Quick start
+
+Run a scan and copy the family ID from the human, markdown, or JSON report:
+
+```sh
+nose scan src --format json --top 0
+```
+
+Create `nose.ignore.json` at the repository root:
+
+```json
+{
+  "ignores": [
+    {
+      "family_id": "479389f590c1234a",
+      "reason": "generated-code",
+      "note": "Generated from the same template; refactor the generator instead.",
+      "owner": "platform",
+      "expires_at": "2026-12-31"
+    }
+  ]
+}
+```
+
+Then run `nose scan` from that root. nose automatically reads
+`nose.ignore.json` when it exists. Use `--ignore-file <file>` or
+`ignore-file = "path/to/file.json"` in [configuration](configuration.md) when the
+file lives elsewhere.
+
+Ignored families are removed from the active report and do not trip `--fail` or
+`--fail-on-new`. JSON output still carries them under `ignored_families` with the
+ignore metadata, so suppressions remain auditable.
+
+## File shape
+
+The preferred file shape is an object with an `ignores` array:
+
+```json
+{
+  "ignores": [
+    {
+      "paths": ["src/generated/**"],
+      "languages": ["typescript"],
+      "reason": "generated-code",
+      "note": "Generated API bindings; source schema is the refactoring point.",
+      "owner": "integrations",
+      "expires_at": "2026-12-31"
+    }
+  ]
+}
+```
+
+A top-level array of entries is also accepted for small files, but the object
+shape is easier to extend in review.
+
+Each entry must have:
+
+| field | required | meaning |
+|---|---:|---|
+| `reason` | yes | Short rationale category, such as `generated-code`, `framework-required`, or `accepted-risk`. |
+| `family_id` | one selector required | Stable family ID printed by nose. Best for one exact finding. |
+| `paths` | one selector required | Gitignore-style path globs matched against the paths shown in the report. Best for generated directories or templates. |
+| `languages` | one selector required | Language names such as `python`, `typescript`, or `rust`. Best as a broad guard combined with another selector. |
+| `note` | no | Human review context. Explain where the real refactoring point is. |
+| `owner` | no | Team or person responsible for revisiting the decision. |
+| `expires_at` | no | `YYYY-MM-DD`. The entry applies through that date; after it, nose reports it as expired and does not apply it. |
+
+When an entry has multiple selectors, all of them must match. For example, an
+entry with both `paths` and `languages` suppresses only families that touch one
+of those paths and one of those languages. If several entries match the same
+family, the first active entry supplies the metadata.
+
+## Family IDs
+
+`family_id` is the same stable key used by baselines. It is derived from the
+family members' displayed file paths and symbol names, not line numbers. That
+makes it stable across ordinary line movement, but intentionally changes when a
+copy is added, removed, renamed, or moved to another displayed path.
+
+Human output includes the ID on each family:
+
+```text
+#1  id 479389f590c1234a · 3 copies · 12 of 14 lines shared, 1 spot differs · ~24 lines removable
+```
+
+JSON output includes `family_id` on both active `families[]` and
+`ignored_families[]`.
+
+## Expired and malformed entries
+
+Malformed ignore files are hard errors. nose fails fast for invalid JSON, unknown
+entry fields, missing `reason`, invalid `family_id`, invalid path globs, invalid
+dates, or entries with no selector. Silent ignore mistakes would make the report
+untrustworthy.
+
+Expired entries are different: they are valid historical decisions whose date has
+passed. nose prints a warning, does not apply the entry, and includes the expired
+entry in the JSON `ignore.expired` list.
+
+## Which suppression to use
+
+| mechanism | use when | tradeoff |
+|---|---|---|
+| Inline `// nose-ignore` | One source unit should never participate in detection. | Removes the unit before families are formed; no family metadata exists later. |
+| Structured ignore file | A reported family was reviewed and intentionally kept. | Keeps rationale, owner, expiry, and machine-readable ignored-family output. |
+| Baseline | You are adopting nose on an existing codebase and want CI to flag only new or changed duplication. | Accepts the current state in bulk; use structured ignores for individual decisions that need explanation. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,6 +96,7 @@ Grouped by what they do. Anything here can also be set in [configuration](config
 | `--mode MODE` | one or more of `syntax`, `semantic`, `near`; comma-list or repeatable; when present, replaces the default |
 | `--threshold T` | acceptance similarity in `[0,1]` for the `near` channel; invalid unless `--mode` includes `near` |
 | `--exclude <glob>` | skip paths matching a gitignore-syntax glob (repeatable) |
+| `--ignore-file <file>` | suppress reviewed families using a structured ignore file with reason/owner/expiry metadata |
 
 ### Ranking
 
@@ -130,8 +131,9 @@ scan scope, ranking metadata, and a `families` array. The stable contract and
 compatibility rule are documented in [scan-json](scan-json.md).
 
 **Workflow** (`--baseline`, `--write-baseline`, `--new-only`, `--fail-on-new`,
-`--fail`, `--cache-dir`, `--config`) is covered in
+`--fail`, `--ignore-file`, `--cache-dir`, `--config`) is covered in
 [continuous-integration](continuous-integration.md) and [configuration](configuration.md).
+Structured suppressions are covered in [structured-ignores](structured-ignores.md).
 
 ### Scan Modes
 


### PR DESCRIPTION
## Summary

- add `nose.ignore.json` / `--ignore-file` structured suppressions with required rationale metadata
- expose stable `family_id` in human, markdown, SARIF properties, and scan JSON so users can create targeted ignore entries
- report active vs ignored findings in human/markdown/JSON, keep ignored families machine-readable, and surface expired/malformed entries clearly
- document the workflow in a new structured-ignores guide and link it from usage, configuration, CI, home, and scan JSON docs

Closes #9

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --quiet`
- `./scripts/check-docs.sh`
- `cargo build --release && ./scripts/check-duplication.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 구조화된 무시 기능 추가: JSON 파일(`nose.ignore.json`)을 통해 검토된 패밀리 억제 가능
  * `--ignore-file` CLI 옵션 및 `nose.toml`의 `ignore-file` 설정 추가
  * 무시된 항목에 사유, 담당자, 만료 날짜 등 메타데이터 기록 가능
  * 무시된 패밀리는 활성 리포트와 실패 조건에서 제외되며, JSON 출력에는 억제 정보와 함께 표시

* **문서**
  * 구조화된 무시 기능 사용 가이드 문서 추가
  * 설정, 지속적 통합, 스캔 JSON 형식 등 관련 문서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->