### PR TITLE
type4(fragment): contract-migration substrate — ordered effects, binding-aware inputs, multi-statement lowering (#43, PR 1)

### DIFF
--- a/crates/nose-detect/src/fragment.rs
+++ b/crates/nose-detect/src/fragment.rs
@@ -23,7 +23,7 @@ mod contract;
 mod oracle;
 pub(crate) mod recognize;
 
-pub use contract::{Effect, FragmentContract, Place};
+pub use contract::{Effect, EffectSite, FragmentContract, Place};
 pub use oracle::{fragment_behavior, free_input_cids, synthesize_wrapper};
 
 /// The shape of an accepted exact sub-function fragment.

--- a/crates/nose-detect/src/fragment/contract.rs
+++ b/crates/nose-detect/src/fragment/contract.rs
@@ -8,20 +8,54 @@
 //! into a wrapper, the contract is underspecified, which is exactly the soundness property
 //! we want to force.
 //!
-//! This is the minimal contract: it models the direct-return shape (inputs + a value/throw
-//! exit). Heap writes, effect algebra, and [`Place`] receiver identity are layered on in
-//! later steps; the placeholder [`Place`] enum below fixes the fail-closed default now so
-//! receiver-bearing shapes have a home to migrate into.
+//! A contract describes a fragment as an ordered sequence of observable effects (possibly
+//! empty, for a pure value/control sink) plus the control exit it terminates in. A
+//! single-statement sink (direct return/throw) carries no effects; a single-statement write
+//! carries one; a multi-statement body (a conditional branch, a loop body, an ordered effect
+//! sequence) carries its effects in execution order. The [`Place`] receiver-identity model
+//! is fail-closed so receiver-bearing effects can only be admitted when proven.
 
 use super::{Exit, FragmentKind};
 use nose_il::NodeId;
 
+/// One observable effect in a fragment body, paired with its write-target identity.
+///
+/// The [`place`](Self::place) is `Some` only when the effect's soundness depends on knowing
+/// *whose* state it touches — i.e. [`Effect::requires_proven_place`]. Append/index writes are
+/// observable in the interpreter's effect trace and so carry no receiver-identity obligation;
+/// their `place` is `None` even though they do mutate a collection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EffectSite {
+    /// How this effect is observed (see [`Effect`]).
+    pub effect: Effect,
+    /// The proven write target, for receiver-bearing effects; `None` otherwise.
+    pub place: Option<Place>,
+}
+
+impl EffectSite {
+    /// An effect whose observability carries no receiver-identity obligation (append/index).
+    pub fn observable(effect: Effect) -> Self {
+        EffectSite {
+            effect,
+            place: None,
+        }
+    }
+
+    /// A receiver-bearing effect (a field write) over a resolved [`Place`].
+    pub fn at(effect: Effect, place: Place) -> Self {
+        EffectSite {
+            effect,
+            place: Some(place),
+        }
+    }
+}
+
 /// A first-class description of one exact sub-function fragment.
 ///
 /// The contract is recognizer-independent: two fragments with the same inputs, exit, and
-/// effect are interchangeable to the oracle regardless of which predicate matched them. The
-/// [`root`](Self::root) points at the fragment statement in the *source* IL; lowering
-/// deep-copies that subtree into a synthetic wrapper.
+/// ordered effects are interchangeable to the oracle regardless of which predicate matched
+/// them. The [`root`](Self::root) points at the fragment statement (or block) in the *source*
+/// IL; lowering deep-copies that subtree into a synthetic wrapper.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FragmentContract {
     /// Which recognizer shape produced this contract.
