### PR TITLE
type4: add adversarial coverage harness

### DIFF
--- a/bench/type4/README.md
+++ b/bench/type4/README.md
@@ -209,6 +209,24 @@ hard negatives, and batch assignment. Use `already-covered`, `real-miss`, `hard-
 `unsupported`, and `closed` as the audit states so prioritizer frequency, real evidence,
 and detector progress stay separate.
 
+## Adversarial coverage matrix
+
+The agent-facing coverage ledger lives in `bench/type4/adversarial/`. It is not a
+replacement for the generator, evaluator, or frontier platform. It connects their signals
+to repeatable coding-agent tasks:
+
+```sh
+bench/type4/adversarial/scripts/type4-check
+bench/type4/adversarial/scripts/type4-report
+bench/type4/adversarial/scripts/type4-next --limit 3
+bench/type4/adversarial/scripts/type4-ingest-leads /tmp/leads.json --draft-json
+```
+
+The matrix separates `under-merged`, `oracle-blocked`, `proof-fact-blocked`,
+`perf-blocked`, and `false-merged` states so the next PR improves the right actor. See
+[`docs/type4-adversarial-coverage.md`](../../docs/type4-adversarial-coverage.md) for the
+workflow and status model.
+
 ## Frontier evidence platform
 
 `frontier_platform.py` is a companion to the prioritizer that ranks axes by **presence

--- a/bench/type4/adversarial/README.md
+++ b/bench/type4/adversarial/README.md
@@ -1,0 +1,54 @@
+# Type-4 adversarial coverage harness
+
+This directory is the agent-facing control plane for Type-4 co-evolution. The
+generated benchmark in `bench/type4/` asks whether exact semantic detection
+covers a synthetic manifest; this harness asks which semantic gap an engineer or
+coding agent should work on next.
+
+It is deliberately small and mostly data-driven:
+
+- `coverage_matrix.v1.json` records semantic-family cells, their current status,
+  required engine/oracle/proof/perf work, hard negatives, and focused gates.
+- `rule_registry.v1.json` records the engine/oracle/proof/perf rules that cells
+  depend on, including implementation locations and boundaries.
+- `cases/cases.v1.json` records positive, hard-negative, and oracle-gap case
+  handles used by matrix cells.
+- `scripts/type4-next` prints the next actionable task cards.
+- `scripts/type4-check` validates matrix/registry/case consistency.
+- `scripts/type4-report` summarizes backlog shape.
+- `scripts/type4-ingest-leads` summarizes `nose verify --leads` JSON and emits
+  draft matrix cells for manual curation.
+
+## Agent loop
+
+```sh
+bench/type4/adversarial/scripts/type4-check
+bench/type4/adversarial/scripts/type4-next --limit 3
+bench/type4/adversarial/scripts/type4-report
+bench/type4/adversarial/scripts/type4-ingest-leads /tmp/leads.json --draft-json
+```
+
+For a selected task, the agent should:
+
+1. add or confirm focused positives and adversarial negatives;
+2. reproduce the current matrix state (`under-merged`, `oracle-blocked`, etc.);
+3. fix the correct actor: engine, oracle, proof facts, or performance;
+4. run the cell's focused gates and the ordinary repo gates;
+5. update the matrix, registry, cases, and docs in the same PR.
+
+The status values intentionally separate actors:
+
+| status | meaning |
+|---|---|
+| `candidate` | plausible gap, not yet reproduced enough to classify |
+| `covered` | positives converge, hard negatives split, oracle/gates are satisfied |
+| `under-merged` | behavior-equivalent positives do not yet converge |
+| `false-merged` | fingerprint-equal code was refuted by the oracle |
+| `oracle-blocked` | engine work cannot be accepted until the oracle can judge the case |
+| `proof-fact-blocked` | a safe rule needs more type/provenance/order facts |
+| `perf-blocked` | the semantic rule is plausible but representation/runtime cost is too high |
+| `unsafe` | semantics are too broad or language-specific edge cases are unresolved |
+| `not-applicable` | the family/surface combination is intentionally out of scope |
+
+The highest-priority ordinary work is usually `under-merged`, but `false-merged`
+always wins because it is a soundness bug.

--- a/bench/type4/adversarial/cases/cases.v1.json
+++ b/bench/type4/adversarial/cases/cases.v1.json
@@ -1,0 +1,185 @@
+{
+  "schema_version": 1,
+  "description": "Case handles used by the adversarial coverage matrix. These are task anchors, not a generated manifest.",
+  "cases": [
+    {
+      "id": "flat_map_py_loop_js",
+      "kind": "positive",
+      "semantic_family": "hof.flat_map",
+      "claim": "Python multi-clause comprehension, nested append loop, and JS flatMap/map compute the same flattened list.",
+      "fixtures": [
+        "crates/nose-cli/tests/fixtures/issue57_flatmap.py",
+        "crates/nose-cli/tests/fixtures/issue57_flatmap.js"
+      ],
+      "evidence": "Focused verify corpus after PR #66: no false merges and complete behavior-equal convergence."
+    },
+    {
+      "id": "flat_map_vs_nested_list",
+      "kind": "hard-negative",
+      "semantic_family": "hof.flat_map",
+      "claim": "A flattened list is not a nested list of lists.",
+      "mutation": "FlatMap[A, lambda a. Map[B, lambda b. e]] -> Map[A, lambda a. Map[B, lambda b. e]]",
+      "evidence": "The #57 equivalence test asserts flat-map and nested-list fingerprints differ."
+    },
+    {
+      "id": "flat_map_vs_map",
+      "kind": "hard-negative",
+      "semantic_family": "hof.flat_map",
+      "claim": "Mapping to a list without flattening is not one-level flat-map.",
+      "mutation": "flatMap callback result is kept nested",
+      "evidence": "Required sibling for any future FlatMap idiom extension."
+    },
+    {
+      "id": "filter_map_filter_map_equiv",
+      "kind": "positive",
+      "semantic_family": "hof.filter_map",
+      "claim": "filter_map-style option-producing callbacks can converge with explicit filter+map where None drops elements.",
+      "evidence": "Candidate; first task must add focused source fixtures and classify current behavior."
+    },
+    {
+      "id": "filter_map_none_boundary",
+      "kind": "hard-negative",
+      "semantic_family": "hof.filter_map",
+      "claim": "Dropping None differs from mapping None as a value.",
+      "mutation": "filter_map callback returns None where map keeps a sentinel value",
+      "evidence": "Must be counterexample-backed before filter_map is promoted."
+    },
+    {
+      "id": "filter_map_value_change",
+      "kind": "hard-negative",
+      "semantic_family": "hof.filter_map",
+      "claim": "Changing the mapped Some value changes behavior even when the predicate stays the same.",
+      "mutation": "Some(x) -> Some(x + 1)",
+      "evidence": "Required value-boundary sibling."
+    },
+    {
+      "id": "sum_flat_map_nested_loop",
+      "kind": "positive",
+      "semantic_family": "hof.flat_map",
+      "claim": "An aggregate over a flat-map stream equals the corresponding nested reduction loop.",
+      "evidence": "Candidate; must be reproduced after FlatMap landed."
+    },
+    {
+      "id": "sum_flat_map_wrong_seed",
+      "kind": "hard-negative",
+      "semantic_family": "hof.flat_map",
+      "claim": "Changing the reduction seed changes aggregate behavior.",
+      "mutation": "sum seed 0 -> 1",
+      "evidence": "Existing reduction tests use seed hard negatives; reuse that boundary for FlatMap aggregates."
+    },
+    {
+      "id": "sum_flat_map_nested_list",
+      "kind": "hard-negative",
+      "semantic_family": "hof.flat_map",
+      "claim": "Aggregating a nested list shape differs from aggregating a flattened stream unless a separate flatten is proven.",
+      "mutation": "flat stream -> nested list",
+      "evidence": "Protects aggregate bridge rules from assuming arbitrary flattening."
+    },
+    {
+      "id": "java_stream_flat_map_py_comp",
+      "kind": "positive",
+      "semantic_family": "hof.flat_map",
+      "claim": "A pure Java Stream.flatMap chain can express the same one-level flat-map as Python multi-clause comprehension.",
+      "evidence": "Oracle-blocked candidate; needs interpretable Java stream subset before promotion."
+    },
+    {
+      "id": "java_stream_map_not_flat_map",
+      "kind": "hard-negative",
+      "semantic_family": "hof.flat_map",
+      "claim": "Java Stream.map returning streams is not Stream.flatMap.",
+      "mutation": "flatMap -> map",
+      "evidence": "Hard negative for Java stream idiom work."
+    },
+    {
+      "id": "java_stream_effectful_lambda",
+      "kind": "hard-negative",
+      "semantic_family": "hof.flat_map",
+      "claim": "Effectful stream callbacks cannot be treated as pure HoF transformations.",
+      "mutation": "lambda mutates external state or performs an effect",
+      "evidence": "Oracle boundary for stream support."
+    },
+    {
+      "id": "clamp_minmax_guarded_bounds",
+      "kind": "positive",
+      "semantic_family": "numeric.clamp",
+      "claim": "Clamp-shaped min/max compositions converge when numeric lo<=hi is proven.",
+      "evidence": "Frontier platform records numeric_clamp as a real miss; proof facts are partial."
+    },
+    {
+      "id": "clamp_unordered_bounds",
+      "kind": "hard-negative",
+      "semantic_family": "numeric.clamp",
+      "claim": "Clamp composition is not sound when lo<=hi is not proven.",
+      "mutation": "remove or invert the bound-order proof",
+      "evidence": "Required for any clamp canon."
+    },
+    {
+      "id": "clamp_float_nan_boundary",
+      "kind": "hard-negative",
+      "semantic_family": "numeric.clamp",
+      "claim": "Floating-point NaN/min/max behavior is not covered by integer clamp facts.",
+      "mutation": "numeric domain becomes floatish",
+      "evidence": "Boundary recorded in normalization docs and clamp proof-fact tests."
+    },
+    {
+      "id": "map_default_imported_literal",
+      "kind": "positive",
+      "semantic_family": "map_default_lookup",
+      "claim": "Imported immutable literal map lookup with default can converge with local literal/default forms when provenance is proven.",
+      "evidence": "Proof-fact-blocked candidate."
+    },
+    {
+      "id": "map_default_mutated_receiver",
+      "kind": "hard-negative",
+      "semantic_family": "map_default_lookup",
+      "claim": "Receiver mutation between binding/import and lookup changes behavior.",
+      "mutation": "insert write to receiver before lookup",
+      "evidence": "Whole-file mutation exclusion boundary."
+    },
+    {
+      "id": "map_default_wrong_map",
+      "kind": "hard-negative",
+      "semantic_family": "map_default_lookup",
+      "claim": "Looking up the same key/default on a different map is behaviorally different.",
+      "mutation": "receiver map coordinate changes",
+      "evidence": "Existing map-default tests use wrong-map siblings."
+    },
+    {
+      "id": "hof_error_propagation",
+      "kind": "oracle-gap",
+      "semantic_family": "oracle",
+      "claim": "HoF oracle behavior must preserve lambda error propagation and empty-collection behavior.",
+      "evidence": "FlatMap has interpreter tests; future HoF adapters need the same coverage."
+    },
+    {
+      "id": "hof_non_list_flat_map",
+      "kind": "hard-negative",
+      "semantic_family": "oracle",
+      "claim": "FlatMap callback results must be lists; non-list callback results are Err in the oracle.",
+      "mutation": "callback returns scalar",
+      "evidence": "Boundary for FlatMap interpreter support."
+    },
+    {
+      "id": "hof_effectful_lambda",
+      "kind": "hard-negative",
+      "semantic_family": "oracle",
+      "claim": "Effectful callbacks cannot be folded into pure value-graph HoF facts without effect modeling.",
+      "mutation": "callback emits or mutates",
+      "evidence": "General HoF purity boundary."
+    },
+    {
+      "id": "deep_hof_chain_budget",
+      "kind": "perf",
+      "semantic_family": "performance",
+      "claim": "Deep HoF chains should retain compact value fingerprints.",
+      "evidence": "Perf smoke candidate for future broad iterator fusion."
+    },
+    {
+      "id": "wide_hof_chain_budget",
+      "kind": "perf",
+      "semantic_family": "performance",
+      "claim": "Wide generated HoF expressions should not explode value-node count or scan runtime.",
+      "evidence": "Perf hard-negative for representation growth."
+    }
+  ]
+}

--- a/bench/type4/adversarial/coverage_matrix.v1.json
+++ b/bench/type4/adversarial/coverage_matrix.v1.json
@@ -1,0 +1,172 @@
+{
+  "schema_version": 1,
+  "description": "Agent-facing Type-4 adversarial coverage matrix. It selects co-evolution work across engine, oracle, proof facts, and performance.",
+  "cells": [
+    {
+      "id": "hof.flat_map.python_js_loop",
+      "semantic_family": "hof.flat_map",
+      "title": "Python multi-clause comprehension equals nested builder loop and JS flatMap/map",
+      "status": "covered",
+      "next_action": "monitor",
+      "priority": 0,
+      "languages": ["python", "javascript"],
+      "representations": ["multi_clause_comprehension", "nested_builder_loop", "method_chain"],
+      "rule_ids": ["hof.flat_map", "oracle.hof.flat_map"],
+      "positive_cases": ["flat_map_py_loop_js"],
+      "adversarial_cases": ["flat_map_vs_nested_list", "flat_map_vs_map"],
+      "evidence": "PR #66 added HoFKind::FlatMap, removed the Python Raw fallback, and verified the focused flat-map corpus with zero false merges.",
+      "required_gates": [
+        "cargo test -p nose-cli --test equivalence multi_clause_comprehension_converges_as_flat_map",
+        "cargo run -p nose-cli -- verify --max-violations 0 crates/nose-cli/tests/fixtures/issue57_flatmap.py crates/nose-cli/tests/fixtures/issue57_flatmap.js"
+      ],
+      "docs": ["docs/clone-types.md", "docs/normalization.md"]
+    },
+    {
+      "id": "hof.filter_map.rust_iterator",
+      "semantic_family": "hof.filter_map",
+      "title": "Rust filter_map converges with filter+map and option-producing loops",
+      "status": "candidate",
+      "next_action": "survey",
+      "priority": 74,
+      "languages": ["rust", "python", "javascript"],
+      "representations": ["iterator_chain", "filtered_comprehension", "guarded_builder_loop"],
+      "rule_ids": ["hof.filter_map", "oracle.option_iterator"],
+      "positive_cases": ["filter_map_filter_map_equiv"],
+      "adversarial_cases": ["filter_map_none_boundary", "filter_map_value_change"],
+      "evidence": "Plausible high-leverage HoF family after FlatMap; first task is to add focused reproductions and classify as under-merged or already covered.",
+      "agent_task": "Create a minimal Rust filter_map vs Python/JS filter+map positive, plus None/predicate/value hard negatives. If it under-merges and the oracle can judge it, add the shared HoF representation instead of a Rust-only exception.",
+      "required_gates": [
+        "bench/type4/adversarial/scripts/type4-check --item hof.filter_map.rust_iterator",
+        "cargo test -p nose-cli --test equivalence filter_map",
+        "GATE=focused AXIS=hof_filter_map scripts/type4-smoke.sh"
+      ],
+      "docs": ["docs/type4-adversarial-coverage.md", "docs/normalization.md"]
+    },
+    {
+      "id": "hof.flat_map.aggregate_bridge",
+      "semantic_family": "hof.flat_map",
+      "title": "Aggregates over flat-map streams converge with nested reduction loops",
+      "status": "candidate",
+      "next_action": "survey",
+      "priority": 69,
+      "languages": ["python", "javascript", "rust"],
+      "representations": ["flat_map_chain", "nested_reduction_loop", "sum_generator"],
+      "rule_ids": ["hof.flat_map", "hof.aggregate_bridge", "oracle.hof.flat_map"],
+      "positive_cases": ["sum_flat_map_nested_loop"],
+      "adversarial_cases": ["sum_flat_map_wrong_seed", "sum_flat_map_nested_list"],
+      "evidence": "FlatMap now exists, but aggregate consumers must be audited so reductions do not accidentally treat FlatMap args as filtered Map args.",
+      "agent_task": "Reproduce sum/max/any over flatMap against equivalent nested loops, then either mark covered or add a Map-only/FlatMap-aware aggregate bridge with hard negatives.",
+      "required_gates": [
+        "bench/type4/adversarial/scripts/type4-check --item hof.flat_map.aggregate_bridge",
+        "cargo test -p nose-cli --test equivalence flat_map",
+        "cargo run -p nose-cli -- verify --max-violations 0 <focused-flatmap-aggregate-corpus>"
+      ],
+      "docs": ["docs/type4-adversarial-coverage.md", "docs/normalization.md"]
+    },
+    {
+      "id": "iterator.java_stream.flat_map",
+      "semantic_family": "hof.flat_map",
+      "title": "Java Stream.flatMap converges with shared FlatMap HoF",
+      "status": "oracle-blocked",
+      "next_action": "oracle",
+      "priority": 30,
+      "languages": ["java", "python"],
+      "representations": ["java_stream", "multi_clause_comprehension", "nested_builder_loop"],
+      "rule_ids": ["hof.flat_map", "idiom.java_stream", "oracle.java_stream"],
+      "positive_cases": ["java_stream_flat_map_py_comp"],
+      "adversarial_cases": ["java_stream_map_not_flat_map", "java_stream_effectful_lambda"],
+      "evidence": "The idiom family is likely valuable, but acceptance needs oracle support for enough Java stream/lambda behavior to reject hard negatives.",
+      "agent_task": "Start with oracle capability: determine which Java stream flatMap examples are interpretable. Extend oracle only for pure, bounded forms before adding idiom canonicalization.",
+      "required_gates": [
+        "bench/type4/adversarial/scripts/type4-check --item iterator.java_stream.flat_map",
+        "cargo test -p nose-normalize java_stream",
+        "cargo run -p nose-cli -- verify --max-violations 0 <focused-java-stream-corpus>"
+      ],
+      "docs": ["docs/type4-adversarial-coverage.md", "docs/normalization.md"]
+    },
+    {
+      "id": "numeric.clamp.minmax_composition",
+      "semantic_family": "numeric.clamp",
+      "title": "Clamp-shaped min/max compositions converge under proven bounds",
+      "status": "proof-fact-blocked",
+      "next_action": "proof-facts",
+      "priority": 67,
+      "languages": ["c", "go", "java", "javascript", "python", "ruby", "rust", "typescript"],
+      "representations": ["minmax_composition", "guarded_ternary", "library_clamp"],
+      "rule_ids": ["numeric.clamp_composition", "proof.bound_order"],
+      "positive_cases": ["clamp_minmax_guarded_bounds"],
+      "adversarial_cases": ["clamp_unordered_bounds", "clamp_float_nan_boundary"],
+      "evidence": "The frontier platform records numeric_clamp as a real miss; bound-order proof facts exist but canonicalization remains gated on sound preconditions.",
+      "agent_task": "Audit current bound-order facts against clamp hard negatives, then land the smallest value-graph clamp composition rule only where lo<=hi and numeric-domain facts are proven.",
+      "required_gates": [
+        "bench/type4/adversarial/scripts/type4-check --item numeric.clamp.minmax_composition",
+        "cargo test -p nose-cli --test equivalence clamp",
+        "GATE=focused AXIS=numeric_clamp scripts/type4-smoke.sh"
+      ],
+      "docs": ["docs/frontier-platform.md", "docs/normalization.md"]
+    },
+    {
+      "id": "map_default.cross_file_binding",
+      "semantic_family": "map_default_lookup",
+      "title": "Cross-file immutable map/default lookup facts",
+      "status": "proof-fact-blocked",
+      "next_action": "proof-facts",
+      "priority": 55,
+      "languages": ["python", "javascript", "typescript", "java", "go", "rust", "ruby"],
+      "representations": ["module_binding", "imported_binding", "literal_factory", "method_default"],
+      "rule_ids": ["proof.collection_provenance", "idiom.map_default_lookup"],
+      "positive_cases": ["map_default_imported_literal"],
+      "adversarial_cases": ["map_default_mutated_receiver", "map_default_wrong_map"],
+      "evidence": "Existing map-default lookup coverage is strong for inline/local/same-file facts; cross-file provenance remains an explicit proof-fact backlog.",
+      "agent_task": "Do not broaden map default idioms directly. First add provenance facts that prove receiver/key/default identity across imports while rejecting mutation and shadowing siblings.",
+      "required_gates": [
+        "bench/type4/adversarial/scripts/type4-check --item map_default.cross_file_binding",
+        "cargo test -p nose-cli --test equivalence map_default",
+        "GATE=focused AXIS=map_default_lookup scripts/type4-smoke.sh"
+      ],
+      "docs": ["docs/type4-adversarial-coverage.md", "docs/clone-types.md"]
+    },
+    {
+      "id": "oracle.hof.error_semantics",
+      "semantic_family": "oracle",
+      "title": "Oracle keeps HoF and iterator error semantics in step with engine canons",
+      "status": "oracle-blocked",
+      "next_action": "oracle",
+      "priority": 78,
+      "languages": ["python", "javascript", "rust", "java"],
+      "representations": ["hof", "iterator_chain", "lambda", "closure"],
+      "rule_ids": ["oracle.hof.flat_map", "oracle.option_iterator"],
+      "positive_cases": ["hof_error_propagation"],
+      "adversarial_cases": ["hof_non_list_flat_map", "hof_effectful_lambda"],
+      "evidence": "Every new HoF canon should force an oracle audit. FlatMap is covered; filter_map and richer iterator chains are not yet classified.",
+      "agent_task": "Before adding broad iterator canons, add oracle tests for lambda capture, error propagation, empty collection behavior, and non-list flatMap/filterMap boundaries.",
+      "required_gates": [
+        "bench/type4/adversarial/scripts/type4-check --item oracle.hof.error_semantics",
+        "cargo test -p nose-normalize interp::tests::hof",
+        "cargo run -p nose-cli -- verify --max-violations 0 <focused-hof-oracle-corpus>"
+      ],
+      "docs": ["docs/type4-adversarial-coverage.md", "docs/normalization.md"]
+    },
+    {
+      "id": "perf.value_graph.hof_budget",
+      "semantic_family": "performance",
+      "title": "HoF value-graph growth stays bounded as iterator coverage expands",
+      "status": "perf-blocked",
+      "next_action": "performance",
+      "priority": 43,
+      "languages": ["all"],
+      "representations": ["value_graph", "hof_chain", "generated_corpus"],
+      "rule_ids": ["perf.value_graph_budget"],
+      "positive_cases": ["deep_hof_chain_budget"],
+      "adversarial_cases": ["wide_hof_chain_budget"],
+      "evidence": "Iterator/HOF coverage can increase fingerprint DAG size. A reusable smoke budget should exist before accepting broad chain-fusion work.",
+      "agent_task": "Add a compact perf smoke that records runtime and value-node/fingerprint-size budgets for representative HoF chains; use it before broadening iterator fusion.",
+      "required_gates": [
+        "bench/type4/adversarial/scripts/type4-check --item perf.value_graph.hof_budget",
+        "cargo test -p nose-cli --test equivalence large_generated",
+        "python3 bench/type4/scan_regression/scan_regression.py compare --nose ./target/release/nose"
+      ],
+      "docs": ["docs/type4-adversarial-coverage.md", "docs/type4-benchmark.md"]
+    }
+  ]
+}

--- a/bench/type4/adversarial/rule_registry.v1.json
+++ b/bench/type4/adversarial/rule_registry.v1.json
@@ -1,0 +1,143 @@
+{
+  "schema_version": 1,
+  "description": "Rules and substrates referenced by the Type-4 adversarial coverage matrix.",
+  "rules": [
+    {
+      "id": "hof.flat_map",
+      "kind": "engine",
+      "status": "landed",
+      "summary": "Represent one-level flat-map as a first-class HoF and value-graph node.",
+      "implementation": [
+        "crates/nose-il/src/node.rs",
+        "crates/nose-frontend/src/python.rs",
+        "crates/nose-normalize/src/idioms.rs",
+        "crates/nose-normalize/src/value_graph.rs"
+      ],
+      "positive_cases": ["flat_map_py_loop_js"],
+      "hard_negatives": ["flat_map_vs_nested_list", "flat_map_vs_map"],
+      "boundaries": ["Do not model depth-parameterized Array.prototype.flat(depth) as this rule.", "Nested-list comprehensions remain Map-of-Map, not FlatMap."],
+      "docs": ["docs/clone-types.md", "docs/normalization.md"]
+    },
+    {
+      "id": "oracle.hof.flat_map",
+      "kind": "oracle",
+      "status": "landed",
+      "summary": "Interpreter executes FlatMap and propagates lambda errors or non-list lambda results as Err.",
+      "implementation": ["crates/nose-normalize/src/interp.rs"],
+      "positive_cases": ["flat_map_py_loop_js", "hof_error_propagation"],
+      "hard_negatives": ["hof_non_list_flat_map"],
+      "boundaries": ["Oracle support must land before broadening HoF canonicalization."],
+      "docs": ["docs/normalization.md"]
+    },
+    {
+      "id": "hof.filter_map",
+      "kind": "engine",
+      "status": "proposed",
+      "summary": "Canonicalize option-producing filter-map forms to a shared representation.",
+      "implementation": ["crates/nose-normalize/src/idioms.rs", "crates/nose-normalize/src/value_graph.rs"],
+      "positive_cases": ["filter_map_filter_map_equiv"],
+      "hard_negatives": ["filter_map_none_boundary", "filter_map_value_change"],
+      "boundaries": ["Must distinguish dropped None values from mapped Some values.", "Do not assume arbitrary callbacks are pure."],
+      "docs": ["docs/type4-adversarial-coverage.md"]
+    },
+    {
+      "id": "hof.aggregate_bridge",
+      "kind": "engine",
+      "status": "proposed",
+      "summary": "Teach aggregate consumers how to consume FlatMap streams without confusing them with filtered Map nodes.",
+      "implementation": ["crates/nose-normalize/src/value_graph.rs"],
+      "positive_cases": ["sum_flat_map_nested_loop"],
+      "hard_negatives": ["sum_flat_map_wrong_seed", "sum_flat_map_nested_list"],
+      "boundaries": ["Map and FlatMap argument layouts are different; aggregate code must match the HoF kind explicitly."],
+      "docs": ["docs/normalization.md"]
+    },
+    {
+      "id": "idiom.java_stream",
+      "kind": "engine",
+      "status": "proposed",
+      "summary": "Lower pure Java stream adapters into shared HoF/value-graph representations.",
+      "implementation": ["crates/nose-normalize/src/idioms.rs"],
+      "positive_cases": ["java_stream_flat_map_py_comp"],
+      "hard_negatives": ["java_stream_map_not_flat_map", "java_stream_effectful_lambda"],
+      "boundaries": ["Requires oracle support for enough Java lambda/stream behavior before detection can claim soundness."],
+      "docs": ["docs/type4-adversarial-coverage.md"]
+    },
+    {
+      "id": "oracle.java_stream",
+      "kind": "oracle",
+      "status": "proposed",
+      "summary": "Interpreter support for a small, pure subset of Java stream chains.",
+      "implementation": ["crates/nose-normalize/src/interp.rs"],
+      "positive_cases": ["java_stream_flat_map_py_comp"],
+      "hard_negatives": ["java_stream_effectful_lambda"],
+      "boundaries": ["No effectful stream callbacks; no parallel stream semantics."],
+      "docs": ["docs/type4-adversarial-coverage.md"]
+    },
+    {
+      "id": "oracle.option_iterator",
+      "kind": "oracle",
+      "status": "proposed",
+      "summary": "Interpreter support for option-producing iterator adapters used by filter_map-like idioms.",
+      "implementation": ["crates/nose-normalize/src/interp.rs"],
+      "positive_cases": ["filter_map_filter_map_equiv"],
+      "hard_negatives": ["filter_map_none_boundary"],
+      "boundaries": ["Must preserve Err/None/Some distinctions."],
+      "docs": ["docs/type4-adversarial-coverage.md"]
+    },
+    {
+      "id": "numeric.clamp_composition",
+      "kind": "engine",
+      "status": "proposed",
+      "summary": "Canonicalize clamp-shaped min/max compositions when numeric bounds are proven ordered.",
+      "implementation": ["crates/nose-normalize/src/value_graph.rs"],
+      "positive_cases": ["clamp_minmax_guarded_bounds"],
+      "hard_negatives": ["clamp_unordered_bounds", "clamp_float_nan_boundary"],
+      "boundaries": ["Requires numeric domain and lo<=hi proof; float/NaN behavior remains a boundary."],
+      "docs": ["docs/frontier-platform.md", "docs/normalization.md"]
+    },
+    {
+      "id": "proof.bound_order",
+      "kind": "proof-fact",
+      "status": "partial",
+      "summary": "Recover conservative facts that prove lower bound order for clamp-like canons.",
+      "implementation": ["crates/nose-normalize/src/value_graph.rs", "formal/obligations/normalize/value_graph/clamp"],
+      "positive_cases": ["clamp_minmax_guarded_bounds"],
+      "hard_negatives": ["clamp_unordered_bounds"],
+      "boundaries": ["No order fact means no clamp canon."],
+      "docs": ["docs/formal-soundness.md", "docs/normalization.md"]
+    },
+    {
+      "id": "proof.collection_provenance",
+      "kind": "proof-fact",
+      "status": "partial",
+      "summary": "Prove receiver/key/default identity for collection and map-default idioms across local/module/import boundaries.",
+      "implementation": ["crates/nose-normalize/src/module_facts.rs", "crates/nose-normalize/src/value_graph.rs"],
+      "positive_cases": ["map_default_imported_literal"],
+      "hard_negatives": ["map_default_mutated_receiver", "map_default_wrong_map"],
+      "boundaries": ["Mutation, shadowing, and unresolved imports stay fail-closed."],
+      "docs": ["docs/clone-types.md"]
+    },
+    {
+      "id": "idiom.map_default_lookup",
+      "kind": "engine",
+      "status": "partial",
+      "summary": "Canonicalize proven map/dict lookup-with-default idioms.",
+      "implementation": ["crates/nose-normalize/src/idioms.rs", "crates/nose-normalize/src/value_graph.rs"],
+      "positive_cases": ["map_default_imported_literal"],
+      "hard_negatives": ["map_default_mutated_receiver", "map_default_wrong_map"],
+      "boundaries": ["Requires proven receiver/key/default coordinates."],
+      "docs": ["docs/clone-types.md"]
+    },
+    {
+      "id": "perf.value_graph_budget",
+      "kind": "performance",
+      "status": "proposed",
+      "summary": "Keep HoF value-graph growth and semantic scan runtime bounded while coverage expands.",
+      "implementation": ["bench/type4/scan_regression", "crates/nose-normalize/src/value_graph.rs"],
+      "positive_cases": ["deep_hof_chain_budget"],
+      "hard_negatives": ["wide_hof_chain_budget"],
+      "boundaries": ["Coverage wins that expand fingerprints without bound are perf-blocked until represented compactly."],
+      "docs": ["docs/type4-benchmark.md"]
+    }
+  ]
+}

--- a/bench/type4/adversarial/scripts/_type4_adversarial.py
+++ b/bench/type4/adversarial/scripts/_type4_adversarial.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Shared helpers for the Type-4 adversarial coverage harness."""
+
+from __future__ import annotations
+
+from collections import Counter
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = ROOT.parents[2]
+MATRIX_PATH = ROOT / "coverage_matrix.v1.json"
+REGISTRY_PATH = ROOT / "rule_registry.v1.json"
+CASES_PATH = ROOT / "cases" / "cases.v1.json"
+
+VALID_STATUSES = {
+    "candidate",
+    "covered",
+    "under-merged",
+    "false-merged",
+    "oracle-blocked",
+    "proof-fact-blocked",
+    "perf-blocked",
+    "unsafe",
+    "not-applicable",
+}
+VALID_ACTIONS = {
+    "engine",
+    "monitor",
+    "oracle",
+    "performance",
+    "proof-facts",
+    "soundness",
+    "survey",
+}
+ACTIONABLE_STATUSES = {
+    "candidate",
+    "under-merged",
+    "false-merged",
+    "oracle-blocked",
+    "proof-fact-blocked",
+    "perf-blocked",
+}
+STATUS_WEIGHT = {
+    "false-merged": 1000,
+    "under-merged": 500,
+    "oracle-blocked": 360,
+    "proof-fact-blocked": 330,
+    "candidate": 260,
+    "perf-blocked": 160,
+    "unsafe": -100,
+    "covered": -500,
+    "not-applicable": -1000,
+}
+ACTION_WEIGHT = {
+    "soundness": 120,
+    "engine": 90,
+    "oracle": 70,
+    "proof-facts": 60,
+    "survey": 35,
+    "performance": 20,
+    "monitor": 0,
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def load_all() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    return load_json(MATRIX_PATH), load_json(REGISTRY_PATH), load_json(CASES_PATH)
+
+
+def registry_rules(registry: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {rule["id"]: rule for rule in registry.get("rules", [])}
+
+
+def case_index(cases: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {case["id"]: case for case in cases.get("cases", [])}
+
+
+def cell_score(cell: dict[str, Any]) -> int:
+    status = cell.get("status", "")
+    action = cell.get("next_action", "")
+    return (
+        int(cell.get("priority", 0))
+        + STATUS_WEIGHT.get(status, -100)
+        + ACTION_WEIGHT.get(action, 0)
+    )
+
+
+def actionable_cells(matrix: dict[str, Any], include_covered: bool = False) -> list[dict[str, Any]]:
+    cells = matrix.get("cells", [])
+    if include_covered:
+        return list(cells)
+    return [cell for cell in cells if cell.get("status") in ACTIONABLE_STATUSES]
+
+
+def find_cell(matrix: dict[str, Any], item_id: str) -> dict[str, Any] | None:
+    for cell in matrix.get("cells", []):
+        if cell.get("id") == item_id:
+            return cell
+    return None
+
+
+def validate_all(
+    matrix: dict[str, Any], registry: dict[str, Any], cases: dict[str, Any]
+) -> list[str]:
+    errors: list[str] = []
+
+    if matrix.get("schema_version") != 1:
+        errors.append("coverage_matrix.v1.json schema_version must be 1")
+    if registry.get("schema_version") != 1:
+        errors.append("rule_registry.v1.json schema_version must be 1")
+    if cases.get("schema_version") != 1:
+        errors.append("cases.v1.json schema_version must be 1")
+
+    rules = registry_rules(registry)
+    known_cases = case_index(cases)
+
+    _check_unique("rule", registry.get("rules", []), errors)
+    _check_unique("case", cases.get("cases", []), errors)
+    _check_unique("cell", matrix.get("cells", []), errors)
+
+    for rule in registry.get("rules", []):
+        _require(rule, "id", "rule", errors)
+        _require(rule, "kind", f"rule {rule.get('id', '?')}", errors)
+        _require(rule, "status", f"rule {rule.get('id', '?')}", errors)
+        for field in ("positive_cases", "hard_negatives"):
+            for case_id in rule.get(field, []):
+                if case_id not in known_cases:
+                    errors.append(f"rule {rule['id']} references unknown case {case_id}")
+
+    for case in cases.get("cases", []):
+        _require(case, "id", "case", errors)
+        _require(case, "kind", f"case {case.get('id', '?')}", errors)
+        _require(case, "semantic_family", f"case {case.get('id', '?')}", errors)
+        _require(case, "claim", f"case {case.get('id', '?')}", errors)
+        for fixture in case.get("fixtures", []):
+            if not (REPO_ROOT / fixture).exists():
+                errors.append(f"case {case['id']} fixture does not exist: {fixture}")
+
+    for cell in matrix.get("cells", []):
+        cell_id = cell.get("id", "?")
+        for field in (
+            "id",
+            "semantic_family",
+            "title",
+            "status",
+            "next_action",
+            "priority",
+            "languages",
+            "representations",
+            "rule_ids",
+            "positive_cases",
+            "adversarial_cases",
+            "required_gates",
+            "docs",
+        ):
+            _require(cell, field, f"cell {cell_id}", errors)
+        if cell.get("status") not in VALID_STATUSES:
+            errors.append(f"cell {cell_id} has invalid status {cell.get('status')}")
+        if cell.get("next_action") not in VALID_ACTIONS:
+            errors.append(f"cell {cell_id} has invalid next_action {cell.get('next_action')}")
+        for rule_id in cell.get("rule_ids", []):
+            if rule_id not in rules:
+                errors.append(f"cell {cell_id} references unknown rule {rule_id}")
+        for field in ("positive_cases", "adversarial_cases"):
+            for case_id in cell.get(field, []):
+                if case_id not in known_cases:
+                    errors.append(f"cell {cell_id} references unknown case {case_id}")
+        if cell.get("status") in ACTIONABLE_STATUSES:
+            if not cell.get("agent_task"):
+                errors.append(f"actionable cell {cell_id} must include agent_task")
+            if not cell.get("required_gates"):
+                errors.append(f"actionable cell {cell_id} must include required_gates")
+        for doc in cell.get("docs", []):
+            if not (REPO_ROOT / doc).exists():
+                errors.append(f"cell {cell_id} doc does not exist: {doc}")
+    return errors
+
+
+def _require(item: dict[str, Any], field: str, label: str, errors: list[str]) -> None:
+    if field not in item or item[field] in ("", None, []):
+        errors.append(f"{label} missing required field {field}")
+
+
+def _check_unique(label: str, items: list[dict[str, Any]], errors: list[str]) -> None:
+    ids = [item.get("id") for item in items]
+    counts = Counter(ids)
+    for item_id, count in counts.items():
+        if not item_id:
+            errors.append(f"{label} list contains item without id")
+        elif count > 1:
+            errors.append(f"{label} id {item_id} appears {count} times")
+
+
+def task_card(cell: dict[str, Any], rules: dict[str, Any], cases: dict[str, Any]) -> str:
+    lines = [
+        f"ID: {cell['id']}",
+        f"Score: {cell_score(cell)}",
+        f"Status: {cell['status']}",
+        f"Action: {cell['next_action']}",
+        f"Family: {cell['semantic_family']}",
+        f"Title: {cell['title']}",
+    ]
+    if cell.get("evidence"):
+        lines.extend(["", "Evidence:", f"  {cell['evidence']}"])
+    if cell.get("agent_task"):
+        lines.extend(["", "Agent task:", f"  {cell['agent_task']}"])
+
+    lines.append("")
+    lines.append("Rules:")
+    for rule_id in cell.get("rule_ids", []):
+        rule = rules.get(rule_id, {})
+        lines.append(f"  - {rule_id}: {rule.get('summary', 'unknown rule')}")
+
+    lines.append("")
+    lines.append("Positive cases:")
+    for case_id in cell.get("positive_cases", []):
+        case = cases.get(case_id, {})
+        lines.append(f"  - {case_id}: {case.get('claim', 'unknown case')}")
+
+    lines.append("")
+    lines.append("Adversarial cases:")
+    for case_id in cell.get("adversarial_cases", []):
+        case = cases.get(case_id, {})
+        lines.append(f"  - {case_id}: {case.get('claim', 'unknown case')}")
+
+    lines.append("")
+    lines.append("Required gates:")
+    for gate in cell.get("required_gates", []):
+        lines.append(f"  - {gate}")
+
+    if cell.get("docs"):
+        lines.append("")
+        lines.append("Docs:")
+        for doc in cell["docs"]:
+            lines.append(f"  - {doc}")
+    return "\n".join(lines)

--- a/bench/type4/adversarial/scripts/type4-check
+++ b/bench/type4/adversarial/scripts/type4-check
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Validate the Type-4 adversarial coverage harness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from _type4_adversarial import (
+    case_index,
+    find_cell,
+    load_all,
+    registry_rules,
+    task_card,
+    validate_all,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--item", help="validate and print one task card")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable summary")
+    args = parser.parse_args()
+
+    matrix, registry, cases = load_all()
+    errors = validate_all(matrix, registry, cases)
+    cell = None
+    if args.item:
+        cell = find_cell(matrix, args.item)
+        if cell is None:
+            errors.append(f"unknown matrix item: {args.item}")
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ok": not errors,
+                    "errors": errors,
+                    "cells": len(matrix.get("cells", [])),
+                    "rules": len(registry.get("rules", [])),
+                    "cases": len(cases.get("cases", [])),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        if errors:
+            print("Type-4 adversarial harness check failed:", file=sys.stderr)
+            for error in errors:
+                print(f"  - {error}", file=sys.stderr)
+        else:
+            print(
+                "ok: "
+                f"{len(matrix.get('cells', []))} cells, "
+                f"{len(registry.get('rules', []))} rules, "
+                f"{len(cases.get('cases', []))} cases"
+            )
+        if cell is not None:
+            print()
+            print(task_card(cell, registry_rules(registry), case_index(cases)))
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/type4/adversarial/scripts/type4-ingest-leads
+++ b/bench/type4/adversarial/scripts/type4-ingest-leads
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Summarize `nose verify --leads` output into matrix candidate drafts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def lead_score(lead: dict) -> float:
+    return float(lead.get("vj", 0.0)) + (1.0 if lead.get("structurally_near") else 0.0)
+
+
+def draft_cell(lead: dict, idx: int, family: str, source: Path) -> dict:
+    return {
+        "id": f"lead.{family}.{idx + 1:03d}",
+        "semantic_family": family,
+        "title": "Verifier lead: behavior-equal units are fingerprint-split",
+        "status": "under-merged",
+        "next_action": "engine",
+        "priority": 50 + int(float(lead.get("vj", 0.0)) * 100),
+        "languages": ["unknown"],
+        "representations": ["unknown"],
+        "rule_ids": [],
+        "positive_cases": [],
+        "adversarial_cases": [],
+        "evidence": (
+            f"Imported from {source}: vj={float(lead.get('vj', 0.0)):.2f}, "
+            f"structurally_near={bool(lead.get('structurally_near'))}; "
+            f"a={lead.get('a')}; b={lead.get('b')}"
+        ),
+        "agent_task": "Audit this verifier lead, classify the semantic family, add focused positives and hard negatives, then replace this draft with a real matrix cell.",
+        "required_gates": [
+            "bench/type4/adversarial/scripts/type4-check",
+            "cargo run -p nose-cli -- verify --max-violations 0 <focused-lead-corpus>"
+        ],
+        "docs": ["docs/type4-adversarial-coverage.md"]
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("leads_json", type=Path)
+    parser.add_argument("--family", default="unclassified")
+    parser.add_argument("--limit", default=10, type=int)
+    parser.add_argument("--draft-json", action="store_true", help="emit candidate cell drafts")
+    args = parser.parse_args()
+
+    payload = json.loads(args.leads_json.read_text())
+    leads = list(payload.get("leads", []))
+    leads.sort(key=lambda lead: (-lead_score(lead), lead.get("a", ""), lead.get("b", "")))
+    selected = leads[: max(args.limit, 0)]
+
+    if args.draft_json:
+        print(
+            json.dumps(
+                [draft_cell(lead, idx, args.family, args.leads_json) for idx, lead in enumerate(selected)],
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    total = int(payload.get("under_merged_pairs", len(leads)))
+    near = int(payload.get("structurally_near", sum(1 for lead in leads if lead.get("structurally_near"))))
+    print(f"under-merged pairs: {total}")
+    print(f"structurally-near: {near}")
+    print()
+    if not selected:
+        print("No leads found.")
+        return 0
+    print("top leads:")
+    for idx, lead in enumerate(selected, start=1):
+        marker = "near" if lead.get("structurally_near") else "low"
+        print(
+            f"  {idx:2d}. vj={float(lead.get('vj', 0.0)):.2f} [{marker}] "
+            f"{lead.get('a')} <-> {lead.get('b')}"
+        )
+    print()
+    print("Use --draft-json to emit candidate cells for manual matrix curation.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/type4/adversarial/scripts/type4-next
+++ b/bench/type4/adversarial/scripts/type4-next
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Print the next actionable Type-4 adversarial coverage task cards."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from _type4_adversarial import (
+    actionable_cells,
+    case_index,
+    cell_score,
+    load_all,
+    registry_rules,
+    task_card,
+    validate_all,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", default=1, type=int)
+    parser.add_argument("--status", action="append", help="filter by matrix status")
+    parser.add_argument("--action", action="append", help="filter by next_action")
+    parser.add_argument("--include-covered", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    matrix, registry, cases = load_all()
+    errors = validate_all(matrix, registry, cases)
+    if errors:
+        for error in errors:
+            print(f"error: {error}")
+        return 1
+
+    cells = actionable_cells(matrix, include_covered=args.include_covered)
+    if args.status:
+        allowed = set(args.status)
+        cells = [cell for cell in cells if cell.get("status") in allowed]
+    if args.action:
+        allowed = set(args.action)
+        cells = [cell for cell in cells if cell.get("next_action") in allowed]
+    cells = sorted(cells, key=lambda cell: (-cell_score(cell), cell["id"]))
+    selected = cells[: max(args.limit, 0)]
+
+    if args.json:
+        print(
+            json.dumps(
+                [
+                    {
+                        "id": cell["id"],
+                        "score": cell_score(cell),
+                        "status": cell["status"],
+                        "next_action": cell["next_action"],
+                        "semantic_family": cell["semantic_family"],
+                        "title": cell["title"],
+                        "agent_task": cell.get("agent_task"),
+                        "required_gates": cell.get("required_gates", []),
+                    }
+                    for cell in selected
+                ],
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    rules = registry_rules(registry)
+    known_cases = case_index(cases)
+    if not selected:
+        print("No actionable Type-4 adversarial coverage cells matched the filters.")
+        return 0
+    for idx, cell in enumerate(selected):
+        if idx:
+            print("\n" + "-" * 78 + "\n")
+        print(task_card(cell, rules, known_cases))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/type4/adversarial/scripts/type4-report
+++ b/bench/type4/adversarial/scripts/type4-report
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Summarize Type-4 adversarial coverage matrix state."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+
+from _type4_adversarial import ACTIONABLE_STATUSES, cell_score, load_all, validate_all
+
+
+def print_counter(title: str, counter: Counter[str]) -> None:
+    print(f"\n{title}:")
+    for key, count in sorted(counter.items()):
+        print(f"  {key}: {count}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", default=10, type=int)
+    args = parser.parse_args()
+
+    matrix, registry, cases = load_all()
+    errors = validate_all(matrix, registry, cases)
+    if errors:
+        for error in errors:
+            print(f"error: {error}")
+        return 1
+
+    cells = matrix.get("cells", [])
+    by_status = Counter(cell["status"] for cell in cells)
+    by_action = Counter(cell["next_action"] for cell in cells)
+    by_family = Counter(cell["semantic_family"] for cell in cells)
+    by_family_status: dict[str, Counter[str]] = defaultdict(Counter)
+    for cell in cells:
+        by_family_status[cell["semantic_family"]][cell["status"]] += 1
+
+    print(f"cells: {len(cells)}")
+    print(f"rules: {len(registry.get('rules', []))}")
+    print(f"cases: {len(cases.get('cases', []))}")
+    print_counter("by status", by_status)
+    print_counter("by action", by_action)
+    print_counter("by semantic family", by_family)
+
+    print("\nfamily/status:")
+    for family in sorted(by_family_status):
+        parts = ", ".join(
+            f"{status}={count}" for status, count in sorted(by_family_status[family].items())
+        )
+        print(f"  {family}: {parts}")
+
+    backlog = [
+        cell for cell in cells if cell["status"] in ACTIONABLE_STATUSES
+    ]
+    backlog = sorted(backlog, key=lambda cell: (-cell_score(cell), cell["id"]))
+    print("\nnext backlog:")
+    for cell in backlog[: args.limit]:
+        print(
+            f"  {cell_score(cell):4d}  {cell['id']}  "
+            f"[{cell['status']} / {cell['next_action']}]"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/home.md
+++ b/docs/home.md
@@ -49,6 +49,7 @@ You want to *change* nose or understand how it works inside.
 - [experiments](experiments.md) — the measured log of what was tried and what happened.
 - [benchmark](benchmark.md) — the gold set, methodology, and the headline precision/recall numbers.
 - [type4-benchmark](type4-benchmark.md) — the evidence-carrying synthetic Type-4 benchmark factory.
+- [type4-adversarial-coverage](type4-adversarial-coverage.md) — the agent-facing Type-4 coverage matrix, adversarial cases, rule registry, and next-task workflow.
 - [frontier-platform](frontier-platform.md) — corpus-balanced evidence platform that ranks the next Type-4 axis by presence breadth (not raw count) and separates the queue signal from human-verified evidence.
 - [fragment-output-audit](fragment-output-audit.md) — exact semantic fragment output quality, ranking/grouping recommendations, and metadata requirements for default/review/debug surfaces.
 - [field-evaluation](field-evaluation.md) — qualitative results from running nose on real third-party projects.

--- a/docs/type4-adversarial-coverage.md
+++ b/docs/type4-adversarial-coverage.md
@@ -1,0 +1,139 @@
+# Type-4 adversarial coverage
+
+Back to [home](home.md). This page is the operating guide for the agent-facing
+Type-4 coverage loop. It complements the synthetic [type4-benchmark](type4-benchmark.md)
+and the real-corpus [frontier-platform](frontier-platform.md).
+
+## Purpose
+
+Type-4 coverage should grow by co-evolution, not by a pile of ad hoc canons. The
+engine, oracle, proof facts, adversarial cases, and performance guards should
+pressure each other:
+
+```text
+generator/cases attack -> engine tries to converge positives
+  -> hard negatives and oracle refute unsafe merges
+  -> proof/type facts gate risky generalization
+  -> performance guards reject expensive representations
+  -> matrix records the state
+  -> the next agent task is selected from the matrix
+```
+
+The harness is intentionally not a fully automatic optimizer. It gives a coding
+agent enough structure to choose the next item, reproduce the current state, make
+the smallest correct engine/oracle/proof/perf change, and record the result.
+
+## Files
+
+The control plane lives in [`bench/type4/adversarial`](../bench/type4/adversarial/):
+
+| file | role |
+|---|---|
+| `coverage_matrix.v1.json` | semantic-family cells, status, next actor, cases, gates, docs |
+| `rule_registry.v1.json` | engine/oracle/proof/perf rules and their boundaries |
+| `cases/cases.v1.json` | positive, hard-negative, oracle-gap, and perf case handles |
+| `scripts/type4-next` | print the next actionable task cards |
+| `scripts/type4-check` | validate matrix/registry/case consistency |
+| `scripts/type4-report` | summarize backlog by status, action, and family |
+| `scripts/type4-ingest-leads` | summarize `nose verify --leads` output and emit draft matrix cells |
+
+Run the basic harness check:
+
+```sh
+bench/type4/adversarial/scripts/type4-check
+bench/type4/adversarial/scripts/type4-report
+bench/type4/adversarial/scripts/type4-next --limit 3
+bench/type4/adversarial/scripts/type4-ingest-leads /tmp/leads.json --draft-json
+```
+
+## Status Model
+
+Each matrix cell has one status. The status says which actor should move next:
+
+| status | next work |
+|---|---|
+| `covered` | monitor only; positives converge, hard negatives split, gates passed |
+| `candidate` | add focused reproductions and classify the cell |
+| `under-merged` | engine/value graph/idiom work: behavior-equal positives split |
+| `false-merged` | soundness bug hunt: oracle refuted a fingerprint-equal pair |
+| `oracle-blocked` | interpreter/oracle must learn enough behavior before engine work is safe |
+| `proof-fact-blocked` | type/provenance/order facts are missing |
+| `perf-blocked` | semantics are plausible but representation/runtime cost is too high |
+| `unsafe` | semantics are too broad or edge cases are unresolved |
+| `not-applicable` | intentionally out of scope |
+
+`type4-next` scores actionable cells. Soundness bugs rank first, then
+under-merged engine work, then oracle/proof-fact blockers, then survey
+candidates and performance blockers.
+
+## Agent Loop
+
+For a selected task card:
+
+1. Read the matrix cell, referenced rules, referenced cases, and docs.
+2. Add or confirm focused positive cases and adjacent hard negatives.
+3. Reproduce the current status. Do not implement a canon from speculation.
+4. Fix the actor named by `next_action`:
+   - `engine`: frontend lowering, idiom canonicalization, value graph, or shared representation;
+   - `oracle`: interpreter behavior and `nose verify` coverage;
+   - `proof-facts`: type/provenance/order facts that make a canon safe;
+   - `performance`: compact representation, runtime guard, or scan-regression harness;
+   - `soundness`: remove or gate a false merge.
+5. Run the cell's focused gates, then the normal project gate.
+6. Update the matrix, registry, cases, and docs in the same PR.
+
+The ordinary PR/push gate remains:
+
+```sh
+./scripts/check-ci-local.sh --fast
+```
+
+For Type-4 cells, also run the focused command listed in the cell. When a cell
+has a generated benchmark axis, prefer:
+
+```sh
+GATE=focused AXIS=<axis> scripts/type4-smoke.sh
+```
+
+## Rule Registry
+
+The registry is the anti-duplication mechanism for the semantic engine. Every new
+rule should declare:
+
+- whether it is engine, oracle, proof-fact, or performance work;
+- implementation files;
+- positive cases and hard negatives;
+- boundaries where the rule must fail closed;
+- docs that explain the rule.
+
+When two cells need the same proof invariant or value-graph representation, extend
+one registry rule instead of adding parallel language-specific exceptions.
+
+## Adversarial Cases
+
+Every positive family needs adjacent negatives. The case library stores handles,
+not necessarily full generated source. A case can point to existing fixtures,
+future generated manifest items, or a real frontier packet. Good hard negatives
+attack exactly the proof invariant a rule needs:
+
+- flattened list vs nested list;
+- changed predicate or mapped value;
+- wrong collection/key/default coordinate;
+- missing type/provenance/order proof;
+- effectful callback where a pure HoF rule would be unsound;
+- representation growth that makes a coverage win too expensive.
+
+## Relationship To Existing Type-4 Tools
+
+- `bench/type4/generate.py` creates evidence-carrying synthetic pairs.
+- `scripts/type4-smoke.sh` runs generated positives, hard negatives, verifier leads,
+  stats, and frontier summaries.
+- `bench/type4/frontier_platform.py` ranks real-corpus axes by breadth and evidence.
+- The adversarial harness turns those signals into agent task cards and a durable
+  coverage ledger.
+
+The loop should normally start from `type4-next`, but real-code evidence from the
+frontier platform or `nose verify --leads` can add or update matrix cells. Use
+`type4-ingest-leads` to turn verifier lead output into draft cells, then manually
+classify the semantic family, positives, hard negatives, and gates before committing
+the matrix update.

--- a/docs/type4-benchmark.md
+++ b/docs/type4-benchmark.md
@@ -303,6 +303,9 @@ The seed lives in `bench/type4/`:
   baseline, fragment/reason-code/surface bucket drift, enclosing-unit recovery metrics,
   and threshold docs; see
   `bench/type4/scan_regression/README.md`;
+- `adversarial/` — the agent-facing coverage matrix, rule registry, adversarial case
+  handles, and next-task scripts; see
+  [type4-adversarial-coverage](type4-adversarial-coverage.md);
 - `README.md` — commands and current smoke numbers.
 
 The long-term direction is an adversarial semantic test factory: the generator creates


### PR DESCRIPTION
## Summary
- Add an agent-facing Type-4 adversarial coverage matrix, rule registry, and reusable case catalog.
- Add local workflow commands: `type4-check`, `type4-next`, `type4-report`, and `type4-ingest-leads`.
- Document the Type-4 adversarial coverage program and link it from the Type-4 benchmark docs and docs home.

## Why
This gives coding agents a stable way to pick the next Type-4 improvement without asking for manual prioritization each time. It explicitly tracks adversarial co-evolution across engine rules, oracle capability, proof facts, hard negatives, and performance gates.

## Current Next Item
`bench/type4/adversarial/scripts/type4-next --limit 3` currently selects:
1. `oracle.hof.error_semantics`
2. `iterator.java_stream.flat_map`
3. `numeric.clamp.minmax_composition`

## Gates
- [x] `bench/type4/adversarial/scripts/type4-check`
- [x] `bench/type4/adversarial/scripts/type4-next --limit 3`
- [x] `bench/type4/adversarial/scripts/type4-report --limit 3`
- [x] `bench/type4/adversarial/scripts/type4-ingest-leads <sample-leads-json> --draft-json`
- [x] `python3 -m py_compile bench/type4/adversarial/scripts/_type4_adversarial.py bench/type4/adversarial/scripts/type4-check bench/type4/adversarial/scripts/type4-next bench/type4/adversarial/scripts/type4-report bench/type4/adversarial/scripts/type4-ingest-leads`
- [x] `awiki lint --root docs`
- [x] `git diff --check`
- [x] `./scripts/check-ci-local.sh --fast`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * Type-4 적대적 커버리지 루프에 대한 완전한 운영 가이드 추가
  * 커버리지 매트릭스, 규칙 레지스트리, 케이스 시스템 문서화

* **새 기능**
  * 커버리지 검증 및 상태 보고 도구 추가
  * 우선순위 기반 작업 선택 및 리드 수집 기능 구현
  * 17개의 의미론적 테스트 케이스 및 매트릭스 추적 시스템 도입

<!-- end of auto-generated comment: release notes by coderabbit.ai -->