### PR TITLE
[codex] strengthen exact type4 idioms

### DIFF
--- a/bench/type4/ITERATIONS.md
+++ b/bench/type4/ITERATIONS.md
@@ -4126,3 +4126,32 @@ and simultaneously removed a previous false merge, so batching did not weaken th
 proof bar. The important constraint is that a batch should still share one invariant:
 here, all three items are about the same stable module binding proof and its mutation
 boundary.
+
+## Extreme exact Type-4 idiom slice: loops 407-411
+
+This pass implements the four highest-priority Type-4 improvements selected from the
+current frontier proposal, but keeps each one in a strict first slice rather than opening
+the full fuzzy space:
+
+- JS/TS record-shape guards now accept `Array.isArray(value) === false` and its symmetric
+  false comparison as the same not-array proof as `!Array.isArray(value)`, while preserving
+  the existing shadowed-`Array` boundary.
+- Simple boolean flag loops with `assign; break` branches now converge with `any`/`all`
+  reductions when the predicate is over the loop element.
+- Equality OR-chains over the same candidate and static literals now converge with literal
+  collection membership, with collection item order ignored.
+- Python ordered string builders of the form `out = ""; for x in xs: out += f(x)` now
+  converge with literal-separator `sep.join(xs)` when the contribution is genuinely
+  per-element; prepend and non-element builders remain outside the canon.
+
+| loop | pressure | change | measured result |
+|---|---|---|---:|
+| 407 | priority batch selection | implement record not-array comparisons, flag+break reductions, equality-chain membership, and ordered string builder joins as four strict slices | focused hand corpus covers 4 positives and 4 hard negatives |
+| 408 | detector strengthening | add common value-graph canons plus the JS/TS record guard and Python literal-separator `join` idiom | targeted CLI regression passed |
+| 409 | cache boundary | bump the scan cache schema because semantic feature extraction changed | stale v4 cache entries ignored |
+| 410 | focused regression gate | run the new `scan_mode_semantic_proves_extreme_type4_idioms` test | CLI test passed |
+| 411 | local semantic probe | scan a hand-written four-file corpus in semantic JSON mode | 4/4 expected families, 0/4 hard-negative inclusions |
+
+Assessment: this is an exactness-first widening. The useful new merges are deliberately
+small and high-confidence, and every slice has an adjacent hard negative in the CLI gate:
+missing not-array proof, wrong early-exit predicate, wrong literal set, and ordered prepend.

--- a/crates/nose-cli/src/cache.rs
+++ b/crates/nose-cli/src/cache.rs
@@ -16,9 +16,10 @@ use rayon::prelude::*;
 use std::path::Path;
 
 /// Bump when the cached payload's layout, extraction, or feature hashing changes — old
