### PR TITLE
type4(fragment): contract-migrate LoopEffect onto the substrate (#49, migration 1)

### DIFF
--- a/crates/nose-detect/src/fragment.rs
+++ b/crates/nose-detect/src/fragment.rs
@@ -20,6 +20,7 @@
 //! [`reason_code`]: FragmentKind::reason_code
 
 mod contract;
+mod loop_effect;
 mod oracle;
 pub(crate) mod recognize;
 

--- a/crates/nose-detect/src/fragment/loop_effect.rs
+++ b/crates/nose-detect/src/fragment/loop_effect.rs
@@ -1,0 +1,445 @@
+//! Independent contract-path recognizer for the [`FragmentKind::LoopEffect`] shape.
+//!
+//! Issue #49 (Team A), migration 1. The production authority stays the predicate matrix in
+//! [`crate::units`]; this re-expresses the *same acceptance boundary* on the contract path so
+//! the differential gate (`super::recognize`) can hold the two in lockstep. Per the issue
+//! decision, the re-expression is **independent**: it shares only substrate-level generic
+//! utilities (AST traversal over canonical ids), never the predicate's acceptance helpers
+//! (`units::exact_loop_effect_fragment_root`, `foreach_effect_body_depends_on_iter`, …).
+//!
+//! A `LoopEffect` is a `for-each` loop whose body produces at least one **iteration-dependent
+//! observable effect** — an append or an index write whose written value/key depends on the
+//! loop variable but whose receiver does not — possibly routed through one or two local temps,
+//! and possibly nested inside `if` branches. Every statement in the body must be one of these
+//! recognized effect shapes (or an `if`/block composed of them); any unrecognized statement
+//! rejects the whole loop. That strictness is what keeps the fragment self-contained and
+//! exactly reproducible behavior in the oracle wrapper.
+
+use super::contract::{Effect, EffectSite, FragmentContract};
+use super::oracle::free_input_cids;
+use super::{Exit, FragmentKind};
+use nose_il::{Builtin, Il, Lang, LoopKind, NodeId, NodeKind, Payload};
+use rustc_hash::FxHashSet;
+
+/// Recognize `node` as a `LoopEffect` contract, or `None` if it is not the shape.
+///
+/// Independent of `units::exact_loop_effect_fragment_root`; the caller has already applied the
+/// shared span/context-safety gates (see [`super::recognize::recognize_contract`]).
+pub(crate) fn recognize_loop_effect(il: &Il, node: NodeId) -> Option<FragmentContract> {
+    if !matches!(il.node(node).payload, Payload::Loop(LoopKind::ForEach)) {
+        return None;
+    }
+    let kids = il.children(node);
+    if kids.len() != 3 {
+        return None;
+    }
+    // Loop variables bound by the for-each pattern. An effect's dependence on *these* cids is
+    // what makes it iteration-dependent.
+    let mut iter_cids = FxHashSet::default();
+    collect_var_cids(il, kids[0], &mut iter_cids);
+    if iter_cids.is_empty() {
+        return None;
+    }
+
+    let mut effects = Vec::new();
+    if !body_depends_on_iter(il, kids[2], &iter_cids, &mut effects)? {
+        return None;
+    }
+
+    Some(FragmentContract::ordered_effects(
+        FragmentKind::LoopEffect,
+        node,
+        free_input_cids(il, node),
+        Exit::Normal,
+        effects,
+    ))
+}
+
+/// Whether the loop `body` is composed entirely of recognized iteration-dependent effect
+/// shapes, with at least one real effect. `None` means a statement was not recognized (the
+/// whole loop is rejected); `Some(false)` means recognized but effect-free (e.g. an empty
+/// branch). Recognized effects are pushed onto `effects` in body order.
+fn body_depends_on_iter(
+    il: &Il,
+    node: NodeId,
+    iter_cids: &FxHashSet<u32>,
+    effects: &mut Vec<EffectSite>,
+) -> Option<bool> {
+    match il.kind(node) {
+        NodeKind::Block => {
+            let kids = il.children(node);
+            let mut has_effect = false;
+            let mut idx = 0;
+            while idx < kids.len() {
+                // Two- and three-statement temp windows consume their statements as a unit.
+                if idx + 2 < kids.len()
+                    && temp_chain_consumed_by_effect(
+                        il,
+                        kids[idx],
+                        kids[idx + 1],
+                        kids[idx + 2],
+                        iter_cids,
+                        effects,
+                    )
+                {
+                    has_effect = true;
+                    idx += 3;
+                    continue;
+                }
+                if idx + 1 < kids.len()
+                    && temp_assignment_consumed_by_effect(
+                        il,
+                        kids[idx],
+                        kids[idx + 1],
+                        iter_cids,
+                        effects,
+                    )
+                {
+                    has_effect = true;
+                    idx += 2;
+                    continue;
+                }
+                has_effect |= body_depends_on_iter(il, kids[idx], iter_cids, effects)?;
+                idx += 1;
+            }
+            Some(has_effect)
+        }
+        NodeKind::ExprStmt => {
+            let kids = il.children(node);
+            if kids.len() == 1 && append_depends_on_iter(il, kids[0], iter_cids) {
+                effects.push(EffectSite::observable(Effect::Append));
+                Some(true)
+            } else {
+                None
+            }
+        }
+        NodeKind::Assign => {
+            if index_assignment_depends_on_iter(il, node, iter_cids) {
+                effects.push(EffectSite::observable(Effect::IndexWrite));
+                Some(true)
+            } else {
+                None
+            }
+        }
+        NodeKind::If => {
+            let kids = il.children(node);
+            if !(kids.len() == 2 || kids.len() == 3) {
+                return None;
+            }
+            let mut has_effect = false;
+            for &branch in kids.iter().skip(1) {
+                if il.kind(branch) != NodeKind::Block {
+                    return None;
+                }
+                has_effect |= body_depends_on_iter(il, branch, iter_cids, effects)?;
+            }
+            Some(has_effect)
+        }
+        _ => None,
+    }
+}
+
+// ---- direct iteration-dependent effects --------------------------------------------------
+
+/// `recv.append(value)` where the appended value depends on the loop var but the receiver
+/// (the appended-to collection) does not — so the receiver is loop-invariant.
+fn append_depends_on_iter(il: &Il, node: NodeId, iter_cids: &FxHashSet<u32>) -> bool {
+    let Some(kids) = append_call_args(il, node) else {
+        return false;
+    };
+    !mentions_any(il, kids.0, iter_cids) && mentions_any(il, kids.1, iter_cids)
+}
+
+/// `recv[key] = value` (non-overloadable C/Go/Java index write) where key or value depends on
+/// the loop var and the receiver does not.
+fn index_assignment_depends_on_iter(il: &Il, node: NodeId, iter_cids: &FxHashSet<u32>) -> bool {
+    let Some((receiver, key, value)) = index_assignment_parts(il, node) else {
+        return false;
+    };
+    if mentions_any(il, receiver, iter_cids) {
+        return false;
+    }
+    key.is_some_and(|k| mentions_any(il, k, iter_cids)) || mentions_any(il, value, iter_cids)
+}
+
+// ---- single-temp window: `t = f(iter); recv.append/idx(t)` -------------------------------
+
+/// `t = <expr over iter>;  <effect consuming t>` over two adjacent statements.
+fn temp_assignment_consumed_by_effect(
+    il: &Il,
+    assign: NodeId,
+    effect: NodeId,
+    iter_cids: &FxHashSet<u32>,
+    effects: &mut Vec<EffectSite>,
+) -> bool {
+    let Some(temp) = iter_temp_assignment(il, assign, iter_cids) else {
+        return false;
+    };
+    let mut temp_cids = FxHashSet::default();
+    temp_cids.insert(temp);
+    effect_consumes_temp(il, effect, iter_cids, &temp_cids, effects)
+}
+
+/// A local `t = rhs` whose `rhs` is non-trivial, depends on the loop var, does not read `t`
+/// itself, and whose target is not a loop var. Returns the temp cid.
+fn iter_temp_assignment(il: &Il, node: NodeId, iter_cids: &FxHashSet<u32>) -> Option<u32> {
+    let (temp, rhs) = local_nontrivial_assignment(il, node)?;
+    if iter_cids.contains(&temp) {
+        return None;
+    }
+    if !mentions_any(il, rhs, iter_cids) {
+        return None;
+    }
+    Some(temp)
+}
+
+/// An effect that consumes `temp_cids`: an append whose value reads the temp (receiver reads
+/// neither iter nor temp), or an index write whose key/value reads the temp.
+fn effect_consumes_temp(
+    il: &Il,
+    node: NodeId,
+    iter_cids: &FxHashSet<u32>,
+    temp_cids: &FxHashSet<u32>,
+    effects: &mut Vec<EffectSite>,
+) -> bool {
+    match il.kind(node) {
+        NodeKind::ExprStmt => {
+            let kids = il.children(node);
+            if kids.len() == 1 && append_consumes_temp(il, kids[0], iter_cids, temp_cids) {
+                effects.push(EffectSite::observable(Effect::Append));
+                return true;
+            }
+            false
+        }
+        NodeKind::Assign => {
+            if index_assignment_consumes_temp(il, node, iter_cids, temp_cids) {
+                effects.push(EffectSite::observable(Effect::IndexWrite));
+                return true;
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+fn append_consumes_temp(
+    il: &Il,
+    node: NodeId,
+    iter_cids: &FxHashSet<u32>,
+    temp_cids: &FxHashSet<u32>,
+) -> bool {
+    let Some((recv, value)) = append_call_args(il, node) else {
+        return false;
+    };
+    !mentions_any(il, recv, iter_cids)
+        && !mentions_any(il, recv, temp_cids)
+        && mentions_any(il, value, temp_cids)
+}
+
+fn index_assignment_consumes_temp(
+    il: &Il,
+    node: NodeId,
+    iter_cids: &FxHashSet<u32>,
+    temp_cids: &FxHashSet<u32>,
+) -> bool {
+    let Some((receiver, key, value)) = index_assignment_parts(il, node) else {
+        return false;
+    };
+    if mentions_any(il, receiver, iter_cids) || mentions_any(il, receiver, temp_cids) {
+        return false;
+    }
+    key.is_some_and(|k| mentions_any(il, k, temp_cids)) || mentions_any(il, value, temp_cids)
+}
+
+// ---- two-temp chain: `a = f(iter); b = g(a); recv.append/idx(b)` --------------------------
+
+/// `a = <expr over iter>;  b = <expr over a>;  <effect consuming b but not a>` over three
+/// adjacent statements.
+fn temp_chain_consumed_by_effect(
+    il: &Il,
+    first: NodeId,
+    second: NodeId,
+    effect: NodeId,
+    iter_cids: &FxHashSet<u32>,
+    effects: &mut Vec<EffectSite>,
+) -> bool {
+    let Some((first_cid, first_rhs)) = local_nontrivial_assignment(il, first) else {
+        return false;
+    };
+    if iter_cids.contains(&first_cid) || !mentions_any(il, first_rhs, iter_cids) {
+        return false;
+    }
+    let Some((second_cid, second_rhs)) = local_nontrivial_assignment(il, second) else {
+        return false;
+    };
+    if iter_cids.contains(&second_cid) || first_cid == second_cid {
+        return false;
+    }
+    let mut first_temp = FxHashSet::default();
+    first_temp.insert(first_cid);
+    if !mentions_any(il, second_rhs, &first_temp) {
+        return false;
+    }
+    let mut all_temps = first_temp.clone();
+    all_temps.insert(second_cid);
+    let mut final_temp = FxHashSet::default();
+    final_temp.insert(second_cid);
+    effect_consumes_chained_temp(
+        il,
+        effect,
+        iter_cids,
+        &all_temps,
+        &final_temp,
+        &first_temp,
+        effects,
+    )
+}
+
+fn effect_consumes_chained_temp(
+    il: &Il,
+    node: NodeId,
+    iter_cids: &FxHashSet<u32>,
+    all_temps: &FxHashSet<u32>,
+    final_temp: &FxHashSet<u32>,
+    prior_temp: &FxHashSet<u32>,
+    effects: &mut Vec<EffectSite>,
+) -> bool {
+    match il.kind(node) {
+        NodeKind::ExprStmt => {
+            let kids = il.children(node);
+            if kids.len() == 1
+                && append_consumes_chained_temp(
+                    il, kids[0], iter_cids, all_temps, final_temp, prior_temp,
+                )
+            {
+                effects.push(EffectSite::observable(Effect::Append));
+                return true;
+            }
+            false
+        }
+        NodeKind::Assign => {
+            if index_assignment_consumes_chained_temp(
+                il, node, iter_cids, all_temps, final_temp, prior_temp,
+            ) {
+                effects.push(EffectSite::observable(Effect::IndexWrite));
+                return true;
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+fn append_consumes_chained_temp(
+    il: &Il,
+    node: NodeId,
+    iter_cids: &FxHashSet<u32>,
+    all_temps: &FxHashSet<u32>,
+    final_temp: &FxHashSet<u32>,
+    prior_temp: &FxHashSet<u32>,
+) -> bool {
+    let Some((recv, value)) = append_call_args(il, node) else {
+        return false;
+    };
+    !mentions_any(il, recv, iter_cids)
+        && !mentions_any(il, recv, all_temps)
+        && mentions_any(il, value, final_temp)
+        && !mentions_any(il, value, prior_temp)
+}
+
+fn index_assignment_consumes_chained_temp(
+    il: &Il,
+    node: NodeId,
+    iter_cids: &FxHashSet<u32>,
+    all_temps: &FxHashSet<u32>,
+    final_temp: &FxHashSet<u32>,
+    prior_temp: &FxHashSet<u32>,
+) -> bool {
+    let Some((receiver, key, value)) = index_assignment_parts(il, node) else {
+        return false;
+    };
+    if mentions_any(il, receiver, iter_cids) || mentions_any(il, receiver, all_temps) {
+        return false;
+    }
+    let key_final = key.is_some_and(|k| mentions_any(il, k, final_temp));
+    let key_prior = key.is_some_and(|k| mentions_any(il, k, prior_temp));
+    let value_final = mentions_any(il, value, final_temp);
+    let value_prior = mentions_any(il, value, prior_temp);
+    (key_final || value_final) && !key_prior && !value_prior
+}
+
+// ---- shared structural readers (no acceptance semantics) ----------------------------------
+
+/// `(receiver, value)` of an `append`/`push` builtin call with exactly two children.
+fn append_call_args(il: &Il, node: NodeId) -> Option<(NodeId, NodeId)> {
+    if il.kind(node) != NodeKind::Call
+        || !matches!(il.node(node).payload, Payload::Builtin(Builtin::Append))
+    {
+        return None;
+    }
+    let kids = il.children(node);
+    (kids.len() == 2).then(|| (kids[0], kids[1]))
+}
+
+/// `(receiver, key, value)` of a non-overloadable `recv[key] = value` index assignment
+/// (C/Go/Java only — the same surface the migrated `IndexAssignEffect` admits).
+fn index_assignment_parts(il: &Il, node: NodeId) -> Option<(NodeId, Option<NodeId>, NodeId)> {
+    if !matches!(il.meta.lang, Lang::C | Lang::Go | Lang::Java) {
+        return None;
+    }
+    let kids = il.children(node);
+    if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Index {
+        return None;
+    }
+    let target = il.children(kids[0]);
+    let receiver = *target.first()?;
+    Some((receiver, target.get(1).copied(), kids[1]))
+}
+
+/// A local `var = rhs` where `rhs` is not a bare var/lit and does not read the target itself.
+/// Returns `(target cid, rhs node)`.
+fn local_nontrivial_assignment(il: &Il, node: NodeId) -> Option<(u32, NodeId)> {
+    if il.kind(node) != NodeKind::Assign {
+        return None;
+    }
+    let kids = il.children(node);
+    if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Var {
+        return None;
+    }
+    if matches!(il.kind(kids[1]), NodeKind::Var | NodeKind::Lit) {
+        return None;
+    }
+    let Payload::Cid(cid) = il.node(kids[0]).payload else {
+        return None;
+    };
+    let mut target = FxHashSet::default();
+    target.insert(cid);
+    if mentions_any(il, kids[1], &target) {
+        return None;
+    }
+    Some((cid, kids[1]))
+}
+
+// ---- generic AST utilities (substrate-level, shareable) -----------------------------------
+
+/// Collect every canonical id read as a `Var` in the subtree.
+fn collect_var_cids(il: &Il, node: NodeId, out: &mut FxHashSet<u32>) {
+    if let (NodeKind::Var, Payload::Cid(cid)) = (il.kind(node), il.node(node).payload) {
+        out.insert(cid);
+    }
+    for &child in il.children(node) {
+        collect_var_cids(il, child, out);
+    }
+}
+
+/// Whether the subtree reads any of `cids` as a `Var`.
+fn mentions_any(il: &Il, node: NodeId, cids: &FxHashSet<u32>) -> bool {
+    if let (NodeKind::Var, Payload::Cid(cid)) = (il.kind(node), il.node(node).payload) {
+        if cids.contains(&cid) {
+            return true;
+        }
+    }
+    il.children(node)
+        .iter()
+        .any(|&child| mentions_any(il, child, cids))
+}

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -28,6 +28,7 @@ pub(crate) const MIGRATED: &[FragmentKind] = &[
     FragmentKind::IndexAssignEffect,
     FragmentKind::SelfFieldAssign,
     FragmentKind::ExprEffect,
+    FragmentKind::LoopEffect,
 ];
 
 /// Recognize `node` as a migrated exact-fragment shape by building its contract directly,
@@ -76,6 +77,7 @@ pub(crate) fn recognize_contract(
                 EffectSite::observable(effect),
             ))
         }
+        NodeKind::Loop => super::loop_effect::recognize_loop_effect(il, node),
         _ => None,
     }
 }
@@ -312,9 +314,25 @@ mod tests {
 
     #[test]
     fn differential_ignores_non_migrated_shapes() {
-        // Loop/append and conditional effect shapes are accepted by the predicate path
-        // under OTHER kinds and must be excluded from the contract path — the migrated
-        // intersection stays empty and equal.
+        // ConditionalGuard and SelfFieldBody are still predicate-owned: the predicate accepts
+        // the `if`/body as those kinds, but the contract path must not produce them. Only the
+        // migrated *leaves* inside them (DirectReturn, SelfFieldAssign) appear on both paths,
+        // so the migrated intersection stays equal.
+        assert_paths_agree(
+            "function f(a){ if (a > 0) { return a * a; } }",
+            Lang::JavaScript,
+        );
+        assert_paths_agree(
+            "class C { int x; int y; void set(int a, int b){ this.x = a; this.y = b; } }",
+            Lang::Java,
+        );
+    }
+
+    #[test]
+    fn differential_loop_effect() {
+        // Accepted: for-each loops whose body is an iteration-dependent append/index effect,
+        // including a local-temp variant — the predicate and the independent contract
+        // recognizer must agree on the loop node (and every migrated leaf).
         assert_paths_agree(
             "function h(xs){ const out=[]; for(const x of xs){ out.push(x*2); } return out; }",
             Lang::JavaScript,
@@ -322,6 +340,30 @@ mod tests {
         assert_paths_agree(
             "def k(xs):\n    out = []\n    for x in xs:\n        out.append(x + 1)\n    return out\n",
             Lang::Python,
+        );
+        assert_paths_agree(
+            "function t(xs){ const out=[]; for(const x of xs){ const v = x*2; out.push(v); } return out; }",
+            Lang::JavaScript,
+        );
+        // Go index-write loop: `out[x] = x*2`, key/value depend on the loop var, receiver does not.
+        assert_paths_agree(
+            "package p\nfunc f(xs []int, out []int) {\n\tfor _, x := range xs {\n\t\tout[x] = x * 2\n\t}\n}\n",
+            Lang::Go,
+        );
+        // Rejected by both paths: receiver depends on the loop var (not loop-invariant);
+        // appended value is loop-invariant; the loop is not a for-each. Each leaves the
+        // migrated set empty at the loop node on both sides.
+        assert_paths_agree(
+            "function r(xs){ for(const x of xs){ x.push(1); } }",
+            Lang::JavaScript,
+        );
+        assert_paths_agree(
+            "function r(xs, out){ for(const x of xs){ out.push(1); } }",
+            Lang::JavaScript,
+        );
+        assert_paths_agree(
+            "function r(xs, out){ let i = 0; while (i < xs.length){ out.push(xs[i]); i = i + 1; } }",
+            Lang::JavaScript,
         );
     }
 

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -350,6 +350,14 @@ mod tests {
             "package p\nfunc f(xs []int, out []int) {\n\tfor _, x := range xs {\n\t\tout[x] = x * 2\n\t}\n}\n",
             Lang::Go,
         );
+        // `if`-guarded effect body: both paths recurse into the branch identically. (The
+        // condition is not effect-checked on either path — the contract recognizer is a
+        // faithful mirror of the predicate here, which is exactly what output-preserving
+        // migration requires; the differential gate locks the two together.)
+        assert_paths_agree(
+            "function g(xs){ const out=[]; for(const x of xs){ if (x > 0) { out.push(x); } } return out; }",
+            Lang::JavaScript,
+        );
         // Rejected by both paths: receiver depends on the loop var (not loop-invariant);
         // appended value is loop-invariant; the loop is not a for-each. Each leaves the
         // migrated set empty at the loop node on both sides.

--- a/docs/fragment-contracts.md
+++ b/docs/fragment-contracts.md
@@ -125,16 +125,22 @@ and adding it to that gate — it does **not** change production output.
 |---|---|
 | `DirectReturn`, `DirectThrow` | yes — value/control sinks |
 | `IndexAssignEffect`, `SelfFieldAssign`, `ExprEffect` | yes — single-effect writes |
+| `LoopEffect` | yes — for-each iteration-dependent effect body |
 | `ConditionalGuard` | not yet — predicate-owned |
-| `LoopEffect` | not yet — predicate-owned |
 | `SelfFieldBody` | not yet — predicate-owned |
 
-The remaining three need substrate the migrated single-statement shapes did not: binding-aware
-free inputs (loop variables, branch-local temps), an ordered multi-effect sequence, and
-multi-statement wrapper lowering. Those capabilities are now in place (described above); the
-kinds migrate onto them one at a time, each behind the differential gate, in follow-up work.
-The interim "branch-local temp" and "ordered multi-effect" shapes are proof mechanisms *inside*
-those three kinds, not new `FragmentKind` variants or reason codes.
+`LoopEffect` is the first multi-statement-body migration: its independent recognizer lives in
+`fragment/loop_effect.rs` and re-expresses the for-each acceptance (an iteration-dependent
+append/index effect, possibly through one or two local temps or nested `if` branches) on the
+binding-aware free-input + multi-statement-lowering substrate, with no reuse of the predicate's
+acceptance helpers.
+
+The remaining two need the same treatment: `ConditionalGuard` re-expresses its full recursive
+branch admissibility independently, and `SelfFieldBody` reproduces the body-level acceptance
+boundary that bypasses the top-level context gate (proving self-containment through the fixed
+`this` receiver instead). Both migrate behind the differential gate in follow-up work. The
+interim "branch-local temp" and "ordered multi-effect" shapes are proof mechanisms *inside*
+these kinds, not new `FragmentKind` variants or reason codes.
 
 ## What stays closed
 


### PR DESCRIPTION
## What

**Team A (#49), migration 1 of 3.** Contract-migrates `LoopEffect` — the first of the remaining predicate-owned fragment kinds — onto the #46 substrate, behind the differential gate. Output-preserving; production stays on the `units.rs` predicate path.

Per the [issue #49 decision](https://github.com/corca-ai/nose/issues/49): migration order `LoopEffect → SelfFieldBody → ConditionalGuard`, each an **independent** re-expression that shares only substrate-level utilities, never predicate acceptance helpers.

## Changes

- **`crates/nose-detect/src/fragment/loop_effect.rs` (new)** — independent contract recognizer for the for-each iteration-dependent effect shape. It re-derives the acceptance boundary (append/index write whose value/key depends on the loop variable but whose receiver does not; one- and two-temp windows; nested `if`/blocks; any unrecognized statement rejects the loop) using only generic AST traversal — **no** reuse of `exact_loop_effect_fragment_root`, `foreach_effect_body_depends_on_iter`, or the temp-window predicate helpers. Builds on #46: binding-aware free inputs exclude the loop variable; the body lowers through multi-statement wrapper synthesis.
- **`recognize.rs`** — `NodeKind::Loop` arm → `recognize_loop_effect`; `LoopEffect` added to `MIGRATED`; differential tests for accept (append / local-temp / Go index-write) and reject (iter-dependent receiver, loop-invariant value, non-for-each `while`) cases.
- **`fragment.rs`** — module wiring.
- **`docs/fragment-contracts.md`** — migrated/remaining status updated.

This is the first **multi-statement-body** migration, exercising the #46 substrate (binding-aware inputs + ordered multi-effect + block lowering) end to end on a real kind.

## Verification (output-preserving + independent parity)

- **Differential gate**: predicate vs contract `(span, kind)` set-equality fixture tests (accept + reject); the collector `debug_assert` forward check now covers `LoopEffect` — run across **24 real repos** spanning all 8 languages with **no divergence**.
- **Byte-identical** `nose scan --mode semantic --format json --top 0` vs origin/main across **20 repos / all 8 languages** (incl. guava 3 MB, netty/sympy 1.9 MB, hugo 921 KB).
- **#37 scan-regression** `compare`: **0 triggers** — `fragment_kind_counts` / `reason_code_counts` / `recommended_surface` unchanged (baseline NOT refreshed, as required for an output-preserving migration).
- **Type-4 core smoke**: positive recall **492/492**, hard-negative false merges **0/922**.
- `cargo test` (full), `clippy -D warnings`, `cargo fmt --check`, `awiki lint` — all green.

No new `FragmentKind`/reason code; no scan JSON schema or ranking change.

## Next

migration 2: `SelfFieldBody` (body-level acceptance that bypasses the top-level context gate via the fixed-`this` receiver), then migration 3: `ConditionalGuard` (full independent branch-admissibility re-expression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 루프 패턴에 대한 인식 기능 추가로 코드 분석 범위 확대
  * for-each 루프에서 반복 변수 의존 효과 검증 지원

* **문서**
  * 마이그레이션된 계약 종류에 대한 처리 범위 및 기술 세부사항 명시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->