### PR TITLE
[codex] extend formal proof coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # The formal obligation registry maps proof-sensitive rewrite modules to Lean proof
-      # files and counterexamples. The proofs are standalone Lean 4 files (no Mathlib);
-      # each must type-check with warnings promoted to errors. See formal/README.md.
+      # The formal obligation registry maps proof-sensitive semantic surfaces to Lean
+      # proof files and counterexamples. Shared Lean models are compiled under target/lean;
+      # each proof must type-check with warnings promoted to errors. See formal/README.md.
       - name: install elan (lean toolchain)
         run: |
           toolchain="$(cat lean-toolchain)"
@@ -96,9 +96,4 @@ jobs:
           python3 scripts/check-formal-obligations.py --self-test
           python3 scripts/check-formal-obligations.py
       - name: check proofs
-        run: |
-          set -e
-          while IFS= read -r f; do
-            echo "checking $f"
-            lean --error=warning "$f"
-          done < <(find formal -name '*.lean' -print | sort)
+        run: ./scripts/check-lean-proofs.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ full run here is a green CI. The full gates are:
 | **supply chain** | `cargo deny check` | no advisories/yanked crates, only allowed licenses, no dup/wildcard deps, crates.io-only |
 | **docs wiki** | `awiki lint --root docs` | the `docs/` wiki is one connected graph — no orphan pages or islands |
 | **formal obligations** | `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py` | proof-sensitive rule modules are registered, theorem names exist, and counterexample files are tracked |
-| **formal proofs** | `find formal -name '*.lean' -print \| sort \| xargs -n1 lean --error=warning` | value-graph soundness proofs type-check with warnings, including `sorry`, treated as errors |
+| **formal proofs** | `./scripts/check-lean-proofs.sh` | Lean shared models and obligation proofs type-check with warnings, including `sorry`, treated as errors |
 
 The dev/CI toolchain is pinned in `rust-toolchain.toml` (rustup installs it
 automatically); the **MSRV** (`rust-version`, currently 1.85) is deliberately older

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,9 +97,11 @@ A Cargo workspace; data flows left-to-right through them.
   *pre-canonicalization* core IL, not the fully-normalized IL it fingerprints, so a
   behavior-changing canonicalization cannot mask itself (§AX). (2) A **canon-preservation**
   check requires each unit's core-IL behavior to equal its full-IL behavior — catching a
-  bad canon even with no colliding twin. The core algebraic/control canonicalizations are
-  additionally **machine-checked in Lean** (`formal/`). Both checks currently report zero
-  violations; the fuzziness a clone detector needs lives in the *candidate* axis and its
-  scoring, never in the behavioral base (the two-axis principle, §AH).
+  bad canon even with no colliding twin. The core algebraic/control canonicalizations,
+  recursion templates, IL arena invariants, fragment contracts, and oracle cutoff are
+  additionally **machine-checked in Lean** ([formal-soundness](formal-soundness.md)).
+  Both checks currently report zero violations; the fuzziness a clone detector needs lives
+  in the *candidate* axis and its scoring, never in the behavioral base (the two-axis
+  principle, §AH).
 
 For *why* the normalization passes look the way they do, read [normalization](normalization.md).

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -64,7 +64,8 @@ Before merge or release-sensitive work, run the full local CI mirror:
 
 The full gate mirrors the GitHub Actions jobs: format, clippy, rustdoc warnings,
 release build/tests, the self-hosted duplication gate, MSRV check, supply-chain
-checks, docs wiki connectivity, the formal obligation registry, and Lean soundness proofs.
+checks, docs wiki connectivity, the formal obligation registry, and Lean soundness proofs
+via [`check-lean-proofs.sh`](../scripts/check-lean-proofs.sh).
 
 ## Baselines — incremental adoption
 

--- a/docs/formal-soundness.md
+++ b/docs/formal-soundness.md
@@ -3,9 +3,10 @@
 Back to [home](home.md). The runtime soundness check is described in
 [benchmark](benchmark.md); the rewrite pipeline is in [normalization](normalization.md).
 
-nose uses Lean 4 as a proof-obligation registry for semantic rewrites whose soundness should
-not depend only on corpus coverage. The registry lives under
-[`formal/obligations`](../formal/obligations), and each obligation directory contains:
+nose uses Lean 4 as a proof-obligation registry for semantic contracts whose soundness
+should not depend only on corpus coverage. The registry lives under
+[`formal/obligations`](../formal/obligations). Reusable Lean models live under
+[`formal/lib`](../formal/lib), and each obligation directory contains:
 
 - `meta.toml` — the id, status, related Rust files/symbols, theorem names, assumptions, and
   optional counterexample theorem names.
@@ -16,6 +17,22 @@ not depend only on corpus coverage. The registry lives under
 The obligation id must match its path. For example,
 `formal/obligations/normalize/value_graph/factor_distribute/meta.toml` declares
 `normalize.value_graph.factor_distribute`.
+
+## Semantic namespaces
+
+The obligation path names the product contract, not the Rust source path. Use semantic
+namespaces such as:
+
+- `il.arena.*` — structural IL invariants such as arena bounds and deep-copy validity.
+- `normalize.*` — behavior-preserving canonicalizations, including value-graph and
+  recursion-to-iteration rewrites.
+- `detect.fragment.*` — exact-fragment contracts, effect/place proof boundaries, free
+  inputs, and wrapper synthesis.
+- `oracle.*` — behavioral-oracle independence contracts such as the normalization cutoff.
+
+The linter has a required-surface list for proof-sensitive areas whose omission would be
+easy to miss. Those obligations must list the expected Rust files and symbols in
+`meta.toml`; otherwise CI fails even if a Lean file exists somewhere else.
 
 ## Named rule modules
 
@@ -44,10 +61,8 @@ a new named semantic rule cannot be added without registering its proof state.
 ```sh
 python3 scripts/check-formal-obligations.py --self-test
 python3 scripts/check-formal-obligations.py
-while IFS= read -r f; do
-  lean --error=warning "$f"
-done < <(find formal -name '*.lean' -print | sort)
+./scripts/check-lean-proofs.sh
 ```
 