-/// cache entries then live under a different directory and are ignored. (v4: `UnitFeat`
-/// stores strict exact-safety for the semantic scan contract.)
-const SCHEMA: u32 = 4;
+/// cache entries then live under a different directory and are ignored. (v5: exact
+/// Type-4 features include the newly modeled record, membership, flag-loop, and ordered
+/// string-builder idioms.)
+const SCHEMA: u32 = 5;
 
 pub(crate) struct CachedUnits {
     pub units: Vec<UnitFeat>,

--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -433,6 +433,91 @@ fn scan_mode_semantic_allows_proved_js_static_builtins() {
 }
 
 #[test]
+fn scan_mode_semantic_proves_extreme_type4_idioms() {
+    let dir = std::env::temp_dir().join(format!("nose_extreme_type4_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("record.ts"),
+        "export function recordA(value: unknown) { return value !== null && typeof value === 'object' && Array.isArray(value) === false; }\n\
+         export function recordB(input: unknown) { return typeof input === 'object' && input !== null && !Array.isArray(input); }\n\
+         export function recordMissingArray(value: unknown) { return typeof value === 'object' && value !== null; }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("early.ts"),
+        "export function anyLoop(xs: number[]) { let found = false; for (const x of xs) { if (x > 0) { found = true; break; } } return found; }\n\
+         export function anySome(xs: number[]) { return xs.some(x => x > 0); }\n\
+         export function anyWrongPredicate(xs: number[]) { let found = false; for (const x of xs) { if (x < 0) { found = true; break; } } return found; }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("membership.ts"),
+        "export function colorOr(value: string) { return value === 'red' || value === 'blue'; }\n\
+         export function colorIncludes(value: string) { return ['blue', 'red'].includes(value); }\n\
+         export function colorWrongLiteral(value: string) { return value === 'red' || value === 'green'; }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("builder.py"),
+        concat!(
+            "def concat_loop(xs):\n",
+            "    out = \"\"\n",
+            "    for x in xs:\n",
+            "        out += x\n",
+            "    return out\n\n",
+            "def concat_join(xs):\n",
+            "    return \"\".join(xs)\n\n",
+            "def concat_prepend(xs):\n",
+            "    out = \"\"\n",
+            "    for x in xs:\n",
+            "        out = x + out\n",
+            "    return out\n",
+        ),
+    )
+    .unwrap();
+
+    let semantic = run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--min-lines",
+        "1",
+        "--min-tokens",
+        "1",
+        "--format",
+        "json",
+        "--top",
+        "0",
+    ]);
+    let semantic_json = scan_json(&semantic);
+    let semantic_families = scan_families(&semantic_json);
+    let family = |positives: &[&str], negatives: &[&str]| {
+        semantic_families
+            .iter()
+            .map(serde_json::Value::to_string)
+            .find(|text| {
+                positives.iter().all(|name| text.contains(name))
+                    && negatives.iter().all(|name| !text.contains(name))
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "semantic mode should report {:?} without {:?}: {semantic}",
+                    positives, negatives
+                )
+            })
+    };
+
+    family(&["recordA", "recordB"], &["recordMissingArray"]);
+    family(&["anyLoop", "anySome"], &["anyWrongPredicate"]);
+    family(&["colorOr", "colorIncludes"], &["colorWrongLiteral"]);
+    family(&["concat_loop", "concat_join"], &["concat_prepend"]);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn scan_mode_semantic_proves_collection_empty_checks() {
     let dir = std::env::temp_dir().join(format!("nose_collection_empty_{}", std::process::id()));
     let _ = fs::remove_dir_all(&dir);

--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -503,8 +503,7 @@ fn scan_mode_semantic_proves_extreme_type4_idioms() {
             })
             .unwrap_or_else(|| {
                 panic!(
-                    "semantic mode should report {:?} without {:?}: {semantic}",
-                    positives, negatives
+                    "semantic mode should report {positives:?} without {negatives:?}: {semantic}"
                 )
             })
     };

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -1289,6 +1289,11 @@ fn lower_record_shape_guard(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     if !(has_typeof_object && has_non_null_or_truthy && has_not_array) {
         return None;
     }
+    if file_prefix_has_binding_ident(lo, node, "Array")
+        || enclosing_function_prefix_has_binding_ident(lo, node, "Array")
+    {
+        return None;
+    }
     let span = lo.span(node);
     let value = lo.var(&ident?, span);
     let object = lo.str_lit("object", span);
@@ -1364,10 +1369,30 @@ fn parse_truthy_clause(clause: &str) -> Option<String> {
 }
 
 fn parse_not_array_clause(clause: &str) -> Option<String> {
-    clause
+    if let Some(name) = clause
         .strip_prefix("!Array.isArray(")
         .and_then(|inner| inner.strip_suffix(')'))
-        .map(str::to_string)
+    {
+        return Some(name.to_string());
+    }
+    for op in ["===", "=="] {
+        if let Some(call) = clause.strip_suffix(&format!("{op}false")) {
+            if let Some(name) = call
+                .strip_prefix("Array.isArray(")
+                .and_then(|inner| inner.strip_suffix(')'))
+            {
+                return Some(name.to_string());
+            }
+        }
+        let prefix = format!("false{op}Array.isArray(");
+        if let Some(name) = clause
+            .strip_prefix(&prefix)
+            .and_then(|inner| inner.strip_suffix(')'))
+        {
+            return Some(name.to_string());
+        }
+    }
+    None
 }
 
 fn is_object_literal(value: &str) -> bool {

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -277,6 +277,8 @@ pub enum Builtin {
     IsNull,
     /// Non-null/some presence predicate over `(value)`.
     IsNotNull,
+    /// Ordered string join over `(separator, collection)`.
+    Join,
 }
 
 /// Kinds of canonical higher-order operation.

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -267,6 +267,23 @@ pub(crate) fn canon_call(old: &Il, interner: &Interner, call_id: NodeId) -> Call
                             arg_olds: vec![args[0], collection],
                         };
                     }
