### PR TITLE
[codex] Track fragment surface regression metrics

### DIFF
--- a/bench/type4/scan_regression/README.md
+++ b/bench/type4/scan_regression/README.md
@@ -10,7 +10,7 @@ Everything a fresh worker needs is in this directory:
 
 | file | what it is |
 |---|---|
-| `scan_regression.py` | the harness (`baseline`, `compare`, `cache` subcommands) |
+| `scan_regression.py` | the harness (`baseline`, `compare`, `cache`, `selftest` subcommands) |
 | `subset.json` | the small, language-diverse repo subset to measure |
 | `baseline.v1.json` | the recorded reference snapshot (binary identity + per-repo canonical output + runtime medians) |
 | `compare-summary.md` | the latest `compare` markdown report (regenerated each run) |
@@ -60,6 +60,12 @@ python3 bench/type4/scan_regression/scan_regression.py compare \
 fire** — triggers are investigation prompts, not merge blockers (see below). Pass
 `--strict` to make any trigger non-zero once the thresholds are calibrated.
 
+Run the corpus-free unit checks for the canonicalization/gate logic:
+
+```sh
+python3 bench/type4/scan_regression/scan_regression.py selftest
+```
+
 ## What gets compared (output drift)
 
 The `--top 0` full JSON is canonicalized so **family order and ranking tie-breaks are
@@ -73,15 +79,31 @@ main worktree or any other path you pass to `--repos-root`. Per repo we record a
 - `product_json_bytes` — payload byte size with the volatile `tool_version` removed
 - `kind_counts` — unit kinds across all locations (`Block`, `Function`, `Method`, …)
 - `span_buckets` — families bucketed by `mean_lines` (`1`, `2-3`, `4-10`, `11-30`, `31+`)
+- `recommended_surface_counts` — family product placement counts for `default`,
+  `review`, `hidden`, and reserved `debug`
+- `family_shape_counts` — whole-only, all-fragment, and mixed family counts
 - per family — **keyed by the normalized location set, not `family_id`** (the product
   `family_id` is not unique; distinct families can share one id, so keying on it would
   silently drop a family): `family_id` (kept as an attribute and a drift signal),
-  `members`, `location_count`, `mean_lines`, per-kind counts, and the sorted locations.
-  `distinct_location_sets` is recorded so a true location-set collision would surface
-  rather than collapse silently.
+  `members`, `location_count`, `mean_lines`, `recommended_surface`, family shape,
+  fragment count, per-kind counts, fragment-only span buckets, enclosing-unit recovery,
+  and the sorted locations. `distinct_location_sets` is recorded so a true location-set
+  collision would surface rather than collapse silently.
 - `fragment_kind_counts` / `reason_code_counts` — exact-fragment metadata buckets from
   product scan JSON. #45 makes these live for current output, so fragment/reason drift is
   visible separately from generic `Block` counts.
+- `fragment_kind_surface_counts` / `reason_code_surface_counts` — exact-fragment proof
+  buckets crossed with `recommended_surface`, so calibration drift is visible before it
+  changes detector output.
+- `fragment_line_span_buckets` / `fragment_token_span_buckets` — fragment-location span
+  distributions. Line spans use the same buckets as family `mean_lines`; token spans use
+  `0`, `1-8`, `9-23`, `24-49`, `50-99`, and `100+`.
+- `enclosing_unit_recovery_counts` — recovered vs missing exact enclosing unit metadata
+  across fragment locations.
+
+These #51 C1 metrics are computed by the harness from stable scan JSON. They do not add
+new scan JSON fields and do not change detector acceptance, ranking, or `--top 0`
+visibility.
 
 `baseline` runs each repo `runtime_repeats` times and asserts the canonical output is
 **identical across runs** on one binary — a determinism guard. A mismatch aborts before
@@ -118,10 +140,10 @@ for a human to look at, not to gate:
 
 | signal | trigger |
 |---|---|
-| family set | any added/removed `family_id`, or a family changing shape (members/locations/mean_lines/kinds) |
+| family set | any added/removed location set, or a family changing shape (members/locations/mean_lines/kinds/surface/fragment metadata) |
 | `total_families` | any change |
 | `product_json_bytes` | > 5% change |
-| kind / span / fragment / reason-code buckets | any count change |
+| kind / span / fragment / reason-code / surface / enclosing-unit buckets | any count change |
 | runtime (per-phase + wall median) | > 25% growth **and** > 5 ms absolute (loose + floored because it's noisy) |
 
 The thresholds live in `THRESHOLDS` at the top of `scan_regression.py`. Tune them there

--- a/bench/type4/scan_regression/README.md
+++ b/bench/type4/scan_regression/README.md
@@ -86,9 +86,10 @@ main worktree or any other path you pass to `--repos-root`. Per repo we record a
   `family_id` is not unique; distinct families can share one id, so keying on it would
   silently drop a family): `family_id` (kept as an attribute and a drift signal),
   `members`, `location_count`, `mean_lines`, `recommended_surface`, family shape,
-  fragment count, per-kind counts, fragment-only span buckets, enclosing-unit recovery,
-  and the sorted locations. `distinct_location_sets` is recorded so a true location-set
-  collision would surface rather than collapse silently.
+  fragment count, per-kind counts, family-local fragment kind/reason-code counts,
+  family-local kind/reason-by-surface counts, fragment-only span buckets,
+  enclosing-unit recovery, and the sorted locations. `distinct_location_sets` is
+  recorded so a true location-set collision would surface rather than collapse silently.
 - `fragment_kind_counts` / `reason_code_counts` — exact-fragment metadata buckets from
   product scan JSON. #45 makes these live for current output, so fragment/reason drift is
   visible separately from generic `Block` counts.
@@ -104,6 +105,13 @@ main worktree or any other path you pass to `--repos-root`. Per repo we record a
 These #51 C1 metrics are computed by the harness from stable scan JSON. They do not add
 new scan JSON fields and do not change detector acceptance, ranking, or `--top 0`
 visibility.
+
+Family-local fragment metadata is intentional. Global fragment/reason buckets catch
+overall distribution drift, but they cannot catch a balanced swap where two families keep
+the same `recommended_surface` and the repo-wide buckets stay identical while each
+family's exact proof shape changes. The per-family records therefore include
+`fragment_kind_counts`, `reason_code_counts`, `fragment_kind_surface_counts`, and
+`reason_code_surface_counts`, and `compare` treats those as family drift.
 
 `baseline` runs each repo `runtime_repeats` times and asserts the canonical output is
 **identical across runs** on one binary — a determinism guard. A mismatch aborts before
@@ -123,6 +131,16 @@ comparison, record the baseline and run `compare` **on the same machine**: build
 baseline, the summary says so explicitly and any delta is environment noise. The
 committed `baseline.v1.json` runtime numbers are a snapshot from one machine; the
 **output drift** in it is portable, the **runtime** is not.
+
+## Compare summary identity
+
+`compare-summary.md` is a committed generated report. Its `current` `source_git_describe`
+and `build_ref` identify the checkout and binary that generated the report, not
+necessarily the later commit that stores the markdown. This avoids a self-referential
+hash: if the report recorded the artifact commit itself, committing the report would
+change the commit hash it claims to contain. For committed summaries, use an explicit
+generator label such as `issue-51-generator@<sha>` or `main@<sha>` and treat that as the
+reproducible input identity.
 
 Cache performance is a **separate** mode that never feeds the baseline:
 

--- a/bench/type4/scan_regression/baseline.v1.json
+++ b/bench/type4/scan_regression/baseline.v1.json
@@ -1,12 +1,12 @@
 {
   "binary": {
     "binary_path": "/Users/ak/prjs/cc/nose/.claude/worktrees/issue-51-fragment-measurement/target/release/nose",
-    "build_ref": "issue-51@a592075",
-    "sha256": "00511c77fdb0f5878deed159594e9970e2e83914fc71035440324e435ecc212d",
-    "size_bytes": 13549648,
+    "build_ref": "issue-51-generator@cb0c549",
+    "sha256": "bdd103dfc3e3e3d26545c2aac04049dbeb5aa8250fb84567829ffcfe6040f079",
+    "size_bytes": 13549664,
     "source_dirty": false,
-    "source_git_describe": "v0.5.0-185-ga592075",
-    "source_git_sha": "a5920752058bab950e06e12b49a5b67dc2f86b29",
+    "source_git_describe": "v0.5.0-188-gcb0c549",
+    "source_git_sha": "cb0c54974c64bb8d5e8d01e6a73fa4acaca4b5e9",
     "version": "nose 0.5.0"
   },
   "generated_by": "bench/type4/scan_regression/scan_regression.py baseline",
@@ -27,6 +27,8 @@
             "family_id": "c1a7ee35d645dfb8",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -44,6 +46,8 @@
             ],
             "mean_lines": 2,
             "members": 5,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -55,6 +59,8 @@
             "family_id": "bf3614d2ad0776e2",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -69,6 +75,8 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -80,6 +88,12 @@
             "family_id": "0bdc5238e860ca25",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -98,6 +112,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -109,6 +129,8 @@
             "family_id": "89d8d6810dd22a60",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -123,6 +145,8 @@
             ],
             "mean_lines": 16,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "11-30"
           },
@@ -134,6 +158,8 @@
             "family_id": "317cdc648c21457d",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -148,6 +174,8 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -159,6 +187,12 @@
             "family_id": "221fac5b06a56791",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -177,6 +211,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -188,6 +228,8 @@
             "family_id": "dc9e5e2e0733adea",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -202,6 +244,8 @@
             ],
             "mean_lines": 8,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -213,6 +257,8 @@
             "family_id": "88f32e5afb8f1f10",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -227,6 +273,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -238,6 +286,12 @@
             "family_id": "d501e0bf7fb4023f",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "conditional-guard": 2
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "2-3": 2
             },
@@ -256,6 +310,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-conditional-guard": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -267,6 +327,8 @@
             "family_id": "03fd32e6d5c1416f",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -281,6 +343,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -292,6 +356,8 @@
             "family_id": "befde3f12eba7a81",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -306,6 +372,8 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -317,6 +385,12 @@
             "family_id": "c12a5f75e261382b",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 3
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -336,6 +410,12 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "reason_code_counts": {
+              "exact-expr-effect": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -347,6 +427,12 @@
             "family_id": "f5d7edd64d7d3675",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -365,6 +451,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -376,6 +468,8 @@
             "family_id": "a34a326d9ed57b37",
             "family_shape": "whole-only",
             "files": 4,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -393,6 +487,8 @@
             ],
             "mean_lines": 2,
             "members": 5,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -404,6 +500,12 @@
             "family_id": "c421e937f67d6a85",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 3
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -423,6 +525,12 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "reason_code_counts": {
+              "exact-expr-effect": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -434,6 +542,8 @@
             "family_id": "0d65157602531a65",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -448,6 +558,8 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -459,6 +571,12 @@
             "family_id": "54ca8e7b7b17d7d7",
             "family_shape": "mixed",
             "files": 2,
+            "fragment_kind_counts": {
+              "direct-return": 1
+            },
+            "fragment_kind_surface_counts": {
+              "direct-return|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -478,6 +596,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-direct-return": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-direct-return|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -489,6 +613,8 @@
             "family_id": "096334183198eee0",
             "family_shape": "whole-only",
             "files": 3,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -505,6 +631,8 @@
             ],
             "mean_lines": 2,
             "members": 4,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -516,6 +644,12 @@
             "family_id": "52d091a1c797fb4a",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -534,6 +668,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -545,6 +685,8 @@
             "family_id": "3001ad0849b667c3",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -559,6 +701,8 @@
             ],
             "mean_lines": 34,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "31+"
           },
@@ -570,6 +714,8 @@
             "family_id": "68067a7d2e9931ea",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -584,6 +730,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -595,6 +743,8 @@
             "family_id": "c22aaec191559be9",
             "family_shape": "whole-only",
             "files": 3,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -610,6 +760,8 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -621,6 +773,8 @@
             "family_id": "da5521864dd50141",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -635,6 +789,8 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -646,6 +802,8 @@
             "family_id": "cc6dda466a93ac9d",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -660,6 +818,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -671,6 +831,12 @@
             "family_id": "f5d7edd64d7d3675",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -689,6 +855,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -700,6 +872,8 @@
             "family_id": "aff74ff2549b5c1e",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -716,6 +890,8 @@
             ],
             "mean_lines": 6,
             "members": 4,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -727,6 +903,8 @@
             "family_id": "f49a5aa0e8108bdf",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -741,6 +919,8 @@
             ],
             "mean_lines": 8,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -752,6 +932,12 @@
             "family_id": "52d091a1c797fb4a",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "conditional-guard": 2
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "2-3": 2
             },
@@ -770,6 +956,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-conditional-guard": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -781,6 +973,12 @@
             "family_id": "e60652555898f589",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 18
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 18
+            },
             "fragment_line_span_buckets": {
               "1": 18
             },
@@ -815,6 +1013,12 @@
             ],
             "mean_lines": 1,
             "members": 18,
+            "reason_code_counts": {
+              "exact-expr-effect": 18
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 18
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -826,6 +1030,8 @@
             "family_id": "be87bec48929d902",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -840,6 +1046,8 @@
             ],
             "mean_lines": 8,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -851,6 +1059,12 @@
             "family_id": "3ef7f89fc7052764",
             "family_shape": "all-fragment",
             "files": 4,
+            "fragment_kind_counts": {
+              "conditional-guard": 5
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 5
+            },
             "fragment_line_span_buckets": {
               "2-3": 5
             },
@@ -872,6 +1086,12 @@
             ],
             "mean_lines": 2,
             "members": 5,
+            "reason_code_counts": {
+              "exact-conditional-guard": 5
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 5
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -883,6 +1103,12 @@
             "family_id": "943290def00e3eeb",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "conditional-guard": 2
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "2-3": 2
             },
@@ -901,6 +1127,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-conditional-guard": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -912,6 +1144,8 @@
             "family_id": "aa88b4085f8c6f66",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -926,6 +1160,8 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -937,6 +1173,12 @@
             "family_id": "ed6bd8b1c8a22ded",
             "family_shape": "all-fragment",
             "files": 3,
+            "fragment_kind_counts": {
+              "conditional-guard": 3
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "2-3": 3
             },
@@ -956,6 +1198,12 @@
             ],
             "mean_lines": 2,
             "members": 3,
+            "reason_code_counts": {
+              "exact-conditional-guard": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -967,6 +1215,8 @@
             "family_id": "52d091a1c797fb4a",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -981,6 +1231,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -992,6 +1244,8 @@
             "family_id": "88c27a78caf274b0",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -1006,6 +1260,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -1017,6 +1273,12 @@
             "family_id": "8625bfb61cdefb25",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 16
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 16
+            },
             "fragment_line_span_buckets": {
               "1": 16
             },
@@ -1049,6 +1311,12 @@
             ],
             "mean_lines": 1,
             "members": 16,
+            "reason_code_counts": {
+              "exact-expr-effect": 16
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 16
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -1060,6 +1328,8 @@
             "family_id": "bb6a0cc094762b7c",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -1074,6 +1344,8 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -1085,6 +1357,12 @@
             "family_id": "162e33869320bb7d",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -1103,6 +1381,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -1114,6 +1398,12 @@
             "family_id": "aab95bae61012b3d",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 7
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 7
+            },
             "fragment_line_span_buckets": {
               "1": 7
             },
@@ -1137,6 +1427,12 @@
             ],
             "mean_lines": 1,
             "members": 7,
+            "reason_code_counts": {
+              "exact-expr-effect": 7
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 7
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -1148,6 +1444,12 @@
             "family_id": "ed6bd8b1c8a22ded",
             "family_shape": "all-fragment",
             "files": 3,
+            "fragment_kind_counts": {
+              "conditional-guard": 3
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "2-3": 3
             },
@@ -1167,6 +1469,12 @@
             ],
             "mean_lines": 2,
             "members": 3,
+            "reason_code_counts": {
+              "exact-conditional-guard": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -1178,6 +1486,12 @@
             "family_id": "c421e937f67d6a85",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 3
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -1197,6 +1511,12 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "reason_code_counts": {
+              "exact-expr-effect": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -1208,6 +1528,8 @@
             "family_id": "d04448284a8828f4",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -1222,6 +1544,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -1233,6 +1557,12 @@
             "family_id": "82ac7e88d1d8e025",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 6
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 6
+            },
             "fragment_line_span_buckets": {
               "1": 6
             },
@@ -1255,6 +1585,12 @@
             ],
             "mean_lines": 1,
             "members": 6,
+            "reason_code_counts": {
+              "exact-expr-effect": 6
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 6
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -1266,6 +1602,8 @@
             "family_id": "260229e6609d1830",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -1280,6 +1618,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           }
@@ -1346,19 +1686,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 2.5,
+          "candidates": 2.1,
           "cluster": 0.1,
           "contiguous": 0.0,
           "discover": 3.4,
           "groups": 0.3,
-          "lower": 13.1,
-          "normalize+extract": 9.1,
-          "parse+lower": 9.7,
+          "lower": 13.0,
+          "normalize+extract": 8.6,
+          "parse+lower": 9.5,
           "score": 0.3
         },
         "repeats": 5,
-        "wall_ms_median": 39.52,
-        "wall_ms_min": 37.31
+        "wall_ms_median": 38.15,
+        "wall_ms_min": 35.64
       }
     },
     "chi": {
@@ -1377,6 +1717,12 @@
             "family_id": "1b8f7e5b24f35a84",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "expr-effect": 5
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 5
+            },
             "fragment_line_span_buckets": {
               "1": 5
             },
@@ -1398,6 +1744,12 @@
             ],
             "mean_lines": 1,
             "members": 5,
+            "reason_code_counts": {
+              "exact-expr-effect": 5
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 5
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -1409,6 +1761,12 @@
             "family_id": "c55b843732270ba0",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -1427,6 +1785,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -1438,6 +1802,12 @@
             "family_id": "57d3ad5ed5c000af",
             "family_shape": "all-fragment",
             "files": 4,
+            "fragment_kind_counts": {
+              "expr-effect": 6
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 6
+            },
             "fragment_line_span_buckets": {
               "1": 6
             },
@@ -1460,6 +1830,12 @@
             ],
             "mean_lines": 1,
             "members": 6,
+            "reason_code_counts": {
+              "exact-expr-effect": 6
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 6
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -1471,6 +1847,12 @@
             "family_id": "c55b843732270ba0",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -1489,6 +1871,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           }
@@ -1538,19 +1926,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 0.9,
+          "candidates": 1.0,
           "cluster": 0.0,
           "contiguous": 0.0,
-          "discover": 3.8,
+          "discover": 3.4,
           "groups": 0.1,
-          "lower": 12.5,
-          "normalize+extract": 6.9,
-          "parse+lower": 8.1,
+          "lower": 12.9,
+          "normalize+extract": 7.3,
+          "parse+lower": 9.4,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 31.16,
-        "wall_ms_min": 30.66
+        "wall_ms_median": 30.66,
+        "wall_ms_min": 30.34
       }
     },
     "cmark": {
@@ -1569,6 +1957,8 @@
             "family_id": "26ced6842ce520b9",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -1583,6 +1973,8 @@
             ],
             "mean_lines": 23,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "11-30"
           },
@@ -1594,6 +1986,12 @@
             "family_id": "fcc9256e3e7a7eed",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "conditional-guard": 2
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "2-3": 2
             },
@@ -1612,6 +2010,12 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {
+              "exact-conditional-guard": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -1623,6 +2027,8 @@
             "family_id": "170d015e2ec1088d",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -1637,6 +2043,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -1648,6 +2056,8 @@
             "family_id": "9e9b104e3f14e44f",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -1663,6 +2073,8 @@
             ],
             "mean_lines": 25,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "11-30"
           },
@@ -1674,6 +2086,12 @@
             "family_id": "c8aef64af19c431d",
             "family_shape": "all-fragment",
             "files": 3,
+            "fragment_kind_counts": {
+              "conditional-guard": 4
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 4
+            },
             "fragment_line_span_buckets": {
               "2-3": 4
             },
@@ -1694,6 +2112,12 @@
             ],
             "mean_lines": 2,
             "members": 4,
+            "reason_code_counts": {
+              "exact-conditional-guard": 4
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 4
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -1705,6 +2129,12 @@
             "family_id": "b9b46d92887b4874",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "conditional-guard": 17
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 17
+            },
             "fragment_line_span_buckets": {
               "2-3": 17
             },
@@ -1738,6 +2168,12 @@
             ],
             "mean_lines": 3,
             "members": 17,
+            "reason_code_counts": {
+              "exact-conditional-guard": 17
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 17
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -1749,6 +2185,8 @@
             "family_id": "26ced6842ce520b9",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -1763,6 +2201,8 @@
             ],
             "mean_lines": 21,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "11-30"
           },
@@ -1774,6 +2214,8 @@
             "family_id": "767624ff995a5fed",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -1788,6 +2230,8 @@
             ],
             "mean_lines": 11,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "11-30"
           },
@@ -1799,6 +2243,12 @@
             "family_id": "7a4fac3c354dbb1c",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "conditional-guard": 3
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "2-3": 3
             },
