### PR TITLE
type4: model flat-map comprehensions

### DIFF
--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -1621,6 +1621,47 @@ fn list_builder_loop_converges_with_comprehension() {
     assert_ne!(comp, fcomp, "unfiltered and filtered must stay distinct");
 }
 
+/// Multi-clause comprehensions are flat maps, not nested maps. They should converge with
+/// an equivalent nested append loop and JS `.flatMap(... .map(...))`, while staying
+/// distinct from a nested list comprehension.
+#[test]
+fn multi_clause_comprehension_converges_as_flat_map() {
+    let i = Interner::new();
+    let comp = value_fp(
+        &i,
+        "def f(xs, ys):\n    return [x + y for x in xs for y in ys]\n",
+        Lang::Python,
+    );
+    let loop_py = value_fp(
+        &i,
+        "def g(xs, ys):\n    r = []\n    for x in xs:\n        for y in ys:\n            r.append(x + y)\n    return r\n",
+        Lang::Python,
+    );
+    let flat_map_js = value_fp(
+        &i,
+        "function h(xs, ys){ return xs.flatMap(x => ys.map(y => x + y)); }",
+        Lang::JavaScript,
+    );
+    let nested_list = value_fp(
+        &i,
+        "def h(xs, ys):\n    return [[x + y for y in ys] for x in xs]\n",
+        Lang::Python,
+    );
+
+    assert_eq!(
+        comp, loop_py,
+        "flat comprehension should match nested append loop"
+    );
+    assert_eq!(
+        comp, flat_map_js,
+        "flat comprehension should match JS flatMap/map"
+    );
+    assert_ne!(
+        comp, nested_list,
+        "flat-map and nested-list comprehensions differ"
+    );
+}
+
 /// Cross-language `any`/`all` predicate reductions converge to one fingerprint: Python
 /// `any(p(x) for x in xs)`, JS `xs.some(p)`, Rust `xs.iter().any(p)` — and likewise
 /// `all`/`every`. `any` and `all` stay DISTINCT (different short-circuit behavior).

--- a/crates/nose-cli/tests/fixtures/issue57_flatmap.js
+++ b/crates/nose-cli/tests/fixtures/issue57_flatmap.js
@@ -1,0 +1,7 @@
+function flatMapJs(xs, ys) {
+  return xs.flatMap((x) => ys.map((y) => x + y));
+}
+
+function nestedListJs(xs, ys) {
+  return xs.map((x) => ys.map((y) => x + y));
+}

