### PR TITLE
fix: 8 bugs found by a multi-agent bug hunt (TDD)

### DIFF
--- a/crates/nose-cli/src/config.rs
+++ b/crates/nose-cli/src/config.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 /// The `[scan]` table. Every field is optional — absent means "no opinion,
 /// use the CLI value or the built-in default".
 #[derive(Deserialize, Default)]
-#[serde(rename_all = "kebab-case", default)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub(crate) struct ScanConfig {
     pub exclude: Vec<String>,
     pub mode: Vec<crate::ScanMode>,
@@ -35,7 +35,7 @@ pub(crate) struct ScanConfig {
 }
 
 #[derive(Deserialize, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 struct File {
     scan: ScanConfig,
 }
@@ -64,4 +64,44 @@ fn discover() -> Option<PathBuf> {
         .iter()
         .map(PathBuf::from)
         .find(|p| p.is_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_cfg(tag: &str, body: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("nose_cfg_{tag}_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let p = dir.join("nose.toml");
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[test]
+    fn unknown_scan_key_is_a_hard_error() {
+        // `min-valeu` is a typo for `min-value`; silently dropping it would hide the setting.
+        let p = write_cfg("badkey", "[scan]\nmin-valeu = 200\n");
+        assert!(
+            load_scan(Some(&p)).is_err(),
+            "a typo'd key must be a hard error, not silently dropped"
+        );
+    }
+
+    #[test]
+    fn unknown_table_is_a_hard_error() {
+        let p = write_cfg("badtable", "[scna]\nmin-value = 200\n");
+        assert!(
+            load_scan(Some(&p)).is_err(),
+            "a typo'd table must be a hard error"
+        );
+    }
+
+    #[test]
+    fn valid_config_still_loads() {
+        let p = write_cfg("ok", "[scan]\nmin-value = 200\nmin-size = 30\n");
+        let cfg = load_scan(Some(&p)).expect("valid config must load");
+        assert_eq!(cfg.min_value, Some(200.0));
+        assert_eq!(cfg.min_size, Some(30));
+    }
 }

--- a/crates/nose-cli/src/ignores.rs
+++ b/crates/nose-cli/src/ignores.rs
@@ -332,11 +332,16 @@ fn build_path_matcher(index: usize, paths: &[String]) -> Result<Option<Override>
 
 fn parse_family_id(s: &str) -> Result<u64> {
     let s = s.trim();
-    let hex = s.strip_prefix("0x").unwrap_or(s);
-    if hex.len() != 16 {
+    let hex = s
+        .strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .unwrap_or(s);
+    // Require exactly 16 hex digits: this rejects a sign prefix (`+`/`-`) that
+    // u64::from_str_radix would otherwise accept, and any other non-hex character.
+    if hex.len() != 16 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
         anyhow::bail!("family ids must be 16 hex digits, optionally prefixed with 0x");
     }
-    baseline::parse_key(s).ok_or_else(|| {
+    u64::from_str_radix(hex, 16).map_err(|_| {
         anyhow::anyhow!("family ids must be 16 hex digits, optionally prefixed with 0x")
     })
 }
@@ -437,5 +442,35 @@ fn civil_from_days(days_since_epoch: i64) -> Date {
         year: year as i32,
         month: month as u32,
         day: day as u32,
+    }
+}
+
+#[cfg(test)]
+mod parse_id_tests {
+    use super::parse_family_id;
+
+    #[test]
+    fn rejects_non_hex_sign_prefix() {
+        // '+' + 15 hex digits = 16 chars; u64::from_str_radix would accept the '+'.
+        assert!(parse_family_id("+aaaaaaaaaaaaaaa").is_err());
+        assert!(parse_family_id("-aaaaaaaaaaaaaaa").is_err());
+    }
+
+    #[test]
+    fn accepts_uppercase_0x_prefix() {
+        let v = parse_family_id("0XAAAAAAAAAAAAAAAA").expect("uppercase 0X prefix is valid");
+        assert_eq!(v, 0xAAAA_AAAA_AAAA_AAAA);
+    }
+
+    #[test]
+    fn accepts_plain_and_lowercase_prefixed_ids() {
+        assert_eq!(
+            parse_family_id("aaaaaaaaaaaaaaaa").unwrap(),
+            0xAAAA_AAAA_AAAA_AAAA
+        );
+        assert_eq!(
+            parse_family_id("0xaaaaaaaaaaaaaaaa").unwrap(),
+            0xAAAA_AAAA_AAAA_AAAA
+        );
     }
 }

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -2434,6 +2434,15 @@ fn warn_no_files(paths: &[PathBuf]) {
 }
 
 fn cmd_scan(args: ScanArgs) -> Result<()> {
+    // `--fail-on new` gates on families that are new/changed vs a baseline, so without
+    // `--baseline` the gate could never fire — reject the combination instead of silently
+    // passing (a CI gate that always succeeds is the worst failure mode).
+    if matches!(args.fail_on, Some(FailOn::New)) && args.baseline.is_none() {
+        anyhow::bail!(
+            "--fail-on new requires --baseline (it gates on families new vs the baseline)"
+        );
+    }
+
     let refs: Vec<&std::path::Path> = args.paths.iter().map(|p| p.as_path()).collect();
 
     // Resolve each setting: CLI flag wins, else config file, else built-in default.

--- a/crates/nose-cli/src/review.rs
+++ b/crates/nose-cli/src/review.rs
@@ -170,12 +170,16 @@ fn to_site(loc: &Loc) -> Site {
 
 /// Does this member's (repo-relative) base span overlap a changed range of its file?
 fn site_touched_loc(loc: &Loc, changed: &HashMap<String, Vec<(u32, u32)>>) -> bool {
-    let Some(ranges) = changed.get(&loc.file) else {
-        return false;
-    };
-    ranges
-        .iter()
-        .any(|&(s, e)| loc.start_line <= e && s <= loc.end_line)
+    changed
+        .get(&loc.file)
+        .is_some_and(|ranges| ranges_touch(ranges, loc.start_line, loc.end_line))
+}
+
+/// Does the inclusive span `[start, end]` overlap any changed range? A pure-insertion range
+/// is encoded as `(a+1, a)` (an empty interval *between* base lines a and a+1), which by this
+/// test only matches a span that strictly straddles the gap — not one that merely ends at a.
+fn ranges_touch(ranges: &[(u32, u32)], start: u32, end: u32) -> bool {
+    ranges.iter().any(|&(s, e)| start <= e && s <= end)
 }
 
 // ---- git plumbing ---------------------------------------------------------------
@@ -306,21 +310,45 @@ fn git_changed_ranges(
             String::from_utf8_lossy(&out.stderr).trim()
         );
     }
-    let text = String::from_utf8_lossy(&out.stdout);
+    Ok(parse_old_side_ranges(&String::from_utf8_lossy(&out.stdout)))
+}
+
+/// Parse `git diff --unified=0` text into base-side changed line ranges per repo-relative
+/// path. Pure (no git) so it can be unit-tested against crafted diff output.
+fn parse_old_side_ranges(diff: &str) -> HashMap<String, Vec<(u32, u32)>> {
     let mut map: HashMap<String, Vec<(u32, u32)>> = HashMap::new();
     let mut current: Option<String> = None;
-    for line in text.lines() {
-        if let Some(rest) = line.strip_prefix("--- ") {
+    // `--- a/path` is the base-file header, but a *deleted* line whose content starts with
+    // "-- " also renders as "--- …" in the hunk body. They're disambiguated structurally:
+    // the file header sits in the per-file block before the first `@@`; once hunks begin a
+    // "--- " line is body content. `diff --git` resets the block for the next file.
+    let mut in_hunks = false;
+    for line in diff.lines() {
+        if line.starts_with("diff --git") {
+            in_hunks = false;
+            current = None;
+        } else if !in_hunks && line.starts_with("--- ") {
             // "--- a/path" → base-side path; "--- /dev/null" (added file) → no base member
-            current = rest.strip_prefix("a/").map(|p| p.to_string());
+            current = line
+                .strip_prefix("--- ")
+                .and_then(|r| r.strip_prefix("a/"))
+                .map(|p| p.to_string());
         } else if line.starts_with("@@") {
+            in_hunks = true;
             if let (Some(file), Some((start, count))) = (&current, parse_hunk_old(line)) {
-                let end = if count == 0 { start } else { start + count - 1 };
-                map.entry(file.clone()).or_default().push((start, end));
+                // count == 0 is a pure insertion *after* base line `start` (no base line
+                // changed): encode the gap as `(start+1, start)` so it touches only members
+                // that straddle it, not one that merely ends at `start`.
+                let range = if count == 0 {
+                    (start + 1, start)
+                } else {
+                    (start, start + count - 1)
+                };
+                map.entry(file.clone()).or_default().push(range);
             }
         }
     }
-    Ok(map)
+    map
 }
 
 /// Parse the old-side range from a hunk header `@@ -a,b +c,d @@ ...` → `(a, b)`, where a
@@ -483,4 +511,60 @@ fn review_sarif(flagged: &[Divergence]) -> Result<String> {
         "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
         "runs": [run],
     }))?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `git diff --unified=0` for: base "keep1\n-- marker\nkeep2a\nkeep2b\nzzz\n"
+    // → new "KEEP1\nkeep2a\nkeep2b\nZZZ\n". The deleted "-- marker" line shows in the body
+    // as "--- marker", which must NOT be parsed as a "--- a/path" file header.
+    const DIFF_WITH_DASHDASH_CONTENT: &str = "\
+diff --git a/f.txt b/f.txt
+index 1111111..2222222 100644
+--- a/f.txt
++++ b/f.txt
+@@ -1,2 +1 @@
+-keep1
+--- marker
++KEEP1
+@@ -5 +4 @@
+-zzz
++ZZZ
+";
+
+    #[test]
+    fn parse_ignores_deleted_content_lines_that_look_like_headers() {
+        let ranges = parse_old_side_ranges(DIFF_WITH_DASHDASH_CONTENT);
+        let f = ranges.get("f.txt").expect("f.txt has changed ranges");
+        assert!(f.contains(&(1, 2)), "first hunk: {f:?}");
+        assert!(
+            f.contains(&(5, 5)),
+            "second hunk must survive the `--- marker` body line: {f:?}"
+        );
+        assert_eq!(
+            ranges.len(),
+            1,
+            "no phantom file key from a content line: {ranges:?}"
+        );
+    }
+
+    #[test]
+    fn pure_insertion_does_not_touch_a_member_ending_at_the_insertion_point() {
+        // Insert a line after base line 1: `@@ -1,0 +2 @@`. The insertion sits *between*
+        // base lines 1 and 2, so a member occupying only line 1 was not edited.
+        let diff =
+            "diff --git a/g.txt b/g.txt\n--- a/g.txt\n+++ b/g.txt\n@@ -1,0 +2 @@\n+inserted\n";
+        let r = parse_old_side_ranges(diff);
+        let ranges = r.get("g.txt").expect("g.txt range");
+        assert!(
+            !ranges_touch(ranges, 1, 1),
+            "a member ending at the insertion point is not touched: {ranges:?}"
+        );
+        assert!(
+            ranges_touch(ranges, 1, 3),
+            "a member straddling the insertion gap IS touched: {ranges:?}"
+        );
+    }
 }

--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -5438,3 +5438,22 @@ fn review_respects_structured_ignores() {
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn fail_on_new_requires_a_baseline() {
+    let dir = make_project("fail_on_new_nobaseline");
+    let p = dir.to_str().unwrap();
+    // `--fail-on new` compares against a baseline; with no --baseline the gate can never
+    // fire, so it must error rather than silently pass (a CI gate that always passes).
+    let out = Command::new(bin())
+        .args(["scan", p, "--min-size", "12", "--fail-on", "new"])
+        .output()
+        .expect("run scan");
+    assert!(
+        !out.status.success(),
+        "`--fail-on new` without --baseline must error, not silently pass: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -4513,11 +4513,11 @@ fn fail_on_new_fails_for_changed_family_and_passes_when_clean() {
 #[test]
 fn config_file_supplies_defaults() {
     // A nose.toml in the working dir provides defaults (here: an exclude glob and
-    // min-tokens); a CLI flag still overrides.
+    // min-size); a CLI flag still overrides.
     let dir = make_project("cfg");
     fs::write(
         dir.join("nose.toml"),
-        "[scan]\nexclude = [\"a/**\"]\nmin-tokens = 12\n",
+        "[scan]\nexclude = [\"a/**\"]\nmin-size = 12\n",
     )
     .unwrap();
     let out = Command::new(bin())

--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -5457,3 +5457,45 @@ fn fail_on_new_requires_a_baseline() {
     );
     let _ = fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn c_u16_byte_pack_recognized_in_either_operand_order() {
+    // The byte-pack idiom must be recognized whichever way its commutative operands sort by
+    // value-hash. With the base at param 1 the shifted lane sorts second; a `+` form and a
+    // `|` form then cluster into one Type-4 family only if both normalize to the byte-pack op.
+    let dir = std::env::temp_dir().join(format!("nose_bytepack_order_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("add2.c"),
+        "unsigned int add2(int d, const unsigned char *a) {\n  return (a[0] << 8) + a[1];\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("or2.c"),
+        "unsigned int or2(int d, unsigned char *a) {\n  return (a[0] << 8) | a[1];\n}\n",
+    )
+    .unwrap();
+    let out = run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--min-lines",
+        "1",
+        "--min-size",
+        "1",
+        "--format",
+        "json",
+        "--top",
+        "0",
+    ]);
+    let json = scan_json(&out);
+    let families = scan_families(&json);
+    assert_eq!(
+        families.len(),
+        1,
+        "byte-pack must be recognized in either operand order (+ and | should cluster): {out}"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -4001,3 +4001,17 @@ fn loop_accumulator_seed_is_not_abstracted() {
         "two zero-seeded countdown sums must still converge"
     );
 }
+
+#[test]
+fn c_hex_literal_with_e_lowers_to_int_not_float() {
+    // 0xE5 is a hex INTEGER (229); the 'E' is a hex digit, not a float exponent.
+    let i = Interner::new();
+    let il = nose_frontend::lower_source(FileId(0), "t", b"int f(){ return 0xE5; }", Lang::C, &i)
+        .unwrap();
+    let root = first_func(&il);
+    let s = il.to_sexpr(root, &i);
+    assert!(
+        !s.to_lowercase().contains("float"),
+        "0xE5 (hex int) must not lower to a float literal: {s}"
+    );
+}

--- a/crates/nose-frontend/src/c.rs
+++ b/crates/nose-frontend/src/c.rs
@@ -398,7 +398,16 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         }
         "number_literal" => {
             let t = lo.text(node);
-            if t.contains('.') || t.contains('e') || t.contains('E') {
+            let lower = t.to_ascii_lowercase();
+            // In a hex literal (`0x…`) the digits e/E are hex digits, not a float exponent;
+            // a hex float instead uses a `.` or a binary `p`/`P` exponent. A decimal literal
+            // is a float if it has a `.` or an `e`/`E` exponent.
+            let is_float = if lower.starts_with("0x") {
+                lower.contains('.') || lower.contains('p')
+            } else {
+                lower.contains('.') || lower.contains('e')
+            };
+            if is_float {
                 lo.float_lit(t, span)
             } else {
                 lo.int_lit(t.trim_end_matches(['u', 'U', 'l', 'L']), span)

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -4059,8 +4059,14 @@ impl<'a> Builder<'a> {
             return None;
         }
         for (shifted, low) in [(left, right), (right, left)] {
-            let (base, high_index) = self.shifted_byte_lane(shifted)?;
-            let (low_base, low_index) = self.byte_lane(low)?;
+            // `else continue`, not `?`: the operands may sort either way by value-hash, so a
+            // miss on the first ordering must fall through to the second, not abort the fn.
+            let Some((base, high_index)) = self.shifted_byte_lane(shifted) else {
+                continue;
+            };
+            let Some((low_base, low_index)) = self.byte_lane(low) else {
+                continue;
+            };
             if base == low_base
                 && high_index == 0
                 && low_index == 1


### PR DESCRIPTION
A multi-agent bug-hunt workflow fanned out over six code areas, surfaced 8 candidate bugs,
and adversarially verified all 8. Each is fixed **TDD** (a failing red test first), and each
fix narrows nothing it shouldn't (no regressions; e.g. the byte-pack wrong-order and
non-byte-buffer cases stay correctly rejected).

| # | sev | area | bug → fix |
|---|---|---|---|
| 1 | high | `review.rs` | a deleted line starting `-- ` renders as `--- …` and was mistaken for the diff file header, silently dropping later hunks (missed divergence) → structural header/body disambiguation |
| 6 | low | `review.rs` | a pure insertion marked a base line that merely *ends* at the insertion point as changed → encode the gap as `(a+1, a)` |
| 2 | high | `main.rs` | `--fail-on new` with no `--baseline` printed clones and exited 0 — a CI gate that always passes silently → reject the combination |
| 4 | med | `frontend/c.rs` | hex literals with e/E (`0xE5`, `0x1e`) lowered to **float** literals → hex is integer (hex float uses `.`/`p`) |
| 5 | med | `config.rs` | docs promise a hard error, but a typo'd key/table (`min-valeu`, `[scna]`) was silently dropped → `deny_unknown_fields` |
| 7 | low | `ignores.rs` | `parse_family_id` accepted a `+`/`-` sign prefix (from_str_radix) → require 16 ASCII hex digits |
| 8 | low | `ignores.rs` | `parse_family_id` rejected a valid uppercase `0X…` prefix → case-insensitive strip |
| 3 | med | `normalize/value_graph.rs` | the byte-pack idiom's two-ordering loop used `?`, aborting on the first miss, so it was recognized only when the shifted lane sorted first by value-hash → `else { continue }` |

## Testing
Each bug has a red→green test: unit tests for the pure diff parser (`parse_old_side_ranges`,
`ranges_touch`), `parse_family_id`, and config loading; integration tests for the `--fail-on
new` gate and the byte-pack ordering (a `+`/`|` pair at param 1 now clusters, 0 → 1 family);
an equivalence test for the C hex literal. `./scripts/check-ci-local.sh --fast` green
(rustfmt, clippy -D warnings, tests, docs lint); full workspace test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)