### PR TITLE
fix: five correctness bugs (C/Java ++/-- nested-operand, Pow neg exp, LitFloat typing, cache file count)

### DIFF
--- a/crates/nose-cli/src/cache.rs
+++ b/crates/nose-cli/src/cache.rs
@@ -97,7 +97,9 @@ pub(crate) fn build_units_cached(
         })
         .collect();
 
-    let files = per_file.len();
+    // Count only files that actually read + lowered (a `Some` stream), so the reported
+    // count matches the non-cached path, which `filter_map`s read/parse failures away.
+    let files = per_file.iter().filter(|(_, s)| s.is_some()).count();
     let mut all_units = Vec::new();
     let mut all_streams = Vec::new();
     for (u, s) in per_file {
@@ -147,4 +149,43 @@ fn options_signature(opts: &DetectOptions) -> u64 {
         h = (h ^ v).wrapping_mul(0x0000_0100_0000_01b3);
     }
     h
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// `files` must count only files that were actually read+lowered — matching the
+    /// non-cached path (which `filter_map`s read/parse failures away). A discovered but
+    /// unreadable file used to inflate the count.
+    #[test]
+    fn file_count_excludes_unreadable_files() {
+        let dir = std::env::temp_dir().join(format!("nose_cache_count_{}", std::process::id()));
+        let cache = std::env::temp_dir().join(format!("nose_cache_dir_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::create_dir_all(&cache).unwrap();
+
+        std::fs::write(dir.join("ok.py"), "def f():\n    return 1\n").unwrap();
+        let bad = dir.join("bad.py");
+        std::fs::write(&bad, "def g():\n    return 2\n").unwrap();
+        // Make `bad.py` unreadable so `std::fs::read` fails (skips root, where this is moot).
+        std::fs::set_permissions(&bad, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let readable = std::fs::read(&bad).is_ok();
+        let out = build_units_cached(&[dir.as_path()], &[], &DetectOptions::default(), &cache);
+
+        // Restore perms so cleanup can proceed.
+        let _ = std::fs::set_permissions(&bad, std::fs::Permissions::from_mode(0o644));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(&cache);
+
+        if readable {
+            // Running as root (CI sometimes) — the unreadable file is still readable, so
+            // the discrepancy can't be exercised; don't assert.
+            return;
+        }
+        assert_eq!(out.files, 1, "only the readable file should be counted");
+    }
 }

--- a/crates/nose-frontend/src/c.rs
+++ b/crates/nose-frontend/src/c.rs
@@ -478,7 +478,10 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                 .map(|o| lower_expr(lo, o))
                 .unwrap_or_else(|| lo.empty_block(span));
             let one = lo.int_lit("1", span);
-            let op = if lo.text(node).contains("--") {
+            // Decide by the operator TOKEN, scanning only this node's direct children:
+            // a substring check on the whole text misreads a nested `--`/`++` in the
+            // operand (e.g. `a[i--]++`, whose outer op is `++`).
+            let op = if crate::lower::has_direct_token(node, "--") {
                 Op::Sub
             } else {
                 Op::Add
@@ -633,5 +636,32 @@ mod tests {
         // `+x` and `-x` must not collapse to the same operator.
         assert_eq!(unary_ops("int f(int x){ return +x; }"), vec![Op::Pos]);
         assert_eq!(unary_ops("int f(int x){ return -x; }"), vec![Op::Neg]);
+    }
+
+    /// Collect every `Op` carried by a `BinOp` node in the lowered IL.
+    fn binops(src: &str) -> Vec<Op> {
+        let interner = Interner::new();
+        let il = lower(FileId(0), "t.c", src.as_bytes(), &interner).expect("lower");
+        il.nodes
+            .iter()
+            .filter(|n| n.kind == NodeKind::BinOp)
+            .filter_map(|n| match n.payload {
+                Payload::Op(op) => Some(op),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn postfix_increment_with_nested_decrement_in_operand() {
+        // `a[i--]++` desugars to `a[i--] = a[i--] + 1`: the OUTER op is increment
+        // (`+ 1`). Detecting `--` anywhere in the node text misread the nested `i--`
+        // and flipped the outer op to decrement; the operator token, not the text,
+        // decides it.
+        let ops = binops("int f(){ int a[10]; int i=0; a[i--]++; return 0; }");
+        assert!(
+            ops.contains(&Op::Add),
+            "outer `++` must lower to Op::Add despite the nested `i--`, got {ops:?}"
+        );
     }
 }

--- a/crates/nose-frontend/src/c_test_update.rs
+++ b/crates/nose-frontend/src/c_test_update.rs
@@ -1,0 +1,59 @@
+#[cfg(test)]
+mod tests {
+    use crate::c;
+    use nose_il::intern::Interner;
+    use nose_il::node::*;
+
+    fn binop_ops(src: &str) -> Vec<Op> {
+        let interner = Interner::new();
+        let il = c::lower(
+            nose_il::file::FileId(0),
+            "t.c",
+            src.as_bytes(),
+            &interner,
+        )
+        .expect("lower");
+        il.nodes
+            .iter()
+            .filter(|n| n.kind == NodeKind::BinOp)
+            .filter_map(|n| match n.payload {
+                Payload::Op(op) => Some(op),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn update_expression_increment() {
+        let ops = binop_ops("int f() { int i = 0; i++; return 0; }");
+        assert!(ops.contains(&Op::Add), "i++ should have BinOp with Op::Add, got {:?}", ops);
+    }
+
+    #[test]
+    fn update_expression_decrement() {
+        let ops = binop_ops("int f() { int i = 0; i--; return 0; }");
+        assert!(ops.contains(&Op::Sub), "i-- should have BinOp with Op::Sub, got {:?}", ops);
+    }
+
+    #[test]
+    fn update_expression_nested_decrement() {
+        // This is the key test case that reveals the bug
+        let ops = binop_ops("int f() { int arr[10]; int i=0; arr[i--]++; return 0; }");
+        
+        // There should be two BinOps:
+        // 1. The inner i-- gives Op::Sub
+        // 2. The outer arr[i--]++ should give Op::Add (CURRENTLY FAILS)
+        
+        // Count the ops
+        let sub_count = ops.iter().filter(|op| **op == Op::Sub).count();
+        let add_count = ops.iter().filter(|op| **op == Op::Add).count();
+        
+        println!("ops: {:?}", ops);
+        println!("sub_count: {}, add_count: {}", sub_count, add_count);
+        
+        // If the bug exists, both will be Sub
+        // If fixed, we should have 1 Sub (inner i--) and 1 Add (outer ++)
+        assert_eq!(sub_count, 1, "Should have exactly 1 Sub (from i--), got {:?}", ops);
+        assert_eq!(add_count, 1, "Should have exactly 1 Add (from ++), got {:?}", ops);
+    }
+}

--- a/crates/nose-frontend/src/java.rs
+++ b/crates/nose-frontend/src/java.rs
@@ -398,7 +398,10 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                 .map(|o| lower_expr(lo, o))
                 .unwrap_or_else(|| lo.empty_block(span));
             let one = lo.int_lit("1", span);
-            let op = if lo.text(node).contains("--") {
+            // Decide by the operator TOKEN among this node's direct children: a substring
+            // check on the whole text misreads a nested `--`/`++` in the operand (e.g.
+            // `a[i--]++`, whose outer op is `++`).
+            let op = if crate::lower::has_direct_token(node, "--") {
                 Op::Sub
             } else {
                 Op::Add
@@ -705,5 +708,30 @@ mod tests {
             "unary ~ → Op::BitNot, got {ops:?}"
         );
         assert!(ops.contains(&Op::Not), "unary ! → Op::Not, got {ops:?}");
+    }
+
+    fn binops(src: &str) -> Vec<Op> {
+        let interner = Interner::new();
+        lower(FileId(0), "T.java", src.as_bytes(), &interner)
+            .expect("lower")
+            .nodes
+            .iter()
+            .filter(|n| n.kind == NodeKind::BinOp)
+            .filter_map(|n| match n.payload {
+                Payload::Op(op) => Some(op),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn postfix_increment_with_nested_decrement_in_operand() {
+        // `a[i--]++` desugars with the OUTER op being increment (`+ 1`); a substring
+        // `--` check misread the nested `i--` and flipped it to decrement.
+        let ops = binops("class C { void f(){ int[] a = new int[10]; int i = 0; a[i--]++; } }");
+        assert!(
+            ops.contains(&Op::Add),
+            "outer `++` must lower to Op::Add despite the nested `i--`, got {ops:?}"
+        );
     }
 }

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -194,6 +194,16 @@ impl<'a> Lowering<'a> {
     }
 }
 
+/// Does `node` have a *direct* child token of the given `kind`? Used to read an
+/// operator token (`--`, `++`) off the node it belongs to without being fooled by a
+/// nested occurrence in the operand (e.g. the inner `i--` of `a[i--]++`), which a
+/// substring scan over the node's whole text would wrongly match.
+pub(crate) fn has_direct_token(node: TsNode, kind: &str) -> bool {
+    let mut cur = node.walk();
+    let found = node.children(&mut cur).any(|c| c.kind() == kind);
+    found
+}
+
 /// Lower an import / `#include` / `use` statement to a `Seq` of its identifier and
 /// string leaves. Imports carry no behavior, but a *duplicated import block* is real
 /// copy-paste (jscpd flags it); emitting its tokens lets the contiguous copy-paste

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -897,7 +897,11 @@ fn bin(op: Op, a: &Value, b: &Value) -> Value {
                     Int(x.wrapping_rem(*y))
                 }
             }
-            Op::Pow => Int(x.wrapping_pow((*y).max(0) as u32)),
+            // A negative exponent has no i64 value (it is fractional), so it errs like
+            // Div/Mod by zero rather than being clamped to `0` — clamping made `b ** -n`
+            // collapse onto `b ** 0 == 1` and could license a false merge.
+            Op::Pow if *y < 0 => Value::Err,
+            Op::Pow => Int(x.wrapping_pow(*y as u32)),
             Op::Eq => Bool(x == y),
             Op::Ne => Bool(x != y),
             Op::Lt => Bool(x < y),
@@ -986,5 +990,36 @@ mod tests {
         // unknown, so `len(str)` must be `Err` (matching the documented contract and the
         // sibling `IsEmpty`), not a hardcoded `Int(1)`.
         assert_eq!(run_len_of_string(), Value::Err);
+    }
+
+    /// Build `fn() { return base ** exp }` over integer literals and run it.
+    fn run_pow(base: i64, exp: i64) -> Value {
+        let sp = Span::synthetic(FileId(0));
+        let mut b = IlBuilder::new(FileId(0));
+        let x = b.add(NodeKind::Lit, Payload::LitInt(base), sp, &[]);
+        let y = b.add(NodeKind::Lit, Payload::LitInt(exp), sp, &[]);
+        let pow = b.add(NodeKind::BinOp, Payload::Op(Op::Pow), sp, &[x, y]);
+        let ret = b.add(NodeKind::Return, Payload::None, sp, &[pow]);
+        let func = b.add(NodeKind::Func, Payload::None, sp, &[ret]);
+        let il = b.finish(
+            func,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        run_unit(&il, func, &[]).expect("run_unit").ret
+    }
+
+    #[test]
+    fn pow_negative_exponent_is_err_not_clamped_to_zero() {
+        // The oracle models only i64; a negative exponent has no integer value, so it must
+        // `Err` (like Div/Mod by zero) — NOT be silently clamped to `0`, which made
+        // `2 ** -1` indistinguishable from `2 ** 0` and could license a false merge.
+        assert_eq!(run_pow(2, 3), Value::Int(8));
+        assert_eq!(run_pow(2, 0), Value::Int(1));
+        assert_eq!(run_pow(2, -1), Value::Err);
     }
 }

--- a/crates/nose-normalize/src/types.rs
+++ b/crates/nose-normalize/src/types.rs
@@ -213,7 +213,9 @@ fn node_lit_ty(il: &Il, n: NodeId) -> Option<Ty> {
         return None;
     }
     match il.node(n).payload {
-        Payload::LitInt(_) => Some(Ty::Num),
+        // A retained float (`LitFloat`) is as numeric as a `LitInt`; omitting it left
+        // `x + 3.14` unable to type `x`.
+        Payload::LitInt(_) | Payload::LitFloat(_) => Some(Ty::Num),
         Payload::LitStr(_) => Some(Ty::Str),
         Payload::LitBool(_) => Some(Ty::Bool),
         Payload::Lit(nose_il::LitClass::Int) | Payload::Lit(nose_il::LitClass::Float) => {
@@ -222,5 +224,45 @@ fn node_lit_ty(il: &Il, n: NodeId) -> Option<Ty> {
         Payload::Lit(nose_il::LitClass::Str) => Some(Ty::Str),
         Payload::Lit(nose_il::LitClass::Bool) => Some(Ty::Bool),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nose_il::{FileId, FileMeta, IlBuilder, Lang, Span};
+
+    /// Infer the parameter types of `fn(x) { return x + <lit> }`.
+    fn infer_with_added_literal(lit: Payload) -> Vec<Ty> {
+        let sp = Span::synthetic(FileId(0));
+        let mut b = IlBuilder::new(FileId(0));
+        let param = b.add(NodeKind::Param, Payload::Cid(0), sp, &[]);
+        let varx = b.add(NodeKind::Var, Payload::Cid(0), sp, &[]);
+        let lit = b.add(NodeKind::Lit, lit, sp, &[]);
+        let add = b.add(NodeKind::BinOp, Payload::Op(Op::Add), sp, &[varx, lit]);
+        let ret = b.add(NodeKind::Return, Payload::None, sp, &[add]);
+        let func = b.add(NodeKind::Func, Payload::None, sp, &[param, ret]);
+        let il = b.finish(
+            func,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        infer_param_types(&il, func)
+    }
+
+    #[test]
+    fn float_literal_sibling_of_add_types_param_as_num() {
+        // `x + 3.14` (a retained-float `LitFloat`) must type `x` as `Num`, exactly like
+        // `x + 3` (`LitInt`). `node_lit_ty` previously omitted `LitFloat`, leaving the
+        // sibling `Unknown`.
+        assert_eq!(infer_with_added_literal(Payload::LitInt(3)), vec![Ty::Num]);
+        assert_eq!(
+            infer_with_added_literal(Payload::LitFloat(0xBEEF)),
+            vec![Ty::Num]
+        );
     }
 }


### PR DESCRIPTION
Third pass of the automated multi-agent bug-hunt workflow (9 finders over deeper/uncovered logic + adversarial verify), each candidate independently re-checked against source. Five genuine, observable, unit-testable bugs are fixed here TDD-style (red→green).

## 1 & 2. C / Java `x++` / `x--`: operator misread from whole-node text
Both frontends decided increment-vs-decrement with `lo.text(node).contains("--")` over the **entire** node text. A nested update in the operand — e.g. `a[i--]++` — contains `--`, so the **outer** `++` was wrongly lowered as a decrement (`a[i] = a[i] - 1` instead of `+ 1`). Fixed by deciding from the operator **token** among the node's direct children, via a new shared `lower::has_direct_token` helper (the nested `i--` lives in the operand subtree, not as a direct child).

## 3. Interpreter `Pow` clamps negative exponents to 0
`Op::Pow => Int(x.wrapping_pow((*y).max(0) as u32))` made `2 ** -1` evaluate to `1`, identical to `2 ** 0`. The behavioral-oracle interpreter models only `i64`; a negative exponent has no integer value, so (like `Div`/`Mod` by zero) it now returns `Err`. Two distinct operations collapsing to the same value could license a false merge — the cardinal sin for the soundness oracle.

## 4. Type inference: `LitFloat` literals untyped
`node_lit_ty` handled `LitInt`/`LitStr`/`LitBool` and the abstract `Lit(..)` classes but omitted `Payload::LitFloat` (the retained-float literal the frontend emits for `3.14`). It fell through to `None` → `Ty::Unknown`, so `x + 3.14` could not type `x` as `Num` (unlike `x + 3`). Added the `LitFloat` arm.

## 5. CLI cache: file count includes failed reads
The cached path counted **all** discovered paths (`per_file.len()`), keeping `(Vec::new(), None)` placeholders for files that failed to read/lower; the non-cached path counts only successfully-lowered files (`filter_map`). So `metrics.files` differed between cached and non-cached runs on the same input. Now counts only entries that produced a stream.

## Tests
- `c.rs` / `java.rs`: `postfix_increment_with_nested_decrement_in_operand`
- `interp.rs`: `pow_negative_exponent_is_err_not_clamped_to_zero`
- `types.rs`: `float_literal_sibling_of_add_types_param_as_num`
- `cache.rs`: `file_count_excludes_unreadable_files` (`#[cfg(unix)]`, chmod-based; no-ops under root)

All fail before the fix and pass after.

## Gates (local)
`cargo fmt --check`, `clippy -D warnings`, `cargo doc`, `build --release`, `test --release` (all pass), `check-duplication.sh` (4/6), `cargo machete`, `awiki lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)