@@ -33,12 +67,9 @@ pub struct FragmentContract {
     pub inputs: Vec<u32>,
     /// The control sink the fragment terminates in.
     pub exit: Exit,
-    /// The observable effect the fragment produces, for effect-bearing shapes. `None` for
-    /// pure value/control sinks (direct return/throw). See [`Effect`] for the algebra.
-    pub effect: Option<Effect>,
-    /// The proven write-target identity, for shapes that mutate heap/object state. See
-    /// [`Place`]; `None` for shapes with no heap write.
-    pub place: Option<Place>,
+    /// The fragment's observable effects, in execution order. Empty for pure value/control
+    /// sinks; one entry for a single-effect write; several for an ordered multi-effect body.
+    pub effects: Vec<EffectSite>,
 }
 
 impl FragmentContract {
@@ -47,16 +78,61 @@ impl FragmentContract {
         self.inputs.len()
     }
 
-    /// A pure value/control-sink contract (direct return/throw): no effect, no write place.
+    /// A pure value/control-sink contract (direct return/throw): no observable effects.
     pub fn value_sink(kind: FragmentKind, root: NodeId, inputs: Vec<u32>, exit: Exit) -> Self {
         FragmentContract {
             kind,
             root,
             inputs,
             exit,
-            effect: None,
-            place: None,
+            effects: Vec::new(),
         }
+    }
+
+    /// A single-effect contract (one append/index/field/other write), normal exit.
+    pub fn single_effect(
+        kind: FragmentKind,
+        root: NodeId,
+        inputs: Vec<u32>,
+        site: EffectSite,
+    ) -> Self {
+        FragmentContract {
+            kind,
+            root,
+            inputs,
+            exit: Exit::Normal,
+            effects: vec![site],
+        }
+    }
+
+    /// A multi-effect contract: an ordered sequence of effects over a (block) body.
+    pub fn ordered_effects(
+        kind: FragmentKind,
+        root: NodeId,
+        inputs: Vec<u32>,
+        exit: Exit,
+        effects: Vec<EffectSite>,
+    ) -> Self {
+        FragmentContract {
+            kind,
+            root,
+            inputs,
+            exit,
+            effects,
+        }
+    }
+
+    /// Whether every receiver-bearing effect has a proven, exact-safe [`Place`].
+    ///
+    /// Fail-closed: a [`Effect::FieldWrite`] with no place, or a place rooted at
+    /// [`Place::Unknown`], is not proven. Effects that carry no receiver obligation
+    /// ([`Effect::Append`]/[`Effect::IndexWrite`]) never block this. This is the soundness
+    /// predicate receiver-bearing shapes gate on before the contract is admitted.
+    pub fn writes_proven(&self) -> bool {
+        self.effects.iter().all(|site| {
+            !site.effect.requires_proven_place()
+                || site.place.as_ref().is_some_and(Place::is_exact_safe)
+        })
     }
 }
 
@@ -147,5 +223,70 @@ mod tests {
         // A proven receiver with a field/index path is safe.
         assert!(Place::Field(Box::new(Place::This), 3).is_exact_safe());
         assert!(Place::Index(Box::new(Place::Param(0)), 9).is_exact_safe());
+    }
+
+    use super::super::FragmentKind;
+    use nose_il::NodeId;
+
+    #[test]
+    fn writes_proven_gates_only_receiver_bearing_effects() {
+        let root = NodeId(0);
+        // No effects: trivially proven (a pure sink).
+        assert!(FragmentContract::value_sink(
+            FragmentKind::DirectReturn,
+            root,
+            vec![],
+            Exit::Return
+        )
+        .writes_proven());
+
+        // Append/index writes carry no receiver obligation — proven regardless of place.
+        let appends = FragmentContract::ordered_effects(
+            FragmentKind::ExprEffect,
+            root,
+            vec![],
+            Exit::Normal,
+            vec![
+                EffectSite::observable(Effect::Append),
+                EffectSite::observable(Effect::IndexWrite),
+            ],
+        );
+        assert!(appends.writes_proven());
+
+        // A field write over a proven `This` place is admitted; over Unknown it is not.
+        let proven = FragmentContract::single_effect(
+            FragmentKind::SelfFieldAssign,
+            root,
+            vec![],
+            EffectSite::at(Effect::FieldWrite, Place::Field(Box::new(Place::This), 7)),
+        );
+        assert!(proven.writes_proven());
+
+        let unproven = FragmentContract::single_effect(
+            FragmentKind::SelfFieldAssign,
+            root,
+            vec![],
+            EffectSite::at(
+                Effect::FieldWrite,
+                Place::Field(Box::new(Place::Unknown), 7),
+            ),
+        );
+        assert!(
+            !unproven.writes_proven(),
+            "field write through Unknown is fail-closed"
+        );
+
+        // A field write with no resolved place at all is fail-closed too.
+        let missing = FragmentContract::ordered_effects(
+            FragmentKind::SelfFieldBody,
+            root,
+            vec![],
+            Exit::Normal,
+            vec![EffectSite {
+                effect: Effect::FieldWrite,
+                place: None,
+            }],
+        );
+        assert!(!missing.writes_proven());
     }
 }

