### PR TITLE
[codex] strengthen formal obligation markers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ full run here is a green CI. The full gates are:
 | **unused deps** | `cargo machete` | no dependency declared but unused (à la *knip*) |
 | **supply chain** | `cargo deny check` | no advisories/yanked crates, only allowed licenses, no dup/wildcard deps, crates.io-only |
 | **docs wiki** | `awiki lint --root docs` | the `docs/` wiki is one connected graph — no orphan pages or islands |
-| **formal obligations** | `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py` | proof-sensitive rule modules are registered, theorem names exist, and counterexample files are tracked |
+| **formal obligations** | `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py` | proof-sensitive Rust markers are registered, theorem names exist, and counterexample files are tracked |
 | **formal proofs** | `./scripts/check-lean-proofs.sh` | Lean shared models and obligation proofs type-check with warnings, including `sorry`, treated as errors |
 
 The dev/CI toolchain is pinned in `rust-toolchain.toml` (rustup installs it

--- a/crates/nose-detect/src/fragment/contract.rs
+++ b/crates/nose-detect/src/fragment/contract.rs
@@ -14,6 +14,8 @@
 //! carries one; a multi-statement body (a conditional branch, a loop body, an ordered effect
 //! sequence) carries its effects in execution order. The [`Place`] receiver-identity model
 //! is fail-closed so receiver-bearing effects can only be admitted when proven.
+//!
+//! proof-obligation: detect.fragment.effect_place
 
 use super::{Exit, FragmentKind};
 use nose_il::NodeId;

--- a/crates/nose-detect/src/fragment/oracle.rs
+++ b/crates/nose-detect/src/fragment/oracle.rs
@@ -11,6 +11,10 @@
 //! The forcing function: a contract that cannot be lowered into a runnable wrapper is
 //! *underspecified*. [`synthesize_wrapper`] returning `None` is therefore a signal that the
 //! recognizer described a fragment the oracle cannot vouch for — fail closed.
+//!
+//! proof-obligation: detect.fragment.free_inputs
+//! proof-obligation: detect.fragment.wrapper_synthesis
+//! proof-obligation: il.arena.deep_copy
 
 use super::contract::FragmentContract;
 use nose_il::{FileMeta, Il, IlBuilder, LoopKind, NodeId, NodeKind, Payload, Span, Unit, UnitKind};

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -5,6 +5,8 @@
 //! string [`Interner`]. Every node carries a [`Span`] for sourcemap-style
 //! traceback. The crate defines the data model and (de)serialization only — the
 //! frontends build raw IL, and `nose-normalize` rewrites it into canonical form.
+//!
+//! proof-obligation: il.arena.validity
 
 pub mod intern;
 pub mod node;

--- a/crates/nose-normalize/src/algebra.rs
+++ b/crates/nose-normalize/src/algebra.rs
@@ -16,6 +16,9 @@
 //! values, which are abstracted to classes. Full distribution (where the
 //! canonical form is non-obvious) is also deferred; a confluent rewrite gives a
 //! normal form without the cost/ambiguity of equality saturation.
+//!
+//! proof-obligation: normalize.value_graph.algebra
+//! proof-obligation: normalize.value_graph.compare
 
 use crate::combine;
 use nose_il::{Il, IlBuilder, Interner, NodeId, NodeKind, Op, Payload, Span};

--- a/crates/nose-normalize/src/cfg_norm.rs
+++ b/crates/nose-normalize/src/cfg_norm.rs
@@ -8,6 +8,8 @@
 //! - [`run`] (in-place, run last): **branch orientation** — when an `if`'s two
 //!   branches could be swapped, orient them canonically by inverting a comparison
 //!   condition. `if a < b { X } else { Y }` ≡ `if a >= b { Y } else { X }`.
+//!
+//! proof-obligation: normalize.control_flow.guard_returns
 
 use crate::commutative::subtree_hashes;
 use nose_il::{Il, IlBuilder, Interner, NodeId, NodeKind, Op, Payload};

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -2,6 +2,10 @@
 //! different languages to one [`Builtin`] op so that, e.g., Python `len(xs)`,
 //! JS `xs.length`, and Go `len(xs)` all converge. Detection on `xs.length` (a
 //! field access) is handled by the caller; this module only inspects `Call`s.
+//!
+//! proof-obligation: normalize.value_graph.bool_reduce
+//! proof-obligation: normalize.value_graph.functor
+//! proof-obligation: normalize.value_graph.min_max
 
 use nose_il::{stable_symbol_hash, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
 

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -14,6 +14,9 @@
 //! consistent semantics, so a fingerprint merge the interpreter contradicts is a real
 //! bug. A bare `throw`/`raise` is modeled as observable `Err` behavior; exception
 //! handlers remain unsupported.
+//!
+//! proof-obligation: normalize.value_graph.field_writes
+//! proof-obligation: normalize.value_graph.free_monoid
 
 use nose_il::{Builtin, HoFKind, Il, LoopKind, NodeId, NodeKind, Op, Payload, Symbol};
 use rustc_hash::{FxHashMap, FxHashSet};

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -10,6 +10,8 @@
 //! 5. `algebra` — algebraic canonicalization (assoc/comm flatten, comparison
 //!    direction, De Morgan; subsumes commutative operand sorting).
 //! 6. `cfg_norm::run` — orient `if` branches (when `cfg_norm` is enabled).
+//!
+//! proof-obligation: oracle.cutoff
 
 mod algebra;
 mod alpha;

--- a/crates/nose-normalize/src/recursion.rs
+++ b/crates/nose-normalize/src/recursion.rs
@@ -32,9 +32,12 @@
 //! the interpreter now executes as a real call (see [`crate::interp`]) — and the rewritten
 //! loop, and flags any behavioral difference.
 
-use crate::types::{infer_param_types, result_ty, Ty};
+use crate::types::{infer_param_types, Ty};
 use nose_il::{Il, IlBuilder, NodeId, NodeKind, Op, Payload, Symbol, UnitKind};
 use rustc_hash::{FxHashMap, FxHashSet};
+
+mod structural_fold;
+mod tail;
 
 pub(crate) fn run(old: &Il) -> Il {
     // A same-named call inside a standalone function is its self-call. Methods are excluded:
@@ -71,19 +74,8 @@ struct Rebuilder<'a> {
 /// (copied into the new one during emission). `param_cids` is the function's parameters in
 /// order; `args` are the next-call arguments, positionally matched to them.
 enum Plan {
-    Tail {
-        param_cids: Vec<u32>,
-        guards: Vec<(NodeId, NodeId)>, // (cond, returned value)
-        args: Vec<NodeId>,
-    },
-    Structural {
-        param_cids: Vec<u32>,
-        base_cond: NodeId,
-        op: Op,
-        head: NodeId,
-        args: Vec<NodeId>,
-        identity: NodeId,
-    },
+    Tail(tail::Plan),
+    Structural(structural_fold::Plan),
 }
 
 impl Rebuilder<'_> {
@@ -211,63 +203,11 @@ impl Rebuilder<'_> {
         };
         let param_cids = self.param_cids(fid);
 
-        // Tail recursion: the recursive case IS the self-call.
-        if let Some(args) = self.as_self_call(rexpr, name) {
-            if args.len() != param_cids.len() {
-                return None;
-            }
-            return Some(Plan::Tail {
-                param_cids,
-                guards,
-                args,
-            });
+        if let Some(plan) = tail::recognize(self, param_cids.clone(), guards.clone(), rexpr, name) {
+            return Some(Plan::Tail(plan));
         }
-
-        // Structural recursion: `HEAD ⊕ f(a…)` / `f(a…) ⊕ HEAD`, gated to a numeric monoid.
-        if self.old.kind(rexpr) == NodeKind::BinOp {
-            let op = match self.old.node(rexpr).payload {
-                Payload::Op(o) => o,
-                _ => return None,
-            };
-            if !matches!(op, Op::Add | Op::Mul) {
-                return None;
-            }
-            let operands = self.old.children(rexpr);
-            if operands.len() != 2 {
-                return None;
-            }
-            let (a, b) = (operands[0], operands[1]);
-            let (head, args) = match (self.as_self_call(a, name), self.as_self_call(b, name)) {
-                (Some(args), None) => (b, args),
-                (None, Some(args)) => (a, args),
-                _ => return None, // both or neither — not a linear fold
-            };
-            if args.len() != param_cids.len() || guards.len() != 1 {
-                return None;
-            }
-            let (base_cond, identity) = guards[0];
-            // Numeric monoid gate: ⊕ on proven-`Num` operands (so commutative + associative)
-            // and the base case returning ⊕'s identity literal (`0` for `+`, `1` for `·`).
-            let ev = self.param_type_env(fid, &param_cids);
-            if result_ty(self.old, head, &ev) != Ty::Num {
-                return None;
-            }
-            let want_identity = match op {
-                Op::Add => 0,
-                Op::Mul => 1,
-                _ => return None,
-            };
-            if !self.is_int_literal(identity, want_identity) {
-                return None;
-            }
-            return Some(Plan::Structural {
-                param_cids,
-                base_cond,
-                op,
-                head,
-                args,
-                identity,
-            });
+        if let Some(plan) = structural_fold::recognize(self, fid, param_cids, guards, rexpr, name) {
+            return Some(Plan::Structural(plan));
         }
         None
     }
@@ -298,72 +238,8 @@ impl Rebuilder<'_> {
             .collect();
 
         let body = match plan {
-            Plan::Tail {
-                param_cids,
-                guards,
-                args,
-            } => {
-                let updates = self.ordered_updates(param_cids, args)?;
-                let cond = self.not_any(guards.iter().map(|&(c, _)| c).collect());
-                let loop_body = self.b.add(NodeKind::Block, Payload::None, span, &updates);
-                let wl = self.while_loop(cond, loop_body, span);
-                // Post-loop guard chain: exactly one guard holds on exit, so the final one
-                // is an unconditional return.
-                let mut stmts = vec![wl];
-                for (i, &(cond, val)) in guards.iter().enumerate() {
-                    let v = self.go_val(val);
-                    let ret = self.ret(v, span);
-                    if i + 1 == guards.len() {
-                        stmts.push(ret);
-                    } else {
-                        let c = self.go_val(cond);
-                        let then = self.b.add(NodeKind::Block, Payload::None, span, &[ret]);
-                        stmts.push(self.b.add(NodeKind::If, Payload::None, span, &[c, then]));
-                    }
-                }
-                self.b.add(NodeKind::Block, Payload::None, span, &stmts)
-            }
-            Plan::Structural {
-                param_cids,
-                base_cond,
-                op,
-                head,
-                args,
-                identity,
-            } => {
-                let acc = self.fresh_cid(fid);
-                let init = {
-                    let lhs = self.var(acc, span);
-                    let rhs = self.go_val(*identity);
-                    self.b
-                        .add(NodeKind::Assign, Payload::None, span, &[lhs, rhs])
-                };
-                // `acc = acc ⊕ HEAD` runs first (reads the current params/acc), then the
-                // params advance to the next call's arguments.
-                let acc_update = {
-                    let lhs = self.var(acc, span);
-                    let cur = self.var(acc, span);
-                    let h = self.go_val(*head);
-                    let combined = self
-                        .b
-                        .add(NodeKind::BinOp, Payload::Op(*op), span, &[cur, h]);
-                    self.b
-                        .add(NodeKind::Assign, Payload::None, span, &[lhs, combined])
-                };
-                let mut loop_stmts = vec![acc_update];
-                loop_stmts.extend(self.ordered_updates(param_cids, args)?);
-                let cond = self.not_any(vec![*base_cond]);
-                let loop_body = self
-                    .b
-                    .add(NodeKind::Block, Payload::None, span, &loop_stmts);
-                let wl = self.while_loop(cond, loop_body, span);
-                let ret = {
-                    let v = self.var(acc, span);
-                    self.ret(v, span)
-                };
-                self.b
-                    .add(NodeKind::Block, Payload::None, span, &[init, wl, ret])
-            }
+            Plan::Tail(plan) => tail::build_body(self, plan, span)?,
+            Plan::Structural(plan) => structural_fold::build_body(self, fid, plan, span)?,
         };
 
         let mut children = params;

--- a/crates/nose-normalize/src/recursion/structural_fold.rs
+++ b/crates/nose-normalize/src/recursion/structural_fold.rs
@@ -1,0 +1,107 @@
+//! Structural recursion to accumulator-fold recognition and emission.
+//!
+//! proof-obligation: normalize.recursion.structural_fold
+
+use super::Rebuilder;
+use crate::types::{result_ty, Ty};
+use nose_il::{NodeId, NodeKind, Op, Payload, Span};
+
+pub(super) struct Plan {
+    pub(super) param_cids: Vec<u32>,
+    pub(super) base_cond: NodeId,
+    pub(super) op: Op,
+    pub(super) head: NodeId,
+    pub(super) args: Vec<NodeId>,
+    pub(super) identity: NodeId,
+}
+
+pub(super) fn recognize(
+    rb: &Rebuilder<'_>,
+    fid: NodeId,
+    param_cids: Vec<u32>,
+    guards: Vec<(NodeId, NodeId)>,
+    rexpr: NodeId,
+    name: nose_il::Symbol,
+) -> Option<Plan> {
+    // Structural recursion: `HEAD ⊕ f(a…)` / `f(a…) ⊕ HEAD`, gated to a numeric monoid.
+    if rb.old.kind(rexpr) != NodeKind::BinOp {
+        return None;
+    }
+    let op = match rb.old.node(rexpr).payload {
+        Payload::Op(o) => o,
+        _ => return None,
+    };
+    if !matches!(op, Op::Add | Op::Mul) {
+        return None;
+    }
+    let operands = rb.old.children(rexpr);
+    if operands.len() != 2 {
+        return None;
+    }
+    let (a, b) = (operands[0], operands[1]);
+    let (head, args) = match (rb.as_self_call(a, name), rb.as_self_call(b, name)) {
+        (Some(args), None) => (b, args),
+        (None, Some(args)) => (a, args),
+        _ => return None, // both or neither — not a linear fold
+    };
+    if args.len() != param_cids.len() || guards.len() != 1 {
+        return None;
+    }
+    let (base_cond, identity) = guards[0];
+    // Numeric monoid gate: ⊕ on proven-`Num` operands (so commutative + associative)
+    // and the base case returning ⊕'s identity literal (`0` for `+`, `1` for `·`).
+    let ev = rb.param_type_env(fid, &param_cids);
+    if result_ty(rb.old, head, &ev) != Ty::Num {
+        return None;
+    }
+    let want_identity = match op {
+        Op::Add => 0,
+        Op::Mul => 1,
+        _ => return None,
+    };
+    if !rb.is_int_literal(identity, want_identity) {
+        return None;
+    }
+    Some(Plan {
+        param_cids,
+        base_cond,
+        op,
+        head,
+        args,
+        identity,
+    })
+}
+
+pub(super) fn build_body(
+    rb: &mut Rebuilder<'_>,
+    fid: NodeId,
+    plan: &Plan,
+    span: Span,
+) -> Option<NodeId> {
+    let acc = rb.fresh_cid(fid);
+    let init = {
+        let lhs = rb.var(acc, span);
+        let rhs = rb.go_val(plan.identity);
+        rb.b.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs])
+    };
+    // `acc = acc ⊕ HEAD` runs first (reads the current params/acc), then the
+    // params advance to the next call's arguments.
+    let acc_update = {
+        let lhs = rb.var(acc, span);
+        let cur = rb.var(acc, span);
+        let h = rb.go_val(plan.head);
+        let combined =
+            rb.b.add(NodeKind::BinOp, Payload::Op(plan.op), span, &[cur, h]);
+        rb.b.add(NodeKind::Assign, Payload::None, span, &[lhs, combined])
+    };
+    let mut loop_stmts = vec![acc_update];
+    loop_stmts.extend(rb.ordered_updates(&plan.param_cids, &plan.args)?);
+    let cond = rb.not_any(vec![plan.base_cond]);
+    let loop_body = rb.b.add(NodeKind::Block, Payload::None, span, &loop_stmts);
+    let wl = rb.while_loop(cond, loop_body, span);
+    let ret = {
+        let v = rb.var(acc, span);
+        rb.ret(v, span)
+    };
+    Some(rb.b.add(NodeKind::Block, Payload::None, span, &[init, wl, ret]))
+}

--- a/crates/nose-normalize/src/recursion/tail.rs
+++ b/crates/nose-normalize/src/recursion/tail.rs
@@ -1,0 +1,73 @@
+//! Tail-recursion recognition and emission.
+//!
+//! proof-obligation: normalize.recursion.tail
+
+use super::Rebuilder;
+use nose_il::{NodeId, Span};
+
+pub(super) struct Plan {
+    pub(super) param_cids: Vec<u32>,
+    pub(super) guards: Vec<(NodeId, NodeId)>, // (cond, returned value)
+    pub(super) args: Vec<NodeId>,
+}
+
+pub(super) fn recognize(
+    rb: &Rebuilder<'_>,
+    param_cids: Vec<u32>,
+    guards: Vec<(NodeId, NodeId)>,
+    rexpr: NodeId,
+    name: nose_il::Symbol,
+) -> Option<Plan> {
+    // Tail recursion: the recursive case IS the self-call.
+    let args = rb.as_self_call(rexpr, name)?;
+    if args.len() != param_cids.len() {
+        return None;
+    }
+    Some(Plan {
+        param_cids,
+        guards,
+        args,
+    })
+}
+
+pub(super) fn build_body(rb: &mut Rebuilder<'_>, plan: &Plan, span: Span) -> Option<NodeId> {
+    let updates = rb.ordered_updates(&plan.param_cids, &plan.args)?;
+    let cond = rb.not_any(plan.guards.iter().map(|&(c, _)| c).collect());
+    let loop_body = rb.b.add(
+        nose_il::NodeKind::Block,
+        nose_il::Payload::None,
+        span,
+        &updates,
+    );
+    let wl = rb.while_loop(cond, loop_body, span);
+    // Post-loop guard chain: exactly one guard holds on exit, so the final one
+    // is an unconditional return.
+    let mut stmts = vec![wl];
+    for (i, &(cond, val)) in plan.guards.iter().enumerate() {
+        let v = rb.go_val(val);
+        let ret = rb.ret(v, span);
+        if i + 1 == plan.guards.len() {
+            stmts.push(ret);
+        } else {
+            let c = rb.go_val(cond);
+            let then = rb.b.add(
+                nose_il::NodeKind::Block,
+                nose_il::Payload::None,
+                span,
+                &[ret],
+            );
+            stmts.push(rb.b.add(
+                nose_il::NodeKind::If,
+                nose_il::Payload::None,
+                span,
+                &[c, then],
+            ));
+        }
+    }
+    Some(rb.b.add(
+        nose_il::NodeKind::Block,
+        nose_il::Payload::None,
+        span,
+        &stmts,
+    ))
+}

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -17,6 +17,16 @@
 //!
 //! This is a *detection substrate*, not an IL rewrite: it returns a fingerprint
 //! the detector can use instead of (or alongside) subtree shapes.
+//!
+//! proof-obligation: normalize.control_flow.guard_returns
+//! proof-obligation: normalize.value_graph.algebra
+//! proof-obligation: normalize.value_graph.bool_reduce
+//! proof-obligation: normalize.value_graph.clamp
+//! proof-obligation: normalize.value_graph.compare
+//! proof-obligation: normalize.value_graph.field_writes
+//! proof-obligation: normalize.value_graph.free_monoid
+//! proof-obligation: normalize.value_graph.functor
+//! proof-obligation: normalize.value_graph.min_max
 
 mod rules;
 

--- a/crates/nose-normalize/src/value_graph/rules/factor_distribute.rs
+++ b/crates/nose-normalize/src/value_graph/rules/factor_distribute.rs
@@ -6,6 +6,8 @@
 //! The rule fires only when both operands are 2-ary `Mul` nodes sharing exactly one factor
 //! and every leaf is a proven `Num`. Distribution is unsound for the string/list
 //! repetition monoid, so the type gate is part of the proof obligation.
+//!
+//! proof-obligation: normalize.value_graph.factor_distribute
 
 use super::super::{Builder, ValOp, ValueId};
 use crate::types::Ty;

--- a/docs/formal-soundness.md
+++ b/docs/formal-soundness.md
@@ -31,8 +31,18 @@ namespaces such as:
 - `oracle.*` — behavioral-oracle independence contracts such as the normalization cutoff.
 
 The linter has a required-surface list for proof-sensitive areas whose omission would be
-easy to miss. Those obligations must list the expected Rust files and symbols in
+easy to miss. Those obligations must list the expected Rust files, symbols, and markers in
 `meta.toml`; otherwise CI fails even if a Lean file exists somewhere else.
+
+Every Rust-backed obligation must also be marked from the Rust side:
+
+```rust
+//! proof-obligation: normalize.recursion.structural_fold
+```
+
+The linter checks both directions. A marker without a matching `meta.toml` fails, and a
+`meta.toml` whose `rust.markers` entry is not present in one of its `rust.files` fails. This
+keeps proof-sensitive code from drifting away from the registry.
 
 ## Named rule modules
 
@@ -47,6 +57,11 @@ formal/obligations/normalize/value_graph/<rule>/meta.toml
 The linter checks that every file in `value_graph/rules/*.rs` has a matching obligation and
 that the matching obligation sets `rust.rule_module = true`. This makes omission visible:
 a new named semantic rule cannot be added without registering its proof state.
+
+For proof-sensitive rewrites that are not value-graph rule modules, prefer the same shape:
+put the rule-specific recognition/emission in a named module and mark that module with the
+obligation id. Recursion now follows this pattern with `recursion/tail.rs` and
+`recursion/structural_fold.rs`.
 
 ## Statuses
 

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -183,9 +183,11 @@ do not keep equivalent loop recurrences apart.
 
 ## Track 4 — Recursion → iteration
 
-`recursion.rs` rewrites the two recursion schemes that have a behavior-preserving iterative
-form, in the SEMANTIC phase (after the oracle's structural cutoff), so the loops it emits
-flow through dataflow / cfg-norm / the value graph and converge with hand-written iteration.
+`recursion.rs` coordinates the two recursion schemes that have a behavior-preserving
+iterative form, with the proof-sensitive rule bodies split into `recursion/tail.rs` and
+`recursion/structural_fold.rs`. They run in the SEMANTIC phase (after the oracle's structural
+cutoff), so the loops they emit flow through dataflow / cfg-norm / the value graph and
+converge with hand-written iteration.
 
 - **Tail recursion → `while`.** `f(p…): if c₀: return v₀; …; return f(a…)` becomes
   `while not(c₀ or …) { p… := a… }; if c₀: return v₀; …; return vₖ₋₁`. The next call's
@@ -206,8 +208,9 @@ anything else is left untouched. The proof obligations
 [`normalize.recursion.tail`](../formal/obligations/normalize/recursion/tail/Proof.lean)
 and
 [`normalize.recursion.structural_fold`](../formal/obligations/normalize/recursion/structural_fold/Proof.lean)
-record the tail-loop equivalence and the numeric `+`/`*` fold laws. **Soundness** is checked,
-not assumed: the interpreter
+record the tail-loop equivalence, the numeric `+`/`*` fold laws, and boundary
+counterexamples for cyclic tail-call bindings, subtraction, and wrong identities.
+**Soundness** is checked, not assumed: the interpreter
 ([`interp`](../crates/nose-normalize/src/interp.rs)) now executes self-recursion, so
 `nose verify` interprets the original recursion *and* the rewritten loop and flags any
 behavioral difference (when the recursion terminates on the input battery — a guard like

--- a/formal/README.md
+++ b/formal/README.md
@@ -33,6 +33,16 @@ Some semantic surfaces are required even when they are not one-file rule modules
 currently requires obligations for IL arena validity/deep-copy, recursion rewrites, exact
 fragment effect/place and wrapper contracts, and the oracle cutoff.
 
+Every Rust-backed obligation must list `rust.markers = ["<obligation id>"]`, and one of the
+listed Rust files must contain the matching comment marker:
+
+```rust
+//! proof-obligation: detect.fragment.effect_place
+```
+
+The linter also scans Rust files in the other direction: a marker with no matching
+obligation, or a marker in a file not named by that obligation's `rust.files`, fails CI.
+
 ## Registered proof families
 
 - `normalize.value_graph.algebra` — associative-commutative numeric algebra,
@@ -53,7 +63,7 @@ fragment effect/place and wrapper contracts, and the oracle cutoff.
   distinct-field commutativity, and same-field order counterexample.
 - `normalize.recursion.tail` — tail-recursive self-call elimination into a while loop.
 - `normalize.recursion.structural_fold` — numeric structural recursion as an accumulator
-  fold for `+` and `*`.
+  fold for `+` and `*`, with counterexamples for subtraction and wrong identities.
 - `detect.fragment.effect_place` — append/index effects need no receiver proof; field
   writes require an exact-safe place and reject `Unknown`.
 - `detect.fragment.free_inputs` — wrapper parameters are reads minus fragment-local

--- a/formal/obligations/detect/fragment/effect_place/meta.toml
+++ b/formal/obligations/detect/fragment/effect_place/meta.toml
@@ -6,6 +6,7 @@ summary = "Append and index effects are directly observed; field writes require 
 [rust]
 files = ["crates/nose-detect/src/fragment/contract.rs"]
 symbols = ["Effect", "Place", "writes_proven"]
+markers = ["detect.fragment.effect_place"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/detect/fragment/free_inputs/meta.toml
+++ b/formal/obligations/detect/fragment/free_inputs/meta.toml
@@ -6,6 +6,7 @@ summary = "Fragment wrapper inputs are exactly reads from the enclosing scope wi
 [rust]
 files = ["crates/nose-detect/src/fragment/oracle.rs"]
 symbols = ["free_input_cids", "collect_bound_cids", "collect_binding_targets"]
+markers = ["detect.fragment.free_inputs"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/detect/fragment/wrapper_synthesis/meta.toml
+++ b/formal/obligations/detect/fragment/wrapper_synthesis/meta.toml
@@ -6,6 +6,7 @@ summary = "A fragment wrapper exposes one parameter per free input and keeps the
 [rust]
 files = ["crates/nose-detect/src/fragment/oracle.rs"]
 symbols = ["fragment_behavior", "synthesize_wrapper", "run_unit"]
+markers = ["detect.fragment.wrapper_synthesis"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/il/arena/deep_copy/meta.toml
+++ b/formal/obligations/il/arena/deep_copy/meta.toml
@@ -6,6 +6,7 @@ summary = "Deep-copying a subtree into a fresh IL builder keeps old ids valid an
 [rust]
 files = ["crates/nose-detect/src/fragment/oracle.rs"]
 symbols = ["copy_subtree", "synthesize_wrapper"]
+markers = ["il.arena.deep_copy"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/il/arena/validity/meta.toml
+++ b/formal/obligations/il/arena/validity/meta.toml
@@ -6,6 +6,7 @@ summary = "IL validation requires root, unit roots, and child edges to stay insi
 [rust]
 files = ["crates/nose-il/src/lib.rs"]
 symbols = ["validate", "IlBuilder"]
+markers = ["il.arena.validity"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/control_flow/guard_returns/meta.toml
+++ b/formal/obligations/normalize/control_flow/guard_returns/meta.toml
@@ -6,6 +6,7 @@ summary = "Guard-return, dead-code-after-return, and ternary-return control-flow
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/cfg_norm.rs"]
 symbols = ["guarded", "process_block"]
+markers = ["normalize.control_flow.guard_returns"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/recursion/structural_fold/Counterexamples.lean
+++ b/formal/obligations/normalize/recursion/structural_fold/Counterexamples.lean
@@ -1,0 +1,21 @@
+/-
+Boundary counterexamples for structural recursion to accumulator-fold rewrites.
+
+The accepted rewrite depends on an associative monoid and the correct identity.
+Subtraction is not such a monoid, and multiplication with the wrong initial value
+does not preserve the recursive right-fold meaning.
+-/
+
+namespace NoseRecursionStructuralFoldCounterexamples
+
+theorem subtraction_is_not_a_structural_fold_monoid :
+    (([1, 2, 3] : List Int).foldl (fun total head => total - head) 0) ≠
+      (([1, 2, 3] : List Int).foldr (fun head total => head - total) 0) := by
+  decide
+
+theorem wrong_mul_identity_changes_fold :
+    (([2, 3] : List Int).foldl (fun total head => total * head) 0) ≠
+      (([2, 3] : List Int).foldr (fun head total => head * total) 1) := by
+  decide
+
+end NoseRecursionStructuralFoldCounterexamples

--- a/formal/obligations/normalize/recursion/structural_fold/Proof.lean
+++ b/formal/obligations/normalize/recursion/structural_fold/Proof.lean
@@ -4,6 +4,18 @@ namespace NoseRecursionStructuralFold
 
 open NoseFormal.Recursion
 
+theorem add_monoid_preconditions (x y z : Int) :
+    (x + y) + z = x + (y + z) /\ 0 + x = x := by
+  constructor
+  · exact Int.add_assoc x y z
+  · simp
+
+theorem mul_monoid_preconditions (x y z : Int) :
+    (x * y) * z = x * (y * z) /\ 1 * x = x := by
+  constructor
+  · exact Int.mul_assoc x y z
+  · simp
+
 theorem add_structural_fold_sound (heads : List Int) :
     heads.foldl (fun total head => total + head) 0 =
       heads.foldr (fun head total => head + total) 0 := by

--- a/formal/obligations/normalize/recursion/structural_fold/meta.toml
+++ b/formal/obligations/normalize/recursion/structural_fold/meta.toml
@@ -4,12 +4,20 @@ kind = "soundness"
 summary = "Numeric structural recursion can be emitted as an accumulator fold for addition and multiplication monoids."
 
 [rust]
-files = ["crates/nose-normalize/src/recursion.rs"]
-symbols = ["Structural", "result_ty", "is_int_literal"]
+files = ["crates/nose-normalize/src/recursion/structural_fold.rs"]
+symbols = ["recognize", "build_body"]
+markers = ["normalize.recursion.structural_fold"]
 
 [lean]
 proof = "Proof.lean"
 theorems = [
+  "NoseRecursionStructuralFold.add_monoid_preconditions",
+  "NoseRecursionStructuralFold.mul_monoid_preconditions",
   "NoseRecursionStructuralFold.add_structural_fold_sound",
   "NoseRecursionStructuralFold.mul_structural_fold_sound",
+]
+counterexamples = "Counterexamples.lean"
+counterexample_theorems = [
+  "NoseRecursionStructuralFoldCounterexamples.subtraction_is_not_a_structural_fold_monoid",
+  "NoseRecursionStructuralFoldCounterexamples.wrong_mul_identity_changes_fold",
 ]

--- a/formal/obligations/normalize/recursion/tail/Counterexamples.lean
+++ b/formal/obligations/normalize/recursion/tail/Counterexamples.lean
@@ -1,0 +1,23 @@
+/-
+Boundary counterexample for tail-recursion to loop rewrites.
+
+Recursive call arguments are parallel bindings. A naive sequential update can
+clobber a parameter that a later update still needs; Rust's `ordered_updates`
+therefore bails out on cycles such as swaps.
+-/
+
+namespace NoseRecursionTailCounterexamples
+
+def parallelSwap (state : Int × Int) : Int × Int :=
+  (state.2, state.1)
+
+def naiveSequentialSwap (state : Int × Int) : Int × Int :=
+  let nextA := state.2
+  let nextB := nextA
+  (nextA, nextB)
+
+theorem cyclic_binding_needs_hazard_safe_order :
+    naiveSequentialSwap (1, 2) ≠ parallelSwap (1, 2) := by
+  decide
+
+end NoseRecursionTailCounterexamples

--- a/formal/obligations/normalize/recursion/tail/meta.toml
+++ b/formal/obligations/normalize/recursion/tail/meta.toml
@@ -4,9 +4,12 @@ kind = "soundness"
 summary = "Tail-recursive self calls and their emitted while loop reach the same final state before returning."
 
 [rust]
-files = ["crates/nose-normalize/src/recursion.rs"]
-symbols = ["Tail", "ordered_updates", "while_loop"]
+files = ["crates/nose-normalize/src/recursion/tail.rs"]
+symbols = ["recognize", "build_body"]
+markers = ["normalize.recursion.tail"]
 
 [lean]
 proof = "Proof.lean"
 theorems = ["NoseRecursionTail.tail_recursion_loop_sound"]
+counterexamples = "Counterexamples.lean"
+counterexample_theorems = ["NoseRecursionTailCounterexamples.cyclic_binding_needs_hazard_safe_order"]

--- a/formal/obligations/normalize/value_graph/algebra/meta.toml
+++ b/formal/obligations/normalize/value_graph/algebra/meta.toml
@@ -6,6 +6,7 @@ summary = "Associative-commutative numeric algebra and subtraction/negation cano
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/algebra.rs"]
 symbols = ["flatten_into", "intern_ac_chain", "collect_add_sub_expr_operands"]
+markers = ["normalize.value_graph.algebra"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/bool_reduce/meta.toml
+++ b/formal/obligations/normalize/value_graph/bool_reduce/meta.toml
@@ -6,6 +6,7 @@ summary = "Any/all reductions are well-defined Bool folds for cross-language pre
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/idioms.rs"]
 symbols = ["recognize_existence_reduction", "REDUCE_ANY", "REDUCE_ALL"]
+markers = ["normalize.value_graph.bool_reduce"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/clamp/meta.toml
+++ b/formal/obligations/normalize/value_graph/clamp/meta.toml
@@ -6,6 +6,7 @@ summary = "Clamp min/max compositions and two-comparison forms agree only under 
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs"]
 symbols = ["minmax_pattern"]
+markers = ["normalize.value_graph.clamp"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/compare/meta.toml
+++ b/formal/obligations/normalize/value_graph/compare/meta.toml
@@ -6,6 +6,7 @@ summary = "Comparison direction, negated comparisons, and total-order lattice ca
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/algebra.rs"]
 symbols = ["negate_cmp_code", "lattice_le_ne_to_lt", "lattice_lt_eq_to_le"]
+markers = ["normalize.value_graph.compare"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/factor_distribute/meta.toml
+++ b/formal/obligations/normalize/value_graph/factor_distribute/meta.toml
@@ -7,6 +7,7 @@ summary = "The named factor_distribute rule preserves Int denotation and is gate
 rule_module = true
 files = ["crates/nose-normalize/src/value_graph/rules/factor_distribute.rs"]
 symbols = ["apply"]
+markers = ["normalize.value_graph.factor_distribute"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/field_writes/meta.toml
+++ b/formal/obligations/normalize/value_graph/field_writes/meta.toml
@@ -6,6 +6,7 @@ summary = "Field writes are interpreted as final field state with last-write-win
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/interp.rs"]
 symbols = ["flush_fields", "field_env"]
+markers = ["normalize.value_graph.field_writes"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/free_monoid/meta.toml
+++ b/formal/obligations/normalize/value_graph/free_monoid/meta.toml
@@ -6,6 +6,7 @@ summary = "String/list builder semantics are ordered free-monoid concatenation, 
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/interp.rs"]
 symbols = ["is_concat_ty", "join_strings"]
+markers = ["normalize.value_graph.free_monoid"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/functor/meta.toml
+++ b/formal/obligations/normalize/value_graph/functor/meta.toml
@@ -6,6 +6,7 @@ summary = "Map/filter fusion and count-of-filter normalization preserve List den
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/idioms.rs"]
 symbols = ["HoFKind::Map", "HoFKind::Filter", "and_preds"]
+markers = ["normalize.value_graph.functor"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/min_max/meta.toml
+++ b/formal/obligations/normalize/value_graph/min_max/meta.toml
@@ -6,6 +6,7 @@ summary = "Min/max select idioms and accumulator reductions are commutative and 
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/idioms.rs"]
 symbols = ["minmax_pattern", "MIN_CODE", "MAX_CODE"]
+markers = ["normalize.value_graph.min_max"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/oracle/cutoff/meta.toml
+++ b/formal/obligations/oracle/cutoff/meta.toml
@@ -6,6 +6,7 @@ summary = "Oracle-mode normalization stops after desugar and alpha, excluding se
 [rust]
 files = ["crates/nose-normalize/src/lib.rs"]
 symbols = ["NormalizeOptions", "oracle", "recursion::run"]
+markers = ["oracle.cutoff"]
 
 [lean]
 proof = "Proof.lean"

--- a/scripts/check-formal-obligations.py
+++ b/scripts/check-formal-obligations.py
@@ -38,6 +38,8 @@ RULE_ROOTS = {
     "normalize.value_graph": ROOT / "crates" / "nose-normalize" / "src" / "value_graph" / "rules",
 }
 
+RUST_ROOTS = (ROOT / "crates",)
+MARKER_RE = re.compile(r"\bproof-obligation:\s*([A-Za-z0-9_.]+)\b")
 DECL_RE = re.compile(r"^\s*(?:theorem|lemma|def)\s+([A-Za-z_][A-Za-z0-9_']*)\b")
 NAMESPACE_RE = re.compile(r"^\s*namespace\s+([A-Za-z_][A-Za-z0-9_'.]*)\b")
 END_RE = re.compile(r"^\s*end(?:\s+[A-Za-z_][A-Za-z0-9_'.]*)?\s*$")
@@ -72,13 +74,13 @@ REQUIRED_OBLIGATIONS = (
     ),
     RequiredObligation(
         "normalize.recursion.tail",
-        ("crates/nose-normalize/src/recursion.rs",),
-        ("Tail", "ordered_updates", "while_loop"),
+        ("crates/nose-normalize/src/recursion/tail.rs",),
+        ("recognize", "build_body"),
     ),
     RequiredObligation(
         "normalize.recursion.structural_fold",
-        ("crates/nose-normalize/src/recursion.rs",),
-        ("Structural", "result_ty", "is_int_literal"),
+        ("crates/nose-normalize/src/recursion/structural_fold.rs",),
+        ("recognize", "build_body"),
     ),
     RequiredObligation(
         "detect.fragment.effect_place",
@@ -232,7 +234,24 @@ def load_obligations(errors: list[str]) -> dict[str, Obligation]:
     return obligations
 
 
-def lint_meta(obligation: Obligation, all_ids: set[str], errors: list[str]) -> None:
+def collect_rust_markers() -> dict[str, set[str]]:
+    markers: dict[str, set[str]] = {}
+    for root in RUST_ROOTS:
+        if not root.exists():
+            continue
+        for rust_file in sorted(root.rglob("*.rs")):
+            rel = str(rust_file.relative_to(ROOT))
+            for match in MARKER_RE.finditer(rust_file.read_text(encoding="utf-8")):
+                markers.setdefault(match.group(1), set()).add(rel)
+    return markers
+
+
+def lint_meta(
+    obligation: Obligation,
+    all_ids: set[str],
+    errors: list[str],
+    rust_markers: dict[str, set[str]] | None = None,
+) -> None:
     rel = obligation.path.relative_to(ROOT)
     where = str(rel / "meta.toml")
     meta = obligation.meta
@@ -260,6 +279,16 @@ def lint_meta(obligation: Obligation, all_ids: set[str], errors: list[str]) -> N
         for symbol in symbols:
             if re.search(rf"\b{re.escape(symbol)}\b", contents) is None:
                 error(errors, f"{where}: rust symbol `{symbol}` was not found in listed files")
+    markers = as_list(rust.get("markers", []), "rust.markers", errors, where)
+    if rust_files and not markers:
+        error(errors, f"{where}: rust-backed obligations must list at least one `rust.markers` entry")
+    if rust_files and rust_markers is not None:
+        for marker in markers:
+            if marker != obligation.id:
+                error(errors, f"{where}: rust marker `{marker}` must match obligation id `{obligation.id}`")
+            found_files = rust_markers.get(marker, set())
+            if not any(rust_file in found_files for rust_file in rust_files):
+                error(errors, f"{where}: rust marker `{marker}` was not found in listed rust files")
 
     if rust.get("rule_module", False) is True:
         matching_prefix = next((prefix for prefix in RULE_ROOTS if obligation.id.startswith(prefix + ".")), None)
@@ -360,6 +389,26 @@ def lint_rule_modules(obligations: dict[str, Obligation], errors: list[str]) -> 
                 )
 
 
+def lint_rust_marker_index(
+    obligations: dict[str, Obligation],
+    rust_markers: dict[str, set[str]],
+    errors: list[str],
+) -> None:
+    for marker, marker_files in sorted(rust_markers.items()):
+        if marker not in obligations:
+            for marker_file in sorted(marker_files):
+                error(errors, f"{marker_file}: marker references unknown obligation `{marker}`")
+            continue
+        rust = obligations[marker].meta.get("rust", {})
+        rust_files = rust.get("files", []) if isinstance(rust, dict) else []
+        if not isinstance(rust_files, list):
+            rust_files = []
+        for marker_file in sorted(marker_files):
+            if marker_file not in rust_files:
+                where = str(obligations[marker].path.relative_to(ROOT) / "meta.toml")
+                error(errors, f"{where}: marker `{marker}` appears in `{marker_file}` but `rust.files` does not list it")
+
+
 def lint_required_obligations(
     obligations: dict[str, Obligation],
     errors: list[str],
@@ -387,6 +436,9 @@ def lint_required_obligations(
         rust_symbols = rust.get("symbols", [])
         if not isinstance(rust_symbols, list):
             rust_symbols = []
+        rust_markers = rust.get("markers", [])
+        if not isinstance(rust_markers, list):
+            rust_markers = []
 
         for rust_file in item.rust_files:
             if rust_file not in rust_files:
@@ -394,6 +446,8 @@ def lint_required_obligations(
         for symbol in item.rust_symbols:
             if symbol not in rust_symbols:
                 error(errors, f"{where}: required surface must list rust symbol `{symbol}`")
+        if item.id not in rust_markers:
+            error(errors, f"{where}: required surface must list rust marker `{item.id}`")
 
 
 def lint_lean_layout(errors: list[str]) -> None:
@@ -427,9 +481,18 @@ def run_self_tests() -> int:
                 "summary": "self-test obligation",
             }
 
-        def lint(meta: dict[str, Any], all_ids: set[str] | None = None) -> list[str]:
+        def lint(
+            meta: dict[str, Any],
+            all_ids: set[str] | None = None,
+            rust_markers: dict[str, set[str]] | None = None,
+        ) -> list[str]:
             errors: list[str] = []
-            lint_meta(Obligation("self_test", obligation_path, meta), all_ids or {"self_test"}, errors)
+            lint_meta(
+                Obligation("self_test", obligation_path, meta),
+                all_ids or {"self_test"},
+                errors,
+                rust_markers,
+            )
             return errors
 
         def required_lint(obligations: dict[str, Obligation]) -> list[str]:
@@ -445,6 +508,14 @@ def run_self_tests() -> int:
                     ),
                 ),
             )
+            return errors
+
+        def marker_index_lint(
+            obligations: dict[str, Obligation],
+            rust_markers: dict[str, set[str]],
+        ) -> list[str]:
+            errors: list[str] = []
+            lint_rust_marker_index(obligations, rust_markers, errors)
             return errors
 
         cases = [
@@ -481,6 +552,30 @@ def run_self_tests() -> int:
                 True,
                 "rejected-counterexample obligations must list at least one "
                 "`lean.counterexample_theorems`",
+            ),
+            (
+                "rust-backed obligation without marker list",
+                {
+                    **base_meta("proven"),
+                    "rust": {"files": ["required.rs"], "symbols": []},
+                    "lean": {"proof": "Proof.lean", "theorems": ["SelfTest.ok"]},
+                },
+                True,
+                "rust-backed obligations must list at least one `rust.markers` entry",
+            ),
+            (
+                "rust-backed obligation with missing marker",
+                {
+                    **base_meta("proven"),
+                    "rust": {
+                        "files": ["required.rs"],
+                        "symbols": [],
+                        "markers": ["self_test"],
+                    },
+                    "lean": {"proof": "Proof.lean", "theorems": ["SelfTest.ok"]},
+                },
+                True,
+                "rust marker `self_test` was not found in listed rust files",
             ),
         ]
 
@@ -520,11 +615,60 @@ def run_self_tests() -> int:
                 },
                 "required surface must list rust symbol `required_symbol`",
             ),
+            (
+                "required obligation missing rust marker",
+                {
+                    "self_test": Obligation(
+                        "self_test",
+                        obligation_path,
+                        {
+                            **base_meta("proven"),
+                            "rust": {
+                                "files": ["required.rs"],
+                                "symbols": ["required_symbol"],
+                                "markers": [],
+                            },
+                            "lean": {"proof": "Proof.lean", "theorems": ["SelfTest.ok"]},
+                        },
+                    )
+                },
+                "required surface must list rust marker `self_test`",
+            ),
+        ]
+
+        marker_index_cases = [
+            (
+                "orphan rust marker",
+                {},
+                {"missing.obligation": {"crates/missing.rs"}},
+                "crates/missing.rs: marker references unknown obligation `missing.obligation`",
+            ),
+            (
+                "marker file not listed by meta",
+                {
+                    "self_test": Obligation(
+                        "self_test",
+                        obligation_path,
+                        {
+                            **base_meta("proven"),
+                            "rust": {
+                                "files": ["other.rs"],
+                                "symbols": [],
+                                "markers": ["self_test"],
+                            },
+                            "lean": {"proof": "Proof.lean", "theorems": ["SelfTest.ok"]},
+                        },
+                    )
+                },
+                {"self_test": {"required.rs"}},
+                "marker `self_test` appears in `required.rs` but `rust.files` does not list it",
+            ),
         ]
 
         failures = []
         for name, meta, should_fail, expected in cases:
-            errors = lint(meta)
+            rust_marker_index = {"self_test": {"required.rs"}} if "missing marker" not in name else {}
+            errors = lint(meta, rust_markers=rust_marker_index)
             joined = "\n".join(errors)
             if should_fail and expected not in joined:
                 failures.append(f"{name}: expected `{expected}`, got {errors}")
@@ -532,6 +676,11 @@ def run_self_tests() -> int:
                 failures.append(f"{name}: expected no errors, got {errors}")
         for name, obligations, expected in required_cases:
             errors = required_lint(obligations)
+            joined = "\n".join(errors)
+            if expected not in joined:
+                failures.append(f"{name}: expected `{expected}`, got {errors}")
+        for name, obligations, rust_markers, expected in marker_index_cases:
+            errors = marker_index_lint(obligations, rust_markers)
             joined = "\n".join(errors)
             if expected not in joined:
                 failures.append(f"{name}: expected `{expected}`, got {errors}")
@@ -555,9 +704,11 @@ def main() -> int:
     errors: list[str] = []
     obligations = load_obligations(errors)
     all_ids = set(obligations)
+    rust_markers = collect_rust_markers()
     for obligation in obligations.values():
-        lint_meta(obligation, all_ids, errors)
+        lint_meta(obligation, all_ids, errors, rust_markers)
     lint_rule_modules(obligations, errors)
+    lint_rust_marker_index(obligations, rust_markers, errors)
     lint_required_obligations(obligations, errors)
     lint_lean_layout(errors)
 


### PR DESCRIPTION
## What changed

- Split recursion proof-sensitive Rust surfaces into `recursion/tail.rs` and `recursion/structural_fold.rs` so each obligation maps to a focused implementation file.
- Added `proof-obligation: ...` Rust markers and `rust.markers` metadata for IL, fragment-oracle, oracle cutoff, recursion, and value-graph obligations.
- Extended the formal-obligation linter to check marker coverage bidirectionally: metadata markers must exist in listed Rust files, and Rust markers must reference known obligations whose metadata lists the file.
- Added Lean precondition and boundary counterexample coverage for recursion rewrites.
- Updated formal and normalization docs to document the marker contract and recursion layout.

## Impact

This strengthens the mechanical guarantee that proof-sensitive Rust code has a corresponding registered formal obligation. Missing or orphaned proof markers now fail the formal-obligation linter.

## Validation

- `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `./scripts/check-ci-local.sh --fast`