### PR TITLE
[codex] Expose capabilities contract

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -19,7 +19,8 @@ use std::path::PathBuf;
                   • `nose scan <paths>` — default: syntax + semantic clone families\n\
                   • `nose scan <paths> --mode near` — opt into Type-3 near-duplicates\n\
                   • `nose stats <paths>`    — IL lowering coverage\n\
-                  • `nose il <file>`        — inspect the IL"
+                  • `nose il <file>`        — inspect the IL\n\
+                  • `nose capabilities`     — machine-readable integration contract"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -28,6 +29,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Cmd {
+    /// Emit the machine-readable capability contract for integrations.
+    Capabilities,
     /// Dump the IL for a source file (inspection / debugging the transpiler).
     Il {
         /// Path to a source file.
@@ -506,6 +509,145 @@ impl ScanScope {
 }
 
 const SCAN_JSON_SCHEMA_VERSION: u32 = 1;
+const CAPABILITIES_SCHEMA_VERSION: u32 = 1;
+
+#[derive(serde::Serialize)]
+struct CapabilitiesReport {
+    schema_version: u32,
+    tool: CapabilitiesTool,
+    platform: CapabilitiesPlatform,
+    interfaces: CapabilitiesInterfaces,
+    commands: CapabilitiesCommands,
+    schemas: CapabilitiesSchemas,
+    scan: CapabilitiesScan,
+    il: CapabilitiesIl,
+    stats: CapabilitiesStats,
+}
+
+#[derive(serde::Serialize)]
+struct CapabilitiesTool {
+    name: &'static str,
+    version: &'static str,
+}
+
+#[derive(serde::Serialize)]
+struct CapabilitiesPlatform {
+    os: &'static str,
+    arch: &'static str,
+    family: &'static str,
+}
+
+#[derive(serde::Serialize)]
+struct CapabilitiesInterfaces {
+    capabilities_json: bool,
+    version_json: bool,
+    doctor_json: bool,
+}
+
+#[derive(serde::Serialize)]
+struct CapabilitiesCommands {
+    stable: Vec<&'static str>,
+}
+
+#[derive(serde::Serialize)]
+struct CapabilitiesSchemas {
+    capabilities: Vec<u32>,
+    scan_json: Vec<u32>,
+}
+
+#[derive(serde::Serialize)]
+struct CapabilitiesScan {
+    modes: Vec<&'static str>,
+    default_modes: Vec<&'static str>,
+    output_formats: Vec<&'static str>,
+    sort_keys: Vec<&'static str>,
+    config_keys: Vec<&'static str>,
+    capabilities: std::collections::BTreeMap<&'static str, bool>,
+}
+
+#[derive(serde::Serialize)]
+struct CapabilitiesIl {
+    output_formats: Vec<&'static str>,
+    normalized: bool,
+    cfg_norm_toggle: bool,
+}
+
+#[derive(serde::Serialize)]
+struct CapabilitiesStats {
+    output_formats: Vec<&'static str>,
+}
+
+impl CapabilitiesReport {
+    fn current() -> Self {
+        CapabilitiesReport {
+            schema_version: CAPABILITIES_SCHEMA_VERSION,
+            tool: CapabilitiesTool {
+                name: "nose",
+                version: env!("CARGO_PKG_VERSION"),
+            },
+            platform: CapabilitiesPlatform {
+                os: std::env::consts::OS,
+                arch: std::env::consts::ARCH,
+                family: std::env::consts::FAMILY,
+            },
+            interfaces: CapabilitiesInterfaces {
+                capabilities_json: true,
+                version_json: false,
+                doctor_json: false,
+            },
+            commands: CapabilitiesCommands {
+                stable: vec!["capabilities", "il", "scan", "stats"],
+            },
+            schemas: CapabilitiesSchemas {
+                capabilities: vec![CAPABILITIES_SCHEMA_VERSION],
+                scan_json: vec![SCAN_JSON_SCHEMA_VERSION],
+            },
+            scan: CapabilitiesScan {
+                modes: vec!["syntax", "semantic", "near"],
+                default_modes: vec!["syntax", "semantic"],
+                output_formats: vec!["human", "json", "markdown", "sarif"],
+                sort_keys: vec!["extractability", "value", "sites"],
+                config_keys: vec![
+                    "exclude",
+                    "ignore-file",
+                    "min-lines",
+                    "min-members",
+                    "min-tokens",
+                    "min-value",
+                    "mode",
+                    "sort",
+                    "threshold",
+                    "top",
+                ],
+                capabilities: scan_capability_flags(),
+            },
+            il: CapabilitiesIl {
+                output_formats: vec!["sexpr", "json"],
+                normalized: true,
+                cfg_norm_toggle: true,
+            },
+            stats: CapabilitiesStats {
+                output_formats: vec!["human", "json"],
+            },
+        }
+    }
+}
+
+fn scan_capability_flags() -> std::collections::BTreeMap<&'static str, bool> {
+    [
+        ("baseline", true),
+        ("baseline_changed_detection", true),
+        ("cache", true),
+        ("ci_fail_gate", true),
+        ("diff", true),
+        ("hotspots", true),
+        ("inline_suppression", true),
+        ("proposal", true),
+        ("structured_ignores", true),
+    ]
+    .into_iter()
+    .collect()
+}
 
 #[derive(serde::Serialize)]
 struct ScanJsonReport<'a> {