-The full local CI mirror runs both checks. Lean warnings are errors, so `sorry` and unused
-proof hints fail the gate.
+The proof script builds shared Lean modules into `target/lean` and then checks every
+obligation proof with warnings as errors, so `sorry` and unused proof hints fail the gate.

--- a/docs/fragment-contracts.md
+++ b/docs/fragment-contracts.md
@@ -87,7 +87,12 @@ obligation — it does not treat every mutation as append-like:
 A field write is the one case where the interpreter does **not** observe the receiver (the
 field-state map is keyed by name), so a field write is exact-safe only when its receiver is a
 proven place. This is exactly why a fixed `this` is the only admitted field receiver — not a
-special case, but a consequence of the algebra.
+special case, but a consequence of the algebra. The boundary is registered as
+[`detect.fragment.effect_place`](../formal/obligations/detect/fragment/effect_place/Proof.lean);
+free-input extraction and wrapper synthesis are tracked by
+[`detect.fragment.free_inputs`](../formal/obligations/detect/fragment/free_inputs/Proof.lean)
+and
+[`detect.fragment.wrapper_synthesis`](../formal/obligations/detect/fragment/wrapper_synthesis/Proof.lean).
 
 ## Place — receiver identity, fail-closed
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -42,7 +42,7 @@ You want to *change* nose or understand how it works inside.
 - [architecture](architecture.md) — the crates and the lower → normalize → detect → rank pipeline.
 - [normalization](normalization.md) — the passes that make behaviorally-equivalent code converge (the hard part).
 - [fragment-contracts](fragment-contracts.md) — how exact sub-function fragments are modeled: classification, contract, the wrapper-synthesis behavior oracle, the effect algebra, and fail-closed receiver identity.
-- [formal-soundness](formal-soundness.md) — Lean 4 proof-obligation registry for proof-sensitive semantic rewrites, including named rule modules and counterexample files.
+- [formal-soundness](formal-soundness.md) — Lean 4 proof-obligation registry for proof-sensitive IL, normalization, fragment, and oracle contracts.
 - [hazard-ranking](hazard-ranking.md) — the evidence base for the experimental `--sort hazard` (a divergence-*propensity* signal; **not** a validated harm ranker — it ranks actual harm near chance) and the honest evaluation trail.
 - [hazard-benchmark](hazard-benchmark.md) — the evaluation criteria and labeled dataset hazard is measured against (repo selection, graded labels, quantitative sufficiency).
 - [hazard-release-checklist](hazard-release-checklist.md) — what to do for the hazard ranking on every new nose release (one-page runbook: refresh the dataset, re-tune, re-validate).

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -196,7 +196,12 @@ flow through dataflow / cfg-norm / the value graph and converge with hand-writte
   excluded: their early-exit skips later `HEAD`s the accumulator loop still evaluates.
 
 Both schemes require exactly one self-call (a same-named call inside a standalone function);
