### PR TITLE
Cover Java stream flatMap oracle

### DIFF
--- a/bench/type4/adversarial/cases/cases.v1.json
+++ b/bench/type4/adversarial/cases/cases.v1.json
@@ -88,7 +88,11 @@
       "kind": "positive",
       "semantic_family": "hof.flat_map",
       "claim": "A pure Java Stream.flatMap chain can express the same one-level flat-map as Python multi-clause comprehension.",
-      "evidence": "Oracle-blocked candidate; needs interpretable Java stream subset before promotion."
+      "fixtures": [
+        "bench/type4/adversarial/cases/java_stream_flat_map/FlatMap.java",
+        "bench/type4/adversarial/cases/java_stream_flat_map/flat_map.py"
+      ],
+      "evidence": "Focused Java stream corpus verifies with 4/4 interpretable units, zero false merges, and complete behavior-equal convergence; the source-level equivalence test asserts Java Stream.flatMap/map matches Python multi-clause comprehension."
     },
     {
       "id": "java_stream_map_not_flat_map",
@@ -96,7 +100,11 @@
       "semantic_family": "hof.flat_map",
       "claim": "Java Stream.map returning streams is not Stream.flatMap.",
       "mutation": "flatMap -> map",
-      "evidence": "Hard negative for Java stream idiom work."
+      "fixtures": [
+        "bench/type4/adversarial/cases/java_stream_flat_map/FlatMap.java",
+        "bench/type4/adversarial/cases/java_stream_flat_map/flat_map.py"
+      ],
+      "evidence": "The focused corpus includes nestedMapJava and nested_map_py as the nested-shape sibling, and the source-level equivalence test asserts nested-map fingerprints differ from flat-map fingerprints."
     },
     {
       "id": "java_stream_effectful_lambda",
@@ -104,7 +112,7 @@
       "semantic_family": "hof.flat_map",
       "claim": "Effectful stream callbacks cannot be treated as pure HoF transformations.",
       "mutation": "lambda mutates external state or performs an effect",
-      "evidence": "Oracle boundary for stream support."
+      "evidence": "The Java stream oracle tests execute a FlatMap callback containing a print effect and assert the effect trace is preserved, so callback effects remain observable and outside the pure idiom rule."
     },
     {
       "id": "clamp_minmax_guarded_bounds",

--- a/bench/type4/adversarial/cases/java_stream_flat_map/FlatMap.java
+++ b/bench/type4/adversarial/cases/java_stream_flat_map/FlatMap.java
@@ -1,0 +1,11 @@
+import java.util.Arrays;
+
+class FlatMap {
+    static Object flatMapJava(int[] xs, int[] ys) {
+        return Arrays.stream(xs).flatMap(x -> Arrays.stream(ys).map(y -> x + y));
+    }
+
+    static Object nestedMapJava(int[] xs, int[] ys) {
+        return Arrays.stream(xs).map(x -> Arrays.stream(ys).map(y -> x + y));
+    }
+}

--- a/bench/type4/adversarial/cases/java_stream_flat_map/flat_map.py
+++ b/bench/type4/adversarial/cases/java_stream_flat_map/flat_map.py
@@ -1,0 +1,6 @@
+def flat_map_py(xs, ys):
+    return [x + y for x in xs for y in ys]
+
+
+def nested_map_py(xs, ys):
+    return [[x + y for y in ys] for x in xs]

--- a/bench/type4/adversarial/coverage_matrix.v1.json
+++ b/bench/type4/adversarial/coverage_matrix.v1.json
@@ -67,20 +67,21 @@
       "id": "iterator.java_stream.flat_map",
       "semantic_family": "hof.flat_map",
       "title": "Java Stream.flatMap converges with shared FlatMap HoF",
-      "status": "oracle-blocked",
-      "next_action": "oracle",
-      "priority": 30,
+      "status": "covered",
+      "next_action": "monitor",
+      "priority": 0,
       "languages": ["java", "python"],
       "representations": ["java_stream", "multi_clause_comprehension", "nested_builder_loop"],
       "rule_ids": ["hof.flat_map", "idiom.java_stream", "oracle.java_stream"],
       "positive_cases": ["java_stream_flat_map_py_comp"],
       "adversarial_cases": ["java_stream_map_not_flat_map", "java_stream_effectful_lambda"],
-      "evidence": "The idiom family is likely valuable, but acceptance needs oracle support for enough Java stream/lambda behavior to reject hard negatives.",
-      "agent_task": "Start with oracle capability: determine which Java stream flatMap examples are interpretable. Extend oracle only for pure, bounded forms before adding idiom canonicalization.",
+      "evidence": "Pure Java Arrays.stream(xs).flatMap(x -> Arrays.stream(ys).map(...)) now converges with Python multi-clause comprehension through the shared FlatMap HoF. The oracle interprets Java expression-body stream lambdas; map-returning-stream remains nested, and effectful callbacks are observable rather than assumed pure. Successor audit: the closed gap was the Java stream oracle/lambda blocker; no new successor cell was added because aggregate/terminal FlatMap consumers are already tracked by hof.flat_map.aggregate_bridge.",
+      "agent_task": "Monitor pure Java stream flatMap coverage. New aggregate or terminal-consumer gaps should attach to hof.flat_map.aggregate_bridge unless they require a Java-only oracle boundary.",
       "required_gates": [
         "bench/type4/adversarial/scripts/type4-check --item iterator.java_stream.flat_map",
         "cargo test -p nose-normalize java_stream",
-        "cargo run -p nose-cli -- verify --max-violations 0 <focused-java-stream-corpus>"
+        "cargo test -p nose-cli --test equivalence java_stream_flat_map",
+        "cargo run -p nose-cli -- verify --max-violations 0 bench/type4/adversarial/cases/java_stream_flat_map"
       ],
       "docs": ["docs/type4-adversarial-coverage.md", "docs/normalization.md"]
     },

