### PR TITLE
Bug hunt (#56): fix Python multi-clause comprehension false merge + sweep findings

### DIFF
--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -943,14 +943,45 @@ fn lower_comparison(lo: &mut Lowering, node: TsNode) -> NodeId {
     acc.unwrap_or_else(|| lo.empty_block(span))
 }
 
+/// Build a lambda `λ<pattern>. <Block[Return[body]]>` over a comprehension's
+/// iteration pattern (the `for x in …` target), so the body converges with a JS
+/// `x => body` arrow.
+fn comp_lambda(
+    lo: &mut Lowering,
+    pattern: Option<TsNode>,
+    body: NodeId,
+    bspan: Span,
+) -> NodeId {
+    let mut kids = Vec::new();
+    if let Some(p) = pattern {
+        push_pattern_params(lo, p, &mut kids);
+    }
+    let ret = lo.add(NodeKind::Return, Payload::None, bspan, &[body]);
+    let block = lo.add(NodeKind::Block, Payload::None, bspan, &[ret]);
+    kids.push(block);
+    lo.add(NodeKind::Lambda, Payload::None, bspan, &kids)
+}
+
 /// A comprehension `[body for x in xs]` lowers to `HoF(Map)[xs, λx. body]`, with
 /// the body wrapped as `Block[Return[body]]` so it converges with a JS
 /// `xs.map(x => body)` arrow (whose expression body lowers the same way). A filter
 /// `… if cond` wraps the collection in `HoF(Filter)[xs, λx. cond]`, so a filtered
 /// comprehension converges with a guarded loop (`if cond: …`) — see §AI.
+///
+/// A *multi-clause* comprehension (`[body for a in A for b in B]`) is a flat-map
+/// nesting with no first-class IL primitive yet, so it is lowered fail-closed —
+/// see [`lower_multi_clause_comprehension`].
 fn lower_comprehension(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
     let body_node = node.named_child(0);
+
+    let for_clauses = Lowering::named_children(node)
+        .into_iter()
+        .filter(|c| c.kind() == "for_in_clause")
+        .count();
+    if for_clauses >= 2 {
+        return lower_multi_clause_comprehension(lo, node, span, body_node);
+    }
 
     let clause = Lowering::named_children(node)
         .into_iter()
@@ -961,18 +992,6 @@ fn lower_comprehension(lo: &mut Lowering, node: TsNode) -> NodeId {
         .map(|r| lower_expr(lo, r))
         .unwrap_or_else(|| lo.empty_block(span));
 
-    // Build a lambda `λ<pattern>. <Block[Return[body]]>` over the iteration pattern.
-    let lambda = |lo: &mut Lowering, body: NodeId, bspan| {
-        let mut kids = Vec::new();
-        if let Some(p) = pattern {
-            push_pattern_params(lo, p, &mut kids);
-        }
-        let ret = lo.add(NodeKind::Return, Payload::None, bspan, &[body]);
-        let block = lo.add(NodeKind::Block, Payload::None, bspan, &[ret]);
-        kids.push(block);
-        lo.add(NodeKind::Lambda, Payload::None, bspan, &kids)
-    };
-
     // Each `if cond` clause wraps the collection in a `HoF(Filter)`.
     for f in Lowering::named_children(node) {
         if f.kind() != "if_clause" {
@@ -981,7 +1000,7 @@ fn lower_comprehension(lo: &mut Lowering, node: TsNode) -> NodeId {
         if let Some(cn) = f.named_child(0) {
             let fspan = lo.span(f);
             let cond = lower_expr(lo, cn);
-            let flam = lambda(lo, cond, fspan);
+            let flam = comp_lambda(lo, pattern, cond, fspan);
             collection = lo.add(
                 NodeKind::HoF,
                 Payload::HoF(HoFKind::Filter),
@@ -994,13 +1013,88 @@ fn lower_comprehension(lo: &mut Lowering, node: TsNode) -> NodeId {
     let body = body_node
         .map(|b| lower_expr(lo, b))
         .unwrap_or_else(|| lo.empty_block(span));
-    let map_lam = lambda(lo, body, span);
+    let map_lam = comp_lambda(lo, pattern, body, span);
     lo.add(
         NodeKind::HoF,
         Payload::HoF(HoFKind::Map),
         span,
         &[collection, map_lam],
     )
+}
+
+/// Lower a comprehension with more than one `for` clause. `[body for a in A for
+/// b in B]` is Python sugar for nested iteration that *flattens* — equivalent to
+/// `A.flatMap(a => B.map(b => body))`. nose has no `FlatMap` HoF primitive, so a
+/// naive `Map[A, λa. Map[B, λb. body]]` would be byte-identical to the genuinely
+/// different *nested* comprehension `[[body for b in B] for a in A]` (a list of
+/// lists) — an unsound false merge.
+///
+/// Until flat-map is modeled (tracked separately), this lowers fail-closed: it
+/// builds the nested `Map`/`Filter` structure (so every clause's collection and
+/// target is preserved and bound) and wraps the whole thing in an opaque `Raw`
+/// node. The value graph keys `Raw` by full subtree content, so two flat-maps
+/// converge only when structurally identical and never collide with a nested
+/// comprehension, a single-clause `Map`, or any other construct. Convergence with
+/// the equivalent explicit nested loop is deferred to the flat-map work.
+fn lower_multi_clause_comprehension(
+    lo: &mut Lowering,
+    node: TsNode,
+    span: Span,
+    body_node: Option<TsNode>,
+) -> NodeId {
+    // Group each `for` clause with the `if` clauses that follow it, in source order.
+    let mut groups: Vec<(TsNode, Vec<TsNode>)> = Vec::new();
+    for c in Lowering::named_children(node) {
+        match c.kind() {
+            "for_in_clause" => groups.push((c, Vec::new())),
+            "if_clause" => {
+                if let Some(last) = groups.last_mut() {
+                    last.1.push(c);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Build inside-out: the body is the innermost produced element; each `for`
+    // clause (outer→inner in source, so iterated in reverse) wraps it in a `Map`
+    // over its (optionally filtered) collection, binding that clause's target.
+    let mut inner = body_node
+        .map(|b| lower_expr(lo, b))
+        .unwrap_or_else(|| lo.empty_block(span));
+    for (forc, ifs) in groups.iter().rev() {
+        let pattern = forc
+            .child_by_field_name("left")
+            .or_else(|| forc.named_child(0));
+        let mut collection = forc
+            .child_by_field_name("right")
+            .or_else(|| forc.named_child(1))
+            .map(|r| lower_expr(lo, r))
+            .unwrap_or_else(|| lo.empty_block(span));
+        for ifc in ifs {
+            if let Some(cn) = ifc.named_child(0) {
+                let fspan = lo.span(*ifc);
+                let cond = lower_expr(lo, cn);
+                let flam = comp_lambda(lo, pattern, cond, fspan);
+                collection = lo.add(
+                    NodeKind::HoF,
+                    Payload::HoF(HoFKind::Filter),
+                    fspan,
+                    &[collection, flam],
+                );
+            }
+        }
+        let lam = comp_lambda(lo, pattern, inner, span);
+        inner = lo.add(
+            NodeKind::HoF,
+            Payload::HoF(HoFKind::Map),
+            span,
+            &[collection, lam],
+        );
+    }
+
+    // Fail-closed: an opaque wrapper that cannot be confused with a nested `Map`.
+    lo.raw("comprehension", span, &[inner])
 }
 
 /// Emit `Param` nodes for a comprehension/loop target (identifier or tuple).
@@ -1264,6 +1358,63 @@ mod tests {
     }
 
     #[test]
+    fn multi_clause_comprehension_binds_all_iterables() {
+        // `[a + b for a in A for b in B]` is sugar for nested iteration: every
+        // clause and target must survive lowering. Dropping the second clause
+        // leaves `b` unbound and makes this comprehension collide with the
+        // single-clause `[a + b for a in A]` (a false merge).
+        // `xs`/`ys` are free module-level iterables (not params) so a reference
+        // to `ys` can only come from the second clause actually being lowered.
+        let interner = Interner::new();
+        let il = lower(
+            FileId(0),
+            "t.py",
+            b"def f():\n    return [a + b for a in xs for b in ys]\n",
+            &interner,
+        )
+        .expect("lower");
+
+        let names: Vec<_> = il
+            .nodes
+            .iter()
+            .filter_map(|node| match node.payload {
+                Payload::Name(sym) => Some(interner.resolve(sym)),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            names.contains(&"ys"),
+            "second clause `for b in ys` was dropped; names = {names:?}"
+        );
+    }
+
+    #[test]
+    fn multi_clause_comprehension_differs_from_single_clause() {
+        // The two-clause comprehension must not lower identically to the
+        // one-clause version — otherwise the value graph false-merges them.
+        let interner = Interner::new();
+        let two = lower(
+            FileId(0),
+            "t.py",
+            b"def f(A, B):\n    return [a + b for a in A for b in B]\n",
+            &interner,
+        )
+        .expect("lower");
+        let one = lower(
+            FileId(0),
+            "t.py",
+            b"def f(A, B):\n    return [a + b for a in A]\n",
+            &interner,
+        )
+        .expect("lower");
+        assert_ne!(
+            two.nodes.len(),
+            one.nodes.len(),
+            "two-clause and one-clause comprehensions lowered to the same shape"
+        );
+    }
+
+    #[test]
     fn wildcard_guard_match_is_not_unconditional() {
         let interner = Interner::new();
         let il = lower(
@@ -1280,3 +1431,5 @@ mod tests {
         );
     }
 }
+
+

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -946,12 +946,7 @@ fn lower_comparison(lo: &mut Lowering, node: TsNode) -> NodeId {
 /// Build a lambda `λ<pattern>. <Block[Return[body]]>` over a comprehension's
 /// iteration pattern (the `for x in …` target), so the body converges with a JS
 /// `x => body` arrow.
-fn comp_lambda(
-    lo: &mut Lowering,
-    pattern: Option<TsNode>,
-    body: NodeId,
-    bspan: Span,
-) -> NodeId {
+fn comp_lambda(lo: &mut Lowering, pattern: Option<TsNode>, body: NodeId, bspan: Span) -> NodeId {
     let mut kids = Vec::new();
     if let Some(p) = pattern {
         push_pattern_params(lo, p, &mut kids);
@@ -1431,5 +1426,3 @@ mod tests {
         );
     }
 }
-
-

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -109,6 +109,10 @@ Lean (`formal/`). See [normalization](normalization.md) for the full pass list.
   boundaries. Multiple statement-level effects are ordered through control-flow-aware
   sink tags; swapping appends/emits on one execution path is a behavior change, not a
   Type-4 clone.
+- **Multi-clause (flat-map) comprehensions** — a Python `[e for a in A for b in B]`
+  flattens (`A.flatMap(a => B.map(b => e))`), and nose has no `FlatMap` IL primitive yet,
+  so these lower fail-closed (an opaque node) rather than converging with the equivalent
+  nested loop. Single-clause comprehensions converge as above. Tracked in issue #57.
 
 Exact fragment proof is not the same thing as user-facing refactorability. The
 [fragment output audit](fragment-output-audit.md) classifies current real-corpus fragment


### PR DESCRIPTION
Systematic bug hunt from #56 (module + cross-module sweeps), TDD-verified. Baseline `origin/main` @ `4643d1b`.

## Fix landed

**Python multi-clause comprehensions dropped `for`-clauses** (`crates/nose-frontend/src/python.rs`). `lower_comprehension` kept only the first `for_in_clause`, so `[e for a in A for b in B]` silently dropped `for b in B`: `b` was left unbound and the comprehension lowered **byte-identically** to the single-clause `[e for a in A]` — an unsound false merge.

- RED→GREEN tests: `multi_clause_comprehension_binds_all_iterables`, `multi_clause_comprehension_differs_from_single_clause`.
- Fix is **fail-closed**: multi-clause comprehensions build the nested `Map`/`Filter` structure (every collection + target preserved and bound) wrapped in an opaque `Raw` node, which the value graph keys by full subtree content. Cannot collide with the single-clause `Map`, with the genuinely-different nested comprehension `[[e for b in B] for a in A]`, or anything else.
- Single-clause path unchanged (early branch on clause count): `nose scan` over `crates/` is **byte-identical** across semantic/near/syntax, and the eval/bench Python corpora have identical family location-sets. `nose verify --max-violations 0` stays SOUND.
- Root cause (no `FlatMap` IL primitive → no convergence with the equivalent nested loop) tracked in **#57**; honest limit documented in `clone-types.md`.

## Swept — verified, no code change

| Item | Finding |
|---|---|
| Frontend panics (`lower.rs:511` retain, `embedded.rs:88` slice, `java/c/go .pop().unwrap()`) | All guarded by construction (len checks / `find_ci` bounds) — not reachable |
| `cid_names` global table wrong per-function name resolution | **Real code defect, currently latent** — module-binding folding doesn't reach per-unit fingerprints, so the corrupted shadow/mutation fact changes no output. Filed **#59** |
| Soundness: commutative `+`, boolean `&&`/`\|\|`, non-commutative ops | `&&`/`\|\|`, `-`, `/`, `<`, `**`, `%`, `<<`, indexing all correctly held ordered. Commutative `+`/`*` for *untyped* operands is the documented optimistic-commute tradeoff (`value_graph.rs:1597`); oracle battery is numeric. No fresh bug |
| Determinism (RAYON 1 vs 8, run-to-run, all modes) | Byte-identical ✓ |
| Cache correctness / feature portability | cold == warm == no-cache, byte-identical ✓ (cached features interner-independent) |
| Span/provenance (embedded `<script>`, multi-byte UTF-8 prefix) | `blank_except` preserves `\n` byte-for-byte; line numbers correct ✓ |
| `detect` union-find / RANSAC casts | Indices `< n` by construction; i32 cast only at >2.1B tokens (impractical) |
| `eval` `lib.rs:409 as u32` | Benchmark scoring (cand-pair key), not the interpreter; small indices — not a soundness path |
| `nose-il` NodeId(u32) / edge-arena truncation | Requires >4.3B nodes in one file — physically unreachable |

Full checklist disposition in #56.

## Gates
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` green
- `nose verify --max-violations 0` SOUND over crates + eval + bench
- Determinism diff (1 vs N threads) empty

Closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)