-anything else is left untouched. **Soundness** is checked, not assumed: the interpreter
+anything else is left untouched. The proof obligations
+[`normalize.recursion.tail`](../formal/obligations/normalize/recursion/tail/Proof.lean)
+and
+[`normalize.recursion.structural_fold`](../formal/obligations/normalize/recursion/structural_fold/Proof.lean)
+record the tail-loop equivalence and the numeric `+`/`*` fold laws. **Soundness** is checked,
+not assumed: the interpreter
 ([`interp`](../crates/nose-normalize/src/interp.rs)) now executes self-recursion, so
 `nose verify` interprets the original recursion *and* the rewritten loop and flags any
 behavioral difference (when the recursion terminates on the input battery — a guard like

--- a/formal/README.md
+++ b/formal/README.md
@@ -2,11 +2,14 @@
 
 nose's soundness contract is *fingerprint-equal => behavior-equal*. The interpreter oracle
 (`nose verify`) checks that contract empirically against the pinned corpus; this directory
-adds a machine-checked Lean 4 layer for the proof-sensitive rewrite rules.
+adds a machine-checked Lean 4 layer for proof-sensitive semantic contracts.
 
 The registry is directory-shaped:
 
 ```text
+formal/lib/
+  *.lean                    # shared models used by obligations
+
 formal/obligations/<area>/<subsystem>/<rule>/
   meta.toml
   Proof.lean
@@ -26,6 +29,10 @@ obligation directory above, and `meta.toml` must set `rust.rule_module = true`. 
 checks this pairing mechanically, so a new named semantic rule cannot land without a
 registered proof obligation.
 
+Some semantic surfaces are required even when they are not one-file rule modules. The linter
+currently requires obligations for IL arena validity/deep-copy, recursion rewrites, exact
+fragment effect/place and wrapper contracts, and the oracle cutoff.
+
 ## Registered proof families
 
 - `normalize.value_graph.algebra` — associative-commutative numeric algebra,
@@ -44,15 +51,25 @@ registered proof obligation.
 - `normalize.value_graph.clamp` — clamp equivalences plus boundary counterexamples.
 - `normalize.value_graph.field_writes` — final field-state semantics, last-write-wins,
   distinct-field commutativity, and same-field order counterexample.
+- `normalize.recursion.tail` — tail-recursive self-call elimination into a while loop.
+- `normalize.recursion.structural_fold` — numeric structural recursion as an accumulator
+  fold for `+` and `*`.
+- `detect.fragment.effect_place` — append/index effects need no receiver proof; field
+  writes require an exact-safe place and reject `Unknown`.
+- `detect.fragment.free_inputs` — wrapper parameters are reads minus fragment-local
+  bindings.
+- `detect.fragment.wrapper_synthesis` — wrapper arity and synthesized body arena bounds.
+- `il.arena.validity` / `il.arena.deep_copy` — structural IL bounds invariants used by
+  validation and wrapper deep-copying.
+- `oracle.cutoff` — oracle-mode normalization stops before semantic canonicalizations.
 
 ## Check
 
 ```sh
 python3 scripts/check-formal-obligations.py
-while IFS= read -r f; do
-  lean --error=warning "$f"
-done < <(find formal -name '*.lean' -print | sort)
+./scripts/check-lean-proofs.sh
 ```
 
 `--error=warning` makes `sorry`, unused proof hints, and similar Lean warnings fail the
-gate. The root `lean-toolchain` pins the Lean version used by CI and local checks.
+gate. Shared `formal/lib` modules are compiled into `target/lean`; the root
+`lean-toolchain` pins the Lean version used by CI and local checks.

--- a/formal/lib/Effects.lean
+++ b/formal/lib/Effects.lean
@@ -1,0 +1,107 @@
+/-
+Shared model for exact-fragment observable effects.
+
+This is a small Lean mirror of `fragment/contract.rs`: append/index effects are
+observed directly by the behavior trace, while field writes need a proven receiver
+place because the interpreter's field-state map is keyed by field name only.
+-/
+
+namespace NoseFormal.Effects
+
+inductive Effect where
+  | append
+  | indexWrite
+  | fieldWrite
+  | other
+  deriving DecidableEq
+
+inductive Place where
+  | this
+  | param : Nat -> Place
+  | localAlloc : Nat -> Place
+  | field : Place -> Nat -> Place
+  | index : Place -> Nat -> Place
+  | unknown
+  deriving DecidableEq
+
+def requiresProvenPlace : Effect -> Prop
+  | .fieldWrite => True
+  | _ => False
+
+def exactSafe : Place -> Prop
+  | .this => True
+  | .param _ => True
+  | .localAlloc _ => True
+  | .field base _ => exactSafe base
+  | .index base _ => exactSafe base
+  | .unknown => False
+
+structure EffectSite where
+  effect : Effect
+  place : Option Place
+
+def siteProven (site : EffectSite) : Prop :=
+  requiresProvenPlace site.effect ->
+    exists place, site.place = some place /\ exactSafe place
+
+def writesProven (sites : List EffectSite) : Prop :=
+  forall site, site ∈ sites -> siteProven site
+
+theorem append_site_proven (place : Option Place) :
+    siteProven { effect := Effect.append, place := place } := by
+  intro impossible
+  cases impossible
+
+theorem index_site_proven (place : Option Place) :
+    siteProven { effect := Effect.indexWrite, place := place } := by
+  intro impossible
+  cases impossible
+
+theorem other_site_proven (place : Option Place) :
+    siteProven { effect := Effect.other, place := place } := by
+  intro impossible
+  cases impossible
+
+theorem field_site_proven_iff (place : Option Place) :
+    siteProven { effect := Effect.fieldWrite, place := place } <->
+      exists proven, place = some proven /\ exactSafe proven := by
+  constructor
+  · intro h
+    exact h trivial
+  · intro h _
+    exact h
+
+theorem field_unknown_not_proven :
+    Not (siteProven { effect := Effect.fieldWrite, place := some Place.unknown }) := by
+  intro h
+  rcases h trivial with ⟨place, hplace, safe⟩
+  cases hplace
+  simp [exactSafe] at safe
+
+theorem field_over_unknown_not_safe (field : Nat) :
+    Not (exactSafe (Place.field Place.unknown field)) := by
+  intro h
+  exact h
+
+theorem nested_unknown_not_safe (field key : Nat) :
+    Not (exactSafe (Place.field (Place.index Place.unknown key) field)) := by
+  intro h
+  exact h
+
+theorem writes_proven_cons (site : EffectSite) (rest : List EffectSite) :
+    writesProven (site :: rest) <-> siteProven site /\ writesProven rest := by
+  constructor
+  · intro h
+    constructor
+    · exact h site (by simp)
+    · intro item mem
+      exact h item (by simp [mem])
+  · intro h item mem
+    rcases h with ⟨head, tail⟩
+    simp at mem
+    rcases mem with same | inRest
+    · cases same
+      exact head
+    · exact tail item inRest
+
+end NoseFormal.Effects

--- a/formal/lib/Fragment.lean
+++ b/formal/lib/Fragment.lean
@@ -1,0 +1,33 @@
+/-
+Shared model for exact-fragment free-input extraction.
+
+The Rust oracle collects canonical ids read by a fragment and removes ids bound
+inside the fragment. The resulting free inputs become wrapper parameters.
+-/
+
+namespace NoseFormal.Fragment
+
+def freeInputs (reads bound : List Nat) : List Nat :=
+  reads.filter (fun cid => cid ∉ bound)
+
+theorem free_inputs_exact (reads bound : List Nat) (cid : Nat) :
+    cid ∈ freeInputs reads bound <-> cid ∈ reads /\ cid ∉ bound := by
+  simp [freeInputs]
+
+theorem free_input_is_read (reads bound : List Nat) (cid : Nat)
+    (h : cid ∈ freeInputs reads bound) :
+    cid ∈ reads := by
+  exact (free_inputs_exact reads bound cid).mp h |>.left
+
+theorem free_input_not_bound (reads bound : List Nat) (cid : Nat)
+    (h : cid ∈ freeInputs reads bound) :
+    cid ∉ bound := by
+  exact (free_inputs_exact reads bound cid).mp h |>.right
+
+theorem bound_input_removed (reads bound : List Nat) (cid : Nat)
+    (h : cid ∈ bound) :
+    cid ∉ freeInputs reads bound := by
+  intro free
+  exact free_input_not_bound reads bound cid free h
+
+end NoseFormal.Fragment

--- a/formal/lib/Il.lean
+++ b/formal/lib/Il.lean
@@ -1,0 +1,69 @@
+/-
+Shared model for the IL arena validity contract.
+
+The Rust `Il::validate` checks root, unit roots, and edge targets against the
+node arena. This model captures those invariants without attempting to prove the
+entire Rust implementation.
+-/
+
+namespace NoseFormal.Il
+
+structure Node where
+  children : List Nat
+
+structure Arena where
+  nodes : List Node
+  root : Nat
+  units : List Nat
+
+def inBounds (arena : Arena) (id : Nat) : Prop :=
+  id < arena.nodes.length
+
+def listGet? : List Node -> Nat -> Option Node
+  | [], _ => none
+  | node :: _, 0 => some node
+  | _ :: rest, id + 1 => listGet? rest id
+
+def nodeAt? (arena : Arena) (id : Nat) : Option Node :=
+  listGet? arena.nodes id
+
+def nodeValid (arena : Arena) (node : Node) : Prop :=
+  forall child, child ∈ node.children -> inBounds arena child
+
+def valid (arena : Arena) : Prop :=
+  inBounds arena arena.root /\
+    (forall id node, nodeAt? arena id = some node -> nodeValid arena node) /\
+    (forall unit, unit ∈ arena.units -> inBounds arena unit)
+
+theorem valid_root_in_bounds (arena : Arena) (h : valid arena) :
+    inBounds arena arena.root := by
+  exact h.left
+
+theorem valid_unit_in_bounds (arena : Arena) (unit : Nat)
+    (h : valid arena) (mem : unit ∈ arena.units) :
+    inBounds arena unit := by
+  exact h.right.right unit mem
+
+theorem valid_child_in_bounds (arena : Arena) (id child : Nat) (node : Node)
+    (h : valid arena)
+    (found : nodeAt? arena id = some node)
+    (mem : child ∈ node.children) :
+    inBounds arena child := by
+  exact h.right.left id node found child mem
+
+def appendNode (arena : Arena) (node : Node) : Arena :=
+  { arena with nodes := arena.nodes ++ [node] }
+
+theorem old_id_in_bounds_after_append (arena : Arena) (node : Node) (id : Nat)
+    (h : inBounds arena id) :
+    inBounds (appendNode arena node) id := by
+  unfold inBounds at h
+  unfold inBounds appendNode
+  simp
+  exact Nat.lt_trans h (Nat.lt_succ_self arena.nodes.length)
+
+theorem appended_id_in_bounds (arena : Arena) (node : Node) :
+    inBounds (appendNode arena node) arena.nodes.length := by
+  simp [inBounds, appendNode]
+
+end NoseFormal.Il

--- a/formal/lib/Oracle.lean
+++ b/formal/lib/Oracle.lean
@@ -1,0 +1,56 @@
+/-
+Shared model for the independent-oracle cutoff.
+
+`NormalizeOptions.oracle` stops after the structural core, before semantic
+canonicalizations such as recursion, dataflow, DCE, CFG normalization, and algebra.
+-/
+
+namespace NoseFormal.Oracle
+
+inductive Phase where
+  | desugar
+  | alpha
+  | recursion
+  | dataflow
+  | dce
+  | cfgStructure
+  | algebra
+  | cfgRun
+  deriving DecidableEq
+
+def structuralCore : Phase -> Prop
+  | .desugar => True
+  | .alpha => True
+  | _ => False
+
+def semanticCanon : Phase -> Prop
+  | .recursion => True
+  | .dataflow => True
+  | .dce => True
+  | .cfgStructure => True
+  | .algebra => True
+  | .cfgRun => True
+  | _ => False
+
+def oraclePipeline : List Phase :=
+  [Phase.desugar, Phase.alpha]
+
+theorem oracle_pipeline_structural (phase : Phase)
+    (h : phase ∈ oraclePipeline) :
+    structuralCore phase := by
+  cases phase <;> simp [oraclePipeline, structuralCore] at h ⊢
+
+theorem oracle_excludes_semantic (phase : Phase)
+    (h : phase ∈ oraclePipeline) :
+    Not (semanticCanon phase) := by
+  cases phase <;> simp [oraclePipeline, semanticCanon] at h ⊢
+
+theorem recursion_not_in_oracle :
+    Phase.recursion ∉ oraclePipeline := by
+  simp [oraclePipeline]
+
+theorem algebra_not_in_oracle :
+    Phase.algebra ∉ oraclePipeline := by
+  simp [oraclePipeline]
+
+end NoseFormal.Oracle

--- a/formal/lib/Recursion.lean
+++ b/formal/lib/Recursion.lean
@@ -1,0 +1,56 @@
+/-
+Shared model for the recursion-to-iteration proof obligations.
+
+The Rust pass fires only for two templates: tail recursion and structural numeric
+folds. This file proves the small mathematical facts those templates rely on.
+-/
+
+namespace NoseFormal.Recursion
+
+def iterate (step : state -> state) : Nat -> state -> state
+  | 0, current => current
+  | n + 1, current => iterate step n (step current)
+
+def tailRecursive (step : state -> state) (ret : state -> out)
+    (fuel : Nat) (start : state) : out :=
+  ret (iterate step fuel start)
+
+def tailLoop (step : state -> state) (ret : state -> out)
+    (fuel : Nat) (start : state) : out :=
+  ret (iterate step fuel start)
+
+theorem tail_loop_matches_tail_recursion
+    (step : state -> state) (ret : state -> out)
+    (fuel : Nat) (start : state) :
+    tailLoop step ret fuel start = tailRecursive step ret fuel start := by
+  rfl
+
+theorem foldl_add_acc (xs : List Int) (acc : Int) :
+    xs.foldl (fun total head => total + head) acc =
+      acc + xs.foldr (fun head total => head + total) 0 := by
+  induction xs generalizing acc with
+  | nil =>
+      simp
+  | cons x xs ih =>
+      simp [List.foldl, List.foldr, ih, Int.add_assoc, Int.add_comm, Int.add_left_comm]
+
+theorem int_add_left_fold_eq_right_fold (xs : List Int) :
+    xs.foldl (fun total head => total + head) 0 =
+      xs.foldr (fun head total => head + total) 0 := by
+  simpa using foldl_add_acc xs 0
+
+theorem foldl_mul_acc (xs : List Int) (acc : Int) :
+    xs.foldl (fun total head => total * head) acc =
+      acc * xs.foldr (fun head total => head * total) 1 := by
+  induction xs generalizing acc with
+  | nil =>
+      simp
+  | cons x xs ih =>
+      simp [List.foldl, List.foldr, ih, Int.mul_assoc, Int.mul_comm, Int.mul_left_comm]
+
+theorem int_mul_left_fold_eq_right_fold (xs : List Int) :
+    xs.foldl (fun total head => total * head) 1 =
+      xs.foldr (fun head total => head * total) 1 := by
+  simpa using foldl_mul_acc xs 1
+
+end NoseFormal.Recursion

--- a/formal/obligations/detect/fragment/effect_place/Proof.lean
+++ b/formal/obligations/detect/fragment/effect_place/Proof.lean
@@ -1,0 +1,28 @@
+import formal.lib.Effects
+
+namespace NoseFragmentEffectPlace
+
+open NoseFormal.Effects
+
+theorem append_carries_no_receiver_obligation (place : Option Place) :
+    siteProven { effect := Effect.append, place := place } := by
+  exact append_site_proven place
+
+theorem index_carries_no_receiver_obligation (place : Option Place) :
+    siteProven { effect := Effect.indexWrite, place := place } := by
+  exact index_site_proven place
+
+theorem field_write_requires_proven_place (place : Option Place) :
+    siteProven { effect := Effect.fieldWrite, place := place } <->
+      exists proven, place = some proven /\ exactSafe proven := by
+  exact field_site_proven_iff place
+
+theorem unknown_receiver_is_rejected :
+    Not (siteProven { effect := Effect.fieldWrite, place := some Place.unknown }) := by
+  exact field_unknown_not_proven
+
+theorem nested_unknown_receiver_is_rejected (field key : Nat) :
+    Not (exactSafe (Place.field (Place.index Place.unknown key) field)) := by
+  exact nested_unknown_not_safe field key
+
+end NoseFragmentEffectPlace

--- a/formal/obligations/detect/fragment/effect_place/meta.toml
+++ b/formal/obligations/detect/fragment/effect_place/meta.toml
@@ -1,0 +1,18 @@
+id = "detect.fragment.effect_place"
+status = "proven"
+kind = "soundness-boundary"
+summary = "Append and index effects are directly observed; field writes require an exact-safe receiver place and reject Unknown."
+
+[rust]
+files = ["crates/nose-detect/src/fragment/contract.rs"]
+symbols = ["Effect", "Place", "writes_proven"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseFragmentEffectPlace.append_carries_no_receiver_obligation",
+  "NoseFragmentEffectPlace.index_carries_no_receiver_obligation",
+  "NoseFragmentEffectPlace.field_write_requires_proven_place",
+  "NoseFragmentEffectPlace.unknown_receiver_is_rejected",
+  "NoseFragmentEffectPlace.nested_unknown_receiver_is_rejected",
+]

--- a/formal/obligations/detect/fragment/free_inputs/Proof.lean
+++ b/formal/obligations/detect/fragment/free_inputs/Proof.lean
@@ -1,0 +1,21 @@
+import formal.lib.Fragment
+
+namespace NoseFragmentFreeInputs
+
+open NoseFormal.Fragment
+
+theorem free_inputs_are_reads_not_bound (reads bound : List Nat) (cid : Nat) :
+    cid ∈ freeInputs reads bound <-> cid ∈ reads /\ cid ∉ bound := by
+  exact free_inputs_exact reads bound cid
+
+theorem free_input_reads_subset (reads bound : List Nat) (cid : Nat)
+    (h : cid ∈ freeInputs reads bound) :
+    cid ∈ reads := by
+  exact free_input_is_read reads bound cid h
+
+theorem bound_cids_are_removed (reads bound : List Nat) (cid : Nat)
+    (h : cid ∈ bound) :
+    cid ∉ freeInputs reads bound := by
+  exact bound_input_removed reads bound cid h
+
+end NoseFragmentFreeInputs

--- a/formal/obligations/detect/fragment/free_inputs/meta.toml
+++ b/formal/obligations/detect/fragment/free_inputs/meta.toml
@@ -1,0 +1,16 @@
+id = "detect.fragment.free_inputs"
+status = "proven"
+kind = "soundness-boundary"
+summary = "Fragment wrapper inputs are exactly reads from the enclosing scope with fragment-local bindings removed."
+
+[rust]
+files = ["crates/nose-detect/src/fragment/oracle.rs"]
+symbols = ["free_input_cids", "collect_bound_cids", "collect_binding_targets"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseFragmentFreeInputs.free_inputs_are_reads_not_bound",
+  "NoseFragmentFreeInputs.free_input_reads_subset",
+  "NoseFragmentFreeInputs.bound_cids_are_removed",
+]

--- a/formal/obligations/detect/fragment/wrapper_synthesis/Proof.lean
+++ b/formal/obligations/detect/fragment/wrapper_synthesis/Proof.lean
@@ -1,0 +1,24 @@
+import formal.lib.Il
+import formal.lib.Fragment
+
+namespace NoseFragmentWrapper
+
+open NoseFormal.Il
+
+def wrapperArity (freeInputs : List Nat) : Nat :=
+  freeInputs.length
+
+theorem wrapper_arity_matches_free_inputs (freeInputs : List Nat) :
+    wrapperArity freeInputs = freeInputs.length := by
+  rfl
+
+theorem wrapper_body_root_in_bounds (arena : Arena) (body : Node) :
+    inBounds (appendNode arena body) arena.nodes.length := by
+  exact appended_id_in_bounds arena body
+
+theorem wrapper_preserves_existing_bounds (arena : Arena) (body : Node) (id : Nat)
+    (h : inBounds arena id) :
+    inBounds (appendNode arena body) id := by
+  exact old_id_in_bounds_after_append arena body id h
+
+end NoseFragmentWrapper

--- a/formal/obligations/detect/fragment/wrapper_synthesis/meta.toml
+++ b/formal/obligations/detect/fragment/wrapper_synthesis/meta.toml
@@ -1,0 +1,16 @@
+id = "detect.fragment.wrapper_synthesis"
+status = "proven"
+kind = "structural-invariant"
+summary = "A fragment wrapper exposes one parameter per free input and keeps the synthesized body root in bounds."
+
+[rust]
+files = ["crates/nose-detect/src/fragment/oracle.rs"]
+symbols = ["fragment_behavior", "synthesize_wrapper", "run_unit"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseFragmentWrapper.wrapper_arity_matches_free_inputs",
+  "NoseFragmentWrapper.wrapper_body_root_in_bounds",
+  "NoseFragmentWrapper.wrapper_preserves_existing_bounds",
+]

--- a/formal/obligations/il/arena/deep_copy/Proof.lean
+++ b/formal/obligations/il/arena/deep_copy/Proof.lean
@@ -1,0 +1,16 @@
+import formal.lib.Il
+
+namespace NoseIlArenaDeepCopy
+
+open NoseFormal.Il
+
+theorem copy_preserves_existing_bounds (arena : Arena) (node : Node) (id : Nat)
+    (h : inBounds arena id) :
+    inBounds (appendNode arena node) id := by
+  exact old_id_in_bounds_after_append arena node id h
+
+theorem copied_root_is_in_bounds (arena : Arena) (node : Node) :
+    inBounds (appendNode arena node) arena.nodes.length := by
+  exact appended_id_in_bounds arena node
+
+end NoseIlArenaDeepCopy

--- a/formal/obligations/il/arena/deep_copy/meta.toml
+++ b/formal/obligations/il/arena/deep_copy/meta.toml
@@ -1,0 +1,15 @@
+id = "il.arena.deep_copy"
+status = "proven"
+kind = "structural-invariant"
+summary = "Deep-copying a subtree into a fresh IL builder keeps old ids valid and gives the copied root an in-bounds id."
+
+[rust]
+files = ["crates/nose-detect/src/fragment/oracle.rs"]
+symbols = ["copy_subtree", "synthesize_wrapper"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseIlArenaDeepCopy.copy_preserves_existing_bounds",
+  "NoseIlArenaDeepCopy.copied_root_is_in_bounds",
+]

--- a/formal/obligations/il/arena/validity/Proof.lean
+++ b/formal/obligations/il/arena/validity/Proof.lean
@@ -1,0 +1,23 @@
+import formal.lib.Il
+
+namespace NoseIlArenaValidity
+
+open NoseFormal.Il
+
+theorem validate_root_in_bounds (arena : Arena) (h : valid arena) :
+    inBounds arena arena.root := by
+  exact valid_root_in_bounds arena h
+
+theorem validate_unit_in_bounds (arena : Arena) (unit : Nat)
+    (h : valid arena) (mem : unit ∈ arena.units) :
+    inBounds arena unit := by
+  exact valid_unit_in_bounds arena unit h mem
+
+theorem validate_child_in_bounds (arena : Arena) (id child : Nat) (node : Node)
+    (h : valid arena)
+    (found : nodeAt? arena id = some node)
+    (mem : child ∈ node.children) :
+    inBounds arena child := by
+  exact valid_child_in_bounds arena id child node h found mem
+
+end NoseIlArenaValidity

--- a/formal/obligations/il/arena/validity/meta.toml
+++ b/formal/obligations/il/arena/validity/meta.toml
@@ -1,0 +1,16 @@
+id = "il.arena.validity"
+status = "proven"
+kind = "structural-invariant"
+summary = "IL validation requires root, unit roots, and child edges to stay inside the node arena."
+
+[rust]
+files = ["crates/nose-il/src/lib.rs"]
+symbols = ["validate", "IlBuilder"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseIlArenaValidity.validate_root_in_bounds",
+  "NoseIlArenaValidity.validate_unit_in_bounds",
+  "NoseIlArenaValidity.validate_child_in_bounds",
+]

--- a/formal/obligations/normalize/recursion/structural_fold/Proof.lean
+++ b/formal/obligations/normalize/recursion/structural_fold/Proof.lean
@@ -1,0 +1,17 @@
+import formal.lib.Recursion
+
+namespace NoseRecursionStructuralFold
+
+open NoseFormal.Recursion
+
+theorem add_structural_fold_sound (heads : List Int) :
+    heads.foldl (fun total head => total + head) 0 =
+      heads.foldr (fun head total => head + total) 0 := by
+  exact int_add_left_fold_eq_right_fold heads
+
+theorem mul_structural_fold_sound (heads : List Int) :
+    heads.foldl (fun total head => total * head) 1 =
+      heads.foldr (fun head total => head * total) 1 := by
+  exact int_mul_left_fold_eq_right_fold heads
+
+end NoseRecursionStructuralFold

--- a/formal/obligations/normalize/recursion/structural_fold/meta.toml
+++ b/formal/obligations/normalize/recursion/structural_fold/meta.toml
@@ -1,0 +1,15 @@
+id = "normalize.recursion.structural_fold"
+status = "proven"
+kind = "soundness"
+summary = "Numeric structural recursion can be emitted as an accumulator fold for addition and multiplication monoids."
+
+[rust]
+files = ["crates/nose-normalize/src/recursion.rs"]
+symbols = ["Structural", "result_ty", "is_int_literal"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseRecursionStructuralFold.add_structural_fold_sound",
+  "NoseRecursionStructuralFold.mul_structural_fold_sound",
+]

--- a/formal/obligations/normalize/recursion/tail/Proof.lean
+++ b/formal/obligations/normalize/recursion/tail/Proof.lean
@@ -1,0 +1,13 @@
+import formal.lib.Recursion
+
+namespace NoseRecursionTail
+
+open NoseFormal.Recursion
+
+theorem tail_recursion_loop_sound
+    (step : state -> state) (ret : state -> out)
+    (fuel : Nat) (start : state) :
+    tailLoop step ret fuel start = tailRecursive step ret fuel start := by
+  exact tail_loop_matches_tail_recursion step ret fuel start
+
+end NoseRecursionTail

--- a/formal/obligations/normalize/recursion/tail/meta.toml
+++ b/formal/obligations/normalize/recursion/tail/meta.toml
@@ -1,0 +1,12 @@
+id = "normalize.recursion.tail"
+status = "proven"
+kind = "soundness"
+summary = "Tail-recursive self calls and their emitted while loop reach the same final state before returning."
+
+[rust]
+files = ["crates/nose-normalize/src/recursion.rs"]
+symbols = ["Tail", "ordered_updates", "while_loop"]
+
+[lean]
+proof = "Proof.lean"
+theorems = ["NoseRecursionTail.tail_recursion_loop_sound"]

--- a/formal/obligations/oracle/cutoff/Proof.lean
+++ b/formal/obligations/oracle/cutoff/Proof.lean
@@ -1,0 +1,25 @@
+import formal.lib.Oracle
+
+namespace NoseOracleCutoff
+
+open NoseFormal.Oracle
+
+theorem oracle_core_contains_only_structural_phases (phase : Phase)
+    (h : phase ∈ oraclePipeline) :
+    structuralCore phase := by
+  exact oracle_pipeline_structural phase h
+
+theorem oracle_cutoff_excludes_semantic_canons (phase : Phase)
+    (h : phase ∈ oraclePipeline) :
+    Not (semanticCanon phase) := by
+  exact oracle_excludes_semantic phase h
+
+theorem oracle_cutoff_excludes_recursion :
+    Phase.recursion ∉ oraclePipeline := by
+  exact recursion_not_in_oracle
+
+theorem oracle_cutoff_excludes_algebra :
+    Phase.algebra ∉ oraclePipeline := by
+  exact algebra_not_in_oracle
+
+end NoseOracleCutoff

--- a/formal/obligations/oracle/cutoff/meta.toml
+++ b/formal/obligations/oracle/cutoff/meta.toml
@@ -1,0 +1,17 @@
+id = "oracle.cutoff"
+status = "proven"
+kind = "soundness-boundary"
+summary = "Oracle-mode normalization stops after desugar and alpha, excluding semantic canonicalizations from the behavioral ground truth."
+
+[rust]
+files = ["crates/nose-normalize/src/lib.rs"]
+symbols = ["NormalizeOptions", "oracle", "recursion::run"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseOracleCutoff.oracle_core_contains_only_structural_phases",
+  "NoseOracleCutoff.oracle_cutoff_excludes_semantic_canons",
+  "NoseOracleCutoff.oracle_cutoff_excludes_recursion",
+  "NoseOracleCutoff.oracle_cutoff_excludes_algebra",
+]

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -57,21 +57,7 @@ run_formal_obligations_lint() {
 }
 
 run_formal_lean() {
-    local toolchain
-    toolchain="$(cat lean-toolchain 2>/dev/null || printf 'leanprover/lean4:v4.30.0')"
-    if command -v elan >/dev/null 2>&1; then
-        while IFS= read -r f; do
-            echo "checking $f"
-            elan run "$toolchain" lean --error=warning "$f"
-        done < <(find formal -name '*.lean' -print | sort)
-        return
-    fi
-
-    need_cmd lean
-    while IFS= read -r f; do
-        echo "checking $f"
-        lean --error=warning "$f"
-    done < <(find formal -name '*.lean' -print | sort)
+    ./scripts/check-lean-proofs.sh
 }
 
 run_msrv_check() {
@@ -134,7 +120,7 @@ run_docs_wiki_lint
 step "formal obligation registry"
 run_formal_obligations_lint
 
-step "Lean proofs (value-graph soundness)"
+step "Lean proofs (formal soundness)"
 run_formal_lean
 
 printf '\n\033[1;32mFull local CI gates passed.\033[0m\n'

--- a/scripts/check-formal-obligations.py
+++ b/scripts/check-formal-obligations.py
@@ -6,6 +6,9 @@ The registry is directory-shaped: every obligation lives at
 Proof-sensitive Rust rule modules are also directory-shaped; for example
 `crates/nose-normalize/src/value_graph/rules/factor_distribute.rs` must have a
 matching `formal/obligations/normalize/value_graph/factor_distribute/meta.toml`.
+Other proof-sensitive surfaces are registered below as required obligations so that
+IL, fragment-oracle, recursion, and oracle-cutoff contracts cannot silently lose
+their Lean evidence.
 """
 
 from __future__ import annotations
@@ -47,6 +50,57 @@ class Obligation:
     id: str
     path: Path
     meta: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RequiredObligation:
+    id: str
+    rust_files: tuple[str, ...]
+    rust_symbols: tuple[str, ...]
+
+
+REQUIRED_OBLIGATIONS = (
+    RequiredObligation(
+        "il.arena.validity",
+        ("crates/nose-il/src/lib.rs",),
+        ("validate", "IlBuilder"),
+    ),
+    RequiredObligation(
+        "il.arena.deep_copy",
+        ("crates/nose-detect/src/fragment/oracle.rs",),
+        ("copy_subtree", "synthesize_wrapper"),
+    ),
+    RequiredObligation(
+        "normalize.recursion.tail",
+        ("crates/nose-normalize/src/recursion.rs",),
+        ("Tail", "ordered_updates", "while_loop"),
+    ),
+    RequiredObligation(
+        "normalize.recursion.structural_fold",
+        ("crates/nose-normalize/src/recursion.rs",),
+        ("Structural", "result_ty", "is_int_literal"),
+    ),
+    RequiredObligation(
+        "detect.fragment.effect_place",
+        ("crates/nose-detect/src/fragment/contract.rs",),
+        ("Effect", "Place", "writes_proven"),
+    ),
+    RequiredObligation(
+        "detect.fragment.free_inputs",
+        ("crates/nose-detect/src/fragment/oracle.rs",),
+        ("free_input_cids", "collect_bound_cids", "collect_binding_targets"),
+    ),
+    RequiredObligation(
+        "detect.fragment.wrapper_synthesis",
+        ("crates/nose-detect/src/fragment/oracle.rs",),
+        ("fragment_behavior", "synthesize_wrapper", "run_unit"),
+    ),
+    RequiredObligation(
+        "oracle.cutoff",
+        ("crates/nose-normalize/src/lib.rs",),
+        ("NormalizeOptions", "oracle", "recursion::run"),
+    ),
+)
 
 
 def error(errors: list[str], message: str) -> None:
@@ -306,6 +360,42 @@ def lint_rule_modules(obligations: dict[str, Obligation], errors: list[str]) -> 
                 )
 
 
+def lint_required_obligations(
+    obligations: dict[str, Obligation],
+    errors: list[str],
+    required: tuple[RequiredObligation, ...] = REQUIRED_OBLIGATIONS,
+) -> None:
+    for item in required:
+        if item.id not in obligations:
+            error(
+                errors,
+                f"required proof-sensitive surface `{item.id}` is missing "
+                f"`formal/obligations/{'/'.join(item.id.split('.'))}/meta.toml`",
+            )
+            continue
+
+        obligation = obligations[item.id]
+        where = str(obligation.path.relative_to(ROOT) / "meta.toml")
+        rust = obligation.meta.get("rust", {})
+        if not isinstance(rust, dict):
+            error(errors, f"{where}: `[rust]` must be a table")
+            continue
+
+        rust_files = rust.get("files", [])
+        if not isinstance(rust_files, list):
+            rust_files = []
+        rust_symbols = rust.get("symbols", [])
+        if not isinstance(rust_symbols, list):
+            rust_symbols = []
+
+        for rust_file in item.rust_files:
+            if rust_file not in rust_files:
+                error(errors, f"{where}: required surface must list rust file `{rust_file}`")
+        for symbol in item.rust_symbols:
+            if symbol not in rust_symbols:
+                error(errors, f"{where}: required surface must list rust symbol `{symbol}`")
+
+
 def lint_lean_layout(errors: list[str]) -> None:
     for lean_file in sorted(OBLIGATION_ROOT.rglob("*.lean")):
         if lean_file.name not in {"Proof.lean", "Counterexamples.lean"}:
@@ -340,6 +430,21 @@ def run_self_tests() -> int:
         def lint(meta: dict[str, Any], all_ids: set[str] | None = None) -> list[str]:
             errors: list[str] = []
             lint_meta(Obligation("self_test", obligation_path, meta), all_ids or {"self_test"}, errors)
+            return errors
+
+        def required_lint(obligations: dict[str, Obligation]) -> list[str]:
+            errors: list[str] = []
+            lint_required_obligations(
+                obligations,
+                errors,
+                (
+                    RequiredObligation(
+                        "self_test",
+                        ("required.rs",),
+                        ("required_symbol",),
+                    ),
+                ),
+            )
             return errors
 
         cases = [
@@ -379,6 +484,44 @@ def run_self_tests() -> int:
             ),
         ]
 
+        required_cases = [
+            (
+                "missing required obligation",
+                {},
+                "required proof-sensitive surface `self_test` is missing",
+            ),
+            (
+                "required obligation missing rust file",
+                {
+                    "self_test": Obligation(
+                        "self_test",
+                        obligation_path,
+                        {
+                            **base_meta("proven"),
+                            "rust": {"files": [], "symbols": ["required_symbol"]},
+                            "lean": {"proof": "Proof.lean", "theorems": ["SelfTest.ok"]},
+                        },
+                    )
+                },
+                "required surface must list rust file `required.rs`",
+            ),
+            (
+                "required obligation missing rust symbol",
+                {
+                    "self_test": Obligation(
+                        "self_test",
+                        obligation_path,
+                        {
+                            **base_meta("proven"),
+                            "rust": {"files": ["required.rs"], "symbols": []},
+                            "lean": {"proof": "Proof.lean", "theorems": ["SelfTest.ok"]},
+                        },
+                    )
+                },
+                "required surface must list rust symbol `required_symbol`",
+            ),
+        ]
+
         failures = []
         for name, meta, should_fail, expected in cases:
             errors = lint(meta)
@@ -387,6 +530,11 @@ def run_self_tests() -> int:
                 failures.append(f"{name}: expected `{expected}`, got {errors}")
             elif not should_fail and errors:
                 failures.append(f"{name}: expected no errors, got {errors}")
+        for name, obligations, expected in required_cases:
+            errors = required_lint(obligations)
+            joined = "\n".join(errors)
+            if expected not in joined:
+                failures.append(f"{name}: expected `{expected}`, got {errors}")
 
     if failures:
         print("formal obligation self-test failed:", file=sys.stderr)
@@ -410,6 +558,7 @@ def main() -> int:
     for obligation in obligations.values():
         lint_meta(obligation, all_ids, errors)
     lint_rule_modules(obligations, errors)
+    lint_required_obligations(obligations, errors)
     lint_lean_layout(errors)
 
     if errors:

--- a/scripts/check-lean-proofs.sh
+++ b/scripts/check-lean-proofs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Type-check the Lean proof corpus.
+#
+# Obligation proofs may import shared modules from formal/lib. Lean needs those
+# modules compiled to .olean files first; keep that build output under target/lean
+# so the formal tree stays source-only.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+toolchain="$(cat lean-toolchain 2>/dev/null || printf 'leanprover/lean4:v4.30.0')"
+if command -v elan >/dev/null 2>&1; then
+    lean_cmd=(elan run "$toolchain" lean)
+else
+    if ! command -v lean >/dev/null 2>&1; then
+        echo "missing required command: lean" >&2
+        exit 127
+    fi
+    lean_cmd=(lean)
+fi
+
+build_dir="target/lean"
+mkdir -p "$build_dir"
+
+while IFS= read -r f; do
+    out="$build_dir/${f%.lean}.olean"
+    mkdir -p "$(dirname "$out")"
+    echo "building $f"
+    LEAN_PATH="$PWD/$build_dir${LEAN_PATH:+:$LEAN_PATH}" \
+        "${lean_cmd[@]}" --error=warning -R . -o "$out" "$f"
+done < <(find formal/lib -name '*.lean' -print | sort)
+
+while IFS= read -r f; do
+    echo "checking $f"
+    LEAN_PATH="$PWD/$build_dir${LEAN_PATH:+:$LEAN_PATH}" \
+        "${lean_cmd[@]}" --error=warning -R . "$f"
+done < <(find formal/obligations -name '*.lean' -print | sort)


### PR DESCRIPTION

## Summary

- add reusable Lean models under `formal/lib` for effects/place, free inputs, IL arena bounds, oracle cutoff, and recursion folds
- register new proof obligations for IL arena validity/deep-copy, fragment effect/place/free-input/wrapper contracts, recursion tail/structural folds, and oracle cutoff
- extend the formal obligation linter with required proof-sensitive surfaces and negative self-tests
- add `scripts/check-lean-proofs.sh` so shared Lean modules are compiled into `target/lean` before obligation proofs are checked
- update CI and docs to describe the broader semantic obligation structure

## Validation

- `python3 scripts/check-formal-obligations.py --self-test`
- `python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `awiki lint --root docs`
- `python3 -m py_compile scripts/check-formal-obligations.py`
- `cargo fmt --all --check`
- `./scripts/check-ci-local.sh --fast`
