### PR TITLE
Surface --top truncation in SARIF + de-version doc examples (closes #17, #18)

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -2476,7 +2476,7 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
             }
             print_refactor_human(&families, &shown, sort, channels, args.diff, args.proposal)
         }
-        ReportFormat::Sarif => println!("{}", refactor_sarif(&shown)?),
+        ReportFormat::Sarif => println!("{}", refactor_sarif(&shown, families.len())?),
     }
     if args.hotspots && matches!(args.format, ReportFormat::Human | ReportFormat::Markdown) {
         print_hotspots(&families);
@@ -2577,7 +2577,12 @@ fn total_dup_lines(fs: &[nose_detect::RefactorFamily]) -> u32 {
 /// Build a SARIF 2.1.0 document — one result per family, every member site a
 /// location so GitHub code-scanning annotates each. The first location is primary;
 /// the rest are `relatedLocations`.
-fn refactor_sarif(families: &[&nose_detect::RefactorFamily]) -> Result<String> {
+/// `shown` is the (possibly `--top`-truncated) slice that gets emitted; `total` is the
+/// full active-family count before truncation. A SARIF consumer (GitHub code scanning)
+/// otherwise can't tell a truncated upload from a complete one, so the run carries both
+/// counts in `properties` and — when families were hidden — a `note` notification telling
+/// the reader to pass `--top 0` for the full set.
+fn refactor_sarif(shown: &[&nose_detect::RefactorFamily], total: usize) -> Result<String> {
     use serde_json::json;
     let phys = |l: &nose_detect::Loc| {
         json!({
@@ -2587,7 +2592,7 @@ fn refactor_sarif(families: &[&nose_detect::RefactorFamily]) -> Result<String> {
             }
         })
     };
-    let results: Vec<_> = families
+    let results: Vec<_> = shown
         .iter()
         .map(|f| {
             let msg = format!(
@@ -2608,22 +2613,37 @@ fn refactor_sarif(families: &[&nose_detect::RefactorFamily]) -> Result<String> {
             })
         })
         .collect();
+    let mut run = json!({
+        "tool": { "driver": {
+            "name": "nose",
+            "informationUri": "https://github.com/",
+            "version": env!("CARGO_PKG_VERSION"),
+            "rules": [{
+                "id": "duplicate-family",
+                "name": "DuplicateFamily",
+                "shortDescription": { "text": "Duplicated code worth refactoring" }
+            }]
+        }},
+        "results": results,
+        "properties": { "total_families": total, "shown_families": shown.len() },
+    });
+    if shown.len() < total {
+        run["invocations"] = json!([{
+            "executionSuccessful": true,
+            "toolExecutionNotifications": [{
+                "level": "note",
+                "message": { "text": format!(
+                    "Showing {} of {total} clone families (the --top limit). \
+                     Pass --top 0 to emit every family.",
+                    shown.len()
+                ) }
+            }]
+        }]);
+    }
     let doc = json!({
         "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
         "version": "2.1.0",
-        "runs": [{
-            "tool": { "driver": {
-                "name": "nose",
-                "informationUri": "https://github.com/",
-                "version": env!("CARGO_PKG_VERSION"),
-                "rules": [{
-                    "id": "duplicate-family",
-                    "name": "DuplicateFamily",
-                    "shortDescription": { "text": "Duplicated code worth refactoring" }
-                }]
-            }},
-            "results": results,
-        }]
+        "runs": [run],
     });
     Ok(serde_json::to_string_pretty(&doc)?)
 }

--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -4707,6 +4707,101 @@ fn sarif_output_is_well_formed() {
         !v["runs"][0]["results"].as_array().unwrap().is_empty(),
         "should have at least one result: {out}"
     );
+    // The run records the full family count, so a consumer can tell a complete upload
+    // from a truncated one. This single-family project is not truncated (default --top 30),
+    // so total == shown and there is no truncation notification.
+    let props = &v["runs"][0]["properties"];
+    let total = props["total_families"].as_u64().expect("total_families");
+    let shown = props["shown_families"].as_u64().expect("shown_families");
+    assert_eq!(shown, total, "untruncated run: shown == total ({out})");
+    assert_eq!(
+        shown as usize,
+        v["runs"][0]["results"].as_array().unwrap().len()
+    );
+    assert!(
+        v["runs"][0].get("invocations").is_none(),
+        "no truncation note when nothing is hidden: {out}"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// A project with several behaviorally-distinct duplicated functions, so `nose scan`
+/// reports multiple clone families. `--top N` can then truncate the report.
+fn make_multi_family_project(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("nose_cli_{tag}_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    // Four distinct computations (distinct value fingerprints, so they don't merge into
+    // one family), each duplicated across two directories → four families.
+    let logics = [
+        ("sq", "def f(items):\n    a = 0\n    for x in items:\n        if x > 0:\n            a = a + x * x\n    return a\n"),
+        ("prod", "def f(items):\n    a = 1\n    for x in items:\n        a = a * x\n    return a\n"),
+        ("cnt", "def f(items):\n    a = 0\n    for x in items:\n        if x < 0:\n            a = a + 1\n    return a\n"),
+        ("join", "def f(items):\n    a = ''\n    for x in items:\n        a = a + x + ','\n    return a\n"),
+    ];
+    for sub in ["x", "y"] {
+        for (name, src) in logics {
+            let d = dir.join(sub);
+            fs::create_dir_all(&d).unwrap();
+            fs::write(d.join(format!("{name}.py")), src).unwrap();
+        }
+    }
+    dir
+}
+
+#[test]
+fn sarif_records_and_notes_top_truncation() {
+    let dir = make_multi_family_project("sarif_trunc");
+
+    // --top 1: only one family is emitted, but the run must record the true total and
+    // carry an explicit truncation note pointing at --top 0.
+    let out = run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--min-tokens",
+        "12",
+        "--format",
+        "sarif",
+        "--top",
+        "1",
+    ]);
+    let v: serde_json::Value = serde_json::from_str(&out).expect("SARIF must be valid JSON");
+    let props = &v["runs"][0]["properties"];
+    let total = props["total_families"].as_u64().expect("total_families");
+    let shown = props["shown_families"].as_u64().expect("shown_families");
+    assert!(total >= 2, "fixture should yield multiple families: {out}");
+    assert_eq!(shown, 1, "--top 1 shows exactly one family: {out}");
+    assert_eq!(v["runs"][0]["results"].as_array().unwrap().len(), 1);
+    let note = v["runs"][0]["invocations"][0]["toolExecutionNotifications"][0].clone();
+    assert_eq!(note["level"], "note", "truncation note present: {out}");
+    assert!(
+        note["message"]["text"]
+            .as_str()
+            .unwrap()
+            .contains("--top 0"),
+        "note points the reader at --top 0: {out}"
+    );
+
+    // --top 0: the whole set is emitted, so there is no truncation note.
+    let full = run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--min-tokens",
+        "12",
+        "--format",
+        "sarif",
+        "--top",
+        "0",
+    ]);
+    let fv: serde_json::Value = serde_json::from_str(&full).expect("SARIF must be valid JSON");
+    let fp = &fv["runs"][0]["properties"];
+    assert_eq!(
+        fp["shown_families"], fp["total_families"],
+        "--top 0 emits every family: {full}"
+    );
+    assert!(
+        fv["runs"][0].get("invocations").is_none(),
+        "no truncation note with --top 0: {full}"
+    );
     let _ = fs::remove_dir_all(&dir);
 }
 

--- a/crates/nose-cli/tests/fixtures/scan-json-v1.json
+++ b/crates/nose-cli/tests/fixtures/scan-json-v1.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "tool_version": "0.4.0",
+  "tool_version": "<version>",
   "scope": {
     "files": 2,
     "languages": [

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -26,7 +26,7 @@ nose capabilities
   "schema_version": 1,
   "tool": {
     "name": "nose",
-    "version": "0.4.0"
+    "version": "<version>"
   },
   "platform": {
     "os": "linux",
@@ -68,7 +68,9 @@ nose capabilities
 ```
 
 The real `config_keys` and `scan.capabilities` objects may contain more entries
-than this shortened example.
+than this shortened example. `tool.version` is shown as the `<version>` placeholder
+because the field always reports the installed binary's own version (`nose --version`);
+the example deliberately does not pin a release so it can't drift.
 
 ## Version 1 fields
 

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -128,12 +128,20 @@ for the file format and selector semantics.
 findings as inline PR annotations:
 
 ```sh
-nose scan src --format sarif > nose.sarif
+nose scan src --format sarif --top 0 > nose.sarif
 # then upload nose.sarif via github/codeql-action/upload-sarif
 ```
 
+**Pass `--top 0` for a complete upload.** `--top` (default 30) truncates *every*
+output format, SARIF included — without `--top 0` a repo with more than 30 families
+uploads only the first 30. The SARIF run records the full count in
+`runs[].properties` (`total_families` / `shown_families`) and, when families were
+hidden, adds a `note` notification under `runs[].invocations[]`, so a truncated upload
+is at least detectable; `--top 0` avoids the cap entirely.
+
 `--format json` is the general machine-readable form for any other tooling. Its
-versioned contract is documented in [scan-json](scan-json.md).
+versioned contract is documented in [scan-json](scan-json.md); it is truncated by
+`--top` in the same way.
 
 ## Fast re-runs: `--cache-dir`
 

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -14,7 +14,7 @@ The top-level value is always an object:
 ```json
 {
   "schema_version": 1,
-  "tool_version": "0.4.0",
+  "tool_version": "<version>",
   "scope": {
     "files": 4,
     "languages": [
@@ -40,7 +40,15 @@ The top-level value is always an object:
 
 A checked-in example lives at
 [`crates/nose-cli/tests/fixtures/scan-json-v1.json`](../crates/nose-cli/tests/fixtures/scan-json-v1.json)
-and is read by the CLI test suite.
+and is read by the CLI test suite. `tool_version` is shown above as the `<version>`
+placeholder: it always reports the installed binary's own version, so the example does not
+pin a release.
+
+> **`--top` truncates machine output too.** `families` contains only the top `--top`
+> families (default 30), exactly like the human report — it is *not* the full set by
+> default. `ranking.total_families` vs `ranking.shown_families` (and `ranking.limit`) make
+> any truncation explicit; pass **`--top 0`** to emit every family. `ranking.total_families`
+> is always the complete post-filter count regardless of `--top`.
 
 ## Top-level fields
 


### PR DESCRIPTION
Resolves the two ambiguous items left as issues from the docs↔implementation audit. Both take option 2 — keep current behavior, but make it visible / un-driftable — rather than changing defaults.

## #17 — JSON/SARIF silently truncated by `--top` (default 30)

- **SARIF now carries the counts.** `runs[].properties` reports `total_families` / `shown_families`, and when families were hidden the run adds a `note` under `runs[].invocations[].toolExecutionNotifications[]` pointing the reader at `--top 0`. A GitHub code-scanning upload is no longer silently capped without a trace.
- **Docs say it plainly.** `scan-json.md` and `continuous-integration.md` now state that `--top` truncates *every* format (SARIF/JSON included) and that `--top 0` emits the full set; the CI SARIF example uses `--top 0`.

## #18 — example version strings drifted (`0.4.0` vs released `0.5.0`)

- De-versioned the examples: `capabilities.md`, `scan-json.md`, and the `scan-json-v1.json` fixture now show `"<version>"`, since the field always reports the installed binary's own version. Nothing left to keep in sync → it can't drift again. The fixture stays a valid non-empty string, so the v1 contract test is unaffected.

## Tests

- Extended `sarif_output_is_well_formed` — asserts `properties.total_families`/`shown_families` and that an untruncated run has no `invocations` note.
- Added `sarif_records_and_notes_top_truncation` — a multi-family project where `--top 1` carries the truncation note + true total, and `--top 0` does not.

Local fast CI gates (rustfmt, clippy `-D warnings`, `nose-cli` tests, awiki) pass.

Closes #17
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * SARIF 출력 결과에 전체 및 표시된 항목 수 정보 추가
  * `--top` 옵션으로 결과가 잘린 경우 안내 메시지 포함

* **문서화**
  * `--top` 옵션이 SARIF 및 JSON 형식 출력에 미치는 영향 명확화
  * CI 통합 가이드에서 전체 결과 업로드 방법 설명 추가

* **테스트**
  * SARIF 절단 동작 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->