### PR TITLE
Curate issue 36 Type-4 frontier evidence

### DIFF
--- a/bench/type4/ITERATIONS.md
+++ b/bench/type4/ITERATIONS.md
@@ -92,11 +92,41 @@ in `bench/type4/real_frontier.v1.json`.
 | C include typedef u16 | SQLite local/direct include typedef byte aliases | `u8` aliases may prove byte-buffer lanes only when typedef provenance is explicit | include-blind guesses remain rejected |
 | C u32 unsigned-cast byte-pack | SQLite cast-proven big-endian 32-bit decoders | four byte lanes are accepted only when the high lane has a proven unsigned 32-bit cast | uncasted high lane remains a hard negative |
 | Four unsupported-lead audit (#32/#34) | Java EnumSet, Java class-literal API chain, Ruby custom fetch receivers, Java single-arg collection factories | abstain unless receiver/domain/API-chain proof is explicit; a single factory argument is not a one-element literal without proof | three leads remain unsupported; one latent `Arrays.asList`/`of` false merge was fixed; real-corpus family-set diff stayed 0 |
+| Issue #36 frontier curation | Prioritizer rerun plus focused audits of SymPy, SQLAlchemy, Guava, RuboCop, ANTLR Python, and Alacritty Rust | priority hits, verifier leads, and implementation-ready Type-4 misses are separate evidence tiers | no same-invariant implementation batch is ready; one semantic-only SymPy lead is already covered by default output, and one Guava verifier lead is recorded as a hard negative |
 
-Current frontier state in `real_frontier.v1.json`: 18 items, 14 closed and 4 unsupported.
-The unsupported items are intentionally parked because they need stronger proof facts:
-Java EnumSet/method-level mismatch, Java `Arrays.asList` provenance in one audited case,
-JUnit reflection/API-chain purity, and Ruby custom receiver `fetch` semantics.
+Current frontier state in `real_frontier.v1.json`: 20 items: 14 closed, 4 unsupported,
+1 already-covered, and 1 hard-negative. The unsupported items are intentionally parked
+because they need stronger proof facts: Java EnumSet/method-level mismatch, Java
+`Arrays.asList` provenance in one audited case, JUnit reflection/API-chain purity, and
+Ruby custom receiver `fetch` semantics.
+
+The Issue #36 audit used current `main` (`target/release/nose` 0.5.0 at
+`0b57dd25a0e6cdb6f2742abad82585ca8c517e38`) and the pinned corpus from
+`bench/repos`. `bench/type4/prioritize_frontier.py --repos-root /Users/ak/prjs/cc/nose/bench/repos`
+was byte-identical to `FRONTIER_PRIORITIES.md`: `membership_contains` and
+`map_default_lookup` remain the top queue signals, but both still show 100% broad-probe
+coverage and no uncovered gap samples. Selected `nose verify` passes then separated
+actual evidence from queue noise:
+
+- SymPy and SQLAlchemy top Python repos still have verifier under-merges, but the strong
+  SymPy `rot90` lead is already reported by default `syntax,semantic` output, and the
+  SQLAlchemy leads are low-nearness oracle groups rather than a shared map-default or
+  membership proof.
+- Guava was audited instead of avoiding Java. Its `Sets.minSize`/`maxSize` verifier lead
+  is a concrete hard negative because `SetView.minSize()` and `SetView.maxSize()` may
+  differ, and whole-Guava verify was otherwise SOUND.
+- RuboCop was SOUND but produced only low-nearness leads unrelated to the map-default
+  receiver-provenance frontier already parked in `real_frontier.v1.json`.
+- ANTLR Python `dict.get(..., None)` and Alacritty Rust `TermMode::VI` `contains` samples
+  did not produce under-merged leads in selected scans. The Alacritty hits are dynamic
+  bitflag receiver calls, so they remain queue noise unless a future proof fact can prove
+  the receiver/domain and a concrete clone pair.
+
+Conclusion for #36: do not force a three-item recommendation. The audited evidence does
+not support a same-proof `real-miss` batch. The next useful handoff to #37 is to track
+these audited repos/axes as performance/output-regression samples while detector work
+continues only when a new candidate has a current semantic miss, a proof invariant, and an
+adjacent hard negative.
 
 ## Soundness Hardening
 