@@ -1818,6 +2268,12 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "reason_code_counts": {
+              "exact-conditional-guard": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -1829,6 +2285,12 @@
             "family_id": "daf11c9215fb53e1",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "conditional-guard": 2
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "2-3": 2
             },
@@ -1847,6 +2309,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-conditional-guard": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -1858,6 +2326,8 @@
             "family_id": "d8d475406c21ae4f",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -1872,6 +2342,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -1883,6 +2355,12 @@
             "family_id": "5122da1710c96f93",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "conditional-guard": 2
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "2-3": 2
             },
@@ -1901,6 +2379,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-conditional-guard": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -1912,6 +2396,12 @@
             "family_id": "5122da1710c96f93",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "conditional-guard": 2
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "2-3": 2
             },
@@ -1930,6 +2420,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-conditional-guard": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -1941,6 +2437,12 @@
             "family_id": "17857b88e1f45cc6",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "conditional-guard": 13
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 13
+            },
             "fragment_line_span_buckets": {
               "2-3": 13
             },
@@ -1970,6 +2472,12 @@
             ],
             "mean_lines": 3,
             "members": 13,
+            "reason_code_counts": {
+              "exact-conditional-guard": 13
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 13
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -1981,6 +2489,8 @@
             "family_id": "4fa35f7ab1a6ca1d",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -2053,6 +2563,8 @@
             ],
             "mean_lines": 28,
             "members": 60,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "11-30"
           },
@@ -2064,6 +2576,8 @@
             "family_id": "3f29c523d7246497",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -2131,6 +2645,8 @@
             ],
             "mean_lines": 21,
             "members": 55,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "11-30"
           },
@@ -2142,6 +2658,12 @@
             "family_id": "fcc9256e3e7a7eed",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -2160,6 +2682,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           }
@@ -2224,16 +2752,16 @@
           "candidates": 1.4,
           "cluster": 0.0,
           "contiguous": 0.0,
-          "discover": 3.4,
+          "discover": 4.9,
           "groups": 0.1,
-          "lower": 21.5,
-          "normalize+extract": 21.5,
-          "parse+lower": 17.3,
-          "score": 0.2
+          "lower": 22.5,
+          "normalize+extract": 21.9,
+          "parse+lower": 17.6,
+          "score": 0.3
         },
         "repeats": 5,
-        "wall_ms_median": 56.5,
-        "wall_ms_min": 56.15
+        "wall_ms_median": 58.62,
+        "wall_ms_min": 54.73
       }
     },
     "gin": {
@@ -2252,6 +2780,12 @@
             "family_id": "11872955a669aabd",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -2270,6 +2804,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -2281,6 +2821,12 @@
             "family_id": "5b6f1fdf00d78bfe",
             "family_shape": "all-fragment",
             "files": 4,
+            "fragment_kind_counts": {
+              "expr-effect": 5
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 5
+            },
             "fragment_line_span_buckets": {
               "1": 5
             },
@@ -2302,6 +2848,12 @@
             ],
             "mean_lines": 1,
             "members": 5,
+            "reason_code_counts": {
+              "exact-expr-effect": 5
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 5
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -2313,6 +2865,8 @@
             "family_id": "515439eb60de28eb",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -2327,6 +2881,8 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           }
@@ -2378,19 +2934,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 1.7,
+          "candidates": 2.0,
           "cluster": 0.1,
           "contiguous": 0.0,
           "discover": 3.4,
           "groups": 0.1,
-          "lower": 19.3,
-          "normalize+extract": 13.0,
-          "parse+lower": 15.7,
-          "score": 0.2
+          "lower": 21.0,
+          "normalize+extract": 13.3,
+          "parse+lower": 17.6,
+          "score": 0.3
         },
         "repeats": 5,
-        "wall_ms_median": 47.49,
-        "wall_ms_min": 44.48
+        "wall_ms_median": 49.28,
+        "wall_ms_min": 47.02
       }
     },
     "junit5": {
@@ -2409,6 +2965,8 @@
             "family_id": "2143942e284cf486",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -2426,6 +2984,8 @@
             ],
             "mean_lines": 5,
             "members": 5,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -2437,6 +2997,12 @@
             "family_id": "e0728d4490777b48",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 3
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -2456,6 +3022,12 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "reason_code_counts": {
+              "exact-expr-effect": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -2467,6 +3039,8 @@
             "family_id": "ab0f921c1cbe0836",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -2482,6 +3056,8 @@
             ],
             "mean_lines": 4,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -2493,6 +3069,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -2511,6 +3093,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -2522,6 +3110,12 @@
             "family_id": "6d7e90f44ec4127f",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -2541,6 +3135,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -2552,6 +3152,12 @@
             "family_id": "4c2c96ab825e8236",
             "family_shape": "mixed",
             "files": 21,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -2590,6 +3196,12 @@
             ],
             "mean_lines": 2,
             "members": 21,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -2601,6 +3213,8 @@
             "family_id": "76c6c4d6601b5773",
             "family_shape": "whole-only",
             "files": 3,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -2616,6 +3230,8 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -2627,6 +3243,12 @@
             "family_id": "4255208f745f46fb",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "expr-effect": 4
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 4
+            },
             "fragment_line_span_buckets": {
               "1": 4
             },
@@ -2647,6 +3269,12 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "reason_code_counts": {
+              "exact-expr-effect": 4
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 4
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -2658,6 +3286,12 @@
             "family_id": "9dfa3678f03263d3",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 3
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -2679,6 +3313,12 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "reason_code_counts": {
+              "exact-expr-effect": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 3
+            },
             "recommended_surface": "default",
             "span_bucket": "1"
           },
@@ -2690,6 +3330,8 @@
             "family_id": "bca5a5a55ade0006",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -2706,6 +3348,8 @@
             ],
             "mean_lines": 8,
             "members": 4,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -2717,6 +3361,12 @@
             "family_id": "43f5ea9611cf5b11",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 4
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 4
+            },
             "fragment_line_span_buckets": {
               "1": 4
             },
@@ -2737,6 +3387,12 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "reason_code_counts": {
+              "exact-expr-effect": 4
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 4
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -2748,6 +3404,8 @@
             "family_id": "d1018b34e92cc6c7",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -2762,6 +3420,8 @@
             ],
             "mean_lines": 8,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -2773,6 +3433,12 @@
             "family_id": "0d28fc3ca805c28d",
             "family_shape": "mixed",
             "files": 5,
+            "fragment_kind_counts": {
+              "expr-effect": 5
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 5
+            },
             "fragment_line_span_buckets": {
               "1": 5
             },
@@ -2797,6 +3463,12 @@
             ],
             "mean_lines": 2,
             "members": 7,
+            "reason_code_counts": {
+              "exact-expr-effect": 5
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 5
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -2808,6 +3480,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -2826,6 +3504,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -2837,6 +3521,12 @@
             "family_id": "6fb988936b3d3f08",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "conditional-guard": 2
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "2-3": 2
             },
@@ -2855,6 +3545,12 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {
+              "exact-conditional-guard": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -2866,6 +3562,12 @@
             "family_id": "f73cb1974ad97af2",
             "family_shape": "mixed",
             "files": 4,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -2887,6 +3589,12 @@
             ],
             "mean_lines": 3,
             "members": 4,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 2
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -2898,6 +3606,8 @@
             "family_id": "d88dd594718b3b6c",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -2912,6 +3622,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -2923,6 +3635,8 @@
             "family_id": "1be4bc830ed32051",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -2937,6 +3651,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -2948,6 +3664,8 @@
             "family_id": "ab37cb8aa4dba419",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -2962,6 +3680,8 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -2973,6 +3693,8 @@
             "family_id": "d2cb1c30398b890e",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -2987,6 +3709,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -2998,6 +3722,12 @@
             "family_id": "e53f8d946f20b6e1",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -3016,6 +3746,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -3027,6 +3763,12 @@
             "family_id": "8b18a08c0d3e331d",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "self-field-body": 2
+            },
+            "fragment_kind_surface_counts": {
+              "self-field-body|review": 2
+            },
             "fragment_line_span_buckets": {
               "4-10": 2
             },
@@ -3045,6 +3787,12 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {
+              "exact-self-field-body": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-self-field-body|review": 2
+            },
             "recommended_surface": "review",
             "span_bucket": "4-10"
           },
@@ -3056,6 +3804,8 @@
             "family_id": "f55ea4cfd0feeae1",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -3070,6 +3820,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -3081,6 +3833,12 @@
             "family_id": "d67f6f6f1964d5f0",
             "family_shape": "mixed",
             "files": 4,
+            "fragment_kind_counts": {
+              "expr-effect": 3
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -3102,6 +3860,12 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "reason_code_counts": {
+              "exact-expr-effect": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 3
+            },
             "recommended_surface": "default",
             "span_bucket": "1"
           },
@@ -3113,6 +3877,12 @@
             "family_id": "a4936437856ae127",
             "family_shape": "all-fragment",
             "files": 5,
+            "fragment_kind_counts": {
+              "conditional-guard": 5
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 5
+            },
             "fragment_line_span_buckets": {
               "2-3": 5
             },
@@ -3134,6 +3904,12 @@
             ],
             "mean_lines": 3,
             "members": 5,
+            "reason_code_counts": {
+              "exact-conditional-guard": 5
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 5
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -3145,6 +3921,12 @@
             "family_id": "bdfc531cb3d705e9",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -3164,6 +3946,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -3175,6 +3963,12 @@
             "family_id": "a84c990d8f7a7231",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "self-field-assign": 2
+            },
+            "fragment_kind_surface_counts": {
+              "self-field-assign|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -3193,6 +3987,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-self-field-assign": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-self-field-assign|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -3204,6 +4004,12 @@
             "family_id": "3010f335ef366f67",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -3223,6 +4029,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -3234,6 +4046,8 @@
             "family_id": "f8690b33f8ee1d50",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -3248,6 +4062,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -3259,6 +4075,12 @@
             "family_id": "e2278a0a8987f4cb",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "self-field-body": 2
+            },
+            "fragment_kind_surface_counts": {
+              "self-field-body|review": 2
+            },
             "fragment_line_span_buckets": {
               "4-10": 2
             },
@@ -3277,6 +4099,12 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {
+              "exact-self-field-body": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-self-field-body|review": 2
+            },
             "recommended_surface": "review",
             "span_bucket": "4-10"
           },
@@ -3288,6 +4116,12 @@
             "family_id": "c350578012489fcd",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 8
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 8
+            },
             "fragment_line_span_buckets": {
               "1": 8
             },
@@ -3312,6 +4146,12 @@
             ],
             "mean_lines": 1,
             "members": 8,
+            "reason_code_counts": {
+              "exact-expr-effect": 8
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 8
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -3323,6 +4163,12 @@
             "family_id": "db6182162c37f866",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "conditional-guard": 12
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 12
+            },
             "fragment_line_span_buckets": {
               "2-3": 12
             },
@@ -3351,6 +4197,12 @@
             ],
             "mean_lines": 3,
             "members": 12,
+            "reason_code_counts": {
+              "exact-conditional-guard": 12
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 12
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -3362,6 +4214,12 @@
             "family_id": "e1a53c94b04b2272",
             "family_shape": "mixed",
             "files": 4,
+            "fragment_kind_counts": {
+              "expr-effect": 5
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 5
+            },
             "fragment_line_span_buckets": {
               "1": 5
             },
@@ -3385,6 +4243,12 @@
             ],
             "mean_lines": 1,
             "members": 6,
+            "reason_code_counts": {
+              "exact-expr-effect": 5
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 5
+            },
             "recommended_surface": "default",
             "span_bucket": "1"
           },
@@ -3396,6 +4260,12 @@
             "family_id": "c350578012489fcd",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 8
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 8
+            },
             "fragment_line_span_buckets": {
               "1": 8
             },
@@ -3420,6 +4290,12 @@
             ],
             "mean_lines": 1,
             "members": 8,
+            "reason_code_counts": {
+              "exact-expr-effect": 8
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 8
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -3431,6 +4307,8 @@
             "family_id": "e61e9bc27e381359",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -3445,6 +4323,8 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -3456,6 +4336,12 @@
             "family_id": "9877ce64af1f59b5",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -3474,6 +4360,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -3485,6 +4377,12 @@
             "family_id": "a1ce072397dad29a",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 19
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 19
+            },
             "fragment_line_span_buckets": {
               "1": 19
             },
@@ -3520,6 +4418,12 @@
             ],
             "mean_lines": 1,
             "members": 19,
+            "reason_code_counts": {
+              "exact-expr-effect": 19
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 19
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -3531,6 +4435,12 @@
             "family_id": "54a961c71502a4fc",
             "family_shape": "all-fragment",
             "files": 3,
+            "fragment_kind_counts": {
+              "self-field-body": 3
+            },
+            "fragment_kind_surface_counts": {
+              "self-field-body|review": 3
+            },
             "fragment_line_span_buckets": {
               "4-10": 3
             },
@@ -3550,6 +4460,12 @@
             ],
             "mean_lines": 6,
             "members": 3,
+            "reason_code_counts": {
+              "exact-self-field-body": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-self-field-body|review": 3
+            },
             "recommended_surface": "review",
             "span_bucket": "4-10"
           },
@@ -3561,6 +4477,8 @@
             "family_id": "b3d48309fdd743df",
             "family_shape": "whole-only",
             "files": 4,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -3578,6 +4496,8 @@
             ],
             "mean_lines": 3,
             "members": 5,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -3589,6 +4509,12 @@
             "family_id": "0dd96d3d8d2dc31f",
             "family_shape": "mixed",
             "files": 16,
+            "fragment_kind_counts": {
+              "direct-return": 1
+            },
+            "fragment_kind_surface_counts": {
+              "direct-return|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -3624,6 +4550,12 @@
             ],
             "mean_lines": 3,
             "members": 18,
+            "reason_code_counts": {
+              "exact-direct-return": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-direct-return|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -3635,6 +4567,12 @@
             "family_id": "acc03cae66d1faf2",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -3654,6 +4592,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -3665,6 +4609,12 @@
             "family_id": "7f37a94ee382840d",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -3684,6 +4634,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -3695,6 +4651,8 @@
             "family_id": "d2bad11185a36c2d",
             "family_shape": "whole-only",
             "files": 5,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -3714,6 +4672,8 @@
             ],
             "mean_lines": 4,
             "members": 7,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -3725,6 +4685,12 @@
             "family_id": "db1604d0005f4b27",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 23
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 23
+            },
             "fragment_line_span_buckets": {
               "1": 23
             },
@@ -3764,6 +4730,12 @@
             ],
             "mean_lines": 1,
             "members": 23,
+            "reason_code_counts": {
+              "exact-expr-effect": 23
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 23
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -3775,6 +4747,8 @@
             "family_id": "a2cb0765594b08b5",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -3794,6 +4768,8 @@
             ],
             "mean_lines": 4,
             "members": 7,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -3805,6 +4781,12 @@
             "family_id": "99d425da8ef6d48c",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -3824,6 +4806,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -3835,6 +4823,8 @@
             "family_id": "05d2e0bdfc2e0b4d",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -3849,6 +4839,8 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -3860,6 +4852,8 @@
             "family_id": "3ed50d87b1fa4c3b",
             "family_shape": "whole-only",
             "files": 6,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -3878,6 +4872,8 @@
             ],
             "mean_lines": 3,
             "members": 6,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -3889,6 +4885,12 @@
             "family_id": "43f5ea9611cf5b11",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 4
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 4
+            },
             "fragment_line_span_buckets": {
               "1": 4
             },
@@ -3909,6 +4911,12 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "reason_code_counts": {
+              "exact-expr-effect": 4
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 4
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -3920,6 +4928,8 @@
             "family_id": "d9a3ae65a28a3560",
             "family_shape": "whole-only",
             "files": 4,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -3936,6 +4946,8 @@
             ],
             "mean_lines": 9,
             "members": 4,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -3947,6 +4959,12 @@
             "family_id": "da5d8f99df433f90",
             "family_shape": "mixed",
             "files": 7,
+            "fragment_kind_counts": {
+              "expr-effect": 14
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 14
+            },
             "fragment_line_span_buckets": {
               "1": 14
             },
@@ -4003,6 +5021,12 @@
             ],
             "mean_lines": 3,
             "members": 39,
+            "reason_code_counts": {
+              "exact-expr-effect": 14
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 14
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -4014,6 +5038,8 @@
             "family_id": "81a3c1fba74e2baa",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4032,6 +5058,8 @@
             ],
             "mean_lines": 5,
             "members": 6,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4043,6 +5071,12 @@
             "family_id": "5b5d9b975eadd9ee",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -4064,6 +5098,12 @@
             ],
             "mean_lines": 3,
             "members": 4,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 2
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -4075,6 +5115,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -4093,6 +5139,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -4104,6 +5156,12 @@
             "family_id": "0d87b515f7f4cdb9",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "self-field-body": 2
+            },
+            "fragment_kind_surface_counts": {
+              "self-field-body|review": 2
+            },
             "fragment_line_span_buckets": {
               "4-10": 2
             },
@@ -4122,6 +5180,12 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {
+              "exact-self-field-body": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-self-field-body|review": 2
+            },
             "recommended_surface": "review",
             "span_bucket": "4-10"
           },
@@ -4133,6 +5197,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -4151,6 +5221,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -4162,6 +5238,8 @@
             "family_id": "df239aa2aaa409e3",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4176,6 +5254,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4187,6 +5267,12 @@
             "family_id": "c350578012489fcd",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 8
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 8
+            },
             "fragment_line_span_buckets": {
               "1": 8
             },
@@ -4211,6 +5297,12 @@
             ],
             "mean_lines": 1,
             "members": 8,
+            "reason_code_counts": {
+              "exact-expr-effect": 8
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 8
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -4222,6 +5314,12 @@
             "family_id": "dcd46868e73e1a62",
             "family_shape": "all-fragment",
             "files": 3,
+            "fragment_kind_counts": {
+              "direct-return": 6
+            },
+            "fragment_kind_surface_counts": {
+              "direct-return|hidden": 6
+            },
             "fragment_line_span_buckets": {
               "1": 6
             },
@@ -4244,6 +5342,12 @@
             ],
             "mean_lines": 1,
             "members": 6,
+            "reason_code_counts": {
+              "exact-direct-return": 6
+            },
+            "reason_code_surface_counts": {
+              "exact-direct-return|hidden": 6
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -4255,6 +5359,12 @@
             "family_id": "9877ce64af1f59b5",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -4273,6 +5383,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -4284,6 +5400,12 @@
             "family_id": "9877ce64af1f59b5",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -4302,6 +5424,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -4313,6 +5441,8 @@
             "family_id": "17042f858679169d",
             "family_shape": "whole-only",
             "files": 3,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4328,6 +5458,8 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -4339,6 +5471,8 @@
             "family_id": "338352926aa4c5a2",
             "family_shape": "whole-only",
             "files": 4,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4355,6 +5489,8 @@
             ],
             "mean_lines": 4,
             "members": 4,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4366,6 +5502,12 @@
             "family_id": "7590e21d9ebe3744",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "self-field-assign": 2
+            },
+            "fragment_kind_surface_counts": {
+              "self-field-assign|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -4384,6 +5526,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-self-field-assign": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-self-field-assign|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -4395,6 +5543,8 @@
             "family_id": "d5286b31f9abe095",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4411,6 +5561,8 @@
             ],
             "mean_lines": 5,
             "members": 4,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4422,6 +5574,12 @@
             "family_id": "1212bfd748b723fc",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -4441,6 +5599,12 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -4452,6 +5616,8 @@
             "family_id": "dfbe73614adc1d15",
             "family_shape": "whole-only",
             "files": 5,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4469,6 +5635,8 @@
             ],
             "mean_lines": 4,
             "members": 5,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4480,6 +5648,8 @@
             "family_id": "1d20f56e7a17eb3d",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4494,6 +5664,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -4505,6 +5677,12 @@
             "family_id": "741727513b76e4b0",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "self-field-body": 2
+            },
+            "fragment_kind_surface_counts": {
+              "self-field-body|review": 2
+            },
             "fragment_line_span_buckets": {
               "4-10": 2
             },
@@ -4523,6 +5701,12 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {
+              "exact-self-field-body": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-self-field-body|review": 2
+            },
             "recommended_surface": "review",
             "span_bucket": "4-10"
           },
