### PR TITLE
normalize: scope cid name resolution

### DIFF
--- a/crates/nose-normalize/src/module_facts.rs
+++ b/crates/nose-normalize/src/module_facts.rs
@@ -14,6 +14,15 @@ pub fn top_level_statements_for(il: &Il) -> Vec<NodeId> {
 }
 
 pub fn assignment_name_in(il: &Il, stmt: NodeId) -> Option<Symbol> {
+    let local_scope = local_scope_nodes(il);
+    assignment_name_in_scope(il, stmt, &local_scope)
+}
+
+pub(crate) fn assignment_name_in_scope(
+    il: &Il,
+    stmt: NodeId,
+    local_scope: &[bool],
+) -> Option<Symbol> {
     if il.kind(stmt) != NodeKind::Assign {
         return None;
     }
@@ -24,15 +33,28 @@ pub fn assignment_name_in(il: &Il, stmt: NodeId) -> Option<Symbol> {
     let Payload::Cid(cid) = il.node(kids[0]).payload else {
         return None;
     };
+    if !cid_is_module_scoped(kids[0], local_scope) {
+        return None;
+    }
     il.cid_names.get(cid as usize).copied()
 }
 
 pub fn collect_all_node_symbols(il: &Il, node: NodeId, out: &mut FxHashSet<Symbol>) {
-    if let Some(symbol) = node_symbol_in(il, node) {
+    let local_scope = local_scope_nodes(il);
+    collect_all_node_symbols_in_scope(il, node, &local_scope, out);
+}
+
+pub(crate) fn collect_all_node_symbols_in_scope(
+    il: &Il,
+    node: NodeId,
+    local_scope: &[bool],
+    out: &mut FxHashSet<Symbol>,
+) {
+    if let Some(symbol) = node_symbol_in_scope(il, node, local_scope) {
         out.insert(symbol);
     }
     for &child in il.children(node) {
-        collect_all_node_symbols(il, child, out);
+        collect_all_node_symbols_in_scope(il, child, local_scope, out);
     }
 }
 
@@ -42,17 +64,35 @@ pub fn collect_module_mutations(
     candidates: &FxHashSet<Symbol>,
     is_top_level: &[bool],
 ) -> FxHashSet<Symbol> {
+    let local_scope = local_scope_nodes(il);
+    collect_module_mutations_in_scope(il, interner, candidates, is_top_level, &local_scope)
+}
+
+pub(crate) fn collect_module_mutations_in_scope(
+    il: &Il,
+    interner: &Interner,
+    candidates: &FxHashSet<Symbol>,
+    is_top_level: &[bool],
+    local_scope: &[bool],
+) -> FxHashSet<Symbol> {
     let mut mutated = FxHashSet::default();
     if candidates.is_empty() {
         return mutated;
     }
-    let shadowed = shadowed_js_like_module_binding_nodes(il, candidates);
+    let shadowed = shadowed_js_like_module_binding_nodes(il, candidates, local_scope);
     for (idx, node) in il.nodes.iter().enumerate() {
         let node_id = NodeId(idx as u32);
         match node.kind {
             NodeKind::Call if matches!(node.payload, Payload::Builtin(Builtin::Append)) => {
                 if let Some(receiver) = il.children(node_id).first().copied() {
-                    mark_direct_symbol(il, receiver, candidates, &shadowed, &mut mutated);
+                    mark_direct_symbol(
+                        il,
+                        receiver,
+                        candidates,
+                        &shadowed,
+                        local_scope,
+                        &mut mutated,
+                    );
                 }
             }
             NodeKind::Field => {
@@ -63,12 +103,26 @@ pub fn collect_module_mutations(
                     continue;
                 }
                 if let Some(receiver) = il.children(node_id).first().copied() {
-                    mark_direct_symbol(il, receiver, candidates, &shadowed, &mut mutated);
+                    mark_direct_symbol(
+                        il,
+                        receiver,
+                        candidates,
+                        &shadowed,
+                        local_scope,
+                        &mut mutated,
+                    );
                 }
             }
             NodeKind::Assign if !is_top_level.get(idx).copied().unwrap_or(false) => {
                 if let Some(lhs) = il.children(node_id).first().copied() {
-                    collect_unshadowed_node_symbols(il, lhs, candidates, &shadowed, &mut mutated);
+                    collect_unshadowed_node_symbols(
+                        il,
+                        lhs,
+                        candidates,
+                        &shadowed,
+                        local_scope,
+                        &mut mutated,
+                    );
                 }
             }
             _ => {}
@@ -81,9 +135,18 @@ pub fn shadowed_js_like_module_binding_nodes_for_symbol(
     il: &Il,
     name: Symbol,
 ) -> FxHashSet<NodeId> {
+    let local_scope = local_scope_nodes(il);
+    shadowed_js_like_module_binding_nodes_for_symbol_in_scope(il, name, &local_scope)
+}
+
+pub(crate) fn shadowed_js_like_module_binding_nodes_for_symbol_in_scope(
+    il: &Il,
+    name: Symbol,
+    local_scope: &[bool],
+) -> FxHashSet<NodeId> {
     let mut candidates = FxHashSet::default();
     candidates.insert(name);
-    shadowed_js_like_module_binding_nodes(il, &candidates)
+    shadowed_js_like_module_binding_nodes(il, &candidates, local_scope)
         .into_iter()
         .filter_map(|(node, symbols)| symbols.contains(&name).then_some(node))
         .collect()
@@ -124,9 +187,10 @@ fn mark_direct_symbol(
     node: NodeId,
     candidates: &FxHashSet<Symbol>,
     shadowed: &FxHashMap<NodeId, FxHashSet<Symbol>>,
+    local_scope: &[bool],
     out: &mut FxHashSet<Symbol>,
 ) {
-    if let Some(symbol) = node_symbol_in(il, node) {
+    if let Some(symbol) = node_symbol_in_scope(il, node, local_scope) {
         if candidates.contains(&symbol)
             && !shadowed
                 .get(&node)
@@ -142,17 +206,19 @@ fn collect_unshadowed_node_symbols(
     node: NodeId,
     candidates: &FxHashSet<Symbol>,
     shadowed: &FxHashMap<NodeId, FxHashSet<Symbol>>,
+    local_scope: &[bool],
     out: &mut FxHashSet<Symbol>,
 ) {
-    mark_direct_symbol(il, node, candidates, shadowed, out);
+    mark_direct_symbol(il, node, candidates, shadowed, local_scope, out);
     for &child in il.children(node) {
-        collect_unshadowed_node_symbols(il, child, candidates, shadowed, out);
+        collect_unshadowed_node_symbols(il, child, candidates, shadowed, local_scope, out);
     }
 }
 
 fn shadowed_js_like_module_binding_nodes(
     il: &Il,
     candidates: &FxHashSet<Symbol>,
+    local_scope: &[bool],
 ) -> FxHashMap<NodeId, FxHashSet<Symbol>> {
     let mut out = FxHashMap::default();
     if candidates.is_empty() || !js_like_lang(il.meta.lang) {
@@ -163,6 +229,7 @@ fn shadowed_js_like_module_binding_nodes(
         il.root,
         candidates,
         &FxHashSet::default(),
+        local_scope,
         &mut out,
     );
     out
@@ -173,6 +240,7 @@ fn collect_shadowed_js_like_module_binding_nodes(
     node: NodeId,
     candidates: &FxHashSet<Symbol>,
     inherited: &FxHashSet<Symbol>,
+    local_scope: &[bool],
     out: &mut FxHashMap<NodeId, FxHashSet<Symbol>>,
 ) {
     let mut shadowed = inherited.clone();
@@ -181,7 +249,7 @@ fn collect_shadowed_js_like_module_binding_nodes(
             if il.kind(child) != NodeKind::Param {
                 continue;
             }
-            if let Some(symbol) = node_symbol_in(il, child) {
+            if let Some(symbol) = node_symbol_in_scope(il, child, local_scope) {
                 if candidates.contains(&symbol) {
                     shadowed.insert(symbol);
                 }
@@ -192,7 +260,14 @@ fn collect_shadowed_js_like_module_binding_nodes(
         out.insert(node, shadowed.clone());
     }
     for &child in il.children(node) {
-        collect_shadowed_js_like_module_binding_nodes(il, child, candidates, &shadowed, out);
+        collect_shadowed_js_like_module_binding_nodes(
+            il,
+            child,
+            candidates,
+            &shadowed,
+            local_scope,
+            out,
+        );
     }
 }
 
@@ -203,10 +278,135 @@ fn js_like_lang(lang: Lang) -> bool {
     )
 }
 
+#[cfg(test)]
 fn node_symbol_in(il: &Il, node: NodeId) -> Option<Symbol> {
+    let local_scope = local_scope_nodes(il);
+    node_symbol_in_scope(il, node, &local_scope)
+}
+
+pub(crate) fn node_symbol_in_scope(il: &Il, node: NodeId, local_scope: &[bool]) -> Option<Symbol> {
     match il.node(node).payload {
         Payload::Name(symbol) => Some(symbol),
-        Payload::Cid(cid) => il.cid_names.get(cid as usize).copied(),
+        Payload::Cid(cid) if cid_is_module_scoped(node, local_scope) => {
+            il.cid_names.get(cid as usize).copied()
+        }
         _ => None,
+    }
+}
+
+pub(crate) fn local_scope_nodes(il: &Il) -> Vec<bool> {
+    let mut local_scope = vec![false; il.nodes.len()];
+    mark_local_scope_nodes(il, il.root, false, &mut local_scope);
+    local_scope
+}
+
+fn mark_local_scope_nodes(il: &Il, node: NodeId, in_local_scope: bool, out: &mut [bool]) {
+    if let Some(slot) = out.get_mut(node.0 as usize) {
+        *slot = in_local_scope;
+    }
+    let child_local_scope =
+        in_local_scope || matches!(il.kind(node), NodeKind::Func | NodeKind::Lambda);
+    for &child in il.children(node) {
+        mark_local_scope_nodes(il, child, child_local_scope, out);
+    }
+}
+
+fn cid_is_module_scoped(node: NodeId, local_scope: &[bool]) -> bool {
+    !local_scope.get(node.0 as usize).copied().unwrap_or(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nose_il::{FileId, FileMeta, IlBuilder, Span, Unit, UnitKind};
+
+    fn sp(line: u32) -> Span {
+        Span::new(FileId(0), line, line, line, line)
+    }
+
+    struct CidFixture {
+        il: Il,
+        interner: Interner,
+        arr: Symbol,
+        top_level_arr: NodeId,
+        function_param: NodeId,
+    }
+
+    fn cid_reuse_fixture() -> CidFixture {
+        let interner = Interner::new();
+        let arr = interner.intern("arr");
+        let push = interner.intern("push");
+        let grow = interner.intern("grow");
+
+        let mut b = IlBuilder::new(FileId(0));
+        let top_level_arr = b.add(NodeKind::Var, Payload::Cid(0), sp(1), &[]);
+        let empty_array = b.add(NodeKind::Seq, Payload::None, sp(1), &[]);
+        let assign_arr = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            sp(1),
+            &[top_level_arr, empty_array],
+        );
+
+        let function_param = b.add(NodeKind::Param, Payload::Cid(0), sp(2), &[]);
+        let receiver = b.add(NodeKind::Var, Payload::Name(arr), sp(3), &[]);
+        let field = b.add(NodeKind::Field, Payload::Name(push), sp(3), &[receiver]);
+        let arg = b.add(NodeKind::Var, Payload::Cid(0), sp(3), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(3), &[field, arg]);
+        let expr = b.add(NodeKind::ExprStmt, Payload::None, sp(3), &[call]);
+        let body = b.add(NodeKind::Block, Payload::None, sp(3), &[expr]);
+        let func = b.add(
+            NodeKind::Func,
+            Payload::None,
+            sp(2),
+            &[function_param, body],
+        );
+        let module = b.add(NodeKind::Module, Payload::None, sp(1), &[assign_arr, func]);
+
+        let il = b.finish(
+            module,
+            FileMeta {
+                path: "t.js".to_string(),
+                lang: Lang::JavaScript,
+            },
+            vec![Unit {
+                root: func,
+                kind: UnitKind::Function,
+                name: Some(grow),
+            }],
+            vec![arr],
+        );
+        CidFixture {
+            il,
+            interner,
+            arr,
+            top_level_arr,
+            function_param,
+        }
+    }
+
+    #[test]
+    fn node_symbol_does_not_resolve_function_local_cid_through_global_cid_names() {
+        let fixture = cid_reuse_fixture();
+        assert_eq!(
+            node_symbol_in(&fixture.il, fixture.top_level_arr),
+            Some(fixture.arr)
+        );
+        assert_eq!(node_symbol_in(&fixture.il, fixture.function_param), None);
+    }
+
+    #[test]
+    fn function_param_cid_reuse_does_not_hide_module_binding_mutation() {
+        let fixture = cid_reuse_fixture();
+        let mut candidates = FxHashSet::default();
+        candidates.insert(fixture.arr);
+        let top_level = top_level_statements_for(&fixture.il);
+        let mut is_top_level = vec![false; fixture.il.nodes.len()];
+        for stmt in top_level {
+            is_top_level[stmt.0 as usize] = true;
+        }
+        let mutated =
+            collect_module_mutations(&fixture.il, &fixture.interner, &candidates, &is_top_level);
+        assert!(mutated.contains(&fixture.arr));
     }
 }

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -22,8 +22,9 @@ mod rules;
 
 use crate::combine;
 use crate::module_facts::{
-    assignment_name_in, collect_all_node_symbols, collect_module_mutations, mutating_method_name,
-    shadowed_js_like_module_binding_nodes_for_symbol, top_level_statements_for,
+    assignment_name_in_scope, collect_all_node_symbols_in_scope, collect_module_mutations_in_scope,
+    local_scope_nodes, mutating_method_name, node_symbol_in_scope,
+    shadowed_js_like_module_binding_nodes_for_symbol_in_scope, top_level_statements_for,
 };
 use crate::types::Ty;
 use nose_il::{
@@ -97,6 +98,7 @@ impl ValueFingerprintContext {
 }
 
 struct ModuleSeedContext {
+    local_scope: Vec<bool>,
     top_level: Vec<NodeId>,
     assignment_counts: FxHashMap<Symbol, usize>,
     assignment_deps: FxHashMap<Symbol, FxHashSet<Symbol>>,
@@ -106,6 +108,7 @@ struct ModuleSeedContext {
 
 impl ModuleSeedContext {
     fn new(il: &Il, interner: &Interner) -> Self {
+        let local_scope = local_scope_nodes(il);
         let top_level = top_level_statements_for(il);
         let mut is_top_level = vec![false; il.nodes.len()];
         for &stmt in &top_level {
@@ -116,18 +119,18 @@ impl ModuleSeedContext {
 
         let mut assignment_counts: FxHashMap<Symbol, usize> = FxHashMap::default();
         for &stmt in &top_level {
-            if let Some(name) = assignment_name_in(il, stmt) {
+            if let Some(name) = assignment_name_in_scope(il, stmt, &local_scope) {
                 *assignment_counts.entry(name).or_insert(0) += 1;
             }
         }
         let mut assignment_deps: FxHashMap<Symbol, FxHashSet<Symbol>> = FxHashMap::default();
         for &stmt in &top_level {
-            let Some(name) = assignment_name_in(il, stmt) else {
+            let Some(name) = assignment_name_in_scope(il, stmt, &local_scope) else {
                 continue;
             };
             if let Some(&rhs) = il.children(stmt).get(1) {
                 let mut deps = FxHashSet::default();
-                collect_all_node_symbols(il, rhs, &mut deps);
+                collect_all_node_symbols_in_scope(il, rhs, &local_scope, &mut deps);
                 assignment_deps.insert(name, deps);
             }
         }
@@ -140,10 +143,16 @@ impl ModuleSeedContext {
                 (count == 1 && !unit_symbols.contains(&name)).then_some(name)
             })
             .collect();
-        let mutated_bindings =
-            collect_module_mutations(il, interner, &candidate_names, &is_top_level);
+        let mutated_bindings = collect_module_mutations_in_scope(
+            il,
+            interner,
+            &candidate_names,
+            &is_top_level,
+            &local_scope,
+        );
 
         Self {
+            local_scope,
             top_level,
             assignment_counts,
             assignment_deps,
@@ -154,7 +163,7 @@ impl ModuleSeedContext {
 
     fn required_bindings_for(&self, il: &Il, root: NodeId) -> FxHashSet<Symbol> {
         let mut required = FxHashSet::default();
-        collect_all_node_symbols(il, root, &mut required);
+        collect_all_node_symbols_in_scope(il, root, &self.local_scope, &mut required);
         let mut stack: Vec<Symbol> = required.iter().copied().collect();
         while let Some(name) = stack.pop() {
             let Some(deps) = self.assignment_deps.get(&name) else {
@@ -336,6 +345,9 @@ struct Builder<'a> {
     /// targets are alpha-renamed to `Cid`; this map reconnects safe top-level literal
     /// data (`const table = {...}`) to free uses inside the function.
     global_env: FxHashMap<Symbol, ValueId>,
+    /// Nodes under function/lambda scopes use local cid numbering. Their `Cid(0)` is not
+    /// the module `cid_names[0]`, so module-symbol resolution fails closed there.
+    local_scope_nodes: Vec<bool>,
     /// Current loop-carried placeholders while evaluating a loop body. Used only to
     /// compact coupled recurrences such as `s1 += f(s2); s2 += g(s1)`, which otherwise
     /// expand into a large raw expression DAG even though they are not clean reductions.
@@ -398,6 +410,7 @@ impl<'a> Builder<'a> {
             effect_slot: 0,
             building: FxHashMap::default(),
             global_env: FxHashMap::default(),
+            local_scope_nodes: local_scope_nodes(il),
             loop_recurrence: None,
             next_loop_key_base: 0,
             contracts: Vec::new(),
@@ -2229,17 +2242,7 @@ impl<'a> Builder<'a> {
     }
 
     fn assignment_name(&self, stmt: NodeId) -> Option<Symbol> {
-        if self.il.kind(stmt) != NodeKind::Assign {
-            return None;
-        }
-        let kids = self.il.children(stmt);
-        if kids.len() != 2 || self.il.kind(kids[0]) != NodeKind::Var {
-            return None;
-        }
-        let Payload::Cid(cid) = self.il.node(kids[0]).payload else {
-            return None;
-        };
-        self.il.cid_names.get(cid as usize).copied()
+        assignment_name_in_scope(self.il, stmt, &self.local_scope_nodes)
     }
 
     fn unit_defines_symbol(&self, symbol: Symbol) -> bool {
@@ -2251,7 +2254,11 @@ impl<'a> Builder<'a> {
 
     fn module_binding_mutated(&self, name: Symbol) -> bool {
         let top_level = self.top_level_statements();
-        let shadowed = shadowed_js_like_module_binding_nodes_for_symbol(self.il, name);
+        let shadowed = shadowed_js_like_module_binding_nodes_for_symbol_in_scope(
+            self.il,
+            name,
+            &self.local_scope_nodes,
+        );
         self.il.nodes.iter().enumerate().any(|(idx, node)| {
             let node_id = NodeId(idx as u32);
             if shadowed.contains(&node_id) {
@@ -2300,11 +2307,7 @@ impl<'a> Builder<'a> {
     }
 
     fn node_symbol(&self, node: NodeId) -> Option<Symbol> {
-        match self.il.node(node).payload {
-            Payload::Name(symbol) => Some(symbol),
-            Payload::Cid(cid) => self.il.cid_names.get(cid as usize).copied(),
-            _ => None,
-        }
+        node_symbol_in_scope(self.il, node, &self.local_scope_nodes)
     }
 
     fn node_contains_symbol(&self, node: NodeId, name: Symbol) -> bool {

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -94,6 +94,9 @@ Guiding constraints for every pass:
   Java `Arrays.asList(values).contains(x)` also carries the array domain when `values` is
   a proven array parameter, keeping element membership distinct from singleton-list
   membership such as `List.of(values).contains(x)` or `Arrays.asList(listParam).contains(x)`.
+  Module-binding facts respect alpha's per-function cid spaces: top-level assignment cids may
+  resolve back to module symbols, but cids inside functions and lambdas are local and never
+  prove or shadow a module binding by table index alone.
   The oracle also propagates `Err` through append receivers (including computed and
   field receivers) and arguments, so list-building effects do not silently absorb failed
   target or item computations; binary left operands and index bases fail before later


### PR DESCRIPTION
Closes #59

## Summary
- Add scope-aware module-symbol resolution so top-level cids can resolve to module bindings, while function/lambda-local cids fail closed instead of indexing global `cid_names`.
- Reuse the scope mask in module-fact collection and value-graph module-binding mutation checks.
- Add regression tests that first reproduced the latent defect: a reused function param `Cid(0)` no longer resolves as top-level `arr`, and `arr.push(...)` mutation is no longer hidden by false shadowing.
- Document the module-binding cid-scope invariant in the normalization guide.

## Validation
- Reproduced before fix: `cargo test -p nose-normalize module_facts::tests -- --nocapture` failed with function param `Cid(0)` resolving to `arr` and mutation not detected.
- `cargo fmt --all --check`
- `cargo test -p nose-normalize module_facts::tests`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --release --bin nose`
- `python3 scripts/check-formal-obligations.py`
- `while IFS= read -r f; do lean --error=warning "$f"; done < <(find formal -name '*.lean' -print | sort)`\n- `awiki lint --root docs`\n- `NOSE=target/release/nose scripts/type4-smoke.sh` (positive recall 1113/1113; hard-negative false merges 0/2061)\n- `target/release/nose verify --max-violations 0 crates` (SOUND: no false merges; gate 0 <= 0 OK)\n- `python3 bench/type4/scan_regression/scan_regression.py compare --nose ./target/release/nose --repos-root bench/repos --build-ref issue-59@$(git rev-parse --short HEAD) --summary /tmp/nose-issue59-scan-regression.md` (0 triggers, but 0 repos compared because this checkout is missing pinned `bench/repos`)\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 함수 및 람다 내부에서 심볼 해석이 모듈 스코프를 올바르게 구분하도록 개선
  * 모듈 변이 탐지 시 로컬 스코프 경계를 반영하여 정확성 향상

* **문서**
  * CID 해석 규칙 및 스코프 범위에 대한 설명 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->