### PR TITLE
[codex] Productize exact fragment metadata

### DIFF
--- a/bench/labels/eval_by_language.py
+++ b/bench/labels/eval_by_language.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Per-language refactoring-ranking eval with bootstrap CIs and a dev/heldout split.
 
-Uses refactoring_families.v4.json (dev + heldout). Reports, per language and split:
+Uses refactoring_families.v5.json (dev + heldout). Reports, per language and split:
 precision@10 (baseline value-rank) and (anti-unification re-rank), each with a 95%
 bootstrap CI so a difference like "Rust 47% vs 38%" can be judged significant or
 noise; worthy-recall; and mean Raw-node ratio (the lowering confound). The CI is the
@@ -57,6 +57,13 @@ def refactorability(f):
     return r
 
 
+def scan_families(stdout):
+    payload = json.loads(stdout or "[]")
+    if isinstance(payload, dict):
+        return payload.get("families", [])
+    return payload
+
+
 def ci(flags, b=2000):
     """95% bootstrap CI for the mean of a 0/1 list; returns (lo, hi) in %."""
     if not flags:
@@ -90,7 +97,8 @@ def main():
         a["worthy"] += sum(x["worthy"] for x in labs)
         r = subprocess.run([str(NOSE), "scan", str(repo), "--format", "json", "--top", "1000000"],
                            cwd=ROOT, capture_output=True, text=True, timeout=300)
-        fams = sorted(json.loads(r.stdout or "[]"), key=lambda f: -f["value"])
+        r.check_returncode()
+        fams = sorted(scan_families(r.stdout), key=lambda f: -f["value"])
         top = fams[:40]
         for f in top:
             f["rv"] = f["value"] * refactorability(f)

--- a/bench/type4/scan_regression/README.md
+++ b/bench/type4/scan_regression/README.md
@@ -79,11 +79,9 @@ main worktree or any other path you pass to `--repos-root`. Per repo we record a
   `members`, `location_count`, `mean_lines`, per-kind counts, and the sorted locations.
   `distinct_location_sets` is recorded so a true location-set collision would surface
   rather than collapse silently.
-- `fragment_kind_counts` / `reason_code_counts` — a **forward-compatible hook that is
-  inert today**: #33 has merged, but the product scan JSON still serializes only `kind`
-  per location, so these stay empty until a separate scan-JSON change exposes the fields
-  (then they light up with no code change here). Until then the kind + span buckets are
-  the interim output-quality view; they are where #35's buckets plug in.
+- `fragment_kind_counts` / `reason_code_counts` — exact-fragment metadata buckets from
+  product scan JSON. #45 makes these live for current output, so fragment/reason drift is
+  visible separately from generic `Block` counts.
 
 `baseline` runs each repo `runtime_repeats` times and asserts the canonical output is
 **identical across runs** on one binary — a determinism guard. A mismatch aborts before

--- a/bench/type4/scan_regression/baseline.v1.json
+++ b/bench/type4/scan_regression/baseline.v1.json
@@ -1,12 +1,12 @@
 {
   "binary": {
-    "binary_path": "/Users/ak/prjs/cc/nose/target/release/nose",
-    "build_ref": "main@0b57dd2",
-    "sha256": "c675b831b24dfed2942f64ca58764cf8e83d11a5e9139877aa30ea7988bb11f3",
-    "size_bytes": 13510272,
-    "source_dirty": true,
-    "source_git_describe": "v0.5.0-161-g0cf4317-dirty",
-    "source_git_sha": "0cf4317df8a0ecebccd18e4fddb8fca8a1e27da2",
+    "binary_path": "/Users/ak/prjs/cc/nose/.claude/worktrees/issue-45-productize-fragments/target/release/nose",
+    "build_ref": "issue-45@416325e",
+    "sha256": "afc8212b9480a812a3f5c52f3977f89c1905f130001ca53b4ee47820969b02de",
+    "size_bytes": 13549744,
+    "source_dirty": false,
+    "source_git_describe": "v0.5.0-175-ge4d381d",
+    "source_git_sha": "e4d381d82922c591330da297c82d5aa2cc3c6552",
     "version": "nose 0.5.0"
   },
   "generated_by": "bench/type4/scan_regression/scan_regression.py baseline",
@@ -795,7 +795,11 @@
             "span_bucket": "2-3"
           }
         },
-        "fragment_kind_counts": {},
+        "fragment_kind_counts": {
+          "conditional-guard": 17,
+          "direct-return": 1,
+          "expr-effect": 68
+        },
         "kind_counts": {
           "Block": 94,
           "Function": 12,
@@ -805,8 +809,12 @@
           "javascript": 1,
           "python": 64
         },
-        "product_json_bytes": 28210,
-        "reason_code_counts": {},
+        "product_json_bytes": 59246,
+        "reason_code_counts": {
+          "exact-conditional-guard": 17,
+          "exact-direct-return": 1,
+          "exact-expr-effect": 68
+        },
         "scope_files": 65,
         "shown_families": 45,
         "span_buckets": {
@@ -820,19 +828,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 2.2,
+          "candidates": 2.1,
           "cluster": 0.1,
           "contiguous": 0.0,
-          "discover": 3.4,
-          "groups": 0.1,
-          "lower": 13.3,
-          "normalize+extract": 9.2,
-          "parse+lower": 9.4,
+          "discover": 5.0,
+          "groups": 0.2,
+          "lower": 14.2,
+          "normalize+extract": 8.8,
+          "parse+lower": 9.2,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 37.93,
-        "wall_ms_min": 37.19
+        "wall_ms_median": 38.96,
+        "wall_ms_min": 36.6
       }
     },
     "chi": {
@@ -911,15 +919,19 @@
             "span_bucket": "1"
           }
         },
-        "fragment_kind_counts": {},
+        "fragment_kind_counts": {
+          "expr-effect": 15
+        },
         "kind_counts": {
           "Block": 15
         },
         "languages": {
           "go": 78
         },
-        "product_json_bytes": 2776,
-        "reason_code_counts": {},
+        "product_json_bytes": 7717,
+        "reason_code_counts": {
+          "exact-expr-effect": 15
+        },
         "scope_files": 78,
         "shown_families": 4,
         "span_buckets": {
@@ -933,15 +945,15 @@
           "cluster": 0.0,
           "contiguous": 0.0,
           "discover": 3.4,
-          "groups": 0.0,
-          "lower": 12.5,
-          "normalize+extract": 7.2,
-          "parse+lower": 8.2,
+          "groups": 0.1,
+          "lower": 12.2,
+          "normalize+extract": 7.3,
+          "parse+lower": 8.1,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 30.65,
-        "wall_ms_min": 29.64
+        "wall_ms_median": 31.49,
+        "wall_ms_min": 29.0
       }
     },
     "cmark": {
@@ -1362,7 +1374,10 @@
             "span_bucket": "1"
           }
         },
-        "fragment_kind_counts": {},
+        "fragment_kind_counts": {
+          "conditional-guard": 45,
+          "expr-effect": 2
+        },
         "kind_counts": {
           "Block": 171,
           "Function": 2,
@@ -1373,8 +1388,11 @@
           "python": 12,
           "ruby": 1
         },
-        "product_json_bytes": 21245,
-        "reason_code_counts": {},
+        "product_json_bytes": 43287,
+        "reason_code_counts": {
+          "exact-conditional-guard": 45,
+          "exact-expr-effect": 2
+        },
         "scope_files": 51,
         "shown_families": 17,
         "span_buckets": {
@@ -1386,19 +1404,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 1.7,
-          "cluster": 0.0,
+          "candidates": 1.5,
+          "cluster": 0.1,
           "contiguous": 0.0,
           "discover": 3.4,
           "groups": 0.1,
-          "lower": 21.5,
-          "normalize+extract": 22.1,
-          "parse+lower": 18.2,
+          "lower": 20.7,
+          "normalize+extract": 22.5,
+          "parse+lower": 17.3,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 57.89,
-        "wall_ms_min": 54.03
+        "wall_ms_median": 57.51,
+        "wall_ms_min": 55.93
       }
     },
     "gin": {
@@ -1457,7 +1475,9 @@
             "span_bucket": "4-10"
           }
         },