@@ -890,6 +1032,7 @@ fn run() -> Result<()> {
             normalized,
             no_cfg_norm,
         } => cmd_il(path, format, normalized, no_cfg_norm),
+        Cmd::Capabilities => cmd_capabilities(),
         Cmd::Detect {
             paths,
             min_lines,
@@ -2018,6 +2161,12 @@ fn cmd_stats(paths: Vec<PathBuf>, top: usize, json: bool) -> Result<()> {
     for u in &report.top_unhandled {
         println!("  {:<12} {:<34} {:>8}", u.lang, u.surface_kind, u.count);
     }
+    Ok(())
+}
+
+fn cmd_capabilities() -> Result<()> {
+    let report = CapabilitiesReport::current();
+    println!("{}", serde_json::to_string_pretty(&report)?);
     Ok(())
 }
 

--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -101,6 +101,18 @@ fn scan_families(json: &serde_json::Value) -> &[serde_json::Value] {
         .expect("scan JSON should contain families array")
 }
 
+fn json_array_strings<'a>(value: &'a serde_json::Value, key: &str) -> Vec<&'a str> {
+    value[key]
+        .as_array()
+        .unwrap_or_else(|| panic!("{key} should be an array"))
+        .iter()
+        .map(|item| {
+            item.as_str()
+                .unwrap_or_else(|| panic!("{key} entries should be strings"))
+        })
+        .collect()
+}
+
 fn assert_scan_json_v1_contract(json: &serde_json::Value) {
     assert_eq!(json["schema_version"], 1);
     assert!(
@@ -1804,6 +1816,65 @@ fn diff_shows_the_differing_line() {
 fn version_flag_works() {
     let out = run(&["--version"]);
     assert!(out.starts_with("nose "), "version line: {out}");
+}
+
+#[test]
+fn capabilities_command_emits_machine_readable_contract() {
+    let out = run(&["capabilities"]);
+    let json: serde_json::Value =
+        serde_json::from_str(&out).expect("capabilities must emit valid JSON");
+
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["tool"]["name"], "nose");
+    assert_eq!(json["tool"]["version"], env!("CARGO_PKG_VERSION"));
+    assert!(
+        json["platform"]["os"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "platform.os should be non-empty: {out}"
+    );
+    assert!(
+        json["platform"]["arch"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "platform.arch should be non-empty: {out}"
+    );
+    assert_eq!(json["interfaces"]["capabilities_json"], true);
+    assert_eq!(json["interfaces"]["version_json"], false);
+    assert_eq!(json["interfaces"]["doctor_json"], false);
+
+    assert_eq!(
+        json_array_strings(&json["commands"], "stable"),
+        vec!["capabilities", "il", "scan", "stats"]
+    );
+    assert_eq!(json["schemas"]["capabilities"][0], 1);
+    assert_eq!(json["schemas"]["scan_json"][0], 1);
+    assert_eq!(
+        json_array_strings(&json["scan"], "modes"),
+        vec!["syntax", "semantic", "near"]
+    );
+    assert_eq!(
+        json_array_strings(&json["scan"], "default_modes"),
+        vec!["syntax", "semantic"]
+    );
+    assert_eq!(
+        json_array_strings(&json["scan"], "output_formats"),
+        vec!["human", "json", "markdown", "sarif"]
+    );
+    assert_eq!(
+        json_array_strings(&json["scan"], "sort_keys"),
+        vec!["extractability", "value", "sites"]
+    );
+    assert_eq!(json["scan"]["capabilities"]["baseline"], true);
+    assert_eq!(json["scan"]["capabilities"]["structured_ignores"], true);
+    assert_eq!(
+        json_array_strings(&json["il"], "output_formats"),
+        vec!["sexpr", "json"]
+    );
+    assert_eq!(
+        json_array_strings(&json["stats"], "output_formats"),
+        vec!["human", "json"]
+    );
 }
 
 #[test]

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,0 +1,120 @@
+# Capabilities contract
+
+`nose capabilities` emits the stable machine-readable contract for the installed
+binary. Use it from installers, editor integrations, CI wrappers, and doctor
+commands before invoking `nose scan`. For the human command guide see
+[usage](usage.md); for scan result JSON see [scan-json](scan-json.md). Back to
+[home](home.md).
+
+## Why this is not help text
+
+`nose --help` is a human interface. It can change wording, examples, wrapping,
+and ordering to improve readability. Tools should not scrape it.
+
+`nose capabilities` is an integration interface. It is JSON-only, has its own
+`schema_version`, and reports what the binary supports as data: stable commands,
+scan modes, output formats, schema versions, config keys, and capability flags.
+
+## Example
+
+```sh
+nose capabilities
+```
+
+```json
+{
+  "schema_version": 1,
+  "tool": {
+    "name": "nose",
+    "version": "0.4.0"
+  },
+  "platform": {
+    "os": "linux",
+    "arch": "x86_64",
+    "family": "unix"
+  },
+  "interfaces": {
+    "capabilities_json": true,
+    "version_json": false,
+    "doctor_json": false
+  },
+  "commands": {
+    "stable": ["capabilities", "il", "scan", "stats"]
+  },
+  "schemas": {
+    "capabilities": [1],
+    "scan_json": [1]
+  },
+  "scan": {
+    "modes": ["syntax", "semantic", "near"],
+    "default_modes": ["syntax", "semantic"],
+    "output_formats": ["human", "json", "markdown", "sarif"],
+    "sort_keys": ["extractability", "value", "sites"],
+    "config_keys": ["exclude", "ignore-file", "min-lines"],
+    "capabilities": {
+      "baseline": true,
+      "structured_ignores": true
+    }
+  },
+  "il": {
+    "output_formats": ["sexpr", "json"],
+    "normalized": true,
+    "cfg_norm_toggle": true
+  },
+  "stats": {
+    "output_formats": ["human", "json"]
+  }
+}
+```
+
+The real `config_keys` and `scan.capabilities` objects may contain more entries
+than this shortened example.
+
+## Version 1 fields
+
+| field | type | meaning |
+|---|---|---|
+| `schema_version` | integer | Capabilities contract version. Version 1 is documented here. |
+| `tool.name` | string | Always `nose`. |
+| `tool.version` | string | Package version of the installed binary. |
+| `platform.os` | string | Rust target OS name, such as `linux`, `macos`, or `windows`. |
+| `platform.arch` | string | Rust target architecture, such as `x86_64` or `aarch64`. |
+| `platform.family` | string | Rust target family, such as `unix` or `windows`. |
+| `interfaces.capabilities_json` | boolean | Whether `nose capabilities` is the supported capability query interface. |
+| `interfaces.version_json` | boolean | Whether `nose --version --json` is supported. Version 1 reports `false`. |
+| `interfaces.doctor_json` | boolean | Whether `nose doctor --json` is supported. Version 1 reports `false`. |
+| `commands.stable` | array | Stable user-facing commands that integrations may invoke. Hidden research commands are intentionally omitted. |
+| `schemas.capabilities` | array | Supported capabilities schema versions. |
+| `schemas.scan_json` | array | Supported `nose scan --format json` schema versions. |
+| `scan.modes` | array | Supported `--mode` values. |
+| `scan.default_modes` | array | Modes used by `nose scan` when `--mode` is omitted. |
+| `scan.output_formats` | array | Supported `nose scan --format` values. |
+| `scan.sort_keys` | array | Supported `nose scan --sort` values. |
+| `scan.config_keys` | array | Supported `[scan]` keys in `nose.toml` / `.nose.toml`. |
+| `scan.capabilities` | object | Stable boolean capability flags for scan workflows. |
+| `il.output_formats` | array | Supported `nose il --format` values. |
+| `il.normalized` | boolean | Whether `nose il --normalized` is supported. |
+| `il.cfg_norm_toggle` | boolean | Whether `nose il --no-cfg-norm` is supported. |
+| `stats.output_formats` | array | Supported stats output formats. |
+
+Known unsupported capabilities or query interfaces should be represented as
+`false` when nose has a stable key for them. Unknown keys should be ignored by
+consumers. New fields may be added to existing objects without changing
+`schema_version`; changing a documented field's type or meaning requires a new
+capabilities schema version.
+
+## Scan capability flags
+
+Version 1 defines these `scan.capabilities` keys:
+
+| key | meaning |
+|---|---|
+| `baseline` | `--baseline` and `--write-baseline` are supported. |
+| `baseline_changed_detection` | Baseline comparisons can classify changed and resolved families. |
+| `cache` | `--cache-dir` file analysis caching is supported. |
+| `ci_fail_gate` | `--fail` and `--fail-on-new` gate behavior is supported. |
+| `diff` | Human `--diff` review output is supported. |
+| `hotspots` | `--hotspots` module-level duplicate-line summary is supported. |
+| `inline_suppression` | Source-level `nose-ignore` markers are supported. |
+| `proposal` | Human `--proposal` extraction skeletons are supported. |
+| `structured_ignores` | `nose.ignore.json` / `--ignore-file` audited suppressions are supported. |

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -34,6 +34,9 @@ For an exact semantic-only gate, use `--mode semantic`. It does not use a
 similarity threshold.
 
 With committed settings in `nose.toml`, the CI command can be just `nose scan src --fail`.
+If a wrapper needs to support multiple installed nose versions, have it query
+`nose capabilities` first instead of scraping `--help`; the JSON contract is
+documented in [capabilities](capabilities.md).
 
 ## Baselines — incremental adoption
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -13,7 +13,8 @@ docs browse cleanly on GitHub and in any Markdown viewer.
 
 Start here if you want to *run* nose on a codebase.
 
-- [usage](usage.md) — install, the commands (`scan`, `il`, `stats`), every flag, and how to read the report.
+- [usage](usage.md) — install, the commands (`scan`, `il`, `stats`, `capabilities`), every flag, and how to read the report.
+- [capabilities](capabilities.md) — the `nose capabilities` JSON contract for installers, CI wrappers, and editor integrations.
 - [scan-json](scan-json.md) — the versioned `nose scan --format json` contract for downstream tooling.
 - [clone-types](clone-types.md) — what nose covers across the standard Type-1/2/3/4 taxonomy, with its honest limits.
 - [configuration](configuration.md) — the `nose.toml` file: excludes, thresholds, baselines, caching, inline `// nose-ignore`.

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -3,7 +3,9 @@
 `nose scan --format json` emits a versioned machine-readable report for CI,
 dashboards, editor integrations, and baselines that need clone families as data.
 For the command context see [usage](usage.md); for CI-oriented formats see
-[continuous-integration](continuous-integration.md). Back to [home](home.md).
+[continuous-integration](continuous-integration.md). Tools can discover supported
+scan JSON schema versions with [capabilities](capabilities.md). Back to
+[home](home.md).
 
 ## Version 1
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -166,6 +166,22 @@ start or end in the middle of a function. The normalized unit channels (`semanti
 `near`) are where renamed identifiers, cross-language convergence, and Type-3 edits are
 handled.
 
+## Integrating with nose
+
+Use `nose capabilities` when another tool needs to decide what this installed
+binary supports before it invokes a scan:
+
+```sh
+nose capabilities
+```
+
+The command emits JSON only. It reports the tool version, platform, stable
+commands, supported scan modes and output formats, JSON schema versions, config
+keys, and scan capability flags such as baselines, caching, SARIF, and
+structured ignores. Do not scrape `nose --help`; help text is for humans and may
+change to improve readability. The stable contract is documented in
+[capabilities](capabilities.md).
+
 ## Inspecting & measuring
 
 - `nose il <file> [--normalized] [--format sexpr|json]` — dump the IL for one


### PR DESCRIPTION
## Summary

- add `nose capabilities`, a JSON-only machine-readable contract for integrations
- report tool version, platform, stable commands, schema versions, scan modes/defaults/output formats, config keys, and scan capability flags
- explicitly mark unsupported alternate query interfaces (`--version --json`, `doctor --json`) as false
- document why the capabilities contract is separate from human help text and link it from usage, CI, home, and scan JSON docs

Closes #10

## Validation

- `cargo fmt --all --check`
- `./scripts/check-docs.sh`
- `git diff --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --quiet`
- `cargo build --release && ./scripts/check-duplication.sh`