@@ -4534,6 +5718,12 @@
             "family_id": "d8179569e58ce18c",
             "family_shape": "mixed",
             "files": 2,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -4553,6 +5743,12 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -4564,6 +5760,8 @@
             "family_id": "0cc22f843db81fef",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4578,6 +5776,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -4589,6 +5789,8 @@
             "family_id": "5b1b31cca36ba575",
             "family_shape": "whole-only",
             "files": 3,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4605,6 +5807,8 @@
             ],
             "mean_lines": 5,
             "members": 4,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4616,6 +5820,8 @@
             "family_id": "a14db4860a7641fa",
             "family_shape": "whole-only",
             "files": 4,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4633,6 +5839,8 @@
             ],
             "mean_lines": 5,
             "members": 5,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4644,6 +5852,12 @@
             "family_id": "0e78734476d15bdd",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -4663,6 +5877,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -4674,6 +5894,8 @@
             "family_id": "81697e54fcaace1c",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4688,6 +5910,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4699,6 +5923,8 @@
             "family_id": "ce251eda98b1e3a1",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4716,6 +5942,8 @@
             ],
             "mean_lines": 4,
             "members": 5,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4727,6 +5955,12 @@
             "family_id": "9877ce64af1f59b5",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -4745,6 +5979,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -4756,6 +5996,8 @@
             "family_id": "1f38b13bdbbedeeb",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4770,6 +6012,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4781,6 +6025,8 @@
             "family_id": "54feecf6a08b7e70",
             "family_shape": "whole-only",
             "files": 3,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4798,6 +6044,8 @@
             ],
             "mean_lines": 4,
             "members": 5,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4809,6 +6057,8 @@
             "family_id": "667c976d88b07fe4",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4824,6 +6074,8 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -4835,6 +6087,8 @@
             "family_id": "952d57af41288b17",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4849,6 +6103,8 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4860,6 +6116,8 @@
             "family_id": "50e3c86cc78eef19",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4875,6 +6133,8 @@
             ],
             "mean_lines": 6,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4886,6 +6146,8 @@
             "family_id": "8161fd205551fbf9",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -4900,6 +6162,8 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -4911,6 +6175,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -4929,6 +6199,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -4940,6 +6216,12 @@
             "family_id": "1403ea654a505247",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -4959,6 +6241,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -4970,6 +6258,12 @@
             "family_id": "04937b5c97ecfb45",
             "family_shape": "mixed",
             "files": 4,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -4992,6 +6286,12 @@
             ],
             "mean_lines": 3,
             "members": 5,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -5003,6 +6303,8 @@
             "family_id": "451c840f3aed0f5e",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5017,6 +6319,8 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5028,6 +6332,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -5046,6 +6356,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -5057,6 +6373,8 @@
             "family_id": "b4598cb9bb0bbd5e",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5071,6 +6389,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -5082,6 +6402,8 @@
             "family_id": "bb8e343f0aef42c5",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5096,6 +6418,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -5107,6 +6431,12 @@
             "family_id": "b5844d386ab99691",
             "family_shape": "mixed",
             "files": 2,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -5159,6 +6489,12 @@
             ],
             "mean_lines": 5,
             "members": 35,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5170,6 +6506,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -5188,6 +6530,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -5199,6 +6547,8 @@
             "family_id": "d4adfc512c01eeb7",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5215,6 +6565,8 @@
             ],
             "mean_lines": 5,
             "members": 4,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5226,6 +6578,8 @@
             "family_id": "a77724a5fdfcefb0",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5240,6 +6594,8 @@
             ],
             "mean_lines": 7,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5251,6 +6607,8 @@
             "family_id": "40d028f3da647b65",
             "family_shape": "whole-only",
             "files": 3,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5266,6 +6624,8 @@
             ],
             "mean_lines": 4,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5277,6 +6637,12 @@
             "family_id": "297b86e9a1c7af62",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 3
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -5296,6 +6662,12 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "reason_code_counts": {
+              "exact-expr-effect": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -5307,6 +6679,8 @@
             "family_id": "52e612cc3c05277b",
             "family_shape": "whole-only",
             "files": 5,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5324,6 +6698,8 @@
             ],
             "mean_lines": 4,
             "members": 5,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5335,6 +6711,12 @@
             "family_id": "c77d9cdc336f09c5",
             "family_shape": "mixed",
             "files": 6,
+            "fragment_kind_counts": {
+              "expr-effect": 7
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 7
+            },
             "fragment_line_span_buckets": {
               "1": 7
             },
@@ -5361,6 +6743,12 @@
             ],
             "mean_lines": 1,
             "members": 9,
+            "reason_code_counts": {
+              "exact-expr-effect": 7
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 7
+            },
             "recommended_surface": "default",
             "span_bucket": "1"
           },
@@ -5372,6 +6760,12 @@
             "family_id": "297b86e9a1c7af62",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 3
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -5391,6 +6785,12 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "reason_code_counts": {
+              "exact-expr-effect": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -5402,6 +6802,8 @@
             "family_id": "3af516c04fca08e2",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5416,6 +6818,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5427,6 +6831,12 @@
             "family_id": "8a108c32b1d5a718",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "direct-return": 3
+            },
+            "fragment_kind_surface_counts": {
+              "direct-return|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -5446,6 +6856,12 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "reason_code_counts": {
+              "exact-direct-return": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-direct-return|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -5457,6 +6873,8 @@
             "family_id": "d996426dc1aa67b7",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5473,6 +6891,8 @@
             ],
             "mean_lines": 7,
             "members": 4,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5484,6 +6904,12 @@
             "family_id": "4c72daf37946c2b3",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -5503,6 +6929,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -5514,6 +6946,8 @@
             "family_id": "67ced0dc8d5f3b26",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5556,6 +6990,8 @@
             ],
             "mean_lines": 6,
             "members": 30,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5567,6 +7003,8 @@
             "family_id": "e72a9e05a67d3a32",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5582,6 +7020,8 @@
             ],
             "mean_lines": 5,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5593,6 +7033,12 @@
             "family_id": "8b850ab2be11fa11",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -5611,6 +7057,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -5622,6 +7074,8 @@
             "family_id": "d21a9f347a1616cf",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5636,6 +7090,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -5647,6 +7103,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -5665,6 +7127,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -5676,6 +7144,12 @@
             "family_id": "c350578012489fcd",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 8
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 8
+            },
             "fragment_line_span_buckets": {
               "1": 8
             },
@@ -5700,6 +7174,12 @@
             ],
             "mean_lines": 1,
             "members": 8,
+            "reason_code_counts": {
+              "exact-expr-effect": 8
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 8
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -5711,6 +7191,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -5729,6 +7215,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -5740,6 +7232,12 @@
             "family_id": "a817a833fec8efec",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 3
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -5759,6 +7257,12 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "reason_code_counts": {
+              "exact-expr-effect": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -5770,6 +7274,8 @@
             "family_id": "d50bb3d159f309a9",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5785,6 +7291,8 @@
             ],
             "mean_lines": 5,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5796,6 +7304,8 @@
             "family_id": "81aab54a66d9b56f",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5811,6 +7321,8 @@
             ],
             "mean_lines": 4,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5822,6 +7334,12 @@
             "family_id": "1a4990efefa3ce95",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -5840,6 +7358,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -5851,6 +7375,8 @@
             "family_id": "dbd8065f90391018",
             "family_shape": "whole-only",
             "files": 3,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5866,6 +7392,8 @@
             ],
             "mean_lines": 4,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5877,6 +7405,8 @@
             "family_id": "718f59b29e3e3774",
             "family_shape": "whole-only",
             "files": 3,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5892,6 +7422,8 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -5903,6 +7435,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -5921,6 +7459,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -5932,6 +7476,8 @@
             "family_id": "efd2bdc14522ae2d",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -5946,6 +7492,8 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -5957,6 +7505,12 @@
             "family_id": "94cc02144a8bfa3b",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -5976,6 +7530,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -5987,6 +7547,8 @@
             "family_id": "26137d475bfc2f4e",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6001,6 +7563,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -6012,6 +7576,8 @@
             "family_id": "ccdb5ca61bafe62e",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6028,6 +7594,8 @@
             ],
             "mean_lines": 7,
             "members": 4,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -6039,6 +7607,8 @@
             "family_id": "48def426c4ac4fda",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6053,6 +7623,8 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -6064,6 +7636,8 @@
             "family_id": "9dbd48403f577f14",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6078,6 +7652,8 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -6089,6 +7665,8 @@
             "family_id": "1b9092454c9ac906",
             "family_shape": "whole-only",
             "files": 4,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6105,6 +7683,8 @@
             ],
             "mean_lines": 4,
             "members": 4,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -6116,6 +7696,12 @@
             "family_id": "370bf55dbf47b6ba",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "self-field-body": 2
+            },
+            "fragment_kind_surface_counts": {
+              "self-field-body|review": 2
+            },
             "fragment_line_span_buckets": {
               "4-10": 2
             },
@@ -6134,6 +7720,12 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {
+              "exact-self-field-body": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-self-field-body|review": 2
+            },
             "recommended_surface": "review",
             "span_bucket": "4-10"
           },
@@ -6145,6 +7737,12 @@
             "family_id": "9877ce64af1f59b5",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -6163,6 +7761,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -6174,6 +7778,12 @@
             "family_id": "27f948eedd152caf",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -6193,6 +7803,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -6204,6 +7820,12 @@
             "family_id": "22ca8b89294ba6f4",
             "family_shape": "mixed",
             "files": 2,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -6224,6 +7846,12 @@
             ],
             "mean_lines": 2,
             "members": 3,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 2
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -6235,6 +7863,12 @@
             "family_id": "59be20b108ab3d9a",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "self-field-body": 2
+            },
+            "fragment_kind_surface_counts": {
+              "self-field-body|review": 2
+            },
             "fragment_line_span_buckets": {
               "4-10": 2
             },
@@ -6253,6 +7887,12 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {
+              "exact-self-field-body": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-self-field-body|review": 2
+            },
             "recommended_surface": "review",
             "span_bucket": "4-10"
           },
@@ -6264,6 +7904,12 @@
             "family_id": "276ee63009995506",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "expr-effect": 4
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 4
+            },
             "fragment_line_span_buckets": {
               "1": 4
             },
@@ -6284,6 +7930,12 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "reason_code_counts": {
+              "exact-expr-effect": 4
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 4
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -6295,6 +7947,8 @@
             "family_id": "cf6cdd886e48a175",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6309,6 +7963,8 @@
             ],
             "mean_lines": 22,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "11-30"
           },
@@ -6320,6 +7976,12 @@
             "family_id": "932b2bb0cc6e0070",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "conditional-guard": 4
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 4
+            },
             "fragment_line_span_buckets": {
               "2-3": 4
             },
@@ -6340,6 +8002,12 @@
             ],
             "mean_lines": 3,
             "members": 4,
+            "reason_code_counts": {
+              "exact-conditional-guard": 4
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 4
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -6351,6 +8019,12 @@
             "family_id": "5b9ca6bebdb793cd",
             "family_shape": "all-fragment",
             "files": 5,
+            "fragment_kind_counts": {
+              "conditional-guard": 10
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 10
+            },
             "fragment_line_span_buckets": {
               "2-3": 10
             },
@@ -6377,6 +8051,12 @@
             ],
             "mean_lines": 3,
             "members": 10,
+            "reason_code_counts": {
+              "exact-conditional-guard": 10
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 10
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -6388,6 +8068,8 @@
             "family_id": "123075daa7af496f",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6402,6 +8084,8 @@
             ],
             "mean_lines": 74,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "31+"
           },
@@ -6413,6 +8097,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -6431,6 +8121,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -6442,6 +8138,8 @@
             "family_id": "4c0a5c00536755a2",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6456,6 +8154,8 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -6467,6 +8167,12 @@
             "family_id": "43f5ea9611cf5b11",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 4
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 4
+            },
             "fragment_line_span_buckets": {
               "1": 4
             },
@@ -6487,6 +8193,12 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "reason_code_counts": {
+              "exact-expr-effect": 4
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 4
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -6498,6 +8210,12 @@
             "family_id": "d5d4ef35b9c4941d",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -6516,6 +8234,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -6527,6 +8251,12 @@
             "family_id": "b55fe592fb55bc17",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "self-field-assign": 3
+            },
+            "fragment_kind_surface_counts": {
+              "self-field-assign|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -6546,6 +8276,12 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "reason_code_counts": {
+              "exact-self-field-assign": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-self-field-assign|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -6557,6 +8293,12 @@
             "family_id": "434468096b49a83d",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -6575,6 +8317,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -6586,6 +8334,12 @@
             "family_id": "b9a80f700dee5662",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 3
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -6605,6 +8359,12 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "reason_code_counts": {
+              "exact-expr-effect": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -6616,6 +8376,12 @@
             "family_id": "cb28ebf51398c134",
             "family_shape": "all-fragment",
             "files": 3,
+            "fragment_kind_counts": {
+              "expr-effect": 5
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 5
+            },
             "fragment_line_span_buckets": {
               "1": 5
             },
@@ -6637,6 +8403,12 @@
             ],
             "mean_lines": 1,
             "members": 5,
+            "reason_code_counts": {
+              "exact-expr-effect": 5
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 5
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -6648,6 +8420,8 @@
             "family_id": "39bd79ecdd76f59e",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6663,6 +8437,8 @@
             ],
             "mean_lines": 5,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -6674,6 +8450,12 @@
             "family_id": "4dcfe2ade2e50d1b",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -6695,6 +8477,12 @@
             ],
             "mean_lines": 3,
             "members": 4,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 2
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -6706,6 +8494,8 @@
             "family_id": "892507fd578d252d",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6724,6 +8514,8 @@
             ],
             "mean_lines": 5,
             "members": 6,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -6735,6 +8527,8 @@
             "family_id": "b92d28747f692386",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6749,6 +8543,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -6760,6 +8556,12 @@
             "family_id": "9877ce64af1f59b5",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -6778,6 +8580,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -6789,6 +8597,8 @@
             "family_id": "2f0ce67332ea01fa",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6804,6 +8614,8 @@
             ],
             "mean_lines": 4,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -6815,6 +8627,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -6833,6 +8651,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -6844,6 +8668,8 @@
             "family_id": "195a660bab7bfc9c",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6858,6 +8684,8 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -6869,6 +8697,12 @@
             "family_id": "7e6fe1ee85168fda",
             "family_shape": "mixed",
             "files": 4,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -6890,6 +8724,12 @@
             ],
             "mean_lines": 3,
             "members": 4,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -6901,6 +8741,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -6919,6 +8765,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -6930,6 +8782,12 @@
             "family_id": "b934b8a29aeba1af",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "conditional-guard": 2
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "2-3": 2
             },
@@ -6948,6 +8806,12 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {
+              "exact-conditional-guard": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
@@ -6959,6 +8823,8 @@
             "family_id": "48522a5cdb987b57",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -6984,6 +8850,8 @@
             ],
             "mean_lines": 3,
             "members": 13,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -6995,6 +8863,12 @@
             "family_id": "3806784fd261674b",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -7014,6 +8888,12 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -7025,6 +8905,8 @@
             "family_id": "abe20a06b2a339fd",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7039,6 +8921,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -7050,6 +8934,12 @@
             "family_id": "d851463c4ec906dd",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -7068,6 +8958,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -7079,6 +8975,12 @@
             "family_id": "5a568fe9355c648c",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -7104,6 +9006,12 @@
             ],
             "mean_lines": 3,
             "members": 8,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 2
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -7115,6 +9023,12 @@
             "family_id": "a2da4db67e5225e6",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 1
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -7134,6 +9048,12 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -7145,6 +9065,12 @@
             "family_id": "fde80121ae3096ff",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 6
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 6
+            },
             "fragment_line_span_buckets": {
               "1": 6
             },
@@ -7167,6 +9093,12 @@
             ],
             "mean_lines": 1,
             "members": 6,
+            "reason_code_counts": {
+              "exact-expr-effect": 6
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 6
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -7178,6 +9110,8 @@
             "family_id": "db4842d46086325d",
             "family_shape": "whole-only",
             "files": 3,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7216,6 +9150,8 @@
             ],
             "mean_lines": 4,
             "members": 26,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -7227,6 +9163,12 @@
             "family_id": "8b18a08c0d3e331d",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "self-field-body": 2
+            },
+            "fragment_kind_surface_counts": {
+              "self-field-body|review": 2
+            },
             "fragment_line_span_buckets": {
               "4-10": 2
             },
@@ -7245,6 +9187,12 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {
+              "exact-self-field-body": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-self-field-body|review": 2
+            },
             "recommended_surface": "review",
             "span_bucket": "4-10"
           },
@@ -7256,6 +9204,12 @@
             "family_id": "d93ee3cd23cc0a85",
             "family_shape": "all-fragment",
             "files": 3,
+            "fragment_kind_counts": {
+              "expr-effect": 3
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -7275,6 +9229,12 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "reason_code_counts": {
+              "exact-expr-effect": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 3
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -7286,6 +9246,8 @@
             "family_id": "83eba3548175b08c",
             "family_shape": "whole-only",
             "files": 5,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7315,6 +9277,8 @@
             ],
             "mean_lines": 5,
             "members": 17,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -7326,6 +9290,8 @@
             "family_id": "acc54c51920acc79",
             "family_shape": "whole-only",
             "files": 4,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7344,6 +9310,8 @@
             ],
             "mean_lines": 3,
             "members": 6,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -7355,6 +9323,8 @@
             "family_id": "5cfeb93e1d748570",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7369,6 +9339,8 @@
             ],
             "mean_lines": 7,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -7380,6 +9352,12 @@
             "family_id": "b10ac7c95afc9b33",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -7398,6 +9376,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -7409,6 +9393,8 @@
             "family_id": "aa92227fb21f6b95",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7423,6 +9409,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -7434,6 +9422,8 @@
             "family_id": "48def426c4ac4fda",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7448,6 +9438,8 @@
             ],
             "mean_lines": 8,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -7459,6 +9451,8 @@
             "family_id": "a3ab09b856d99fb7",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7473,6 +9467,8 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -7484,6 +9480,8 @@
             "family_id": "7fb06e488f4f66bd",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7498,6 +9496,8 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -7509,6 +9509,12 @@
             "family_id": "ed25c2922b485156",
             "family_shape": "mixed",
             "files": 2,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|default": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -7529,6 +9535,12 @@
             ],
             "mean_lines": 2,
             "members": 3,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|default": 2
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           }
@@ -7608,19 +9620,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 7.5,
+          "candidates": 7.9,
           "cluster": 0.4,
           "contiguous": 0.0,
           "discover": 10.5,
           "groups": 2.4,
-          "lower": 52.0,
-          "normalize+extract": 39.2,
-          "parse+lower": 41.9,
+          "lower": 51.9,
+          "normalize+extract": 39.3,
+          "parse+lower": 42.1,
           "score": 0.4
         },
         "repeats": 5,
-        "wall_ms_median": 183.1,
-        "wall_ms_min": 176.04
+        "wall_ms_median": 183.29,
+        "wall_ms_min": 176.42
       }
     },
     "ky": {
@@ -7639,6 +9651,8 @@
             "family_id": "7490df14f9361713",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7653,6 +9667,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -7664,6 +9680,8 @@
             "family_id": "5fbd95eaff90e98d",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7678,6 +9696,8 @@
             ],
             "mean_lines": 10,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -7689,6 +9709,8 @@
             "family_id": "2f0d340158c80b31",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7705,6 +9727,8 @@
             ],
             "mean_lines": 6,
             "members": 4,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -7716,6 +9740,12 @@
             "family_id": "dc1cd0cfbefcac6d",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "conditional-guard": 2
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "2-3": 2
             },
@@ -7734,6 +9764,12 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {
+              "exact-conditional-guard": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "2-3"
           }
@@ -7784,19 +9820,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 1.0,
+          "candidates": 0.7,
           "cluster": 0.0,
           "contiguous": 0.0,
           "discover": 3.4,
           "groups": 0.0,
-          "lower": 16.5,
-          "normalize+extract": 7.4,
-          "parse+lower": 13.1,
+          "lower": 15.5,
+          "normalize+extract": 7.5,
+          "parse+lower": 12.0,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 35.51,
-        "wall_ms_min": 33.71
+        "wall_ms_median": 34.42,
+        "wall_ms_min": 33.83
       }
     },
     "liquid": {
@@ -7815,6 +9851,8 @@
             "family_id": "6caa2ef93eaffa55",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7829,6 +9867,8 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -7840,6 +9880,12 @@
             "family_id": "d27c3b2e93cae4a5",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "conditional-guard": 4
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 4
+            },
             "fragment_line_span_buckets": {
               "1": 4
             },
@@ -7860,6 +9906,12 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "reason_code_counts": {
+              "exact-conditional-guard": 4
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 4
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -7871,6 +9923,12 @@
             "family_id": "33a17da33703efc9",
             "family_shape": "all-fragment",
             "files": 1,
+            "fragment_kind_counts": {
+              "conditional-guard": 2
+            },
+            "fragment_kind_surface_counts": {
+              "conditional-guard|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -7889,6 +9947,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-conditional-guard": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-conditional-guard|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -7900,6 +9964,8 @@
             "family_id": "67318164927549c5",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -7914,6 +9980,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           }
@@ -7966,19 +10034,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 1.8,
+          "candidates": 1.7,
           "cluster": 0.1,
           "contiguous": 0.0,
           "discover": 3.4,
           "groups": 0.1,
-          "lower": 14.5,
-          "normalize+extract": 10.8,
-          "parse+lower": 11.0,
+          "lower": 14.6,
+          "normalize+extract": 11.0,
+          "parse+lower": 11.5,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 40.56,
-        "wall_ms_min": 38.43
+        "wall_ms_median": 39.81,
+        "wall_ms_min": 38.63
       }
     },
     "serde_json": {
@@ -7997,6 +10065,12 @@
             "family_id": "f182d3c11d972de6",
             "family_shape": "all-fragment",
             "files": 2,
+            "fragment_kind_counts": {
+              "expr-effect": 2
+            },
+            "fragment_kind_surface_counts": {
+              "expr-effect|hidden": 2
+            },
             "fragment_line_span_buckets": {
               "1": 2
             },
@@ -8015,6 +10089,12 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "reason_code_counts": {
+              "exact-expr-effect": 2
+            },
+            "reason_code_surface_counts": {
+              "exact-expr-effect|hidden": 2
+            },
             "recommended_surface": "hidden",
             "span_bucket": "1"
           },