--- a/bench/type4/adversarial/rule_registry.v1.json
+++ b/bench/type4/adversarial/rule_registry.v1.json
@@ -54,23 +54,23 @@
     {
       "id": "idiom.java_stream",
       "kind": "engine",
-      "status": "proposed",
-      "summary": "Lower pure Java stream adapters into shared HoF/value-graph representations.",
+      "status": "partial",
+      "summary": "Lower proven pure Java stream adapters into shared HoF/value-graph representations, including flatMap/map chains.",
       "implementation": ["crates/nose-normalize/src/idioms.rs"],
       "positive_cases": ["java_stream_flat_map_py_comp"],
       "hard_negatives": ["java_stream_map_not_flat_map", "java_stream_effectful_lambda"],
-      "boundaries": ["Requires oracle support for enough Java lambda/stream behavior before detection can claim soundness."],
+      "boundaries": ["Only the modeled pure stream subset is covered.", "Stream.map returning streams remains nested and must not collapse to FlatMap.", "Effectful callbacks and parallel stream semantics remain outside the pure idiom rule."],
       "docs": ["docs/type4-adversarial-coverage.md"]
     },
     {
       "id": "oracle.java_stream",
       "kind": "oracle",
-      "status": "proposed",
-      "summary": "Interpreter support for a small, pure subset of Java stream chains.",
+      "status": "landed",
+      "summary": "Interpreter support for the pure Java stream HoF subset, including expression-body lambda callbacks.",
       "implementation": ["crates/nose-normalize/src/interp.rs"],
       "positive_cases": ["java_stream_flat_map_py_comp"],
-      "hard_negatives": ["java_stream_effectful_lambda"],
-      "boundaries": ["No effectful stream callbacks; no parallel stream semantics."],
+      "hard_negatives": ["java_stream_map_not_flat_map", "java_stream_effectful_lambda"],
+      "boundaries": ["Expression-body lambdas are evaluated as expressions; statement/block lambdas still execute through the statement path.", "Effects inside callbacks are recorded by the oracle and are not proof of a pure canonicalization.", "No parallel stream semantics."],
       "docs": ["docs/type4-adversarial-coverage.md"]
     },
     {

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -386,6 +386,32 @@ fn java_stream_aggregates_converge_with_loops() {
 }
 
 #[test]
+fn java_stream_flat_map_converges_with_python_comprehension() {
+    let i = Interner::new();
+    let py_flat = "def f(xs, ys):\n    return [x + y for x in xs for y in ys]\n";
+    let java_flat = "import java.util.Arrays; class C { static Object f(int[] xs, int[] ys) { return Arrays.stream(xs).flatMap(x -> Arrays.stream(ys).map(y -> x + y)); } }";
+    let py_nested = "def f(xs, ys):\n    return [[x + y for y in ys] for x in xs]\n";
+    let java_nested = "import java.util.Arrays; class C { static Object f(int[] xs, int[] ys) { return Arrays.stream(xs).map(x -> Arrays.stream(ys).map(y -> x + y)); } }";
+
+    let flat_fp = value_fp(&i, py_flat, Lang::Python);
+    let nested_fp = value_fp(&i, py_nested, Lang::Python);
+    assert_eq!(
+        flat_fp,
+        value_fp(&i, java_flat, Lang::Java),
+        "Java Stream.flatMap/map should match Python multi-clause comprehension"
+    );
+    assert_eq!(
+        nested_fp,
+        value_fp(&i, java_nested, Lang::Java),
+        "Java Stream.map returning streams should stay nested"
+    );
+    assert_ne!(
+        flat_fp, nested_fp,
+        "flatMap and map-returning-stream must remain distinct"
+    );
+}
+
+#[test]
 fn ruby_select_reduce_converges_with_guarded_loop() {
     // Ruby `select { p }.reduce(init) { |a, x| ... }` is the same filtered fold as
     // a guarded `each` accumulator loop. The changed seed remains a hard negative.

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -977,11 +977,22 @@ impl<'a> Interp<'a> {
             return Err(Unsupported);
         }
         let body = *kids.last().ok_or(Unsupported)?;
-        match self.exec(body, &mut local)? {
-            Flow::Ret(v) => Ok(v),
-            Flow::Err => Ok(Value::Err),
-            Flow::Normal => Ok(Value::Null),
-            Flow::Break | Flow::Continue => Err(Unsupported),
+        match self.il.kind(body) {
+            NodeKind::Block
+            | NodeKind::Assign
+            | NodeKind::ExprStmt
+            | NodeKind::Return
+            | NodeKind::Throw
+            | NodeKind::Loop
+            | NodeKind::Try
+            | NodeKind::Break
+            | NodeKind::Continue => match self.exec(body, &mut local)? {
+                Flow::Ret(v) => Ok(v),
+                Flow::Err => Ok(Value::Err),
+                Flow::Normal => Ok(Value::Null),
+                Flow::Break | Flow::Continue => Err(Unsupported),
+            },
+            _ => self.eval(body, &mut local),
         }
     }
 }
@@ -2271,6 +2282,144 @@ mod tests {
     #[test]
     fn hof_filter_map_effectful_lambda_records_effects() {
         let behavior = hof_filter_map_effectful_lambda();
+        assert_eq!(
+            behavior.ret,
+            Value::List(vec![Value::Int(1), Value::Int(2)])
+        );
+        assert_eq!(behavior.effects, vec![Value::Int(1), Value::Int(2)]);
+    }
+
+    fn java_stream_nested_expression_lambda_behavior(outer_kind: HoFKind) -> Behavior {
+        let sp = Span::synthetic(FileId(0));
+        let mut b = IlBuilder::new(FileId(0));
+        let xs_param = b.add(NodeKind::Param, Payload::Cid(0), sp, &[]);
+        let ys_param = b.add(NodeKind::Param, Payload::Cid(1), sp, &[]);
+
+        let x_param = b.add(NodeKind::Param, Payload::Cid(2), sp, &[]);
+        let y_param = b.add(NodeKind::Param, Payload::Cid(3), sp, &[]);
+        let x_in_inner = b.add(NodeKind::Var, Payload::Cid(2), sp, &[]);
+        let y = b.add(NodeKind::Var, Payload::Cid(3), sp, &[]);
+        let sum = b.add(NodeKind::BinOp, Payload::Op(Op::Add), sp, &[x_in_inner, y]);
+        let inner_lambda = b.add(NodeKind::Lambda, Payload::None, sp, &[y_param, sum]);
+        let ys = b.add(NodeKind::Var, Payload::Cid(1), sp, &[]);
+        let inner_map = b.add(
+            NodeKind::HoF,
+            Payload::HoF(HoFKind::Map),
+            sp,
+            &[ys, inner_lambda],
+        );
+        let outer_lambda = b.add(NodeKind::Lambda, Payload::None, sp, &[x_param, inner_map]);
+        let xs = b.add(NodeKind::Var, Payload::Cid(0), sp, &[]);
+        let outer = b.add(
+            NodeKind::HoF,
+            Payload::HoF(outer_kind),
+            sp,
+            &[xs, outer_lambda],
+        );
+        let ret = b.add(NodeKind::Return, Payload::None, sp, &[outer]);
+        let func = b.add(
+            NodeKind::Func,
+            Payload::None,
+            sp,
+            &[xs_param, ys_param, ret],
+        );
+        let il = b.finish(
+            func,
+            FileMeta {
+                path: "T.java".into(),
+                lang: Lang::Java,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        run_unit(
+            &il,
+            func,
+            &[
+                Value::List(vec![Value::Int(1), Value::Int(2)]),
+                Value::List(vec![Value::Int(10), Value::Int(20)]),
+            ],
+        )
+        .expect("run_unit")
+    }
+
+    #[test]
+    fn java_stream_flat_map_expression_lambdas_are_interpretable() {
+        assert_eq!(
+            java_stream_nested_expression_lambda_behavior(HoFKind::FlatMap).ret,
+            Value::List(vec![
+                Value::Int(11),
+                Value::Int(21),
+                Value::Int(12),
+                Value::Int(22),
+            ])
+        );
+    }
+
+    #[test]
+    fn java_stream_map_returning_stream_stays_nested() {
+        assert_eq!(
+            java_stream_nested_expression_lambda_behavior(HoFKind::Map).ret,
+            Value::List(vec![
+                Value::List(vec![Value::Int(11), Value::Int(21)]),
+                Value::List(vec![Value::Int(12), Value::Int(22)]),
+            ])
+        );
+    }
+
+    fn java_stream_flat_map_effectful_lambda_behavior() -> Behavior {
+        let sp = Span::synthetic(FileId(0));
+        let mut b = IlBuilder::new(FileId(0));
+        let xs_param = b.add(NodeKind::Param, Payload::Cid(0), sp, &[]);
+
+        let x_param = b.add(NodeKind::Param, Payload::Cid(1), sp, &[]);
+        let printed = b.add(NodeKind::Var, Payload::Cid(1), sp, &[]);
+        let print = b.add(
+            NodeKind::Call,
+            Payload::Builtin(Builtin::Print),
+            sp,
+            &[printed],
+        );
+        let print_stmt = b.add(NodeKind::ExprStmt, Payload::None, sp, &[print]);
+        let returned = b.add(NodeKind::Var, Payload::Cid(1), sp, &[]);
+        let single = b.add(NodeKind::Seq, Payload::None, sp, &[returned]);
+        let lambda_ret = b.add(NodeKind::Return, Payload::None, sp, &[single]);
+        let lambda_body = b.add(
+            NodeKind::Block,
+            Payload::None,
+            sp,
+            &[print_stmt, lambda_ret],
+        );
+        let lambda = b.add(NodeKind::Lambda, Payload::None, sp, &[x_param, lambda_body]);
+        let xs = b.add(NodeKind::Var, Payload::Cid(0), sp, &[]);
+        let flat_map = b.add(
+            NodeKind::HoF,
+            Payload::HoF(HoFKind::FlatMap),
+            sp,
+            &[xs, lambda],
+        );
+        let ret = b.add(NodeKind::Return, Payload::None, sp, &[flat_map]);
+        let func = b.add(NodeKind::Func, Payload::None, sp, &[xs_param, ret]);
+        let il = b.finish(
+            func,
+            FileMeta {
+                path: "T.java".into(),
+                lang: Lang::Java,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        run_unit(
+            &il,
+            func,
+            &[Value::List(vec![Value::Int(1), Value::Int(2)])],
+        )
+        .expect("run_unit")
+    }
+
+    #[test]
+    fn java_stream_flat_map_effectful_lambda_records_effects() {
+        let behavior = java_stream_flat_map_effectful_lambda_behavior();
         assert_eq!(
             behavior.ret,
             Value::List(vec![Value::Int(1), Value::Int(2)])

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -17,8 +17,9 @@
 > fixpoint over subexpression result types) gating the type-dependent canons, free-monoid
 > strings, map **and filter** fusion (a filter is the element-carrying `Hof(Map,[Elem,p])`,
 > so nested filters fuse to `p∧q`), first-class **flat-map** modeling for Python
-> multi-clause comprehensions, JS `.flatMap`, and equivalent nested list-builder loops
-> (kept distinct from nested-list comprehensions), full **AC flatten+sort in the value graph itself** (not
+> multi-clause comprehensions, JS `.flatMap`, pure Java `Arrays.stream(...).flatMap(...map...)`,
+> and equivalent nested list-builder loops (kept distinct from nested-list comprehensions
+> and Java stream `map` returning streams), full **AC flatten+sort in the value graph itself** (not
 > only the `algebra` IL pass), **distribution/factoring** `a*c+b*c→(a+b)*c` (Num-gated),
 > min/max and any/all reductions (cross-language), simple **flag+break existence/universal
 > loops** (`found=false; if p { found=true; break }` / the dual `all` form),
@@ -109,7 +110,9 @@ Guiding constraints for every pass:
   self-recursion call-by-value arguments, list/tuple literal items, reduce initial values,
   higher-order map/filter/filter-map/flat-map/reduce, and `any`/`all` predicate errors also stay
   observable instead of being hidden inside a collection value or coerced through truthiness
-  into `false`. The filter-map oracle model treats `Null` as absence, propagates `Err`,
+  into `false`. Java stream expression-body lambdas are evaluated as callback expressions,
+  while block/effectful callbacks still execute through the statement path and preserve
+  their effect trace. The filter-map oracle model treats `Null` as absence, propagates `Err`,
   and emits every other value, including falsey values such as `0`; richer wrapped
   `Some(None)`-style payloads remain outside the modeled option subset.
   The remaining documented *exceptions* are large-constant/float abstraction (genuinely

--- a/docs/type4-adversarial-coverage.md
+++ b/docs/type4-adversarial-coverage.md
@@ -111,6 +111,10 @@ one registry rule instead of adding parallel language-specific exceptions.
 For option-producing iterator rules, record the absence/value boundary explicitly:
 the current oracle `FilterMap` model treats `Null` as absence, propagates `Err`,
 and emits every other value, including falsey values such as `0`.
+For Java stream rules, keep the registry scoped to the proven pure subset:
+`Arrays.stream(...).flatMap(...map...)` can share the FlatMap HoF only while
+`map`-returning-stream siblings stay nested and callback effects remain observable
+oracle evidence instead of purity assumptions.
 
 ## Adversarial Cases
 
@@ -124,6 +128,7 @@ attack exactly the proof invariant a rule needs:
 - wrong collection/key/default coordinate;
 - missing type/provenance/order proof;
 - filter-map absence vs emitted falsey value;
+- Java stream `flatMap` vs `map` returning streams;
 - effectful callback where a pure HoF rule would be unsound;
 - representation growth that makes a coverage win too expensive.
 


### PR DESCRIPTION
## Selected item

`iterator.java_stream.flat_map` — Java Stream.flatMap converges with shared FlatMap HoF.

## Implementation summary

- Let the interpreter apply expression-body lambdas by evaluating the lambda body as an expression while preserving statement/block lambda execution through the existing statement path.
- Added Java-stream oracle tests for pure expression-body `FlatMap`, `map` returning streams, and an effectful callback that records effects.
- Added a source-level equivalence test proving Java `Arrays.stream(xs).flatMap(x -> Arrays.stream(ys).map(...))` converges with Python multi-clause comprehension while `map` returning streams stays nested.
- Added a focused Java/Python corpus for `nose verify`.

## Matrix/rule/case/docs changes

- Marked `iterator.java_stream.flat_map` covered with the focused Java stream gates.
- Promoted `oracle.java_stream` to landed for the pure HoF subset and marked `idiom.java_stream` partial with explicit boundaries.
- Added fixtures/evidence for `java_stream_flat_map_py_comp` and `java_stream_map_not_flat_map`; recorded effectful callback evidence for `java_stream_effectful_lambda`.
- Updated `docs/type4-adversarial-coverage.md` and `docs/normalization.md` with the pure Java stream flatMap boundary.

## Successor Audit

1. Closed gap: Java stream `flatMap` was oracle-blocked because expression-body stream lambdas were not interpretable enough to validate the pure flatMap positive and hard negatives.
2. Newly revealed gap: no distinct new gap from this work. Aggregate/terminal consumers over flatMap remain a separate existing frontier.
3. Successor cell/rule/case added: no new successor cell was added.
4. Why existing matrix is sufficient: `hof.flat_map.aggregate_bridge` already tracks aggregate/terminal FlatMap consumer work; `java_stream_map_not_flat_map` and `java_stream_effectful_lambda` cover the immediate Java stream hard negatives for this cell.

## Gates run

- `bench/type4/adversarial/scripts/type4-check --item iterator.java_stream.flat_map`
- `bench/type4/adversarial/scripts/type4-check`
- `cargo test -p nose-normalize java_stream`
- `cargo test -p nose-cli --test equivalence java_stream_flat_map`
- `cargo run -p nose-cli -- verify --max-violations 0 bench/type4/adversarial/cases/java_stream_flat_map`
- `awiki lint --root docs`
- `./scripts/check-ci-local.sh --fast`
- `cargo build --release -p nose-cli && ./scripts/check-duplication.sh`

## `bench/type4/adversarial/scripts/type4-next --limit 3`

1. `numeric.clamp.minmax_composition` — proof-fact-blocked / proof-facts
2. `map_default.cross_file_binding` — proof-fact-blocked / proof-facts
3. `hof.filter_map.rust_iterator` — candidate / survey
