### PR TITLE
type4: exact fragment contracts for sound sub-function clones (#33)

### DIFF
--- a/crates/nose-detect/src/fragment.rs
+++ b/crates/nose-detect/src/fragment.rs
@@ -1,0 +1,179 @@
+//! Substrate for exact sub-function semantic fragments.
+//!
+//! Exact fragment extraction historically grew as a set of standalone predicates in
+//! [`crate::units`]: each accepted shape (direct return, conditional guard, append
+//! effect, Java `this.field` body, …) was a boolean branch, and the *reason* a
+//! fragment was accepted lived only in the shape of the predicate that matched it.
+//!
+//! This module is the first-class classification those predicates lower into. Every
+//! accepted fragment root carries a [`FragmentKind`], a stable [`reason_code`], and a
+//! set of [`ProofFacts`] describing what was proven at acceptance time. The predicates
+//! in [`crate::units`] remain the recognizers; they now return a `FragmentKind` instead
+//! of a bare `bool`, so downstream code (reporting, ranking, the fragment oracle) can
+//! reason about *why* a fragment is exact-safe without re-reading the predicate matrix.
+//!
+//! Step 1 of issue #33 is deliberately behavior-invariant: each [`FragmentKind`] variant
+//! corresponds 1:1 to a predicate branch that previously returned `true`, and the set of
+//! accepted roots is unchanged. Later steps re-express these recognizers through an
+//! explicit fragment contract and an independent behavior oracle.
+//!
+//! [`reason_code`]: FragmentKind::reason_code
+
+/// The shape of an accepted exact sub-function fragment.
+///
+/// Each variant is the classification of one recognizer branch in
+/// [`crate::units::exact_statement_fragment_root`]. The discriminant is the *why*: a
+/// `DirectReturn` fragment is an exact-safe `return <expr>` lifted out of a larger body,
+/// a `LoopEffect` fragment is a `for-each` whose body is a single proven append, and so
+/// on. Two fragments with the same kind were accepted by the same proof argument.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FragmentKind {
+    /// `return <computed expr>` — a value sink whose returned expression is exact-safe.
+    DirectReturn,
+    /// `throw <computed expr>` — a control sink whose thrown expression is exact-safe.
+    DirectThrow,
+    /// `target[key] = value` — a non-overloadable index-assignment effect (C/Go/Java).
+    IndexAssignEffect,
+    /// `this.field = value` — a Java fixed-receiver self-field write.
+    SelfFieldAssign,
+    /// A single expression statement evaluated for its proven side effect.
+    ExprEffect,
+    /// An `if`/`else` whose non-empty branches are themselves exact exit/effect shapes.
+    ConditionalGuard,
+    /// A `for-each` loop whose body is a single iteration-dependent append effect.
+    LoopEffect,
+    /// A Java method body of `this.field = …` writes (plus optional `return this`).
+    SelfFieldBody,
+}
+
+impl FragmentKind {
+    /// A stable, user-facing kebab-case identifier for this fragment shape.
+    ///
+    /// Reason codes are part of the detector's external contract (issue #11): they name
+    /// *why* a fragment is an exact semantic clone. They must stay stable across releases,
+    /// so changing one is a breaking change to consumers that key on it.
+    pub fn reason_code(self) -> &'static str {
+        match self {
+            FragmentKind::DirectReturn => "exact-direct-return",
+            FragmentKind::DirectThrow => "exact-direct-throw",
+            FragmentKind::IndexAssignEffect => "exact-index-assign-effect",
+            FragmentKind::SelfFieldAssign => "exact-self-field-assign",
+            FragmentKind::ExprEffect => "exact-expr-effect",
+            FragmentKind::ConditionalGuard => "exact-conditional-guard",
+            FragmentKind::LoopEffect => "exact-loop-effect",
+            FragmentKind::SelfFieldBody => "exact-self-field-body",
+        }
+    }
+
+    /// The control sink this fragment terminates in, when it is a pure exit shape.
+    ///
+    /// Effect and body fragments fall through to normal completion ([`Exit::Normal`]);
+    /// the dedicated control sinks (`return`/`throw`) report themselves. This is the
+    /// seed of the contract's exit set — later steps widen it to break/continue once
+    /// those shapes are admitted.
+    pub fn primary_exit(self) -> Exit {
+        match self {
+            FragmentKind::DirectReturn => Exit::Return,
+            FragmentKind::DirectThrow => Exit::Throw,
+            FragmentKind::IndexAssignEffect
+            | FragmentKind::SelfFieldAssign
+            | FragmentKind::ExprEffect
+            | FragmentKind::ConditionalGuard
+            | FragmentKind::LoopEffect
+            | FragmentKind::SelfFieldBody => Exit::Normal,
+        }
+    }
+}
+
+/// A fragment's terminal control behavior.
+///
+/// Kept intentionally small for Step 1 — only the exits the current recognizers can
+/// produce. `break`/`continue` are reserved for when loop-body fragment windows open.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Exit {
+    /// Falls off the end of the fragment into the enclosing body.
+    Normal,
+    /// Returns a value out of the enclosing function.
+    Return,
+    /// Throws/raises out of the enclosing function.
+    Throw,
+}
+
+/// What the recognizer proved about a fragment at acceptance time.
+///
+/// These are the invariants the exact gate already established — recorded explicitly so
+/// later steps (the contract lowering and the behavior oracle) can consume them instead
+/// of re-deriving them from the IL. Step 1 records only facts that are guaranteed true by
+/// construction of the accepting predicate; the set grows as the contract model lands.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, serde::Serialize, serde::Deserialize)]
+pub struct ProofFacts {
+    /// No preceding statement in the enclosing block aliases or mutates the fragment's
+    /// free inputs, so the fragment's meaning does not depend on hidden prior state.
+    ///
+    /// True by construction for the top-level statement recognizers (they pass through
+    /// `top_level_statement_fragment_context_safe`). The Java self-field *body* shape
+    /// proves self-containment through its own receiver-fixed analysis rather than the
+    /// shared context gate, and records `false` here to mark that distinction.
+    pub context_safe: bool,
+    /// The fragment's terminal control behavior (see [`Exit`]).
+    pub exit: Exit,
+}
+
+impl ProofFacts {
+    /// Proof facts for a `kind` accepted through the shared top-level context gate.
+    pub fn context_gated(kind: FragmentKind) -> Self {
+        ProofFacts {
+            context_safe: true,
+            exit: kind.primary_exit(),
+        }
+    }
+
+    /// Proof facts for the Java self-field body shape, which establishes
+    /// self-containment through its fixed `this` receiver rather than the shared gate.
+    pub fn self_field_body() -> Self {
+        ProofFacts {
+            context_safe: false,
+            exit: Exit::Normal,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reason_codes_are_distinct_and_kebab() {
+        let kinds = [
+            FragmentKind::DirectReturn,
+            FragmentKind::DirectThrow,
+            FragmentKind::IndexAssignEffect,
+            FragmentKind::SelfFieldAssign,
+            FragmentKind::ExprEffect,
+            FragmentKind::ConditionalGuard,
+            FragmentKind::LoopEffect,
+            FragmentKind::SelfFieldBody,
+        ];
+        let mut codes: Vec<&str> = kinds.iter().map(|k| k.reason_code()).collect();
+        let total = codes.len();
+        codes.sort_unstable();
+        codes.dedup();
+        assert_eq!(codes.len(), total, "reason codes must be unique");
+        for code in codes {
+            assert!(
+                code.starts_with("exact-")
+                    && code.chars().all(|c| c.is_ascii_lowercase() || c == '-'),
+                "reason code `{code}` must be kebab-case and exact-prefixed"
+            );
+        }
+    }
+
+    #[test]
+    fn primary_exit_matches_sink_kinds() {
+        assert_eq!(FragmentKind::DirectReturn.primary_exit(), Exit::Return);
+        assert_eq!(FragmentKind::DirectThrow.primary_exit(), Exit::Throw);
+        assert_eq!(FragmentKind::LoopEffect.primary_exit(), Exit::Normal);
+    }
+}

--- a/crates/nose-detect/src/fragment.rs
+++ b/crates/nose-detect/src/fragment.rs
@@ -19,6 +19,12 @@
 //!
 //! [`reason_code`]: FragmentKind::reason_code
 
+mod contract;
+mod oracle;
+
+pub use contract::{FragmentContract, Place};
+pub use oracle::{fragment_behavior, free_input_cids, synthesize_wrapper};
+
 /// The shape of an accepted exact sub-function fragment.
 ///
 /// Each variant is the classification of one recognizer branch in

--- a/crates/nose-detect/src/fragment.rs
+++ b/crates/nose-detect/src/fragment.rs
@@ -21,6 +21,7 @@
 
 mod contract;
 mod oracle;
+pub(crate) mod recognize;
 
 pub use contract::{FragmentContract, Place};
 pub use oracle::{fragment_behavior, free_input_cids, synthesize_wrapper};

--- a/crates/nose-detect/src/fragment.rs
+++ b/crates/nose-detect/src/fragment.rs
@@ -29,7 +29,7 @@ pub use oracle::{fragment_behavior, free_input_cids, synthesize_wrapper};
 /// The shape of an accepted exact sub-function fragment.
 ///
 /// Each variant is the classification of one recognizer branch in
-/// [`crate::units::exact_statement_fragment_root`]. The discriminant is the *why*: a
+/// `units::exact_statement_fragment_root`. The discriminant is the *why*: a
 /// `DirectReturn` fragment is an exact-safe `return <expr>` lifted out of a larger body,
 /// a `LoopEffect` fragment is a `for-each` whose body is a single proven append, and so
 /// on. Two fragments with the same kind were accepted by the same proof argument.

--- a/crates/nose-detect/src/fragment.rs
+++ b/crates/nose-detect/src/fragment.rs
@@ -23,7 +23,7 @@ mod contract;
 mod oracle;
 pub(crate) mod recognize;
 
-pub use contract::{FragmentContract, Place};
+pub use contract::{Effect, FragmentContract, Place};
 pub use oracle::{fragment_behavior, free_input_cids, synthesize_wrapper};
 
 /// The shape of an accepted exact sub-function fragment.

--- a/crates/nose-detect/src/fragment/contract.rs
+++ b/crates/nose-detect/src/fragment/contract.rs
@@ -1,0 +1,95 @@
+//! The exact-fragment contract: the explicit, recognizer-independent description of a
+//! sub-function fragment that the behavior oracle consumes.
+//!
+//! Issue #33 step 3. A [`FragmentContract`] is what a shape recognizer *produces* once it
+//! accepts a fragment: the free inputs the fragment reads, the control exit it terminates
+//! in, and the source node to lower. It deliberately carries only what the oracle needs to
+//! synthesize a runnable wrapper (see [`super::oracle`]) — if a contract cannot be lowered
+//! into a wrapper, the contract is underspecified, which is exactly the soundness property
+//! we want to force.
+//!
+//! This is the minimal contract: it models the direct-return shape (inputs + a value/throw
+//! exit). Heap writes, effect algebra, and [`Place`] receiver identity are layered on in
+//! later steps; the placeholder [`Place`] enum below fixes the fail-closed default now so
+//! receiver-bearing shapes have a home to migrate into.
+
+use super::{Exit, FragmentKind};
+use nose_il::NodeId;
+
+/// A first-class description of one exact sub-function fragment.
+///
+/// The contract is recognizer-independent: two fragments with the same inputs, exit, and
+/// (eventually) effects are interchangeable to the oracle regardless of which predicate
+/// matched them. The [`root`](Self::root) points at the fragment statement in the *source*
+/// IL; lowering deep-copies that subtree into a synthetic wrapper.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FragmentContract {
+    /// Which recognizer shape produced this contract.
+    pub kind: FragmentKind,
+    /// The fragment statement (or block) in the source IL, lowered by the oracle.
+    pub root: NodeId,
+    /// Free canonical ids the fragment reads, in canonical (ascending) order. These become
+    /// the synthetic wrapper's parameters, bound positionally from the input battery.
+    pub inputs: Vec<u32>,
+    /// The control sink the fragment terminates in.
+    pub exit: Exit,
+}
+
+impl FragmentContract {
+    /// The arity of the synthesized wrapper — one parameter per free input.
+    pub fn arity(&self) -> usize {
+        self.inputs.len()
+    }
+}
+
+/// A write target's proven identity — the receiver-identity model heap-effect fragments
+/// migrate onto in step 6.
+///
+/// It is defined now, ahead of the effect-algebra work, so the substrate has a single
+/// fail-closed answer to "whose state does this write touch?". The cardinal rule is that
+/// [`Place::Unknown`] is the **default**: any receiver that does not resolve to a proven
+/// place is `Unknown` and therefore not exact-safe. A fragment that writes through an
+/// `Unknown` place must be rejected, never merged.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Place {
+    /// A fixed `self`/`this` receiver (currently Java `this`).
+    This,
+    /// A parameter's identity, keyed by canonical id.
+    Param(u32),
+    /// A locally allocated object/collection, keyed by its allocation site's canonical id.
+    LocalAlloc(u32),
+    /// A field path off another place: `<base>.<field>`, field keyed by its name hash.
+    Field(Box<Place>, u64),
+    /// An index/key path off another place: `<base>[<key>]`, key keyed by a stable hash.
+    Index(Box<Place>, u64),
+    /// An unproven receiver. The fail-closed default — writes here are never exact-safe.
+    Unknown,
+}
+
+impl Place {
+    /// Whether this place's identity is proven well enough to support an exact effect.
+    /// Fail-closed: anything reaching an [`Place::Unknown`] base is rejected.
+    pub fn is_exact_safe(&self) -> bool {
+        match self {
+            Place::This | Place::Param(_) | Place::LocalAlloc(_) => true,
+            Place::Field(base, _) | Place::Index(base, _) => base.is_exact_safe(),
+            Place::Unknown => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_place_is_fail_closed() {
+        assert!(!Place::Unknown.is_exact_safe());
+        // An otherwise-proven path rooted at Unknown stays unsafe.
+        let nested = Place::Field(Box::new(Place::Index(Box::new(Place::Unknown), 7)), 3);
+        assert!(!nested.is_exact_safe());
+        // A proven receiver with a field/index path is safe.
+        assert!(Place::Field(Box::new(Place::This), 3).is_exact_safe());
+        assert!(Place::Index(Box::new(Place::Param(0)), 9).is_exact_safe());
+    }
+}

--- a/crates/nose-detect/src/fragment/contract.rs
+++ b/crates/nose-detect/src/fragment/contract.rs
@@ -19,9 +19,9 @@ use nose_il::NodeId;
 /// A first-class description of one exact sub-function fragment.
 ///
 /// The contract is recognizer-independent: two fragments with the same inputs, exit, and
-/// (eventually) effects are interchangeable to the oracle regardless of which predicate
-/// matched them. The [`root`](Self::root) points at the fragment statement in the *source*
-/// IL; lowering deep-copies that subtree into a synthetic wrapper.
+/// effect are interchangeable to the oracle regardless of which predicate matched them. The
+/// [`root`](Self::root) points at the fragment statement in the *source* IL; lowering
+/// deep-copies that subtree into a synthetic wrapper.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FragmentContract {
     /// Which recognizer shape produced this contract.
@@ -33,12 +33,68 @@ pub struct FragmentContract {
     pub inputs: Vec<u32>,
     /// The control sink the fragment terminates in.
     pub exit: Exit,
+    /// The observable effect the fragment produces, for effect-bearing shapes. `None` for
+    /// pure value/control sinks (direct return/throw). See [`Effect`] for the algebra.
+    pub effect: Option<Effect>,
+    /// The proven write-target identity, for shapes that mutate heap/object state. See
+    /// [`Place`]; `None` for shapes with no heap write.
+    pub place: Option<Place>,
 }
 
 impl FragmentContract {
     /// The arity of the synthesized wrapper — one parameter per free input.
     pub fn arity(&self) -> usize {
         self.inputs.len()
+    }
+
+    /// A pure value/control-sink contract (direct return/throw): no effect, no write place.
+    pub fn value_sink(kind: FragmentKind, root: NodeId, inputs: Vec<u32>, exit: Exit) -> Self {
+        FragmentContract {
+            kind,
+            root,
+            inputs,
+            exit,
+            effect: None,
+            place: None,
+        }
+    }
+}
+
+/// The observable-effect algebra for effect-bearing fragments.
+///
+/// Issue #33 asked to "extend the effect algebra rather than treating every mutation as
+/// append-like". Each variant names how the effect is observed — which is exactly what
+/// determines its soundness obligations in the behavior oracle:
+///
+/// - [`Effect::Append`] and [`Effect::IndexWrite`] are recorded in the interpreter's
+///   *ordered effect trace*: the written key/value is observable, so two fragments that
+///   write different keys or values diverge in [`Behavior`](nose_normalize::Behavior)
+///   without needing receiver-identity proof.
+/// - [`Effect::FieldWrite`] is recorded in the interpreter's *field-state map*, keyed by
+///   field name only — the receiver identity is **not** observed. A field write is
+///   therefore exact-safe only when its [`Place`] receiver is proven (fail-closed); this is
+///   why only a fixed `this` receiver is admitted today.
+/// - [`Effect::Other`] is any other proven single effect (e.g. a generic effectful call
+///   statement) whose observability the oracle establishes by running it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Effect {
+    /// An ordered append/push to a collection (free monoid over appended values).
+    Append,
+    /// An index/key assignment `target[key] = value`; key and value are observable.
+    IndexWrite,
+    /// A field assignment `receiver.field = value`; final per-field state, receiver
+    /// identity unobserved — requires a proven [`Place`].
+    FieldWrite,
+    /// Any other single proven observable effect.
+    Other,
+}
+
+impl Effect {
+    /// Whether soundness for this effect requires the write target's [`Place`] to be a
+    /// proven (exact-safe) receiver. Only field writes do: the interpreter does not observe
+    /// the receiver of a field write, so an unproven receiver could falsely merge.
+    pub fn requires_proven_place(self) -> bool {
+        matches!(self, Effect::FieldWrite)
     }
 }
 

--- a/crates/nose-detect/src/fragment/oracle.rs
+++ b/crates/nose-detect/src/fragment/oracle.rs
@@ -13,19 +13,13 @@
 //! recognizer described a fragment the oracle cannot vouch for — fail closed.
 
 use super::contract::FragmentContract;
-use nose_il::{
-    FileMeta, Il, IlBuilder, NodeId, NodeKind, Payload, Span, Unit, UnitKind,
-};
+use nose_il::{FileMeta, Il, IlBuilder, NodeId, NodeKind, Payload, Span, Unit, UnitKind};
 use nose_normalize::{run_unit, Behavior, Value};
 
 /// Run the fragment described by `contract` on `args` (bound to its inputs in order) and
 /// return its observable [`Behavior`], or `None` if the wrapper cannot be synthesized or
 /// the interpreter cannot model the fragment.
-pub fn fragment_behavior(
-    il: &Il,
-    contract: &FragmentContract,
-    args: &[Value],
-) -> Option<Behavior> {
+pub fn fragment_behavior(il: &Il, contract: &FragmentContract, args: &[Value]) -> Option<Behavior> {
     let (synth, func) = synthesize_wrapper(il, contract)?;
     run_unit(&synth, func, args)
 }

--- a/crates/nose-detect/src/fragment/oracle.rs
+++ b/crates/nose-detect/src/fragment/oracle.rs
@@ -1,0 +1,213 @@
+//! The fragment behavior oracle: lower a [`FragmentContract`] into a runnable wrapper and
+//! run it through the existing unit interpreter.
+//!
+//! Issue #33 decision: fragments go through the *same* independent behavior check as
+//! whole functions, via **wrapper synthesis** rather than a new `run_fragment` interpreter
+//! path. A contract is lowered into a synthetic `Func` — its free inputs become parameters,
+//! its body is a deep copy of the fragment subtree — and handed to
+//! [`nose_normalize::run_unit`]. We reuse `run_unit`, its [`Behavior`] (return value +
+//! ordered effects + final field state), and the caller's input battery unchanged.
+//!
+//! The forcing function: a contract that cannot be lowered into a runnable wrapper is
+//! *underspecified*. [`synthesize_wrapper`] returning `None` is therefore a signal that the
+//! recognizer described a fragment the oracle cannot vouch for — fail closed.
+
+use super::contract::FragmentContract;
+use nose_il::{
+    FileMeta, Il, IlBuilder, NodeId, NodeKind, Payload, Span, Unit, UnitKind,
+};
+use nose_normalize::{run_unit, Behavior, Value};
+
+/// Run the fragment described by `contract` on `args` (bound to its inputs in order) and
+/// return its observable [`Behavior`], or `None` if the wrapper cannot be synthesized or
+/// the interpreter cannot model the fragment.
+pub fn fragment_behavior(
+    il: &Il,
+    contract: &FragmentContract,
+    args: &[Value],
+) -> Option<Behavior> {
+    let (synth, func) = synthesize_wrapper(il, contract)?;
+    run_unit(&synth, func, args)
+}
+
+/// Lower `contract` into a fresh single-`Func` [`Il`] and return that IL plus the func id.
+///
+/// Layout of the synthesized function: `Func[ Param(input₀) … Param(inputₙ) , Block[ <copy
+/// of fragment subtree> ] ]`. Parameters carry the fragment's free canonical ids so the
+/// deep-copied `Var` references resolve against them; the interpreter binds them
+/// positionally from `args`.
+pub fn synthesize_wrapper(il: &Il, contract: &FragmentContract) -> Option<(Il, NodeId)> {
+    let mut b = IlBuilder::new(il.file);
+    let syn = Span::synthetic(il.file);
+
+    // Parameters: one per free input, in the contract's canonical order.
+    let mut children: Vec<NodeId> = contract
+        .inputs
+        .iter()
+        .map(|&cid| b.add(NodeKind::Param, Payload::Cid(cid), syn, &[]))
+        .collect();
+
+    // Body: a deep copy of the fragment statement, wrapped in a Block.
+    let body_stmt = copy_subtree(il, contract.root, &mut b);
+    let body = b.add(NodeKind::Block, Payload::None, syn, &[body_stmt]);
+    children.push(body);
+
+    let func = b.add(NodeKind::Func, Payload::None, syn, &children);
+    let meta = FileMeta {
+        path: il.meta.path.clone(),
+        lang: il.meta.lang,
+    };
+    let units = vec![Unit {
+        root: func,
+        kind: UnitKind::Function,
+        name: None,
+    }];
+    let synth = b.finish(func, meta, units, Vec::new());
+    debug_assert!(
+        synth.validate().is_ok(),
+        "synthesized fragment wrapper must be a valid arena"
+    );
+    Some((synth, func))
+}
+
+/// Deep-copy the subtree rooted at `node` from `src` into `b`, preserving kind, payload,
+/// and span. Post-order: children are copied first so their fresh ids are known when the
+/// parent is added.
+fn copy_subtree(src: &Il, node: NodeId, b: &mut IlBuilder) -> NodeId {
+    let kids: Vec<NodeId> = src
+        .children(node)
+        .to_vec()
+        .iter()
+        .map(|&c| copy_subtree(src, c, b))
+        .collect();
+    let n = src.node(node);
+    b.add(n.kind, n.payload, n.span, &kids)
+}
+
+/// Collect the free canonical ids read in the subtree rooted at `node`, in ascending
+/// (canonical) order. Only `Var` references count; this is correct for fragment shapes
+/// with no internal bindings (e.g. a direct `return <expr>`). Shapes that introduce locals
+/// (loop variables, temps) need binding-aware input inference, added when they migrate.
+pub fn free_input_cids(il: &Il, node: NodeId) -> Vec<u32> {
+    let mut out = Vec::new();
+    collect_var_cids(il, node, &mut out);
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+fn collect_var_cids(il: &Il, node: NodeId, out: &mut Vec<u32>) {
+    if il.kind(node) == NodeKind::Var {
+        if let Payload::Cid(c) = il.node(node).payload {
+            out.push(c);
+        }
+    }
+    for &k in il.children(node) {
+        collect_var_cids(il, k, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fragment::{Exit, FragmentKind};
+    use nose_il::{FileId, Interner, Lang};
+    use nose_normalize::{normalize, NormalizeOptions};
+
+    /// Lower + normalize `src`, returning the normalized IL.
+    fn norm(interner: &Interner, src: &str, lang: Lang) -> Il {
+        let il = nose_frontend::lower_source(FileId(0), "t", src.as_bytes(), lang, interner)
+            .expect("lowering should succeed");
+        normalize(&il, interner, &NormalizeOptions::default())
+    }
+
+    /// Find the first `Return` node with one computed (non-var/lit) child — a direct-return
+    /// fragment root.
+    fn first_direct_return(il: &Il, node: NodeId) -> Option<NodeId> {
+        if il.kind(node) == NodeKind::Return {
+            let kids = il.children(node);
+            if kids.len() == 1 && !matches!(il.kind(kids[0]), NodeKind::Var | NodeKind::Lit) {
+                return Some(node);
+            }
+        }
+        for &c in il.children(node) {
+            if let Some(found) = first_direct_return(il, c) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    fn direct_return_contract(il: &Il, root: NodeId) -> FragmentContract {
+        FragmentContract {
+            kind: FragmentKind::DirectReturn,
+            root,
+            inputs: free_input_cids(il, root),
+            exit: Exit::Return,
+        }
+    }
+
+    /// A small single-argument battery — enough to separate the spike's fragments.
+    fn battery_1() -> Vec<Vec<Value>> {
+        [-2i64, -1, 0, 1, 2, 3, 5]
+            .into_iter()
+            .map(|n| vec![Value::Int(n)])
+            .collect()
+    }
+
+    fn behavior_vector(il: &Il, c: &FragmentContract, battery: &[Vec<Value>]) -> Vec<Behavior> {
+        battery
+            .iter()
+            .map(|row| {
+                fragment_behavior(il, c, row).expect("direct-return fragment must be interpretable")
+            })
+            .collect()
+    }
+
+    #[test]
+    fn wrapper_synthesis_runs_a_direct_return_fragment() {
+        let i = Interner::new();
+        let il = norm(&i, "function f(a){ return a*a + 1; }", Lang::JavaScript);
+        let root = first_direct_return(&il, il.root).expect("a direct-return fragment");
+        let contract = direct_return_contract(&il, root);
+        assert_eq!(contract.arity(), 1, "one free input (the parameter)");
+
+        let (synth, func) = synthesize_wrapper(&il, &contract).expect("wrapper synthesizes");
+        assert_eq!(synth.kind(func), NodeKind::Func);
+        let b = run_unit(&synth, func, &[Value::Int(4)]).expect("interpretable");
+        assert_eq!(b.ret, Value::Int(17), "4*4 + 1 = 17");
+    }
+
+    #[test]
+    fn equivalent_fragments_agree_on_the_battery() {
+        let i = Interner::new();
+        // Same spec, different surface: squared-plus-one.
+        let f = norm(&i, "function f(a){ return a*a + 1; }", Lang::JavaScript);
+        let g = norm(&i, "function g(b){ return 1 + b*b; }", Lang::JavaScript);
+        let cf = direct_return_contract(&f, first_direct_return(&f, f.root).unwrap());
+        let cg = direct_return_contract(&g, first_direct_return(&g, g.root).unwrap());
+
+        let battery = battery_1();
+        assert_eq!(
+            behavior_vector(&f, &cf, &battery),
+            behavior_vector(&g, &cg, &battery),
+            "equivalent direct-return fragments must agree on every battery input"
+        );
+    }
+
+    #[test]
+    fn distinct_fragments_diverge_on_the_battery() {
+        let i = Interner::new();
+        let f = norm(&i, "function f(a){ return a*a + 1; }", Lang::JavaScript);
+        let h = norm(&i, "function h(a){ return a*a - 1; }", Lang::JavaScript);
+        let cf = direct_return_contract(&f, first_direct_return(&f, f.root).unwrap());
+        let ch = direct_return_contract(&h, first_direct_return(&h, h.root).unwrap());
+
+        let battery = battery_1();
+        assert_ne!(
+            behavior_vector(&f, &cf, &battery),
+            behavior_vector(&h, &ch, &battery),
+            "behaviorally distinct fragments must diverge on the battery"
+        );
+    }
+}

--- a/crates/nose-detect/src/fragment/oracle.rs
+++ b/crates/nose-detect/src/fragment/oracle.rs
@@ -139,12 +139,12 @@ mod tests {
     }
 
     fn direct_return_contract(il: &Il, root: NodeId) -> FragmentContract {
-        FragmentContract {
-            kind: FragmentKind::DirectReturn,
+        FragmentContract::value_sink(
+            FragmentKind::DirectReturn,
             root,
-            inputs: free_input_cids(il, root),
-            exit: Exit::Return,
-        }
+            free_input_cids(il, root),
+            Exit::Return,
+        )
     }
 
     /// A small single-argument battery — enough to separate the spike's fragments.

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -13,11 +13,11 @@
 //! changes which nodes are accepted fails this test. As [`MIGRATED`] grows, the gate keeps
 //! the two paths in lockstep until every shape is contract-expressed.
 
-use super::contract::FragmentContract;
+use super::contract::{Effect, FragmentContract};
 use super::oracle::free_input_cids;
-use super::{Exit, FragmentKind};
-use crate::units::exact_java_this_field;
-use nose_il::{Il, Interner, Lang, NodeId, NodeKind};
+use super::{Exit, FragmentKind, Place};
+use crate::units::{exact_java_this_field, exact_java_this_var};
+use nose_il::{stable_symbol_hash, Builtin, Il, Interner, Lang, NodeId, NodeKind, Payload};
 
 /// Fragment kinds that have been migrated onto the contract path. The differential gate
 /// compares the predicate and contract paths over exactly this set; everything outside it
@@ -51,15 +51,32 @@ pub(crate) fn recognize_contract(
         kids.len() == 1 && !matches!(il.kind(kids[0]), NodeKind::Var | NodeKind::Lit)
     };
     match il.kind(node) {
-        NodeKind::Return if computed_unary() => {
-            Some(contract(FragmentKind::DirectReturn, Exit::Return, il, node))
-        }
-        NodeKind::Throw if computed_unary() => {
-            Some(contract(FragmentKind::DirectThrow, Exit::Throw, il, node))
-        }
+        NodeKind::Return if computed_unary() => Some(FragmentContract::value_sink(
+            FragmentKind::DirectReturn,
+            node,
+            free_input_cids(il, node),
+            Exit::Return,
+        )),
+        NodeKind::Throw if computed_unary() => Some(FragmentContract::value_sink(
+            FragmentKind::DirectThrow,
+            node,
+            free_input_cids(il, node),
+            Exit::Throw,
+        )),
         NodeKind::Assign => recognize_assignment_effect(il, interner, node),
         NodeKind::ExprStmt if expr_effect_shape(il, kids) => {
-            Some(contract(FragmentKind::ExprEffect, Exit::Normal, il, node))
+            let effect = if is_append_call(il, kids[0]) {
+                Effect::Append
+            } else {
+                Effect::Other
+            };
+            Some(effect_contract(
+                FragmentKind::ExprEffect,
+                il,
+                node,
+                effect,
+                None,
+            ))
         }
         _ => None,
     }
@@ -76,13 +93,34 @@ fn recognize_assignment_effect(
     if kids.len() != 2 {
         return None;
     }
-    if matches!(il.meta.lang, Lang::C | Lang::Go | Lang::Java)
-        && il.kind(kids[0]) == NodeKind::Index
+    let target = kids[0];
+    if matches!(il.meta.lang, Lang::C | Lang::Go | Lang::Java) && il.kind(target) == NodeKind::Index
     {
-        return Some(contract(FragmentKind::IndexAssignEffect, Exit::Normal, il, node));
+        let place = resolve_place(il, interner, target);
+        return Some(effect_contract(
+            FragmentKind::IndexAssignEffect,
+            il,
+            node,
+            Effect::IndexWrite,
+            Some(place),
+        ));
     }
-    if il.meta.lang == Lang::Java && exact_java_this_field(il, interner, kids[0]) {
-        return Some(contract(FragmentKind::SelfFieldAssign, Exit::Normal, il, node));
+    if il.meta.lang == Lang::Java && exact_java_this_field(il, interner, target) {
+        let place = resolve_place(il, interner, target);
+        // Field writes do not observe their receiver in the oracle (the field-state map is
+        // keyed by name only), so the write is exact-safe only with a proven receiver. The
+        // `this.field` recognizer guarantees this; assert the invariant fail-closed.
+        debug_assert!(
+            place.is_exact_safe(),
+            "self-field write must resolve to a proven place, got {place:?}"
+        );
+        return Some(effect_contract(
+            FragmentKind::SelfFieldAssign,
+            il,
+            node,
+            Effect::FieldWrite,
+            Some(place),
+        ));
     }
     None
 }
@@ -102,21 +140,83 @@ fn expr_effect_shape(il: &Il, kids: &[NodeId]) -> bool {
         )
 }
 
-fn contract(kind: FragmentKind, exit: Exit, il: &Il, node: NodeId) -> FragmentContract {
+fn is_append_call(il: &Il, node: NodeId) -> bool {
+    il.kind(node) == NodeKind::Call
+        && matches!(il.node(node).payload, Payload::Builtin(Builtin::Append))
+}
+
+fn effect_contract(
+    kind: FragmentKind,
+    il: &Il,
+    node: NodeId,
+    effect: Effect,
+    place: Option<Place>,
+) -> FragmentContract {
     FragmentContract {
         kind,
         root: node,
         inputs: free_input_cids(il, node),
-        exit,
+        exit: Exit::Normal,
+        effect: Some(effect),
+        place,
+    }
+}
+
+/// Resolve a write target's [`Place`] receiver identity, fail-closed to [`Place::Unknown`].
+///
+/// - `this` (Java) → [`Place::This`]
+/// - a free variable → [`Place::Param`] (its canonical id)
+/// - `base.field` → [`Place::Field`] over the resolved base, keyed by field-name hash
+/// - `base[key]` → [`Place::Index`] over the resolved base, keyed by a coarse key hash
+/// - anything else (a call result, an unresolved receiver) → [`Place::Unknown`]
+fn resolve_place(il: &Il, interner: &Interner, node: NodeId) -> Place {
+    match il.kind(node) {
+        NodeKind::Var if exact_java_this_var(il, interner, node) => Place::This,
+        NodeKind::Var => match il.node(node).payload {
+            Payload::Cid(c) => Place::Param(c),
+            _ => Place::Unknown,
+        },
+        NodeKind::Field => {
+            let base = il.children(node).first().copied();
+            let receiver = base.map_or(Place::Unknown, |b| resolve_place(il, interner, b));
+            match il.node(node).payload {
+                Payload::Name(sym) => {
+                    Place::Field(Box::new(receiver), stable_symbol_hash(interner.resolve(sym)))
+                }
+                _ => Place::Unknown,
+            }
+        }
+        NodeKind::Index => {
+            let kids = il.children(node);
+            let receiver = kids
+                .first()
+                .map_or(Place::Unknown, |&b| resolve_place(il, interner, b));
+            let key = kids.get(1).map_or(0, |&k| place_key_hash(il, interner, k));
+            Place::Index(Box::new(receiver), key)
+        }
+        _ => Place::Unknown,
+    }
+}
+
+/// A coarse, stable identity for an index/key expression — enough to distinguish constant
+/// keys and variable keys in a [`Place`], without modeling arbitrary key expressions.
+fn place_key_hash(il: &Il, interner: &Interner, node: NodeId) -> u64 {
+    match il.node(node).payload {
+        Payload::Cid(c) => 0x01_0000_0000 | u64::from(c),
+        Payload::Name(sym) => stable_symbol_hash(interner.resolve(sym)),
+        Payload::LitInt(v) => 0x02_0000_0000 ^ (v as u64),
+        Payload::LitStr(h) | Payload::LitFloat(h) => h,
+        _ => u64::from(il.kind(node) as u8),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fragment::{fragment_behavior, Place};
     use crate::units::{build_parent_index, exact_statement_fragment_root};
     use nose_il::{FileId, Lang, Span};
-    use nose_normalize::{normalize, NormalizeOptions};
+    use nose_normalize::{normalize, NormalizeOptions, Value};
 
     /// Walk `il` exactly as the real fragment collector does (skipping `Lambda` subtrees),
     /// applying `classify` to each node and collecting the accepted `(span, kind)` pairs.
@@ -233,5 +333,99 @@ mod tests {
             "def k(xs):\n    out = []\n    for x in xs:\n        out.append(x + 1)\n    return out\n",
             Lang::Python,
         );
+    }
+
+    /// Lower + normalize `src`, returning the IL and its parent index.
+    fn norm(src: &str, lang: Lang) -> (Il, Vec<Option<NodeId>>, Interner) {
+        let interner = Interner::new();
+        let raw = nose_frontend::lower_source(FileId(0), "t", src.as_bytes(), lang, &interner)
+            .expect("lowering should succeed");
+        let il = normalize(&raw, &interner, &NormalizeOptions::default());
+        let parents = build_parent_index(&il);
+        (il, parents, interner)
+    }
+
+    /// The first contract the contract path produces for `src`, walking pre-order.
+    fn first_contract(il: &Il, parents: &[Option<NodeId>], interner: &Interner) -> FragmentContract {
+        fn walk(
+            il: &Il,
+            node: NodeId,
+            parents: &[Option<NodeId>],
+            interner: &Interner,
+        ) -> Option<FragmentContract> {
+            if il.kind(node) == NodeKind::Lambda {
+                return None;
+            }
+            if let Some(c) = recognize_contract(il, node, parents, interner) {
+                return Some(c);
+            }
+            il.children(node)
+                .iter()
+                .find_map(|&c| walk(il, c, parents, interner))
+        }
+        walk(il, il.root, parents, interner).expect("a contract for the migrated shape")
+    }
+
+    #[test]
+    fn resolves_place_and_effect_for_write_shapes() {
+        // Java `this.x = …` → FieldWrite over a proven This.field place (fail-closed safe).
+        let (il, parents, interner) = norm("class C { int x; void s(int v){ this.x = v + 1; } }", Lang::Java);
+        let c = first_contract(&il, &parents, &interner);
+        assert_eq!(c.kind, FragmentKind::SelfFieldAssign);
+        assert_eq!(c.effect, Some(Effect::FieldWrite));
+        assert!(matches!(c.place, Some(Place::Field(ref base, _)) if **base == Place::This));
+        assert!(c.place.as_ref().unwrap().is_exact_safe());
+        assert!(c.effect.unwrap().requires_proven_place());
+
+        // Java `a[i] = v` → IndexWrite over an index place. The base here is an instance
+        // field accessed bare, so it resolves to a fail-closed `Unknown` receiver — yet the
+        // write stays exact-safe because an index write is observable in the effect trace
+        // and so does not require a proven receiver.
+        let (il, parents, interner) =
+            norm("class C { int[] a; void f(int i, int v){ a[i] = v; } }", Lang::Java);
+        let c = first_contract(&il, &parents, &interner);
+        assert_eq!(c.kind, FragmentKind::IndexAssignEffect);
+        assert_eq!(c.effect, Some(Effect::IndexWrite));
+        assert!(matches!(c.place, Some(Place::Index(_, _))));
+        assert!(!c.effect.unwrap().requires_proven_place());
+
+        // JS `xs.push(v)` → Append effect, no heap place.
+        let (il, parents, interner) = norm("function f(xs, v){ xs.push(v + 1); }", Lang::JavaScript);
+        let c = first_contract(&il, &parents, &interner);
+        assert_eq!(c.kind, FragmentKind::ExprEffect);
+        assert_eq!(c.effect, Some(Effect::Append));
+        assert_eq!(c.place, None);
+    }
+
+    #[test]
+    fn effect_as_output_preserved_through_wrapper() {
+        // An append effect must survive wrapper synthesis as observable behavior: appending
+        // to a parameter list is a caller-visible mutation, recorded in the effect trace.
+        let battery = [vec![Value::List(vec![])], vec![Value::List(vec![Value::Int(9)])]];
+
+        let run = |src: &str| -> Vec<nose_normalize::Behavior> {
+            let (il, parents, interner) = norm(src, Lang::JavaScript);
+            let c = first_contract(&il, &parents, &interner);
+            assert_eq!(c.effect, Some(Effect::Append));
+            battery
+                .iter()
+                .map(|row| {
+                    fragment_behavior(&il, &c, row).expect("append fragment is interpretable")
+                })
+                .collect()
+        };
+
+        let f = run("function f(xs){ xs.push(1); }");
+        let g = run("function g(ys){ ys.push(1); }");
+        let h = run("function h(zs){ zs.push(2); }");
+
+        // The effect is actually observed (not silently dropped).
+        assert!(
+            f.iter().all(|b| !b.effects.is_empty()),
+            "append must surface as a non-empty effect trace"
+        );
+        // Equivalent effect fragments agree; a different appended value diverges.
+        assert_eq!(f, g, "identical append effects must agree on the battery");
+        assert_ne!(f, h, "appending a different value must diverge in observable behavior");
     }
 }

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -47,9 +47,8 @@ pub(crate) fn recognize_contract(
         return None;
     }
     let kids = il.children(node);
-    let computed_unary = || {
-        kids.len() == 1 && !matches!(il.kind(kids[0]), NodeKind::Var | NodeKind::Lit)
-    };
+    let computed_unary =
+        || kids.len() == 1 && !matches!(il.kind(kids[0]), NodeKind::Var | NodeKind::Lit);
     match il.kind(node) {
         NodeKind::Return if computed_unary() => Some(FragmentContract::value_sink(
             FragmentKind::DirectReturn,
@@ -180,9 +179,10 @@ fn resolve_place(il: &Il, interner: &Interner, node: NodeId) -> Place {
             let base = il.children(node).first().copied();
             let receiver = base.map_or(Place::Unknown, |b| resolve_place(il, interner, b));
             match il.node(node).payload {
-                Payload::Name(sym) => {
-                    Place::Field(Box::new(receiver), stable_symbol_hash(interner.resolve(sym)))
-                }
+                Payload::Name(sym) => Place::Field(
+                    Box::new(receiver),
+                    stable_symbol_hash(interner.resolve(sym)),
+                ),
                 _ => Place::Unknown,
             }
         }
@@ -257,11 +257,12 @@ mod tests {
         let il = normalize(&raw, &interner, &NormalizeOptions::default());
         let parents = build_parent_index(&il);
 
-        let mut predicate: Vec<(Span, FragmentKind)> =
-            index(&il, &|node| exact_statement_fragment_root(&il, node, &parents, &interner))
-                .into_iter()
-                .filter(|(_, kind)| MIGRATED.contains(kind))
-                .collect();
+        let mut predicate: Vec<(Span, FragmentKind)> = index(&il, &|node| {
+            exact_statement_fragment_root(&il, node, &parents, &interner)
+        })
+        .into_iter()
+        .filter(|(_, kind)| MIGRATED.contains(kind))
+        .collect();
         let mut contract: Vec<(Span, FragmentKind)> = index(&il, &|node| {
             recognize_contract(&il, node, &parents, &interner).map(|c| c.kind)
         });
@@ -279,10 +280,7 @@ mod tests {
         // Accepted: top-level computed return / throw.
         assert_paths_agree("function g(b){ return b*b + 1; }", Lang::JavaScript);
         assert_paths_agree("function f(a){ throw a + 1; }", Lang::JavaScript);
-        assert_paths_agree(
-            "def h(a, c):\n    return a * a + c\n",
-            Lang::Python,
-        );
+        assert_paths_agree("def h(a, c):\n    return a * a + c\n", Lang::Python);
     }
 
     #[test]
@@ -293,7 +291,10 @@ mod tests {
         assert_paths_agree("function f(a){ return 1; }", Lang::JavaScript);
         // A preceding reassignment of the returned input invalidates context safety;
         // both paths must reject the return.
-        assert_paths_agree("function f(a){ a = a + 1; return a * a; }", Lang::JavaScript);
+        assert_paths_agree(
+            "function f(a){ a = a + 1; return a * a; }",
+            Lang::JavaScript,
+        );
     }
 
     #[test]
@@ -313,10 +314,7 @@ mod tests {
             Lang::Java,
         );
         // Expression-statement effect: an append/push call.
-        assert_paths_agree(
-            "function f(xs, v){ xs.push(v + 1); }",
-            Lang::JavaScript,
-        );
+        assert_paths_agree("function f(xs, v){ xs.push(v + 1); }", Lang::JavaScript);
         assert_paths_agree("def f(xs, v):\n    xs.append(v + 1)\n", Lang::Python);
     }
 
@@ -346,7 +344,11 @@ mod tests {
     }
 
     /// The first contract the contract path produces for `src`, walking pre-order.
-    fn first_contract(il: &Il, parents: &[Option<NodeId>], interner: &Interner) -> FragmentContract {
+    fn first_contract(
+        il: &Il,
+        parents: &[Option<NodeId>],
+        interner: &Interner,
+    ) -> FragmentContract {
         fn walk(
             il: &Il,
             node: NodeId,
@@ -369,7 +371,10 @@ mod tests {
     #[test]
     fn resolves_place_and_effect_for_write_shapes() {
         // Java `this.x = …` → FieldWrite over a proven This.field place (fail-closed safe).
-        let (il, parents, interner) = norm("class C { int x; void s(int v){ this.x = v + 1; } }", Lang::Java);
+        let (il, parents, interner) = norm(
+            "class C { int x; void s(int v){ this.x = v + 1; } }",
+            Lang::Java,
+        );
         let c = first_contract(&il, &parents, &interner);
         assert_eq!(c.kind, FragmentKind::SelfFieldAssign);
         assert_eq!(c.effect, Some(Effect::FieldWrite));
@@ -381,8 +386,10 @@ mod tests {
         // field accessed bare, so it resolves to a fail-closed `Unknown` receiver — yet the
         // write stays exact-safe because an index write is observable in the effect trace
         // and so does not require a proven receiver.
-        let (il, parents, interner) =
-            norm("class C { int[] a; void f(int i, int v){ a[i] = v; } }", Lang::Java);
+        let (il, parents, interner) = norm(
+            "class C { int[] a; void f(int i, int v){ a[i] = v; } }",
+            Lang::Java,
+        );
         let c = first_contract(&il, &parents, &interner);
         assert_eq!(c.kind, FragmentKind::IndexAssignEffect);
         assert_eq!(c.effect, Some(Effect::IndexWrite));
@@ -390,7 +397,8 @@ mod tests {
         assert!(!c.effect.unwrap().requires_proven_place());
 
         // JS `xs.push(v)` → Append effect, no heap place.
-        let (il, parents, interner) = norm("function f(xs, v){ xs.push(v + 1); }", Lang::JavaScript);
+        let (il, parents, interner) =
+            norm("function f(xs, v){ xs.push(v + 1); }", Lang::JavaScript);
         let c = first_contract(&il, &parents, &interner);
         assert_eq!(c.kind, FragmentKind::ExprEffect);
         assert_eq!(c.effect, Some(Effect::Append));
@@ -401,7 +409,10 @@ mod tests {
     fn effect_as_output_preserved_through_wrapper() {
         // An append effect must survive wrapper synthesis as observable behavior: appending
         // to a parameter list is a caller-visible mutation, recorded in the effect trace.
-        let battery = [vec![Value::List(vec![])], vec![Value::List(vec![Value::Int(9)])]];
+        let battery = [
+            vec![Value::List(vec![])],
+            vec![Value::List(vec![Value::Int(9)])],
+        ];
 
         let run = |src: &str| -> Vec<nose_normalize::Behavior> {
             let (il, parents, interner) = norm(src, Lang::JavaScript);
@@ -426,6 +437,9 @@ mod tests {
         );
         // Equivalent effect fragments agree; a different appended value diverges.
         assert_eq!(f, g, "identical append effects must agree on the battery");
-        assert_ne!(f, h, "appending a different value must diverge in observable behavior");
+        assert_ne!(
+            f, h,
+            "appending a different value must diverge in observable behavior"
+        );
     }
 }

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -1,0 +1,165 @@
+//! The contract-path recognizer and its differential gate against the shape predicates.
+//!
+//! Issue #33 steps 4–5. As each fragment family migrates off the standalone shape
+//! predicates in [`crate::units`], its recognition is re-expressed here as the
+//! construction of a [`FragmentContract`]. [`recognize_contract`] is an *independent*
+//! recognizer for the migrated shapes: it matches structure directly and builds a contract,
+//! reusing only the shared invalidation-boundary gates (span containment + context safety),
+//! which are substrate, not per-shape predicates.
+//!
+//! The differential test below is the acceptance gate the maintainer required: over a
+//! representative corpus, the set of `(span, kind)` the predicate path accepts (restricted
+//! to migrated kinds) must equal the set the contract path produces. A migration step that
+//! changes which nodes are accepted fails this test. As [`MIGRATED`] grows, the gate keeps
+//! the two paths in lockstep until every shape is contract-expressed.
+
+use super::contract::FragmentContract;
+use super::oracle::free_input_cids;
+use super::{Exit, FragmentKind};
+use nose_il::{Il, Interner, NodeId, NodeKind};
+
+/// Fragment kinds that have been migrated onto the contract path. The differential gate
+/// compares the predicate and contract paths over exactly this set; everything outside it
+/// is still owned solely by the [`crate::units`] predicates.
+pub(crate) const MIGRATED: &[FragmentKind] = &[FragmentKind::DirectReturn, FragmentKind::DirectThrow];
+
+/// Recognize `node` as a migrated exact-fragment shape by building its contract directly,
+/// independently of [`crate::units::exact_statement_fragment_root`]. Returns `None` for
+/// non-fragments and for shapes not yet migrated.
+pub(crate) fn recognize_contract(
+    il: &Il,
+    node: NodeId,
+    parents: &[Option<NodeId>],
+    interner: &Interner,
+) -> Option<FragmentContract> {
+    // Shared substrate gates — the invalidation-boundary model, reused (not duplicated).
+    if !crate::units::subtree_spans_within(il, node, il.node(node).span) {
+        return None;
+    }
+    if !crate::units::top_level_statement_fragment_context_safe(il, node, parents, interner) {
+        return None;
+    }
+    let kids = il.children(node);
+    let computed_unary = || {
+        kids.len() == 1 && !matches!(il.kind(kids[0]), NodeKind::Var | NodeKind::Lit)
+    };
+    match il.kind(node) {
+        NodeKind::Return if computed_unary() => {
+            Some(contract(FragmentKind::DirectReturn, Exit::Return, il, node))
+        }
+        NodeKind::Throw if computed_unary() => {
+            Some(contract(FragmentKind::DirectThrow, Exit::Throw, il, node))
+        }
+        _ => None,
+    }
+}
+
+fn contract(kind: FragmentKind, exit: Exit, il: &Il, node: NodeId) -> FragmentContract {
+    FragmentContract {
+        kind,
+        root: node,
+        inputs: free_input_cids(il, node),
+        exit,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::units::{build_parent_index, exact_statement_fragment_root};
+    use nose_il::{FileId, Lang, Span};
+    use nose_normalize::{normalize, NormalizeOptions};
+
+    /// Walk `il` exactly as the real fragment collector does (skipping `Lambda` subtrees),
+    /// applying `classify` to each node and collecting the accepted `(span, kind)` pairs.
+    fn index<F>(il: &Il, classify: &F) -> Vec<(Span, FragmentKind)>
+    where
+        F: Fn(NodeId) -> Option<FragmentKind>,
+    {
+        fn walk<F: Fn(NodeId) -> Option<FragmentKind>>(
+            il: &Il,
+            node: NodeId,
+            classify: &F,
+            out: &mut Vec<(Span, FragmentKind)>,
+        ) {
+            if il.kind(node) == NodeKind::Lambda {
+                return;
+            }
+            if let Some(kind) = classify(node) {
+                out.push((il.node(node).span, kind));
+            }
+            for &c in il.children(node) {
+                walk(il, c, classify, out);
+            }
+        }
+        let mut out = Vec::new();
+        walk(il, il.root, classify, &mut out);
+        out
+    }
+
+    fn sort_key(entry: &(Span, FragmentKind)) -> (u32, u32, &'static str) {
+        (entry.0.start_byte, entry.0.end_byte, entry.1.reason_code())
+    }
+
+    /// The two paths must agree on the migrated kinds for `src`.
+    fn assert_paths_agree(src: &str, lang: Lang) {
+        let interner = Interner::new();
+        let raw = nose_frontend::lower_source(FileId(0), "t", src.as_bytes(), lang, &interner)
+            .expect("lowering should succeed");
+        let il = normalize(&raw, &interner, &NormalizeOptions::default());
+        let parents = build_parent_index(&il);
+
+        let mut predicate: Vec<(Span, FragmentKind)> =
+            index(&il, &|node| exact_statement_fragment_root(&il, node, &parents, &interner))
+                .into_iter()
+                .filter(|(_, kind)| MIGRATED.contains(kind))
+                .collect();
+        let mut contract: Vec<(Span, FragmentKind)> = index(&il, &|node| {
+            recognize_contract(&il, node, &parents, &interner).map(|c| c.kind)
+        });
+
+        predicate.sort_by_key(sort_key);
+        contract.sort_by_key(sort_key);
+        assert_eq!(
+            predicate, contract,
+            "predicate and contract paths disagree on migrated fragments in `{src}`"
+        );
+    }
+
+    #[test]
+    fn differential_direct_return_and_throw() {
+        // Accepted: top-level computed return / throw.
+        assert_paths_agree("function g(b){ return b*b + 1; }", Lang::JavaScript);
+        assert_paths_agree("function f(a){ throw a + 1; }", Lang::JavaScript);
+        assert_paths_agree(
+            "def h(a, c):\n    return a * a + c\n",
+            Lang::Python,
+        );
+    }
+
+    #[test]
+    fn differential_rejects_match_for_non_fragments() {
+        // `return x` (bare var) and `return 1` (bare lit) are not computed returns;
+        // both paths must reject — yielding empty, equal sets.
+        assert_paths_agree("function f(a){ return a; }", Lang::JavaScript);
+        assert_paths_agree("function f(a){ return 1; }", Lang::JavaScript);
+        // A preceding reassignment of the returned input invalidates context safety;
+        // both paths must reject the return.
+        assert_paths_agree("function f(a){ a = a + 1; return a * a; }", Lang::JavaScript);
+    }
+
+    #[test]
+    fn differential_ignores_non_migrated_shapes() {
+        // Loop/append and conditional effect shapes are accepted by the predicate path
+        // under OTHER kinds and must be excluded from the contract path — the migrated
+        // intersection stays empty and equal.
+        assert_paths_agree(
+            "function h(xs){ const out=[]; for(const x of xs){ out.push(x*2); } return out; }",
+            Lang::JavaScript,
+        );
+        assert_paths_agree(
+            "def k(xs):\n    out = []\n    for x in xs:\n        out.append(x + 1)\n    return out\n",
+            Lang::Python,
+        );
+    }
+}

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -16,12 +16,19 @@
 use super::contract::FragmentContract;
 use super::oracle::free_input_cids;
 use super::{Exit, FragmentKind};
-use nose_il::{Il, Interner, NodeId, NodeKind};
+use crate::units::exact_java_this_field;
+use nose_il::{Il, Interner, Lang, NodeId, NodeKind};
 
 /// Fragment kinds that have been migrated onto the contract path. The differential gate
 /// compares the predicate and contract paths over exactly this set; everything outside it
 /// is still owned solely by the [`crate::units`] predicates.
-pub(crate) const MIGRATED: &[FragmentKind] = &[FragmentKind::DirectReturn, FragmentKind::DirectThrow];
+pub(crate) const MIGRATED: &[FragmentKind] = &[
+    FragmentKind::DirectReturn,
+    FragmentKind::DirectThrow,
+    FragmentKind::IndexAssignEffect,
+    FragmentKind::SelfFieldAssign,
+    FragmentKind::ExprEffect,
+];
 
 /// Recognize `node` as a migrated exact-fragment shape by building its contract directly,
 /// independently of [`crate::units::exact_statement_fragment_root`]. Returns `None` for
@@ -50,8 +57,49 @@ pub(crate) fn recognize_contract(
         NodeKind::Throw if computed_unary() => {
             Some(contract(FragmentKind::DirectThrow, Exit::Throw, il, node))
         }
+        NodeKind::Assign => recognize_assignment_effect(il, interner, node),
+        NodeKind::ExprStmt if expr_effect_shape(il, kids) => {
+            Some(contract(FragmentKind::ExprEffect, Exit::Normal, il, node))
+        }
         _ => None,
     }
+}
+
+/// Classify an assignment-effect fragment: a non-overloadable index write (C/Go/Java) or a
+/// Java fixed-receiver `this.field` write. The two shapes are structurally disjoint.
+fn recognize_assignment_effect(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<FragmentContract> {
+    let kids = il.children(node);
+    if kids.len() != 2 {
+        return None;
+    }
+    if matches!(il.meta.lang, Lang::C | Lang::Go | Lang::Java)
+        && il.kind(kids[0]) == NodeKind::Index
+    {
+        return Some(contract(FragmentKind::IndexAssignEffect, Exit::Normal, il, node));
+    }
+    if il.meta.lang == Lang::Java && exact_java_this_field(il, interner, kids[0]) {
+        return Some(contract(FragmentKind::SelfFieldAssign, Exit::Normal, il, node));
+    }
+    None
+}
+
+/// An expression statement evaluated for its side effect: a single child that is not a
+/// control sink, bare variable, or bare literal (those carry no observable effect).
+fn expr_effect_shape(il: &Il, kids: &[NodeId]) -> bool {
+    kids.len() == 1
+        && !matches!(
+            il.kind(kids[0]),
+            NodeKind::Return
+                | NodeKind::Throw
+                | NodeKind::Break
+                | NodeKind::Continue
+                | NodeKind::Var
+                | NodeKind::Lit
+        )
 }
 
 fn contract(kind: FragmentKind, exit: Exit, il: &Il, node: NodeId) -> FragmentContract {
@@ -146,6 +194,30 @@ mod tests {
         // A preceding reassignment of the returned input invalidates context safety;
         // both paths must reject the return.
         assert_paths_agree("function f(a){ a = a + 1; return a * a; }", Lang::JavaScript);
+    }
+
+    #[test]
+    fn differential_index_self_field_and_expr_effects() {
+        // Index-assignment effect (Go): a top-level `m[k] = v`.
+        assert_paths_agree(
+            "package p\nfunc f(m map[string]int, k string, v int) {\n\tm[k] = v\n}\n",
+            Lang::Go,
+        );
+        // Java index-assignment and `this.field` write.
+        assert_paths_agree(
+            "class C { int[] a; void f(int i, int v){ a[i] = v; } }",
+            Lang::Java,
+        );
+        assert_paths_agree(
+            "class C { int x; void set(int v){ this.x = v + 1; } }",
+            Lang::Java,
+        );
+        // Expression-statement effect: an append/push call.
+        assert_paths_agree(
+            "function f(xs, v){ xs.push(v + 1); }",
+            Lang::JavaScript,
+        );
+        assert_paths_agree("def f(xs, v):\n    xs.append(v + 1)\n", Lang::Python);
     }
 
     #[test]

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -31,7 +31,7 @@ pub(crate) const MIGRATED: &[FragmentKind] = &[
 ];
 
 /// Recognize `node` as a migrated exact-fragment shape by building its contract directly,
-/// independently of [`crate::units::exact_statement_fragment_root`]. Returns `None` for
+/// independently of `units::exact_statement_fragment_root`. Returns `None` for
 /// non-fragments and for shapes not yet migrated.
 pub(crate) fn recognize_contract(
     il: &Il,

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -16,7 +16,10 @@ mod report;
 mod units;
 
 pub use contiguous::Stream;
-pub use fragment::{Exit, FragmentKind, ProofFacts};
+pub use fragment::{
+    fragment_behavior, free_input_cids, synthesize_wrapper, Exit, FragmentContract, FragmentKind,
+    Place, ProofFacts,
+};
 pub use report::{rank_families, RefactorFamily};
 pub use units::UnitFeat;
 

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -9,12 +9,14 @@
 mod align;
 mod cluster;
 mod contiguous;
+mod fragment;
 mod lsh;
 mod minhash;
 mod report;
 mod units;
 
 pub use contiguous::Stream;
+pub use fragment::{Exit, FragmentKind, ProofFacts};
 pub use report::{rank_families, RefactorFamily};
 pub use units::UnitFeat;
 

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -17,8 +17,8 @@ mod units;
 
 pub use contiguous::Stream;
 pub use fragment::{
-    fragment_behavior, free_input_cids, synthesize_wrapper, Exit, FragmentContract, FragmentKind,
-    Place, ProofFacts,
+    fragment_behavior, free_input_cids, synthesize_wrapper, Effect, Exit, FragmentContract,
+    FragmentKind, Place, ProofFacts,
 };
 pub use report::{rank_families, RefactorFamily};
 pub use units::UnitFeat;

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -2599,7 +2599,7 @@ pub(crate) fn exact_java_this_field(il: &Il, interner: &Interner, node: NodeId) 
     exact_java_this_var(il, interner, receiver)
 }
 
-fn exact_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
+pub(crate) fn exact_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
     il.meta.lang == Lang::Java
         && il.kind(node) == NodeKind::Var
         && matches!(il.node(node).payload, Payload::Name(name) if interner.resolve(name) == "this")

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -2586,7 +2586,7 @@ fn exact_self_field_assignment_fragment_root(il: &Il, interner: &Interner, node:
     kids.len() == 2 && exact_java_this_field(il, interner, kids[0])
 }
 
-fn exact_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
+pub(crate) fn exact_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
     if il.meta.lang != Lang::Java || il.kind(node) != NodeKind::Field {
         return false;
     }

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -1837,6 +1837,17 @@ fn collect_exact_statement_fragment_units(
         return;
     }
     if let Some(kind) = exact_statement_fragment_root(il, node, parents, interner) {
+        // The predicate path is the production authority; for kinds that have migrated
+        // onto the contract substrate, the independent contract recognizer must agree
+        // (issue #33 differential gate). The corpus-level set-equality check lives in
+        // `fragment::recognize`; this asserts the forward direction on every accepted
+        // fragment, including real scans in debug builds.
+        debug_assert!(
+            !crate::fragment::recognize::MIGRATED.contains(&kind)
+                || crate::fragment::recognize::recognize_contract(il, node, parents, interner)
+                    .is_some_and(|contract| contract.kind == kind),
+            "contract path must agree with predicate path on migrated fragment kind {kind:?}"
+        );
         push_or_upgrade_exact_fragment_root(out, node, kind);
     }
     for &c in il.children(node) {
@@ -1867,7 +1878,7 @@ fn push_or_upgrade_exact_fragment_root(
 /// accepted (`true`); the [`FragmentKind`] names which recognizer branch matched. This
 /// is the single dispatch that lowers the standalone shape predicates into the fragment
 /// substrate (issue #33, step 1).
-fn exact_statement_fragment_root(
+pub(crate) fn exact_statement_fragment_root(
     il: &Il,
     node: NodeId,
     parents: &[Option<NodeId>],
@@ -3141,7 +3152,7 @@ fn index_assignment_effect_depends_on_iter(
         || node_mentions_any_cid(il, kids[1], iter_cids)
 }
 
-fn top_level_statement_fragment_context_safe(
+pub(crate) fn top_level_statement_fragment_context_safe(
     il: &Il,
     node: NodeId,
     parents: &[Option<NodeId>],
@@ -3292,7 +3303,7 @@ fn parent_of(parents: &[Option<NodeId>], node: NodeId) -> Option<NodeId> {
     parents.get(node.0 as usize).copied().flatten()
 }
 
-fn build_parent_index(il: &Il) -> Vec<Option<NodeId>> {
+pub(crate) fn build_parent_index(il: &Il) -> Vec<Option<NodeId>> {
     let mut parents = vec![None; il.nodes.len()];
     for idx in 0..il.nodes.len() {
         let parent = NodeId(idx as u32);
@@ -3305,7 +3316,7 @@ fn build_parent_index(il: &Il) -> Vec<Option<NodeId>> {
     parents
 }
 
-fn subtree_spans_within(il: &Il, node: NodeId, span: nose_il::Span) -> bool {
+pub(crate) fn subtree_spans_within(il: &Il, node: NodeId, span: nose_il::Span) -> bool {
     let node_span = il.node(node).span;
     if node_span.file != span.file
         || node_span.start_line < span.start_line

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -3,6 +3,7 @@
 //! tag combined with its children's tags), a pre-order **linearization** of node
 //! tags for alignment, and a **MinHash** signature for candidate generation.
 
+use crate::fragment::{FragmentKind, ProofFacts};
 use nose_il::{
     stable_symbol_hash, Builtin, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op,
     ParamSemantic, Payload, Symbol, UnitKind,
@@ -55,6 +56,18 @@ pub struct UnitFeat {
     /// units can still participate in `near` via structural scoring.
     #[serde(default)]
     pub exact_safe: bool,
+    /// The exact-fragment classification, when this unit is a sub-function fragment.
+    ///
+    /// `None` for ordinary function/method/class/block units; `Some(_)` names *why* the
+    /// fragment is an exact semantic clone (its [`FragmentKind`], with a stable
+    /// [`reason_code`](FragmentKind::reason_code)). Surfaced so reporting and ranking can
+    /// separate proof fragments from actionable refactors without re-deriving the shape.
+    #[serde(default)]
+    pub fragment_kind: Option<FragmentKind>,
+    /// What the recognizer proved about this fragment at acceptance time. Present iff
+    /// [`fragment_kind`](Self::fragment_kind) is `Some`.
+    #[serde(default)]
+    pub proof_facts: Option<ProofFacts>,
 }
 
 const SEED: u64 = 0x9E37_79B9_7F4A_7C15;
@@ -324,7 +337,11 @@ struct UnitRoot {
     root: NodeId,
     kind: UnitKind,
     name: Option<Symbol>,
-    exact_fragment: bool,
+    /// The exact-fragment classification, when this root was admitted as an exact
+    /// sub-function fragment. `None` for ordinary function/method/class/block units.
+    /// `Some(_)` is the authoritative "this is an exact fragment" signal; the boolean
+    /// `fragment_kind.is_some()` replaces the previous standalone `exact_fragment` flag.
+    fragment_kind: Option<FragmentKind>,
 }
 
 /// Extract all units of `il` passing the size gates, with features computed.
@@ -351,7 +368,7 @@ pub(crate) fn extract(
             root: u.root,
             kind: u.kind,
             name: u.name,
-            exact_fragment: false,
+            fragment_kind: None,
         })
         .collect();
     let parents = if block_units {
@@ -372,9 +389,10 @@ pub(crate) fn extract(
         root,
         kind,
         name: uname,
-        exact_fragment,
+        fragment_kind,
     } in roots
     {
+        let exact_fragment = fragment_kind.is_some();
         let unit_start = unit_timer.start();
         let span = il.node(root).span;
         let lines = span.line_count();
@@ -532,6 +550,10 @@ pub(crate) fn extract(
             value_ms,
         });
 
+        let proof_facts = fragment_kind.map(|fk| match fk {
+            FragmentKind::SelfFieldBody => ProofFacts::self_field_body(),
+            other => ProofFacts::context_gated(other),
+        });
         out.push(UnitFeat {
             path: il.meta.path.clone(),
             lang: il.meta.lang,
@@ -548,6 +570,8 @@ pub(crate) fn extract(
             lits,
             returns,
             exact_safe,
+            fragment_kind,
+            proof_facts,
         });
     }
     unit_timer.report_summary(&il.meta.path);
@@ -1792,7 +1816,7 @@ fn collect_block_units(il: &Il, node: NodeId, out: &mut Vec<UnitRoot>) {
             root: node,
             kind: UnitKind::Block,
             name: None,
-            exact_fragment: false,
+            fragment_kind: None,
         });
     }
     for &c in il.children(node) {
@@ -1812,55 +1836,69 @@ fn collect_exact_statement_fragment_units(
     if il.kind(node) == NodeKind::Lambda {
         return;
     }
-    if exact_statement_fragment_root(il, node, parents, interner) {
-        push_or_upgrade_exact_fragment_root(out, node);
+    if let Some(kind) = exact_statement_fragment_root(il, node, parents, interner) {
+        push_or_upgrade_exact_fragment_root(out, node, kind);
     }
     for &c in il.children(node) {
         collect_exact_statement_fragment_units(il, c, parents, interner, out);
     }
 }
 
-fn push_or_upgrade_exact_fragment_root(out: &mut Vec<UnitRoot>, root: NodeId) {
+fn push_or_upgrade_exact_fragment_root(
+    out: &mut Vec<UnitRoot>,
+    root: NodeId,
+    kind: FragmentKind,
+) {
     if let Some(existing) = out.iter_mut().find(|candidate| candidate.root == root) {
-        existing.exact_fragment = true;
+        existing.fragment_kind = Some(kind);
     } else {
         out.push(UnitRoot {
             root,
             kind: UnitKind::Block,
             name: None,
-            exact_fragment: true,
+            fragment_kind: Some(kind),
         });
     }
 }
 
+/// Classify `node` as an exact sub-function fragment root, or `None` if it is not one.
+///
+/// `Some(kind)` is returned for exactly the nodes the previous boolean recognizer
+/// accepted (`true`); the [`FragmentKind`] names which recognizer branch matched. This
+/// is the single dispatch that lowers the standalone shape predicates into the fragment
+/// substrate (issue #33, step 1).
 fn exact_statement_fragment_root(
     il: &Il,
     node: NodeId,
     parents: &[Option<NodeId>],
     interner: &Interner,
-) -> bool {
+) -> Option<FragmentKind> {
     if !subtree_spans_within(il, node, il.node(node).span) {
-        return false;
+        return None;
     }
     if exact_function_body_self_field_fragment_root(il, interner, parents, node) {
-        return true;
+        return Some(FragmentKind::SelfFieldBody);
     }
     if !top_level_statement_fragment_context_safe(il, node, parents, interner) {
-        return false;
+        return None;
     }
     let kids = il.children(node);
     match il.kind(node) {
-        NodeKind::Return => {
-            kids.len() == 1 && !matches!(il.kind(kids[0]), NodeKind::Var | NodeKind::Lit)
+        NodeKind::Return => (kids.len() == 1
+            && !matches!(il.kind(kids[0]), NodeKind::Var | NodeKind::Lit))
+        .then_some(FragmentKind::DirectReturn),
+        NodeKind::Throw => (kids.len() == 1
+            && !matches!(il.kind(kids[0]), NodeKind::Var | NodeKind::Lit))
+        .then_some(FragmentKind::DirectThrow),
+        NodeKind::Assign => exact_assignment_fragment_kind(il, interner, node),
+        NodeKind::ExprStmt => {
+            exact_expr_statement_fragment_root(il, node).then_some(FragmentKind::ExprEffect)
         }
-        NodeKind::Throw => {
-            kids.len() == 1 && !matches!(il.kind(kids[0]), NodeKind::Var | NodeKind::Lit)
-        }
-        NodeKind::Assign => exact_assignment_fragment_root(il, interner, node),
-        NodeKind::ExprStmt => exact_expr_statement_fragment_root(il, node),
-        NodeKind::If => exact_conditional_fragment_root(il, interner, node),
-        NodeKind::Loop => exact_loop_effect_fragment_root(il, interner, node),
-        _ => false,
+        NodeKind::If => exact_conditional_fragment_root(il, interner, node)
+            .then_some(FragmentKind::ConditionalGuard),
+        NodeKind::Loop => exact_loop_effect_fragment_root(il, interner, node)
+            .then_some(FragmentKind::LoopEffect),
+        _ => None,
     }
 }
 
@@ -2498,8 +2536,24 @@ fn exact_index_assignment_consumes_temp(
 }
 
 fn exact_assignment_fragment_root(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    exact_index_assignment_fragment_root(il, node)
-        || exact_self_field_assignment_fragment_root(il, interner, node)
+    exact_assignment_fragment_kind(il, interner, node).is_some()
+}
+
+/// Classify an assignment fragment as an index-assignment effect or a Java self-field
+/// write — the two exact assignment shapes. Index assignment is checked first so the
+/// classification is deterministic (the two shapes are structurally disjoint regardless).
+fn exact_assignment_fragment_kind(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<FragmentKind> {
+    if exact_index_assignment_fragment_root(il, node) {
+        Some(FragmentKind::IndexAssignEffect)
+    } else if exact_self_field_assignment_fragment_root(il, interner, node) {
+        Some(FragmentKind::SelfFieldAssign)
+    } else {
+        None
+    }
 }
 
 fn exact_index_assignment_fragment_root(il: &Il, node: NodeId) -> bool {

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -1855,11 +1855,7 @@ fn collect_exact_statement_fragment_units(
     }
 }
 
-fn push_or_upgrade_exact_fragment_root(
-    out: &mut Vec<UnitRoot>,
-    root: NodeId,
-    kind: FragmentKind,
-) {
+fn push_or_upgrade_exact_fragment_root(out: &mut Vec<UnitRoot>, root: NodeId, kind: FragmentKind) {
     if let Some(existing) = out.iter_mut().find(|candidate| candidate.root == root) {
         existing.fragment_kind = Some(kind);
     } else {
@@ -1907,8 +1903,9 @@ pub(crate) fn exact_statement_fragment_root(
         }
         NodeKind::If => exact_conditional_fragment_root(il, interner, node)
             .then_some(FragmentKind::ConditionalGuard),
-        NodeKind::Loop => exact_loop_effect_fragment_root(il, interner, node)
-            .then_some(FragmentKind::LoopEffect),
+        NodeKind::Loop => {
+            exact_loop_effect_fragment_root(il, interner, node).then_some(FragmentKind::LoopEffect)
+        }
         _ => None,
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,9 +43,11 @@ source ──tree-sitter──▶ raw IL ──normalize──▶ canonical IL �
 3. **Extract units & features**: frontend units are augmented with bounded
    sub-function units: control-flow blocks (`loop` / statement `if` / `try`) and
    exact-safe statement fragments whose whole value subtree stays inside the reported
-   source span. Each unit becomes a multiset of subtree-shape hashes, a value-graph
-   fingerprint, a pre-order linearization for alignment, a MinHash signature, plus
-   literal- and return-value multisets used by the strict precision gates.
+   source span. Exact fragments carry a first-class classification, contract, and
+   behavior oracle — see [fragment-contracts](fragment-contracts.md). Each unit becomes a
+   multiset of subtree-shape hashes, a value-graph fingerprint, a pre-order linearization
+   for alignment, a MinHash signature, plus literal- and return-value multisets used by
+   the strict precision gates.
 4. **Candidate generation**: the selected scan channels decide which candidates exist.
    `semantic` uses value-fingerprint MinHash signatures, `near` uses shape MinHash
    signatures, and `syntax` bypasses unit LSH with a Rabin-Karp token-stream pass.

--- a/docs/fragment-contracts.md
+++ b/docs/fragment-contracts.md
@@ -1,0 +1,109 @@
+# Exact fragment contracts
+
+How nose models **exact sub-function semantic fragments** — the return/throw/effect
+shapes it lifts out of larger function bodies — as a shared substrate rather than an
+accumulating set of ad-hoc predicates. Back to [architecture](architecture.md); the
+benchmark that drives the frontier is [type4-benchmark](type4-benchmark.md).
+
+## Why a substrate
+
+A whole function is the natural unit, but many real Type-4 clones are a *region* inside a
+larger body: a guarded `return`, an append loop, a `this.field` write. nose extracts these
+as **exact fragments** (see the extract step in [architecture](architecture.md)) under a
+hard rule — a fragment is admitted only when its behavior is self-contained and provable,
+so opaque surrounding code can never smuggle in unproven semantics.
+
+Historically each admissible shape was a standalone boolean predicate in
+`nose-detect/src/units.rs`. That found sound cases but trended toward a case matrix: the
+*reason* a fragment was accepted lived only in whichever predicate matched it, and nothing
+verified a fragment's behavior the way [`nose verify`](architecture.md) verifies whole
+functions. The substrate replaces the implicit predicate web with three explicit pieces.
+
+## The three pieces
+
+### 1. Classification — `FragmentKind`
+
+Every accepted fragment carries a `FragmentKind` (direct return/throw, index-assign effect,
+self-field assign, expression effect, conditional guard, loop effect, self-field body) and a
+stable kebab-case **reason code** (`exact-direct-return`, `exact-loop-effect`, …). The reason
+code is part of the external contract (issue #11): it names *why* a fragment is an exact
+clone, so reporting and ranking can separate proof fragments from actionable refactors
+without re-reading the recognizer. The recognizer returns a `FragmentKind` instead of a bare
+`bool`; `ProofFacts` records what was established at acceptance time (context-safety, exit).
+
+### 2. The contract — `FragmentContract`
+
+A recognizer-independent description of one fragment: its free **inputs** (the canonical ids
+it reads), its **exit** (normal / return / throw), its observable **effect**, and the write
+**place** for heap-mutating shapes. Two fragments with the same contract are interchangeable
+to the oracle regardless of which predicate matched them.
+
+The contract carries only what the oracle needs to build a runnable wrapper. That is the
+forcing function: **a contract that cannot be lowered into a wrapper is underspecified**, so
+the model cannot drift into describing fragments the oracle can't vouch for.
+
+### 3. The oracle — wrapper synthesis
+
+A fragment is verified through the *same* independent behavior check as a whole function. We
+do **not** add a new interpreter path. Instead the contract is lowered into a synthetic
+single-function IL — free inputs become parameters, the fragment subtree is deep-copied into
+the body — and handed to the existing [`run_unit`](architecture.md) interpreter. We reuse
+its `Behavior` (returned value + ordered effect trace + final field state) and the same input
+battery whole functions use.
+
+Because `Behavior` already records effects and field state, **effects are preserved as
+observable behavior for free**: appending to a parameter list shows up in the effect trace,
+so two append fragments that append different values diverge without any special handling.
+
+## The effect algebra
+
+The substrate names *how* each effect is observed, because that determines its soundness
+obligation — it does not treat every mutation as append-like:
+
+| effect | observed as | receiver identity |
+|---|---|---|
+| `Append` | ordered effect trace (the appended values, in order) | not required |
+| `IndexWrite` | ordered effect trace (key then value) | not required |
+| `FieldWrite` | field-state map, keyed by **field name only** | **required (proven place)** |
+| `Other` | established by running the fragment | — |
+
+A field write is the one case where the interpreter does **not** observe the receiver (the
+field-state map is keyed by name), so a field write is exact-safe only when its receiver is a
+proven place. This is exactly why a fixed `this` is the only admitted field receiver — not a
+special case, but a consequence of the algebra.
+
+## Place — receiver identity, fail-closed
+
+A write target resolves to a `Place`: `This`, `Param(cid)`, `LocalAlloc(id)`, a `Field` or
+`Index` path over another place, or `Unknown`. The cardinal rule is that **`Unknown` is the
+default**: any receiver that does not resolve to a proven place is `Unknown`, and a write that
+*requires* a proven place (a field write) through an `Unknown` receiver is rejected, never
+merged. An index write whose base is unproven (e.g. a Java instance field) still resolves —
+to `Index(Unknown, …)` — and stays safe, because an index write is observable in the effect
+trace and so carries no receiver-identity obligation.
+
+This folds the former Java `this.field` special case into the general model: `this.x = v`
+resolves to `Field(This, …)`, and the recognizer asserts the place is exact-safe.
+
+## The differential gate
+
+The recognizers are migrated onto the contract path one family at a time. An independent
+contract recognizer (`fragment::recognize`) re-expresses each migrated shape, reusing only the
+shared invalidation gates (span containment + context safety) rather than the per-shape
+predicates. A test asserts that over a multi-language corpus the predicate path and the
+contract path accept **exactly the same `(span, kind)` set** for migrated kinds, and a
+`debug_assert` in the collector cross-checks the forward direction on every accepted fragment
+across the whole fixture corpus. A migration step that changes which fragments are accepted
+fails the gate — that is what keeps the re-expression behavior-invariant.
+
+## What stays closed
+
+In keeping with the exact-semantic goal, the substrate does not open new ground by itself:
+
+- no arbitrary statement windows — only shapes with explicit input/exit/effect contracts;
+- no dynamic-receiver semantics inferred from method names;
+- no overloadable operations or library-purity assumptions without proof facts;
+- map/set/object-update effect families stay closed until the substrate proves them sound.
+
+The point is a clear model that makes the *next* sound family cheap to add, not more
+proof-fragment noise.

--- a/docs/home.md
+++ b/docs/home.md
@@ -41,6 +41,7 @@ You want to *change* nose or understand how it works inside.
 
 - [architecture](architecture.md) — the crates and the lower → normalize → detect → rank pipeline.
 - [normalization](normalization.md) — the passes that make behaviorally-equivalent code converge (the hard part).
+- [fragment-contracts](fragment-contracts.md) — how exact sub-function fragments are modeled: classification, contract, the wrapper-synthesis behavior oracle, the effect algebra, and fail-closed receiver identity.
 - [hazard-ranking](hazard-ranking.md) — the evidence base for the experimental `--sort hazard` (a divergence-*propensity* signal; **not** a validated harm ranker — it ranks actual harm near chance) and the honest evaluation trail.
 - [hazard-benchmark](hazard-benchmark.md) — the evaluation criteria and labeled dataset hazard is measured against (repo selection, graded labels, quantitative sufficiency).
 - [hazard-release-checklist](hazard-release-checklist.md) — what to do for the hazard ranking on every new nose release (one-page runbook: refresh the dataset, re-tune, re-validate).


### PR DESCRIPTION
## Summary

Builds the exact-fragment **substrate** that issue #33 designed: a shared model for sub-function semantic fragments, replacing the accumulating set of ad-hoc shape predicates in `units.rs` with a first-class classification, a recognizer-independent contract, a wrapper-synthesis behavior oracle, an explicit effect algebra, and a fail-closed receiver-identity model — gated by a predicate-vs-contract differential so every step stays behavior-invariant.

Closes #33. (The substrate is the deliverable; opening *new* map/set/object-update families — the issue's explicit step 7 — is the future work this enables, and stays closed here.)

Follows the execution order agreed on the issue.

## What landed, step by step

1. **`FragmentKind` / reason codes / `ProofFacts`** — every accepted fragment carries a first-class classification (8 variants), a stable kebab-case reason code (feeds #11), and what was proven at acceptance time. The recognizer returns `Option<FragmentKind>` instead of `bool`. Behavior-invariant.
2. **Wrapper-oracle spike + minimal `FragmentContract`** — a recognizer-independent contract (inputs / exit / effect / place) lowered into a synthetic `Func` and run through the existing `nose_normalize::run_unit`. No new interpreter path; we reuse `Behavior` (ret + ordered effects + final fields) and the battery. A contract that can't be lowered is, by construction, underspecified.
3. **Differential gate** — an independent contract recognizer (`fragment::recognize`) re-expresses each migrated shape; a multi-language test asserts the predicate path and contract path accept the same `(span, kind)` set, and a collector `debug_assert` cross-checks every accepted fragment across the whole CLI fixture corpus.
4. **Migrated families** — direct return/throw, index-assign, Java `this.field`, and expression effects now flow through the contract path.
5. **Effect algebra + `Place`** — `Append`/`IndexWrite` are observed in the effect trace; `FieldWrite` is keyed by name only, so it alone requires a proven receiver — which is *why* a fixed `this` is the lone admitted field receiver, now expressed as `Field(This, ...)` rather than a special case. `Place` is fail-closed: anything unresolved is `Unknown` and rejected where a proof is required.
6. **Docs** — new `docs/fragment-contracts.md`, linked from architecture + home; `awiki lint` clean.

## Verification

Behavior-invariance is the cardinal claim; it was checked from several angles:

- **Real-corpus diff (old vs new binary):** `nose scan --format json` is **byte-identical** across **30 repos** spanning all 8 languages (Java, Go, C, Rust, JS/TS, Python, Ruby, Lua) and every migrated fragment kind.
- **Corpus-wide differential:** a debug binary (predicate-vs-contract `debug_assert` active) scanned 18 repos including large Java/Go/C (guava, netty, etcd, nginx, sqlite) — the contract path agreed with the predicate path on **every accepted fragment**, no panic.
- **Determinism:** every repo scanned twice, identical.
- **Post-rebase re-check:** rebased onto current `main`; rebuilt and re-diffed against the new-main binary on 10 diverse repos — still byte-identical.
- **Gates:** `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `rustdoc -D warnings`, `cargo test --release` (all suites green); `awiki lint` clean.
- **Cache:** `UnitFeat`'s new serde-`default` fields round-trip and stay cross-version compatible (old binary reads new-written cache identically).
- **Performance:** no regression (the contract path runs only under `debug_assert`; production stays on the predicate path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
