### PR TITLE
fix: three correctness bugs (neg i64::MIN panic, Pow exponent truncation, Go &^ bit-clear)

### DIFF
--- a/crates/nose-frontend/src/go.rs
+++ b/crates/nose-frontend/src/go.rs
@@ -7,7 +7,7 @@
 
 use crate::lower::Lowering;
 use nose_il::{
-    Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload,
+    Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload, Span,
 };
 use tree_sitter::Node as TsNode;
 
@@ -242,13 +242,18 @@ fn lower_assign_like(lo: &mut Lowering, node: TsNode) -> NodeId {
         let lspan = lo.span(*l);
         let lhs = lower_expr(lo, *l);
         let rhs = if compound {
-            let op = js_like_compound_op(op_text).unwrap_or(Op::Add);
             let lhs2 = lower_expr(lo, *l);
             let r = rights
                 .get(i)
                 .map(|n| lower_expr(lo, *n))
                 .unwrap_or_else(|| lo.empty_block(lspan));
-            lo.add(NodeKind::BinOp, Payload::Op(op), lspan, &[lhs2, r])
+            // `a &^= b` → `a = a & ^b`, same bit-clear desugar as the binary form.
+            if op_text.trim_end_matches('=') == "&^" {
+                go_bitclear(lo, lspan, lhs2, r)
+            } else {
+                let op = js_like_compound_op(op_text).unwrap_or(Op::Add);
+                lo.add(NodeKind::BinOp, Payload::Op(op), lspan, &[lhs2, r])
+            }
         } else {
             rights
                 .get(i)
@@ -706,7 +711,29 @@ fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {
 }
 
 fn lower_binary(lo: &mut Lowering, node: TsNode) -> NodeId {
+    // `a &^ b` (bit-clear / AND-NOT) desugars to `a & ^b`; the generic op-map can only
+    // yield a single BinOp, so it is built here rather than in `go_bin_op`.
+    if node.child_by_field_name("operator").map(|o| lo.text(o)) == Some("&^") {
+        let span = lo.span(node);
+        let l = node
+            .child_by_field_name("left")
+            .map(|x| lower_expr(lo, x))
+            .unwrap_or_else(|| lo.empty_block(span));
+        let r = node
+            .child_by_field_name("right")
+            .map(|x| lower_expr(lo, x))
+            .unwrap_or_else(|| lo.empty_block(span));
+        return go_bitclear(lo, span, l, r);
+    }
     crate::lower::binary(lo, node, go_bin_op, lower_expr)
+}
+
+/// Go's bit-clear `a &^ b` ≡ `a & ^b` (AND-NOT) — it clears the bits of `a` that are set
+/// in `b`, which is NOT the same as `a & b`. Desugar to that two-node form so the two
+/// operators don't collapse to one fingerprint.
+fn go_bitclear(lo: &mut Lowering, span: Span, l: NodeId, r: NodeId) -> NodeId {
+    let not_r = lo.add(NodeKind::UnOp, Payload::Op(Op::BitNot), span, &[r]);
+    lo.add(NodeKind::BinOp, Payload::Op(Op::BitAnd), span, &[l, not_r])
 }
 
 fn lower_unary(lo: &mut Lowering, node: TsNode) -> NodeId {
@@ -737,13 +764,53 @@ fn lower_unary(lo: &mut Lowering, node: TsNode) -> NodeId {
 }
 
 fn go_bin_op(text: &str) -> Option<Op> {
-    // shared C-family set, plus Go's bit-clear `&^`
-    crate::lower::common_bin_op(text).or(match text {
-        "&^" => Some(Op::BitAnd),
-        _ => None,
-    })
+    // `&^` (bit-clear) is handled by desugaring in `lower_binary` / the compound path,
+    // not here, since it expands to two nodes rather than a single BinOp.
+    crate::lower::common_bin_op(text)
 }
 
 fn js_like_compound_op(text: &str) -> Option<Op> {
     go_bin_op(text.trim_end_matches('='))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ops(src: &str) -> Vec<Op> {
+        let interner = Interner::new();
+        lower(FileId(0), "t.go", src.as_bytes(), &interner)
+            .expect("lower")
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::BinOp | NodeKind::UnOp))
+            .filter_map(|n| match n.payload {
+                Payload::Op(op) => Some(op),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn bit_clear_is_not_plain_bitand() {
+        // Go's `a &^ b` is AND-NOT (`a & ^b`): it must desugar to a `BitAnd` over a
+        // `BitNot` of the right operand, NOT collapse to a plain `a & b` (different bits,
+        // and a false merge with real `&`).
+        let clear = ops("package main\nfunc f(a int, b int) int { return a &^ b }\n");
+        assert!(
+            clear.contains(&Op::BitNot),
+            "`a &^ b` must introduce BitNot, got {clear:?}"
+        );
+        assert!(
+            clear.contains(&Op::BitAnd),
+            "`a &^ b` must keep BitAnd, got {clear:?}"
+        );
+
+        // Plain `a & b` must NOT introduce a BitNot — the two operators stay distinct.
+        let and = ops("package main\nfunc f(a int, b int) int { return a & b }\n");
+        assert!(
+            !and.contains(&Op::BitNot),
+            "`a & b` must not introduce BitNot, got {and:?}"
+        );
+    }
 }

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -897,10 +897,11 @@ fn bin(op: Op, a: &Value, b: &Value) -> Value {
                     Int(x.wrapping_rem(*y))
                 }
             }
-            // A negative exponent has no i64 value (it is fractional), so it errs like
-            // Div/Mod by zero rather than being clamped to `0` — clamping made `b ** -n`
-            // collapse onto `b ** 0 == 1` and could license a false merge.
-            Op::Pow if *y < 0 => Value::Err,
+            // An exponent that isn't a non-negative `u32` has no usable value here: a
+            // negative one is fractional, and one past `u32::MAX` truncated under `as u32`
+            // (so `b ** 2^32` collapsed onto `b ** 0 == 1`). Both err, like Div/Mod by zero,
+            // rather than silently colliding distinct exponents.
+            Op::Pow if !(0..=u32::MAX as i64).contains(y) => Value::Err,
             Op::Pow => Int(x.wrapping_pow(*y as u32)),
             Op::Eq => Bool(x == y),
             Op::Ne => Bool(x != y),
@@ -946,7 +947,9 @@ fn bin(op: Op, a: &Value, b: &Value) -> Value {
 
 fn un(op: Op, a: &Value) -> Value {
     match (op, a) {
-        (Op::Neg, Value::Int(i)) => Value::Int(-i),
+        // `wrapping_neg` (not `-i`) so negating `i64::MIN` wraps to `i64::MIN` instead of
+        // panicking on overflow — consistent with the wrapping binary arithmetic above.
+        (Op::Neg, Value::Int(i)) => Value::Int(i.wrapping_neg()),
         (Op::Pos, Value::Int(i)) => Value::Int(*i),
         (Op::BitNot, Value::Int(i)) => Value::Int(!i),
         // Negating an ERROR propagates the error — `not (1/0)` raises in Python, it does
@@ -1021,5 +1024,42 @@ mod tests {
         assert_eq!(run_pow(2, 3), Value::Int(8));
         assert_eq!(run_pow(2, 0), Value::Int(1));
         assert_eq!(run_pow(2, -1), Value::Err);
+    }
+
+    #[test]
+    fn pow_exponent_beyond_u32_is_err_not_truncated() {
+        // The exponent was cast `as u32`, so `2 ** 2^32` truncated to `2 ** 0 == 1` —
+        // colliding distinct exponents. An exponent that doesn't fit u32 has no usable
+        // value here, so it errs rather than wrap to a smaller exponent.
+        assert_eq!(run_pow(2, 1 << 32), Value::Err);
+        assert_eq!(run_pow(2, (1 << 32) + 5), Value::Err);
+    }
+
+    /// Build `fn() { return -lit }` over an integer literal and run it.
+    fn run_neg(v: i64) -> Value {
+        let sp = Span::synthetic(FileId(0));
+        let mut b = IlBuilder::new(FileId(0));
+        let x = b.add(NodeKind::Lit, Payload::LitInt(v), sp, &[]);
+        let neg = b.add(NodeKind::UnOp, Payload::Op(Op::Neg), sp, &[x]);
+        let ret = b.add(NodeKind::Return, Payload::None, sp, &[neg]);
+        let func = b.add(NodeKind::Func, Payload::None, sp, &[ret]);
+        let il = b.finish(
+            func,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        run_unit(&il, func, &[]).expect("run_unit").ret
+    }
+
+    #[test]
+    fn neg_of_i64_min_wraps_instead_of_panicking() {
+        // Plain `-i` panics on `i64::MIN` (overflow); every other arithmetic op here uses
+        // wrapping semantics, so negation must too — `wrapping_neg(i64::MIN) == i64::MIN`.
+        assert_eq!(run_neg(5), Value::Int(-5));
+        assert_eq!(run_neg(i64::MIN), Value::Int(i64::MIN));
     }
 }


### PR DESCRIPTION
Fourth pass of the automated multi-agent bug-hunt workflow (9 finders over the least-examined deep logic incl. the 6k-line `value_graph.rs`; strict adversarial verify rejected 3/8). Three genuine, observable, unit-testable bugs are fixed here TDD-style (red→green).

## 1. Interpreter unary `Neg` panics on `i64::MIN`
`(Op::Neg, Value::Int(i)) => Value::Int(-i)` — plain `-i` panics ("attempt to negate with overflow") for `i64::MIN`, on valid input, while every other arithmetic op in the oracle uses wrapping variants. A literal `-9223372036854775808` (or any computed `Neg` of `MIN`) would unwind the detection run. Fixed with `i.wrapping_neg()` (`-i64::MIN` wraps to `i64::MIN`).

## 2. Interpreter `Pow` truncates exponents past `u32::MAX`
The exponent was cast `as u32`, so `2 ** 2^32` truncated to `2 ** 0 == 1`, colliding distinct exponents in the behavioral-oracle (a potential false merge). Extends the existing negative-exponent guard (added in #29) to err for any exponent outside `0..=u32::MAX`, rather than silently wrapping it to a smaller one.

## 3. Go bit-clear `&^` mapped to plain `BitAnd`
`go_bin_op` mapped `&^` (AND-NOT: `a &^ b` ≡ `a & ^b`, clears `a`'s bits that are set in `b`) to `Op::BitAnd`, making `a &^ b` and `a & b` identical in the IL — a false equivalence. Desugars to `BitAnd(a, BitNot(b))` in both the binary and the `&^=` compound-assignment paths (the generic op-map can only yield a single `BinOp`, so the two-node form is built explicitly).

## Also investigated, deliberately NOT changed
- `fold_arith` folding constants in an `Add`/`Mul` chain reorders/combines them, which is unsound for string concat/repeat (`"a"+1+"b"`, `"ab"*2*3`). A correct fix needs **type-gating** (the untyped algebra pass can't tell concat from numeric add) — a high-blast-radius change to the core normalizer, deferred rather than risk a soundness/convergence regression.
- `contiguous.rs` `has_op` checks only the current stream, not the reference. But `op[i] = is_operation(kind)` is a pure function of node kind and matched runs are tag-equal (tags encode kind), so the two streams' op-flags always agree for any real match — the asymmetry is only reachable via hand-built test `Stream`s. Not a real bug.

## Tests
- `interp.rs`: `neg_of_i64_min_wraps_instead_of_panicking`, `pow_exponent_beyond_u32_is_err_not_truncated`
- `go.rs`: `bit_clear_is_not_plain_bitand`

All fail before the fix and pass after.

## Gates (local)
`cargo fmt --check`, `clippy -D warnings`, `cargo doc`, `build --release`, `test --release` (all pass), `check-duplication.sh` (4/6), `cargo machete`, `awiki lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Go 비트 AND-NOT 연산자의 올바른 처리 강화
  * 숫자 거듭제곱 연산의 범위 초과 및 음수 부호 처리 안정화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->