-        "fragment_kind_counts": {},
+        "fragment_kind_counts": {
+          "expr-effect": 7
+        },
         "kind_counts": {
           "Block": 7,
           "Function": 2
@@ -1465,8 +1485,10 @@
         "languages": {
           "go": 98
         },
-        "product_json_bytes": 1926,
-        "reason_code_counts": {},
+        "product_json_bytes": 4403,
+        "reason_code_counts": {
+          "exact-expr-effect": 7
+        },
         "scope_files": 98,
         "shown_families": 3,
         "span_buckets": {
@@ -1477,19 +1499,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 1.6,
+          "candidates": 1.7,
           "cluster": 0.1,
           "contiguous": 0.0,
-          "discover": 4.9,
-          "groups": 0.0,
-          "lower": 19.1,
-          "normalize+extract": 13.3,
-          "parse+lower": 14.5,
-          "score": 0.3
+          "discover": 3.4,
+          "groups": 0.1,
+          "lower": 18.8,
+          "normalize+extract": 13.7,
+          "parse+lower": 15.4,
+          "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 46.48,
-        "wall_ms_min": 45.23
+        "wall_ms_median": 46.38,
+        "wall_ms_min": 44.43
       }
     },
     "junit5": {
@@ -4696,7 +4718,13 @@
             "span_bucket": "2-3"
           }
         },
-        "fragment_kind_counts": {},
+        "fragment_kind_counts": {
+          "conditional-guard": 35,
+          "direct-return": 10,
+          "expr-effect": 243,
+          "self-field-assign": 7,
+          "self-field-body": 17
+        },
         "kind_counts": {
           "Block": 312,
           "Class": 4,
@@ -4706,8 +4734,14 @@
           "java": 1724,
           "javascript": 1
         },
-        "product_json_bytes": 191816,
-        "reason_code_counts": {},
+        "product_json_bytes": 369736,
+        "reason_code_counts": {
+          "exact-conditional-guard": 35,
+          "exact-direct-return": 10,
+          "exact-expr-effect": 243,
+          "exact-self-field-assign": 7,
+          "exact-self-field-body": 17
+        },
         "scope_files": 1725,
         "shown_families": 172,
         "span_buckets": {
@@ -4721,19 +4755,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 8.2,
+          "candidates": 7.0,
           "cluster": 0.5,
           "contiguous": 0.0,
-          "discover": 9.1,
-          "groups": 0.5,
-          "lower": 50.4,
-          "normalize+extract": 40.9,
-          "parse+lower": 40.2,
+          "discover": 10.5,
+          "groups": 2.3,
+          "lower": 50.9,
+          "normalize+extract": 39.1,
+          "parse+lower": 41.9,
           "score": 0.4
         },
         "repeats": 5,
-        "wall_ms_median": 178.62,
-        "wall_ms_min": 168.15
+        "wall_ms_median": 180.12,
+        "wall_ms_min": 175.56
       }
     },
     "ky": {
@@ -4807,15 +4841,19 @@
             "span_bucket": "2-3"
           }
         },
-        "fragment_kind_counts": {},
+        "fragment_kind_counts": {
+          "conditional-guard": 2
+        },
         "kind_counts": {
           "Block": 10
         },
         "languages": {
           "typescript": 52
         },
-        "product_json_bytes": 2237,
-        "reason_code_counts": {},
+        "product_json_bytes": 3412,
+        "reason_code_counts": {
+          "exact-conditional-guard": 2
+        },
         "scope_files": 52,
         "shown_families": 4,
         "span_buckets": {
@@ -4826,19 +4864,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 0.7,
+          "candidates": 0.9,
           "cluster": 0.0,
           "contiguous": 0.0,
-          "discover": 3.4,
+          "discover": 3.3,
           "groups": 0.0,
-          "lower": 17.8,
-          "normalize+extract": 7.9,
+          "lower": 16.3,
+          "normalize+extract": 7.8,
           "parse+lower": 12.9,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 35.43,
-        "wall_ms_min": 33.29
+        "wall_ms_median": 35.77,
+        "wall_ms_min": 32.95
       }
     },
     "liquid": {
@@ -4912,7 +4950,9 @@
             "span_bucket": "2-3"
           }
         },
-        "fragment_kind_counts": {},
+        "fragment_kind_counts": {
+          "conditional-guard": 6
+        },
         "kind_counts": {
           "Block": 6,
           "Method": 4
@@ -4920,8 +4960,10 @@
         "languages": {
           "ruby": 153
         },
-        "product_json_bytes": 2360,
-        "reason_code_counts": {},
+        "product_json_bytes": 4654,
+        "reason_code_counts": {
+          "exact-conditional-guard": 6
+        },
         "scope_files": 153,
         "shown_families": 4,
         "span_buckets": {
@@ -4937,15 +4979,15 @@
           "cluster": 0.1,
           "contiguous": 0.0,
           "discover": 3.4,
-          "groups": 0.0,
-          "lower": 14.4,
-          "normalize+extract": 11.0,
-          "parse+lower": 11.2,
+          "groups": 0.1,
+          "lower": 14.8,
+          "normalize+extract": 10.6,
+          "parse+lower": 11.4,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 39.75,
-        "wall_ms_min": 39.15
+        "wall_ms_median": 40.33,
+        "wall_ms_min": 38.74
       }
     },
     "serde_json": {
@@ -5157,7 +5199,10 @@
             "span_bucket": "2-3"
           }
         },
-        "fragment_kind_counts": {},
+        "fragment_kind_counts": {
+          "direct-return": 5,
+          "expr-effect": 2
+        },
         "kind_counts": {
           "Block": 7,
           "Function": 26
@@ -5165,8 +5210,11 @@
         "languages": {
           "rust": 71
         },
-        "product_json_bytes": 7010,
-        "reason_code_counts": {},
+        "product_json_bytes": 10889,
+        "reason_code_counts": {
+          "exact-direct-return": 5,
+          "exact-expr-effect": 2
+        },
         "scope_files": 71,
         "shown_families": 12,
         "span_buckets": {
@@ -5178,19 +5226,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 1.9,
+          "candidates": 1.7,
           "cluster": 0.1,
           "contiguous": 0.0,
           "discover": 4.9,
-          "groups": 0.0,
-          "lower": 14.6,
-          "normalize+extract": 10.6,
-          "parse+lower": 9.6,
+          "groups": 0.1,
+          "lower": 14.2,
+          "normalize+extract": 10.7,
+          "parse+lower": 8.8,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 38.11,
-        "wall_ms_min": 34.56
+        "wall_ms_median": 38.32,
+        "wall_ms_min": 37.09
       }
     }
   },

--- a/bench/type4/scan_regression/compare-summary.md
+++ b/bench/type4/scan_regression/compare-summary.md
@@ -7,9 +7,9 @@
 | | baseline | current |
 |---|---|---|
 | version | `nose 0.5.0` | `nose 0.5.0` |
-| sha256 | `c675b831b24dfed2942f64ca58764cf8e83d11a5e9139877aa30ea7988bb11f3` | `c675b831b24dfed2942f64ca58764cf8e83d11a5e9139877aa30ea7988bb11f3` |
-| source_git_describe | `v0.5.0-161-g0cf4317-dirty` | `v0.5.0-161-g0cf4317-dirty` |
-| build_ref | `main@0b57dd2` | `` |
+| sha256 | `afc8212b9480a812a3f5c52f3977f89c1905f130001ca53b4ee47820969b02de` | `afc8212b9480a812a3f5c52f3977f89c1905f130001ca53b4ee47820969b02de` |
+| source_git_describe | `v0.5.0-175-ge4d381d` | `v0.5.0-175-ge4d381d-dirty` |
+| build_ref | `issue-45@416325e` | `` |
 
 **Note: identical binary sha256 — any output/runtime delta below is environment noise, not a code change.**
 