@@ -8026,6 +10106,12 @@
             "family_id": "1051970f845496b4",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "direct-return": 1
+            },
+            "fragment_kind_surface_counts": {
+              "direct-return|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -8045,6 +10131,12 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {
+              "exact-direct-return": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-direct-return|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -8056,6 +10148,8 @@
             "family_id": "fbb253861b54e9ed",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -8070,6 +10164,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -8081,6 +10177,8 @@
             "family_id": "52f1ce45e98c9e1a",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -8096,6 +10194,8 @@
             ],
             "mean_lines": 6,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -8107,6 +10207,8 @@
             "family_id": "cf1f75081d0ceec1",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -8121,6 +10223,8 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -8132,6 +10236,12 @@
             "family_id": "202cd8c3b8e31f52",
             "family_shape": "mixed",
             "files": 1,
+            "fragment_kind_counts": {
+              "direct-return": 1
+            },
+            "fragment_kind_surface_counts": {
+              "direct-return|default": 1
+            },
             "fragment_line_span_buckets": {
               "1": 1
             },
@@ -8151,6 +10261,12 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {
+              "exact-direct-return": 1
+            },
+            "reason_code_surface_counts": {
+              "exact-direct-return|default": 1
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -8162,6 +10278,8 @@
             "family_id": "a9070706acf347ba",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -8179,6 +10297,8 @@
             ],
             "mean_lines": 5,
             "members": 5,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -8190,6 +10310,8 @@
             "family_id": "4ca8b9749aab45cd",
             "family_shape": "whole-only",
             "files": 2,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -8204,6 +10326,8 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -8215,6 +10339,8 @@
             "family_id": "e9c0156f4388acc7",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -8230,6 +10356,8 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -8241,6 +10369,8 @@
             "family_id": "79e903477a6a5faa",
             "family_shape": "whole-only",
             "files": 3,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -8256,6 +10386,8 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "2-3"
           },
@@ -8267,6 +10399,8 @@
             "family_id": "8cb22fd507f5c505",
             "family_shape": "whole-only",
             "files": 1,
+            "fragment_kind_counts": {},
+            "fragment_kind_surface_counts": {},
             "fragment_line_span_buckets": {},
             "fragment_location_count": 0,
             "fragment_token_span_buckets": {},
@@ -8281,6 +10415,8 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "reason_code_counts": {},
+            "reason_code_surface_counts": {},
             "recommended_surface": "default",
             "span_bucket": "4-10"
           },
@@ -8292,6 +10428,12 @@
             "family_id": "e4dfbe75341879a1",
             "family_shape": "mixed",
             "files": 2,
+            "fragment_kind_counts": {
+              "direct-return": 3
+            },
+            "fragment_kind_surface_counts": {
+              "direct-return|default": 3
+            },
             "fragment_line_span_buckets": {
               "1": 3
             },
@@ -8314,6 +10456,12 @@
             ],
             "mean_lines": 3,
             "members": 5,
+            "reason_code_counts": {
+              "exact-direct-return": 3
+            },
+            "reason_code_surface_counts": {
+              "exact-direct-return|default": 3
+            },
             "recommended_surface": "default",
             "span_bucket": "2-3"
           }
@@ -8370,19 +10518,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 1.9,
+          "candidates": 2.1,
           "cluster": 0.1,
           "contiguous": 0.0,
           "discover": 3.4,
           "groups": 0.1,
-          "lower": 12.7,
+          "lower": 14.7,
           "normalize+extract": 10.3,
-          "parse+lower": 9.4,
-          "score": 0.2
+          "parse+lower": 11.3,
+          "score": 0.3
         },
         "repeats": 5,
-        "wall_ms_median": 38.17,
-        "wall_ms_min": 35.83
+        "wall_ms_median": 41.86,
+        "wall_ms_min": 39.78
       }
     }
   },

--- a/bench/type4/scan_regression/baseline.v1.json
+++ b/bench/type4/scan_regression/baseline.v1.json
@@ -1,12 +1,12 @@
 {
   "binary": {
-    "binary_path": "/Users/ak/prjs/cc/nose/.claude/worktrees/issue-45-productize-fragments/target/release/nose",
-    "build_ref": "issue-45@416325e",
-    "sha256": "afc8212b9480a812a3f5c52f3977f89c1905f130001ca53b4ee47820969b02de",
-    "size_bytes": 13549744,
+    "binary_path": "/Users/ak/prjs/cc/nose/.claude/worktrees/issue-51-fragment-measurement/target/release/nose",
+    "build_ref": "issue-51@a592075",
+    "sha256": "00511c77fdb0f5878deed159594e9970e2e83914fc71035440324e435ecc212d",
+    "size_bytes": 13549648,
     "source_dirty": false,
-    "source_git_describe": "v0.5.0-175-ge4d381d",
-    "source_git_sha": "e4d381d82922c591330da297c82d5aa2cc3c6552",
+    "source_git_describe": "v0.5.0-185-ga592075",
+    "source_git_sha": "a5920752058bab950e06e12b49a5b67dc2f86b29",
     "version": "nose 0.5.0"
   },
   "generated_by": "bench/type4/scan_regression/scan_regression.py baseline",
@@ -14,10 +14,22 @@
     "boltons": {
       "output": {
         "distinct_location_sets": 45,
+        "enclosing_unit_recovery_counts": {
+          "missing": 0,
+          "recovered": 86
+        },
         "families": {
           "1935a4e0c1065651": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "c1a7ee35d645dfb8",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 5
             },
@@ -32,11 +44,20 @@
             ],
             "mean_lines": 2,
             "members": 5,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "2b8ee41935f90de5": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "bf3614d2ad0776e2",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -48,11 +69,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "2ba606a76bdfdf34": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "0bdc5238e860ca25",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -64,11 +98,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "30371ffa5dddbddd": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "89d8d6810dd22a60",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -80,11 +123,20 @@
             ],
             "mean_lines": 16,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "11-30"
           },
           "32216f6990145589": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "317cdc648c21457d",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 2
             },
@@ -96,11 +148,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "388d2f7c5ae3d000": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "221fac5b06a56791",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -112,11 +177,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "3c3401fc5810ed4d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "dc9e5e2e0733adea",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -128,11 +202,20 @@
             ],
             "mean_lines": 8,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "44b82485f8878c0d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "88f32e5afb8f1f10",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -144,11 +227,24 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "471a44aa277d31f4": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "d501e0bf7fb4023f",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "2-3": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -160,11 +256,20 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "5d5e10b8611a561d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "03fd32e6d5c1416f",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -176,11 +281,20 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "692943faf9c38b42": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "befde3f12eba7a81",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -192,11 +306,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "7c495cad2601949b": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "c12a5f75e261382b",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -209,11 +336,24 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "895380690b5321f0": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "f5d7edd64d7d3675",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -225,11 +365,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "8a1053467dcea1d6": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "a34a326d9ed57b37",
+            "family_shape": "whole-only",
             "files": 4,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 5
             },
@@ -244,11 +393,24 @@
             ],
             "mean_lines": 2,
             "members": 5,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "8b00fc7952e0edd4": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "c421e937f67d6a85",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -261,11 +423,20 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "8e3599e3647221cf": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "0d65157602531a65",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -277,11 +448,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "8fcca6ac78ff4df3": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "54ca8e7b7b17d7d7",
+            "family_shape": "mixed",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Function": 1
@@ -294,11 +478,20 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "91c878ccfbb8188c": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "096334183198eee0",
+            "family_shape": "whole-only",
             "files": 3,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 4
             },
@@ -312,11 +505,24 @@
             ],
             "mean_lines": 2,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "95bb1f13977086db": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "52d091a1c797fb4a",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -328,11 +534,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "97176bce620e9322": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "3001ad0849b667c3",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Block": 2
             },
@@ -344,11 +559,20 @@
             ],
             "mean_lines": 34,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "31+"
           },
           "972697f6edbc72b4": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "68067a7d2e9931ea",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -360,11 +584,20 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "9d55a55829ff1b7a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "c22aaec191559be9",
+            "family_shape": "whole-only",
             "files": 3,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -377,11 +610,20 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "9e48dd01b131522c": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "da5521864dd50141",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -393,11 +635,20 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "a172fe445bb75a68": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "cc6dda466a93ac9d",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Block": 2
             },
@@ -409,11 +660,24 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "a3121508b9128bfe": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "f5d7edd64d7d3675",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -425,11 +689,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "a511107a8e405aba": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "aff74ff2549b5c1e",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 4
             },
@@ -443,11 +716,20 @@
             ],
             "mean_lines": 6,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "b132b524d26d759e": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "f49a5aa0e8108bdf",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Block": 2
             },
@@ -459,11 +741,24 @@
             ],
             "mean_lines": 8,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "b7d1140d2bcdedca": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "52d091a1c797fb4a",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "2-3": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -475,11 +770,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "b8f5ca7534c30604": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 18
+            },
             "family_id": "e60652555898f589",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 18
+            },
+            "fragment_location_count": 18,
+            "fragment_token_span_buckets": {
+              "1-8": 18
+            },
             "kinds": {
               "Block": 18
             },
@@ -507,11 +815,20 @@
             ],
             "mean_lines": 1,
             "members": 18,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "c36efc5d5aa8929a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "be87bec48929d902",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -523,11 +840,24 @@
             ],
             "mean_lines": 8,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "c425035bb491fb28": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 5
+            },
             "family_id": "3ef7f89fc7052764",
+            "family_shape": "all-fragment",
             "files": 4,
+            "fragment_line_span_buckets": {
+              "2-3": 5
+            },
+            "fragment_location_count": 5,
+            "fragment_token_span_buckets": {
+              "1-8": 5
+            },
             "kinds": {
               "Block": 5
             },
@@ -542,11 +872,24 @@
             ],
             "mean_lines": 2,
             "members": 5,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "c6e5488281398be3": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "943290def00e3eeb",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "2-3": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -558,11 +901,20 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "cb47dad6f67f7be4": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "aa88b4085f8c6f66",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 2
             },
@@ -574,11 +926,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "ccd735bf292c6e83": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "ed6bd8b1c8a22ded",
+            "family_shape": "all-fragment",
             "files": 3,
+            "fragment_line_span_buckets": {
+              "2-3": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -591,11 +956,20 @@
             ],
             "mean_lines": 2,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "ccfc7be8e94a6725": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "52d091a1c797fb4a",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Block": 2
             },
@@ -607,11 +981,20 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "cf5ff1b3ba24b9c9": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "88c27a78caf274b0",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -623,11 +1006,24 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "d16be088d9ea211f": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 16
+            },
             "family_id": "8625bfb61cdefb25",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 16
+            },
+            "fragment_location_count": 16,
+            "fragment_token_span_buckets": {
+              "1-8": 16
+            },
             "kinds": {
               "Block": 16
             },
@@ -653,11 +1049,20 @@
             ],
             "mean_lines": 1,
             "members": 16,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "d37fe741d8233b78": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "bb6a0cc094762b7c",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 2
             },
@@ -669,11 +1074,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "d42ecd14671b3480": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "162e33869320bb7d",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -685,11 +1103,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "d4dd8a33e86b599a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 7
+            },
             "family_id": "aab95bae61012b3d",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 7
+            },
+            "fragment_location_count": 7,
+            "fragment_token_span_buckets": {
+              "1-8": 7
+            },
             "kinds": {
               "Block": 7
             },
@@ -706,11 +1137,24 @@
             ],
             "mean_lines": 1,
             "members": 7,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "de1a941a84bab443": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "ed6bd8b1c8a22ded",
+            "family_shape": "all-fragment",
             "files": 3,
+            "fragment_line_span_buckets": {
+              "2-3": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -723,11 +1167,24 @@
             ],
             "mean_lines": 2,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "e23cac11b31e85ac": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "c421e937f67d6a85",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -740,11 +1197,20 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "f3405ba8c3f220e2": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "d04448284a8828f4",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -756,11 +1222,24 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "f3aa5802b504fd76": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 6
+            },
             "family_id": "82ac7e88d1d8e025",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 6
+            },
+            "fragment_location_count": 6,
+            "fragment_token_span_buckets": {
+              "1-8": 6
+            },
             "kinds": {
               "Block": 6
             },
@@ -776,11 +1255,20 @@
             ],
             "mean_lines": 1,
             "members": 6,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "fa38e1768ebb7c2a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "260229e6609d1830",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -792,13 +1280,32 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           }
+        },
+        "family_shape_counts": {
+          "all-fragment": 19,
+          "mixed": 1,
+          "whole-only": 25
         },
         "fragment_kind_counts": {
           "conditional-guard": 17,
           "direct-return": 1,
           "expr-effect": 68
+        },
+        "fragment_kind_surface_counts": {
+          "conditional-guard|hidden": 17,
+          "direct-return|default": 1,
+          "expr-effect|hidden": 68
+        },
+        "fragment_line_span_buckets": {
+          "1": 69,
+          "2-3": 17
+        },
+        "fragment_token_span_buckets": {
+          "1-8": 82,
+          "9-23": 4
         },
         "kind_counts": {
           "Block": 94,
@@ -815,6 +1322,17 @@
           "exact-direct-return": 1,
           "exact-expr-effect": 68
         },
+        "reason_code_surface_counts": {
+          "exact-conditional-guard|hidden": 17,
+          "exact-direct-return|default": 1,
+          "exact-expr-effect|hidden": 68
+        },
+        "recommended_surface_counts": {
+          "debug": 0,
+          "default": 26,
+          "hidden": 19,
+          "review": 0
+        },
         "scope_files": 65,
         "shown_families": 45,
         "span_buckets": {
@@ -828,28 +1346,44 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 2.1,
+          "candidates": 2.5,
           "cluster": 0.1,
           "contiguous": 0.0,
-          "discover": 5.0,
-          "groups": 0.2,
-          "lower": 14.2,
-          "normalize+extract": 8.8,
-          "parse+lower": 9.2,
-          "score": 0.2
+          "discover": 3.4,
+          "groups": 0.3,
+          "lower": 13.1,
+          "normalize+extract": 9.1,
+          "parse+lower": 9.7,
+          "score": 0.3
         },
         "repeats": 5,
-        "wall_ms_median": 38.96,
-        "wall_ms_min": 36.6
+        "wall_ms_median": 39.52,
+        "wall_ms_min": 37.31
       }
     },
     "chi": {
       "output": {
         "distinct_location_sets": 4,
+        "enclosing_unit_recovery_counts": {
+          "missing": 0,
+          "recovered": 15
+        },
         "families": {
           "0bf468e4c400c1a3": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 5
+            },
             "family_id": "1b8f7e5b24f35a84",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 5
+            },
+            "fragment_location_count": 5,
+            "fragment_token_span_buckets": {
+              "1-8": 5
+            },
             "kinds": {
               "Block": 5
             },
@@ -864,11 +1398,24 @@
             ],
             "mean_lines": 1,
             "members": 5,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "27071101d404e54d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "c55b843732270ba0",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -880,11 +1427,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "798c23436a0230bb": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 6
+            },
             "family_id": "57d3ad5ed5c000af",
+            "family_shape": "all-fragment",
             "files": 4,
+            "fragment_line_span_buckets": {
+              "1": 6
+            },
+            "fragment_location_count": 6,
+            "fragment_token_span_buckets": {
+              "1-8": 6
+            },
             "kinds": {
               "Block": 6
             },
@@ -900,11 +1460,24 @@
             ],
             "mean_lines": 1,
             "members": 6,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "c32d103aa3dd50df": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "c55b843732270ba0",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -916,11 +1489,26 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           }
         },
+        "family_shape_counts": {
+          "all-fragment": 4,
+          "mixed": 0,
+          "whole-only": 0
+        },
         "fragment_kind_counts": {
           "expr-effect": 15
+        },
+        "fragment_kind_surface_counts": {
+          "expr-effect|hidden": 15
+        },
+        "fragment_line_span_buckets": {
+          "1": 15
+        },
+        "fragment_token_span_buckets": {
+          "1-8": 15
         },
         "kind_counts": {
           "Block": 15
@@ -932,6 +1520,15 @@
         "reason_code_counts": {
           "exact-expr-effect": 15
         },
+        "reason_code_surface_counts": {
+          "exact-expr-effect|hidden": 15
+        },
+        "recommended_surface_counts": {
+          "debug": 0,
+          "default": 0,
+          "hidden": 4,
+          "review": 0
+        },
         "scope_files": 78,
         "shown_families": 4,
         "span_buckets": {
@@ -941,28 +1538,40 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 0.8,
+          "candidates": 0.9,
           "cluster": 0.0,
           "contiguous": 0.0,
-          "discover": 3.4,
+          "discover": 3.8,
           "groups": 0.1,
-          "lower": 12.2,
-          "normalize+extract": 7.3,
+          "lower": 12.5,
+          "normalize+extract": 6.9,
           "parse+lower": 8.1,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 31.49,
-        "wall_ms_min": 29.0
+        "wall_ms_median": 31.16,
+        "wall_ms_min": 30.66
       }
     },
     "cmark": {
       "output": {
         "distinct_location_sets": 17,
+        "enclosing_unit_recovery_counts": {
+          "missing": 0,
+          "recovered": 47
+        },
         "families": {
           "04fe5aa1c1734ad8": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "26ced6842ce520b9",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Block": 2
             },
@@ -974,11 +1583,24 @@
             ],
             "mean_lines": 23,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "11-30"
           },
           "0d0773d7e954e3d3": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "fcc9256e3e7a7eed",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "2-3": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -990,11 +1612,20 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "4130e314fa063de6": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "170d015e2ec1088d",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 2
             },
@@ -1006,11 +1637,20 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "434042e1f0195edd": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "9e9b104e3f14e44f",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Block": 3
             },
@@ -1023,11 +1663,24 @@
             ],
             "mean_lines": 25,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "11-30"
           },
           "45194398d1fb6afa": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 4
+            },
             "family_id": "c8aef64af19c431d",
+            "family_shape": "all-fragment",
             "files": 3,
+            "fragment_line_span_buckets": {
+              "2-3": 4
+            },
+            "fragment_location_count": 4,
+            "fragment_token_span_buckets": {
+              "1-8": 4
+            },
             "kinds": {
               "Block": 4
             },
@@ -1041,11 +1694,24 @@
             ],
             "mean_lines": 2,
             "members": 4,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "56a7e77a74ed13f0": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 17
+            },
             "family_id": "b9b46d92887b4874",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "2-3": 17
+            },
+            "fragment_location_count": 17,
+            "fragment_token_span_buckets": {
+              "1-8": 17
+            },
             "kinds": {
               "Block": 17
             },
@@ -1072,11 +1738,20 @@
             ],
             "mean_lines": 3,
             "members": 17,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "6090aad985f5ff6a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "26ced6842ce520b9",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Block": 2
             },
@@ -1088,11 +1763,20 @@
             ],
             "mean_lines": 21,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "11-30"
           },
           "8837c72bc50ae2bf": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "767624ff995a5fed",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Block": 2
             },
@@ -1104,11 +1788,24 @@
             ],
             "mean_lines": 11,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "11-30"
           },
           "8a80c13b5c865ee8": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "7a4fac3c354dbb1c",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "2-3": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -1121,11 +1818,24 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "95c0f5a16d19f937": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "daf11c9215fb53e1",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "2-3": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -1137,11 +1847,20 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "a15e5dc715b04e9f": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "d8d475406c21ae4f",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -1153,11 +1872,24 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "bc2d2268a5557579": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "5122da1710c96f93",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "2-3": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -1169,11 +1901,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "beb2c4f6a116ff34": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "5122da1710c96f93",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "2-3": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -1185,11 +1930,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "bf46a6bf709bc394": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 13
+            },
             "family_id": "17857b88e1f45cc6",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "2-3": 13
+            },
+            "fragment_location_count": 13,
+            "fragment_token_span_buckets": {
+              "1-8": 13
+            },
             "kinds": {
               "Block": 13
             },
@@ -1212,11 +1970,20 @@
             ],
             "mean_lines": 3,
             "members": 13,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "e237754cc25a1d4b": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "4fa35f7ab1a6ca1d",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Block": 60
             },
@@ -1286,11 +2053,20 @@
             ],
             "mean_lines": 28,
             "members": 60,
+            "recommended_surface": "default",
             "span_bucket": "11-30"
           },
           "fae0fee7351f8e88": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "3f29c523d7246497",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Block": 55
             },
@@ -1355,11 +2131,24 @@
             ],
             "mean_lines": 21,
             "members": 55,