--- a/crates/nose-cli/tests/fixtures/issue57_flatmap.py
+++ b/crates/nose-cli/tests/fixtures/issue57_flatmap.py
@@ -1,0 +1,14 @@
+def flat_comp(xs, ys):
+    return [x + y for x in xs for y in ys]
+
+
+def nested_loop(xs, ys):
+    out = []
+    for x in xs:
+        for y in ys:
+            out.append(x + y)
+    return out
+
+
+def nested_list_comp(xs, ys):
+    return [[x + y for y in ys] for x in xs]

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -963,9 +963,8 @@ fn comp_lambda(lo: &mut Lowering, pattern: Option<TsNode>, body: NodeId, bspan: 
 /// `… if cond` wraps the collection in `HoF(Filter)[xs, λx. cond]`, so a filtered
 /// comprehension converges with a guarded loop (`if cond: …`) — see §AI.
 ///
-/// A *multi-clause* comprehension (`[body for a in A for b in B]`) is a flat-map
-/// nesting with no first-class IL primitive yet, so it is lowered fail-closed —
-/// see [`lower_multi_clause_comprehension`].
+/// A *multi-clause* comprehension (`[body for a in A for b in B]`) lowers to a
+/// first-class flat-map nesting — see [`lower_multi_clause_comprehension`].
 fn lower_comprehension(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
     let body_node = node.named_child(0);
@@ -1019,18 +1018,10 @@ fn lower_comprehension(lo: &mut Lowering, node: TsNode) -> NodeId {
 
 /// Lower a comprehension with more than one `for` clause. `[body for a in A for
 /// b in B]` is Python sugar for nested iteration that *flattens* — equivalent to
-/// `A.flatMap(a => B.map(b => body))`. nose has no `FlatMap` HoF primitive, so a
-/// naive `Map[A, λa. Map[B, λb. body]]` would be byte-identical to the genuinely
-/// different *nested* comprehension `[[body for b in B] for a in A]` (a list of
-/// lists) — an unsound false merge.
-///
-/// Until flat-map is modeled (tracked separately), this lowers fail-closed: it
-/// builds the nested `Map`/`Filter` structure (so every clause's collection and
-/// target is preserved and bound) and wraps the whole thing in an opaque `Raw`
-/// node. The value graph keys `Raw` by full subtree content, so two flat-maps
-/// converge only when structurally identical and never collide with a nested
-/// comprehension, a single-clause `Map`, or any other construct. Convergence with
-/// the equivalent explicit nested loop is deferred to the flat-map work.
+/// `A.flatMap(a => B.map(b => body))`. The innermost clause maps to produced
+/// elements; each outer clause flat-maps the list produced by the next inner
+/// layer. This stays distinct from the genuinely different nested comprehension
+/// `[[body for b in B] for a in A]`, which lowers to `Map[A, λa. Map[B, ...]]`.
 fn lower_multi_clause_comprehension(
     lo: &mut Lowering,
     node: TsNode,
@@ -1051,13 +1042,13 @@ fn lower_multi_clause_comprehension(
         }
     }
 
-    // Build inside-out: the body is the innermost produced element; each `for`
-    // clause (outer→inner in source, so iterated in reverse) wraps it in a `Map`
-    // over its (optionally filtered) collection, binding that clause's target.
+    // Build inside-out: the body is the innermost produced element. The innermost
+    // `for` maps to elements; every outer `for` flat-maps the list produced by the
+    // inner layer.
     let mut inner = body_node
         .map(|b| lower_expr(lo, b))
         .unwrap_or_else(|| lo.empty_block(span));
-    for (forc, ifs) in groups.iter().rev() {
+    for (idx, (forc, ifs)) in groups.iter().rev().enumerate() {
         let pattern = forc
             .child_by_field_name("left")
             .or_else(|| forc.named_child(0));
@@ -1080,16 +1071,20 @@ fn lower_multi_clause_comprehension(
             }
         }
         let lam = comp_lambda(lo, pattern, inner, span);
+        let hof_kind = if idx == 0 {
+            HoFKind::Map
+        } else {
+            HoFKind::FlatMap
+        };
         inner = lo.add(
             NodeKind::HoF,
-            Payload::HoF(HoFKind::Map),
+            Payload::HoF(hof_kind),
             span,
             &[collection, lam],
         );
     }
 
-    // Fail-closed: an opaque wrapper that cannot be confused with a nested `Map`.
-    lo.raw("comprehension", span, &[inner])
+    inner
 }
 
 /// Emit `Param` nodes for a comprehension/loop target (identifier or tuple).
@@ -1380,6 +1375,49 @@ mod tests {
         assert!(
             names.contains(&"ys"),
             "second clause `for b in ys` was dropped; names = {names:?}"
+        );
+    }
+
+    #[test]
+    fn multi_clause_comprehension_lowers_to_flat_map_without_raw() {
+        let interner = Interner::new();
+        let il = lower(
+            FileId(0),
+            "t.py",
+            b"def f(A, B):\n    return [a + b for a in A for b in B]\n",
+            &interner,
+        )
+        .expect("lower");
+
+        let hof_kinds: Vec<_> = il
+            .nodes
+            .iter()
+            .filter_map(|node| match node.payload {
+                Payload::HoF(kind) => Some(kind),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            hof_kinds.contains(&HoFKind::FlatMap),
+            "multi-clause comprehension should contain a FlatMap HoF: {hof_kinds:?}"
+        );
+        assert!(
+            hof_kinds.contains(&HoFKind::Map),
+            "multi-clause comprehension should keep the innermost Map: {hof_kinds:?}"
+        );
+
+        let raw: Vec<_> = il
+            .nodes
+            .iter()
+            .filter(|node| node.kind == NodeKind::Raw)
+            .filter_map(|node| match node.payload {
+                Payload::Name(sym) => Some(interner.resolve(sym)),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !raw.contains(&"comprehension"),
+            "flat-map comprehension should no longer use Raw fallback: {raw:?}"
         );
     }
 

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -75,8 +75,8 @@ pub enum NodeKind {
     Lambda,
     /// An array/tuple/set/map literal. Children: the elements.
     Seq,
-    /// A canonical higher-order operation (comprehension / map / filter /
-    /// reduce). Payload: `HoF`. Children: `[collection, fn]`.
+    /// A canonical higher-order operation (comprehension / map / flat-map /
+    /// filter / reduce). Payload: `HoF`. Children: `[collection, fn]`.
     HoF,
 
     /// Escape hatch for surface constructs a frontend does not yet lower. Payload
@@ -294,6 +294,7 @@ pub enum HoFKind {
     Map,
     Filter,
     Reduce,
+    FlatMap,
 }
 
 /// One IL node. Children are stored out-of-line in [`crate::Il::edges`] as a

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -17,8 +17,8 @@ pub(crate) enum CallCanon {
         op: Builtin,
         arg_olds: Vec<NodeId>,
     },
-    /// `xs.map(f)` / `.filter(f)` / `.reduce(f)` → `HoF[xs, f]`, converging with
-    /// Python comprehensions.
+    /// `xs.map(f)` / `.flatMap(f)` / `.filter(f)` / `.reduce(f)` → `HoF[xs, f]`,
+    /// converging with Python comprehensions.
     HoF {
         kind: HoFKind,
         collection_old: NodeId,
@@ -358,13 +358,13 @@ pub(crate) fn canon_call(old: &Il, interner: &Interner, call_id: NodeId) -> Call
                             arg_olds: vec![coll, args[0]],
                         };
                     }
-                    "map" | "collect" | "filter" | "select"
+                    "map" | "collect" | "flatMap" | "flat_map" | "filter" | "select"
                         if base.is_some() && !args.is_empty() =>
                     {
-                        let kind = if matches!(fname, "map" | "collect") {
-                            HoFKind::Map
-                        } else {
-                            HoFKind::Filter
+                        let kind = match fname {
+                            "map" | "collect" => HoFKind::Map,
+                            "flatMap" | "flat_map" => HoFKind::FlatMap,
+                            _ => HoFKind::Filter,
                         };
                         return CallCanon::HoF {
                             kind,

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -880,6 +880,17 @@ impl<'a> Interp<'a> {
                 }
                 Ok(Value::List(out))
             }
+            HoFKind::FlatMap => {
+                let mut out = Vec::new();
+                for x in coll {
+                    match self.apply(f, &[x], env)? {
+                        Value::Err => return Ok(Value::Err),
+                        Value::List(items) => out.extend(items),
+                        _ => return Ok(Value::Err),
+                    }
+                }
+                Ok(Value::List(out))
+            }
             HoFKind::Filter => {
                 let mut out = Vec::new();
                 for x in coll {
@@ -1944,6 +1955,56 @@ mod tests {
     #[test]
     fn hof_filter_propagates_lambda_errors() {
         assert_eq!(hof_with_error_lambda(HoFKind::Filter), Value::Err);
+    }
+
+    #[test]
+    fn hof_flat_map_propagates_lambda_errors() {
+        assert_eq!(hof_with_error_lambda(HoFKind::FlatMap), Value::Err);
+    }
+
+    fn hof_flat_map_value() -> Value {
+        let sp = Span::synthetic(FileId(0));
+        let mut b = IlBuilder::new(FileId(0));
+        let param = b.add(NodeKind::Param, Payload::Cid(0), sp, &[]);
+        let var = b.add(NodeKind::Var, Payload::Cid(0), sp, &[]);
+        let pair = b.add(NodeKind::Seq, Payload::None, sp, &[var, var]);
+        let lambda_ret = b.add(NodeKind::Return, Payload::None, sp, &[pair]);
+        let lambda_body = b.add(NodeKind::Block, Payload::None, sp, &[lambda_ret]);
+        let lambda = b.add(NodeKind::Lambda, Payload::None, sp, &[param, lambda_body]);
+        let one = b.add(NodeKind::Lit, Payload::LitInt(1), sp, &[]);
+        let two = b.add(NodeKind::Lit, Payload::LitInt(2), sp, &[]);
+        let coll = b.add(NodeKind::Seq, Payload::None, sp, &[one, two]);
+        let hof = b.add(
+            NodeKind::HoF,
+            Payload::HoF(HoFKind::FlatMap),
+            sp,
+            &[coll, lambda],
+        );
+        let ret = b.add(NodeKind::Return, Payload::None, sp, &[hof]);
+        let func = b.add(NodeKind::Func, Payload::None, sp, &[ret]);
+        let il = b.finish(
+            func,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        run_unit(&il, func, &[]).expect("run_unit").ret
+    }
+
+    #[test]
+    fn hof_flat_map_flattens_lambda_lists() {
+        assert_eq!(
+            hof_flat_map_value(),
+            Value::List(vec![
+                Value::Int(1),
+                Value::Int(1),
+                Value::Int(2),
+                Value::Int(2)
+            ])
+        );
     }
 
     fn print_with_error_arg_then_return() -> Value {

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -3113,7 +3113,7 @@ impl<'a> Builder<'a> {
         if self.il.kind(expr) == NodeKind::HoF
             && matches!(
                 self.il.node(expr).payload,
-                Payload::HoF(HoFKind::Map | HoFKind::Filter)
+                Payload::HoF(HoFKind::Map | HoFKind::FlatMap | HoFKind::Filter)
             )
         {
             let kids = self.il.children(expr).to_vec();
@@ -3805,6 +3805,9 @@ impl<'a> Builder<'a> {
         // Finalize list builders: `r = []; for x: r.append(f(x))` → `r = Map(elem, f(x))`,
         // converging the loop with the comprehension `[f(x) for x in xs]` / `.map`. A
         // guarded append (`if cond: r.append(f(x))`) becomes the filtered map `Map(_, pred)`.
+        // If the append happens inside a nested loop, the inner loop has already produced a
+        // `Map`/`FlatMap`; wrap that per-outer-iteration collection in a `FlatMap` so
+        // `for x: for y: r.append(f(x,y))` converges with `[f(x,y) for x in xs for y in ys]`.
         for &c in &builder_cands {
             if let Some(Some((mut contrib, guard))) = self.building.remove(&c) {
                 let map = if !index_vals.is_empty() {
@@ -3824,6 +3827,11 @@ impl<'a> Builder<'a> {
                     }
                 };
                 env.insert(c, map);
+            } else if let Some(&nested) = body_env.get(&c) {
+                if let Some(flat) = self.flat_map_builder_value(nested, &pattern_bindings) {
+                    env.insert(c, flat);
+                }
+                self.building.remove(&c);
             } else {
                 self.building.remove(&c);
             }
@@ -3920,6 +3928,21 @@ impl<'a> Builder<'a> {
         } else {
             let pred = self.mk(ValOp::Un(Op::Not as u32), vec![cond]);
             Some(self.mk(ValOp::Reduce(REDUCE_ALL), vec![pred]))
+        }
+    }
+
+    fn flat_map_builder_value(
+        &mut self,
+        value: ValueId,
+        pattern_bindings: &[(u32, ValueId)],
+    ) -> Option<ValueId> {
+        let outer_elem = pattern_bindings.first()?.1;
+        let op = self.nodes[value as usize].op.clone();
+        match op {
+            ValOp::Hof(k) if k == HoFKind::Map as u32 || k == HoFKind::FlatMap as u32 => {
+                Some(self.mk(ValOp::Hof(HoFKind::FlatMap as u32), vec![outer_elem, value]))
+            }
+            _ => None,
         }
     }
 
@@ -4963,11 +4986,11 @@ impl<'a> Builder<'a> {
                     (n.op.clone(), n.args.clone())
                 };
                 let contrib = match op {
-                    ValOp::Hof(_) if args.len() >= 2 => {
+                    ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() >= 2 => {
                         let zero = self.int_const(0);
                         self.mk(ValOp::Phi, vec![args[1], args[0], zero])
                     }
-                    ValOp::Hof(_) if args.len() == 1 => args[0],
+                    ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() == 1 => args[0],
                     _ => self.elem(av),
                 };
                 let init = self.int_const(0);
@@ -4981,7 +5004,7 @@ impl<'a> Builder<'a> {
                 let (elems, guard) = if let Some((source, predicate)) = filtered {
                     let coll = self.eval(source, env);
                     let elem = self.elem(coll);
-                    let guard = self.eval_lambda_body(predicate, &[elem])?;
+                    let guard = self.eval_lambda_body(predicate, &[elem], env)?;
                     (vec![elem], Some(guard))
                 } else {
                     (self.elem_bindings(kids.get(1).copied(), env), None)
@@ -4990,7 +5013,7 @@ impl<'a> Builder<'a> {
                 let mut params = Vec::with_capacity(elems.len() + 1);
                 params.push(acc);
                 params.extend(elems);
-                let body = self.eval_lambda_body(kids[0], &params)?;
+                let body = self.eval_lambda_body(kids[0], &params, env)?;
                 let (op, contrib) = self.as_reduction(body, acc)?;
                 let contrib = if let Some(guard) = guard {
                     let ident = self.int_const(identity_of(op)?);
@@ -5029,7 +5052,7 @@ impl<'a> Builder<'a> {
                     (n.op.clone(), n.args.clone())
                 };
                 let contrib = match op {
-                    ValOp::Hof(_) if !args.is_empty() => args[0],
+                    ValOp::Hof(k) if k == HoFKind::Map as u32 && !args.is_empty() => args[0],
                     _ => self.elem(av),
                 };
                 Some(self.mk(ValOp::Reduce(reduce_code), vec![contrib]))
@@ -5047,7 +5070,7 @@ impl<'a> Builder<'a> {
                 let contrib = if kids.len() >= 2 && self.il.kind(kids[1]) == NodeKind::Lambda {
                     let coll = self.eval(kids[0], env);
                     let elem = self.elem(coll);
-                    let pred = self.eval_lambda_body(kids[1], &[elem])?;
+                    let pred = self.eval_lambda_body(kids[1], &[elem], env)?;
                     if code == REDUCE_ANY && self.is_static_non_float_collection_expr(kids[0]) {
                         if let Some((element, collection)) =
                             self.static_literal_membership_predicate(pred)
@@ -5074,12 +5097,12 @@ impl<'a> Builder<'a> {
                         (n.op.clone(), n.args.clone())
                     };
                     match op {
-                        ValOp::Hof(_) if args.len() >= 2 => {
+                        ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() >= 2 => {
                             let ident =
                                 self.mk(ValOp::Const(0x3000_0001 + code - REDUCE_ANY), vec![]);
                             self.mk(ValOp::Phi, vec![args[1], args[0], ident])
                         }
-                        ValOp::Hof(_) if args.len() == 1 => args[0],
+                        ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() == 1 => args[0],
                         _ => self.elem(av),
                     }
                 };
@@ -5191,7 +5214,7 @@ impl<'a> Builder<'a> {
         }
         let collection = self.eval(source, env);
         let elem = self.elem(collection);
-        let pred = self.eval_lambda_body(predicate, &[elem])?;
+        let pred = self.eval_lambda_body(predicate, &[elem], env)?;
         self.static_literal_membership_predicate(pred)
     }
 
@@ -5276,7 +5299,7 @@ impl<'a> Builder<'a> {
         if method == "findIndex" && self.il.kind(kids[1]) == NodeKind::Lambda {
             let collection = self.eval(receiver, env);
             let elem = self.elem(collection);
-            let pred = self.eval_lambda_body(kids[1], &[elem])?;
+            let pred = self.eval_lambda_body(kids[1], &[elem], env)?;
             return self.static_literal_membership_predicate(pred);
         }
         None
@@ -5666,7 +5689,7 @@ impl<'a> Builder<'a> {
     ) -> Option<ValueId> {
         let coll = self.eval(source, env);
         let elem = self.elem(coll);
-        let pred = self.eval_lambda_body(predicate, &[elem])?;
+        let pred = self.eval_lambda_body(predicate, &[elem], env)?;
         let one = self.int_const(1);
         let zero = self.int_const(0);
         let contrib = self.mk(ValOp::Phi, vec![pred, one, zero]);
@@ -5729,11 +5752,11 @@ impl<'a> Builder<'a> {
             (n.op.clone(), n.args.clone())
         };
         let contrib = match op {
-            ValOp::Hof(_) if args.len() >= 2 => {
+            ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() >= 2 => {
                 let one = self.int_const(1);
                 self.mk(ValOp::Phi, vec![args[1], args[0], one])
             }
-            ValOp::Hof(_) if args.len() == 1 => args[0],
+            ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() == 1 => args[0],
             _ => self.elem(coll),
         };
         let init = kids
@@ -5809,12 +5832,17 @@ impl<'a> Builder<'a> {
     /// Evaluate a lambda's body with its positional parameters bound to `params`,
     /// returning the value of its first `return` (intermediate assignments update the
     /// local env). Used to unfold a `map`/`reduce` lambda over a canonical `Elem`.
-    fn eval_lambda_body(&mut self, lambda: NodeId, params: &[ValueId]) -> Option<ValueId> {
+    fn eval_lambda_body(
+        &mut self,
+        lambda: NodeId,
+        params: &[ValueId],
+        parent_env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
         if self.il.kind(lambda) != NodeKind::Lambda {
             return None;
         }
         let kids = self.il.children(lambda).to_vec();
-        let mut env: FxHashMap<u32, ValueId> = FxHashMap::default();
+        let mut env = parent_env.clone();
         let mut pi = 0;
         for &k in &kids {
             if self.il.kind(k) == NodeKind::Param {
@@ -6245,13 +6273,31 @@ impl<'a> Builder<'a> {
                             .copied()
                             .unwrap_or_else(|| self.fresh_opaque());
                         let contrib = match kids.get(1) {
-                            Some(&l) => self.eval_lambda_body(l, &elems).unwrap_or(fallback),
+                            Some(&l) => self.eval_lambda_body(l, &elems, env).unwrap_or(fallback),
                             None => fallback,
                         };
                         match carried_pred {
                             Some(p) => self.mk(ValOp::Hof(kind as u32), vec![contrib, p]),
                             None => self.mk(ValOp::Hof(kind as u32), vec![contrib]),
                         }
+                    }
+                    HoFKind::FlatMap => {
+                        let (elems, carried_pred) = self.map_source(kids.first().copied(), env);
+                        let outer_elem = elems
+                            .first()
+                            .copied()
+                            .unwrap_or_else(|| self.fresh_opaque());
+                        let inner = match kids.get(1) {
+                            Some(&l) => self
+                                .eval_lambda_body(l, &elems, env)
+                                .unwrap_or_else(|| self.fresh_opaque()),
+                            None => self.fresh_opaque(),
+                        };
+                        let mut args = vec![outer_elem, inner];
+                        if let Some(p) = carried_pred {
+                            args.push(p);
+                        }
+                        self.mk(ValOp::Hof(kind as u32), args)
                     }
                     HoFKind::Filter => {
                         // `filter(p, coll)` ≡ the *identity map with a predicate*:
@@ -6269,7 +6315,9 @@ impl<'a> Builder<'a> {
                             .first()
                             .copied()
                             .unwrap_or_else(|| self.fresh_opaque());
-                        let own_pred = kids.get(1).and_then(|&l| self.eval_lambda_body(l, &elems));
+                        let own_pred = kids
+                            .get(1)
+                            .and_then(|&l| self.eval_lambda_body(l, &elems, env));
                         match self.and_preds(own_pred, carried_pred) {
                             Some(p) => self.mk(ValOp::Hof(HoFKind::Map as u32), vec![elem, p]),
                             None => self.mk(ValOp::Hof(HoFKind::Map as u32), vec![elem]),

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -53,9 +53,11 @@ This is nose's distinguishing capability, but it is **bounded, not total** — a
 semantic equivalence is undecidable. nose converges the equivalence classes its IL, value
 graph, and canonicalizations actually model:
 
-- loop ↔ `reduce`/`sum` ↔ comprehension ↔ `.append`/`.map` builder loop; an `any`/`all` loop
-  ↔ the functional form; a `reduce`-lambda min/max ↔ `max`/`min`; `len([… if p]) ↔ Σ(p?1:0)`;
-  a dict-building loop `d={}; for x: d[k]=v` ↔ the dict comprehension `{k: v for x in xs}`;
+- loop ↔ `reduce`/`sum` ↔ comprehension ↔ `.append`/`.map` builder loop; nested list
+  builders ↔ Python multi-clause comprehensions ↔ `.flatMap(... .map(...))`; an `any`/`all`
+  loop ↔ the functional form; a `reduce`-lambda min/max ↔ `max`/`min`;
+  `len([… if p]) ↔ Σ(p?1:0)`; a dict-building loop `d={}; for x: d[k]=v` ↔ the dict
+  comprehension `{k: v for x in xs}`;
 - literal map-default lookup through proven map/key/fallback coordinates, including
   Python `dict.get(key, fallback)` and Ruby literal `Hash#fetch(key, fallback)` or
   zero-arg pure fallback blocks such as `Hash#fetch(key) { fallback }`;
@@ -76,6 +78,10 @@ Lean (`formal/`). See [normalization](normalization.md) for the full pass list.
 - **Different algorithms with the same result** — e.g. bubble sort vs quicksort, or two
   different primality tests — are **not** recognized. Only the modeled transformations
   converge; nose does not search for arbitrary input/output equivalence.
+- **General collection flattening** — depth-parameterized flattening such as
+  `Array.prototype.flat(depth)` is not canonicalized. The modeled flattening is the
+  one-level flat-map shape (`FlatMap[A, λa. Map[B, λb. e]]`) used by Python multi-clause
+  comprehensions, JS `.flatMap`, and equivalent nested builder loops.
 - **Recursion ↔ iteration** is partially modeled — a bounded subset converges (see
   [normalization](normalization.md)); general recursion↔iteration remains out of scope.
 - The behavioral *proof* (`nose verify`) covers only interpretable (≈ pure) units; detection
@@ -109,11 +115,6 @@ Lean (`formal/`). See [normalization](normalization.md) for the full pass list.
   boundaries. Multiple statement-level effects are ordered through control-flow-aware
   sink tags; swapping appends/emits on one execution path is a behavior change, not a
   Type-4 clone.
-- **Multi-clause (flat-map) comprehensions** — a Python `[e for a in A for b in B]`
-  flattens (`A.flatMap(a => B.map(b => e))`), and nose has no `FlatMap` IL primitive yet,
-  so these lower fail-closed (an opaque node) rather than converging with the equivalent
-  nested loop. Single-clause comprehensions converge as above. Tracked in issue #57.
-
 Exact fragment proof is not the same thing as user-facing refactorability. The
 [fragment output audit](fragment-output-audit.md) classifies current real-corpus fragment
 output into refactor-worthy, review-hazard, proof-only/noise, and metadata-ambiguous

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -16,7 +16,9 @@
 > Later additions on the value graph: a purpose-fit **type inference** (`types.rs`, now a
 > fixpoint over subexpression result types) gating the type-dependent canons, free-monoid
 > strings, map **and filter** fusion (a filter is the element-carrying `Hof(Map,[Elem,p])`,
-> so nested filters fuse to `p∧q`), full **AC flatten+sort in the value graph itself** (not
+> so nested filters fuse to `p∧q`), first-class **flat-map** modeling for Python
+> multi-clause comprehensions, JS `.flatMap`, and equivalent nested list-builder loops
+> (kept distinct from nested-list comprehensions), full **AC flatten+sort in the value graph itself** (not
 > only the `algebra` IL pass), **distribution/factoring** `a*c+b*c→(a+b)*c` (Num-gated),
 > min/max and any/all reductions (cross-language), simple **flag+break existence/universal
 > loops** (`found=false; if p { found=true; break }` / the dual `all` form),


### PR DESCRIPTION
## Summary
- add `HoFKind::FlatMap` and lower Python multi-clause comprehensions without the Raw fallback
- canonicalize `.flatMap` / `.flat_map`, interpret FlatMap, and fingerprint it in the value graph
- make nested append builder loops converge with flat-map comprehensions while nested-list comprehensions stay distinct
- update Type-4 docs and add a #57 verify fixture corpus

## Gates
- `./scripts/check-ci-local.sh --fast`
- `cargo test --workspace`
- `cargo run -p nose-cli -- verify --max-violations 0 crates/nose-cli/tests/fixtures/issue57_flatmap.py crates/nose-cli/tests/fixtures/issue57_flatmap.js`

Closes #57