--- a/bench/type4/scan_regression/scan_regression.py
+++ b/bench/type4/scan_regression/scan_regression.py
@@ -33,11 +33,9 @@ Why this exists, and the rules it follows (from the issue #37 decision):
    (repo-relative) location set, because the product `family_id` is NOT unique (distinct
    families can share one id); family_id is compared as an attribute and is itself a
    drift signal. We also compare unit kind, mean_lines / span size, location count, and
-   product JSON byte size. There is a forward-compatible hook for
-   `fragment_kind` / `reason_code`, but it is INERT today: #33 has merged yet the product
-   scan JSON still serializes only `kind` per location, so those counts stay empty until
-   a separate scan-JSON change exposes the fields. Until then we bucket by unit `kind`
-   (e.g. `Block`) + span size as the interim view (#35).
+   product JSON byte size. `fragment_kind` / `reason_code` are counted from product
+   scan JSON when exact-fragment locations expose them, so #45 metadata changes become
+   visible as bucket drift instead of hiding inside generic `Block` counts.
 
 6. Durable artifacts live next to this script in `bench/type4/scan_regression/`:
    `subset.json` (the small subset), `baseline.v1.json` (the recorded baseline),
@@ -238,9 +236,8 @@ def _span_bucket(mean_lines: int) -> str:
 
 def _count_meta(obj: dict, key: str, sink: dict) -> None:
     """Count a forward-compatible metadata field (fragment_kind / reason_code) wherever
-    it appears. INERT today: although #33 has merged, the product scan JSON still
-    serializes only `kind` per location, so these stay empty until a separate scan-JSON
-    change exposes the fields — at which point this lights up with no code change."""
+    it appears. The product scan path emits these for exact-fragment locations; older
+    baselines that lack the fields naturally count as empty buckets."""
     val = obj.get(key)
     if isinstance(val, str):
         sink[val] = sink.get(val, 0) + 1

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3565,7 +3565,7 @@ fn cmd_il(path: PathBuf, format: Format, normalized: bool, no_cfg_norm: bool) ->
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_detect::{Loc, RefactorFamily};
+    use nose_detect::{LineSpan, Loc, LocInit, RefactorFamily};
 
     fn fam(langs: usize, modules: usize, names: &[Option<&str>]) -> RefactorFamily {
         fam_kind(langs, modules, names, nose_il::UnitKind::Function)
@@ -3581,16 +3581,15 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(i, n)| {
-                Loc::new(
-                    format!("m{i}/f.rs"),
-                    1,
-                    10,
-                    "rust".into(),
+                Loc::new(LocInit {
+                    file: format!("m{i}/f.rs"),
+                    source_span: LineSpan::new(1, 10),
+                    lang: "rust".into(),
                     kind,
-                    n.map(|s| s.to_string()),
-                    50,
-                    50,
-                )
+                    name: n.map(|s| s.to_string()),
+                    sem: 50,
+                    span_tokens: 50,
+                })
             })
             .collect();
         RefactorFamily {
@@ -3634,16 +3633,15 @@ mod tests {
         let missing = dir.join("missing.rs").to_string_lossy().to_string();
 
         let mk = |file: String| {
-            Loc::new(
+            Loc::new(LocInit {
                 file,
-                1,
-                3,
-                "rust".into(),
-                nose_il::UnitKind::Function,
-                None,
-                50,
-                50,
-            )
+                source_span: LineSpan::new(1, 3),
+                lang: "rust".into(),
+                kind: nose_il::UnitKind::Function,
+                name: None,
+                sem: 50,
+                span_tokens: 50,
+            })
         };
         // locs[1] (the first compared pair) is unreadable; locs[2] reads and differs
         // from the representative by one parameter line.

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -802,6 +802,7 @@ struct ScanJsonFamily<'a> {
     family_id: String,
     #[serde(flatten)]
     family: &'a nose_detect::RefactorFamily,
+    recommended_surface: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     baseline_status: Option<&'static str>,
 }
@@ -811,6 +812,7 @@ struct ScanJsonIgnoredFamily<'a> {
     family_id: String,
     #[serde(flatten)]
     family: &'a nose_detect::RefactorFamily,
+    recommended_surface: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     baseline_status: Option<&'static str>,
     ignore: &'a ignores::IgnoreMatch,
@@ -861,6 +863,7 @@ impl<'a> ScanJsonReport<'a> {
                 .map(|family| ScanJsonFamily {
                     family_id: baseline::family_id(family),
                     family,
+                    recommended_surface: family.recommended_surface(),
                     baseline_status: statuses
                         .and_then(|s| s.get(&baseline::family_key(family)))
                         .map(BaselineStatus::as_str),
@@ -872,6 +875,7 @@ impl<'a> ScanJsonReport<'a> {
                 .map(|ignored| ScanJsonIgnoredFamily {
                     family_id: baseline::family_id(&ignored.family),
                     family: &ignored.family,
+                    recommended_surface: ignored.family.recommended_surface(),
                     baseline_status: statuses
                         .and_then(|s| s.get(&baseline::family_key(&ignored.family)))
                         .map(BaselineStatus::as_str),
@@ -2428,6 +2432,14 @@ fn relativize(file: &str, cwd: &std::path::Path) -> String {
         .unwrap_or_else(|| file.to_string())
 }
 
+fn relativize_loc(loc: &mut nose_detect::Loc, cwd: &std::path::Path) {
+    loc.file = relativize(&loc.file, cwd);
+    if let Some(parent) = &mut loc.enclosing_unit {
+        parent.file = relativize(&parent.file, cwd);
+        parent.refresh_unit_key();
+    }
+}
+
 /// Stderr notice that discovery found nothing — so a mistyped path or unsupported
 /// tree doesn't masquerade as "no duplication found".
 fn warn_no_files(paths: &[PathBuf]) {
@@ -2526,7 +2538,7 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
     if let Ok(cwd) = std::env::current_dir() {
         for f in &mut families {
             for l in &mut f.locations {
-                l.file = relativize(&l.file, &cwd);
+                relativize_loc(l, &cwd);
             }
         }
     }
@@ -3568,14 +3580,17 @@ mod tests {
         let locations = names
             .iter()
             .enumerate()
-            .map(|(i, n)| Loc {
-                file: format!("m{i}/f.rs"),
-                start_line: 1,
-                end_line: 10,
-                lang: "rust".into(),
-                kind,
-                name: n.map(|s| s.to_string()),
-                sem: 50,
+            .map(|(i, n)| {
+                Loc::new(
+                    format!("m{i}/f.rs"),
+                    1,
+                    10,
+                    "rust".into(),
+                    kind,
+                    n.map(|s| s.to_string()),
+                    50,
+                    50,
+                )
             })
             .collect();
         RefactorFamily {
@@ -3618,14 +3633,17 @@ mod tests {
         let f2 = write("c.rs", "BBB\nshared1\nshared2\n");
         let missing = dir.join("missing.rs").to_string_lossy().to_string();
 
-        let mk = |file: String| Loc {
-            file,
-            start_line: 1,
-            end_line: 3,
-            lang: "rust".into(),
-            kind: nose_il::UnitKind::Function,
-            name: None,
-            sem: 50,
+        let mk = |file: String| {
+            Loc::new(
+                file,
+                1,
+                3,
+                "rust".into(),
+                nose_il::UnitKind::Function,
+                None,
+                50,
+                50,
+            )
         };
         // locs[1] (the first compared pair) is unreadable; locs[2] reads and differs
         // from the representative by one parameter line.

--- a/crates/nose-cli/src/review.rs
+++ b/crates/nose-cli/src/review.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::{ReportFormat, ScanMode};
-use nose_detect::{Loc, RefactorFamily};
+use nose_detect::{EnclosingUnit, FragmentKind, Loc, RefactorFamily};
 
 pub(crate) struct ReviewArgs {
     pub paths: Vec<PathBuf>,
@@ -54,6 +54,13 @@ struct Site {
     start_line: u32,
     end_line: u32,
     lang: String,
+    kind: nose_il::UnitKind,
+    span_lines: u32,
+    span_tokens: usize,
+    is_fragment: bool,
+    fragment_kind: Option<FragmentKind>,
+    reason_code: Option<&'static str>,
+    enclosing_unit: Option<EnclosingUnit>,
 }
 
 pub(crate) fn cmd_review(args: ReviewArgs) -> Result<()> {
@@ -150,12 +157,24 @@ pub(crate) fn cmd_review(args: ReviewArgs) -> Result<()> {
 fn repo_relative(fam: &RefactorFamily, base_prefix: &Path) -> RefactorFamily {
     let mut fam = fam.clone();
     for loc in &mut fam.locations {
-        loc.file = canonical(Path::new(&loc.file))
-            .strip_prefix(base_prefix)
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or_else(|_| loc.file.clone());
+        repo_relative_loc(loc, base_prefix);
     }
     fam
+}
+
+fn repo_relative_loc(loc: &mut Loc, base_prefix: &Path) {
+    loc.file = repo_relative_file(&loc.file, base_prefix);
+    if let Some(parent) = &mut loc.enclosing_unit {
+        parent.file = repo_relative_file(&parent.file, base_prefix);
+        parent.refresh_unit_key();
+    }
+}
+
+fn repo_relative_file(file: &str, base_prefix: &Path) -> String {
+    canonical(Path::new(file))
+        .strip_prefix(base_prefix)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| file.to_string())
 }
 
 fn to_site(loc: &Loc) -> Site {
@@ -165,6 +184,13 @@ fn to_site(loc: &Loc) -> Site {
         start_line: loc.start_line,
         end_line: loc.end_line,
         lang: loc.lang.clone(),
+        kind: loc.kind,
+        span_lines: loc.span_lines,
+        span_tokens: loc.span_tokens,
+        is_fragment: loc.is_fragment,
+        fragment_kind: loc.fragment_kind,
+        reason_code: loc.reason_code,
+        enclosing_unit: loc.enclosing_unit.clone(),
     }
 }
 
@@ -379,6 +405,38 @@ fn site_label(s: &Site) -> String {
     }
 }
 
+fn fragment_context(s: &Site) -> Option<String> {
+    if !s.is_fragment {
+        return None;
+    }
+    let kind = s
+        .fragment_kind
+        .map(|k| {
+            k.reason_code()
+                .strip_prefix("exact-")
+                .unwrap_or(k.reason_code())
+                .to_string()
+        })
+        .unwrap_or_else(|| "fragment".to_string());
+    let reason = s.reason_code.unwrap_or("unknown");
+    let parent = s.enclosing_unit.as_ref().map(|p| {
+        let name = p
+            .name
+            .as_deref()
+            .filter(|n| !n.is_empty())
+            .map(|n| format!(" `{n}`"))
+            .unwrap_or_default();
+        format!(
+            " in {:?}{name} {}:{}-{}",
+            p.kind, p.file, p.start_line, p.end_line
+        )
+    });
+    Some(format!(
+        "{kind} fragment ({reason}){}",
+        parent.unwrap_or_default()
+    ))
+}
+
 fn print_review_human(flagged: &[Divergence], base: &str, changed_files: usize, top: usize) {
     let plural = |n: usize, s: &str| {
         if n == 1 {
@@ -420,6 +478,9 @@ fn print_review_human(flagged: &[Divergence], base: &str, changed_files: usize, 
         );
         for s in &d.not_updated {
             println!("    not updated: {}", site_label(s));
+            if let Some(context) = fragment_context(s) {
+                println!("      context: {context}");
+            }
         }
         println!("    → review whether the change should also apply to the sibling(s)\n");
     }
@@ -434,6 +495,13 @@ fn review_json(flagged: &[Divergence], base: &str, changed_files: usize) -> Resu
         json!({
             "file": s.file, "name": s.name,
             "start_line": s.start_line, "end_line": s.end_line, "lang": s.lang,
+            "kind": s.kind,
+            "span_lines": s.span_lines,
+            "span_tokens": s.span_tokens,
+            "is_fragment": s.is_fragment,
+            "fragment_kind": s.fragment_kind,
+            "reason_code": s.reason_code,
+            "enclosing_unit": s.enclosing_unit,
         })
     };
     let items: Vec<_> = flagged
@@ -461,7 +529,9 @@ fn review_json(flagged: &[Divergence], base: &str, changed_files: usize) -> Resu
 fn review_sarif(flagged: &[Divergence]) -> Result<String> {
     use serde_json::json;
     let phys = |s: &Site| {
+        let message = fragment_context(s).unwrap_or_else(|| site_label(s));
         json!({
+            "message": { "text": message },
             "physicalLocation": {
                 "artifactLocation": { "uri": s.file },
                 "region": { "startLine": s.start_line, "endLine": s.end_line }

--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -59,6 +59,24 @@ fn make_mode_project(tag: &str) -> PathBuf {
     dir
 }
 
+fn make_fragment_project(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("nose_frag_{tag}_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("a")).unwrap();
+    fs::create_dir_all(dir.join("b")).unwrap();
+    fs::write(
+        dir.join("a/f.py"),
+        "def first(xs):\n    total = 0\n    if xs:\n        return xs[0] + 1\n    return total\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("b/f.py"),
+        "def second(items):\n    acc = 10\n    if items:\n        return items[0] + 1\n    return acc\n",
+    )
+    .unwrap();
+    dir
+}
+
 fn run(args: &[&str]) -> String {
     let out = Command::new(bin()).args(args).output().expect("run nose");
     assert!(
@@ -154,6 +172,7 @@ fn assert_scan_json_v1_contract(json: &serde_json::Value) {
         "mean_sem",
         "scope",
         "discount",
+        "recommended_surface",
     ] {
         assert!(family.contains_key(key), "family.{key} missing: {json}");
     }
@@ -163,7 +182,17 @@ fn assert_scan_json_v1_contract(json: &serde_json::Value) {
         .and_then(|locations| locations.first())
         .and_then(|location| location.as_object())
         .expect("family.locations should contain location objects");
-    for key in ["file", "start_line", "end_line", "lang", "kind", "sem"] {
+    for key in [
+        "file",
+        "start_line",
+        "end_line",
+        "lang",
+        "kind",
+        "sem",
+        "span_lines",
+        "span_tokens",
+        "is_fragment",
+    ] {
         assert!(loc.contains_key(key), "location.{key} missing: {json}");
     }
 }
@@ -195,6 +224,54 @@ fn scan_json_report_has_versioned_contract() {
     assert_eq!(json["ranking"]["sort"], "extractability");
     assert_eq!(json["ranking"]["shown_families"], 1);
     assert_eq!(json["ranking"]["limit"], 1);
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn scan_json_exposes_exact_fragment_metadata() {
+    let dir = make_fragment_project("json");
+
+    let out = run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--format",
+        "json",
+        "--top",
+        "0",
+        "--min-size",
+        "1",
+    ]);
+    let json = scan_json(&out);
+    let family = scan_families(&json)
+        .iter()
+        .find(|family| family["recommended_surface"] == "hidden")
+        .expect("tiny exact fragment family should be present");
+    assert_eq!(family["mean_lines"], 2);
+    let locs = family["locations"].as_array().expect("locations");
+    assert_eq!(locs.len(), 2);
+    for loc in locs {
+        assert_eq!(loc["kind"], "Block");
+        assert_eq!(loc["span_lines"], 2);
+        assert!(loc["span_tokens"].as_u64().is_some_and(|n| n > 0));
+        assert_eq!(loc["is_fragment"], true);
+        assert_eq!(loc["fragment_kind"], "conditional-guard");
+        assert_eq!(loc["reason_code"], "exact-conditional-guard");
+        assert!(
+            loc.get("proof_facts").is_none(),
+            "proof facts must not be stable scan JSON: {loc}"
+        );
+        let parent = &loc["enclosing_unit"];
+        assert_eq!(parent["kind"], "Function");
+        assert!(parent["name"]
+            .as_str()
+            .is_some_and(|name| { name == "first" || name == "second" }));
+        assert!(parent["unit_key"]
+            .as_str()
+            .is_some_and(|key| { key.contains(":Function:1-5:") }));
+    }
+
     let _ = fs::remove_dir_all(&dir);
 }
 
@@ -9998,6 +10075,44 @@ fn review_flags_a_clone_changed_in_one_copy_only() {
         !gated.status.success(),
         "--fail should exit non-zero when flagged"
     );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn review_json_includes_fragment_context() {
+    let dir = make_fragment_project("review_json");
+    init_git_repo(&dir);
+
+    let a = dir.join("a/f.py");
+    let src = fs::read_to_string(&a).unwrap();
+    fs::write(&a, src.replace("return xs[0] + 1", "return xs[0] + 2")).unwrap();
+
+    let out = nose_review(&dir, &["--format", "json"]);
+    assert!(
+        out.status.success(),
+        "review JSON should succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("review JSON");
+    let finding = json["findings"]
+        .as_array()
+        .and_then(|findings| findings.first())
+        .expect("one fragment review finding");
+    for key in ["changed", "not_updated"] {
+        let site = finding[key]
+            .as_array()
+            .and_then(|sites| sites.first())
+            .unwrap_or_else(|| panic!("{key} should contain a site: {finding}"));
+        assert_eq!(site["is_fragment"], true);
+        assert_eq!(site["fragment_kind"], "conditional-guard");
+        assert_eq!(site["reason_code"], "exact-conditional-guard");
+        assert_eq!(site["span_lines"], 2);
+        assert_eq!(site["enclosing_unit"]["kind"], "Function");
+        assert!(site["enclosing_unit"]["unit_key"]
+            .as_str()
+            .is_some_and(|key| key.contains(":Function:1-5:")));
+    }
 
     let _ = fs::remove_dir_all(&dir);
 }

--- a/crates/nose-cli/tests/fixtures/scan-json-v1.json
+++ b/crates/nose-cli/tests/fixtures/scan-json-v1.json
@@ -38,7 +38,10 @@
           "lang": "python",
           "kind": "Function",
           "name": "f",
-          "sem": 8
+          "sem": 8,
+          "span_lines": 5,
+          "span_tokens": 8,
+          "is_fragment": false
         },
         {
           "file": "b/f.py",
@@ -47,12 +50,16 @@
           "lang": "python",
           "kind": "Function",
           "name": "f",
-          "sem": 8
+          "sem": 8,
+          "span_lines": 5,
+          "span_tokens": 8,
+          "is_fragment": false
         }
       ],
       "mean_sem": 8.0,
       "scope": "prod",
-      "discount": 1.0
+      "discount": 1.0,
+      "recommended_surface": "default"
     }
   ]
 }

--- a/crates/nose-detect/src/contiguous.rs
+++ b/crates/nose-detect/src/contiguous.rs
@@ -12,7 +12,7 @@
 //! source spans via per-token provenance, then clusters them into families.
 
 use crate::cluster::UnionFind;
-use crate::Loc;
+use crate::{LineSpan, Loc, LocInit};
 use nose_il::{Il, Interner, NodeId, UnitKind};
 use nose_normalize::node_tag_valued;
 use rustc_hash::FxHashMap;
@@ -139,16 +139,15 @@ fn extend(sa: &Stream, a: usize, sb: &Stream, b: usize) -> usize {
 fn loc(s: &Stream, lo: usize, hi: usize) -> Loc {
     let start = s.start[lo..hi].iter().copied().min().unwrap_or(0);
     let end = s.end[lo..hi].iter().copied().max().unwrap_or(0);
-    Loc::new(
-        s.path.clone(),
-        start,
-        end,
-        s.lang.name().to_string(),
-        UnitKind::Block,
-        None,
-        hi - lo,
-        hi - lo,
-    )
+    Loc::new(LocInit {
+        file: s.path.clone(),
+        source_span: LineSpan::new(start, end),
+        lang: s.lang.name().to_string(),
+        kind: UnitKind::Block,
+        name: None,
+        sem: hi - lo,
+        span_tokens: hi - lo,
+    })
 }
 
 /// Find maximal duplicated runs across all streams and cluster them into groups.

--- a/crates/nose-detect/src/contiguous.rs
+++ b/crates/nose-detect/src/contiguous.rs
@@ -139,15 +139,16 @@ fn extend(sa: &Stream, a: usize, sb: &Stream, b: usize) -> usize {
 fn loc(s: &Stream, lo: usize, hi: usize) -> Loc {
     let start = s.start[lo..hi].iter().copied().min().unwrap_or(0);
     let end = s.end[lo..hi].iter().copied().max().unwrap_or(0);
-    Loc {
-        file: s.path.clone(),
-        start_line: start,
-        end_line: end,
-        lang: s.lang.name().to_string(),
-        kind: UnitKind::Block,
-        name: None,
-        sem: hi - lo,
-    }
+    Loc::new(
+        s.path.clone(),
+        start,
+        end,
+        s.lang.name().to_string(),
+        UnitKind::Block,
+        None,
+        hi - lo,
+        hi - lo,
+    )
 }
 
 /// Find maximal duplicated runs across all streams and cluster them into groups.

--- a/crates/nose-detect/src/fragment.rs
+++ b/crates/nose-detect/src/fragment.rs
@@ -57,9 +57,9 @@ pub enum FragmentKind {
 impl FragmentKind {
     /// A stable, user-facing kebab-case identifier for this fragment shape.
     ///
-    /// Reason codes are part of the detector's external contract (issue #11): they name
-    /// *why* a fragment is an exact semantic clone. They must stay stable across releases,
-    /// so changing one is a breaking change to consumers that key on it.
+    /// Fragment reason codes name the exact proof shape, such as a direct return or
+    /// conditional guard, that made a sub-function fragment exact-safe. They are not
+    /// the broader family/actionability reason codes tracked in issue #11.
     pub fn reason_code(self) -> &'static str {
         match self {
             FragmentKind::DirectReturn => "exact-direct-return",

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -417,26 +417,72 @@ pub struct Loc {
     pub enclosing_unit: Option<EnclosingUnit>,
 }
 
-impl Loc {
-    pub fn new(
-        file: String,
-        start_line: u32,
-        end_line: u32,
-        lang: String,
-        kind: nose_il::UnitKind,
-        name: Option<String>,
-        sem: usize,
-        span_tokens: usize,
-    ) -> Self {
-        Loc {
-            file,
+/// Inclusive source-line range used to construct a [`Loc`].
+#[derive(Clone, Copy)]
+pub struct LineSpan {
+    /// First 1-based source line included in the location.
+    pub start_line: u32,
+    /// Last 1-based source line included in the location.
+    pub end_line: u32,
+}
+
+impl LineSpan {
+    /// Build an inclusive source-line range.
+    pub fn new(start_line: u32, end_line: u32) -> Self {
+        Self {
             start_line,
             end_line,
+        }
+    }
+
+    /// Inclusive line count, saturating for malformed ranges.
+    pub fn line_count(self) -> u32 {
+        self.end_line.saturating_sub(self.start_line) + 1
+    }
+}
+
+/// Constructor input for [`Loc`].
+///
+/// Keeping this as a named struct makes location metadata additions explicit at call sites
+/// without widening a positional constructor.
+#[derive(Clone)]
+pub struct LocInit {
+    /// Source file path as reported to users.
+    pub file: String,
+    /// Inclusive source-line range.
+    pub source_span: LineSpan,
+    /// Normalized language name.
+    pub lang: String,
+    /// Syntactic unit kind at this location.
+    pub kind: nose_il::UnitKind,
+    /// Optional function/method/class name.
+    pub name: Option<String>,
+    /// Value-graph size for this location.
+    pub sem: usize,
+    /// Normalized-token span used by detector size gates.
+    pub span_tokens: usize,
+}
+
+impl Loc {
+    pub fn new(init: LocInit) -> Self {
+        let LocInit {
+            file,
+            source_span,
             lang,
             kind,
             name,
             sem,
-            span_lines: line_span(start_line, end_line),
+            span_tokens,
+        } = init;
+        Loc {
+            file,
+            start_line: source_span.start_line,
+            end_line: source_span.end_line,
+            lang,
+            kind,
+            name,
+            sem,
+            span_lines: source_span.line_count(),
             span_tokens,
             is_fragment: false,
             fragment_kind: None,
@@ -481,25 +527,20 @@ pub struct Report {
 
 fn loc_of(u: &UnitFeat, enclosing_unit: Option<EnclosingUnit>) -> Loc {
     let fragment_kind = u.fragment_kind;
-    Loc {
+    let mut loc = Loc::new(LocInit {
         file: u.path.clone(),
-        start_line: u.start_line,
-        end_line: u.end_line,
+        source_span: LineSpan::new(u.start_line, u.end_line),
         lang: u.lang.name().to_string(),
         kind: u.kind,
         name: u.name.clone(),
         sem: u.value.len(),
-        span_lines: line_span(u.start_line, u.end_line),
         span_tokens: u.token_count,
-        is_fragment: fragment_kind.is_some(),
-        fragment_kind,
-        reason_code: fragment_kind.map(FragmentKind::reason_code),
-        enclosing_unit,
-    }
-}
-
-fn line_span(start_line: u32, end_line: u32) -> u32 {
-    end_line.saturating_sub(start_line) + 1
+    });
+    loc.is_fragment = fragment_kind.is_some();
+    loc.fragment_kind = fragment_kind;
+    loc.reason_code = fragment_kind.map(FragmentKind::reason_code);
+    loc.enclosing_unit = enclosing_unit;
+    loc
 }
 
 fn unit_kind_name(kind: nose_il::UnitKind) -> &'static str {
@@ -571,7 +612,7 @@ fn enclosing_units(units: &[UnitFeat]) -> Vec<Option<EnclosingUnit>> {
             .collect();
         parents.sort_by_key(|&idx| {
             (
-                line_span(units[idx].start_line, units[idx].end_line),
+                LineSpan::new(units[idx].start_line, units[idx].end_line).line_count(),
                 units[idx].start_line,
                 units[idx].end_line,
             )

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -363,6 +363,29 @@ where
 }
 
 #[derive(Serialize, Clone)]
+pub struct EnclosingUnit {
+    pub file: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub kind: nose_il::UnitKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub unit_key: String,
+}
+
+impl EnclosingUnit {
+    pub fn refresh_unit_key(&mut self) {
+        self.unit_key = unit_key(
+            &self.file,
+            self.kind,
+            self.name.as_deref(),
+            self.start_line,
+            self.end_line,
+        );
+    }
+}
+
+#[derive(Serialize, Clone)]
 pub struct Loc {
     pub file: String,
     pub start_line: u32,
@@ -378,6 +401,49 @@ pub struct Loc {
     /// or data/match table has a near-empty one and can only match on *shape* —
     /// the signal the refactor ranking uses to discount structural-only families.
     pub sem: usize,
+    /// Explicit source-line span so consumers do not have to recalculate inclusive
+    /// ranges. Kept for every location, not only fragments.
+    pub span_lines: u32,
+    /// Stable normalized-token span used by the detector's size gates.
+    pub span_tokens: usize,
+    /// Whether this location is an exact sub-function fragment rather than a whole
+    /// function/method/class location.
+    pub is_fragment: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fragment_kind: Option<FragmentKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason_code: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enclosing_unit: Option<EnclosingUnit>,
+}
+
+impl Loc {
+    pub fn new(
+        file: String,
+        start_line: u32,
+        end_line: u32,
+        lang: String,
+        kind: nose_il::UnitKind,
+        name: Option<String>,
+        sem: usize,
+        span_tokens: usize,
+    ) -> Self {
+        Loc {
+            file,
+            start_line,
+            end_line,
+            lang,
+            kind,
+            name,
+            sem,
+            span_lines: line_span(start_line, end_line),
+            span_tokens,
+            is_fragment: false,
+            fragment_kind: None,
+            reason_code: None,
+            enclosing_unit: None,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -413,7 +479,8 @@ pub struct Report {
     pub metrics: Metrics,
 }
 
-fn loc_of(u: &UnitFeat) -> Loc {
+fn loc_of(u: &UnitFeat, enclosing_unit: Option<EnclosingUnit>) -> Loc {
+    let fragment_kind = u.fragment_kind;
     Loc {
         file: u.path.clone(),
         start_line: u.start_line,
@@ -422,7 +489,108 @@ fn loc_of(u: &UnitFeat) -> Loc {
         kind: u.kind,
         name: u.name.clone(),
         sem: u.value.len(),
+        span_lines: line_span(u.start_line, u.end_line),
+        span_tokens: u.token_count,
+        is_fragment: fragment_kind.is_some(),
+        fragment_kind,
+        reason_code: fragment_kind.map(FragmentKind::reason_code),
+        enclosing_unit,
     }
+}
+
+fn line_span(start_line: u32, end_line: u32) -> u32 {
+    end_line.saturating_sub(start_line) + 1
+}
+
+fn unit_kind_name(kind: nose_il::UnitKind) -> &'static str {
+    match kind {
+        nose_il::UnitKind::Function => "Function",
+        nose_il::UnitKind::Method => "Method",
+        nose_il::UnitKind::Class => "Class",
+        nose_il::UnitKind::Block => "Block",
+    }
+}
+
+fn unit_key(
+    file: &str,
+    kind: nose_il::UnitKind,
+    name: Option<&str>,
+    start_line: u32,
+    end_line: u32,
+) -> String {
+    format!(
+        "{}:{}:{}-{}:{}",
+        file,
+        unit_kind_name(kind),
+        start_line,
+        end_line,
+        name.unwrap_or("")
+    )
+}
+
+fn can_enclose_fragment(u: &UnitFeat) -> bool {
+    u.fragment_kind.is_none()
+        && matches!(
+            u.kind,
+            nose_il::UnitKind::Function | nose_il::UnitKind::Method | nose_il::UnitKind::Class
+        )
+}
+
+fn contains_span(parent: &UnitFeat, child: &UnitFeat) -> bool {
+    parent.path == child.path
+        && parent.start_line <= child.start_line
+        && parent.end_line >= child.end_line
+        && (parent.start_line < child.start_line || parent.end_line > child.end_line)
+}
+
+fn enclosing_unit_of(parent: &UnitFeat) -> EnclosingUnit {
+    let mut unit = EnclosingUnit {
+        file: parent.path.clone(),
+        start_line: parent.start_line,
+        end_line: parent.end_line,
+        kind: parent.kind,
+        name: parent.name.clone(),
+        unit_key: String::new(),
+    };
+    unit.refresh_unit_key();
+    unit
+}
+
+fn enclosing_units(units: &[UnitFeat]) -> Vec<Option<EnclosingUnit>> {
+    let mut by_file: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (idx, unit) in units.iter().enumerate() {
+        by_file.entry(unit.path.as_str()).or_default().push(idx);
+    }
+
+    let mut out = vec![None; units.len()];
+    for indices in by_file.values() {
+        let mut parents: Vec<usize> = indices
+            .iter()
+            .copied()
+            .filter(|&idx| can_enclose_fragment(&units[idx]))
+            .collect();
+        parents.sort_by_key(|&idx| {
+            (
+                line_span(units[idx].start_line, units[idx].end_line),
+                units[idx].start_line,
+                units[idx].end_line,
+            )
+        });
+
+        for &idx in indices {
+            if units[idx].fragment_kind.is_none() {
+                continue;
+            }
+            if let Some(parent) = parents
+                .iter()
+                .copied()
+                .find(|&parent_idx| contains_span(&units[parent_idx], &units[idx]))
+            {
+                out[idx] = Some(enclosing_unit_of(&units[parent]));
+            }
+        }
+    }
+    out
 }
 
 /// Two units from the same file where one span contains the other (e.g. a method
@@ -641,12 +809,14 @@ pub fn detect_from_units(
     let raw_groups = uf.groups(units.len());
     clk.lap("cluster");
 
+    let enclosing = enclosing_units(&units);
+
     // Build pair output (sorted by score desc).
     let mut duplicates: Vec<DupPair> = accepted
         .iter()
         .map(|&(i, j, s)| DupPair {
-            left: loc_of(&units[i]),
-            right: loc_of(&units[j]),
+            left: loc_of(&units[i], enclosing[i].clone()),
+            right: loc_of(&units[j], enclosing[j].clone()),
             score: round3(s),
             cross_language: units[i].lang != units[j].lang,
         })
@@ -676,7 +846,10 @@ pub fn detect_from_units(
             let score = if n == 0 { 0.0 } else { sum / n as f64 };
             Group {
                 score: round3(score),
-                members: members.iter().map(|&m| loc_of(&units[m])).collect(),
+                members: members
+                    .iter()
+                    .map(|&m| loc_of(&units[m], enclosing[m].clone()))
+                    .collect(),
             }
         })
         .collect();

--- a/crates/nose-detect/src/report.rs
+++ b/crates/nose-detect/src/report.rs
@@ -507,15 +507,31 @@ fn subsumes(outer: &RefactorFamily, inner: &RefactorFamily) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Metrics, Report};
+    use crate::{LineSpan, LocInit, Metrics, Report};
     use nose_il::UnitKind::{Class, Function};
 
     fn loc(file: &str, s: u32, e: u32, lang: &str) -> Loc {
-        Loc::new(file.into(), s, e, lang.into(), Function, None, 50, 50)
+        Loc::new(LocInit {
+            file: file.into(),
+            source_span: LineSpan::new(s, e),
+            lang: lang.into(),
+            kind: Function,
+            name: None,
+            sem: 50,
+            span_tokens: 50,
+        })
     }
     /// A site with explicit kind / value-graph size / name (for discount tests).
     fn loc_k(file: &str, s: u32, e: u32, kind: nose_il::UnitKind, sem: usize) -> Loc {
-        Loc::new(file.into(), s, e, "rust".into(), kind, None, sem, sem)
+        Loc::new(LocInit {
+            file: file.into(),
+            source_span: LineSpan::new(s, e),
+            lang: "rust".into(),
+            kind,
+            name: None,
+            sem,
+            span_tokens: sem,
+        })
     }
 
     fn fragment_loc(file: &str, s: u32, e: u32) -> Loc {
@@ -523,16 +539,15 @@ mod tests {
             is_fragment: true,
             fragment_kind: Some(crate::FragmentKind::ConditionalGuard),
             reason_code: Some(crate::FragmentKind::ConditionalGuard.reason_code()),
-            ..Loc::new(
-                file.into(),
-                s,
-                e,
-                "rust".into(),
-                nose_il::UnitKind::Block,
-                None,
-                50,
-                50,
-            )
+            ..Loc::new(LocInit {
+                file: file.into(),
+                source_span: LineSpan::new(s, e),
+                lang: "rust".into(),
+                kind: nose_il::UnitKind::Block,
+                name: None,
+                sem: 50,
+                span_tokens: 50,
+            })
         }
     }
     /// A family with the given locations and metrics, other fields at neutral values.

--- a/crates/nose-detect/src/report.rs
+++ b/crates/nose-detect/src/report.rs
@@ -115,6 +115,37 @@ impl RefactorFamily {
             * param_penalty
             * tightness
             * self.discount
+            * self.default_surface_weight()
+    }
+
+    /// Product placement for the default scan/review/debug surfaces. This is a
+    /// presentation/ranking decision, not detector semantics: exact fragments remain
+    /// present in `--top 0` JSON even when their default ranking is dampened.
+    pub fn recommended_surface(&self) -> &'static str {
+        let fragment_sites = self.locations.iter().filter(|l| l.is_fragment).count();
+        if fragment_sites == 0 {
+            return "default";
+        }
+        if fragment_sites < self.locations.len() {
+            return "default";
+        }
+        if self.mean_lines <= 3 {
+            "hidden"
+        } else if self.mean_lines <= 8 {
+            "review"
+        } else {
+            "default"
+        }
+    }
+
+    fn default_surface_weight(&self) -> f64 {
+        match self.recommended_surface() {
+            "default" => 1.0,
+            "review" => 0.35,
+            "hidden" => 0.05,
+            "debug" => 0.02,
+            _ => 1.0,
+        }
     }
 
     /// Divergent-edit **hazard**: how likely this family is to be edited inconsistently
@@ -166,7 +197,7 @@ fn module_of(file: &str) -> &str {
 }
 
 fn span_lines(l: &Loc) -> u32 {
-    l.end_line.saturating_sub(l.start_line) + 1
+    l.span_lines
 }
 
 /// Fraction of `b`'s lines that lie inside `a` (both in the same file). Used to
@@ -480,26 +511,28 @@ mod tests {
     use nose_il::UnitKind::{Class, Function};
 
     fn loc(file: &str, s: u32, e: u32, lang: &str) -> Loc {
-        Loc {
-            file: file.into(),
-            start_line: s,
-            end_line: e,
-            lang: lang.into(),
-            kind: Function,
-            name: None,
-            sem: 50,
-        }
+        Loc::new(file.into(), s, e, lang.into(), Function, None, 50, 50)
     }
     /// A site with explicit kind / value-graph size / name (for discount tests).
     fn loc_k(file: &str, s: u32, e: u32, kind: nose_il::UnitKind, sem: usize) -> Loc {
+        Loc::new(file.into(), s, e, "rust".into(), kind, None, sem, sem)
+    }
+
+    fn fragment_loc(file: &str, s: u32, e: u32) -> Loc {
         Loc {
-            file: file.into(),
-            start_line: s,
-            end_line: e,
-            lang: "rust".into(),
-            kind,
-            name: None,
-            sem,
+            is_fragment: true,
+            fragment_kind: Some(crate::FragmentKind::ConditionalGuard),
+            reason_code: Some(crate::FragmentKind::ConditionalGuard.reason_code()),
+            ..Loc::new(
+                file.into(),
+                s,
+                e,
+                "rust".into(),
+                nose_il::UnitKind::Block,
+                None,
+                50,
+                50,
+            )
         }
     }
     /// A family with the given locations and metrics, other fields at neutral values.
@@ -938,6 +971,34 @@ mod tests {
         assert_eq!(
             fmixed.value, fpure.value,
             "test↔prod duplication is not discounted"
+        );
+    }
+
+    #[test]
+    fn tiny_all_fragment_family_is_hidden_and_downranked() {
+        let whole = fam(
+            10.0,
+            2,
+            2,
+            0,
+            vec![loc("src/a.rs", 1, 2, "rust"), loc("src/b.rs", 1, 2, "rust")],
+        );
+        let fragment = fam(
+            10.0,
+            2,
+            2,
+            0,
+            vec![
+                fragment_loc("src/a.rs", 3, 4),
+                fragment_loc("src/b.rs", 3, 4),
+            ],
+        );
+
+        assert_eq!(whole.recommended_surface(), "default");
+        assert_eq!(fragment.recommended_surface(), "hidden");
+        assert!(
+            fragment.extractability() < whole.extractability(),
+            "tiny exact fragments remain present but should not outrank whole-unit candidates"
         );
     }
 

--- a/docs/fragment-contracts.md
+++ b/docs/fragment-contracts.md
@@ -26,10 +26,11 @@ functions. The substrate replaces the implicit predicate web with three explicit
 Every accepted fragment carries a `FragmentKind` (direct return/throw, index-assign effect,
 self-field assign, expression effect, conditional guard, loop effect, self-field body) and a
 stable kebab-case **reason code** (`exact-direct-return`, `exact-loop-effect`, …). The reason
-code is part of the external contract (issue #11): it names *why* a fragment is an exact
-clone, so reporting and ranking can separate proof fragments from actionable refactors
-without re-reading the recognizer. The recognizer returns a `FragmentKind` instead of a bare
-`bool`; `ProofFacts` records what was established at acceptance time (context-safety, exit).
+code names the exact proof shape that made the fragment safe; it is not the broader
+family/actionability reason code tracked in issue #11. Reporting and ranking can separate
+proof fragments from actionable refactors without re-reading the recognizer. The recognizer
+returns a `FragmentKind` instead of a bare `bool`; `ProofFacts` records what was established
+at acceptance time (context-safety, exit).
 
 ### 2. The contract — `FragmentContract`
 

--- a/docs/fragment-output-audit.md
+++ b/docs/fragment-output-audit.md
@@ -7,13 +7,15 @@ ranking implementation, or fragment families changed. Back to
 [review](review.md).
 
 The work was prompted by
-[issue #35](https://github.com/corca-ai/nose/issues/35) and feeds three follow-up
-contracts:
+[issue #35](https://github.com/corca-ai/nose/issues/35) and feeds the product
+surface work tracked in [#45](https://github.com/corca-ai/nose/issues/45):
 
-- [#33](https://github.com/corca-ai/nose/issues/33) should expose stable fragment
-  kind and diagnostic proof metadata.
+- [#33](https://github.com/corca-ai/nose/issues/33) exposed stable fragment kind
+  and internal proof metadata.
+- [#45](https://github.com/corca-ai/nose/issues/45) exposes the stable product
+  metadata while keeping proof facts internal.
 - [#11](https://github.com/corca-ai/nose/issues/11) should define stable
-  refactorability and actionability reason codes.
+  family-level refactorability and actionability reason codes.
 - [#23](https://github.com/corca-ai/nose/issues/23) should consume review-hazard
   metadata without treating every exact fragment as a direct extraction.
 
@@ -235,8 +237,9 @@ that need future `enclosing_unit` metadata if they ever move out of debug output
 
    Blocks with field writes, pointer writes, index assignment, receiver method
    calls, temp chains, and ordered effect sequences should not be promoted from
-   debug to default output unless #33 can expose a stable `FragmentKind` and a
-   clear diagnostic explanation of receiver/place/effect identity.
+   debug to default output unless the stable `fragment_kind` / `reason_code`
+   metadata and any future diagnostics can explain receiver/place/effect
+   identity clearly enough for users.
 
 7. Group by role, not only by fingerprint.
 
@@ -246,32 +249,37 @@ that need future `enclosing_unit` metadata if they ever move out of debug output
    fixture input/output pairs should be explainable as distinct roles even when
    the exact fingerprint matches.
 
-## Post-#33 Metadata Requirements
+## Stable Fragment Product Metadata
 
-These requirements are split between stable public fields and diagnostic facts.
-Per the issue decision, `proof_facts` should not become a public contract until
-#33 explicitly stabilizes and documents it.
+The product scan JSON now separates stable public fields from diagnostic facts.
+`proof_facts` are deliberately not public scan JSON; they remain internal unless
+a future diagnostics namespace explicitly documents them as unstable.
 
 ### Stable Public Fields
 
 - `is_fragment`: whether the location is a sub-function fragment rather than a
-  whole function/method/class.
-- `FragmentKind`: stable coarse kind, for example whole unit, control block,
-  guard return, guard throw, ordered effect sequence, foreach effect, index
-  assignment effect, Java self-field assignment, or pure expression return.
-- `reason_code`: stable actionability vocabulary coordinated with #11. It should
-  describe product placement, such as direct extraction candidate, overload
-  synchronization hazard, cross-language port hazard, test fixture/golden,
-  proof-only guard, or requires diagnostic proof.
+  whole function/method/class. It is serialized for every location.
+- `fragment_kind`: stable exact-fragment proof shape, such as direct return,
+  direct throw, conditional guard, loop effect, index assignment effect,
+  expression effect, or Java self-field body.
+- `reason_code`: stable exact-fragment proof reason derived from
+  `fragment_kind`, for example `exact-direct-return` or
+  `exact-conditional-guard`. This answers why the fragment was accepted as
+  exact-safe; it is not the broader actionability vocabulary from #11.
 - `enclosing_unit`: kind, name when available, file, start line, end line, and a
   stable unit key. This is required for review-hazard output and for grouping
   child fragments under parent findings.
 - `span_lines` and `span_tokens`: explicit span size without consumers
   recalculating from locations.
-- `family_size`, `scope`, and path role: production, test, fixture/golden,
-  generated/vendor when known, mixed prod/test, and module spread.
+- family-level `members`, `scope`, module/file spread, and path role:
+  production, test, fixture/golden, generated/vendor when known, mixed
+  prod/test, and module spread.
 - `recommended_surface`: a ranking-time result, not detector semantics:
   default, review, hidden, or debug.
+
+Future #11 family/actionability reason codes should live in a separate family
+field. They answer why a family is worth refactoring or reviewing, and must not
+share a field with exact-fragment proof reasons.
 
 ### Diagnostic Fields
 
@@ -293,8 +301,10 @@ Per the issue decision, `proof_facts` should not become a public contract until
 | refactor-worthy | yes, unless contained by a better parent or fixture-only | yes | optional detail |
 | review-hazard | only when span/spread is strong enough for standalone attention | yes | optional detail |
 | proof-only/noise | no | only when directly changed and grouped under context | yes |
-| unsupported/ambiguous | no until #33 metadata explains the proof | yes after #33 for changed regions | yes |
+| unsupported/ambiguous | no unless stable metadata explains the proof | yes when stable metadata gives enough context for changed regions | yes |
 
-The ranking implementation can remain unchanged until #33 and #11 provide the
-fields above. The important product decision is that exact semantic fragments
+The current product implementation keeps exact fragments visible in full
+machine-readable output while using `recommended_surface` and default ranking
+damping so tiny proof fragments do not read as first-class refactoring
+candidates. The important product decision remains: exact semantic fragments
 are evidence, not automatically refactoring candidates.

--- a/docs/review.md
+++ b/docs/review.md
@@ -65,6 +65,21 @@ touched, not that the change definitely belongs there. Review each flagged sibli
 | `--ignore-file <file>` | suppress accepted divergences (auto-reads `nose.ignore.json`) |
 | `--top N` | show at most N findings (`0` = all; default 30) |
 
+## Exact fragment context
+
+Semantic mode can flag exact sub-function fragments, not only whole functions or methods.
+Those small fragments are often too small to be default refactoring candidates, but they
+are useful review hazards when the changed lines touch one copy and skip another. Review
+output therefore carries the same stable fragment metadata as scan JSON:
+`is_fragment`, `fragment_kind`, `reason_code`, `span_lines`, `span_tokens`, and
+`enclosing_unit` when a containing function/method/class is recovered exactly.
+
+Human and SARIF output keep annotations anchored on the changed or not-updated fragment
+span, while the context text names the enclosing unit. JSON output includes the full
+fragment metadata for both `changed` and `not_updated` sites. `proof_facts` are not
+emitted; fragment `reason_code` explains the exact proof shape, not the broader
+family/actionability reasons planned in #11.
+
 ## Suppressing intentional divergences
 
 Some clones are *meant* to diverge (a fast path vs a clear path, a sync vs async variant).

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -140,6 +140,7 @@ schema version 1:
 | `mean_sem` | number | Mean value-graph size across members. |
 | `scope` | string | `prod`, `test`, or `mixed` test/production classification. |
 | `discount` | number | Refactor-worthiness discount for generated or type-heavy families. |
+| `recommended_surface` | string | Product placement hint: `default`, `review`, `hidden`, or `debug`. This is ranking/presentation policy, not detector exactness. |
 | `baseline_status` | string, optional | `new` or `changed` when this family is shown because of `--baseline`. |
 
 Each `locations[]` item has:
@@ -153,17 +154,40 @@ Each `locations[]` item has:
 | `kind` | string | Unit kind, such as `Function`, `Method`, `Class`, or `Block`. |
 | `name` | string, optional | Symbol name when the frontend can recover one. |
 | `sem` | integer | Value-graph size for the site. |
+| `span_lines` | integer | Inclusive source-line span for this location. |
+| `span_tokens` | integer | Normalized-token span used by the detector's size gates. |
+| `is_fragment` | boolean | `true` when this location is an exact sub-function fragment; `false` for whole units and syntax-channel copy-paste spans. |
+| `fragment_kind` | string, optional | Exact fragment proof shape, present only when `is_fragment` is `true`; examples include `direct-return`, `conditional-guard`, and `self-field-body`. |
+| `reason_code` | string, optional | Stable exact-fragment proof reason derived from `fragment_kind`, present only when `is_fragment` is `true`; examples include `exact-direct-return` and `exact-conditional-guard`. |
+| `enclosing_unit` | object, optional | Exact enclosing function/method/class recovered from the same extracted unit set when available. |
 
-### Fragment metadata gap
+### Fragment metadata
 
-Current schema v1 reports sub-function exact fragments as ordinary locations, usually with
-`locations[].kind == "Block"`. That is enough for compatibility, but not enough to explain
-whether a small exact fragment is a guarded return, ordered effect sequence, Java self-field
-body, proof-only guard, or review-hazard fragment. The
-[fragment output audit](fragment-output-audit.md) records the current pre-fragment-metadata
-behavior and recommends future stable fields such as `is_fragment`, `FragmentKind`,
-`reason_code`, enclosing unit metadata, and diagnostic `proof_facts`. Those fields would be
-additive to schema v1 unless their types or required meanings force a later schema version.
+Exact semantic fragments are reported as ordinary family locations plus additive metadata.
+`is_fragment` is always present; `fragment_kind`, `reason_code`, and `enclosing_unit` are
+present only when the detector has exact data to serialize. A fragment with no
+`enclosing_unit` is still a valid exact fragment; it only means no containing
+function/method/class was recovered without guessing.
+
+The optional `enclosing_unit` object has:
+
+| field | type | meaning |
+|---|---|---|
+| `file` | string | Enclosing unit path, rewritten with the same relative-path policy as `locations[].file`. |
+| `start_line` | integer | 1-based inclusive start line. |
+| `end_line` | integer | 1-based inclusive end line. |
+| `kind` | string | Enclosing `Function`, `Method`, or `Class`. |
+| `name` | string, optional | Enclosing symbol name when recoverable. |
+| `unit_key` | string | Stable key built from file, kind, span, and name for grouping/review context. |
+
+Do not confuse fragment `reason_code` with future family/actionability reason codes from
+[#11](https://github.com/corca-ai/nose/issues/11). Fragment `reason_code` answers why this
+sub-function fragment was accepted as exact-safe. Future family/actionability reason codes
+answer why a clone family is worth refactoring or reviewing. They intentionally do not
+share one field.
+
+`proof_facts` are not part of the stable scan JSON contract. They remain internal
+diagnostic facts unless a future schema explicitly adds an unstable diagnostics namespace.
 
 ## Compatibility
 

--- a/docs/type4-benchmark.md
+++ b/docs/type4-benchmark.md
@@ -296,7 +296,8 @@ The seed lives in `bench/type4/`:
 - `schema.json` — pair-level manifest schema;
 - `scan_regression/` — the repeatable product-scan runtime/output-drift harness
   (`nose scan --mode semantic --format json --top 0`), with its own subset, recorded
-  baseline, and threshold docs; see `bench/type4/scan_regression/README.md`;
+  baseline, fragment/reason-code bucket drift, and threshold docs; see
+  `bench/type4/scan_regression/README.md`;
 - `README.md` — commands and current smoke numbers.
 
 The long-term direction is an adversarial semantic test factory: the generator creates


### PR DESCRIPTION
Closes #45.

## Summary

- Exposes stable exact-fragment metadata on product scan locations: `is_fragment`, `fragment_kind`, `reason_code`, `span_lines`, `span_tokens`, and exact `enclosing_unit` when recoverable.
- Keeps `proof_facts` out of public scan/review JSON, and documents fragment `reason_code` as exact proof-shape reason rather than #11 family/actionability reason.
- Adds `recommended_surface` as a ranking-time product placement field and damps tiny all-fragment families in default extractability ranking without removing them from `--top 0` JSON.
- Carries fragment context through `nose review` JSON/human/SARIF output so small changed-line hazards keep enclosing function/method/class context.
- Refreshes scan-regression baseline so `fragment_kind_counts` / `reason_code_counts` are live buckets.
- Fixes the labelset eval script to read current scan JSON v1 top-level objects as well as the old array shape.

## Validation

- `cargo fmt --check`
- `cargo check -q`
- `cargo test -q`
- `cargo build --release --bin nose`
- `awiki lint --root docs`
- `./scripts/check-docs.sh`
- `python3 -m py_compile bench/type4/scan_regression/scan_regression.py bench/labels/eval_by_language.py`
- `python3 bench/type4/scan_regression/scan_regression.py compare --nose "$(pwd)/target/release/nose" --repos-root /Users/ak/prjs/cc/nose/bench/repos`
  - same binary compare: 8 repos, 0 triggers
  - refreshed baseline has non-empty fragment/reason buckets for every subset repo
- `python3 bench/labels/eval_by_language.py` using the local main-worktree corpus
  - dev overall: base 58%, re-rank 59%
  - heldout overall: base 56%, re-rank 54%

## Notes

This intentionally does not change exact fragment recognizer semantics, add new Type-4 families, migrate predicates to contracts, or expose `proof_facts` as stable API.