+            "recommended_surface": "default",
             "span_bucket": "11-30"
           },
           "fd7f90ed6510cb6a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "fcc9256e3e7a7eed",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -1371,12 +2160,30 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           }
+        },
+        "family_shape_counts": {
+          "all-fragment": 9,
+          "mixed": 0,
+          "whole-only": 8
         },
         "fragment_kind_counts": {
           "conditional-guard": 45,
           "expr-effect": 2
+        },
+        "fragment_kind_surface_counts": {
+          "conditional-guard|hidden": 45,
+          "expr-effect|hidden": 2
+        },
+        "fragment_line_span_buckets": {
+          "1": 2,
+          "2-3": 45
+        },
+        "fragment_token_span_buckets": {
+          "1-8": 45,
+          "9-23": 2
         },
         "kind_counts": {
           "Block": 171,
@@ -1393,6 +2200,16 @@
           "exact-conditional-guard": 45,
           "exact-expr-effect": 2
         },
+        "reason_code_surface_counts": {
+          "exact-conditional-guard|hidden": 45,
+          "exact-expr-effect|hidden": 2
+        },
+        "recommended_surface_counts": {
+          "debug": 0,
+          "default": 8,
+          "hidden": 9,
+          "review": 0
+        },
         "scope_files": 51,
         "shown_families": 17,
         "span_buckets": {
@@ -1404,28 +2221,44 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 1.5,
-          "cluster": 0.1,
+          "candidates": 1.4,
+          "cluster": 0.0,
           "contiguous": 0.0,
           "discover": 3.4,
           "groups": 0.1,
-          "lower": 20.7,
-          "normalize+extract": 22.5,
+          "lower": 21.5,
+          "normalize+extract": 21.5,
           "parse+lower": 17.3,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 57.51,
-        "wall_ms_min": 55.93
+        "wall_ms_median": 56.5,
+        "wall_ms_min": 56.15
       }
     },
     "gin": {
       "output": {
         "distinct_location_sets": 3,
+        "enclosing_unit_recovery_counts": {
+          "missing": 0,
+          "recovered": 7
+        },
         "families": {
           "24fe4c25aab8432f": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "11872955a669aabd",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -1437,11 +2270,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "c6e215d29dd24b7d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 5
+            },
             "family_id": "5b6f1fdf00d78bfe",
+            "family_shape": "all-fragment",
             "files": 4,
+            "fragment_line_span_buckets": {
+              "1": 5
+            },
+            "fragment_location_count": 5,
+            "fragment_token_span_buckets": {
+              "1-8": 5
+            },
             "kinds": {
               "Block": 5
             },
@@ -1456,11 +2302,20 @@
             ],
             "mean_lines": 1,
             "members": 5,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "d8cf48c261ddc625": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "515439eb60de28eb",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 2
             },
@@ -1472,11 +2327,26 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           }
         },
+        "family_shape_counts": {
+          "all-fragment": 2,
+          "mixed": 0,
+          "whole-only": 1
+        },
         "fragment_kind_counts": {
           "expr-effect": 7
+        },
+        "fragment_kind_surface_counts": {
+          "expr-effect|hidden": 7
+        },
+        "fragment_line_span_buckets": {
+          "1": 7
+        },
+        "fragment_token_span_buckets": {
+          "1-8": 7
         },
         "kind_counts": {
           "Block": 7,
@@ -1488,6 +2358,15 @@
         "product_json_bytes": 4403,
         "reason_code_counts": {
           "exact-expr-effect": 7
+        },
+        "reason_code_surface_counts": {
+          "exact-expr-effect|hidden": 7
+        },
+        "recommended_surface_counts": {
+          "debug": 0,
+          "default": 1,
+          "hidden": 2,
+          "review": 0
         },
         "scope_files": 98,
         "shown_families": 3,
@@ -1504,23 +2383,35 @@
           "contiguous": 0.0,
           "discover": 3.4,
           "groups": 0.1,
-          "lower": 18.8,
-          "normalize+extract": 13.7,
-          "parse+lower": 15.4,
+          "lower": 19.3,
+          "normalize+extract": 13.0,
+          "parse+lower": 15.7,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 46.38,
-        "wall_ms_min": 44.43
+        "wall_ms_median": 47.49,
+        "wall_ms_min": 44.48
       }
     },
     "junit5": {
       "output": {
         "distinct_location_sets": 172,
+        "enclosing_unit_recovery_counts": {
+          "missing": 0,
+          "recovered": 312
+        },
         "families": {
           "0176fcdad1473a2d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "2143942e284cf486",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 5
             },
@@ -1535,11 +2426,24 @@
             ],
             "mean_lines": 5,
             "members": 5,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "01d8c523aa9022b4": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "e0728d4490777b48",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -1552,11 +2456,20 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "025d70e5025f27ca": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "ab0f921c1cbe0836",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -1569,11 +2482,24 @@
             ],
             "mean_lines": 4,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "047fcb0f0ab5253e": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -1585,11 +2511,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "05763229bafaf034": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "6d7e90f44ec4127f",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -1602,11 +2541,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "05fd5e08cb0c8147": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "4c2c96ab825e8236",
+            "family_shape": "mixed",
             "files": 21,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 20
@@ -1638,11 +2590,20 @@
             ],
             "mean_lines": 2,
             "members": 21,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "08bcbeb06ca5144b": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "76c6c4d6601b5773",
+            "family_shape": "whole-only",
             "files": 3,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -1655,11 +2616,24 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "0aa8bf7e4f67ac5b": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 4
+            },
             "family_id": "4255208f745f46fb",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 4
+            },
+            "fragment_location_count": 4,
+            "fragment_token_span_buckets": {
+              "1-8": 4
+            },
             "kinds": {
               "Block": 4
             },
@@ -1673,11 +2647,24 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "0b3a1d60263d9b48": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "9dfa3678f03263d3",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3,
               "Method": 1
@@ -1692,11 +2679,20 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "1"
           },
           "0c18a8ade724c82a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "bca5a5a55ade0006",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 4
             },
@@ -1710,11 +2706,24 @@
             ],
             "mean_lines": 8,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "0d6e88c3a6265919": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 4
+            },
             "family_id": "43f5ea9611cf5b11",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 4
+            },
+            "fragment_location_count": 4,
+            "fragment_token_span_buckets": {
+              "1-8": 4
+            },
             "kinds": {
               "Block": 4
             },
@@ -1728,11 +2737,20 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "0da006b40a15162d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "d1018b34e92cc6c7",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -1744,11 +2762,24 @@
             ],
             "mean_lines": 8,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "0ee7e8b94b77b484": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 5
+            },
             "family_id": "0d28fc3ca805c28d",
+            "family_shape": "mixed",
             "files": 5,
+            "fragment_line_span_buckets": {
+              "1": 5
+            },
+            "fragment_location_count": 5,
+            "fragment_token_span_buckets": {
+              "1-8": 5
+            },
             "kinds": {
               "Block": 5,
               "Method": 2
@@ -1766,11 +2797,24 @@
             ],
             "mean_lines": 2,
             "members": 7,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "13e3b56338ea6b11": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -1782,11 +2826,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "1475c5b141dec37e": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "6fb988936b3d3f08",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "2-3": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -1798,11 +2855,24 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "159d241ff3683579": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "f73cb1974ad97af2",
+            "family_shape": "mixed",
             "files": 4,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2,
               "Method": 2
@@ -1817,11 +2887,20 @@
             ],
             "mean_lines": 3,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "167065aa51efe21a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "d88dd594718b3b6c",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -1833,11 +2912,20 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "16d641afbcad8873": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "1be4bc830ed32051",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -1849,11 +2937,20 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "171574726470c1e4": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "ab37cb8aa4dba419",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -1865,11 +2962,20 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "1a7048c482648119": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "d2cb1c30398b890e",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -1881,11 +2987,24 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "1bb5f107e13e37cf": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "e53f8d946f20b6e1",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -1897,11 +3016,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "1cf8468796baa5dc": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "8b18a08c0d3e331d",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "4-10": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -1913,11 +3045,20 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "review",
             "span_bucket": "4-10"
           },
           "1e987a4a75afc52e": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "f55ea4cfd0feeae1",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -1929,11 +3070,24 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "1ef880453016f074": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "d67f6f6f1964d5f0",
+            "family_shape": "mixed",
             "files": 4,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3,
               "Method": 1
@@ -1948,11 +3102,24 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "1"
           },
           "213283e0408974f1": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 5
+            },
             "family_id": "a4936437856ae127",
+            "family_shape": "all-fragment",
             "files": 5,
+            "fragment_line_span_buckets": {
+              "2-3": 5
+            },
+            "fragment_location_count": 5,
+            "fragment_token_span_buckets": {
+              "1-8": 5
+            },
             "kinds": {
               "Block": 5
             },
@@ -1967,11 +3134,24 @@
             ],
             "mean_lines": 3,
             "members": 5,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "2503c41f5547ad17": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "bdfc531cb3d705e9",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -1984,11 +3164,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "25a2ac0a825d8d4a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "a84c990d8f7a7231",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -2000,11 +3193,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "27df75638c66bee7": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "3010f335ef366f67",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -2017,11 +3223,20 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "28ea5f41d8d3a20d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "f8690b33f8ee1d50",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -2033,11 +3248,24 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "2c55f340ce294478": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "e2278a0a8987f4cb",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "4-10": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -2049,11 +3277,24 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "review",
             "span_bucket": "4-10"
           },
           "2cae3df8d62caa27": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 8
+            },
             "family_id": "c350578012489fcd",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 8
+            },
+            "fragment_location_count": 8,
+            "fragment_token_span_buckets": {
+              "9-23": 8
+            },
             "kinds": {
               "Block": 8
             },
@@ -2071,11 +3312,24 @@
             ],
             "mean_lines": 1,
             "members": 8,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "2d5cdc514c56a920": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 12
+            },
             "family_id": "db6182162c37f866",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "2-3": 12
+            },
+            "fragment_location_count": 12,
+            "fragment_token_span_buckets": {
+              "1-8": 12
+            },
             "kinds": {
               "Block": 12
             },
@@ -2097,11 +3351,24 @@
             ],
             "mean_lines": 3,
             "members": 12,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "30eb2732a526cc57": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 5
+            },
             "family_id": "e1a53c94b04b2272",
+            "family_shape": "mixed",
             "files": 4,
+            "fragment_line_span_buckets": {
+              "1": 5
+            },
+            "fragment_location_count": 5,
+            "fragment_token_span_buckets": {
+              "1-8": 5
+            },
             "kinds": {
               "Block": 5,
               "Method": 1
@@ -2118,11 +3385,24 @@
             ],
             "mean_lines": 1,
             "members": 6,
+            "recommended_surface": "default",
             "span_bucket": "1"
           },
           "31cb8f3c06b2378d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 8
+            },
             "family_id": "c350578012489fcd",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 8
+            },
+            "fragment_location_count": 8,
+            "fragment_token_span_buckets": {
+              "9-23": 8
+            },
             "kinds": {
               "Block": 8
             },
@@ -2140,11 +3420,20 @@
             ],
             "mean_lines": 1,
             "members": 8,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "31e8d4402bdada6e": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "e61e9bc27e381359",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -2156,11 +3445,24 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "32d17bd7e028e2b7": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "9877ce64af1f59b5",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -2172,11 +3474,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "34402de9d738c46d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 19
+            },
             "family_id": "a1ce072397dad29a",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 19
+            },
+            "fragment_location_count": 19,
+            "fragment_token_span_buckets": {
+              "9-23": 19
+            },
             "kinds": {
               "Block": 19
             },
@@ -2205,11 +3520,24 @@
             ],
             "mean_lines": 1,
             "members": 19,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "363e8a224c3e89c5": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "54a961c71502a4fc",
+            "family_shape": "all-fragment",
             "files": 3,
+            "fragment_line_span_buckets": {
+              "4-10": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "9-23": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -2222,11 +3550,20 @@
             ],
             "mean_lines": 6,
             "members": 3,
+            "recommended_surface": "review",
             "span_bucket": "4-10"
           },
           "3828d2db5a4bf07a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "b3d48309fdd743df",
+            "family_shape": "whole-only",
             "files": 4,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 5
             },
@@ -2241,11 +3578,24 @@
             ],
             "mean_lines": 3,
             "members": 5,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "3849b826deec6a0c": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "0dd96d3d8d2dc31f",
+            "family_shape": "mixed",
             "files": 16,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 17
@@ -2274,11 +3624,24 @@
             ],
             "mean_lines": 3,
             "members": 18,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "3cb94c89c1c980b9": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "acc03cae66d1faf2",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -2291,11 +3654,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "3ceb8d6efb675ec7": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "7f37a94ee382840d",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -2308,11 +3684,20 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "3d0cbbdf17dc512e": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "d2bad11185a36c2d",
+            "family_shape": "whole-only",
             "files": 5,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 7
             },
@@ -2329,11 +3714,24 @@
             ],
             "mean_lines": 4,
             "members": 7,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "3d5a76d53f47c50c": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 23
+            },
             "family_id": "db1604d0005f4b27",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 23
+            },
+            "fragment_location_count": 23,
+            "fragment_token_span_buckets": {
+              "1-8": 23
+            },
             "kinds": {
               "Block": 23
             },
@@ -2366,11 +3764,20 @@
             ],
             "mean_lines": 1,
             "members": 23,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "3e0ec7ef5be4363b": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "a2cb0765594b08b5",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 7
             },
@@ -2387,11 +3794,24 @@
             ],
             "mean_lines": 4,
             "members": 7,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "40139c62fec11bef": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "99d425da8ef6d48c",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -2404,11 +3824,20 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "42b7a0004a5eeabd": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "05d2e0bdfc2e0b4d",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -2420,11 +3849,20 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "43a33b1e6fc6722a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "3ed50d87b1fa4c3b",
+            "family_shape": "whole-only",
             "files": 6,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 6
             },
@@ -2440,11 +3878,24 @@
             ],
             "mean_lines": 3,
             "members": 6,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "43cab45bce61dd33": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 4
+            },
             "family_id": "43f5ea9611cf5b11",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 4
+            },
+            "fragment_location_count": 4,
+            "fragment_token_span_buckets": {
+              "9-23": 4
+            },
             "kinds": {
               "Block": 4
             },
@@ -2458,11 +3909,20 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "440369a211763b10": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "d9a3ae65a28a3560",
+            "family_shape": "whole-only",
             "files": 4,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 4
             },
@@ -2476,11 +3936,24 @@
             ],
             "mean_lines": 9,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "447030bb01ae7cc8": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 14
+            },
             "family_id": "da5d8f99df433f90",
+            "family_shape": "mixed",
             "files": 7,
+            "fragment_line_span_buckets": {
+              "1": 14
+            },
+            "fragment_location_count": 14,
+            "fragment_token_span_buckets": {
+              "1-8": 14
+            },
             "kinds": {
               "Block": 14,
               "Method": 25
@@ -2530,11 +4003,20 @@
             ],
             "mean_lines": 3,
             "members": 39,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "44e7d7cfdb8ddfc5": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "81a3c1fba74e2baa",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 6
             },
@@ -2550,11 +4032,24 @@
             ],
             "mean_lines": 5,
             "members": 6,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "450b8a0cbcb96e53": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "5b5d9b975eadd9ee",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2,
               "Method": 2
@@ -2569,11 +4064,24 @@
             ],
             "mean_lines": 3,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "46236bee5f73c044": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -2585,11 +4093,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "4686be40b9d8ce19": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "0d87b515f7f4cdb9",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "4-10": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -2601,11 +4122,24 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "review",
             "span_bucket": "4-10"
           },
           "46ca9e0bda514663": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -2617,11 +4151,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "46eba21508c11cd5": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "df239aa2aaa409e3",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -2633,11 +4176,24 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "4a3c78a57efb2e95": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 8
+            },
             "family_id": "c350578012489fcd",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 8
+            },
+            "fragment_location_count": 8,
+            "fragment_token_span_buckets": {
+              "1-8": 8
+            },
             "kinds": {
               "Block": 8
             },
@@ -2655,11 +4211,24 @@
             ],
             "mean_lines": 1,
             "members": 8,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "4f5e7e5553560930": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 6
+            },
             "family_id": "dcd46868e73e1a62",
+            "family_shape": "all-fragment",
             "files": 3,
+            "fragment_line_span_buckets": {
+              "1": 6
+            },
+            "fragment_location_count": 6,
+            "fragment_token_span_buckets": {
+              "1-8": 6
+            },
             "kinds": {
               "Block": 6
             },
@@ -2675,11 +4244,24 @@
             ],
             "mean_lines": 1,
             "members": 6,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "50a8d526590e8884": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "9877ce64af1f59b5",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -2691,11 +4273,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "513b38ef4e7d6f13": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "9877ce64af1f59b5",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -2707,11 +4302,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "528b6c279c01f4a6": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "17042f858679169d",
+            "family_shape": "whole-only",
             "files": 3,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -2724,11 +4328,20 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "543cc14cdd41be2a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "338352926aa4c5a2",
+            "family_shape": "whole-only",
             "files": 4,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 4
             },
@@ -2742,11 +4355,24 @@
             ],
             "mean_lines": 4,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "55b4914610ed77c9": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "7590e21d9ebe3744",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -2758,11 +4384,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "55fd4f8df4894b4a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "d5286b31f9abe095",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 4
             },
@@ -2776,11 +4411,24 @@
             ],
             "mean_lines": 5,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "5a0473ca07b50034": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "1212bfd748b723fc",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -2793,11 +4441,20 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "5b4f35ab07089a7e": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "dfbe73614adc1d15",
+            "family_shape": "whole-only",
             "files": 5,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 5
             },
@@ -2812,11 +4469,20 @@
             ],
             "mean_lines": 4,
             "members": 5,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "5e65d1db579823b3": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "1d20f56e7a17eb3d",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -2828,11 +4494,24 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "5e828b3e41690b58": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "741727513b76e4b0",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "4-10": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -2844,11 +4523,24 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "review",
             "span_bucket": "4-10"
           },
           "5ea8f7c13884d60f": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "d8179569e58ce18c",
+            "family_shape": "mixed",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -2861,11 +4553,20 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "621b5600a2bb1a92": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "0cc22f843db81fef",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -2877,11 +4578,20 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "658d46d9315864a1": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "5b1b31cca36ba575",
+            "family_shape": "whole-only",
             "files": 3,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 4
             },
@@ -2895,11 +4605,20 @@
             ],
             "mean_lines": 5,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "66c25f2b1db43646": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "a14db4860a7641fa",
+            "family_shape": "whole-only",
             "files": 4,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 5
             },
@@ -2914,11 +4633,24 @@
             ],
             "mean_lines": 5,
             "members": 5,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "67d0506ac4ef4f0c": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "0e78734476d15bdd",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -2931,11 +4663,20 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "6942c7454aa145d5": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "81697e54fcaace1c",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -2947,11 +4688,20 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "6eaa6051e0e80092": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "ce251eda98b1e3a1",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 5
             },
@@ -2966,11 +4716,24 @@
             ],
             "mean_lines": 4,
             "members": 5,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "727025ef4eab2c7d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "9877ce64af1f59b5",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -2982,11 +4745,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "72afe1c9902bfd52": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "1f38b13bdbbedeeb",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -2998,11 +4770,20 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "754242b1f912e361": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "54feecf6a08b7e70",
+            "family_shape": "whole-only",
             "files": 3,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 5
             },
@@ -3017,11 +4798,20 @@
             ],
             "mean_lines": 4,
             "members": 5,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "760c653cccbe3597": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "667c976d88b07fe4",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -3034,11 +4824,20 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "7a2ca2d055b3d309": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "952d57af41288b17",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -3050,11 +4849,20 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "7a3986300cb9e9c2": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "50e3c86cc78eef19",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -3067,11 +4875,20 @@
             ],
             "mean_lines": 6,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "7e0baa41fa55fa21": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "8161fd205551fbf9",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -3083,11 +4900,24 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "7e871cc735f64edf": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -3099,11 +4929,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "7f195c5d56b1cc29": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "1403ea654a505247",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -3116,11 +4959,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "8425346a171197b0": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "04937b5c97ecfb45",
+            "family_shape": "mixed",
             "files": 4,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 4
@@ -3136,11 +4992,20 @@
             ],
             "mean_lines": 3,
             "members": 5,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "87003b340d952cb5": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "451c840f3aed0f5e",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -3152,11 +5017,24 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "883ea5e663d9655e": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -3168,11 +5046,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "8bb1e341c25bfaab": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "b4598cb9bb0bbd5e",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -3184,11 +5071,20 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "8db765b346a30598": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "bb8e343f0aef42c5",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -3200,11 +5096,24 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "8f0b0913771aa649": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "b5844d386ab99691",
+            "family_shape": "mixed",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 34
@@ -3250,11 +5159,24 @@
             ],
             "mean_lines": 5,
             "members": 35,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "9042d831499aa16a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -3266,11 +5188,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "90b2a9d817cdaf21": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "d4adfc512c01eeb7",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 4
             },