+                    // Python `sep.join(xs)`: ordered string-builder fold. Keep this
+                    // restricted to a literal separator receiver; JavaScript/Ruby
+                    // `xs.join(sep)` have the collection as the receiver and are not this
+                    // surface shape.
+                    "join"
+                        if base.is_some()
+                            && args.len() == 1
+                            && matches!(
+                                old.node(base.unwrap()).payload,
+                                Payload::LitStr(_) | Payload::Lit(nose_il::LitClass::Str)
+                            ) =>
+                    {
+                        return CallCanon::Builtin {
+                            op: Builtin::Join,
+                            arg_olds: vec![base.unwrap(), args[0]],
+                        };
+                    }
                     "get" | "fetch"
                         if base.is_some()
                             && args.len() == 2

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -474,6 +474,7 @@ impl<'a> Interp<'a> {
                 )),
                 _ => Ok(Value::Err),
             },
+            Builtin::Join => Ok(join_strings(args.first(), args.get(1))),
             Builtin::Abs => match args.first() {
                 Some(Value::Int(v)) => Ok(Value::Int(v.abs())),
                 _ => Ok(Value::Err),
@@ -796,6 +797,23 @@ fn string_affix(value: Option<&Value>, affix: Option<&Value>, prefix: bool) -> V
         }
         _ => Value::Err,
     }
