### PR TITLE
[codex] formalize proof obligation registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,19 +78,25 @@ jobs:
         run: awiki lint --root docs
 
   formal:
-    name: lean proofs (value-graph soundness)
+    name: formal obligations · lean proofs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # The formal/ proofs are standalone Lean 4 files (no Mathlib); each must type-check
-      # with no `sorry`. They machine-check the value-graph canonicalization rules
-      # (AC sort, distribution, map/filter fusion, …). See formal/README.md.
+      # The formal obligation registry maps proof-sensitive rewrite modules to Lean proof
+      # files and counterexamples. The proofs are standalone Lean 4 files (no Mathlib);
+      # each must type-check with warnings promoted to errors. See formal/README.md.
       - name: install elan (lean toolchain)
         run: |
+          toolchain="$(cat lean-toolchain)"
           curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --default-toolchain leanprover/lean4:v4.30.0
+            | sh -s -- -y --default-toolchain "$toolchain"
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: lint proof obligations
+        run: python3 scripts/check-formal-obligations.py
       - name: check proofs
         run: |
           set -e
-          for f in formal/*.lean; do echo "checking $f"; lean "$f"; done
+          while IFS= read -r f; do
+            echo "checking $f"
+            lean --error=warning "$f"
+          done < <(find formal -name '*.lean' -print | sort)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,9 @@ jobs:
             | sh -s -- -y --default-toolchain "$toolchain"
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       - name: lint proof obligations
-        run: python3 scripts/check-formal-obligations.py
+        run: |
+          python3 scripts/check-formal-obligations.py --self-test
+          python3 scripts/check-formal-obligations.py
       - name: check proofs
         run: |
           set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,10 +117,11 @@ break.
     the numeric rewrites soundly.
 
 ### Formal
-- New machine-checked Lean proofs: `Algebra.lean::distrib_sound`,
-  `Functor.lean::{filter_fusion, filter_length_eq_count}`, and a new `Compare.lean`
-  (comparison-direction and negated-comparison canons). A CI `formal` job checks
-  `formal/*.lean` on every push.
+- New machine-checked Lean proofs: `NoseAlgebra.distrib_sound`,
+  `NoseFunctor.{filter_fusion, filter_length_eq_count}`, and the
+  `normalize.value_graph.compare` obligation (comparison-direction and
+  negated-comparison canons). A CI `formal` job checks the proof-obligation registry
+  and all `formal/**/*.lean` files on every push.
 
 ## [0.2.0] - 2026-06-04
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ full run here is a green CI. The full gates are:
 | **unused deps** | `cargo machete` | no dependency declared but unused (à la *knip*) |
 | **supply chain** | `cargo deny check` | no advisories/yanked crates, only allowed licenses, no dup/wildcard deps, crates.io-only |
 | **docs wiki** | `awiki lint --root docs` | the `docs/` wiki is one connected graph — no orphan pages or islands |
-| **formal obligations** | `python3 scripts/check-formal-obligations.py` | proof-sensitive rule modules are registered, theorem names exist, and counterexample files are tracked |
+| **formal obligations** | `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py` | proof-sensitive rule modules are registered, theorem names exist, and counterexample files are tracked |
 | **formal proofs** | `find formal -name '*.lean' -print \| sort \| xargs -n1 lean --error=warning` | value-graph soundness proofs type-check with warnings, including `sorry`, treated as errors |
 
 The dev/CI toolchain is pinned in `rust-toolchain.toml` (rustup installs it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,8 @@ full run here is a green CI. The full gates are:
 | **unused deps** | `cargo machete` | no dependency declared but unused (à la *knip*) |
 | **supply chain** | `cargo deny check` | no advisories/yanked crates, only allowed licenses, no dup/wildcard deps, crates.io-only |
 | **docs wiki** | `awiki lint --root docs` | the `docs/` wiki is one connected graph — no orphan pages or islands |
-| **formal proofs** | `lean formal/*.lean` | value-graph soundness proofs type-check with no `sorry` |
+| **formal obligations** | `python3 scripts/check-formal-obligations.py` | proof-sensitive rule modules are registered, theorem names exist, and counterexample files are tracked |
+| **formal proofs** | `find formal -name '*.lean' -print \| sort \| xargs -n1 lean --error=warning` | value-graph soundness proofs type-check with warnings, including `sorry`, treated as errors |
 
 The dev/CI toolchain is pinned in `rust-toolchain.toml` (rustup installs it
 automatically); the **MSRV** (`rust-version`, currently 1.85) is deliberately older

--- a/bench/type4/ITERATIONS.md
+++ b/bench/type4/ITERATIONS.md
@@ -238,9 +238,9 @@ The tool-assisted manual audit produced **one implementation-ready packet**: `nu
   and fzf `Constrain` (max(min)) do not merge across files.
 - Broad and generalizing: present in 26 repos across all 7 primary languages on both splits
   (dev 14 / held-out 12). The identity and its hard negatives (swapped bound order, wrong
-  nesting, the `lo ≤ hi` precondition) are machine-checked in `formal/Clamp.lean`.
+  nesting, the `lo ≤ hi` precondition) are machine-checked in `formal/obligations/normalize/value_graph/clamp/Proof.lean`.
 - Recorded as a `real-miss` in `real_frontier.v1.json` (existing schema/status) and linked by
-  a target packet routed `proof-fact-prerequisite` (no team yet). `formal/Clamp.lean` proves
+  a target packet routed `proof-fact-prerequisite` (no team yet). `formal/obligations/normalize/value_graph/clamp/Proof.lean` proves
   the merge is sound only under `lo ≤ hi`, and no existing scalar min/max fact proves bound
   ordering — parameter naming (e.g. fzf `Constrain(val, minimum, maximum)`) is not a proof, a
   boundary we explicitly forbid. So the packet's value is identifying the next proof fact

--- a/bench/type4/frontier_axes.py
+++ b/bench/type4/frontier_axes.py
@@ -33,7 +33,7 @@ import prioritize_frontier as pf  # noqa: E402  (reuse Candidate / PatternSpec /
 # denote the same value for `lo <= hi`, yet the value graph converges none of them (unlike
 # the structurally-similar abs idiom, which it DOES canonicalize). It is prevalent across all
 # seven corpus primary languages on both splits. The identity (and its hard negatives) is
-# machine-checked in `formal/Clamp.lean`.
+# machine-checked in `formal/obligations/normalize/value_graph/clamp/Proof.lean`.
 #
 # Patterns are the nested-call / built-in `clamp` forms ONLY. The `.min(...).max(...)` method
 # chain is intentionally excluded: it false-positives on schema/query builders such as Zod
@@ -48,7 +48,7 @@ EXTRA_CANDIDATES = [
         "open",
         "min(max(x,lo),hi) clamp composition is a real under-merge vs the two-comparison "
         "form; prevalent across all seven languages on both splits; composes already-proven "
-        "scalar min/max facts. Backed by formal/Clamp.lean.",
+        "scalar min/max facts. Backed by formal/obligations/normalize/value_graph/clamp/Proof.lean.",
         "Audit corpus clamp pairs; require the lo<=hi precondition and reject swapped bound "
         "order, wrong nesting, and float NaN as hard negatives.",
         (
@@ -88,6 +88,6 @@ EXTRA_CURATED: dict[str, dict] = {
         "substrate_required": "none",
         "rationale": "A value-graph clamp canonicalization over already-proven scalar "
         "min/max facts; lo<=hi precondition and float NaN are the soundness boundaries "
-        "(machine-checked in formal/Clamp.lean).",
+        "(machine-checked in formal/obligations/normalize/value_graph/clamp/Proof.lean).",
     },
 }

--- a/bench/type4/frontier_platform.md
+++ b/bench/type4/frontier_platform.md
@@ -94,7 +94,7 @@ Breadth is the headline; raw occurrence is shown but never drives the rank.
 - category: **all-language** · evidence tier: **frontier-recorded** · prioritizer status: `open`
 - presence: 26 repos / 7 primary langs (C, Go, Java, Python, Ruby, Rust, TypeScript) · source langs c, go, java, javascript, python, ruby, rust, typescript · dev 14 · heldout 12 · both-splits
 - curated: cost `medium` · risk `medium` · substrate `none`
-  - rationale: A value-graph clamp canonicalization over already-proven scalar min/max facts; lo<=hi precondition and float NaN are the soundness boundaries (machine-checked in formal/Clamp.lean).
+  - rationale: A value-graph clamp canonicalization over already-proven scalar min/max facts; lo<=hi precondition and float NaN are the soundness boundaries (machine-checked in formal/obligations/normalize/value_graph/clamp/Proof.lean).
   - human evidence: `numeric-clamp-minmax-ternary-real-miss` → **real-miss** (numeric_clamp / clamp_minmax_composition)
 
 ### `own_property_guard` — Own-property guard forms

--- a/bench/type4/frontier_platform.py
+++ b/bench/type4/frontier_platform.py
@@ -811,13 +811,13 @@ TARGET_PACKETS = [
         "evidence_case_ids": ["numeric-clamp-minmax-ternary-real-miss"],
         "owner_route": "proof-fact-prerequisite",
         "owner_issue": None,
-        "why_now": "A genuine machine-checked semantic under-merge (formal/Clamp.lean) that is "
+        "why_now": "A genuine machine-checked semantic under-merge (formal/obligations/normalize/value_graph/clamp/Proof.lean) that is "
         "broad and generalizing — present in all 7 corpus primary languages on both the dev and "
         "held-out splits. It is NOT directly implementable: the merge is sound only under "
         "`lo <= hi`, and no existing proof fact establishes bound ordering. This packet's value "
         "is identifying the next proof fact to pursue, with a machine-checked target invariant.",
         "blocked_by": [
-            "bound-order / guarded-range proof fact that `lo <= hi` (formal/Clamp.lean proves "
+            "bound-order / guarded-range proof fact that `lo <= hi` (formal/obligations/normalize/value_graph/clamp/Counterexamples.lean proves "
             "the precondition is required; existing scalar min/max facts do not prove it, and "
             "parameter naming such as fzf `Constrain(val, minimum, maximum)` is not a proof)",
             "float-NaN domain exclusion (min/max builtins vs comparison chains can diverge on "

--- a/bench/type4/frontier_platform.v1.json
+++ b/bench/type4/frontier_platform.v1.json
@@ -833,7 +833,7 @@
       "candidate_id": "numeric_clamp",
       "curated": {
         "implementation_cost": "medium",
-        "rationale": "A value-graph clamp canonicalization over already-proven scalar min/max facts; lo<=hi precondition and float NaN are the soundness boundaries (machine-checked in formal/Clamp.lean).",
+        "rationale": "A value-graph clamp canonicalization over already-proven scalar min/max facts; lo<=hi precondition and float NaN are the soundness boundaries (machine-checked in formal/obligations/normalize/value_graph/clamp/Proof.lean).",
         "soundness_risk": "medium",
         "substrate_required": "none"
       },
@@ -846,7 +846,7 @@
           {
             "candidate_axis": "numeric_clamp / clamp_minmax_composition",
             "case_id": "numeric-clamp-minmax-ternary-real-miss",
-            "proof_invariant": "Recognize clamp as min(max(x,lo),hi) = max(min(x,hi),lo) = two-comparison form ONLY with proven scalar min/max facts and a lo <= hi precondition; reject swapped bound order min(max(x,hi),lo), wrong nesting max(min(x,lo),hi), the lo>hi precondition violation, and float NaN (where min/max builtins vs comparison chains can diverge by language). Machine-checked in formal/Clamp.lean.",
+            "proof_invariant": "Recognize clamp as min(max(x,lo),hi) = max(min(x,hi),lo) = two-comparison form ONLY with proven scalar min/max facts and a lo <= hi precondition; reject swapped bound order min(max(x,hi),lo), wrong nesting max(min(x,lo),hi), the lo>hi precondition violation, and float NaN (where min/max builtins vs comparison chains can diverge by language). Machine-checked in formal/obligations/normalize/value_graph/clamp/Proof.lean.",
             "status": "real-miss"
           }
         ],

--- a/bench/type4/frontier_target_packets.md
+++ b/bench/type4/frontier_target_packets.md
@@ -14,18 +14,18 @@ status) and adds team routing. See [frontier-platform](../../docs/frontier-platf
 - **owner route**: `proof-fact-prerequisite` (no team yet) · evidence tier: `frontier-recorded` · cost `medium` · risk `medium` · substrate `none`
 - **breadth**: repo 25% · primary-language 100% (7/7) · dev 14 · held-out 12 · both-splits
 - **semantic claim**: min(max(x,lo),hi), max(min(x,hi),lo), and (x<lo ? lo : (x>hi ? hi : x)) all denote the same clamp for a totally-ordered numeric domain with lo <= hi. The boltons `clamp` and the fzf `Constrain` are the two canonical min/max compositions, in different languages, and should converge.
-- **proof invariant**: Recognize clamp as min(max(x,lo),hi) = max(min(x,hi),lo) = two-comparison form ONLY with proven scalar min/max facts and a lo <= hi precondition; reject swapped bound order min(max(x,hi),lo), wrong nesting max(min(x,lo),hi), the lo>hi precondition violation, and float NaN (where min/max builtins vs comparison chains can diverge by language). Machine-checked in formal/Clamp.lean.
+- **proof invariant**: Recognize clamp as min(max(x,lo),hi) = max(min(x,hi),lo) = two-comparison form ONLY with proven scalar min/max facts and a lo <= hi precondition; reject swapped bound order min(max(x,hi),lo), wrong nesting max(min(x,lo),hi), the lo>hi precondition violation, and float NaN (where min/max builtins vs comparison chains can diverge by language). Machine-checked in formal/obligations/normalize/value_graph/clamp/Proof.lean.
 - **hard negatives**:
-  - swapped bound order min(max(x, hi), lo) -- Clamp.lean swapped_bounds_not_clamp
-  - wrong nesting max(min(x, lo), hi) -- Clamp.lean wrong_nesting_not_clamp
-  - lo > hi precondition violation: the two compositions diverge -- Clamp.lean precondition_required
+  - swapped bound order min(max(x, hi), lo) -- clamp Counterexamples.lean swapped_bounds_not_clamp
+  - wrong nesting max(min(x, lo), hi) -- clamp Counterexamples.lean wrong_nesting_not_clamp
+  - lo > hi precondition violation: the two compositions diverge -- clamp Counterexamples.lean precondition_required
   - float NaN inputs where min/max builtins and comparison chains can return different values depending on language NaN semantics
 - **evidence**: `numeric-clamp-minmax-ternary-real-miss` (`real_frontier.v1.json`)
 - **representative locations**:
   - `boltons` (heldout, Python) `boltons/mathutils.py:40-69`
   - `fzf` (heldout, Go) `src/util/util.go:63-65`
 - **current detector result**: miss=True · `nose 0.5.0` @ `58c4c9b0c513` — abs control merges (1 family: absTern, absBuilt); the clamp forms (clampTern, clampBuilt) are NOT merged.
-- **why now**: A genuine machine-checked semantic under-merge (formal/Clamp.lean) that is broad and generalizing — present in all 7 corpus primary languages on both the dev and held-out splits. It is NOT directly implementable: the merge is sound only under `lo <= hi`, and no existing proof fact establishes bound ordering. This packet's value is identifying the next proof fact to pursue, with a machine-checked target invariant.
-- **blocked by**: bound-order / guarded-range proof fact that `lo <= hi` (formal/Clamp.lean proves the precondition is required; existing scalar min/max facts do not prove it, and parameter naming such as fzf `Constrain(val, minimum, maximum)` is not a proof), float-NaN domain exclusion (min/max builtins vs comparison chains can diverge on NaN, by language)
+- **why now**: A genuine machine-checked semantic under-merge (formal/obligations/normalize/value_graph/clamp/Proof.lean) that is broad and generalizing — present in all 7 corpus primary languages on both the dev and held-out splits. It is NOT directly implementable: the merge is sound only under `lo <= hi`, and no existing proof fact establishes bound ordering. This packet's value is identifying the next proof fact to pursue, with a machine-checked target invariant.
+- **blocked by**: bound-order / guarded-range proof fact that `lo <= hi` (formal/obligations/normalize/value_graph/clamp/Counterexamples.lean proves the precondition is required; existing scalar min/max facts do not prove it, and parameter naming such as fzf `Constrain(val, minimum, maximum)` is not a proof), float-NaN domain exclusion (min/max builtins vs comparison chains can diverge on NaN, by language)
 - **notes**: Value-graph clamp canonicalization, blocked on a bound-order proof fact. Routed proof-fact-prerequisite per #50 decision 3: it must NOT be handed to a Team A implementation batch until the precondition is provable, or it would merge clamps without rejecting the swapped/inverted-bound hard negatives. boltons `clamp` source-proves `lower <= upper` via an explicit `raise ValueError` guard — the narrow slice a future guarded-range proof fact would target; fzf `Constrain` only names its bounds.
 

--- a/bench/type4/frontier_target_packets.v1.json
+++ b/bench/type4/frontier_target_packets.v1.json
@@ -19,7 +19,7 @@
   "packets": [
     {
       "blocked_by": [
-        "bound-order / guarded-range proof fact that `lo <= hi` (formal/Clamp.lean proves the precondition is required; existing scalar min/max facts do not prove it, and parameter naming such as fzf `Constrain(val, minimum, maximum)` is not a proof)",
+        "bound-order / guarded-range proof fact that `lo <= hi` (formal/obligations/normalize/value_graph/clamp/Counterexamples.lean proves the precondition is required; existing scalar min/max facts do not prove it, and parameter naming such as fzf `Constrain(val, minimum, maximum)` is not a proof)",
         "float-NaN domain exclusion (min/max builtins vs comparison chains can diverge on NaN, by language)"
       ],
       "breadth": {
@@ -59,7 +59,7 @@
       "candidate_axis": "numeric_clamp",
       "curated": {
         "implementation_cost": "medium",
-        "rationale": "A value-graph clamp canonicalization over already-proven scalar min/max facts; lo<=hi precondition and float NaN are the soundness boundaries (machine-checked in formal/Clamp.lean).",
+        "rationale": "A value-graph clamp canonicalization over already-proven scalar min/max facts; lo<=hi precondition and float NaN are the soundness boundaries (machine-checked in formal/obligations/normalize/value_graph/clamp/Proof.lean).",
         "soundness_risk": "medium",
         "substrate_required": "none"
       },
@@ -78,9 +78,9 @@
       ],
       "evidence_tier": "frontier-recorded",
       "hard_negative_siblings": [
-        "swapped bound order min(max(x, hi), lo) -- Clamp.lean swapped_bounds_not_clamp",
-        "wrong nesting max(min(x, lo), hi) -- Clamp.lean wrong_nesting_not_clamp",
-        "lo > hi precondition violation: the two compositions diverge -- Clamp.lean precondition_required",
+        "swapped bound order min(max(x, hi), lo) -- clamp Counterexamples.lean swapped_bounds_not_clamp",
+        "wrong nesting max(min(x, lo), hi) -- clamp Counterexamples.lean wrong_nesting_not_clamp",
+        "lo > hi precondition violation: the two compositions diverge -- clamp Counterexamples.lean precondition_required",
         "float NaN inputs where min/max builtins and comparison chains can return different values depending on language NaN semantics"
       ],
       "locations": [
@@ -105,9 +105,9 @@
       "owner_issue": null,
       "owner_route": "proof-fact-prerequisite",
       "packet_id": "numeric-clamp-2026-06-06",
-      "proof_invariant": "Recognize clamp as min(max(x,lo),hi) = max(min(x,hi),lo) = two-comparison form ONLY with proven scalar min/max facts and a lo <= hi precondition; reject swapped bound order min(max(x,hi),lo), wrong nesting max(min(x,lo),hi), the lo>hi precondition violation, and float NaN (where min/max builtins vs comparison chains can diverge by language). Machine-checked in formal/Clamp.lean.",
+      "proof_invariant": "Recognize clamp as min(max(x,lo),hi) = max(min(x,hi),lo) = two-comparison form ONLY with proven scalar min/max facts and a lo <= hi precondition; reject swapped bound order min(max(x,hi),lo), wrong nesting max(min(x,lo),hi), the lo>hi precondition violation, and float NaN (where min/max builtins vs comparison chains can diverge by language). Machine-checked in formal/obligations/normalize/value_graph/clamp/Proof.lean.",
       "semantic_claim": "min(max(x,lo),hi), max(min(x,hi),lo), and (x<lo ? lo : (x>hi ? hi : x)) all denote the same clamp for a totally-ordered numeric domain with lo <= hi. The boltons `clamp` and the fzf `Constrain` are the two canonical min/max compositions, in different languages, and should converge.",
-      "why_now": "A genuine machine-checked semantic under-merge (formal/Clamp.lean) that is broad and generalizing \u2014 present in all 7 corpus primary languages on both the dev and held-out splits. It is NOT directly implementable: the merge is sound only under `lo <= hi`, and no existing proof fact establishes bound ordering. This packet's value is identifying the next proof fact to pursue, with a machine-checked target invariant."
+      "why_now": "A genuine machine-checked semantic under-merge (formal/obligations/normalize/value_graph/clamp/Proof.lean) that is broad and generalizing \u2014 present in all 7 corpus primary languages on both the dev and held-out splits. It is NOT directly implementable: the merge is sound only under `lo <= hi`, and no existing proof fact establishes bound ordering. This packet's value is identifying the next proof fact to pursue, with a machine-checked target invariant."
     }
   ],
   "schema_version": 1,

--- a/bench/type4/real_frontier.v1.json
+++ b/bench/type4/real_frontier.v1.json
@@ -827,7 +827,7 @@
         }
       ],
       "semantic_claim": "min(max(x,lo),hi), max(min(x,hi),lo), and (x<lo ? lo : (x>hi ? hi : x)) all denote the same clamp for a totally-ordered numeric domain with lo <= hi. The boltons `clamp` and the fzf `Constrain` are the two canonical min/max compositions, in different languages, and should converge.",
-      "evidence": "formal/Clamp.lean machine-checks the identity and its hard negatives (self-contained Lean 4, no Mathlib). A 196-case integer battery confirms min(max)==max(min)==ternary for every lo<=hi. A controlled semantic scan shows the abs idiom DOES merge (absTern/absBuilt, 1 family) while the clamp idiom does NOT (clampTern/clampBuilt, 0 clamp family); boltons `clamp` and fzf `Constrain` do not merge across files. The idiom appears in 26 repos across all 7 primary languages on both splits (frontier_platform breadth).",
+      "evidence": "the clamp obligation machine-checks the identity and its hard negatives (self-contained Lean 4, no Mathlib). A 196-case integer battery confirms min(max)==max(min)==ternary for every lo<=hi. A controlled semantic scan shows the abs idiom DOES merge (absTern/absBuilt, 1 family) while the clamp idiom does NOT (clampTern/clampBuilt, 0 clamp family); boltons `clamp` and fzf `Constrain` do not merge across files. The idiom appears in 26 repos across all 7 primary languages on both splits (frontier_platform breadth).",
       "detector": {
         "current_detector_miss": true,
         "binary_path": "/Users/ak/prjs/cc/nose/target/release/nose",
@@ -838,16 +838,16 @@
         "semantic_scan_result": "nose scan boltons/boltons/mathutils.py fzf/src/util/util.go --mode semantic --format json --top 0 --min-size 1 --min-lines 1: the clamp pair is not merged across files.",
         "default_scan_result": "Cross-language pair; the value graph does not canonicalize clamp, so syntax/semantic default does not merge them either."
       },
-      "proof_invariant": "Recognize clamp as min(max(x,lo),hi) = max(min(x,hi),lo) = two-comparison form ONLY with proven scalar min/max facts and a lo <= hi precondition; reject swapped bound order min(max(x,hi),lo), wrong nesting max(min(x,lo),hi), the lo>hi precondition violation, and float NaN (where min/max builtins vs comparison chains can diverge by language). Machine-checked in formal/Clamp.lean.",
+      "proof_invariant": "Recognize clamp as min(max(x,lo),hi) = max(min(x,hi),lo) = two-comparison form ONLY with proven scalar min/max facts and a lo <= hi precondition; reject swapped bound order min(max(x,hi),lo), wrong nesting max(min(x,lo),hi), the lo>hi precondition violation, and float NaN (where min/max builtins vs comparison chains can diverge by language). Machine-checked in formal/obligations/normalize/value_graph/clamp/Proof.lean.",
       "hard_negative_siblings": [
-        "swapped bound order min(max(x, hi), lo) -- Clamp.lean swapped_bounds_not_clamp",
-        "wrong nesting max(min(x, lo), hi) -- Clamp.lean wrong_nesting_not_clamp",
-        "lo > hi precondition violation: the two compositions diverge -- Clamp.lean precondition_required",
+        "swapped bound order min(max(x, hi), lo) -- clamp Counterexamples.lean swapped_bounds_not_clamp",
+        "wrong nesting max(min(x, lo), hi) -- clamp Counterexamples.lean wrong_nesting_not_clamp",
+        "lo > hi precondition violation: the two compositions diverge -- clamp Counterexamples.lean precondition_required",
         "float NaN inputs where min/max builtins and comparison chains can return different values depending on language NaN semantics"
       ],
       "batch": null,
-      "reverify": "Re-run the controlled abs-vs-clamp semantic scan and the boltons/fzf cross-file scan; re-check formal/Clamp.lean type-checks. Reclassify if a future value-graph clamp canonicalization lands (then status -> closed).",
-      "notes": "Issue #50 Team B target packet evidence (linked by frontier_target_packets). A real, machine-checked semantic under-merge. Routed proof-fact-prerequisite, NOT directly implementable: formal/Clamp.lean proves the lo<=hi precondition is required, and no existing scalar min/max fact proves bound ordering — parameter naming (e.g. fzf Constrain(val, minimum, maximum)) is not a proof. A new bound-order / guarded-range proof fact (and a float-NaN domain exclusion) is the prerequisite before any detector batch."
+      "reverify": "Re-run the controlled abs-vs-clamp semantic scan and the boltons/fzf cross-file scan; re-check formal/obligations/normalize/value_graph/clamp/Proof.lean type-checks. Reclassify if a future value-graph clamp canonicalization lands (then status -> closed).",
+      "notes": "Issue #50 Team B target packet evidence (linked by frontier_target_packets). A real, machine-checked semantic under-merge. Routed proof-fact-prerequisite, NOT directly implementable: formal/obligations/normalize/value_graph/clamp/Counterexamples.lean proves the lo<=hi precondition is required, and no existing scalar min/max fact proves bound ordering — parameter naming (e.g. fzf Constrain(val, minimum, maximum)) is not a proof. A new bound-order / guarded-range proof fact (and a float-NaN domain exclusion) is the prerequisite before any detector batch."
     }
   ]
 }

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -3967,7 +3967,8 @@ fn normalization_is_idempotent() {
 
 /// DISTRIBUTION / FACTORING (Num-gated): `a*c + b*c` ≡ `(a+b)*c`. The value graph factors
 /// a shared multiplicand out of a sum of products when every leaf is proven numeric
-/// (`value_graph.rs::factor_distribute`, Lean `Algebra.lean::distrib_sound`). The `*`
+/// (`value_graph/rules/factor_distribute.rs`, Lean obligation
+/// `normalize.value_graph.factor_distribute`). The `*`
 /// operands here are provably `Num`, so the factoring fires and the two forms converge.
 #[test]
 fn distribution_factors_common_multiplicand() {
@@ -3991,7 +3992,7 @@ fn distribution_factors_common_multiplicand() {
 
 /// FILTER FUSION: `filter(q, filter(p, xs))` ≡ `filter(p∧q, xs)`. The value graph carries a
 /// filter's element so nested filters fuse (`value_graph.rs` `HoFKind::Filter` arm, Lean
-/// `Functor.lean::filter_fusion`). A two-filter comprehension, an explicitly nested one, and
+/// `normalize.value_graph.functor`). A two-filter comprehension, an explicitly nested one, and
 /// (cross-language) a JS `.filter().filter()` all converge to one filtered stream.
 #[test]
 fn filter_fusion_converges() {

--- a/crates/nose-normalize/src/algebra.rs
+++ b/crates/nose-normalize/src/algebra.rs
@@ -139,7 +139,7 @@ impl Rewriter<'_> {
         }
         match op {
             // Canonicalize comparison direction by reflecting the order: `a > b` → `b < a`
-            // (Lean `Compare.lean::gt_eq_lt_swap`), `a >= b` → `b <= a` (`ge_eq_le_swap`).
+            // (`normalize.value_graph.compare`), `a >= b` → `b <= a`.
             // Both arms swap the operands and emit the mirror operator; only the target
             // opcode differs.
             Op::Gt | Op::Ge => {
@@ -298,7 +298,7 @@ impl Rewriter<'_> {
                     //   !(x > y)  = x <= y   !(x >= y) = x < y     (operands stay)
                     // The strict/non-strict polarity flips (`<`,`>` → `<=`; `<=`,`>=` → `<`),
                     // and only the already-reflected `<`/`<=` cases swap operands so the result
-                    // points the canonical way. Lean: `Compare.lean::not_lt_eq_ge`+`ge_eq_le_swap`,
+                    // points the canonical way. Lean obligation: `normalize.value_graph.compare`,
                     // `not_le_eq_gt`+`gt_eq_lt_swap`, `not_gt_eq_le`, `not_ge_eq_lt`.
                     Op::Lt | Op::Le | Op::Gt | Op::Ge => {
                         let flip = if matches!(op, Op::Lt | Op::Gt) {

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -18,6 +18,8 @@
 //! This is a *detection substrate*, not an IL rewrite: it returns a fingerprint
 //! the detector can use instead of (or alongside) subtree shapes.
 
+mod rules;
+
 use crate::combine;
 use crate::module_facts::{
     assignment_name_in, collect_all_node_symbols, collect_module_mutations, mutating_method_name,
@@ -1687,9 +1689,10 @@ impl<'a> Builder<'a> {
             // DISTRIBUTION / FACTORING: `x*f + y*f → (x+y)*f`. Canonicalizes toward the
             // factored form so `a*c + b*c` converges with `(a+b)*c`. Sound ONLY on numbers —
             // string `*int` is repetition, where `"a"*2 + "b"*2` ("aabb") ≠ `("a"+"b")*2`
-            // ("abab") — so every leaf must be PROVEN `Num`. Lean: `Algebra.lean::distrib_sound`.
+            // ("abab") — so every leaf must be PROVEN `Num`. Lean obligation:
+            // `normalize.value_graph.factor_distribute`.
             if o == Op::Add as u32 && args.len() == 2 {
-                if let Some(v) = self.factor_distribute(args[0], args[1]) {
+                if let Some(v) = rules::factor_distribute::apply(self, args[0], args[1]) {
                     return v;
                 }
             }
@@ -1726,9 +1729,9 @@ impl<'a> Builder<'a> {
                     // conjunction/disjunction converges with the strict comparison:
                     //   (x ≤ y) ∧ (x ≠ y) → x < y     (dual of below)
                     //   (x < y) ∨ (x = y) → x ≤ y
-                    // Sound for any total order (Lean `Compare.lean::le_and_ne_eq_lt`); on a
-                    // type error every comparison Errs identically on both sides. It composes
-                    // through the recursive `mk` fixpoint, so `not (a>b or a==b)` reaches `a<b`.
+                    // Sound for any total order (`normalize.value_graph.compare`); on a type
+                    // error every comparison Errs identically on both sides. It composes through
+                    // the recursive `mk` fixpoint, so `not (a>b or a==b)` reaches `a<b`.
                     if is_and {
                         if let Some(v) = self.lattice_strict_absorbs_nonstrict(args[0], args[1]) {
                             return v;
@@ -1787,7 +1790,7 @@ impl<'a> Builder<'a> {
         // built. The value graph thus canonicalizes AC chains itself, not only via the
         // earlier `algebra` IL pass (which keyed by a different hash and did not see nodes
         // synthesized here). Sound: any operand permutation of an AC chain is denotation-
-        // preserving (Lean `Algebra.lean::canon_sound`). String/list `+` is NOT reordered
+        // preserving (`normalize.value_graph.algebra`). String/list `+` is NOT reordered
         // (it is ordered concat); `* & | ^` Err on non-numeric regardless of order.
         if let ValOp::Bin(o) = op {
             if is_assoc_comm_code(o) && args.len() == 2 {
@@ -1924,43 +1927,6 @@ impl<'a> Builder<'a> {
         self.mk(ValOp::Opaque(c as u64), vec![])
     }
 
-    /// Factor a common multiplicand out of a sum of two products: `x*f + y*f → (x+y)*f`.
-    /// Returns the factored value id when both operands are 2-ary `Mul` nodes sharing
-    /// exactly one factor AND every leaf is a PROVEN `Num` (distribution is unsound on the
-    /// string/list `*`-as-repetition monoid). Terminates: the rebuilt `Add(x,y)` has
-    /// non-`Mul` leaves, so it does not re-distribute. Lean: `Algebra.lean::distrib_sound`.
-    fn factor_distribute(&mut self, a: ValueId, b: ValueId) -> Option<ValueId> {
-        let mul = Op::Mul as u32;
-        let as_mul = |v: ValueId, s: &Self| -> Option<(ValueId, ValueId)> {
-            if let ValOp::Bin(o) = s.nodes[v as usize].op {
-                if o == mul && s.nodes[v as usize].args.len() == 2 {
-                    let ar = &s.nodes[v as usize].args;
-                    return Some((ar[0], ar[1]));
-                }
-            }
-            None
-        };
-        let (a0, a1) = as_mul(a, self)?;
-        let (b0, b1) = as_mul(b, self)?;
-        // (distributed-from-a, distributed-from-b, shared factor)
-        let (x, y, f) = if a0 == b0 {
-            (a1, b1, a0)
-        } else if a0 == b1 {
-            (a1, b0, a0)
-        } else if a1 == b0 {
-            (a0, b1, a1)
-        } else if a1 == b1 {
-            (a0, b0, a1)
-        } else {
-            return None;
-        };
-        if self.vty(x) != Ty::Num || self.vty(y) != Ty::Num || self.vty(f) != Ty::Num {
-            return None;
-        }
-        let sum = self.mk(ValOp::Bin(Op::Add as u32), vec![x, y]);
-        Some(self.mk(ValOp::Bin(mul), vec![sum, f]))
-    }
-
     /// The operands of a comparison node `cmp`, if it has opcode `want`. `Le`/`Lt` are
     /// ORDERED (operands kept in source order); `Eq`/`Ne` are COMMUTATIVE (operands
     /// vhash-sorted), so callers compare them as an unordered pair.
@@ -2001,7 +1967,7 @@ impl<'a> Builder<'a> {
     }
 
     /// `(x ≤ y) ∧ (x ≠ y) → x < y`. Sound on a total order
-    /// (Lean `Compare.lean::le_and_ne_eq_lt`); the post-normalize oracle re-checks it.
+    /// (`normalize.value_graph.compare`); the post-normalize oracle re-checks it.
     fn lattice_le_ne_to_lt(&mut self, a: ValueId, b: ValueId) -> Option<ValueId> {
         self.lattice_pair_canon(a, b, Op::Le as u32, Op::Ne as u32, Op::Lt as u32)
     }
@@ -2031,7 +1997,7 @@ impl<'a> Builder<'a> {
     }
 
     /// `(x < y) ∨ (x = y) → x ≤ y` — the dual of [`lattice_le_ne_to_lt`] over `∨`
-    /// (Lean `Compare.lean::lt_or_eq_eq_le`).
+    /// (`normalize.value_graph.compare`).
     fn lattice_lt_eq_to_le(&mut self, a: ValueId, b: ValueId) -> Option<ValueId> {
         self.lattice_pair_canon(a, b, Op::Lt as u32, Op::Eq as u32, Op::Le as u32)
     }
@@ -2667,7 +2633,7 @@ impl<'a> Builder<'a> {
     /// The canonical value of a dict key→value entry — `Call(DictEntry, [k, v])` — shared by
     /// a dict `pair`, a dict-comprehension body, and a `d[k]=v` building loop, so all three
     /// converge, while staying DISTINCT from a tuple `Seq([k, v])` (a list of pairs is a
-    /// different value than a dict). Lean: `Functor.lean::map_dict_entry` (the build is a map).
+    /// different value than a dict). Covered by the functor/map obligation; the build is a map.
     fn dict_entry(&mut self, kv: Vec<ValueId>) -> ValueId {
         self.mk(ValOp::Call(builtin_tag(Builtin::DictEntry)), kv)
     }
@@ -6173,7 +6139,8 @@ impl<'a> Builder<'a> {
                         // `filter(p∧q, xs)` both reduce to `Hof(Map, [Elem(xs), p∧q])`. It
                         // also unifies a standalone filter with the filtered-loop builder
                         // (`r=[]; for x: if p: r.append(x)` → the same node) and the filtered
-                        // comprehension `[x for x in xs if p]`. Lean: `Functor.lean::filter_fusion`.
+                        // comprehension `[x for x in xs if p]`
+                        // (`normalize.value_graph.functor`).
                         let (elems, carried_pred) = self.map_source(kids.first().copied(), env);
                         let elem = elems
                             .first()

--- a/crates/nose-normalize/src/value_graph/rules.rs
+++ b/crates/nose-normalize/src/value_graph/rules.rs
@@ -1,0 +1,7 @@
+//! Proof-sensitive value-graph rules.
+//!
+//! Any new semantic rewrite in this module tree must have a matching
+//! `formal/obligations/normalize/value_graph/<rule>/meta.toml` entry. The
+//! formal-obligation linter checks that directory/file pairing mechanically.
+
+pub(super) mod factor_distribute;

--- a/crates/nose-normalize/src/value_graph/rules/factor_distribute.rs
+++ b/crates/nose-normalize/src/value_graph/rules/factor_distribute.rs
@@ -1,0 +1,50 @@
+//! Factor a common multiplicand out of a sum of two products.
+//!
+//! Rule:
+//! `x*f + y*f -> (x+y)*f`
+//!
+//! The rule fires only when both operands are 2-ary `Mul` nodes sharing exactly one factor
+//! and every leaf is a proven `Num`. Distribution is unsound for the string/list
+//! repetition monoid, so the type gate is part of the proof obligation.
+
+use super::super::{Builder, ValOp, ValueId};
+use crate::types::Ty;
+use nose_il::Op;
+
+pub(in super::super) fn apply(
+    builder: &mut Builder<'_>,
+    a: ValueId,
+    b: ValueId,
+) -> Option<ValueId> {
+    let mul = Op::Mul as u32;
+    let (a0, a1) = as_mul(builder, a)?;
+    let (b0, b1) = as_mul(builder, b)?;
+    // (distributed-from-a, distributed-from-b, shared factor)
+    let (x, y, f) = if a0 == b0 {
+        (a1, b1, a0)
+    } else if a0 == b1 {
+        (a1, b0, a0)
+    } else if a1 == b0 {
+        (a0, b1, a1)
+    } else if a1 == b1 {
+        (a0, b0, a1)
+    } else {
+        return None;
+    };
+    if builder.vty(x) != Ty::Num || builder.vty(y) != Ty::Num || builder.vty(f) != Ty::Num {
+        return None;
+    }
+    let sum = builder.mk(ValOp::Bin(Op::Add as u32), vec![x, y]);
+    Some(builder.mk(ValOp::Bin(mul), vec![sum, f]))
+}
+
+fn as_mul(builder: &Builder<'_>, value: ValueId) -> Option<(ValueId, ValueId)> {
+    let mul = Op::Mul as u32;
+    if let ValOp::Bin(op) = builder.nodes[value as usize].op {
+        if op == mul && builder.nodes[value as usize].args.len() == 2 {
+            let args = &builder.nodes[value as usize].args;
+            return Some((args[0], args[1]));
+        }
+    }
+    None
+}

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -64,7 +64,7 @@ Before merge or release-sensitive work, run the full local CI mirror:
 
 The full gate mirrors the GitHub Actions jobs: format, clippy, rustdoc warnings,
 release build/tests, the self-hosted duplication gate, MSRV check, supply-chain
-checks, docs wiki connectivity, and Lean soundness proofs.
+checks, docs wiki connectivity, the formal obligation registry, and Lean soundness proofs.
 
 ## Baselines — incremental adoption
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -555,7 +555,8 @@ false merge and gets rolled back.** **Phase 0** drove false merges 15 → 0 via 
 language-general fixes (subtree-hash keying for `Raw` nodes, dead-code-after-unconditional-return
 drop, last-write-wins per field, `Err` propagation through conditions, excluding empty
 fingerprints from `verify`). **Phase 1** moved the soundness contract from empirical ("0 merges on
-N repos") to **proven in Lean 4** (`formal/Algebra.lean`, `Control.lean`, `Functor.lean`:
+N repos") to **proven in Lean 4** (`normalize.value_graph.algebra`,
+`normalize.control_flow.guard_returns`, `normalize.value_graph.functor`:
 AC-flatten+sort denotation-preserving, `a − b → a + (−b)`, guard-clause ≡ if-else, map-fusion
 functor law). Bold canons were verifier-gated: untyped `-(-x) → x` / `x & x → x` were **refuted
 (caught 17 false merges** — they drop the operator's type-error behavior), then re-enabled
@@ -616,10 +617,10 @@ A focused pass to raise *exact* Type-4 convergence while holding full-corpus `ve
 backing each algebraic law with a Lean proof. **Adopted** (93 equivalence tests green, SOUND):
 fixpoint param-type inference over subexpression result types (`types.rs`, licensing the gated
 numeric rewrites); distribution/factoring `a*c + b*c → (a+b)*c` gated on proven Num
-(`Algebra.lean::distrib_sound`); full **AC canonicalization in the value graph itself** (`mk`
+(`NoseAlgebra.distrib_sound`); full **AC canonicalization in the value graph itself** (`mk`
 flattens+sorts `+ * & | ^`, so *synthesized* nodes re-canonicalize, not only the IL algebra pass);
 **filter fusion** representing `filter(p, c)` as a filtered identity-map `Hof(Map, [Elem c, p])` so
-nested filters fuse to `p ∧ q` (`Functor.lean::filter_fusion` — the deferred "make Filter carry its
+nested filters fuse to `p ∧ q` (`NoseFunctor.filter_fusion` — the deferred "make Filter carry its
 element"; an earlier peel-to-bare-`Filter` caused 2 false merges, this does not); reduce-lambda
 min/max selection; count-of-filter; method-form iterator reductions
 (`xs.iter().filter(p).sum()` ≡ Python `sum(… if p)`); and **dict-builder ≡ dict-comprehension**,
@@ -631,7 +632,8 @@ language-semantic divergences, not representation gaps.* Verdict: **full-corpus 
 false merges across 28,113 interpretable units, and the v5 refactoring-precision number is
 unchanged — reconfirming §AY that behavioral-convergence gains don't move the judgment-deep
 number while costing nothing there. The win is squarely on the exact-Type-4 axis.** The Lean core
-gained `Compare.lean`; a `formal` CI job regression-checks all theorems.
+gained the `normalize.value_graph.compare` obligation; a `formal` CI job regression-checks all
+theorems.
 
 ## BB. Confluence audit + lattice comparison canon (rules, not a new engine)
 
@@ -642,7 +644,8 @@ reproduces §C/§AW by construction: **the lever is new sound rules, not a bette
 engine** — an e-graph would still need each rule declared, and the fixpoint it buys is largely
 already present. The one gap was the lattice identity `(x ≤ y) ∧ (x ≠ y) ≡ x < y`; adding just that
 one rule (`value_graph.rs lattice_le_ne_to_lt` + dual) *composes through the `mk` fixpoint* to close
-the full cross-language `not(a > b or a == b) ≡ a < b`. Sound on any total order (`Compare.lean`).
+the full cross-language `not(a > b or a == b) ≡ a < b`. Sound on any total order
+(`normalize.value_graph.compare`).
 
 ## BC–BF. Behavioral-equivalence gate and widening the oracle
 

--- a/docs/formal-soundness.md
+++ b/docs/formal-soundness.md
@@ -1,0 +1,52 @@
+# Formal soundness obligations
+
+Back to [home](home.md). The runtime soundness check is described in
+[benchmark](benchmark.md); the rewrite pipeline is in [normalization](normalization.md).
+
+nose uses Lean 4 as a proof-obligation registry for semantic rewrites whose soundness should
+not depend only on corpus coverage. The registry lives under
+[`formal/obligations`](../formal/obligations), and each obligation directory contains:
+
+- `meta.toml` — the id, status, related Rust files/symbols, theorem names, assumptions, and
+  optional counterexample theorem names.
+- `Proof.lean` — positive proof that the accepted rewrite preserves the modeled semantics.
+- `Counterexamples.lean` — optional boundary proof for rewrites or missing preconditions that
+  must stay closed.
+
+The obligation id must match its path. For example,
+`formal/obligations/normalize/value_graph/factor_distribute/meta.toml` declares
+`normalize.value_graph.factor_distribute`.
+
+## Named rule modules
+
+For new proof-sensitive rewrites, prefer a named Rust rule module instead of adding another
+case inside a large canonicalizer function. The current standard is:
+
+```text
+crates/nose-normalize/src/value_graph/rules/<rule>.rs
+formal/obligations/normalize/value_graph/<rule>/meta.toml
+```
+
+The linter checks that every file in `value_graph/rules/*.rs` has a matching obligation and
+that the matching obligation sets `rust.rule_module = true`. This makes omission visible:
+a new named semantic rule cannot be added without registering its proof state.
+
+## Statuses
+
+- `proven` — Lean proof file and theorem names are present and type-check.
+- `covered` — the rule is covered by another registered obligation.
+- `missing` — the obligation is acknowledged but not proved yet.
+- `empirical-only` — currently guarded by the interpreter oracle or tests only.
+- `rejected-counterexample` — the registry records why a tempting rewrite must stay closed.
+
+## Local checks
+
+```sh
+python3 scripts/check-formal-obligations.py
+while IFS= read -r f; do
+  lean --error=warning "$f"
+done < <(find formal -name '*.lean' -print | sort)
+```
+
+The full local CI mirror runs both checks. Lean warnings are errors, so `sorry` and unused
+proof hints fail the gate.

--- a/docs/formal-soundness.md
+++ b/docs/formal-soundness.md
@@ -42,6 +42,7 @@ a new named semantic rule cannot be added without registering its proof state.
 ## Local checks
 
 ```sh
+python3 scripts/check-formal-obligations.py --self-test
 python3 scripts/check-formal-obligations.py
 while IFS= read -r f; do
   lean --error=warning "$f"

--- a/docs/frontier-platform.md
+++ b/docs/frontier-platform.md
@@ -84,7 +84,7 @@ conclusion cannot silently drift when an axis is added or removed.
 
 The first extra axis is `numeric_clamp` — `min(max(x, lo), hi)` clamp composition, a real
 under-merge whose identity and hard negatives are machine-checked in
-[`formal/Clamp.lean`](../formal/Clamp.lean).
+[`formal/obligations/normalize/value_graph/clamp/Proof.lean`](../formal/obligations/normalize/value_graph/clamp/Proof.lean).
 
 ## Target packets (`frontier_target_packets.v1.json`)
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -42,6 +42,7 @@ You want to *change* nose or understand how it works inside.
 - [architecture](architecture.md) — the crates and the lower → normalize → detect → rank pipeline.
 - [normalization](normalization.md) — the passes that make behaviorally-equivalent code converge (the hard part).
 - [fragment-contracts](fragment-contracts.md) — how exact sub-function fragments are modeled: classification, contract, the wrapper-synthesis behavior oracle, the effect algebra, and fail-closed receiver identity.
+- [formal-soundness](formal-soundness.md) — Lean 4 proof-obligation registry for proof-sensitive semantic rewrites, including named rule modules and counterexample files.
 - [hazard-ranking](hazard-ranking.md) — the evidence base for the experimental `--sort hazard` (a divergence-*propensity* signal; **not** a validated harm ranker — it ranks actual harm near chance) and the honest evaluation trail.
 - [hazard-benchmark](hazard-benchmark.md) — the evaluation criteria and labeled dataset hazard is measured against (repo selection, graded labels, quantitative sufficiency).
 - [hazard-release-checklist](hazard-release-checklist.md) — what to do for the hazard ranking on every new nose release (one-page runbook: refresh the dataset, re-tune, re-validate).

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -46,8 +46,9 @@
 > literal; the interpreter now executes self-recursion so `nose verify` interprets the
 > pre-canon recursive form and validates the rewrite (see *Recursion → iteration* below).
 > Soundness enforced by the independent interpreter oracle + canon-preservation check
-> (`nose verify`) and Lean proofs (`formal/`, incl. `distrib_sound`, `filter_fusion`,
-> `Compare.lean`); see §AJ/§AW/§AX/§BA.
+> (`nose verify`) and Lean proof obligations (`formal/obligations`, incl.
+> `NoseAlgebra.distrib_sound`, `NoseFunctor.filter_fusion`,
+> `normalize.value_graph.compare`); see §AJ/§AW/§AX/§BA.
 > Deferred: value-dependent folding (needs literal values), full distribution
 > (equality saturation), general CFG flag-loop↔break, and non-local early-exit variants
 > beyond the simple flag+break loop; recursion→iteration beyond the tail / numeric-monoid

--- a/formal/README.md
+++ b/formal/README.md
@@ -1,65 +1,58 @@
-# Formal core — machine-checked soundness of value-graph canonicalization
+# Formal core — machine-checked soundness obligations
 
-nose's soundness contract (§AJ) is *fingerprint-equal ⟹ behavior-equal*. Until now that
-was only **empirical** ("0 false merges on N repos", checked by `nose verify`). This
-directory makes the core canonicalization rules **machine-checked** in Lean 4: each rule
-is proven to preserve a denotational semantics of the IL, so it provably cannot change
-behavior. The empirical `verify` oracle then serves as a differential cross-check (it
-catches *lowering* gaps the formal model abstracts over).
+nose's soundness contract is *fingerprint-equal => behavior-equal*. The interpreter oracle
+(`nose verify`) checks that contract empirically against the pinned corpus; this directory
+adds a machine-checked Lean 4 layer for the proof-sensitive rewrite rules.
 
-This is the language-agnostic, rigorous layer; per-language lowering optimization rides on
-top of it (see `docs/experiments.md` §AU/§AV and the phase plan).
+The registry is directory-shaped:
 
-## Proven
+```text
+formal/obligations/<area>/<subsystem>/<rule>/
+  meta.toml
+  Proof.lean
+  Counterexamples.lean    # optional, but required when meta.toml lists counterexamples
+```
 
-- **`Algebra.lean`** — the associative-commutative operand canonicalization
-  (`value_graph.rs`: `flatten_into` + `operands.sort_by_key`). `canon_sound`: if two
-  expressions' flattened `+`-leaves are a permutation (which the structural-hash sort
-  guarantees), they have equal denotation on every environment — flatten-then-sort is
-  denotation-preserving. `sub_eq_add_neg`: `a - b ≡ a + (-b)` over `Int` (the subtraction
-  canonicalization). The commutativity premise is now *enforced* by the value graph's type
-  inference (`+` sorts only on numeric operands).
-- **`Control.lean`** — control-flow canons over a minimal statement/return semantics.
-  `guard_clause`: `if c {return a}; return b ≡ if c {return a} else {return b}` (the
-  guard-clause path narrowing); `guard_clause_cascade`; `dead_code_after_return`;
-  `ternary_return`: `return (a if c else b) ≡ if c {return a} else {return b}` (the
-  `emit_return` ternary-decomposition — composed with `guard_clause` it converges a nested
-  ternary with an `elif` cascade).
-- **`Functor.lean`** — the list-functor laws. `map_fusion`: `map g (map f xs) = map (g∘f) xs`
-  (justifies `Elem(Map f c) → f(Elem c)`, the map-fusion peel); `map_id`; `filter_fusion`:
-  `filter q (filter p xs) = filter (λx. p x ∧ q x) xs` (justifies representing `filter(p,c)`
-  as `Hof(Map, [Elem c, p])` and fusing nested filters via `and_preds`, so a two-filter
-  comprehension, a `.filter().filter()` chain, and the filtered builder loop all converge);
-  `filter_length_eq_count`: `(filter p xs).length = Σ (p x ? 1 : 0)` (justifies folding
-  `len([c for x in xs if p])` to the same count-reduce as `sum(1 for x in xs if p)`).
-- **`Compare.lean`** — comparison-direction and negated-comparison canons over `Int` (the
-  total order the interpreter evaluates). `gt_eq_lt_swap`: `a > b ≡ b < a` (the `Gt → Lt`+swap
-  canon); `ge_eq_le_swap`: `a >= b ≡ b <= a`; `not_le_eq_gt`/`not_lt_eq_ge`: `!(a<=b) ≡ a>b`,
-  `!(a<b) ≡ a>=b` (the `negate_cmp_code` complements); `not_eq_eq_ne`: `!(a==b) ≡ a!=b`.
-- **`Algebra.lean`** also has `neg_add_distrib`: `-(a+b) = -a + -b` (the `Neg(Add)` push-in)
-  and `distrib_sound`: `(x+y)*f = x*f + y*f` over `Int` (the `factor_distribute` rewrite
-  `a*c + b*c → (a+b)*c`, gated on every leaf being proven `Num` since the string/list
-  `*`-as-repetition monoid is not a ring).
-- **`BoolReduce.lean`** — the `any`/`all` predicate reductions. OR/AND are commutative
-  monoids (`or_comm`/`or_assoc`/`or_id`/`or_idem`, and the AND duals) so the seedless
-  `REDUCE_ANY`/`REDUCE_ALL` fold is well-defined; `vany_iff`/`vall_iff` show they denote
-  existence/universality, and `any_map` shows mapping-then-folding equals the cross-language
-  per-element fold — so Python `any(p(x) for x in xs)`, JS `xs.some(p)`, and Rust
-  `xs.iter().any(p)` converge to one node.
-- **`MinMax.lean`** — the 2-way min/max idiom. `min_is_ternary`/`max_is_ternary` (the
-  canonical Min/Max node IS `x if x<y else y` — definitional soundness of the recognition);
-  `vmin_comm`/`vmax_comm` (justify the commutative MIN/MAX codes); `vmin_assoc`/`vmax_assoc`
-  (justify the min/max selection *reduction*); `vmin_idem`.
+The obligation id is the dot-joined directory path. For example,
+`formal/obligations/normalize/value_graph/factor_distribute/meta.toml` must declare:
+
+```toml
+id = "normalize.value_graph.factor_distribute"
+```
+
+Proof-sensitive Rust rule modules follow the same name. A file such as
+`crates/nose-normalize/src/value_graph/rules/factor_distribute.rs` must have the matching
+obligation directory above, and `meta.toml` must set `rust.rule_module = true`. The linter
+checks this pairing mechanically, so a new named semantic rule cannot land without a
+registered proof obligation.
+
+## Registered proof families
+
+- `normalize.value_graph.algebra` — associative-commutative numeric algebra,
+  subtraction-as-add-neg, negation distribution, and distributivity over `Int`.
+- `normalize.value_graph.factor_distribute` — the named Rust rule module for
+  `x*f + y*f -> (x+y)*f`, gated to proven numeric leaves.
+- `normalize.value_graph.free_monoid` — ordered string/list builder concatenation:
+  associative with identity, not commutative, and not a ring for distribution.
+- `normalize.value_graph.compare` — comparison direction, negated comparisons, and
+  total-order lattice canons.
+- `normalize.control_flow.guard_returns` — guard-return, dead-code-after-return, and
+  ternary-return control-flow canons.
+- `normalize.value_graph.functor` — map/filter fusion and count-of-filter.
+- `normalize.value_graph.bool_reduce` — any/all Bool reductions.
+- `normalize.value_graph.min_max` — min/max select idioms and reductions.
+- `normalize.value_graph.clamp` — clamp equivalences plus boundary counterexamples.
+- `normalize.value_graph.field_writes` — final field-state semantics, last-write-wins,
+  distinct-field commutativity, and same-field order counterexample.
 
 ## Check
 
-```
-for f in formal/*.lean; do ~/.elan/bin/lean "$f"; done   # exit 0 each = proofs hold, no `sorry`
+```sh
+python3 scripts/check-formal-obligations.py
+while IFS= read -r f; do
+  lean --error=warning "$f"
+done < <(find formal -name '*.lean' -print | sort)
 ```
 
-## Next (roadmap)
-
-Formalize the remaining canons against the same semantics: field-write last-write-wins
-commutativity, the `Reduce`/fold normal form (selection reductions build on `MinMax.lean`'s
-proven min/max comm+assoc), and the free-monoid (ordered concat) model. Each proof closes a
-class of potential false merges by construction rather than by corpus coverage.
+`--error=warning` makes `sorry`, unused proof hints, and similar Lean warnings fail the
+gate. The root `lean-toolchain` pins the Lean version used by CI and local checks.

--- a/formal/obligations/normalize/control_flow/guard_returns/Proof.lean
+++ b/formal/obligations/normalize/control_flow/guard_returns/Proof.lean
@@ -9,7 +9,7 @@ Proven here:
   • dead_code_after_return — a statement after an unconditional return is unreachable
                             (value_graph.rs `process_block` dead-code break)
 
-Self-contained; check:  ~/.elan/bin/lean formal/Control.lean   (exit 0 = proofs hold)
+Self-contained; checked by the formal obligation CI gate.
 -/
 
 namespace NoseControl

--- a/formal/obligations/normalize/control_flow/guard_returns/meta.toml
+++ b/formal/obligations/normalize/control_flow/guard_returns/meta.toml
@@ -1,0 +1,17 @@
+id = "normalize.control_flow.guard_returns"
+status = "proven"
+kind = "soundness"
+summary = "Guard-return, dead-code-after-return, and ternary-return control-flow canons preserve return semantics."
+
+[rust]
+files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/cfg_norm.rs"]
+symbols = ["guarded", "process_block"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseControl.guard_clause",
+  "NoseControl.guard_clause_cascade",
+  "NoseControl.dead_code_after_return",
+  "NoseControl.ternary_return",
+]

--- a/formal/obligations/normalize/value_graph/algebra/Proof.lean
+++ b/formal/obligations/normalize/value_graph/algebra/Proof.lean
@@ -10,7 +10,7 @@ This file proves exactly that for `+` over `Int`: flattening an add-tree to a le
 preserves its denotation, and ANY permutation of that leaf list (the sort is one) has the
 same denotation. Hence sorting flattened `+`-operands is denotation-preserving — sound.
 
-Self-contained: no Mathlib. Compile:  ~/.elan/bin/lean formal/Algebra.lean
+Self-contained: no Mathlib. Checked by the formal obligation CI gate.
 -/
 
 namespace NoseAlgebra

--- a/formal/obligations/normalize/value_graph/algebra/meta.toml
+++ b/formal/obligations/normalize/value_graph/algebra/meta.toml
@@ -1,0 +1,17 @@
+id = "normalize.value_graph.algebra"
+status = "proven"
+kind = "soundness"
+summary = "Associative-commutative numeric algebra and subtraction/negation canonicalization preserve Int denotation."
+
+[rust]
+files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/algebra.rs"]
+symbols = ["flatten_into", "intern_ac_chain", "collect_add_sub_expr_operands"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseAlgebra.canon_sound",
+  "NoseAlgebra.sub_eq_add_neg",
+  "NoseAlgebra.neg_add_distrib",
+  "NoseAlgebra.distrib_sound",
+]

--- a/formal/obligations/normalize/value_graph/bool_reduce/Proof.lean
+++ b/formal/obligations/normalize/value_graph/bool_reduce/Proof.lean
@@ -9,7 +9,7 @@ AND with identity `true` for `all`. This file proves exactly those laws over `Bo
 that folding a predicate-mapped list with them computes existential / universal truth — so
 the cross-language forms denote the same thing.
 
-Self-contained over `Bool`/`List`; check:  ~/.elan/bin/lean formal/BoolReduce.lean
+Self-contained over `Bool`/`List`; checked by the formal obligation CI gate.
 -/
 
 namespace NoseBoolReduce

--- a/formal/obligations/normalize/value_graph/bool_reduce/meta.toml
+++ b/formal/obligations/normalize/value_graph/bool_reduce/meta.toml
@@ -1,0 +1,22 @@
+id = "normalize.value_graph.bool_reduce"
+status = "proven"
+kind = "soundness"
+summary = "Any/all reductions are well-defined Bool folds for cross-language predicate reductions."
+
+[rust]
+files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/idioms.rs"]
+symbols = ["recognize_existence_reduction", "REDUCE_ANY", "REDUCE_ALL"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseBoolReduce.or_comm",
+  "NoseBoolReduce.or_assoc",
+  "NoseBoolReduce.or_id",
+  "NoseBoolReduce.and_comm",
+  "NoseBoolReduce.and_assoc",
+  "NoseBoolReduce.and_id",
+  "NoseBoolReduce.vany_iff",
+  "NoseBoolReduce.vall_iff",
+  "NoseBoolReduce.any_map",
+]

--- a/formal/obligations/normalize/value_graph/clamp/Counterexamples.lean
+++ b/formal/obligations/normalize/value_graph/clamp/Counterexamples.lean
@@ -1,0 +1,29 @@
+/-
+Boundary counterexamples for the clamp obligation.
+
+These prove why the recognizer must reject swapped bounds, wrong nesting, and missing
+`lo ≤ hi` evidence.
+-/
+
+namespace NoseClampCounterexamples
+
+def vmin (a b : Int) : Int := if a < b then a else b
+def vmax (a b : Int) : Int := if a < b then b else a
+def clampCmp (x lo hi : Int) : Int := if x < lo then lo else if hi < x then hi else x
+
+/-- Swapped bound order `min(max(x, hi), lo)` is not the clamp. -/
+theorem swapped_bounds_not_clamp :
+    ∃ x lo hi : Int, lo ≤ hi ∧ vmin (vmax x hi) lo ≠ clampCmp x lo hi :=
+  ⟨5, 0, 1, by decide, by decide⟩
+
+/-- Wrong nesting `max(min(x, lo), hi)` is not the clamp. -/
+theorem wrong_nesting_not_clamp :
+    ∃ x lo hi : Int, lo ≤ hi ∧ vmax (vmin x lo) hi ≠ clampCmp x lo hi :=
+  ⟨0, 0, 5, by decide, by decide⟩
+
+/-- The `lo ≤ hi` precondition is required. -/
+theorem precondition_required :
+    ∃ x lo hi : Int, hi < lo ∧ vmin (vmax x lo) hi ≠ vmax (vmin x hi) lo :=
+  ⟨0, 1, 0, by decide, by decide⟩
+
+end NoseClampCounterexamples

--- a/formal/obligations/normalize/value_graph/clamp/Proof.lean
+++ b/formal/obligations/normalize/value_graph/clamp/Proof.lean
@@ -4,16 +4,15 @@ for detector convergence (owner: Team A / #49).
 
 A clamp `min(max(x, lo), hi)` (nested min/max composition) and `max(min(x, hi), lo)` and a
 two-comparison `if x < lo then lo else if hi < x then hi else x` all denote the same value,
-PROVIDED `lo ≤ hi`. This file proves that — and proves the boundaries the recognizer must
-reject: swapped bound order is a different function, and the `lo ≤ hi` precondition is
-required (the two min/max compositions diverge without it).
+PROVIDED `lo ≤ hi`. This file proves the positive equivalences. Boundary counterexamples
+live in `Counterexamples.lean`.
 
-Self-contained over `Int` (no Mathlib); check:  ~/.elan/bin/lean formal/Clamp.lean
+Self-contained over `Int` (no Mathlib).
 -/
 
 namespace NoseClamp
 
-/-- Canonical min/max, matching `formal/MinMax.lean` (the ternary they denote). -/
+/-- Canonical min/max, matching the `normalize.value_graph.min_max` obligation. -/
 def vmin (a b : Int) : Int := if a < b then a else b
 def vmax (a b : Int) : Int := if a < b then b else a
 
@@ -38,23 +37,5 @@ theorem clamp_maxmin (x lo hi : Int) (h : lo ≤ hi) :
 theorem clamp_forms_agree (x lo hi : Int) (h : lo ≤ hi) :
     vmin (vmax x lo) hi = vmax (vmin x hi) lo := by
   rw [clamp_minmax x lo hi h, clamp_maxmin x lo hi h]
-
-/-- HARD NEGATIVE: swapped bound order `min(max(x, hi), lo)` is NOT the clamp.
-    x=5, lo=0, hi=1: min(max(5,1),0) = min(5,0) = 0, but clamp(5,0,1) = 1. -/
-theorem swapped_bounds_not_clamp :
-    ∃ x lo hi : Int, lo ≤ hi ∧ vmin (vmax x hi) lo ≠ clampCmp x lo hi :=
-  ⟨5, 0, 1, by decide, by decide⟩
-
-/-- HARD NEGATIVE: wrong nesting `max(min(x, lo), hi)` is NOT the clamp.
-    x=0, lo=0, hi=5: max(min(0,0),5) = max(0,5) = 5, but clamp(0,0,5) = 0. -/
-theorem wrong_nesting_not_clamp :
-    ∃ x lo hi : Int, lo ≤ hi ∧ vmax (vmin x lo) hi ≠ clampCmp x lo hi :=
-  ⟨0, 0, 5, by decide, by decide⟩
-
-/-- The `lo ≤ hi` precondition is REQUIRED: without it the two canonical compositions
-    diverge, so the recognizer must not merge them when bounds can be inverted. -/
-theorem precondition_required :
-    ∃ x lo hi : Int, hi < lo ∧ vmin (vmax x lo) hi ≠ vmax (vmin x hi) lo :=
-  ⟨0, 1, 0, by decide, by decide⟩
 
 end NoseClamp

--- a/formal/obligations/normalize/value_graph/clamp/meta.toml
+++ b/formal/obligations/normalize/value_graph/clamp/meta.toml
@@ -1,0 +1,22 @@
+id = "normalize.value_graph.clamp"
+status = "proven"
+kind = "soundness"
+summary = "Clamp min/max compositions and two-comparison forms agree only under the lo <= hi precondition."
+
+[rust]
+files = ["crates/nose-normalize/src/value_graph.rs"]
+symbols = ["minmax_pattern"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseClamp.clamp_minmax",
+  "NoseClamp.clamp_maxmin",
+  "NoseClamp.clamp_forms_agree",
+]
+counterexamples = "Counterexamples.lean"
+counterexample_theorems = [
+  "NoseClampCounterexamples.swapped_bounds_not_clamp",
+  "NoseClampCounterexamples.wrong_nesting_not_clamp",
+  "NoseClampCounterexamples.precondition_required",
+]

--- a/formal/obligations/normalize/value_graph/compare/Proof.lean
+++ b/formal/obligations/normalize/value_graph/compare/Proof.lean
@@ -7,7 +7,7 @@ negated comparison to its complement (`value_graph.rs` `mk`: `a > b → b < a`, 
 invariant under the rewrite. This file proves that over `Int` (a total order), using the
 decidable comparisons the interpreter (`interp.rs`) evaluates.
 
-Self-contained; check:  ~/.elan/bin/lean formal/Compare.lean   (exit 0 = proofs hold)
+Self-contained; checked by the formal obligation CI gate.
 -/
 
 namespace NoseCompare

--- a/formal/obligations/normalize/value_graph/compare/meta.toml
+++ b/formal/obligations/normalize/value_graph/compare/meta.toml
@@ -1,0 +1,22 @@
+id = "normalize.value_graph.compare"
+status = "proven"
+kind = "soundness"
+summary = "Comparison direction, negated comparisons, and total-order lattice canons preserve Int comparison denotation."
+
+[rust]
+files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/algebra.rs"]
+symbols = ["negate_cmp_code", "lattice_le_ne_to_lt", "lattice_lt_eq_to_le"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseCompare.gt_eq_lt_swap",
+  "NoseCompare.ge_eq_le_swap",
+  "NoseCompare.not_le_eq_gt",
+  "NoseCompare.not_lt_eq_ge",
+  "NoseCompare.not_gt_eq_le",
+  "NoseCompare.not_ge_eq_lt",
+  "NoseCompare.not_eq_eq_ne",
+  "NoseCompare.le_and_ne_eq_lt",
+  "NoseCompare.lt_or_eq_eq_le",
+]

--- a/formal/obligations/normalize/value_graph/factor_distribute/Proof.lean
+++ b/formal/obligations/normalize/value_graph/factor_distribute/Proof.lean
@@ -1,0 +1,27 @@
+/-
+Soundness of the named `factor_distribute` value-graph rule.
+
+The Rust rule rewrites `x*f + y*f` to `(x+y)*f` only when all leaves are proven numeric.
+Over `Int`, this is distributivity. Free-monoid counterexamples explain why the Num gate is
+required.
+-/
+
+namespace NoseFactorDistribute
+
+inductive Expr where
+  | lit : Int → Expr
+  | var : Nat → Expr
+  | add : Expr → Expr → Expr
+  | mul : Expr → Expr → Expr
+
+def eval (env : Nat → Int) : Expr → Int
+  | .lit n => n
+  | .var i => env i
+  | .add a b => eval env a + eval env b
+  | .mul a b => eval env a * eval env b
+
+theorem distrib_sound (env : Nat → Int) (x y f : Expr) :
+    eval env (.mul (.add x y) f) = eval env (.add (.mul x f) (.mul y f)) := by
+  simp [eval, Int.add_mul]
+
+end NoseFactorDistribute

--- a/formal/obligations/normalize/value_graph/factor_distribute/meta.toml
+++ b/formal/obligations/normalize/value_graph/factor_distribute/meta.toml
@@ -1,0 +1,13 @@
+id = "normalize.value_graph.factor_distribute"
+status = "proven"
+kind = "soundness"
+summary = "The named factor_distribute rule preserves Int denotation and is gated away from free-monoid repetition."
+
+[rust]
+rule_module = true
+files = ["crates/nose-normalize/src/value_graph/rules/factor_distribute.rs"]
+symbols = ["apply"]
+
+[lean]
+proof = "Proof.lean"
+theorems = ["NoseFactorDistribute.distrib_sound"]

--- a/formal/obligations/normalize/value_graph/field_writes/Counterexamples.lean
+++ b/formal/obligations/normalize/value_graph/field_writes/Counterexamples.lean
@@ -1,0 +1,24 @@
+/-
+Counterexample for treating same-field writes as order-insensitive.
+-/
+
+namespace NoseFieldWriteCounterexamples
+
+abbrev Field := Nat
+abbrev Value := Int
+abbrev Store := Field → Value
+
+def write (field : Field) (value : Value) (store : Store) : Store :=
+  fun current => if current = field then value else store current
+
+/-- Same-field writes are not commutative; the last value wins. -/
+theorem same_field_write_order_matters :
+    ∃ store field first second,
+      write field second (write field first store)
+        ≠ write field first (write field second store) :=
+  ⟨fun _ => 0, 0, 1, 2, by
+    intro h
+    have pointwise := congrFun h 0
+    simp [write] at pointwise⟩
+
+end NoseFieldWriteCounterexamples

--- a/formal/obligations/normalize/value_graph/field_writes/Proof.lean
+++ b/formal/obligations/normalize/value_graph/field_writes/Proof.lean
@@ -1,0 +1,40 @@
+/-
+Soundness of field-write normalization boundaries.
+
+The interpreter records final field state with last-write-wins semantics. Writes to
+different fields commute in the final state; writes to the same field do not.
+-/
+
+namespace NoseFieldWrites
+
+abbrev Field := Nat
+abbrev Value := Int
+abbrev Store := Field → Value
+
+def write (field : Field) (value : Value) (store : Store) : Store :=
+  fun current => if current = field then value else store current
+
+/-- Two writes to the same field collapse to the last write. -/
+theorem same_field_last_write_wins (store : Store) (field : Field) (first second : Value) :
+    write field second (write field first store) = write field second store := by
+  funext current
+  by_cases h : current = field <;> simp [write, h]
+
+/-- Writes to different fields commute when only the final field state is observed. -/
+theorem different_field_writes_commute
+    (store : Store) (left right : Field) (leftValue rightValue : Value)
+    (distinct : left ≠ right) :
+    write left leftValue (write right rightValue store)
+      = write right rightValue (write left leftValue store) := by
+  funext current
+  by_cases hleft : current = left
+  · by_cases hright : current = right
+    · exfalso
+      exact distinct (Eq.trans (Eq.symm hleft) hright)
+    · simp [write, hleft, distinct]
+  · by_cases hright : current = right
+    · have right_ne_left : right ≠ left := fun same => distinct (Eq.symm same)
+      simp [write, hright, right_ne_left]
+    · simp [write, hleft, hright]
+
+end NoseFieldWrites

--- a/formal/obligations/normalize/value_graph/field_writes/meta.toml
+++ b/formal/obligations/normalize/value_graph/field_writes/meta.toml
@@ -1,0 +1,17 @@
+id = "normalize.value_graph.field_writes"
+status = "proven"
+kind = "soundness-boundary"
+summary = "Field writes are interpreted as final field state with last-write-wins semantics."
+
+[rust]
+files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/interp.rs"]
+symbols = ["flush_fields", "field_env"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseFieldWrites.same_field_last_write_wins",
+  "NoseFieldWrites.different_field_writes_commute",
+]
+counterexamples = "Counterexamples.lean"
+counterexample_theorems = ["NoseFieldWriteCounterexamples.same_field_write_order_matters"]

--- a/formal/obligations/normalize/value_graph/free_monoid/Counterexamples.lean
+++ b/formal/obligations/normalize/value_graph/free_monoid/Counterexamples.lean
@@ -1,0 +1,26 @@
+/-
+Counterexamples for rewrites that would treat ordered concat like a commutative ring.
+-/
+
+namespace NoseFreeMonoidCounterexamples
+
+abbrev Str := List Nat
+
+def concat (left right : Str) : Str := left ++ right
+
+def vrepeat : Str → Nat → Str
+  | _, 0 => []
+  | xs, n + 1 => xs ++ vrepeat xs n
+
+/-- Ordered concat is not commutative. -/
+theorem concat_not_commutative :
+    ∃ xs ys : Str, concat xs ys ≠ concat ys xs :=
+  ⟨[0], [1], by decide⟩
+
+/-- Distribution/factoring over repetition is not sound for strings/lists:
+    `(x+y)*2` gives `xyxy`, while `x*2 + y*2` gives `xxyy`. -/
+theorem repeat_distribution_not_sound :
+    ∃ xs ys : Str, vrepeat (concat xs ys) 2 ≠ concat (vrepeat xs 2) (vrepeat ys 2) :=
+  ⟨[0], [1], by decide⟩
+
+end NoseFreeMonoidCounterexamples

--- a/formal/obligations/normalize/value_graph/free_monoid/Proof.lean
+++ b/formal/obligations/normalize/value_graph/free_monoid/Proof.lean
@@ -1,0 +1,33 @@
+/-
+Soundness boundaries for the free-monoid string/list model.
+
+String/list builders are modeled as ordered concatenation of opaque pieces. Concatenation
+is associative and has an empty identity, but it is not commutative and it is not a ring:
+distribution/factoring across repetition is unsound. These facts are the proof boundary
+behind the value graph's concat ordering and Num gate on `factor_distribute`.
+-/
+
+namespace NoseFreeMonoid
+
+abbrev Str := List Nat
+
+def concat (left right : Str) : Str := left ++ right
+
+def vrepeat : Str → Nat → Str
+  | _, 0 => []
+  | xs, n + 1 => xs ++ vrepeat xs n
+
+theorem concat_assoc (a b c : Str) :
+    concat (concat a b) c = concat a (concat b c) := by
+  simp [concat, List.append_assoc]
+
+theorem concat_left_id (xs : Str) : concat [] xs = xs := rfl
+
+theorem concat_right_id (xs : Str) : concat xs [] = xs := by
+  simp [concat]
+
+/-- Repeating twice is ordered self-concatenation. -/
+theorem repeat_two_eq_concat_self (xs : Str) : vrepeat xs 2 = concat xs xs := by
+  simp [vrepeat, concat]
+
+end NoseFreeMonoid

--- a/formal/obligations/normalize/value_graph/free_monoid/meta.toml
+++ b/formal/obligations/normalize/value_graph/free_monoid/meta.toml
@@ -1,0 +1,22 @@
+id = "normalize.value_graph.free_monoid"
+status = "proven"
+kind = "soundness-boundary"
+summary = "String/list builder semantics are ordered free-monoid concatenation, not commutative algebra."
+
+[rust]
+files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/interp.rs"]
+symbols = ["is_concat_ty", "join_strings"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseFreeMonoid.concat_assoc",
+  "NoseFreeMonoid.concat_left_id",
+  "NoseFreeMonoid.concat_right_id",
+  "NoseFreeMonoid.repeat_two_eq_concat_self",
+]
+counterexamples = "Counterexamples.lean"
+counterexample_theorems = [
+  "NoseFreeMonoidCounterexamples.concat_not_commutative",
+  "NoseFreeMonoidCounterexamples.repeat_distribution_not_sound",
+]

--- a/formal/obligations/normalize/value_graph/functor/Proof.lean
+++ b/formal/obligations/normalize/value_graph/functor/Proof.lean
@@ -8,7 +8,7 @@ The value graph fuses higher-order pipelines via the laws of the list functor:
 This file proves both laws hold for `List`, so the fusions are denotation-preserving —
 the converged pipelines compute the same result.
 
-Self-contained; check:  ~/.elan/bin/lean formal/Functor.lean   (exit 0 = proofs hold)
+Self-contained; checked by the formal obligation CI gate.
 -/
 
 namespace NoseFunctor

--- a/formal/obligations/normalize/value_graph/functor/meta.toml
+++ b/formal/obligations/normalize/value_graph/functor/meta.toml
@@ -1,0 +1,17 @@
+id = "normalize.value_graph.functor"
+status = "proven"
+kind = "soundness"
+summary = "Map/filter fusion and count-of-filter normalization preserve List denotation."
+
+[rust]
+files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/idioms.rs"]
+symbols = ["HoFKind::Map", "HoFKind::Filter", "and_preds"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseFunctor.map_fusion",
+  "NoseFunctor.map_id",
+  "NoseFunctor.filter_fusion",
+  "NoseFunctor.filter_length_eq_count",
+]

--- a/formal/obligations/normalize/value_graph/min_max/Proof.lean
+++ b/formal/obligations/normalize/value_graph/min_max/Proof.lean
@@ -7,7 +7,7 @@ loop as a selection reduction. This file proves the laws those rely on: `Min`/`M
 exactly the ternary, and they are commutative and associative (a commutative monoid up to
 the ±∞ identity) — so the canonical node is order-insensitive and the fold is well-defined.
 
-Self-contained over `Int`; check:  ~/.elan/bin/lean formal/MinMax.lean
+Self-contained over `Int`; checked by the formal obligation CI gate.
 -/
 
 namespace NoseMinMax

--- a/formal/obligations/normalize/value_graph/min_max/meta.toml
+++ b/formal/obligations/normalize/value_graph/min_max/meta.toml
@@ -1,0 +1,20 @@
+id = "normalize.value_graph.min_max"
+status = "proven"
+kind = "soundness"
+summary = "Min/max select idioms and accumulator reductions are commutative and associative over Int."
+
+[rust]
+files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/idioms.rs"]
+symbols = ["minmax_pattern", "MIN_CODE", "MAX_CODE"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseMinMax.min_is_ternary",
+  "NoseMinMax.max_is_ternary",
+  "NoseMinMax.vmin_comm",
+  "NoseMinMax.vmax_comm",
+  "NoseMinMax.vmin_assoc",
+  "NoseMinMax.vmax_assoc",
+  "NoseMinMax.vmin_idem",
+]

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.30.0

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -21,7 +21,8 @@ usage: ./scripts/check-ci-local.sh [--fast|--full]
 
   --fast  rustfmt, clippy -D warnings, nose-cli tests, docs wiki lint
   --full  full local mirror of CI: format, clippy, docs, release build/tests,
-          duplication, MSRV, supply-chain, docs wiki, and Lean proofs
+          duplication, MSRV, supply-chain, docs wiki, formal obligation lint,
+          and Lean proofs
 EOF
         exit 0
         ;;
@@ -49,20 +50,27 @@ run_docs_wiki_lint() {
     awiki lint --root docs
 }
 
+run_formal_obligations_lint() {
+    need_cmd python3
+    python3 scripts/check-formal-obligations.py
+}
+
 run_formal_lean() {
+    local toolchain
+    toolchain="$(cat lean-toolchain 2>/dev/null || printf 'leanprover/lean4:v4.30.0')"
     if command -v elan >/dev/null 2>&1; then
-        for f in formal/*.lean; do
+        while IFS= read -r f; do
             echo "checking $f"
-            elan run leanprover/lean4:v4.30.0 lean "$f"
-        done
+            elan run "$toolchain" lean --error=warning "$f"
+        done < <(find formal -name '*.lean' -print | sort)
         return
     fi
 
     need_cmd lean
-    for f in formal/*.lean; do
+    while IFS= read -r f; do
         echo "checking $f"
-        lean "$f"
-    done
+        lean --error=warning "$f"
+    done < <(find formal -name '*.lean' -print | sort)
 }
 
 run_msrv_check() {
@@ -121,6 +129,9 @@ cargo deny check
 
 step "docs wiki connectivity (awiki)"
 run_docs_wiki_lint
+
+step "formal obligation registry"
+run_formal_obligations_lint
 
 step "Lean proofs (value-graph soundness)"
 run_formal_lean

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -52,6 +52,7 @@ run_docs_wiki_lint() {
 
 run_formal_obligations_lint() {
     need_cmd python3
+    python3 scripts/check-formal-obligations.py --self-test
     python3 scripts/check-formal-obligations.py
 }
 

--- a/scripts/check-formal-obligations.py
+++ b/scripts/check-formal-obligations.py
@@ -14,6 +14,7 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any
 
 try:
@@ -50,6 +51,10 @@ class Obligation:
 
 def error(errors: list[str], message: str) -> None:
     errors.append(message)
+
+
+def non_empty_str(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
 
 
 def as_list(value: Any, field: str, errors: list[str], where: str) -> list[str]:
@@ -220,9 +225,14 @@ def lint_meta(obligation: Obligation, all_ids: set[str], errors: list[str]) -> N
         lean = {}
     proof = lean.get("proof")
     theorems = as_list(lean.get("theorems", []), "lean.theorems", errors, where)
-    if status == "proven" and not isinstance(proof, str):
-        error(errors, f"{where}: proven obligations must name `lean.proof`")
-    if isinstance(proof, str):
+    if status == "proven":
+        if not non_empty_str(proof):
+            error(errors, f"{where}: proven obligations must name `lean.proof`")
+        if not theorems:
+            error(errors, f"{where}: proven obligations must list at least one `lean.theorems`")
+    if proof is not None and not non_empty_str(proof):
+        error(errors, f"{where}: `lean.proof` must be a non-empty string")
+    if non_empty_str(proof):
         proof_path = obligation.path / proof
         if not proof_path.exists():
             error(errors, f"{where}: proof file does not exist: {proof}")
@@ -239,9 +249,21 @@ def lint_meta(obligation: Obligation, all_ids: set[str], errors: list[str]) -> N
         errors,
         where,
     )
-    if status == "rejected-counterexample" and not isinstance(counterexamples, str):
-        error(errors, f"{where}: rejected-counterexample obligations must name `lean.counterexamples`")
-    if isinstance(counterexamples, str):
+    if status == "rejected-counterexample":
+        if not non_empty_str(counterexamples):
+            error(
+                errors,
+                f"{where}: rejected-counterexample obligations must name `lean.counterexamples`",
+            )
+        if not counterexample_theorems:
+            error(
+                errors,
+                f"{where}: rejected-counterexample obligations must list at least one "
+                "`lean.counterexample_theorems`",
+            )
+    if counterexamples is not None and not non_empty_str(counterexamples):
+        error(errors, f"{where}: `lean.counterexamples` must be a non-empty string")
+    if non_empty_str(counterexamples):
         counterexample_path = obligation.path / counterexamples
         if not counterexample_path.exists():
             error(errors, f"{where}: counterexample file does not exist: {counterexamples}")
@@ -250,8 +272,13 @@ def lint_meta(obligation: Obligation, all_ids: set[str], errors: list[str]) -> N
             for theorem in counterexample_theorems:
                 if theorem not in decls:
                     error(errors, f"{where}: counterexample theorem `{theorem}` not found in {counterexamples}")
+        if not counterexample_theorems:
+            error(errors, f"{where}: listed `lean.counterexamples` must name counterexample theorems")
 
-    for covered_id in as_list(meta.get("covered_by", []), "covered_by", errors, where):
+    covered_by = as_list(meta.get("covered_by", []), "covered_by", errors, where)
+    if status == "covered" and not covered_by:
+        error(errors, f"{where}: covered obligations must list at least one `covered_by`")
+    for covered_id in covered_by:
         if covered_id not in all_ids:
             error(errors, f"{where}: covered_by references unknown obligation `{covered_id}`")
 
@@ -287,7 +314,96 @@ def lint_lean_layout(errors: list[str]) -> None:
             error(errors, f"{lean_file.relative_to(ROOT)}: missing sibling meta.toml")
 
 
+def run_self_tests() -> int:
+    target = ROOT / "target"
+    target.mkdir(exist_ok=True)
+    with TemporaryDirectory(prefix="formal-obligation-self-test-", dir=target) as temp:
+        obligation_path = Path(temp) / "formal" / "obligations" / "self_test"
+        obligation_path.mkdir(parents=True)
+        (obligation_path / "Proof.lean").write_text(
+            "namespace SelfTest\n\ntheorem ok : True := by\n  trivial\n\nend SelfTest\n",
+            encoding="utf-8",
+        )
+        (obligation_path / "Counterexamples.lean").write_text(
+            "namespace SelfTest\n\ntheorem bad : True := by\n  trivial\n\nend SelfTest\n",
+            encoding="utf-8",
+        )
+
+        def base_meta(status: str) -> dict[str, Any]:
+            return {
+                "id": "self_test",
+                "status": status,
+                "kind": "self-test",
+                "summary": "self-test obligation",
+            }
+
+        def lint(meta: dict[str, Any], all_ids: set[str] | None = None) -> list[str]:
+            errors: list[str] = []
+            lint_meta(Obligation("self_test", obligation_path, meta), all_ids or {"self_test"}, errors)
+            return errors
+
+        cases = [
+            (
+                "valid proven",
+                {
+                    **base_meta("proven"),
+                    "lean": {"proof": "Proof.lean", "theorems": ["SelfTest.ok"]},
+                },
+                False,
+                "",
+            ),
+            (
+                "proven without theorem list",
+                {
+                    **base_meta("proven"),
+                    "lean": {"proof": "Proof.lean", "theorems": []},
+                },
+                True,
+                "proven obligations must list at least one `lean.theorems`",
+            ),
+            (
+                "covered without covered_by",
+                {**base_meta("covered"), "covered_by": []},
+                True,
+                "covered obligations must list at least one `covered_by`",
+            ),
+            (
+                "rejected counterexample without theorem list",
+                {
+                    **base_meta("rejected-counterexample"),
+                    "lean": {"counterexamples": "Counterexamples.lean", "counterexample_theorems": []},
+                },
+                True,
+                "rejected-counterexample obligations must list at least one "
+                "`lean.counterexample_theorems`",
+            ),
+        ]
+
+        failures = []
+        for name, meta, should_fail, expected in cases:
+            errors = lint(meta)
+            joined = "\n".join(errors)
+            if should_fail and expected not in joined:
+                failures.append(f"{name}: expected `{expected}`, got {errors}")
+            elif not should_fail and errors:
+                failures.append(f"{name}: expected no errors, got {errors}")
+
+    if failures:
+        print("formal obligation self-test failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print("formal obligation self-test passed")
+    return 0
+
+
 def main() -> int:
+    if len(sys.argv) == 2 and sys.argv[1] == "--self-test":
+        return run_self_tests()
+    if len(sys.argv) > 1:
+        print("usage: scripts/check-formal-obligations.py [--self-test]", file=sys.stderr)
+        return 2
+
     errors: list[str] = []
     obligations = load_obligations(errors)
     all_ids = set(obligations)

--- a/scripts/check-formal-obligations.py
+++ b/scripts/check-formal-obligations.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Lint the Lean proof-obligation registry.
+
+The registry is directory-shaped: every obligation lives at
+`formal/obligations/<id path>/meta.toml`, and the id must be the dot-joined path.
+Proof-sensitive Rust rule modules are also directory-shaped; for example
+`crates/nose-normalize/src/value_graph/rules/factor_distribute.rs` must have a
+matching `formal/obligations/normalize/value_graph/factor_distribute/meta.toml`.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # Python < 3.11 on local developer machines.
+    tomllib = None
+
+ROOT = Path(__file__).resolve().parents[1]
+OBLIGATION_ROOT = ROOT / "formal" / "obligations"
+STATUSES = {
+    "proven",
+    "covered",
+    "missing",
+    "empirical-only",
+    "rejected-counterexample",
+}
+RULE_ROOTS = {
+    "normalize.value_graph": ROOT / "crates" / "nose-normalize" / "src" / "value_graph" / "rules",
+}
+
+DECL_RE = re.compile(r"^\s*(?:theorem|lemma|def)\s+([A-Za-z_][A-Za-z0-9_']*)\b")
+NAMESPACE_RE = re.compile(r"^\s*namespace\s+([A-Za-z_][A-Za-z0-9_'.]*)\b")
+END_RE = re.compile(r"^\s*end(?:\s+[A-Za-z_][A-Za-z0-9_'.]*)?\s*$")
+SECTION_RE = re.compile(r"^\[([A-Za-z0-9_.]+)\]$")
+ASSIGN_RE = re.compile(r"^([A-Za-z0-9_.]+)\s*=\s*(.+)$")
+
+
+@dataclass(frozen=True)
+class Obligation:
+    id: str
+    path: Path
+    meta: dict[str, Any]
+
+
+def error(errors: list[str], message: str) -> None:
+    errors.append(message)
+
+
+def as_list(value: Any, field: str, errors: list[str], where: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        error(errors, f"{where}: `{field}` must be a list of strings")
+        return []
+    return value
+
+
+def lean_declarations(path: Path) -> set[str]:
+    names: set[str] = set()
+    namespaces: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if match := NAMESPACE_RE.match(line):
+            namespaces.extend(part for part in match.group(1).split(".") if part)
+            continue
+        if END_RE.match(line):
+            if namespaces:
+                namespaces.pop()
+            continue
+        if match := DECL_RE.match(line):
+            name = match.group(1)
+            names.add(name)
+            if namespaces:
+                names.add(".".join([*namespaces, name]))
+    return names
+
+
+def obligation_id_for(meta_file: Path) -> str:
+    rel = meta_file.parent.relative_to(OBLIGATION_ROOT)
+    return ".".join(rel.parts)
+
+
+def parse_meta(text: str) -> dict[str, Any]:
+    if tomllib is not None:
+        return tomllib.loads(text)
+
+    root: dict[str, Any] = {}
+    current = root
+    pending_key: str | None = None
+    pending_items: list[str] = []
+
+    def finish_array() -> None:
+        nonlocal pending_key, pending_items, current
+        if pending_key is not None:
+            current[pending_key] = pending_items
+            pending_key = None
+            pending_items = []
+
+    def parse_scalar(raw: str) -> Any:
+        value = raw.strip()
+        if value in {"true", "false"}:
+            return value == "true"
+        if value.startswith('"') and value.endswith('"'):
+            return value[1:-1]
+        raise ValueError(f"unsupported TOML value: {value}")
+
+    def parse_array_line(raw: str) -> list[str]:
+        value = raw.strip()
+        if value == "[]":
+            return []
+        if value.startswith("[") and value.endswith("]"):
+            inner = value[1:-1].strip()
+            if not inner:
+                return []
+            return [parse_scalar(item.strip()) for item in inner.split(",") if item.strip()]
+        raise ValueError(f"unsupported TOML array: {value}")
+
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if pending_key is not None:
+            if line == "]":
+                finish_array()
+                continue
+            item = line.rstrip(",").strip()
+            if item:
+                pending_items.append(parse_scalar(item))
+            continue
+        if match := SECTION_RE.match(line):
+            finish_array()
+            current = root
+            for part in match.group(1).split("."):
+                current = current.setdefault(part, {})
+            continue
+        match = ASSIGN_RE.match(line)
+        if not match:
+            raise ValueError(f"unsupported TOML line: {raw_line}")
+        key, raw_value = match.group(1), match.group(2).strip()
+        if raw_value == "[":
+            pending_key = key
+            pending_items = []
+        elif raw_value.startswith("["):
+            current[key] = parse_array_line(raw_value)
+        else:
+            current[key] = parse_scalar(raw_value)
+    finish_array()
+    return root
+
+
+def load_obligations(errors: list[str]) -> dict[str, Obligation]:
+    obligations: dict[str, Obligation] = {}
+    for meta_file in sorted(OBLIGATION_ROOT.rglob("meta.toml")):
+        where = str(meta_file.relative_to(ROOT))
+        try:
+            meta = parse_meta(meta_file.read_text(encoding="utf-8"))
+        except Exception as exc:
+            error(errors, f"{where}: invalid TOML: {exc}")
+            continue
+        obligation_id = meta.get("id")
+        expected_id = obligation_id_for(meta_file)
+        if not isinstance(obligation_id, str):
+            error(errors, f"{where}: `id` must be a string")
+            obligation_id = expected_id
+        if obligation_id != expected_id:
+            error(errors, f"{where}: `id` must match directory path `{expected_id}`")
+        if obligation_id in obligations:
+            error(errors, f"{where}: duplicate obligation id `{obligation_id}`")
+        obligations[obligation_id] = Obligation(obligation_id, meta_file.parent, meta)
+    return obligations
+
+
+def lint_meta(obligation: Obligation, all_ids: set[str], errors: list[str]) -> None:
+    rel = obligation.path.relative_to(ROOT)
+    where = str(rel / "meta.toml")
+    meta = obligation.meta
+
+    for field in ("status", "kind", "summary"):
+        if not isinstance(meta.get(field), str) or not meta[field].strip():
+            error(errors, f"{where}: `{field}` must be a non-empty string")
+
+    status = meta.get("status")
+    if isinstance(status, str) and status not in STATUSES:
+        error(errors, f"{where}: unknown status `{status}`")
+
+    rust = meta.get("rust", {})
+    if not isinstance(rust, dict):
+        error(errors, f"{where}: `[rust]` must be a table")
+        rust = {}
+    rust_files = as_list(rust.get("files", []), "rust.files", errors, where)
+    for rust_file in rust_files:
+        path = ROOT / rust_file
+        if not path.exists():
+            error(errors, f"{where}: rust file does not exist: {rust_file}")
+    symbols = as_list(rust.get("symbols", []), "rust.symbols", errors, where)
+    if rust_files and symbols:
+        contents = "\n".join((ROOT / rust_file).read_text(encoding="utf-8") for rust_file in rust_files if (ROOT / rust_file).exists())
+        for symbol in symbols:
+            if re.search(rf"\b{re.escape(symbol)}\b", contents) is None:
+                error(errors, f"{where}: rust symbol `{symbol}` was not found in listed files")
+
+    if rust.get("rule_module", False) is True:
+        matching_prefix = next((prefix for prefix in RULE_ROOTS if obligation.id.startswith(prefix + ".")), None)
+        if matching_prefix is None:
+            error(errors, f"{where}: `rust.rule_module = true` has no configured rule root")
+        else:
+            rule_name = obligation.id.removeprefix(matching_prefix + ".")
+            expected = RULE_ROOTS[matching_prefix] / f"{rule_name}.rs"
+            if not expected.exists():
+                error(errors, f"{where}: missing rule module `{expected.relative_to(ROOT)}`")
+            elif str(expected.relative_to(ROOT)) not in rust_files:
+                error(errors, f"{where}: `rust.files` must include `{expected.relative_to(ROOT)}`")
+
+    lean = meta.get("lean", {})
+    if not isinstance(lean, dict):
+        error(errors, f"{where}: `[lean]` must be a table")
+        lean = {}
+    proof = lean.get("proof")
+    theorems = as_list(lean.get("theorems", []), "lean.theorems", errors, where)
+    if status == "proven" and not isinstance(proof, str):
+        error(errors, f"{where}: proven obligations must name `lean.proof`")
+    if isinstance(proof, str):
+        proof_path = obligation.path / proof
+        if not proof_path.exists():
+            error(errors, f"{where}: proof file does not exist: {proof}")
+        else:
+            decls = lean_declarations(proof_path)
+            for theorem in theorems:
+                if theorem not in decls:
+                    error(errors, f"{where}: theorem `{theorem}` not found in {proof}")
+
+    counterexamples = lean.get("counterexamples")
+    counterexample_theorems = as_list(
+        lean.get("counterexample_theorems", []),
+        "lean.counterexample_theorems",
+        errors,
+        where,
+    )
+    if status == "rejected-counterexample" and not isinstance(counterexamples, str):
+        error(errors, f"{where}: rejected-counterexample obligations must name `lean.counterexamples`")
+    if isinstance(counterexamples, str):
+        counterexample_path = obligation.path / counterexamples
+        if not counterexample_path.exists():
+            error(errors, f"{where}: counterexample file does not exist: {counterexamples}")
+        else:
+            decls = lean_declarations(counterexample_path)
+            for theorem in counterexample_theorems:
+                if theorem not in decls:
+                    error(errors, f"{where}: counterexample theorem `{theorem}` not found in {counterexamples}")
+
+    for covered_id in as_list(meta.get("covered_by", []), "covered_by", errors, where):
+        if covered_id not in all_ids:
+            error(errors, f"{where}: covered_by references unknown obligation `{covered_id}`")
+
+
+def lint_rule_modules(obligations: dict[str, Obligation], errors: list[str]) -> None:
+    for prefix, root in RULE_ROOTS.items():
+        if not root.exists():
+            continue
+        for rule_file in sorted(root.glob("*.rs")):
+            if rule_file.name == "mod.rs":
+                continue
+            obligation_id = f"{prefix}.{rule_file.stem}"
+            if obligation_id not in obligations:
+                error(
+                    errors,
+                    f"{rule_file.relative_to(ROOT)}: missing matching obligation "
+                    f"`formal/obligations/{'/'.join(obligation_id.split('.'))}/meta.toml`",
+                )
+                continue
+            rust = obligations[obligation_id].meta.get("rust", {})
+            if not isinstance(rust, dict) or rust.get("rule_module") is not True:
+                error(
+                    errors,
+                    f"{rule_file.relative_to(ROOT)}: matching obligation must set `rust.rule_module = true`",
+                )
+
+
+def lint_lean_layout(errors: list[str]) -> None:
+    for lean_file in sorted(OBLIGATION_ROOT.rglob("*.lean")):
+        if lean_file.name not in {"Proof.lean", "Counterexamples.lean"}:
+            error(errors, f"{lean_file.relative_to(ROOT)}: obligation Lean files must be named Proof.lean or Counterexamples.lean")
+        if not (lean_file.parent / "meta.toml").exists():
+            error(errors, f"{lean_file.relative_to(ROOT)}: missing sibling meta.toml")
+
+
+def main() -> int:
+    errors: list[str] = []
+    obligations = load_obligations(errors)
+    all_ids = set(obligations)
+    for obligation in obligations.values():
+        lint_meta(obligation, all_ids, errors)
+    lint_rule_modules(obligations, errors)
+    lint_lean_layout(errors)
+
+    if errors:
+        print("formal obligation lint failed:", file=sys.stderr)
+        for item in errors:
+            print(f"  - {item}", file=sys.stderr)
+        return 1
+    print(f"formal obligation lint passed ({len(obligations)} obligations)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- Replaced the flat `formal/*.lean` layout with a directory-shaped proof obligation registry under `formal/obligations/<area>/<subsystem>/<rule>/`.
- Added `meta.toml` entries for existing Lean proof families and new boundary proofs for free-monoid concat/repetition and field-write last-write-wins semantics.
- Added `scripts/check-formal-obligations.py` to verify obligation IDs, Rust file/symbol references, theorem names, counterexample files, and named rule-module coverage.
- Split `factor_distribute` into the first named proof-sensitive value-graph rule module and registered it as `normalize.value_graph.factor_distribute`.
- Updated CI/local checks to run the obligation linter and check all Lean files recursively with `--error=warning`; added `lean-toolchain`.
- Updated docs and stale `formal/Clamp.lean` references to the new obligation layout.

## Why

This makes proof coverage auditable by structure instead of relying on ad hoc comments. New proof-sensitive rule modules under `value_graph/rules/*.rs` now mechanically require a matching formal obligation, so missing proof registration is visible in CI.

## Validation

- `python3 scripts/check-formal-obligations.py`
- `lean --error=warning` over every `formal/**/*.lean`
- `cargo fmt --all --check`
- `cargo check -p nose-normalize`
- `awiki lint --root docs`
- `python3 -m json.tool` for updated Type-4 JSON artifacts
- `./scripts/check-ci-local.sh --fast`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI/CD gates with formal obligation verification. Added `check-formal-obligations.py` script to validate proof-obligation registry structure and Lean proof references.
  * Expanded Lean proof checking to cover all formal modules with stricter error handling.
  * Updated Lean toolchain to v4.30.0.

* **Documentation**
  * Added comprehensive formal-soundness documentation describing proof-obligation structure and validation process.
  * Updated cross-references to reflect reorganized proof module locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->