@@ -3284,11 +5215,20 @@
             ],
             "mean_lines": 5,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "9218b9d11fab3fcd": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "a77724a5fdfcefb0",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -3300,11 +5240,20 @@
             ],
             "mean_lines": 7,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "94d9d30df5c145b5": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "40d028f3da647b65",
+            "family_shape": "whole-only",
             "files": 3,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -3317,11 +5266,24 @@
             ],
             "mean_lines": 4,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "952079ef650c03f6": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "297b86e9a1c7af62",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -3334,11 +5296,20 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "955fa1bdd53a4858": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "52e612cc3c05277b",
+            "family_shape": "whole-only",
             "files": 5,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 5
             },
@@ -3353,11 +5324,24 @@
             ],
             "mean_lines": 4,
             "members": 5,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "9596b81fcc35e408": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 7
+            },
             "family_id": "c77d9cdc336f09c5",
+            "family_shape": "mixed",
             "files": 6,
+            "fragment_line_span_buckets": {
+              "1": 7
+            },
+            "fragment_location_count": 7,
+            "fragment_token_span_buckets": {
+              "1-8": 7
+            },
             "kinds": {
               "Block": 7,
               "Method": 2
@@ -3377,11 +5361,24 @@
             ],
             "mean_lines": 1,
             "members": 9,
+            "recommended_surface": "default",
             "span_bucket": "1"
           },
           "96c4752859a1115f": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "297b86e9a1c7af62",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -3394,11 +5391,20 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "96d605de6baacaf7": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "3af516c04fca08e2",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -3410,11 +5416,24 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "977612613a150c37": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "8a108c32b1d5a718",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -3427,11 +5446,20 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "9782c1babf1a4bb1": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "d996426dc1aa67b7",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 4
             },
@@ -3445,11 +5473,24 @@
             ],
             "mean_lines": 7,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "98ef65049f9c18b1": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "4c72daf37946c2b3",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -3462,11 +5503,20 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "9b7db4808acec299": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "67ced0dc8d5f3b26",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 30
             },
@@ -3506,11 +5556,20 @@
             ],
             "mean_lines": 6,
             "members": 30,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "9db0d991934b6960": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "e72a9e05a67d3a32",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -3523,11 +5582,24 @@
             ],
             "mean_lines": 5,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "9f0f8642732275d5": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "8b850ab2be11fa11",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -3539,11 +5611,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "a155c8968b5a9cae": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "d21a9f347a1616cf",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -3555,11 +5636,24 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "a17203c615477de3": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -3571,11 +5665,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "a1882a98c1ad5fce": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 8
+            },
             "family_id": "c350578012489fcd",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 8
+            },
+            "fragment_location_count": 8,
+            "fragment_token_span_buckets": {
+              "9-23": 8
+            },
             "kinds": {
               "Block": 8
             },
@@ -3593,11 +5700,24 @@
             ],
             "mean_lines": 1,
             "members": 8,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "a223b0a5eb814b32": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -3609,11 +5729,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "a26eeb8f67875f45": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "a817a833fec8efec",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -3626,11 +5759,20 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "a4ff0bdb28d2fbca": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "d50bb3d159f309a9",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -3643,11 +5785,20 @@
             ],
             "mean_lines": 5,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "a58c477812ec1657": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "81aab54a66d9b56f",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -3660,11 +5811,24 @@
             ],
             "mean_lines": 4,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "a77642c9532828fc": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "1a4990efefa3ce95",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -3676,11 +5840,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "afbdd65c7e7fa92b": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "dbd8065f90391018",
+            "family_shape": "whole-only",
             "files": 3,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -3693,11 +5866,20 @@
             ],
             "mean_lines": 4,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "b119dcf0733308ea": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "718f59b29e3e3774",
+            "family_shape": "whole-only",
             "files": 3,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -3710,11 +5892,24 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "b1673193b852ead6": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -3726,11 +5921,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "b1a88a485c5fbde2": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "efd2bdc14522ae2d",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -3742,11 +5946,24 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "b1ed791aeb6bf6b8": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "94cc02144a8bfa3b",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -3759,11 +5976,20 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "b2da4bf86dce5e1d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "26137d475bfc2f4e",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -3775,11 +6001,20 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "b2dc435720f9a54d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "ccdb5ca61bafe62e",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 4
             },
@@ -3793,11 +6028,20 @@
             ],
             "mean_lines": 7,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "b4b4830f540c7f69": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "48def426c4ac4fda",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -3809,11 +6053,20 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "b9b6dc1f5b189b61": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "9dbd48403f577f14",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -3825,11 +6078,20 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "bb6de463593c86cc": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "1b9092454c9ac906",
+            "family_shape": "whole-only",
             "files": 4,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 4
             },
@@ -3843,11 +6105,24 @@
             ],
             "mean_lines": 4,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "bd20647f99613b8d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "370bf55dbf47b6ba",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "4-10": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -3859,11 +6134,24 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "review",
             "span_bucket": "4-10"
           },
           "bff0c810bda4238d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "9877ce64af1f59b5",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -3875,11 +6163,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "c4bc5e3a52c5cc9e": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "27f948eedd152caf",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -3892,11 +6193,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "c5144af287026689": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "22ca8b89294ba6f4",
+            "family_shape": "mixed",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2,
               "Method": 1
@@ -3910,11 +6224,24 @@
             ],
             "mean_lines": 2,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "c72f500a7554d5fa": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "59be20b108ab3d9a",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "4-10": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -3926,11 +6253,24 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "review",
             "span_bucket": "4-10"
           },
           "c734ed054be09d22": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 4
+            },
             "family_id": "276ee63009995506",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 4
+            },
+            "fragment_location_count": 4,
+            "fragment_token_span_buckets": {
+              "1-8": 4
+            },
             "kinds": {
               "Block": 4
             },
@@ -3944,11 +6284,20 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "c7a71049347bd6bb": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "cf6cdd886e48a175",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Class": 2
             },
@@ -3960,11 +6309,24 @@
             ],
             "mean_lines": 22,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "11-30"
           },
           "c871d51f569d3f51": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 4
+            },
             "family_id": "932b2bb0cc6e0070",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "2-3": 4
+            },
+            "fragment_location_count": 4,
+            "fragment_token_span_buckets": {
+              "1-8": 4
+            },
             "kinds": {
               "Block": 4
             },
@@ -3978,11 +6340,24 @@
             ],
             "mean_lines": 3,
             "members": 4,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "c9879293636ed7e5": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 10
+            },
             "family_id": "5b9ca6bebdb793cd",
+            "family_shape": "all-fragment",
             "files": 5,
+            "fragment_line_span_buckets": {
+              "2-3": 10
+            },
+            "fragment_location_count": 10,
+            "fragment_token_span_buckets": {
+              "1-8": 10
+            },
             "kinds": {
               "Block": 10
             },
@@ -4002,11 +6377,20 @@
             ],
             "mean_lines": 3,
             "members": 10,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "d16ca72c9dab6a21": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "123075daa7af496f",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Class": 2
             },
@@ -4018,11 +6402,24 @@
             ],
             "mean_lines": 74,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "31+"
           },
           "d1ad74171418beb7": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -4034,11 +6431,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "d1b202b792f44562": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "4c0a5c00536755a2",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -4050,11 +6456,24 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "d20f41c73e0c8f47": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 4
+            },
             "family_id": "43f5ea9611cf5b11",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 4
+            },
+            "fragment_location_count": 4,
+            "fragment_token_span_buckets": {
+              "9-23": 4
+            },
             "kinds": {
               "Block": 4
             },
@@ -4068,11 +6487,24 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "d529c9a6dbc3d1e8": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "d5d4ef35b9c4941d",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -4084,11 +6516,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "d590dee508116adf": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "b55fe592fb55bc17",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -4101,11 +6546,24 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "d71f351cfb75c438": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "434468096b49a83d",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -4117,11 +6575,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "d8922b288fa78160": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "b9a80f700dee5662",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -4134,11 +6605,24 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "d99dceea2c87ea15": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 5
+            },
             "family_id": "cb28ebf51398c134",
+            "family_shape": "all-fragment",
             "files": 3,
+            "fragment_line_span_buckets": {
+              "1": 5
+            },
+            "fragment_location_count": 5,
+            "fragment_token_span_buckets": {
+              "1-8": 5
+            },
             "kinds": {
               "Block": 5
             },
@@ -4153,11 +6637,20 @@
             ],
             "mean_lines": 1,
             "members": 5,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "dad598cb469debe7": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "39bd79ecdd76f59e",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -4170,11 +6663,24 @@
             ],
             "mean_lines": 5,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "db7a92a192d444ef": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "4dcfe2ade2e50d1b",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2,
               "Method": 2
@@ -4189,11 +6695,20 @@
             ],
             "mean_lines": 3,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "dbac708ee8045e93": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "892507fd578d252d",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 6
             },
@@ -4209,11 +6724,20 @@
             ],
             "mean_lines": 5,
             "members": 6,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "dbcff84274ca2074": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "b92d28747f692386",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -4225,11 +6749,24 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "e135e83124443c90": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "9877ce64af1f59b5",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -4241,11 +6778,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "e190bd655dc680b3": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "2f0ce67332ea01fa",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 3
             },
@@ -4258,11 +6804,24 @@
             ],
             "mean_lines": 4,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "e291711c473d0388": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -4274,11 +6833,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "e35a0c48c69a44e0": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "195a660bab7bfc9c",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -4290,11 +6858,24 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "e4208e1ed9152415": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "7e6fe1ee85168fda",
+            "family_shape": "mixed",
             "files": 4,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 3
@@ -4309,11 +6890,24 @@
             ],
             "mean_lines": 3,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "e659b270eb3d9dbc": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -4325,11 +6919,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "e6ad8cbfa388b383": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b934b8a29aeba1af",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "2-3": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -4341,11 +6948,20 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           },
           "e81cd562d3566f94": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "48522a5cdb987b57",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 13
             },
@@ -4368,11 +6984,24 @@
             ],
             "mean_lines": 3,
             "members": 13,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "e837111d03d7903b": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "3806784fd261674b",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "9-23": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -4385,11 +7014,20 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "ea0c4cf23597d3ab": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "abe20a06b2a339fd",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -4401,11 +7039,24 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "ea3f2e01335c133f": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "d851463c4ec906dd",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -4417,11 +7068,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "eaf3c4819fbe3614": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "5a568fe9355c648c",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2,
               "Method": 6
@@ -4440,11 +7104,24 @@
             ],
             "mean_lines": 3,
             "members": 8,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "ec45aeb5bec9f3a2": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "a2da4db67e5225e6",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Method": 1
@@ -4457,11 +7134,24 @@
             ],
             "mean_lines": 2,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "ed7fd6b3e623c80b": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 6
+            },
             "family_id": "fde80121ae3096ff",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 6
+            },
+            "fragment_location_count": 6,
+            "fragment_token_span_buckets": {
+              "1-8": 6
+            },
             "kinds": {
               "Block": 6
             },
@@ -4477,11 +7167,20 @@
             ],
             "mean_lines": 1,
             "members": 6,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "eff164d739d6e12a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "db4842d46086325d",
+            "family_shape": "whole-only",
             "files": 3,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 26
             },
@@ -4517,11 +7216,24 @@
             ],
             "mean_lines": 4,
             "members": 26,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "f0422eb09270ee38": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "8b18a08c0d3e331d",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "4-10": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -4533,11 +7245,24 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "review",
             "span_bucket": "4-10"
           },
           "f0700c6659f8226f": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "d93ee3cd23cc0a85",
+            "family_shape": "all-fragment",
             "files": 3,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3
             },
@@ -4550,11 +7275,20 @@
             ],
             "mean_lines": 1,
             "members": 3,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "f0df0a23536bb440": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "83eba3548175b08c",
+            "family_shape": "whole-only",
             "files": 5,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 17
             },
@@ -4581,11 +7315,20 @@
             ],
             "mean_lines": 5,
             "members": 17,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "f2344bf4916e030b": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "acc54c51920acc79",
+            "family_shape": "whole-only",
             "files": 4,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 6
             },
@@ -4601,11 +7344,20 @@
             ],
             "mean_lines": 3,
             "members": 6,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "f3012edc3ae1949b": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "5cfeb93e1d748570",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -4617,11 +7369,24 @@
             ],
             "mean_lines": 7,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "f4b7da8d6b47b71d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "b10ac7c95afc9b33",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "9-23": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -4633,11 +7398,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "f674f8adba33ca25": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "aa92227fb21f6b95",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -4649,11 +7423,20 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "f8561cca23e590b9": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "48def426c4ac4fda",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -4665,11 +7448,20 @@
             ],
             "mean_lines": 8,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "f9ac61f779e984e2": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "a3ab09b856d99fb7",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -4681,11 +7473,20 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "fa4b5bc00c34aebc": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "7fb06e488f4f66bd",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -4697,11 +7498,24 @@
             ],
             "mean_lines": 4,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "fa4ff93d1b37e748": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "ed25c2922b485156",
+            "family_shape": "mixed",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2,
               "Method": 1
@@ -4715,8 +7529,14 @@
             ],
             "mean_lines": 2,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           }
+        },
+        "family_shape_counts": {
+          "all-fragment": 64,
+          "mixed": 32,
+          "whole-only": 76
         },
         "fragment_kind_counts": {
           "conditional-guard": 35,
@@ -4724,6 +7544,24 @@
           "expr-effect": 243,
           "self-field-assign": 7,
           "self-field-body": 17
+        },
+        "fragment_kind_surface_counts": {
+          "conditional-guard|hidden": 35,
+          "direct-return|default": 1,
+          "direct-return|hidden": 9,
+          "expr-effect|default": 68,
+          "expr-effect|hidden": 175,
+          "self-field-assign|hidden": 7,
+          "self-field-body|review": 17
+        },
+        "fragment_line_span_buckets": {
+          "1": 260,
+          "2-3": 35,
+          "4-10": 17
+        },
+        "fragment_token_span_buckets": {
+          "1-8": 231,
+          "9-23": 81
         },
         "kind_counts": {
           "Block": 312,
@@ -4742,6 +7580,21 @@
           "exact-self-field-assign": 7,
           "exact-self-field-body": 17
         },
+        "reason_code_surface_counts": {
+          "exact-conditional-guard|hidden": 35,
+          "exact-direct-return|default": 1,
+          "exact-direct-return|hidden": 9,
+          "exact-expr-effect|default": 68,
+          "exact-expr-effect|hidden": 175,
+          "exact-self-field-assign|hidden": 7,
+          "exact-self-field-body|review": 17
+        },
+        "recommended_surface_counts": {
+          "debug": 0,
+          "default": 108,
+          "hidden": 56,
+          "review": 8
+        },
         "scope_files": 1725,
         "shown_families": 172,
         "span_buckets": {
@@ -4755,28 +7608,40 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 7.0,
-          "cluster": 0.5,
+          "candidates": 7.5,
+          "cluster": 0.4,
           "contiguous": 0.0,
           "discover": 10.5,
-          "groups": 2.3,
-          "lower": 50.9,
-          "normalize+extract": 39.1,
+          "groups": 2.4,
+          "lower": 52.0,
+          "normalize+extract": 39.2,
           "parse+lower": 41.9,
           "score": 0.4
         },
         "repeats": 5,
-        "wall_ms_median": 180.12,
-        "wall_ms_min": 175.56
+        "wall_ms_median": 183.1,
+        "wall_ms_min": 176.04
       }
     },
     "ky": {
       "output": {
         "distinct_location_sets": 4,
+        "enclosing_unit_recovery_counts": {
+          "missing": 0,
+          "recovered": 2
+        },
         "families": {
           "602cbf4e79629e9f": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "7490df14f9361713",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Block": 2
             },
@@ -4788,11 +7653,20 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "61b949cc85b92750": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "5fbd95eaff90e98d",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Block": 2
             },
@@ -4804,11 +7678,20 @@
             ],
             "mean_lines": 10,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "b9e4b49dd2d7513d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "2f0d340158c80b31",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Block": 4
             },
@@ -4822,11 +7705,24 @@
             ],
             "mean_lines": 6,
             "members": 4,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "e80d78629869346a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "dc1cd0cfbefcac6d",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "2-3": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -4838,11 +7734,26 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "2-3"
           }
         },
+        "family_shape_counts": {
+          "all-fragment": 1,
+          "mixed": 0,
+          "whole-only": 3
+        },
         "fragment_kind_counts": {
           "conditional-guard": 2
+        },
+        "fragment_kind_surface_counts": {
+          "conditional-guard|hidden": 2
+        },
+        "fragment_line_span_buckets": {
+          "2-3": 2
+        },
+        "fragment_token_span_buckets": {
+          "1-8": 2
         },
         "kind_counts": {
           "Block": 10
@@ -4854,6 +7765,15 @@
         "reason_code_counts": {
           "exact-conditional-guard": 2
         },
+        "reason_code_surface_counts": {
+          "exact-conditional-guard|hidden": 2
+        },
+        "recommended_surface_counts": {
+          "debug": 0,
+          "default": 3,
+          "hidden": 1,
+          "review": 0
+        },
         "scope_files": 52,
         "shown_families": 4,
         "span_buckets": {
@@ -4864,28 +7784,40 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 0.9,
+          "candidates": 1.0,
           "cluster": 0.0,
           "contiguous": 0.0,
-          "discover": 3.3,
+          "discover": 3.4,
           "groups": 0.0,
-          "lower": 16.3,
-          "normalize+extract": 7.8,
-          "parse+lower": 12.9,
+          "lower": 16.5,
+          "normalize+extract": 7.4,
+          "parse+lower": 13.1,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 35.77,
-        "wall_ms_min": 32.95
+        "wall_ms_median": 35.51,
+        "wall_ms_min": 33.71
       }
     },
     "liquid": {
       "output": {
         "distinct_location_sets": 4,
+        "enclosing_unit_recovery_counts": {
+          "missing": 0,
+          "recovered": 6
+        },
         "families": {
           "542d5ecb48e02e3a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "6caa2ef93eaffa55",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -4897,11 +7829,24 @@
             ],
             "mean_lines": 5,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "86eb9469088efc0f": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 4
+            },
             "family_id": "d27c3b2e93cae4a5",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 4
+            },
+            "fragment_location_count": 4,
+            "fragment_token_span_buckets": {
+              "1-8": 4
+            },
             "kinds": {
               "Block": 4
             },
@@ -4915,11 +7860,24 @@
             ],
             "mean_lines": 1,
             "members": 4,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "8af348218f8d762d": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "33a17da33703efc9",
+            "family_shape": "all-fragment",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -4931,11 +7889,20 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "a64f108d53c04b44": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "67318164927549c5",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Method": 2
             },
@@ -4947,11 +7914,26 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           }
         },
+        "family_shape_counts": {
+          "all-fragment": 2,
+          "mixed": 0,
+          "whole-only": 2
+        },
         "fragment_kind_counts": {
           "conditional-guard": 6
+        },
+        "fragment_kind_surface_counts": {
+          "conditional-guard|hidden": 6
+        },
+        "fragment_line_span_buckets": {
+          "1": 6
+        },
+        "fragment_token_span_buckets": {
+          "1-8": 6
         },
         "kind_counts": {
           "Block": 6,
@@ -4964,6 +7946,15 @@
         "reason_code_counts": {
           "exact-conditional-guard": 6
         },
+        "reason_code_surface_counts": {
+          "exact-conditional-guard|hidden": 6
+        },
+        "recommended_surface_counts": {
+          "debug": 0,
+          "default": 2,
+          "hidden": 2,
+          "review": 0
+        },
         "scope_files": 153,
         "shown_families": 4,
         "span_buckets": {
@@ -4975,28 +7966,44 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 1.6,
+          "candidates": 1.8,
           "cluster": 0.1,
           "contiguous": 0.0,
           "discover": 3.4,
           "groups": 0.1,
-          "lower": 14.8,
-          "normalize+extract": 10.6,
-          "parse+lower": 11.4,
+          "lower": 14.5,
+          "normalize+extract": 10.8,
+          "parse+lower": 11.0,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 40.33,
-        "wall_ms_min": 38.74
+        "wall_ms_median": 40.56,
+        "wall_ms_min": 38.43
       }
     },
     "serde_json": {
       "output": {
         "distinct_location_sets": 12,
+        "enclosing_unit_recovery_counts": {
+          "missing": 0,
+          "recovered": 7
+        },
         "families": {
           "1504737e60a0cc3e": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 2
+            },
             "family_id": "f182d3c11d972de6",
+            "family_shape": "all-fragment",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 2
+            },
+            "fragment_location_count": 2,
+            "fragment_token_span_buckets": {
+              "1-8": 2
+            },
             "kinds": {
               "Block": 2
             },
@@ -5008,11 +8015,24 @@
             ],
             "mean_lines": 1,
             "members": 2,
+            "recommended_surface": "hidden",
             "span_bucket": "1"
           },
           "418176d9aff53964": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "1051970f845496b4",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Function": 1
@@ -5025,11 +8045,20 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "45968aef1c8f99d3": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "fbb253861b54e9ed",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 2
             },