+}
+
+fn join_strings(separator: Option<&Value>, collection: Option<&Value>) -> Value {
+    let (Some(Value::Str(separator)), Some(Value::List(items))) = (separator, collection) else {
+        return Value::Err;
+    };
+    let mut out = Vec::new();
+    for (idx, item) in items.iter().enumerate() {
+        let Value::Str(piece) = item else {
+            return Value::Err;
+        };
+        if idx > 0 {
+            out.extend(separator.iter().copied());
+        }
+        out.extend(piece.iter().copied());
+    }
+    Value::Str(out)
 }
 
 fn bin(op: Op, a: &Value, b: &Value) -> Value {

--- a/crates/nose-normalize/src/types.rs
+++ b/crates/nose-normalize/src/types.rs
@@ -199,6 +199,7 @@ pub(crate) fn result_ty(il: &Il, n: NodeId, ev: &FxHashMap<u32, Ty>) -> Ty {
                 | nose_il::Builtin::EndsWith
                 | nose_il::Builtin::Contains,
             ) => Ty::Bool,
+            Payload::Builtin(nose_il::Builtin::Join) => Ty::Str,
             _ => Ty::Unknown,
         },
         _ => Ty::Unknown,

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -1319,6 +1319,7 @@ impl<'a> Builder<'a> {
                 .proven_collection_value(receiver_value)
                 .or_else(|| self.proven_local_collection_binding_value(receiver, env))
             {
+                let collection = self.canonical_membership_collection_value(collection);
                 return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
             }
             None
@@ -1335,6 +1336,7 @@ impl<'a> Builder<'a> {
             } else {
                 self.proven_collection_expr(kids[1], env)?
             };
+            let collection = self.canonical_membership_collection_value(collection);
             Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]))
         } else {
             None
@@ -1640,6 +1642,11 @@ impl<'a> Builder<'a> {
             let is_and = o == Op::And as u32;
             if (is_or || is_and) && args.len() == 2 {
                 if self.vty(args[0]) == Ty::Bool && self.vty(args[1]) == Ty::Bool {
+                    if is_or {
+                        if let Some(v) = self.literal_equality_disjunction(args[0], args[1]) {
+                            return v;
+                        }
+                    }
                     // LATTICE CANON on a total order — close the strict comparison from a
                     // non-strict one plus an (in)equality, so a guard written as the
                     // conjunction/disjunction converges with the strict comparison:
@@ -3193,6 +3200,7 @@ impl<'a> Builder<'a> {
         let outer_recurrence = self.loop_recurrence.replace(LoopRecurrenceScope {
             loop_values: loop_vals.clone(),
         });
+        let pre_body_env = body_env.clone();
         self.process_stmt(body, &mut body_env);
         self.loop_recurrence = outer_recurrence;
         if !index_vals.is_empty() {
@@ -3205,6 +3213,18 @@ impl<'a> Builder<'a> {
                 if let Some(&v) = body_env.get(&cid) {
                     let nv = self.rewrite_indices(v, &index_vals, &mut memo);
                     body_env.insert(cid, nv);
+                }
+            }
+        }
+        let mut flag_break_reduction = None;
+        for &cid in &carried {
+            if let Some(&init) = env.get(&cid) {
+                if let Some(v) =
+                    self.flag_break_reduction(body, cid, init, &pre_body_env, &index_vals)
+                {
+                    flag_break_reduction = Some((cid, v));
+                    self.sinks.truncate(sink_start);
+                    break;
                 }
             }
         }
@@ -3245,6 +3265,20 @@ impl<'a> Builder<'a> {
         // than a bare opaque `Loop` value reaching the sinks).
         let mut reduction_cache = ReductionCache::default();
         for &cid in &carried {
+            if let Some((flag_cid, v)) = flag_break_reduction {
+                if flag_cid == cid {
+                    env.insert(cid, v);
+                    continue;
+                }
+            }
+            if let Some(&init) = env.get(&cid) {
+                if let Some(v) =
+                    self.ordered_string_concat_loop(body, cid, init, &pre_body_env, &index_vals)
+                {
+                    env.insert(cid, v);
+                    continue;
+                }
+            }
             if iter_vars.contains(&cid) || induction.contains(&cid) {
                 continue; // iteration mechanics, not an accumulator
             }
@@ -3271,6 +3305,128 @@ impl<'a> Builder<'a> {
                 }
             }
         }
+    }
+
+    fn flag_break_reduction(
+        &mut self,
+        body: NodeId,
+        cid: u32,
+        init: ValueId,
+        env: &FxHashMap<u32, ValueId>,
+        index_vals: &FxHashSet<ValueId>,
+    ) -> Option<ValueId> {
+        let init_bool = self.bool_const(init)?;
+        let (cond_node, assigned_bool) = self.flag_break_if(body, cid)?;
+        if init_bool == assigned_bool {
+            return None;
+        }
+        let mut cond = self.eval(cond_node, env);
+        if !index_vals.is_empty() {
+            let mut memo = FxHashMap::default();
+            cond = self.rewrite_indices(cond, index_vals, &mut memo);
+        }
+        if !self.refs_elem(cond) {
+            return None;
+        }
+        if !init_bool && assigned_bool {
+            Some(self.mk(ValOp::Reduce(REDUCE_ANY), vec![cond]))
+        } else {
+            let pred = self.mk(ValOp::Un(Op::Not as u32), vec![cond]);
+            Some(self.mk(ValOp::Reduce(REDUCE_ALL), vec![pred]))
+        }
+    }
+
+    fn flag_break_if(&self, body: NodeId, cid: u32) -> Option<(NodeId, bool)> {
+        let stmts = self.direct_block_statements(body);
+        if stmts.len() != 1 || self.il.kind(stmts[0]) != NodeKind::If {
+            return None;
+        }
+        let if_kids = self.il.children(stmts[0]);
+        if if_kids.len() != 2 {
+            return None;
+        }
+        let branch = self.direct_block_statements(if_kids[1]);
+        if branch.len() != 2 || self.il.kind(branch[1]) != NodeKind::Break {
+            return None;
+        }
+        Some((if_kids[0], self.flag_assignment(branch[0], cid)?))
+    }
+
+    fn ordered_string_concat_loop(
+        &mut self,
+        body: NodeId,
+        cid: u32,
+        init: ValueId,
+        env: &FxHashMap<u32, ValueId>,
+        index_vals: &FxHashSet<ValueId>,
+    ) -> Option<ValueId> {
+        if !self.is_empty_string_value(init) {
+            return None;
+        }
+        let contrib_node = self.ordered_concat_contribution(body, cid)?;
+        let mut contrib = self.eval(contrib_node, env);
+        if !index_vals.is_empty() {
+            let mut memo = FxHashMap::default();
+            contrib = self.rewrite_indices(contrib, index_vals, &mut memo);
+        }
+        if !self.refs_elem(contrib) {
+            return None;
+        }
+        let sep = self.empty_string_value();
+        Some(self.mk(ValOp::Reduce(ORDERED_STRING_JOIN), vec![sep, contrib]))
+    }
+
+    fn ordered_concat_contribution(&self, body: NodeId, cid: u32) -> Option<NodeId> {
+        let stmts = self.direct_block_statements(body);
+        if stmts.len() != 1 || self.il.kind(stmts[0]) != NodeKind::Assign {
+            return None;
+        }
+        let kids = self.il.children(stmts[0]);
+        if kids.len() != 2 || !self.is_var_cid(kids[0], cid) {
+            return None;
+        }
+        if self.il.kind(kids[1]) != NodeKind::BinOp
+            || op_code(self.il.node(kids[1]).payload) != Op::Add as u32
+        {
+            return None;
+        }
+        let add = self.il.children(kids[1]);
+        if add.len() != 2 || !self.is_var_cid(add[0], cid) {
+            return None;
+        }
+        if mentioned_cids(self.il, add[1]).contains(&cid) {
+            return None;
+        }
+        Some(add[1])
+    }
+
+    fn direct_block_statements(&self, node: NodeId) -> Vec<NodeId> {
+        if self.il.kind(node) == NodeKind::Block {
+            self.il.children(node).to_vec()
+        } else {
+            vec![node]
+        }
+    }
+
+    fn flag_assignment(&self, stmt: NodeId, cid: u32) -> Option<bool> {
+        if self.il.kind(stmt) != NodeKind::Assign {
+            return None;
+        }
+        let kids = self.il.children(stmt);
+        if kids.len() != 2 || !self.is_var_cid(kids[0], cid) {
+            return None;
+        }
+        match self.il.node(kids[1]).payload {
+            Payload::LitBool(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    fn is_var_cid(&self, node: NodeId, cid: u32) -> bool {
+        matches!(
+            (self.il.kind(node), self.il.node(node).payload),
+            (NodeKind::Var, Payload::Cid(c)) if c == cid
+        )
     }
 
     /// The iterable of a `while i < len(xs)`-style loop: from a comparison whose
@@ -3709,6 +3865,111 @@ impl<'a> Builder<'a> {
         }
     }
 
+    fn literal_equality_disjunction(&mut self, left: ValueId, right: ValueId) -> Option<ValueId> {
+        let mut element = None;
+        let mut items = Vec::new();
+        self.collect_literal_membership_terms(left, &mut element, &mut items)?;
+        self.collect_literal_membership_terms(right, &mut element, &mut items)?;
+        if items.len() < 2 {
+            return None;
+        }
+        items.sort_by_key(|&v| (self.vhash[v as usize], v));
+        items.dedup();
+        let collection = self.mk(ValOp::Seq(1), items);
+        Some(self.mk(ValOp::Bin(Op::In as u32), vec![element?, collection]))
+    }
+
+    fn collect_literal_membership_terms(
+        &self,
+        value: ValueId,
+        element: &mut Option<ValueId>,
+        items: &mut Vec<ValueId>,
+    ) -> Option<()> {
+        let node = &self.nodes[value as usize];
+        match node.op {
+            ValOp::Bin(op) if op == Op::Or as u32 && node.args.len() == 2 => {
+                self.collect_literal_membership_terms(node.args[0], element, items)?;
+                self.collect_literal_membership_terms(node.args[1], element, items)
+            }
+            ValOp::Bin(op) if op == Op::Eq as u32 && node.args.len() == 2 => {
+                let a = node.args[0];
+                let b = node.args[1];
+                let (candidate, literal) = if self.static_membership_literal_value(a) {
+                    (b, a)
+                } else if self.static_membership_literal_value(b) {
+                    (a, b)
+                } else {
+                    return None;
+                };
+                self.record_literal_membership_term(candidate, literal, element, items)
+            }
+            ValOp::Bin(op) if op == Op::In as u32 && node.args.len() == 2 => {
+                let candidate = node.args[0];
+                let collection = &self.nodes[node.args[1] as usize];
+                if !matches!(collection.op, ValOp::Seq(1))
+                    || !collection
+                        .args
+                        .iter()
+                        .all(|&item| self.static_membership_literal_value(item))
+                {
+                    return None;
+                }
+                match *element {
+                    Some(current) if current != candidate => None,
+                    Some(_) => {
+                        items.extend(collection.args.iter().copied());
+                        Some(())
+                    }
+                    None => {
+                        *element = Some(candidate);
+                        items.extend(collection.args.iter().copied());
+                        Some(())
+                    }
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn record_literal_membership_term(
+        &self,
+        candidate: ValueId,
+        literal: ValueId,
+        element: &mut Option<ValueId>,
+        items: &mut Vec<ValueId>,
+    ) -> Option<()> {
+        match *element {
+            Some(current) if current != candidate => None,
+            Some(_) => {
+                items.push(literal);
+                Some(())
+            }
+            None => {
+                *element = Some(candidate);
+                items.push(literal);
+                Some(())
+            }
+        }
+    }
+
+    fn static_membership_literal_value(&self, value: ValueId) -> bool {
+        matches!(
+            self.nodes[value as usize].op,
+            ValOp::Const(key) if key != 0x3000_0000
+        )
+    }
+
+    fn empty_string_value(&mut self) -> ValueId {
+        self.mk(ValOp::Const(stable_string_const_key("")), vec![])
+    }
+
+    fn is_empty_string_value(&self, value: ValueId) -> bool {
+        matches!(
+            self.nodes[value as usize].op,
+            ValOp::Const(key) if key == stable_string_const_key("")
+        )
+    }
+
     /// A canonical "element of `coll`" value. The collection is carried as an argument
     /// (not just folded into the key) so it is reachable from the fingerprint wherever
     /// the element is used — identically for a loop, a `reduce`, and a `sum(map)` over
@@ -3945,6 +4206,15 @@ impl<'a> Builder<'a> {
                     }
                 };
                 Some(self.mk(ValOp::Reduce(code), vec![contrib]))
+            }
+            Builtin::Join => {
+                if kids.len() != 2 {
+                    return None;
+                }
+                let sep = self.eval(kids[0], env);
+                let coll = self.eval(kids[1], env);
+                let elem = self.elem(coll);
+                Some(self.mk(ValOp::Reduce(ORDERED_STRING_JOIN), vec![sep, elem]))
             }
             _ => None,
         }
@@ -4292,42 +4562,46 @@ impl<'a> Builder<'a> {
         Some((key, map, !negated))
     }
 
-    fn static_literal_membership_predicate(&self, pred: ValueId) -> Option<(ValueId, ValueId)> {
+    fn static_literal_membership_predicate(&mut self, pred: ValueId) -> Option<(ValueId, ValueId)> {
         let node = &self.nodes[pred as usize];
         if !matches!(node.op, ValOp::Bin(o) if o == Op::Eq as u32) || node.args.len() != 2 {
             return None;
         }
-        if let Some(collection) = self.static_literal_elem_collection(node.args[0]) {
-            return Some((node.args[1], collection));
+        let left = node.args[0];
+        let right = node.args[1];
+        if let Some(collection) = self.static_literal_elem_collection(left) {
+            return Some((right, collection));
         }
-        if let Some(collection) = self.static_literal_elem_collection(node.args[1]) {
-            return Some((node.args[0], collection));
+        if let Some(collection) = self.static_literal_elem_collection(right) {
+            return Some((left, collection));
         }
         None
     }
 
-    fn static_literal_absence_predicate(&self, pred: ValueId) -> Option<(ValueId, ValueId)> {
+    fn static_literal_absence_predicate(&mut self, pred: ValueId) -> Option<(ValueId, ValueId)> {
         let node = &self.nodes[pred as usize];
         if !matches!(node.op, ValOp::Bin(o) if o == Op::Ne as u32) || node.args.len() != 2 {
             return None;
         }
-        if let Some(collection) = self.static_literal_elem_collection(node.args[0]) {
-            return Some((node.args[1], collection));
+        let left = node.args[0];
+        let right = node.args[1];
+        if let Some(collection) = self.static_literal_elem_collection(left) {
+            return Some((right, collection));
         }
-        if let Some(collection) = self.static_literal_elem_collection(node.args[1]) {
-            return Some((node.args[0], collection));
+        if let Some(collection) = self.static_literal_elem_collection(right) {
+            return Some((left, collection));
         }
         None
     }
 
-    fn static_literal_elem_collection(&self, value: ValueId) -> Option<ValueId> {
+    fn static_literal_elem_collection(&mut self, value: ValueId) -> Option<ValueId> {
         let node = &self.nodes[value as usize];
         if !matches!(node.op, ValOp::Elem(_)) || node.args.len() != 1 {
             return None;
         }
         let collection = node.args[0];
         self.is_static_membership_collection(collection)
-            .then_some(collection)
+            .then(|| self.canonical_membership_collection_value(collection))
     }
 
     fn is_static_membership_collection(&self, value: ValueId) -> bool {
@@ -4395,13 +4669,27 @@ impl<'a> Builder<'a> {
         }
         if self.il.kind(collection) != NodeKind::Seq {
             let value = self.eval(collection, env);
-            return self
+            let collection = self
                 .proven_collection_value(value)
                 .or_else(|| self.proven_local_collection_binding_value(collection, env))
                 .unwrap_or(value);
+            return self.canonical_membership_collection_value(collection);
         }
         let kids = self.il.children(collection).to_vec();
-        let items: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+        let mut items: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+        items.sort_by_key(|&v| (self.vhash[v as usize], v));
+        items.dedup();
+        self.mk(ValOp::Seq(1), items)
+    }
+
+    fn canonical_membership_collection_value(&mut self, value: ValueId) -> ValueId {
+        let node = &self.nodes[value as usize];
+        if !matches!(node.op, ValOp::Seq(1)) {
+            return value;
+        }
+        let mut items = node.args.clone();
+        items.sort_by_key(|&v| (self.vhash[v as usize], v));
+        items.dedup();
         self.mk(ValOp::Seq(1), items)
     }
 
@@ -5552,6 +5840,7 @@ const REDUCE_MIN: u32 = 0xFF01;
 /// the offset to pick the OR/AND identity false/true).
 const REDUCE_ANY: u32 = 0xFF02;
 const REDUCE_ALL: u32 = 0xFF03;
+const ORDERED_STRING_JOIN: u32 = 0xFF04;
 
 /// `Un` op code for absolute value — `abs(x)` and the `x if x>=0 else -x` idiom both
 /// canonicalize to `Un(ABS_CODE, [x])`. Clear of the small `Op` discriminants.

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -18,17 +18,21 @@
 > strings, map **and filter** fusion (a filter is the element-carrying `Hof(Map,[Elem,p])`,
 > so nested filters fuse to `p∧q`), full **AC flatten+sort in the value graph itself** (not
 > only the `algebra` IL pass), **distribution/factoring** `a*c+b*c→(a+b)*c` (Num-gated),
-> min/max and any/all reductions (cross-language), **reduce-lambda selection** (`reduce(λ. a
-> if a>b else b)≡max`), **count-of-filter** (`len([…if p])≡Σ(p?1:0)`), method-form iterator
-> reductions (Rust `.sum()/.min()/.max()/.count()`), **dict-builder ≡ dict comprehension**
+> min/max and any/all reductions (cross-language), simple **flag+break existence/universal
+> loops** (`found=false; if p { found=true; break }` / the dual `all` form),
+> **reduce-lambda selection** (`reduce(λ. a if a>b else b)≡max`), **count-of-filter**
+> (`len([…if p])≡Σ(p?1:0)`), method-form iterator reductions (Rust
+> `.sum()/.min()/.max()/.count()`), **dict-builder ≡ dict comprehension**
 > (`d={}; for x: d[k]=v` ≡ `{k:v for x}` via a `DictEntry`-distinct rep that cannot collide
-> with a list of tuples), ternary-return decomposition, negated-comparison canon. Soundness
-> enforced by the independent interpreter oracle + canon-preservation check (`nose verify`)
-> and Lean proofs (`formal/`, incl. `distrib_sound`, `filter_fusion`, `Compare.lean`); see
-> §AJ/§AW/§AX/§BA.
+> with a list of tuples), ternary-return decomposition, negated-comparison canon,
+> equality-chain literal membership (`x=="a" || x=="b"`), stricter record-shape guard
+> facts, and ordered string-builder joins (`out += elem` over a loop ≡ `"".join(xs)`).
+> Soundness enforced by the independent interpreter oracle + canon-preservation check
+> (`nose verify`) and Lean proofs (`formal/`, incl. `distrib_sound`, `filter_fusion`,
+> `Compare.lean`); see §AJ/§AW/§AX/§BA.
 > Deferred: value-dependent folding (needs literal values), full distribution
-> (equality saturation), flag-loop↔break, loop↔recursion, the loop-form any/all (existence
-> loop). Rejected as cross-language-unsound: `x*2≡x+x`
+> (equality saturation), general CFG flag-loop↔break, loop↔recursion, and non-local
+> early-exit variants beyond the simple flag+break loop. Rejected as cross-language-unsound: `x*2≡x+x`
 > doubling and `s[-1]≡s[len(s)-1]` negative-index (§BA).
 
 

--- a/docs/type4-benchmark.md
+++ b/docs/type4-benchmark.md
@@ -67,7 +67,7 @@ Useful axes:
 | representation | `for-loop`, `while-index-loop`, `iterator-loop`, `reduce`, `comprehension`, `builder`, `builtin`, `recursion` |
 | control variation | `guard`, `ternary`, `early-return`, `continue`, `break`, `nested-if` |
 | data shape | `int`, `bool`, `string`, `list`, `record`, `field-write` |
-| proof fact | immutable binding, proven callee identity, table-key identity, static import/projection, nullish default, own-property guard, record-shape guard, unsafe boundary |
+| proof fact | immutable binding, proven callee identity, table-key identity, static import/projection, nullish default, own-property guard, record-shape guard, equality-chain membership, flag+break reduction, ordered string-builder, unsafe boundary |
 | language relation | same-language, cross-language, embedded script |
 | label status | positive, hard-negative |
 | evidence | `E1` same-spec/property evidence, `E2` counterexample evidence, future interpreter/symbolic/proof evidence |
@@ -80,7 +80,8 @@ emit the thinnest facts it can prove, while the common strict engine consumes th
 single-assignment immutable bindings, safe function-binding identity, receiver/method
 identity, static import coordinates, nullish-default coordinates, static field/property
 projection coordinates, own-property guard facts, record-shape guard facts, literal table
-keys, and explicit unsafe boundaries.
+keys, equality-chain membership facts, simple flag+break reduction facts, ordered
+string-builder facts, and explicit unsafe boundaries.
 `capabilities.v1.json` records which surfaces currently emit which facts so unsupported
 cells stay visible.
 


### PR DESCRIPTION
## What changed

This PR widens exact semantic Type-4 detection across four strict idiom slices:

- JS/TS record-shape guards now accept `Array.isArray(value) === false` and symmetric false comparisons, while preserving the shadowed-`Array` boundary.
- Simple boolean flag loops with `assign; break` branches now converge with `any`/`all` reductions when the predicate is over the loop element.
- Equality OR-chains over the same candidate and static literals now converge with literal collection membership, using order-insensitive membership collection canon.
- Python ordered string builders of the form `out = ""; for x in xs: out += f(x)` now converge with literal-separator `sep.join(xs)` when the contribution is genuinely per-element.

The scan cache schema is bumped to v5 because semantic feature extraction changed. Docs and the Type-4 iteration log were updated with the new strict scope and validation record.

## Validation

- `cargo check -p nose-cli`
- `cargo test -p nose-cli`
- `cargo test -p nose-normalize`
- `./scripts/check-docs.sh`
- `awiki lint --root docs`
- Local semantic probe: 4/4 expected families, 0/4 hard-negative inclusions