--- a/bench/type4/real_frontier.v1.json
+++ b/bench/type4/real_frontier.v1.json
@@ -139,6 +139,86 @@
       "notes": "Not suitable for a soundness-preserving Type-4 detector batch without shared proof facts for Java reflection/JUnit APIs. Re-verified 2026-06-06: the real duplicate is a syntactic Type-1/Type-2 clone that syntax/near mode already reports; semantic mode correctly abstains on the opaque getType() chain."
     },
     {
+      "case_id": "python-sympy-rot90-default-covered",
+      "status": "already-covered",
+      "candidate_axis": "python_control_flow_equivalence / default_output_covered",
+      "repo": "sympy",
+      "language": "python",
+      "locations": [
+        {
+          "path": "sympy/matrices/common.py",
+          "span": "2372-2415",
+          "snippet": "def rot90(self, k=1): mod = k%4; if mod == 0: return self; if mod == 1: return self[::-1, ::].T; if mod == 2: return self[::-1, ::-1]; if mod == 3: return self[::, ::-1].T"
+        },
+        {
+          "path": "sympy/matrices/matrixbase.py",
+          "span": "2646-2690",
+          "snippet": "def rot90(self, k: int=1) -> Self: mod = k%4; if/elif mod == 0..3 returns the same rotations; else: assert False"
+        }
+      ],
+      "semantic_claim": "Both methods implement the same four-way rotation by `k % 4`; type annotations, `if` versus `elif`, and the unreachable `else: assert False` do not change the returned matrix for the covered integer inputs.",
+      "evidence": "Selected `nose verify` over the two SymPy matrix files is SOUND and writes one structurally-near under-merged pair at vj=0.88 for common.py:2372 and matrixbase.py:2646. Manual source audit confirms identical branch results for mod values 0, 1, 2, and 3.",
+      "detector": {
+        "current_detector_miss": true,
+        "binary_path": "/Users/ak/prjs/cc/nose/target/release/nose",
+        "nose_version": "nose 0.5.0",
+        "build_ref": "0b57dd25a0e6cdb6f2742abad82585ca8c517e38",
+        "baseline_command": "/Users/ak/prjs/cc/nose/target/release/nose verify /Users/ak/prjs/cc/nose/bench/repos/sympy/sympy/matrices/common.py /Users/ak/prjs/cc/nose/bench/repos/sympy/sympy/matrices/matrixbase.py --max-violations 999 --leads /tmp/nose-issue36-sympy-rot90-leads.json",
+        "baseline_result": "SOUND; completeness 7/8; one under-merged lead at vj=0.8809523809523809.",
+        "semantic_scan_result": "`--mode semantic --format json --top 0 --min-lines 1 --min-size 1` reports no family containing both method starts.",
+        "default_scan_result": "`--mode syntax,semantic --format json --top 0 --min-lines 1 --min-size 1` reports family 3225a572821dfef2 containing matrixbase.py:2646-2690 and common.py:2372-2415."
+      },
+      "proof_invariant": "A future semantic-only closure would need a narrow Python control-flow proof that a complete `if`/`elif` ladder over the same local discriminator is equivalent to sequential guard-return `if` statements when every guard returns and the final `else` is unreachable. This is not an implementation-ready Type-4 batch here because the default product output already reports the pair.",
+      "hard_negative_siblings": [
+        "a reachable final `else` that returns a different value instead of asserting unreachable",
+        "one branch returning a different slice or transposition",
+        "a guard that mutates `mod`, `k`, or `self` before a later guard",
+        "a non-returning first branch that can fall through into later effects"
+      ],
+      "batch": "2026-06-06-issue36-frontier-curation",
+      "notes": "Issue #36 audit record. This is a semantic-only under-merge but not a recommended detector batch because `nose scan` default output already covers the refactoring candidate through syntax/semantic mode."
+    },
+    {
+      "case_id": "java-guava-setview-minmax-size-hard-negative",
+      "status": "hard-negative",
+      "candidate_axis": "collection_size_bound / verifier-lead-rejection",
+      "repo": "guava",
+      "language": "java",
+      "locations": [
+        {
+          "path": "android/guava/src/com/google/common/collect/Sets.java",
+          "span": "794-796",
+          "snippet": "static int minSize(Set<?> set) { return set instanceof SetView ? ((SetView<?>) set).minSize() : set.size(); }"
+        },
+        {
+          "path": "android/guava/src/com/google/common/collect/Sets.java",
+          "span": "810-812",
+          "snippet": "static int maxSize(Set<?> set) { return set instanceof SetView ? ((SetView<?>) set).maxSize() : set.size(); }"
+        }
+      ],
+      "semantic_claim": "These helpers are not exact Type-4 clones. They agree for ordinary `Set` receivers but intentionally differ for `SetView`, where `minSize()` and `maxSize()` are different abstract bounds.",
+      "evidence": "Whole-Guava `nose verify` is SOUND and emits this pair as an under-merged oracle lead at vj=0.43, but source audit shows a concrete hard-negative sibling: any `SetView` implementation whose lower and upper bounds differ makes the two methods return different values. The current semantic/default scans report no family for the pair.",
+      "detector": {
+        "current_detector_miss": false,
+        "binary_path": "/Users/ak/prjs/cc/nose/target/release/nose",
+        "nose_version": "nose 0.5.0",
+        "build_ref": "0b57dd25a0e6cdb6f2742abad82585ca8c517e38",
+        "baseline_command": "/Users/ak/prjs/cc/nose/target/release/nose verify /Users/ak/prjs/cc/nose/bench/repos/guava/android/guava/src/com/google/common/collect/Sets.java --max-violations 999 --leads /tmp/nose-issue36-guava-sets-leads.json",
+        "baseline_result": "SOUND; completeness 0/1; one low-nearness oracle lead at vj=0.42857142857142855.",
+        "semantic_scan_result": "`--mode semantic --format json --top 0 --min-lines 1 --min-size 1` reports 0 families containing both starts.",
+        "default_scan_result": "`--mode syntax,semantic --format json --top 0 --min-lines 1 --min-size 1` reports 0 families containing both starts."
+      },
+      "proof_invariant": "Any future size-bound or method-name abstraction must preserve method identity when the receiver domain can dispatch to different abstract operations. `SetView.minSize()` and `SetView.maxSize()` are separate semantic coordinates even though the non-SetView fallback is the same `set.size()` call.",
+      "hard_negative_siblings": [
+        "a `SetView` whose `minSize()` returns 0 while `maxSize()` returns the backing set size",
+        "a subclass where `minSize()` is cheap lower-bound metadata and `maxSize()` is an upper-bound over a different backing set",
+        "renaming or normalizing `min*` and `max*` methods before receiver-domain proof",
+        "collapsing both helpers to `set.size()` without proving the receiver is not a `SetView`"
+      ],
+      "batch": "2026-06-06-issue36-frontier-curation",
+      "notes": "Issue #36 Java audit record. This rejects a real-corpus verifier lead rather than proposing detector work; it is useful as an adjacent hard negative for any future Java collection-size-bound axis."
+    },
+    {
       "case_id": "python-docstring-sympy-dirac-delta",
       "status": "closed",
       "candidate_axis": "python_docstring_noop",


### PR DESCRIPTION
## Summary

Closes #36.

This PR records the next real-corpus Type-4 frontier audit without changing detector behavior. It keeps the existing structured status contract and does not introduce `#33-blocked` or `provenance-needed` statuses.

## Audit result

- Reran `bench/type4/prioritize_frontier.py` against the pinned corpus from the main worktree; the generated priority report is byte-identical to `FRONTIER_PRIORITIES.md`.
- Added a structured `already-covered` SymPy `rot90` record: semantic-only under-merge, but default `syntax,semantic` output already reports the pair.
- Added a structured Guava `hard-negative` record: `Sets.minSize` and `Sets.maxSize` agree on ordinary `Set` fallback but intentionally differ for `SetView`.
- Recorded the conclusion in `ITERATIONS.md`: no same-proof implementation-ready `real-miss` batch is ready from this audit.

## Validation

- `jq empty bench/type4/real_frontier.v1.json`
- `awiki lint --root docs`
- `python3 bench/type4/prioritize_frontier.py --repos-root /Users/ak/prjs/cc/nose/bench/repos --cache /tmp/nose-issue36-frontier.cache.json --json-out /tmp/nose-issue36-frontier-rerun.json --markdown-out /tmp/nose-issue36-frontier-rerun.md && diff -u bench/type4/FRONTIER_PRIORITIES.md /tmp/nose-issue36-frontier-rerun.md`
- selected SymPy `verify` and semantic/default scan checks for `rot90`
- selected Guava `verify` and semantic/default scan checks for `Sets.minSize`/`Sets.maxSize`
- `git diff --check`