@@ -5041,11 +8070,20 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "6eb38854e4eb9709": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "52f1ce45e98c9e1a",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 3
             },
@@ -5058,11 +8096,20 @@
             ],
             "mean_lines": 6,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "85aa6756f317904e": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "cf1f75081d0ceec1",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 2
             },
@@ -5074,11 +8121,24 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "8724f16f2983f3a1": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 1
+            },
             "family_id": "202cd8c3b8e31f52",
+            "family_shape": "mixed",
             "files": 1,
+            "fragment_line_span_buckets": {
+              "1": 1
+            },
+            "fragment_location_count": 1,
+            "fragment_token_span_buckets": {
+              "1-8": 1
+            },
             "kinds": {
               "Block": 1,
               "Function": 1
@@ -5091,11 +8151,20 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "a10f5ff94d82dadf": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "a9070706acf347ba",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 5
             },
@@ -5110,11 +8179,20 @@
             ],
             "mean_lines": 5,
             "members": 5,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "a70d2d6da9de3eb6": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "4ca8b9749aab45cd",
+            "family_shape": "whole-only",
             "files": 2,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 2
             },
@@ -5126,11 +8204,20 @@
             ],
             "mean_lines": 3,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "b8aada8c6847010a": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "e9c0156f4388acc7",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 3
             },
@@ -5143,11 +8230,20 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "bd399218251f946f": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "79e903477a6a5faa",
+            "family_shape": "whole-only",
             "files": 3,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 3
             },
@@ -5160,11 +8256,20 @@
             ],
             "mean_lines": 3,
             "members": 3,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           },
           "c369153c85369aa1": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 0
+            },
             "family_id": "8cb22fd507f5c505",
+            "family_shape": "whole-only",
             "files": 1,
+            "fragment_line_span_buckets": {},
+            "fragment_location_count": 0,
+            "fragment_token_span_buckets": {},
             "kinds": {
               "Function": 2
             },
@@ -5176,11 +8281,24 @@
             ],
             "mean_lines": 6,
             "members": 2,
+            "recommended_surface": "default",
             "span_bucket": "4-10"
           },
           "d4a4b2b91b4b85ae": {
+            "enclosing_unit_recovery": {
+              "missing": 0,
+              "recovered": 3
+            },
             "family_id": "e4dfbe75341879a1",
+            "family_shape": "mixed",
             "files": 2,
+            "fragment_line_span_buckets": {
+              "1": 3
+            },
+            "fragment_location_count": 3,
+            "fragment_token_span_buckets": {
+              "1-8": 3
+            },
             "kinds": {
               "Block": 3,
               "Function": 2
@@ -5196,12 +8314,28 @@
             ],
             "mean_lines": 3,
             "members": 5,
+            "recommended_surface": "default",
             "span_bucket": "2-3"
           }
+        },
+        "family_shape_counts": {
+          "all-fragment": 1,
+          "mixed": 3,
+          "whole-only": 8
         },
         "fragment_kind_counts": {
           "direct-return": 5,
           "expr-effect": 2
+        },
+        "fragment_kind_surface_counts": {
+          "direct-return|default": 5,
+          "expr-effect|hidden": 2
+        },
+        "fragment_line_span_buckets": {
+          "1": 7
+        },
+        "fragment_token_span_buckets": {
+          "1-8": 7
         },
         "kind_counts": {
           "Block": 7,
@@ -5215,6 +8349,16 @@
           "exact-direct-return": 5,
           "exact-expr-effect": 2
         },
+        "reason_code_surface_counts": {
+          "exact-direct-return|default": 5,
+          "exact-expr-effect|hidden": 2
+        },
+        "recommended_surface_counts": {
+          "debug": 0,
+          "default": 11,
+          "hidden": 1,
+          "review": 0
+        },
         "scope_files": 71,
         "shown_families": 12,
         "span_buckets": {
@@ -5226,19 +8370,19 @@
       },
       "runtime": {
         "phase_ms_median": {
-          "candidates": 1.7,
+          "candidates": 1.9,
           "cluster": 0.1,
           "contiguous": 0.0,
-          "discover": 4.9,
+          "discover": 3.4,
           "groups": 0.1,
-          "lower": 14.2,
-          "normalize+extract": 10.7,
-          "parse+lower": 8.8,
+          "lower": 12.7,
+          "normalize+extract": 10.3,
+          "parse+lower": 9.4,
           "score": 0.2
         },
         "repeats": 5,
-        "wall_ms_median": 38.32,
-        "wall_ms_min": 37.09
+        "wall_ms_median": 38.17,
+        "wall_ms_min": 35.83
       }
     }
   },

--- a/bench/type4/scan_regression/compare-summary.md
+++ b/bench/type4/scan_regression/compare-summary.md
@@ -7,9 +7,9 @@
 | | baseline | current |
 |---|---|---|
 | version | `nose 0.5.0` | `nose 0.5.0` |
-| sha256 | `afc8212b9480a812a3f5c52f3977f89c1905f130001ca53b4ee47820969b02de` | `afc8212b9480a812a3f5c52f3977f89c1905f130001ca53b4ee47820969b02de` |
-| source_git_describe | `v0.5.0-175-ge4d381d` | `v0.5.0-175-ge4d381d-dirty` |
-| build_ref | `issue-45@416325e` | `` |
+| sha256 | `00511c77fdb0f5878deed159594e9970e2e83914fc71035440324e435ecc212d` | `00511c77fdb0f5878deed159594e9970e2e83914fc71035440324e435ecc212d` |
+| source_git_describe | `v0.5.0-185-ga592075` | `v0.5.0-187-gef8f439` |
+| build_ref | `issue-51@a592075` | `issue-51@ef8f439` |
 
 **Note: identical binary sha256 — any output/runtime delta below is environment noise, not a code change.**
 