--- a/crates/nose-detect/src/fragment/contract.rs
+++ b/crates/nose-detect/src/fragment/contract.rs
@@ -34,7 +34,16 @@ pub struct EffectSite {
 
 impl EffectSite {
     /// An effect whose observability carries no receiver-identity obligation (append/index).
+    ///
+    /// The effect/place split is an invariant of the model, not just a soundness check: a
+    /// receiver-bearing effect (a field write) must record its [`Place`] via [`Self::at`], and
+    /// an observable effect must not carry one. Enforced at construction so a malformed
+    /// contract is caught the moment it is built, before [`FragmentContract::writes_proven`].
     pub fn observable(effect: Effect) -> Self {
+        debug_assert!(
+            !effect.requires_proven_place(),
+            "observable() is for effects with no receiver obligation, not {effect:?}"
+        );
         EffectSite {
             effect,
             place: None,
@@ -43,6 +52,10 @@ impl EffectSite {
 
     /// A receiver-bearing effect (a field write) over a resolved [`Place`].
     pub fn at(effect: Effect, place: Place) -> Self {
+        debug_assert!(
+            effect.requires_proven_place(),
+            "at() is for receiver-bearing effects, not {effect:?}"
+        );
         EffectSite {
             effect,
             place: Some(place),

--- a/crates/nose-detect/src/fragment/oracle.rs
+++ b/crates/nose-detect/src/fragment/oracle.rs
@@ -13,7 +13,7 @@
 //! recognizer described a fragment the oracle cannot vouch for — fail closed.
 
 use super::contract::FragmentContract;
-use nose_il::{FileMeta, Il, IlBuilder, NodeId, NodeKind, Payload, Span, Unit, UnitKind};
+use nose_il::{FileMeta, Il, IlBuilder, LoopKind, NodeId, NodeKind, Payload, Span, Unit, UnitKind};
 use nose_normalize::{run_unit, Behavior, Value};
 
 /// Run the fragment described by `contract` on `args` (bound to its inputs in order) and
@@ -41,9 +41,21 @@ pub fn synthesize_wrapper(il: &Il, contract: &FragmentContract) -> Option<(Il, N
         .map(|&cid| b.add(NodeKind::Param, Payload::Cid(cid), syn, &[]))
         .collect();
 
-    // Body: a deep copy of the fragment statement, wrapped in a Block.
-    let body_stmt = copy_subtree(il, contract.root, &mut b);
-    let body = b.add(NodeKind::Block, Payload::None, syn, &[body_stmt]);
+    // Body: deep-copy the fragment into the wrapper's body block. A block-rooted fragment
+    // (a conditional branch, a loop or ordered-effect body) is spliced statement-by-statement
+    // so the wrapper body stays flat rather than a `Block` nested in a `Block`; a single
+    // statement becomes the lone body statement. Either way the interpreter executes the same
+    // statements in the same order.
+    let body_stmts: Vec<NodeId> = if il.kind(contract.root) == NodeKind::Block {
+        il.children(contract.root)
+            .to_vec()
+            .iter()
+            .map(|&s| copy_subtree(il, s, &mut b))
+            .collect()
+    } else {
+        vec![copy_subtree(il, contract.root, &mut b)]
+    };
+    let body = b.add(NodeKind::Block, Payload::None, syn, &body_stmts);
     children.push(body);
 
     let func = b.add(NodeKind::Func, Payload::None, syn, &children);
@@ -79,15 +91,34 @@ fn copy_subtree(src: &Il, node: NodeId, b: &mut IlBuilder) -> NodeId {
 }
 
 /// Collect the free canonical ids read in the subtree rooted at `node`, in ascending
-/// (canonical) order. Only `Var` references count; this is correct for fragment shapes
-/// with no internal bindings (e.g. a direct `return <expr>`). Shapes that introduce locals
-/// (loop variables, temps) need binding-aware input inference, added when they migrate.
+/// (canonical) order — the cids the fragment reads from its enclosing scope. These become the
+/// synthesized wrapper's parameters.
+///
+/// "Free" excludes cids *bound within* the fragment: a local assigned before use, a `for-each`
+/// loop variable, a nested lambda parameter. The interpreter binds those as the wrapper runs
+/// (assignment targets and loop patterns enter `env`), so making them parameters would inflate
+/// the arity and feed a battery value the fragment immediately overwrites — the loop-variable
+/// hazard that previously made loop/temp shapes unmodelable. The binding model mirrors the one
+/// alpha-renaming uses (see `nose_normalize::alpha`): assignment targets and `for-each`
+/// patterns — a `Var`, or each `Var` in a destructuring `Seq` — plus nested `Param`s.
+///
+/// Soundness: omitting a *genuine* outer input can only under-report, and an unbound `Var`
+/// read makes the wrapper uninterpretable (`run_unit` returns `None`) — fail-closed, never a
+/// false merge. Index/field stores mutate an existing receiver (which stays a free input) and
+/// bind nothing, so they are deliberately not treated as bindings.
 pub fn free_input_cids(il: &Il, node: NodeId) -> Vec<u32> {
-    let mut out = Vec::new();
-    collect_var_cids(il, node, &mut out);
-    out.sort_unstable();
-    out.dedup();
-    out
+    let mut reads = Vec::new();
+    collect_var_cids(il, node, &mut reads);
+    reads.sort_unstable();
+    reads.dedup();
+
+    let mut bound = Vec::new();
+    collect_bound_cids(il, node, &mut bound);
+    bound.sort_unstable();
+    bound.dedup();
+
+    reads.retain(|c| bound.binary_search(c).is_err());
+    reads
 }
 
 fn collect_var_cids(il: &Il, node: NodeId, out: &mut Vec<u32>) {
@@ -101,10 +132,56 @@ fn collect_var_cids(il: &Il, node: NodeId, out: &mut Vec<u32>) {
     }
 }
 
+/// Collect cids *bound within* the subtree: assignment targets, `for-each` loop patterns, and
+/// nested `Param`s. Mirrors the binding model alpha-renaming uses, so "free" here means the
+/// same thing it does after renaming.
+fn collect_bound_cids(il: &Il, node: NodeId, out: &mut Vec<u32>) {
+    match il.kind(node) {
+        NodeKind::Param => {
+            if let Payload::Cid(c) = il.node(node).payload {
+                out.push(c);
+            }
+        }
+        NodeKind::Assign => {
+            if let Some(&lhs) = il.children(node).first() {
+                collect_binding_targets(il, lhs, out);
+            }
+        }
+        NodeKind::Loop if matches!(il.node(node).payload, Payload::Loop(LoopKind::ForEach)) => {
+            if let Some(&pat) = il.children(node).first() {
+                collect_binding_targets(il, pat, out);
+            }
+        }
+        _ => {}
+    }
+    for &k in il.children(node) {
+        collect_bound_cids(il, k, out);
+    }
+}
+
+/// Assignment / `for`-pattern binding targets: a `Var` cid, or each `Var` in a destructuring
+/// `Seq`. Only plain `Var`/`Seq` targets bind a fresh cid; an `Index`/`Field` store target
+/// mutates an existing receiver and binds nothing.
+fn collect_binding_targets(il: &Il, node: NodeId, out: &mut Vec<u32>) {
+    match il.kind(node) {
+        NodeKind::Var => {
+            if let Payload::Cid(c) = il.node(node).payload {
+                out.push(c);
+            }
+        }
+        NodeKind::Seq => {
+            for &c in il.children(node) {
+                collect_binding_targets(il, c, out);
+            }
+        }
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fragment::{Exit, FragmentKind};
+    use crate::fragment::{Effect, EffectSite, Exit, FragmentKind};
     use nose_il::{FileId, Interner, Lang};
     use nose_normalize::{normalize, NormalizeOptions};
 
@@ -203,5 +280,134 @@ mod tests {
             behavior_vector(&h, &ch, &battery),
             "behaviorally distinct fragments must diverge on the battery"
         );
+    }
+
+    // ---- binding-aware free-input inference --------------------------------------------
+
+    fn find<P: Fn(&Il, NodeId) -> bool>(il: &Il, node: NodeId, pred: &P) -> Option<NodeId> {
+        if pred(il, node) {
+            return Some(node);
+        }
+        il.children(node).iter().find_map(|&c| find(il, c, pred))
+    }
+
+    fn first_foreach(il: &Il) -> NodeId {
+        find(il, il.root, &|il, n| {
+            il.kind(n) == NodeKind::Loop
+                && matches!(il.node(n).payload, Payload::Loop(LoopKind::ForEach))
+        })
+        .expect("a for-each loop")
+    }
+
+    /// The body `Block` of the first `Func` — the multi-statement fragment body.
+    fn first_func_body(il: &Il) -> NodeId {
+        let func = find(il, il.root, &|il, n| il.kind(n) == NodeKind::Func).expect("a func");
+        *il.children(func).last().expect("func has a body block")
+    }
+
+    #[test]
+    fn free_inputs_exclude_the_foreach_loop_variable() {
+        // The loop variable `x` is bound by the for-each pattern, not read from outside; only
+        // the appended-to list `out` and the iterable `xs` are genuine free inputs. Without
+        // binding-aware inference this would be arity 3 and the wrapper would misbind `x`.
+        let i = Interner::new();
+        let il = norm(
+            &i,
+            "function f(out, xs){ for (const x of xs){ out.push(x); } }",
+            Lang::JavaScript,
+        );
+        let loop_node = first_foreach(&il);
+        let inputs = free_input_cids(&il, loop_node);
+        assert_eq!(
+            inputs.len(),
+            2,
+            "only `out` and `xs` are free; the loop variable `x` must be excluded, got {inputs:?}"
+        );
+    }
+
+    #[test]
+    fn free_inputs_exclude_a_local_temp() {
+        // `t` is assigned then read inside the fragment, so it is a local, not a free input.
+        let i = Interner::new();
+        let il = norm(
+            &i,
+            "function f(a){ let t = a * a; return t + 1; }",
+            Lang::JavaScript,
+        );
+        let body = first_func_body(&il);
+        let inputs = free_input_cids(&il, body);
+        assert_eq!(
+            inputs.len(),
+            1,
+            "only `a` is free; the temp `t` must be excluded, got {inputs:?}"
+        );
+    }
+
+    #[test]
+    fn equivalent_foreach_loops_agree_through_the_oracle() {
+        // Two for-each append loops with the same spec must agree; a different appended value
+        // must diverge — exercising binding-aware inputs + multi-statement loop lowering.
+        let battery = || {
+            vec![vec![
+                Value::List(vec![]),
+                Value::List(vec![Value::Int(2), Value::Int(5)]),
+            ]]
+        };
+        let run = |src: &str| -> Vec<Behavior> {
+            let i = Interner::new();
+            let il = norm(&i, src, Lang::JavaScript);
+            let loop_node = first_foreach(&il);
+            let c = FragmentContract::single_effect(
+                FragmentKind::LoopEffect,
+                loop_node,
+                free_input_cids(&il, loop_node),
+                EffectSite::observable(Effect::Append),
+            );
+            assert_eq!(c.arity(), 2, "loop var excluded → arity 2");
+            battery()
+                .iter()
+                .map(|row| fragment_behavior(&il, &c, row).expect("loop fragment interpretable"))
+                .collect()
+        };
+        let f = run("function f(out, xs){ for (const x of xs){ out.push(x); } }");
+        let g = run("function g(acc, ys){ for (const y of ys){ acc.push(y); } }");
+        let h = run("function h(out, xs){ for (const x of xs){ out.push(x * 2); } }");
+        assert!(
+            f.iter().all(|b| !b.effects.is_empty()),
+            "loop append surfaces as effects"
+        );
+        assert_eq!(f, g, "equivalent for-each append loops must agree");
+        assert_ne!(f, h, "appending a different value must diverge");
+    }
+
+    // ---- ordered multi-effect, multi-statement body -----------------------------------
+
+    #[test]
+    fn ordered_multi_effect_body_observes_statement_order() {
+        // A two-append body lowered as an ordered-effect contract: the effect order is
+        // observable, so swapping the two appends diverges while an identical body agrees.
+        let run = |src: &str| -> Behavior {
+            let i = Interner::new();
+            let il = norm(&i, src, Lang::JavaScript);
+            let body = first_func_body(&il);
+            let c = FragmentContract::ordered_effects(
+                FragmentKind::ExprEffect,
+                body,
+                free_input_cids(&il, body),
+                Exit::Normal,
+                vec![
+                    EffectSite::observable(Effect::Append),
+                    EffectSite::observable(Effect::Append),
+                ],
+            );
+            assert_eq!(c.arity(), 1, "only `out` is free (literals are not inputs)");
+            fragment_behavior(&il, &c, &[Value::List(vec![])]).expect("interpretable")
+        };
+        let fwd = run("function f(out){ out.push(1); out.push(2); }");
+        let fwd2 = run("function h(out){ out.push(1); out.push(2); }");
+        let rev = run("function g(out){ out.push(2); out.push(1); }");
+        assert_eq!(fwd.effects.len(), 2, "both appends are recorded in order");
+        assert_eq!(fwd, fwd2, "identical ordered bodies must agree");
+        assert_ne!(fwd, rev, "swapping the append order must be observable");
     }
 }

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -13,7 +13,7 @@
 //! changes which nodes are accepted fails this test. As [`MIGRATED`] grows, the gate keeps
 //! the two paths in lockstep until every shape is contract-expressed.
 
-use super::contract::{Effect, FragmentContract};
+use super::contract::{Effect, EffectSite, FragmentContract};
 use super::oracle::free_input_cids;
 use super::{Exit, FragmentKind, Place};
 use crate::units::{exact_java_this_field, exact_java_this_var};
@@ -151,14 +151,12 @@ fn effect_contract(
     effect: Effect,
     place: Option<Place>,
 ) -> FragmentContract {
-    FragmentContract {
+    FragmentContract::single_effect(
         kind,
-        root: node,
-        inputs: free_input_cids(il, node),
-        exit: Exit::Normal,
-        effect: Some(effect),
-        place,
-    }
+        node,
+        free_input_cids(il, node),
+        EffectSite { effect, place },
+    )
 }
 
 /// Resolve a write target's [`Place`] receiver identity, fail-closed to [`Place::Unknown`].
@@ -377,10 +375,16 @@ mod tests {
         );
         let c = first_contract(&il, &parents, &interner);
         assert_eq!(c.kind, FragmentKind::SelfFieldAssign);
-        assert_eq!(c.effect, Some(Effect::FieldWrite));
-        assert!(matches!(c.place, Some(Place::Field(ref base, _)) if **base == Place::This));
-        assert!(c.place.as_ref().unwrap().is_exact_safe());
-        assert!(c.effect.unwrap().requires_proven_place());
+        assert_eq!(c.effects.len(), 1);
+        let site = &c.effects[0];
+        assert_eq!(site.effect, Effect::FieldWrite);
+        assert!(matches!(site.place, Some(Place::Field(ref base, _)) if **base == Place::This));
+        assert!(site.place.as_ref().unwrap().is_exact_safe());
+        assert!(site.effect.requires_proven_place());
+        assert!(
+            c.writes_proven(),
+            "a proven self-field write must pass writes_proven"
+        );
 
         // Java `a[i] = v` → IndexWrite over an index place. The base here is an instance
         // field accessed bare, so it resolves to a fail-closed `Unknown` receiver — yet the
@@ -392,17 +396,22 @@ mod tests {
         );
         let c = first_contract(&il, &parents, &interner);
         assert_eq!(c.kind, FragmentKind::IndexAssignEffect);
-        assert_eq!(c.effect, Some(Effect::IndexWrite));
-        assert!(matches!(c.place, Some(Place::Index(_, _))));
-        assert!(!c.effect.unwrap().requires_proven_place());
+        assert_eq!(c.effects.len(), 1);
+        let site = &c.effects[0];
+        assert_eq!(site.effect, Effect::IndexWrite);
+        assert!(matches!(site.place, Some(Place::Index(_, _))));
+        assert!(!site.effect.requires_proven_place());
+        // An index write needs no proven receiver, so it passes regardless of the Unknown base.
+        assert!(c.writes_proven());
 
         // JS `xs.push(v)` → Append effect, no heap place.
         let (il, parents, interner) =
             norm("function f(xs, v){ xs.push(v + 1); }", Lang::JavaScript);
         let c = first_contract(&il, &parents, &interner);
         assert_eq!(c.kind, FragmentKind::ExprEffect);
-        assert_eq!(c.effect, Some(Effect::Append));
-        assert_eq!(c.place, None);
+        assert_eq!(c.effects.len(), 1);
+        assert_eq!(c.effects[0].effect, Effect::Append);
+        assert_eq!(c.effects[0].place, None);
     }
 
     #[test]
@@ -417,7 +426,7 @@ mod tests {
         let run = |src: &str| -> Vec<nose_normalize::Behavior> {
             let (il, parents, interner) = norm(src, Lang::JavaScript);
             let c = first_contract(&il, &parents, &interner);
-            assert_eq!(c.effect, Some(Effect::Append));
+            assert_eq!(c.effects.first().map(|s| s.effect), Some(Effect::Append));
             battery
                 .iter()
                 .map(|row| {

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -73,8 +73,7 @@ pub(crate) fn recognize_contract(
                 FragmentKind::ExprEffect,
                 il,
                 node,
-                effect,
-                None,
+                EffectSite::observable(effect),
             ))
         }
         _ => None,
@@ -95,13 +94,15 @@ fn recognize_assignment_effect(
     let target = kids[0];
     if matches!(il.meta.lang, Lang::C | Lang::Go | Lang::Java) && il.kind(target) == NodeKind::Index
     {
-        let place = resolve_place(il, interner, target);
+        // An index write is observable in the effect trace (key and value are recorded), so
+        // it carries no receiver-identity obligation and records no `Place` on the contract.
+        // The write target is identity, not proof; surfacing it is a separate diagnostic
+        // concern, deliberately kept out of the contract model.
         return Some(effect_contract(
             FragmentKind::IndexAssignEffect,
             il,
             node,
-            Effect::IndexWrite,
-            Some(place),
+            EffectSite::observable(Effect::IndexWrite),
         ));
     }
     if il.meta.lang == Lang::Java && exact_java_this_field(il, interner, target) {
@@ -117,8 +118,7 @@ fn recognize_assignment_effect(
             FragmentKind::SelfFieldAssign,
             il,
             node,
-            Effect::FieldWrite,
-            Some(place),
+            EffectSite::at(Effect::FieldWrite, place),
         ));
     }
     None
@@ -148,15 +148,9 @@ fn effect_contract(
     kind: FragmentKind,
     il: &Il,
     node: NodeId,
-    effect: Effect,
-    place: Option<Place>,
+    site: EffectSite,
 ) -> FragmentContract {
-    FragmentContract::single_effect(
-        kind,
-        node,
-        free_input_cids(il, node),
-        EffectSite { effect, place },
-    )
+    FragmentContract::single_effect(kind, node, free_input_cids(il, node), site)
 }
 
 /// Resolve a write target's [`Place`] receiver identity, fail-closed to [`Place::Unknown`].
@@ -386,10 +380,9 @@ mod tests {
             "a proven self-field write must pass writes_proven"
         );
 
-        // Java `a[i] = v` → IndexWrite over an index place. The base here is an instance
-        // field accessed bare, so it resolves to a fail-closed `Unknown` receiver — yet the
-        // write stays exact-safe because an index write is observable in the effect trace
-        // and so does not require a proven receiver.
+        // Java `a[i] = v` → IndexWrite, observable in the effect trace, so it carries no
+        // receiver-identity obligation and records no place on the contract (place is reserved
+        // for receiver-bearing effects like field writes).
         let (il, parents, interner) = norm(
             "class C { int[] a; void f(int i, int v){ a[i] = v; } }",
             Lang::Java,
@@ -399,9 +392,11 @@ mod tests {
         assert_eq!(c.effects.len(), 1);
         let site = &c.effects[0];
         assert_eq!(site.effect, Effect::IndexWrite);
-        assert!(matches!(site.place, Some(Place::Index(_, _))));
+        assert_eq!(
+            site.place, None,
+            "index writes carry no receiver-proof obligation"
+        );
         assert!(!site.effect.requires_proven_place());
-        // An index write needs no proven receiver, so it passes regardless of the Unknown base.
         assert!(c.writes_proven());
 
         // JS `xs.push(v)` → Append effect, no heap place.

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -17,8 +17,8 @@ mod units;
 
 pub use contiguous::Stream;
 pub use fragment::{
-    fragment_behavior, free_input_cids, synthesize_wrapper, Effect, Exit, FragmentContract,
-    FragmentKind, Place, ProofFacts,
+    fragment_behavior, free_input_cids, synthesize_wrapper, Effect, EffectSite, Exit,
+    FragmentContract, FragmentKind, Place, ProofFacts,
 };
 pub use report::{rank_families, RefactorFamily};
 pub use units::UnitFeat;

--- a/docs/fragment-contracts.md
+++ b/docs/fragment-contracts.md
@@ -34,13 +34,18 @@ without re-reading the recognizer. The recognizer returns a `FragmentKind` inste
 ### 2. The contract — `FragmentContract`
 
 A recognizer-independent description of one fragment: its free **inputs** (the canonical ids
-it reads), its **exit** (normal / return / throw), its observable **effect**, and the write
-**place** for heap-mutating shapes. Two fragments with the same contract are interchangeable
-to the oracle regardless of which predicate matched them.
+it reads), its **exit** (normal / return / throw), and its **effects** — an *ordered sequence*
+of observable effects, each paired with the write **place** for the receiver-bearing ones. The
+sequence is empty for a pure value/control sink (a direct return/throw), one entry for a
+single-statement write, and several — in execution order — for a multi-statement body (a
+conditional branch, a loop body, an ordered effect sequence). Two fragments with the same
+contract are interchangeable to the oracle regardless of which predicate matched them.
 
 The contract carries only what the oracle needs to build a runnable wrapper. That is the
 forcing function: **a contract that cannot be lowered into a wrapper is underspecified**, so
-the model cannot drift into describing fragments the oracle can't vouch for.
+the model cannot drift into describing fragments the oracle can't vouch for. The
+`writes_proven` check is the fail-closed gate over the effect sequence: every field write must
+resolve to a proven [`Place`] (an append/index write carries no such obligation).
 
 ### 3. The oracle — wrapper synthesis
 
@@ -53,7 +58,18 @@ battery whole functions use.
 
 Because `Behavior` already records effects and field state, **effects are preserved as
 observable behavior for free**: appending to a parameter list shows up in the effect trace,
-so two append fragments that append different values diverge without any special handling.
+so two append fragments that append different values diverge without any special handling. A
+multi-statement body is lowered by splicing its statements into the wrapper body in order, so
+an ordered effect sequence (e.g. two appends) is observed in order — swapping them diverges.
+
+The wrapper's parameters are the fragment's **free inputs**, computed binding-aware: a cid
+read from the enclosing scope is an input, but one *bound within* the fragment — a local
+assigned before use, a `for-each` loop variable, a nested lambda parameter — is not, because
+the interpreter binds it as the wrapper runs. (The binding model mirrors alpha-renaming's.)
+This is what lets loop- and temp-bearing bodies be modeled at all: treating a loop variable as
+a parameter would inflate the arity and feed it a battery value the loop immediately
+overwrites. Omitting a genuine input only ever under-reports — an unbound read makes the
+wrapper uninterpretable (fail-closed), never a false merge.
 
 ## The effect algebra
 
@@ -95,6 +111,28 @@ contract path accept **exactly the same `(span, kind)` set** for migrated kinds,
 `debug_assert` in the collector cross-checks the forward direction on every accepted fragment
 across the whole fixture corpus. A migration step that changes which fragments are accepted
 fails the gate — that is what keeps the re-expression behavior-invariant.
+
+## Migrated kinds, and what remains
+
+The predicate path in `units.rs` is still the **production authority**: it decides which
+fragments are accepted. The contract path is an independent shadow recognizer, kept in lockstep
+by the differential gate above. Migrating a kind means re-expressing it on the contract path
+and adding it to that gate — it does **not** change production output.
+
+| `FragmentKind` | contract-migrated? |
+|---|---|
+| `DirectReturn`, `DirectThrow` | yes — value/control sinks |
+| `IndexAssignEffect`, `SelfFieldAssign`, `ExprEffect` | yes — single-effect writes |
+| `ConditionalGuard` | not yet — predicate-owned |
+| `LoopEffect` | not yet — predicate-owned |
+| `SelfFieldBody` | not yet — predicate-owned |
+
+The remaining three need substrate the migrated single-statement shapes did not: binding-aware
+free inputs (loop variables, branch-local temps), an ordered multi-effect sequence, and
+multi-statement wrapper lowering. Those capabilities are now in place (described above); the
+kinds migrate onto them one at a time, each behind the differential gate, in follow-up work.
+The interim "branch-local temp" and "ordered multi-effect" shapes are proof mechanisms *inside*
+those three kinds, not new `FragmentKind` variants or reason codes.
 
 ## What stays closed
 

--- a/docs/fragment-contracts.md
+++ b/docs/fragment-contracts.md
@@ -90,13 +90,14 @@ special case, but a consequence of the algebra.
 
 ## Place — receiver identity, fail-closed
 
-A write target resolves to a `Place`: `This`, `Param(cid)`, `LocalAlloc(id)`, a `Field` or
-`Index` path over another place, or `Unknown`. The cardinal rule is that **`Unknown` is the
-default**: any receiver that does not resolve to a proven place is `Unknown`, and a write that
-*requires* a proven place (a field write) through an `Unknown` receiver is rejected, never
-merged. An index write whose base is unproven (e.g. a Java instance field) still resolves —
-to `Index(Unknown, …)` — and stays safe, because an index write is observable in the effect
-trace and so carries no receiver-identity obligation.
+A receiver-bearing write resolves its target to a `Place`: `This`, `Param(cid)`,
+`LocalAlloc(id)`, a `Field` or `Index` path over another place, or `Unknown`. The cardinal
+rule is that **`Unknown` is the default**: any receiver that does not resolve to a proven place
+is `Unknown`, and a field write through an `Unknown` receiver is rejected, never merged. A
+`Place` is recorded on the contract *only* for effects that need this proof — i.e. field
+writes. An index write carries no place at all: it is observable in the effect trace (key and
+value are recorded), so its receiver identity is irrelevant to soundness, and conflating its
+target into the contract would mix proof with diagnostics.
 
 This folds the former Java `this.field` special case into the general model: `this.x = v`
 resolves to `Field(This, …)`, and the recognizer asserts the place is exact-safe.


### PR DESCRIPTION
## What

**PR 1 of the #43 contract-migration sequence** (per the [issue #43 final decision](https://github.com/corca-ai/nose/issues/43)): the output-preserving substrate the remaining predicate-owned fragment kinds (`ConditionalGuard`, `LoopEffect`, `SelfFieldBody`) need before they can migrate onto the contract path. **No kind is migrated here and production output is unchanged** — this is shadow-only foundation work.

Part of umbrella #42. Builds on #33/#39 (substrate) and is verified with the #37/#38 scan-regression harness.

## Why (the decision's PR 1)

> PR 1: binding-aware input inference + block/ordered-effect contract support. Production output 변경 없음.

The three remaining kinds need substrate the migrated single-statement shapes did not:
- **binding-aware free inputs** — a `for-each` loop variable or branch-local temp must not become a wrapper parameter (it would inflate arity and get a battery value the loop overwrites — the loop-variable hazard called out on the issue);
- an **ordered multi-effect sequence** — a conditional branch / loop body / effect sequence has several effects in order;
- **multi-statement wrapper lowering** — a block-rooted body, not a single statement.

## Changes (three logical commits)

1. **Ordered effect sequence contract model** — `FragmentContract.effect: Option<Effect>` + `place: Option<Place>` → `effects: Vec<EffectSite>` (each effect paired with its write `Place`), in execution order. Constructors `value_sink` / `single_effect` / `ordered_effects`; `writes_proven` is the fail-closed gate (every field write resolves to an exact-safe place; append/index never block). Migrated single-statement kinds construct a 0/1-element sequence, so the differential gate is unchanged.
2. **Binding-aware free inputs + multi-statement lowering** — `free_input_cids` excludes cids *bound within* the fragment (assignment targets, `for-each` patterns, nested lambda params), mirroring alpha-renaming's binding model; `synthesize_wrapper` splices a block body's statements in order. Sound by construction: omitting a genuine input only under-reports, and an unbound read makes the wrapper uninterpretable (`run_unit → None`) — fail-closed, never a false merge.
3. **Docs** — `docs/fragment-contracts.md` updated for the ordered-effect model, binding-aware inputs, and a migrated/remaining status table.

No new `FragmentKind` or reason code; no scan JSON / ranking change (per the decision: temp/ordered are proof mechanisms *inside* the three kinds, and metadata exposure stays in #45).

## Verification (the decision's acceptance bar)

- **Differential gate**: predicate vs contract `(span, kind)` set-equality for migrated kinds — green; the per-fragment `debug_assert` forward check is retained and exercised by the debug-build test suite.
- **Product output byte-identical** vs `main` across **16 repos / all 8 languages** (incl. sympy 1.1 MB, guava 1.6 MB, netty 887 KB) — `nose scan --mode semantic --format json --top 0` is identical.
- **#37 scan-regression harness** `compare`: **0 output triggers**.
- **Type-4 core smoke**: positive recall **492/492**, hard-negative false merges **0/922**.
- `cargo test` (full suite), `cargo clippy -D warnings`, `cargo fmt --check`, `awiki lint` — all green. 4 new fragment unit tests (loop-var/temp exclusion, equivalent-loop oracle agreement, ordered-effect order observability).

## Next (separate PRs, gated the same way)

PR 2 `ConditionalGuard` → PR 3 `LoopEffect` → PR 4 `SelfFieldBody` → PR 5+ consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 프래그먼트 계약 및 래퍼 합성 과정에 대한 설명이 개선되고 확장되었습니다.
  * 효과 시퀀스 처리 방식과 마이그레이션 상태에 대한 구체적인 내용이 추가되었습니다.

* **개선**
  * 프래그먼트 효과 처리 시스템이 개선되어 입력 검출 및 효과 관찰이 더 정확해졌습니다.
  * 프래그먼트 래퍼 합성의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->