### PR TITLE
fix: family dedup missed double-counting when one large site covers several smaller

### DIFF
--- a/crates/nose-detect/src/report.rs
+++ b/crates/nose-detect/src/report.rs
@@ -456,9 +456,11 @@ fn total_span(f: &RefactorFamily) -> u32 {
 /// the bulk (≥60%) of each inner site to fall in an outer site collapses both without
 /// merging genuinely distinct code (which would need >60% line overlap to qualify).
 fn subsumes(outer: &RefactorFamily, inner: &RefactorFamily) -> bool {
-    if outer.locations.len() < inner.locations.len() {
-        return false;
-    }
+    // No site-count guard: a single large outer site can cover several smaller inner
+    // sites, so requiring `outer.len() >= inner.len()` wrongly kept those (double-counted)
+    // inner families. Coverage alone — every inner site ≥60% inside some same-file outer
+    // site — is the criterion. The caller only ever asks whether a larger-span (kept)
+    // family subsumes a smaller one, so this can't collapse genuinely distinct code.
     const COVER: f64 = 0.60;
     inner.locations.iter().all(|i| {
         outer
@@ -688,6 +690,36 @@ mod tests {
         assert!(
             !subsumes(&outer, &distinct),
             "non-overlapping family is kept"
+        );
+    }
+
+    #[test]
+    fn subsumes_when_one_outer_site_covers_several_inner_sites() {
+        // A larger family with FEWER but bigger sites can still cover an inner family's
+        // MORE numerous smaller sites — every inner site lands inside an outer one, so it
+        // is double-counting and must be subsumed. (A site-count early-out used to reject
+        // this, leaving both families in the report.)
+        let outer = fam(
+            10.0,
+            100,
+            100,
+            0,
+            vec![loc("a.rs", 1, 100, "rs"), loc("b.rs", 1, 100, "rs")],
+        );
+        let inner = fam(
+            10.0,
+            30,
+            30,
+            0,
+            vec![
+                loc("a.rs", 10, 40, "rs"),
+                loc("a.rs", 60, 90, "rs"),
+                loc("b.rs", 20, 50, "rs"),
+            ],
+        );
+        assert!(
+            subsumes(&outer, &inner),
+            "one big outer site may cover several inner sites"
         );
     }
 


### PR DESCRIPTION
Fifth pass of the bug-hunt workflow (9 finders focused on unsound-merge bugs in `value_graph.rs`, CLI ranking/baseline, and remaining normalize/detect; strict verify rejected 3/5). Yield is tapering — one genuine fix this round.

## Family dedup: `subsumes` site-count early-out left double-counted families
`subsumes(outer, inner)` is documented to return true when *every* inner site lands ≥60% inside some same-file outer site (collapsing strict-containment and window-shifted overlap — the field-eval double-counting cases). But it began with:
```rust
if outer.locations.len() < inner.locations.len() { return false; }
```
A larger family with **fewer but bigger** sites can still cover an inner family's **more numerous smaller** sites (e.g. one `a.rs:1-100` site covering `a.rs:10-40` and `a.rs:60-90`). The early-out rejected exactly those, leaving both families in the report — the double-counting the function exists to remove.

`rank_families` sorts families largest-total-span-first and only ever asks whether an already-kept (larger-span) family subsumes a smaller candidate, so the site-count guard was never needed for correctness and only suppressed valid subsumption. Removed it; coverage is the sole criterion.

## Also investigated, deliberately NOT changed
- `ScanChannels::resolve` dropping a config `near:0.8` threshold when the CLI passes `--mode near` without one. This is **documented, intended** behavior: config.rs states "CLI flags always win" and "near's threshold rides on the mode" — `--mode near` selects the near channel at its default threshold, and merging the config threshold back in would contradict the documented "CLI wins" semantics. Set aside.

## Tests
- `report.rs`: `subsumes_when_one_outer_site_covers_several_inner_sites` (fails before, passes after; existing `subsumes_collapses_window_shift` still holds).

## Gates (local)
`cargo fmt --check`, `clippy -D warnings`, `cargo doc`, `build --release`, `test --release` (all pass), `check-duplication.sh` (4/6), `cargo machete`, `awiki lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)