--- a/bench/type4/scan_regression/compare-summary.md
+++ b/bench/type4/scan_regression/compare-summary.md
@@ -1,15 +1,16 @@
 # Scan-regression compare summary
 
 > Investigation triggers, not merge blockers (issue #37, rule 7).
+> Artifact identity: current `source_git_describe` / `build_ref` name the checkout and binary that generated this report. If the report is committed after generation, those refs intentionally point at the generator commit, not at the later artifact commit.
 
 ## Binaries
 
 | | baseline | current |
 |---|---|---|
 | version | `nose 0.5.0` | `nose 0.5.0` |
-| sha256 | `00511c77fdb0f5878deed159594e9970e2e83914fc71035440324e435ecc212d` | `00511c77fdb0f5878deed159594e9970e2e83914fc71035440324e435ecc212d` |
-| source_git_describe | `v0.5.0-185-ga592075` | `v0.5.0-187-gef8f439` |
-| build_ref | `issue-51@a592075` | `issue-51@ef8f439` |
+| sha256 | `bdd103dfc3e3e3d26545c2aac04049dbeb5aa8250fb84567829ffcfe6040f079` | `bdd103dfc3e3e3d26545c2aac04049dbeb5aa8250fb84567829ffcfe6040f079` |
+| source_git_describe | `v0.5.0-188-gcb0c549` | `v0.5.0-189-g12ec95e` |
+| build_ref | `issue-51-generator@cb0c549` | `issue-51-generator@12ec95e` |
 
 **Note: identical binary sha256 — any output/runtime delta below is environment noise, not a code change.**
 

--- a/bench/type4/scan_regression/scan_regression.py
+++ b/bench/type4/scan_regression/scan_regression.py
@@ -32,10 +32,12 @@ Why this exists, and the rules it follows (from the issue #37 decision):
    and ranking tie-breaks are ignored. Families are keyed by their normalized
    (repo-relative) location set, because the product `family_id` is NOT unique (distinct
    families can share one id); family_id is compared as an attribute and is itself a
-   drift signal. We also compare unit kind, mean_lines / span size, location count, and
-   product JSON byte size. `fragment_kind` / `reason_code` are counted from product
-   scan JSON when exact-fragment locations expose them, so #45 metadata changes become
-   visible as bucket drift instead of hiding inside generic `Block` counts.
+   drift signal. We also compare unit kind, mean_lines / span size, location count,
+   product JSON byte size, fragment product-surface placement, all-fragment vs mixed
+   family shape, fragment span buckets, and enclosing-unit recovery. `fragment_kind` /
+   `reason_code` are counted from product scan JSON when exact-fragment locations expose
+   them, so #45 metadata changes become visible as bucket drift instead of hiding inside
+   generic `Block` counts.
 
 6. Durable artifacts live next to this script in `bench/type4/scan_regression/`:
    `subset.json` (the small subset), `baseline.v1.json` (the recorded baseline),
@@ -53,6 +55,7 @@ Usage:
     python3 bench/type4/scan_regression/scan_regression.py baseline
     python3 bench/type4/scan_regression/scan_regression.py compare
     python3 bench/type4/scan_regression/scan_regression.py cache
+    python3 bench/type4/scan_regression/scan_regression.py selftest
 
 Run with `--help` on any subcommand for the flags.
 """
@@ -94,6 +97,9 @@ THRESHOLDS = {
     # Ignore runtime moves smaller than this many milliseconds (noise floor).
     "runtime_floor_ms": 5.0,
 }
+
+SURFACE_BUCKETS = ("default", "review", "hidden", "debug")
+FAMILY_SHAPE_BUCKETS = ("whole-only", "all-fragment", "mixed")
 
 
 # ---------------------------------------------------------------------------
@@ -234,13 +240,85 @@ def _span_bucket(mean_lines: int) -> str:
     return "31+"
 
 
+def _token_span_bucket(tokens: int) -> str:
+    if tokens <= 0:
+        return "0"
+    if tokens <= 8:
+        return "1-8"
+    if tokens <= 23:
+        return "9-23"
+    if tokens <= 49:
+        return "24-49"
+    if tokens <= 99:
+        return "50-99"
+    return "100+"
+
+
+def _inc(sink: dict[str, int], key: str, n: int = 1) -> None:
+    sink[key] = sink.get(key, 0) + n
+
+
+def _zeroed(keys: tuple[str, ...]) -> dict[str, int]:
+    return {k: 0 for k in keys}
+
+
+def _int_field(obj: dict, key: str) -> int | None:
+    val = obj.get(key)
+    if isinstance(val, bool):
+        return None
+    if isinstance(val, int):
+        return val
+    return None
+
+
+def _line_span_of(loc: dict) -> int | None:
+    explicit = _int_field(loc, "span_lines")
+    if explicit is not None:
+        return explicit
+    start = _int_field(loc, "start_line")
+    end = _int_field(loc, "end_line")
+    if start is None or end is None:
+        return None
+    return max(0, end - start + 1)
+
+
+def _is_fragment_location(loc: dict) -> bool:
+    """Forward-compatible fragment test.
+
+    Current scan JSON emits `is_fragment`, but older/intermediate artifacts may only
+    expose `fragment_kind` / `reason_code`. Treat those as fragment evidence so drift is
+    measured instead of silently disappearing when comparing across schema additions.
+    """
+    return (
+        loc.get("is_fragment") is True
+        or isinstance(loc.get("fragment_kind"), str)
+        or isinstance(loc.get("reason_code"), str)
+    )
+
+
+def _recommended_surface(fam: dict) -> str:
+    val = fam.get("recommended_surface")
+    if isinstance(val, str) and val:
+        return val
+    return "<missing>"
+
+
+def _family_shape(locs: list[dict]) -> tuple[str, int]:
+    fragment_count = sum(1 for loc in locs if _is_fragment_location(loc))
+    if fragment_count == 0:
+        return "whole-only", fragment_count
+    if fragment_count == len(locs):
+        return "all-fragment", fragment_count
+    return "mixed", fragment_count
+
+
 def _count_meta(obj: dict, key: str, sink: dict) -> None:
     """Count a forward-compatible metadata field (fragment_kind / reason_code) wherever
     it appears. The product scan path emits these for exact-fragment locations; older
     baselines that lack the fields naturally count as empty buckets."""
     val = obj.get(key)
     if isinstance(val, str):
-        sink[val] = sink.get(val, 0) + 1
+        _inc(sink, val)
 
 
 def canonicalize(scan_json: dict, repo: Path) -> dict:
@@ -265,8 +343,15 @@ def canonicalize(scan_json: dict, repo: Path) -> dict:
 
     kind_counts: dict[str, int] = {}
     span_buckets: dict[str, int] = {}
+    recommended_surface_counts: dict[str, int] = _zeroed(SURFACE_BUCKETS)
+    family_shape_counts: dict[str, int] = _zeroed(FAMILY_SHAPE_BUCKETS)
     fragment_kind_counts: dict[str, int] = {}
     reason_code_counts: dict[str, int] = {}
+    fragment_kind_surface_counts: dict[str, int] = {}
+    reason_code_surface_counts: dict[str, int] = {}
+    fragment_line_span_buckets: dict[str, int] = {}
+    fragment_token_span_buckets: dict[str, int] = {}
+    enclosing_unit_recovery_counts: dict[str, int] = {"recovered": 0, "missing": 0}
     # NOTE: the product `family_id` is NOT unique — distinct families can share one id
     # (observed in chi: two Block families both keyed `c55b843732270ba0`). Keying by
     # family_id would silently drop a family, so families are keyed by their normalized
@@ -277,13 +362,43 @@ def canonicalize(scan_json: dict, repo: Path) -> dict:
 
     for fam in families_in:
         locs = fam.get("locations", [])
+        surface = _recommended_surface(fam)
+        _inc(recommended_surface_counts, surface)
+        family_shape, fragment_count = _family_shape(locs)
+        _inc(family_shape_counts, family_shape)
         fam_kinds: dict[str, int] = {}
+        fam_fragment_line_span_buckets: dict[str, int] = {}
+        fam_fragment_token_span_buckets: dict[str, int] = {}
+        fam_enclosing_recovery = {"recovered": 0, "missing": 0}
         for loc in locs:
             k = loc.get("kind", "?")
             kind_counts[k] = kind_counts.get(k, 0) + 1
             fam_kinds[k] = fam_kinds.get(k, 0) + 1
             _count_meta(loc, "fragment_kind", fragment_kind_counts)
             _count_meta(loc, "reason_code", reason_code_counts)
+            if _is_fragment_location(loc):
+                fragment_kind = loc.get("fragment_kind")
+                if isinstance(fragment_kind, str):
+                    _inc(fragment_kind_surface_counts, f"{fragment_kind}|{surface}")
+                reason_code = loc.get("reason_code")
+                if isinstance(reason_code, str):
+                    _inc(reason_code_surface_counts, f"{reason_code}|{surface}")
+
+                line_span = _line_span_of(loc)
+                line_bucket = _span_bucket(line_span) if line_span is not None else "<missing>"
+                _inc(fragment_line_span_buckets, line_bucket)
+                _inc(fam_fragment_line_span_buckets, line_bucket)
+
+                token_span = _int_field(loc, "span_tokens")
+                token_bucket = (
+                    _token_span_bucket(token_span) if token_span is not None else "<missing>"
+                )
+                _inc(fragment_token_span_buckets, token_bucket)
+                _inc(fam_fragment_token_span_buckets, token_bucket)
+
+                recovery = "recovered" if isinstance(loc.get("enclosing_unit"), dict) else "missing"
+                _inc(enclosing_unit_recovery_counts, recovery)
+                _inc(fam_enclosing_recovery, recovery)
         _count_meta(fam, "fragment_kind", fragment_kind_counts)
         _count_meta(fam, "reason_code", reason_code_counts)
 
@@ -298,10 +413,16 @@ def canonicalize(scan_json: dict, repo: Path) -> dict:
             "members": fam.get("members"),
             "files": fam.get("files"),
             "languages": fam.get("languages"),
+            "recommended_surface": surface,
+            "family_shape": family_shape,
             "mean_lines": mean_lines,
             "span_bucket": bucket,
             "location_count": len(locs),
+            "fragment_location_count": fragment_count,
             "kinds": dict(sorted(fam_kinds.items())),
+            "fragment_line_span_buckets": dict(sorted(fam_fragment_line_span_buckets.items())),
+            "fragment_token_span_buckets": dict(sorted(fam_fragment_token_span_buckets.items())),
+            "enclosing_unit_recovery": dict(sorted(fam_enclosing_recovery.items())),
             "locations": loc_list,
         }
 
@@ -320,8 +441,15 @@ def canonicalize(scan_json: dict, repo: Path) -> dict:
         "product_json_bytes": product_json_bytes(scan_json),
         "kind_counts": dict(sorted(kind_counts.items())),
         "span_buckets": dict(sorted(span_buckets.items())),
+        "recommended_surface_counts": dict(sorted(recommended_surface_counts.items())),
+        "family_shape_counts": dict(sorted(family_shape_counts.items())),
         "fragment_kind_counts": dict(sorted(fragment_kind_counts.items())),
         "reason_code_counts": dict(sorted(reason_code_counts.items())),
+        "fragment_kind_surface_counts": dict(sorted(fragment_kind_surface_counts.items())),
+        "reason_code_surface_counts": dict(sorted(reason_code_surface_counts.items())),
+        "fragment_line_span_buckets": dict(sorted(fragment_line_span_buckets.items())),
+        "fragment_token_span_buckets": dict(sorted(fragment_token_span_buckets.items())),
+        "enclosing_unit_recovery_counts": dict(sorted(enclosing_unit_recovery_counts.items())),
         "families": families,
     }
 
@@ -471,7 +599,19 @@ def compare_repo(repo_id: str, base: dict, cur: dict) -> dict:
         bf, cf = bfam[k], cfam[k]
         # locations are baked into the key, so they match; compare the rest, including
         # family_id (a new id for the same location set is itself worth a look).
-        fields = ["family_id", "members", "location_count", "mean_lines", "kinds"]
+        fields = [
+            "family_id",
+            "members",
+            "location_count",
+            "mean_lines",
+            "recommended_surface",
+            "family_shape",
+            "fragment_location_count",
+            "kinds",
+            "fragment_line_span_buckets",
+            "fragment_token_span_buckets",
+            "enclosing_unit_recovery",
+        ]
         if any(bf.get(f) != cf.get(f) for f in fields):
             changed.append(label(cf))
 
@@ -489,12 +629,19 @@ def compare_repo(repo_id: str, base: dict, cur: dict) -> dict:
     if ba and abs(ca - ba) / ba > THRESHOLDS["json_bytes_pct"]:
         triggers.append(f"json bytes {ba} -> {ca} ({(ca-ba)/ba:+.1%})")
 
-    # Kind / span / fragment bucket drift (rule 5, interim #35 buckets).
+    # Kind / span / fragment product-surface drift (rule 5, issue #51 C1 buckets).
     for label, key in [
         ("kind", "kind_counts"),
         ("span", "span_buckets"),
+        ("recommended_surface", "recommended_surface_counts"),
+        ("family_shape", "family_shape_counts"),
         ("fragment_kind", "fragment_kind_counts"),
         ("reason_code", "reason_code_counts"),
+        ("fragment_kind_surface", "fragment_kind_surface_counts"),
+        ("reason_code_surface", "reason_code_surface_counts"),
+        ("fragment_line_span", "fragment_line_span_buckets"),
+        ("fragment_token_span", "fragment_token_span_buckets"),
+        ("enclosing_unit_recovery", "enclosing_unit_recovery_counts"),
     ]:
         d = _diff_dict(bo.get(key, {}), co.get(key, {}))
         if d:
@@ -629,6 +776,191 @@ def cmd_cache(args: argparse.Namespace) -> int:
     return 0
 
 
+def _assert_eq(actual, expected, label: str) -> None:
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def _sample_scan_json() -> dict:
+    return {
+        "schema_version": 1,
+        "tool_version": "nose test",
+        "scope": {"files": 3, "languages": [{"language": "python", "files": 3}]},
+        "ranking": {"total_families": 3, "shown_families": 3, "limit": None},
+        "families": [
+            {
+                "family_id": "whole",
+                "recommended_surface": "default",
+                "members": 2,
+                "files": 2,
+                "languages": 1,
+                "mean_lines": 20,
+                "locations": [
+                    {
+                        "file": "a.py",
+                        "start_line": 1,
+                        "end_line": 20,
+                        "kind": "Function",
+                        "is_fragment": False,
+                    },
+                    {
+                        "file": "b.py",
+                        "start_line": 1,
+                        "end_line": 20,
+                        "kind": "Function",
+                        "is_fragment": False,
+                    },
+                ],
+            },
+            {
+                "family_id": "hidden-frag",
+                "recommended_surface": "hidden",
+                "members": 2,
+                "files": 2,
+                "languages": 1,
+                "mean_lines": 2,
+                "locations": [
+                    {
+                        "file": "a.py",
+                        "start_line": 4,
+                        "end_line": 5,
+                        "kind": "Block",
+                        "span_lines": 2,
+                        "span_tokens": 12,
+                        "is_fragment": True,
+                        "fragment_kind": "conditional-guard",
+                        "reason_code": "exact-conditional-guard",
+                        "enclosing_unit": {
+                            "file": "a.py",
+                            "start_line": 1,
+                            "end_line": 20,
+                            "kind": "Function",
+                            "unit_key": "a.py:Function:1-20:",
+                        },
+                    },
+                    {
+                        "file": "b.py",
+                        "start_line": 4,
+                        "end_line": 5,
+                        "kind": "Block",
+                        "span_lines": 2,
+                        "span_tokens": 12,
+                        "is_fragment": True,
+                        "fragment_kind": "conditional-guard",
+                        "reason_code": "exact-conditional-guard",
+                    },
+                ],
+            },
+            {
+                "family_id": "mixed-review",
+                "recommended_surface": "review",
+                "members": 2,
+                "files": 2,
+                "languages": 1,
+                "mean_lines": 5,
+                "locations": [
+                    {
+                        "file": "c.py",
+                        "start_line": 1,
+                        "end_line": 12,
+                        "kind": "Function",
+                        "is_fragment": False,
+                    },
+                    {
+                        "file": "c.py",
+                        "start_line": 10,
+                        "end_line": 14,
+                        "kind": "Block",
+                        "span_tokens": 30,
+                        "is_fragment": True,
+                        "fragment_kind": "direct-return",
+                        "reason_code": "exact-direct-return",
+                        "enclosing_unit": {
+                            "file": "c.py",
+                            "start_line": 1,
+                            "end_line": 14,
+                            "kind": "Function",
+                            "unit_key": "c.py:Function:1-14:",
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def _with_runtime(output: dict) -> dict:
+    return {
+        "output": output,
+        "runtime": {"wall_ms_median": 1.0, "phase_ms_median": {}},
+    }
+
+
+def cmd_selftest(_args: argparse.Namespace) -> int:
+    canon = canonicalize(_sample_scan_json(), Path("/tmp/nose-scan-regression-selftest"))
+    _assert_eq(
+        canon["recommended_surface_counts"],
+        {"debug": 0, "default": 1, "hidden": 1, "review": 1},
+        "recommended surface counts",
+    )
+    _assert_eq(
+        canon["family_shape_counts"],
+        {"all-fragment": 1, "mixed": 1, "whole-only": 1},
+        "family shape counts",
+    )
+    _assert_eq(
+        canon["fragment_kind_counts"],
+        {"conditional-guard": 2, "direct-return": 1},
+        "fragment kind counts",
+    )
+    _assert_eq(
+        canon["reason_code_counts"],
+        {"exact-conditional-guard": 2, "exact-direct-return": 1},
+        "reason code counts",
+    )
+    _assert_eq(
+        canon["fragment_kind_surface_counts"],
+        {"conditional-guard|hidden": 2, "direct-return|review": 1},
+        "fragment kind by surface counts",
+    )
+    _assert_eq(
+        canon["reason_code_surface_counts"],
+        {"exact-conditional-guard|hidden": 2, "exact-direct-return|review": 1},
+        "reason code by surface counts",
+    )
+    _assert_eq(
+        canon["fragment_line_span_buckets"],
+        {"2-3": 2, "4-10": 1},
+        "fragment line-span buckets",
+    )
+    _assert_eq(
+        canon["fragment_token_span_buckets"],
+        {"24-49": 1, "9-23": 2},
+        "fragment token-span buckets",
+    )
+    _assert_eq(
+        canon["enclosing_unit_recovery_counts"],
+        {"missing": 1, "recovered": 2},
+        "enclosing-unit recovery counts",
+    )
+
+    surface_changed = json.loads(json.dumps(canon))
+    surface_changed["recommended_surface_counts"]["hidden"] += 1
+    result = compare_repo("sample", _with_runtime(canon), _with_runtime(surface_changed))
+    if not any("recommended_surface counts" in t for t in result["triggers"]):
+        raise AssertionError(f"surface drift was not reported: {result['triggers']}")
+
+    family_changed = json.loads(json.dumps(canon))
+    first_family = next(iter(family_changed["families"].values()))
+    first_family["recommended_surface"] = "review"
+    result = compare_repo("sample", _with_runtime(canon), _with_runtime(family_changed))
+    if not any("family(ies) changed shape" in t for t in result["triggers"]):
+        raise AssertionError(f"family-level surface drift was not reported: {result['triggers']}")
+
+    print("selftest OK")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -663,6 +995,9 @@ def main(argv: list[str] | None = None) -> int:
     ca.add_argument("--subset", default=str(DEFAULT_SUBSET))
     ca.add_argument("--out", default=None)
     ca.set_defaults(func=cmd_cache)
+
+    st = sub.add_parser("selftest", help="run corpus-free unit tests for canonicalization")
+    st.set_defaults(func=cmd_selftest)
 
     args = p.parse_args(argv)
     return args.func(args)

--- a/bench/type4/scan_regression/scan_regression.py
+++ b/bench/type4/scan_regression/scan_regression.py
@@ -34,10 +34,11 @@ Why this exists, and the rules it follows (from the issue #37 decision):
    families can share one id); family_id is compared as an attribute and is itself a
    drift signal. We also compare unit kind, mean_lines / span size, location count,
    product JSON byte size, fragment product-surface placement, all-fragment vs mixed
-   family shape, fragment span buckets, and enclosing-unit recovery. `fragment_kind` /
-   `reason_code` are counted from product scan JSON when exact-fragment locations expose
-   them, so #45 metadata changes become visible as bucket drift instead of hiding inside
-   generic `Block` counts.
+   family shape, fragment span buckets, enclosing-unit recovery, and family-local
+   `fragment_kind` / `reason_code` summaries. `fragment_kind` / `reason_code` are
+   counted from product scan JSON when exact-fragment locations expose them, so #45
+   metadata changes become visible as bucket drift instead of hiding inside generic
+   `Block` counts.
 
 6. Durable artifacts live next to this script in `bench/type4/scan_regression/`:
    `subset.json` (the small subset), `baseline.v1.json` (the recorded baseline),
@@ -371,6 +372,10 @@ def canonicalize(scan_json: dict, repo: Path) -> dict:
         family_shape, fragment_count = _family_shape(locs)
         _inc(family_shape_counts, family_shape)
         fam_kinds: dict[str, int] = {}
+        fam_fragment_kind_counts: dict[str, int] = {}
+        fam_reason_code_counts: dict[str, int] = {}
+        fam_fragment_kind_surface_counts: dict[str, int] = {}
+        fam_reason_code_surface_counts: dict[str, int] = {}
         fam_fragment_line_span_buckets: dict[str, int] = {}
         fam_fragment_token_span_buckets: dict[str, int] = {}
         fam_enclosing_recovery = {"recovered": 0, "missing": 0}
@@ -380,13 +385,17 @@ def canonicalize(scan_json: dict, repo: Path) -> dict:
             fam_kinds[k] = fam_kinds.get(k, 0) + 1
             _count_meta(loc, "fragment_kind", fragment_kind_counts)
             _count_meta(loc, "reason_code", reason_code_counts)
+            _count_meta(loc, "fragment_kind", fam_fragment_kind_counts)
+            _count_meta(loc, "reason_code", fam_reason_code_counts)
             if _is_fragment_location(loc):
                 fragment_kind = loc.get("fragment_kind")
                 if isinstance(fragment_kind, str):
                     _inc(fragment_kind_surface_counts, f"{fragment_kind}|{surface}")
+                    _inc(fam_fragment_kind_surface_counts, f"{fragment_kind}|{surface}")
                 reason_code = loc.get("reason_code")
                 if isinstance(reason_code, str):
                     _inc(reason_code_surface_counts, f"{reason_code}|{surface}")
+                    _inc(fam_reason_code_surface_counts, f"{reason_code}|{surface}")
 
                 line_span = _line_span_of(loc)
                 line_bucket = _span_bucket(line_span) if line_span is not None else "<missing>"
@@ -405,6 +414,8 @@ def canonicalize(scan_json: dict, repo: Path) -> dict:
                 _inc(fam_enclosing_recovery, recovery)
         _count_meta(fam, "fragment_kind", fragment_kind_counts)
         _count_meta(fam, "reason_code", reason_code_counts)
+        _count_meta(fam, "fragment_kind", fam_fragment_kind_counts)
+        _count_meta(fam, "reason_code", fam_reason_code_counts)
 
         mean_lines = int(fam.get("mean_lines", 0))
         bucket = _span_bucket(mean_lines)
@@ -424,6 +435,14 @@ def canonicalize(scan_json: dict, repo: Path) -> dict:
             "location_count": len(locs),
             "fragment_location_count": fragment_count,
             "kinds": dict(sorted(fam_kinds.items())),
+            "fragment_kind_counts": dict(sorted(fam_fragment_kind_counts.items())),
+            "reason_code_counts": dict(sorted(fam_reason_code_counts.items())),
+            "fragment_kind_surface_counts": dict(
+                sorted(fam_fragment_kind_surface_counts.items())
+            ),
+            "reason_code_surface_counts": dict(
+                sorted(fam_reason_code_surface_counts.items())
+            ),
             "fragment_line_span_buckets": dict(sorted(fam_fragment_line_span_buckets.items())),
             "fragment_token_span_buckets": dict(sorted(fam_fragment_token_span_buckets.items())),
             "enclosing_unit_recovery": dict(sorted(fam_enclosing_recovery.items())),
@@ -612,6 +631,10 @@ def compare_repo(repo_id: str, base: dict, cur: dict) -> dict:
             "family_shape",
             "fragment_location_count",
             "kinds",
+            "fragment_kind_counts",
+            "reason_code_counts",
+            "fragment_kind_surface_counts",
+            "reason_code_surface_counts",
             "fragment_line_span_buckets",
             "fragment_token_span_buckets",
             "enclosing_unit_recovery",
@@ -626,7 +649,7 @@ def compare_repo(repo_id: str, base: dict, cur: dict) -> dict:
     if added or removed:
         triggers.append(f"family set: +{len(added)} / -{len(removed)}")
     if changed:
-        triggers.append(f"{len(changed)} family(ies) changed shape")
+        triggers.append(f"{len(changed)} family(ies) changed shape/metadata")
 
     # Product JSON byte-size drift (rule 5).
     ba, ca = bo["product_json_bytes"], co["product_json_bytes"]
@@ -677,6 +700,12 @@ def compare_repo(repo_id: str, base: dict, cur: dict) -> dict:
 def render_summary(ident_base: dict, ident_cur: dict, results: list[dict], skipped: list[str]) -> str:
     lines = ["# Scan-regression compare summary", ""]
     lines.append("> Investigation triggers, not merge blockers (issue #37, rule 7).")
+    lines.append(
+        "> Artifact identity: current `source_git_describe` / `build_ref` name the "
+        "checkout and binary that generated this report. If the report is committed "
+        "after generation, those refs intentionally point at the generator commit, "
+        "not at the later artifact commit."
+    )
     lines.append("")
     lines.append("## Binaries")
     lines.append("")
@@ -893,6 +922,81 @@ def _sample_scan_json() -> dict:
     }
 
 
+def _balanced_swap_scan_json() -> dict:
+    return {
+        "schema_version": 1,
+        "tool_version": "nose test",
+        "scope": {"files": 4, "languages": [{"language": "python", "files": 4}]},
+        "ranking": {"total_families": 2, "shown_families": 2, "limit": None},
+        "families": [
+            {
+                "family_id": "hidden-guard",
+                "recommended_surface": "hidden",
+                "members": 2,
+                "files": 2,
+                "languages": 1,
+                "mean_lines": 2,
+                "locations": [
+                    {
+                        "file": "guard_a.py",
+                        "start_line": 4,
+                        "end_line": 5,
+                        "kind": "Block",
+                        "span_lines": 2,
+                        "span_tokens": 12,
+                        "is_fragment": True,
+                        "fragment_kind": "conditional-guard",
+                        "reason_code": "exact-conditional-guard",
+                    },
+                    {
+                        "file": "guard_b.py",
+                        "start_line": 4,
+                        "end_line": 5,
+                        "kind": "Block",
+                        "span_lines": 2,
+                        "span_tokens": 12,
+                        "is_fragment": True,
+                        "fragment_kind": "conditional-guard",
+                        "reason_code": "exact-conditional-guard",
+                    },
+                ],
+            },
+            {
+                "family_id": "hidden-return",
+                "recommended_surface": "hidden",
+                "members": 2,
+                "files": 2,
+                "languages": 1,
+                "mean_lines": 2,
+                "locations": [
+                    {
+                        "file": "return_a.py",
+                        "start_line": 8,
+                        "end_line": 9,
+                        "kind": "Block",
+                        "span_lines": 2,
+                        "span_tokens": 12,
+                        "is_fragment": True,
+                        "fragment_kind": "direct-return",
+                        "reason_code": "exact-direct-return",
+                    },
+                    {
+                        "file": "return_b.py",
+                        "start_line": 8,
+                        "end_line": 9,
+                        "kind": "Block",
+                        "span_lines": 2,
+                        "span_tokens": 12,
+                        "is_fragment": True,
+                        "fragment_kind": "direct-return",
+                        "reason_code": "exact-direct-return",
+                    },
+                ],
+            },
+        ],
+    }
+
+
 def _with_runtime(output: dict) -> dict:
     return {
         "output": output,
@@ -953,6 +1057,29 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
         {"missing": 1, "recovered": 2},
         "enclosing-unit recovery counts",
     )
+    hidden_family = next(
+        f for f in canon["families"].values() if f["family_id"] == "hidden-frag"
+    )
+    _assert_eq(
+        hidden_family["fragment_kind_counts"],
+        {"conditional-guard": 2},
+        "family-local fragment kind counts",
+    )
+    _assert_eq(
+        hidden_family["reason_code_counts"],
+        {"exact-conditional-guard": 2},
+        "family-local reason code counts",
+    )
+    _assert_eq(
+        hidden_family["fragment_kind_surface_counts"],
+        {"conditional-guard|hidden": 2},
+        "family-local fragment kind by surface counts",
+    )
+    _assert_eq(
+        hidden_family["reason_code_surface_counts"],
+        {"exact-conditional-guard|hidden": 2},
+        "family-local reason code by surface counts",
+    )
 
     surface_changed = json.loads(json.dumps(canon))
     surface_changed["recommended_surface_counts"]["hidden"] += 1
@@ -964,8 +1091,38 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
     first_family = next(iter(family_changed["families"].values()))
     first_family["recommended_surface"] = "review"
     result = compare_repo("sample", _with_runtime(canon), _with_runtime(family_changed))
-    if not any("family(ies) changed shape" in t for t in result["triggers"]):
+    if not any("family(ies) changed shape/metadata" in t for t in result["triggers"]):
         raise AssertionError(f"family-level surface drift was not reported: {result['triggers']}")
+
+    balanced = _balanced_swap_scan_json()
+    swapped = json.loads(json.dumps(balanced))
+    for loc in swapped["families"][0]["locations"]:
+        loc["fragment_kind"] = "direct-return"
+        loc["reason_code"] = "exact-direct-return"
+    for loc in swapped["families"][1]["locations"]:
+        loc["fragment_kind"] = "conditional-guard"
+        loc["reason_code"] = "exact-conditional-guard"
+    balanced_canon = canonicalize(balanced, Path("/tmp/nose-scan-regression-selftest"))
+    swapped_canon = canonicalize(swapped, Path("/tmp/nose-scan-regression-selftest"))
+    _assert_eq(
+        swapped_canon["fragment_kind_surface_counts"],
+        balanced_canon["fragment_kind_surface_counts"],
+        "balanced swap global fragment kind by surface counts",
+    )
+    _assert_eq(
+        swapped_canon["reason_code_surface_counts"],
+        balanced_canon["reason_code_surface_counts"],
+        "balanced swap global reason code by surface counts",
+    )
+    result = compare_repo(
+        "balanced-swap",
+        _with_runtime(balanced_canon),
+        _with_runtime(swapped_canon),
+    )
+    if not any("family(ies) changed shape/metadata" in t for t in result["triggers"]):
+        raise AssertionError(
+            f"family-local fragment metadata drift was not reported: {result['triggers']}"
+        )
 
     print("selftest OK")
     return 0

--- a/bench/type4/scan_regression/scan_regression.py
+++ b/bench/type4/scan_regression/scan_regression.py
@@ -105,6 +105,10 @@ FAMILY_SHAPE_BUCKETS = ("whole-only", "all-fragment", "mixed")
 # ---------------------------------------------------------------------------
 # Binary identity (rule 3)
 # ---------------------------------------------------------------------------
+def nose_binary_path(nose: str) -> Path:
+    return Path(shutil.which(nose) or nose).resolve()
+
+
 def _git(args: list[str], cwd: Path) -> str:
     try:
         out = subprocess.run(
@@ -117,7 +121,7 @@ def _git(args: list[str], cwd: Path) -> str:
 
 def binary_identity(nose: str, build_ref: str | None) -> dict:
     """Everything needed to know *exactly* which binary produced a result."""
-    path = Path(shutil.which(nose) or nose).resolve()
+    path = nose_binary_path(nose)
     version = ""
     try:
         version = subprocess.run(
@@ -156,7 +160,7 @@ def scan_command(nose: str, scan: dict, cache_dir: Path | None) -> list[str]:
     `product_json_bytes` independent of where the corpus is checked out — the same repo
     canonicalizes identically whether it lives under the main worktree or elsewhere."""
     cmd = [
-        nose,
+        str(nose_binary_path(nose)),
         "scan",
         ".",
         "--mode",
@@ -897,6 +901,12 @@ def _with_runtime(output: dict) -> dict:
 
 
 def cmd_selftest(_args: argparse.Namespace) -> int:
+    cmd = scan_command(
+        "./target/release/nose", {"mode": "semantic", "format": "json", "top": 0}, None
+    )
+    if not Path(cmd[0]).is_absolute():
+        raise AssertionError(f"scan command did not absolutize nose path: {cmd[0]}")
+
     canon = canonicalize(_sample_scan_json(), Path("/tmp/nose-scan-regression-selftest"))
     _assert_eq(
         canon["recommended_surface_counts"],

--- a/docs/fragment-output-audit.md
+++ b/docs/fragment-output-audit.md
@@ -308,3 +308,10 @@ machine-readable output while using `recommended_surface` and default ranking
 damping so tiny proof fragments do not read as first-class refactoring
 candidates. The important product decision remains: exact semantic fragments
 are evidence, not automatically refactoring candidates.
+
+The scan-regression harness measures that placement policy without expanding the
+stable scan JSON schema. Its canonical output tracks `recommended_surface`
+distribution, whole-only/all-fragment/mixed family shape, fragment proof reason by
+surface, fragment line/token span buckets, and enclosing-unit recovery. These metrics
+are regression gates for future calibration: they should move only when product
+placement intentionally changes, while `--top 0` keeps full fragment visibility.

--- a/docs/type4-benchmark.md
+++ b/docs/type4-benchmark.md
@@ -300,7 +300,8 @@ The seed lives in `bench/type4/`:
 - `schema.json` — pair-level manifest schema;
 - `scan_regression/` — the repeatable product-scan runtime/output-drift harness
   (`nose scan --mode semantic --format json --top 0`), with its own subset, recorded
-  baseline, fragment/reason-code bucket drift, and threshold docs; see
+  baseline, fragment/reason-code/surface bucket drift, enclosing-unit recovery metrics,
+  and threshold docs; see
   `bench/type4/scan_regression/README.md`;
 - `README.md` — commands and current smoke numbers.
 


### PR DESCRIPTION
## Summary

Refs #51.

This is the C1 measurement/gate expansion PR only. It adds scan-regression canonical metrics for the fragment product surface without changing detector behavior, ranking behavior, output placement, or the stable scan JSON schema.

- Add canonical scan-regression metrics for `recommended_surface_counts`, `family_shape_counts`, fragment-kind/reason-code by recommended surface, fragment-only line/token span buckets, and enclosing-unit recovery.
- Add per-family canonical fields for recommended surface, family shape, fragment counts, fragment span buckets, and enclosing-unit recovery so metric drift is explainable.
- Add a corpus-free `scan_regression.py selftest` that covers the new C1 metrics, drift detection, and local `--nose ./target/release/nose` path resolution.
- Refresh the scan-regression baseline and compare summary over the current 8-repo subset.
- Update benchmark and fragment-output docs to describe the new gates and their non-goals.

## Non-goals

- No detector-family, location-set, or ranking changes.
- No stable scan JSON schema expansion.
- No public `fragment_parent` / `contained_by_family` fields.
- No generated/fixture/proof-only routing to `debug`; the debug bucket is reserved and remains zero in the refreshed baseline.

## Validation

- `python3 -m py_compile bench/type4/scan_regression/scan_regression.py bench/type4/frontier_platform.py bench/labels/eval_by_language.py`
- `python3 bench/type4/scan_regression/scan_regression.py selftest`
- `python3 bench/type4/frontier_platform.py --selftest`
- `cargo fmt --all --check`
- `awiki lint --root docs`
- `./scripts/check-docs.sh`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`
- `cargo build --release`
- `python3 bench/type4/scan_regression/scan_regression.py compare --nose ./target/release/nose --repos-root /Users/ak/prjs/cc/nose/bench/repos --build-ref "issue-51@$(git rev-parse --short HEAD)"` — 8 repos, 0 triggers
- `./scripts/check-duplication.sh` — 4 substantial near-duplicate families, budget 6 OK
- `cargo test --release`
