### PR TITLE
type4: cover non-python map default imports

### DIFF
--- a/bench/type4/adversarial/cases/cases.v1.json
+++ b/bench/type4/adversarial/cases/cases.v1.json
@@ -279,9 +279,12 @@
       "fixtures": [
         "bench/type4/adversarial/cases/map_default_cross_file/mutated_tables.py",
         "bench/type4/adversarial/cases/map_default_cross_file/imported_mutated_provider.py",
-        "bench/type4/adversarial/cases/map_default_cross_file/imported_mutated_receiver.py"
+        "bench/type4/adversarial/cases/map_default_cross_file/imported_mutated_receiver.py",
+        "bench/type4/adversarial/cases/map_default_non_python_import/js_mutated_tables.js",
+        "bench/type4/adversarial/cases/map_default_non_python_import/js_imported_mutated_provider.js",
+        "bench/type4/adversarial/cases/map_default_non_python_import/js_imported_mutated_receiver.js"
       ],
-      "evidence": "Provider and importer mutation fixtures stay out of the imported/local semantic family."
+      "evidence": "Provider and importer mutation fixtures stay out of the imported/local semantic family across Python and JS imports."
     },
     {
       "id": "map_default_wrong_map",
@@ -289,22 +292,53 @@
       "semantic_family": "map_default_lookup",
       "claim": "Looking up the same key/default on a different map is behaviorally different.",
       "mutation": "receiver map coordinate changes",
-      "fixtures": ["bench/type4/adversarial/cases/map_default_cross_file/wrong_map.py"],
-      "evidence": "Existing map-default tests and the cross-file wrong_map fixture keep changed present-key values split."
+      "fixtures": [
+        "bench/type4/adversarial/cases/map_default_cross_file/wrong_map.py",
+        "bench/type4/adversarial/cases/map_default_non_python_import/js_wrong_map.js",
+        "bench/type4/adversarial/cases/map_default_non_python_import/WrongTables.java",
+        "bench/type4/adversarial/cases/map_default_non_python_import/JavaImportedWrongMap.java",
+        "bench/type4/adversarial/cases/map_default_non_python_import/wrong_tables.rs",
+        "bench/type4/adversarial/cases/map_default_non_python_import/rust_imported_wrong_map.rs"
+      ],
+      "evidence": "Existing map-default tests plus cross-file Python, JS, Java, and Rust wrong-map fixtures keep changed present-key values split."
     },
     {
       "id": "map_default_imported_js_ts_literal",
       "kind": "positive",
       "semantic_family": "map_default_lookup",
       "claim": "Imported JavaScript/TypeScript literal map exports can converge with local map-default forms when module/export provenance is proven.",
-      "evidence": "Successor candidate; current generator lacks focused multi-file JS/TS import fixtures."
+      "fixtures": [
+        "bench/type4/adversarial/cases/map_default_non_python_import/local.py",
+        "bench/type4/adversarial/cases/map_default_non_python_import/js_tables.js",
+        "bench/type4/adversarial/cases/map_default_non_python_import/js_imported.js",
+        "bench/type4/adversarial/cases/map_default_non_python_import/ts_tables.ts",
+        "bench/type4/adversarial/cases/map_default_non_python_import/ts_imported.ts"
+      ],
+      "evidence": "Focused equivalence tests and the map_default_non_python_import corpus prove JS/TS named imports from unmutated sibling map exports converge with local literal map-default lookup."
     },
     {
       "id": "map_default_imported_java_static_literal",
       "kind": "positive",
       "semantic_family": "map_default_lookup",
       "claim": "Imported Java static literal map bindings can converge with local map-default forms when static import provenance is proven.",
-      "evidence": "Successor candidate; current slice intentionally stops at Python sibling imports."
+      "fixtures": [
+        "bench/type4/adversarial/cases/map_default_non_python_import/local.py",
+        "bench/type4/adversarial/cases/map_default_non_python_import/Tables.java",
+        "bench/type4/adversarial/cases/map_default_non_python_import/JavaImported.java"
+      ],
+      "evidence": "Focused equivalence tests and the map_default_non_python_import corpus prove Java static imports from unmutated class Map.of fields converge with local literal map-default lookup."
+    },
+    {
+      "id": "map_default_imported_rust_const_literal",
+      "kind": "positive",
+      "semantic_family": "map_default_lookup",
+      "claim": "Imported Rust const map-entry arrays can converge with local map-default forms when module/export provenance is proven.",
+      "fixtures": [
+        "bench/type4/adversarial/cases/map_default_non_python_import/local.py",
+        "bench/type4/adversarial/cases/map_default_non_python_import/tables.rs",
+        "bench/type4/adversarial/cases/map_default_non_python_import/rust_imported.rs"
+      ],
+      "evidence": "Focused equivalence tests and the map_default_non_python_import corpus prove Rust use-imported const entry arrays consumed by HashMap::from converge with local literal map-default lookup."
     },
     {
       "id": "hof_error_propagation",

--- a/bench/type4/adversarial/cases/map_default_non_python_import/JavaImported.java
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/JavaImported.java
@@ -1,0 +1,7 @@
+import static Tables.LOOKUP;
+
+class JavaImported {
+  static int lookup(String key, String other) {
+    return LOOKUP.getOrDefault(key, 0);
+  }
+}

--- a/bench/type4/adversarial/cases/map_default_non_python_import/JavaImportedWrongMap.java
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/JavaImportedWrongMap.java
@@ -1,0 +1,7 @@
+import static WrongTables.LOOKUP;
+
+class JavaImportedWrongMap {
+  static int lookup(String key, String other) {
+    return LOOKUP.getOrDefault(key, 0);
+  }
+}

--- a/bench/type4/adversarial/cases/map_default_non_python_import/Tables.java
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/Tables.java
@@ -1,0 +1,5 @@
+import java.util.Map;
+
+class Tables {
+  static final Map<String, Integer> LOOKUP = Map.of("red", 1, "blue", 2);
+}

--- a/bench/type4/adversarial/cases/map_default_non_python_import/WrongTables.java
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/WrongTables.java
@@ -1,0 +1,5 @@
+import java.util.Map;
+
+class WrongTables {
+  static final Map<String, Integer> LOOKUP = Map.of("red", 9, "blue", 2);
+}

--- a/bench/type4/adversarial/cases/map_default_non_python_import/js_imported.js
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/js_imported.js
@@ -1,0 +1,5 @@
+import { LOOKUP } from './js_tables';
+
+export function lookup(key, other) {
+  return LOOKUP.get(key) ?? 0;
+}

--- a/bench/type4/adversarial/cases/map_default_non_python_import/js_imported_mutated_provider.js
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/js_imported_mutated_provider.js
@@ -1,0 +1,5 @@
+import { LOOKUP } from './js_mutated_tables';
+
+export function lookup(key, other) {
+  return LOOKUP.get(key) ?? 0;
+}

--- a/bench/type4/adversarial/cases/map_default_non_python_import/js_imported_mutated_receiver.js
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/js_imported_mutated_receiver.js
@@ -1,0 +1,7 @@
+import { LOOKUP } from './js_tables';
+
+LOOKUP.set("red", 9);
+
+export function lookup(key, other) {
+  return LOOKUP.get(key) ?? 0;
+}

--- a/bench/type4/adversarial/cases/map_default_non_python_import/js_mutated_tables.js
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/js_mutated_tables.js
@@ -1,0 +1,3 @@
+export const LOOKUP = new Map([["red", 1], ["blue", 2]]);
+
+LOOKUP.set("red", 9);

--- a/bench/type4/adversarial/cases/map_default_non_python_import/js_tables.js
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/js_tables.js
@@ -1,0 +1,1 @@
+export const LOOKUP = new Map([["red", 1], ["blue", 2]]);

--- a/bench/type4/adversarial/cases/map_default_non_python_import/js_wrong_map.js
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/js_wrong_map.js
@@ -1,0 +1,5 @@
+import { LOOKUP } from './js_tables';
+
+export function lookup(key, other) {
+  return new Map([["red", 9], ["blue", 2]]).get(key) ?? 0;
+}

--- a/bench/type4/adversarial/cases/map_default_non_python_import/local.py
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/local.py
@@ -1,0 +1,2 @@
+def lookup(key, other):
+    return {"red": 1, "blue": 2}.get(key, 0)

--- a/bench/type4/adversarial/cases/map_default_non_python_import/rust_imported.rs
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/rust_imported.rs
@@ -1,0 +1,5 @@
+use tables::LOOKUP;
+
+pub fn lookup(key: &str, other: &str) -> i32 {
+    *std::collections::HashMap::from(LOOKUP).get(key).unwrap_or(&0)
+}

--- a/bench/type4/adversarial/cases/map_default_non_python_import/rust_imported_wrong_map.rs
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/rust_imported_wrong_map.rs
@@ -1,0 +1,5 @@
+use wrong_tables::LOOKUP;
+
+pub fn lookup(key: &str, other: &str) -> i32 {
+    *std::collections::HashMap::from(LOOKUP).get(key).unwrap_or(&0)
+}

--- a/bench/type4/adversarial/cases/map_default_non_python_import/tables.rs
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/tables.rs
@@ -1,0 +1,1 @@
+pub const LOOKUP: [(&str, i32); 2] = [("red", 1), ("blue", 2)];

--- a/bench/type4/adversarial/cases/map_default_non_python_import/ts_imported.ts
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/ts_imported.ts
@@ -1,0 +1,5 @@
+import { LOOKUP } from './ts_tables';
+
+export function lookup(key: string, other: string): number {
+  return LOOKUP.get(key) ?? 0;
+}

--- a/bench/type4/adversarial/cases/map_default_non_python_import/ts_tables.ts
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/ts_tables.ts
@@ -1,0 +1,1 @@
+export const LOOKUP = new Map<string, number>([["red", 1], ["blue", 2]]);

--- a/bench/type4/adversarial/cases/map_default_non_python_import/wrong_tables.rs
+++ b/bench/type4/adversarial/cases/map_default_non_python_import/wrong_tables.rs
@@ -1,0 +1,1 @@
+pub const LOOKUP: [(&str, i32); 2] = [("red", 9), ("blue", 2)];

--- a/bench/type4/adversarial/coverage_matrix.v1.json
+++ b/bench/type4/adversarial/coverage_matrix.v1.json
@@ -186,8 +186,8 @@
       "rule_ids": ["proof.collection_provenance", "idiom.map_default_lookup"],
       "positive_cases": ["map_default_imported_literal"],
       "adversarial_cases": ["map_default_mutated_receiver", "map_default_wrong_map"],
-      "evidence": "Python sibling `from module import LOOKUP` facts now resolve to a cloned literal RHS only when the provider has one safe unmutated literal binding and the import is unambiguous. Focused tests and fixtures prove imported/local map-default convergence while wrong-map, provider mutation, and importer mutation stay split. Successor audit: JS/TS/Java/Rust cross-file import/factory bridges and generated multi-file axis support remain separate work.",
-      "agent_task": "Monitor the landed Python sibling-import slice. Broader non-Python imported module/factory resolution belongs to map_default.non_python_import_bridge.",
+      "evidence": "Python sibling `from module import LOOKUP` facts resolve to a cloned literal RHS only when the provider has one safe unmutated literal binding and the import is unambiguous. Focused tests and fixtures prove imported/local map-default convergence while wrong-map, provider mutation, and importer mutation stay split. The earlier JS/TS/Java/Rust successor is now covered by map_default.non_python_import_bridge.",
+      "agent_task": "Monitor the landed Python sibling-import slice. Broader non-Python imported module/factory resolution is covered by map_default.non_python_import_bridge.",
       "required_gates": [
         "bench/type4/adversarial/scripts/type4-check --item map_default.cross_file_binding",
         "cargo test -p nose-cli --test equivalence map_default",
@@ -201,20 +201,20 @@
       "id": "map_default.non_python_import_bridge",
       "semantic_family": "map_default_lookup",
       "title": "Non-Python imported module map-default bindings converge when provenance is proven",
-      "status": "candidate",
-      "next_action": "survey",
-      "priority": 62,
+      "status": "covered",
+      "next_action": "monitor",
+      "priority": 0,
       "languages": ["javascript", "typescript", "java", "rust"],
       "representations": ["imported_binding", "module_binding", "literal_factory", "method_default"],
       "rule_ids": ["proof.collection_provenance", "idiom.map_default_lookup"],
-      "positive_cases": ["map_default_imported_js_ts_literal", "map_default_imported_java_static_literal"],
+      "positive_cases": ["map_default_imported_js_ts_literal", "map_default_imported_java_static_literal", "map_default_imported_rust_const_literal"],
       "adversarial_cases": ["map_default_mutated_receiver", "map_default_wrong_map"],
-      "evidence": "Successor audit for map_default.cross_file_binding: Python sibling literal imports are covered, but non-Python import/module coordinates and generated multi-file corpus items still need focused reproduction before broadening.",
-      "agent_task": "Survey JS/TS imported map exports, Java static imports, and Rust module constants with explicit provider/importer mutation hard negatives. Add multi-file generator support or focused fixtures before changing more provenance rules.",
+      "evidence": "JS/TS named imports from unambiguous sibling map exports, Java static imports from class static Map.of fields, and Rust use-imported const entry arrays now resolve to safe cloned provider RHS values. Focused tests and map_default_non_python_import fixtures prove convergence with local literal map-default lookup while JS provider/importer mutation and JS/Java/Rust wrong-map imports stay split. Successor audit: the closed gap was non-Python imported map-default provenance; the newly surfaced Rust const-entry fixture need is recorded as map_default_imported_rust_const_literal, and no extra successor cell was added because unsupported coordinates still fail closed under proof.collection_provenance.",
+      "agent_task": "Monitor the landed non-Python import bridge. New map-default import gaps should first test unambiguous provider identity, mutation, shadowing, and wrong-map boundaries before adding another cell.",
       "required_gates": [
         "bench/type4/adversarial/scripts/type4-check --item map_default.non_python_import_bridge",
         "cargo test -p nose-cli --test equivalence map_default",
-        "cargo run -p nose-cli -- verify --max-violations 0 <focused-non-python-map-default-import-corpus>"
+        "cargo run -p nose-cli -- verify --max-violations 0 bench/type4/adversarial/cases/map_default_non_python_import"
       ],
       "docs": ["docs/type4-adversarial-coverage.md", "docs/clone-types.md"]
     },

--- a/bench/type4/adversarial/rule_registry.v1.json
+++ b/bench/type4/adversarial/rule_registry.v1.json
@@ -121,11 +121,11 @@
       "id": "proof.collection_provenance",
       "kind": "proof-fact",
       "status": "partial",
-      "summary": "Prove receiver/key/default identity for collection and map-default idioms across local/module/import boundaries, including unambiguous Python sibling literal imports.",
+      "summary": "Prove receiver/key/default identity for collection and map-default idioms across local/module/import boundaries, including unambiguous Python sibling literal imports, JS/TS imported map exports, Java static imported map fields, and Rust imported const entry arrays.",
       "implementation": ["crates/nose-frontend/src/module_imports.rs", "crates/nose-normalize/src/module_facts.rs", "crates/nose-normalize/src/value_graph.rs"],
-      "positive_cases": ["map_default_imported_literal", "map_default_imported_js_ts_literal", "map_default_imported_java_static_literal"],
+      "positive_cases": ["map_default_imported_literal", "map_default_imported_js_ts_literal", "map_default_imported_java_static_literal", "map_default_imported_rust_const_literal"],
       "hard_negatives": ["map_default_mutated_receiver", "map_default_wrong_map"],
-      "boundaries": ["Python sibling import resolution requires one safe literal provider binding and an unambiguous module/export coordinate.", "Provider mutation, importer mutation, duplicate providers, shadowing, unresolved imports, and non-Python imported module bridges stay fail-closed."],
+      "boundaries": ["Import resolution requires one safe literal/factory provider binding and an unambiguous module/export coordinate.", "Supported non-Python coordinates are JS/TS path imports, Java class/static imports, and Rust module use imports; unsupported coordinates remain fail-closed.", "Provider mutation, importer mutation, duplicate providers, shadowing, and unresolved imports stay fail-closed."],
       "docs": ["docs/type4-adversarial-coverage.md", "docs/clone-types.md"]
     },
     {
@@ -134,7 +134,7 @@
       "status": "partial",
       "summary": "Canonicalize proven map/dict lookup-with-default idioms.",
       "implementation": ["crates/nose-normalize/src/idioms.rs", "crates/nose-normalize/src/value_graph.rs"],
-      "positive_cases": ["map_default_imported_literal", "map_default_imported_js_ts_literal", "map_default_imported_java_static_literal"],
+      "positive_cases": ["map_default_imported_literal", "map_default_imported_js_ts_literal", "map_default_imported_java_static_literal", "map_default_imported_rust_const_literal"],
       "hard_negatives": ["map_default_mutated_receiver", "map_default_wrong_map"],
       "boundaries": ["Requires proven receiver/key/default coordinates.", "Cross-file import facts are proof inputs only when collection provenance has resolved the imported value."],
       "docs": ["docs/type4-adversarial-coverage.md", "docs/clone-types.md"]

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -3625,6 +3625,151 @@ fn literal_map_default_lookup_converges_with_imported_python_literal_binding() {
 }
 
 #[test]
+fn literal_map_default_lookup_converges_with_non_python_imported_bindings() {
+    let dir = std::env::temp_dir().join(format!(
+        "nose_imported_non_python_map_default_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("local.py"),
+        "def lookup(key, other):\n    return {\"red\": 1, \"blue\": 2}.get(key, 0)\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("js_tables.js"),
+        "export const LOOKUP = new Map([[\"red\", 1], [\"blue\", 2]]);\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("js_imported.js"),
+        "import { LOOKUP } from './js_tables';\nexport function lookup(key, other) {\n  return LOOKUP.get(key) ?? 0;\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("js_mutated_tables.js"),
+        "export const LOOKUP = new Map([[\"red\", 1], [\"blue\", 2]]);\nLOOKUP.set(\"red\", 9);\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("js_imported_mutated_provider.js"),
+        "import { LOOKUP } from './js_mutated_tables';\nexport function lookup(key, other) {\n  return LOOKUP.get(key) ?? 0;\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("js_imported_mutated_receiver.js"),
+        "import { LOOKUP } from './js_tables';\nLOOKUP.set(\"red\", 9);\nexport function lookup(key, other) {\n  return LOOKUP.get(key) ?? 0;\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("js_wrong_map.js"),
+        "import { LOOKUP } from './js_tables';\nexport function lookup(key, other) {\n  return new Map([[\"red\", 9], [\"blue\", 2]]).get(key) ?? 0;\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("ts_tables.ts"),
+        "export const LOOKUP = new Map<string, number>([[\"red\", 1], [\"blue\", 2]]);\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("ts_imported.ts"),
+        "import { LOOKUP } from './ts_tables';\nexport function lookup(key: string, other: string): number {\n  return LOOKUP.get(key) ?? 0;\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("Tables.java"),
+        "import java.util.Map;\n\nclass Tables {\n  static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2);\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("JavaImported.java"),
+        "import static Tables.LOOKUP;\n\nclass JavaImported {\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("WrongTables.java"),
+        "import java.util.Map;\n\nclass WrongTables {\n  static final Map<String, Integer> LOOKUP = Map.of(\"red\", 9, \"blue\", 2);\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("JavaImportedWrongMap.java"),
+        "import static WrongTables.LOOKUP;\n\nclass JavaImportedWrongMap {\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("tables.rs"),
+        "pub const LOOKUP: [(&str, i32); 2] = [(\"red\", 1), (\"blue\", 2)];\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("rust_imported.rs"),
+        "use tables::LOOKUP;\n\npub fn lookup(key: &str, other: &str) -> i32 {\n    *std::collections::HashMap::from(LOOKUP).get(key).unwrap_or(&0)\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("wrong_tables.rs"),
+        "pub const LOOKUP: [(&str, i32); 2] = [(\"red\", 9), (\"blue\", 2)];\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("rust_imported_wrong_map.rs"),
+        "use wrong_tables::LOOKUP;\n\npub fn lookup(key: &str, other: &str) -> i32 {\n    *std::collections::HashMap::from(LOOKUP).get(key).unwrap_or(&0)\n}\n",
+    )
+    .unwrap();
+
+    let corpus = nose_frontend::lower_corpus_many(&[dir.as_path()]);
+    let local = corpus_value_fp(&corpus, "local.py", "lookup");
+    assert_eq!(
+        local,
+        corpus_value_fp(&corpus, "js_imported.js", "lookup"),
+        "JS named import should prove the same literal map/default coordinates"
+    );
+    assert_eq!(
+        local,
+        corpus_value_fp(&corpus, "ts_imported.ts", "lookup"),
+        "TS named import should prove the same literal map/default coordinates"
+    );
+    assert_eq!(
+        local,
+        corpus_value_fp(&corpus, "JavaImported.java", "lookup"),
+        "Java static import should prove the same literal map/default coordinates"
+    );
+    assert_eq!(
+        local,
+        corpus_value_fp(&corpus, "rust_imported.rs", "lookup"),
+        "Rust use-imported const entries should prove the same map/default coordinates"
+    );
+    assert_ne!(
+        local,
+        corpus_value_fp(&corpus, "js_imported_mutated_provider.js", "lookup"),
+        "provider mutation must block JS imported map provenance"
+    );
+    assert_ne!(
+        local,
+        corpus_value_fp(&corpus, "js_imported_mutated_receiver.js", "lookup"),
+        "importer mutation must keep JS imported receiver distinct"
+    );
+    assert_ne!(
+        local,
+        corpus_value_fp(&corpus, "js_wrong_map.js", "lookup"),
+        "different JS map contents must stay distinct"
+    );
+    assert_ne!(
+        local,
+        corpus_value_fp(&corpus, "JavaImportedWrongMap.java", "lookup"),
+        "different Java imported map contents must stay distinct"
+    );
+    assert_ne!(
+        local,
+        corpus_value_fp(&corpus, "rust_imported_wrong_map.rs", "lookup"),
+        "different Rust imported map contents must stay distinct"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn literal_map_default_lookup_converges_with_js_object_own_property_boundaries() {
     let i = Interner::new();
     let py_literal = "def f(key, other):\n    return {\"red\": 1, \"blue\": 2}.get(key, 0)\n";

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -1,13 +1,13 @@
 //! Corpus-level import proof facts that need more than one lowered file.
 //!
 //! Frontends lower a static import as `local = import_binding(module, exported)`.
-//! Once the whole corpus is available, a sibling Python module can prove that this
-//! binding names a single immutable literal value. In that narrow case we replace
-//! the import fact RHS with a cloned literal subtree, so the existing per-file
-//! value-graph module-binding seed can reuse its mutation and canonicalization logic.
+//! Once the whole corpus is available, a sibling module can prove that this binding
+//! names a single immutable literal value. In that narrow case we replace the import
+//! fact RHS with a cloned literal subtree, so the existing per-file value-graph
+//! module-binding seed can reuse its mutation and canonicalization logic.
 
 use nose_il::{
-    stable_symbol_hash, Il, Interner, Lang, Node, NodeId, NodeKind, Payload, Span, Symbol,
+    stable_symbol_hash, Il, Interner, Lang, Node, NodeId, NodeKind, Payload, Span, Symbol, UnitKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::Path;
@@ -33,7 +33,7 @@ struct SubtreeSnapshot {
 }
 
 pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &Interner) {
-    let exports = collect_python_literal_exports(files, interner);
+    let exports = collect_literal_exports(files, interner);
     if exports.is_empty() {
         return;
     }
@@ -42,9 +42,6 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
         .iter()
         .enumerate()
         .map(|(file_idx, il)| {
-            if il.meta.lang != Lang::Python {
-                return Vec::new();
-            }
             collect_top_level_statements(il)
                 .into_iter()
                 .filter_map(|stmt| {
@@ -67,53 +64,51 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
     }
 }
 
-fn collect_python_literal_exports(
+fn collect_literal_exports(
     files: &[Il],
     interner: &Interner,
 ) -> FxHashMap<(u64, u64), ExportedBinding> {
     let mut exports = FxHashMap::default();
     let mut ambiguous = FxHashSet::default();
     for (file_idx, il) in files.iter().enumerate() {
-        if il.meta.lang != Lang::Python {
+        let module_hashes = file_module_hashes(il);
+        if !module_hashes.is_empty() {
+            let top_level = collect_top_level_statements(il);
+            collect_statement_exports(
+                il,
+                interner,
+                file_idx,
+                &top_level,
+                &module_hashes,
+                &mut exports,
+                &mut ambiguous,
+            );
+        }
+
+        if il.meta.lang != Lang::Java {
             continue;
         }
-        let module_hashes = python_module_hashes(&il.meta.path);
-        if module_hashes.is_empty() {
-            continue;
-        }
-        let top_level = collect_top_level_statements(il);
-        let mut counts: FxHashMap<Symbol, usize> = FxHashMap::default();
-        for &stmt in &top_level {
-            if let Some(name) = assignment_name(il, stmt) {
-                *counts.entry(name).or_insert(0) += 1;
+        for unit in &il.units {
+            if unit.kind != UnitKind::Class {
+                continue;
             }
-        }
-        for &stmt in &top_level {
-            let Some(name) = assignment_name(il, stmt) else {
+            let Some(class_name) = unit.name else {
                 continue;
             };
-            if counts.get(&name).copied().unwrap_or(0) != 1 {
+            let class_module_hashes = java_class_module_hashes(il, interner, class_name);
+            if class_module_hashes.is_empty() {
                 continue;
             }
-            if binding_mutated(il, interner, name, stmt) {
-                continue;
-            }
-            let Some(rhs) = assignment_rhs(il, stmt) else {
-                continue;
-            };
-            if !literal_map_export_safe(il, interner, rhs) {
-                continue;
-            }
-            let exported = stable_symbol_hash(interner.resolve(name));
-            for &module in &module_hashes {
-                let key = (module, exported);
-                if exports
-                    .insert(key, ExportedBinding { file_idx, rhs })
-                    .is_some()
-                {
-                    ambiguous.insert(key);
-                }
-            }
+            let statements = collect_statements_for_root(il, unit.root);
+            collect_statement_exports(
+                il,
+                interner,
+                file_idx,
+                &statements,
+                &class_module_hashes,
+                &mut exports,
+                &mut ambiguous,
+            );
         }
     }
     for key in ambiguous {
@@ -122,12 +117,74 @@ fn collect_python_literal_exports(
     exports
 }
 
+fn collect_statement_exports(
+    il: &Il,
+    interner: &Interner,
+    file_idx: usize,
+    statements: &[NodeId],
+    module_hashes: &[u64],
+    exports: &mut FxHashMap<(u64, u64), ExportedBinding>,
+    ambiguous: &mut FxHashSet<(u64, u64)>,
+) {
+    let mut counts: FxHashMap<Symbol, usize> = FxHashMap::default();
+    for &stmt in statements {
+        if let Some(name) = assignment_name(il, stmt) {
+            *counts.entry(name).or_insert(0) += 1;
+        }
+    }
+    for &stmt in statements {
+        let Some(name) = assignment_name(il, stmt) else {
+            continue;
+        };
+        if counts.get(&name).copied().unwrap_or(0) != 1 {
+            continue;
+        }
+        if binding_mutated(il, interner, name, stmt) {
+            continue;
+        }
+        let Some(rhs) = assignment_rhs(il, stmt) else {
+            continue;
+        };
+        if !imported_literal_export_safe(il, interner, rhs) {
+            continue;
+        }
+        let exported = stable_symbol_hash(interner.resolve(name));
+        for &module in module_hashes {
+            let key = (module, exported);
+            if exports
+                .insert(key, ExportedBinding { file_idx, rhs })
+                .is_some()
+            {
+                ambiguous.insert(key);
+            }
+        }
+    }
+}
+
 fn collect_top_level_statements(il: &Il) -> Vec<NodeId> {
-    il.children(il.root)
+    let class_roots: FxHashSet<NodeId> = il
+        .units
+        .iter()
+        .filter_map(|unit| (unit.kind == UnitKind::Class).then_some(unit.root))
+        .collect();
+    collect_statements_for_root_except(il, il.root, &class_roots)
+}
+
+fn collect_statements_for_root(il: &Il, root: NodeId) -> Vec<NodeId> {
+    collect_statements_for_root_except(il, root, &FxHashSet::default())
+}
+
+fn collect_statements_for_root_except(
+    il: &Il,
+    root: NodeId,
+    non_flattened_blocks: &FxHashSet<NodeId>,
+) -> Vec<NodeId> {
+    il.children(root)
         .iter()
         .copied()
         .fold(Vec::new(), |mut statements, node| {
             match il.kind(node) {
+                NodeKind::Block if non_flattened_blocks.contains(&node) => statements.push(node),
                 NodeKind::Block => statements.extend_from_slice(il.children(node)),
                 _ => statements.push(node),
             }
@@ -183,19 +240,22 @@ fn literal_string_hash(il: &Il, node: NodeId) -> Option<u64> {
     }
 }
 
-fn literal_map_export_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if il.kind(node) != NodeKind::Seq {
-        return false;
+fn imported_literal_export_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    match il.kind(node) {
+        NodeKind::Seq => {
+            let Payload::Name(tag) = il.node(node).payload else {
+                return false;
+            };
+            if !imported_literal_seq_tag_safe(interner.resolve(tag)) {
+                return false;
+            }
+            il.children(node)
+                .iter()
+                .all(|&child| literal_export_value_safe(il, interner, child))
+        }
+        NodeKind::Call => imported_map_factory_call_safe(il, interner, node),
+        _ => false,
     }
-    let Payload::Name(tag) = il.node(node).payload else {
-        return false;
-    };
-    if interner.resolve(tag) != "dictionary" {
-        return false;
-    }
-    il.children(node)
-        .iter()
-        .all(|&child| literal_export_value_safe(il, interner, child))
 }
 
 fn literal_export_value_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
@@ -215,8 +275,133 @@ fn literal_export_value_safe(il: &Il, interner: &Interner, node: NodeId) -> bool
             .children(node)
             .iter()
             .all(|&child| literal_export_value_safe(il, interner, child)),
+        NodeKind::Call => java_map_entry_call_safe(il, interner, node),
         _ => false,
     }
+}
+
+fn imported_literal_seq_tag_safe(tag: &str) -> bool {
+    matches!(
+        tag,
+        "dictionary" | "object" | "array" | "array_expression" | "tuple_expression"
+    )
+}
+
+fn imported_map_factory_call_safe(il: &Il, interner: &Interner, call: NodeId) -> bool {
+    match il.meta.lang {
+        Lang::JavaScript | Lang::TypeScript => js_map_constructor_call_safe(il, interner, call),
+        Lang::Java => java_map_factory_call_safe(il, interner, call),
+        Lang::Rust => rust_std_map_factory_call_safe(il, interner, call),
+        _ => false,
+    }
+}
+
+fn js_map_constructor_call_safe(il: &Il, interner: &Interner, call: NodeId) -> bool {
+    let kids = il.children(call);
+    if kids.len() != 2 || !var_named(il, interner, kids[0], "Map") {
+        return false;
+    }
+    if file_defines_symbol(il, interner, "Map") {
+        return false;
+    }
+    literal_export_value_safe(il, interner, kids[1])
+}
+
+fn java_map_factory_call_safe(il: &Il, interner: &Interner, call: NodeId) -> bool {
+    let kids = il.children(call);
+    let Some((&callee, args)) = kids.split_first() else {
+        return false;
+    };
+    let Some(method) = field_method_on_var(il, interner, callee, "Map") else {
+        return false;
+    };
+    if java_file_defines_type_name(il, interner, "Map") {
+        return false;
+    }
+    match method {
+        "of" => {
+            args.len() % 2 == 0
+                && args
+                    .iter()
+                    .all(|&arg| literal_export_value_safe(il, interner, arg))
+        }
+        "ofEntries" => args
+            .iter()
+            .all(|&arg| java_map_entry_call_safe(il, interner, arg)),
+        _ => false,
+    }
+}
+
+fn java_map_entry_call_safe(il: &Il, interner: &Interner, call: NodeId) -> bool {
+    if il.kind(call) != NodeKind::Call {
+        return false;
+    }
+    let kids = il.children(call);
+    if kids.len() != 3 {
+        return false;
+    }
+    if field_method_on_var(il, interner, kids[0], "Map") != Some("entry") {
+        return false;
+    }
+    if java_file_defines_type_name(il, interner, "Map") {
+        return false;
+    }
+    literal_export_value_safe(il, interner, kids[1])
+        && literal_export_value_safe(il, interner, kids[2])
+}
+
+fn rust_std_map_factory_call_safe(il: &Il, interner: &Interner, call: NodeId) -> bool {
+    let kids = il.children(call);
+    if kids.len() != 2 {
+        return false;
+    }
+    if !var_named(il, interner, kids[0], "std::collections::HashMap::from")
+        && !var_named(il, interner, kids[0], "std::collections::BTreeMap::from")
+    {
+        return false;
+    }
+    literal_export_value_safe(il, interner, kids[1])
+}
+
+fn field_method_on_var<'a>(
+    il: &Il,
+    interner: &'a Interner,
+    node: NodeId,
+    receiver: &str,
+) -> Option<&'a str> {
+    if il.kind(node) != NodeKind::Field {
+        return None;
+    }
+    let Payload::Name(method) = il.node(node).payload else {
+        return None;
+    };
+    let receiver_node = il.children(node).first().copied()?;
+    var_named(il, interner, receiver_node, receiver).then(|| interner.resolve(method))
+}
+
+fn var_named(il: &Il, interner: &Interner, node: NodeId, expected: &str) -> bool {
+    if il.kind(node) != NodeKind::Var {
+        return false;
+    }
+    matches!(il.node(node).payload, Payload::Name(name) if interner.resolve(name) == expected)
+}
+
+fn file_defines_symbol(il: &Il, interner: &Interner, expected: &str) -> bool {
+    il.units.iter().any(|unit| {
+        unit.name
+            .is_some_and(|name| interner.resolve(name) == expected)
+    }) || collect_top_level_statements(il).into_iter().any(|stmt| {
+        assignment_name(il, stmt).is_some_and(|name| interner.resolve(name) == expected)
+    })
+}
+
+fn java_file_defines_type_name(il: &Il, interner: &Interner, expected: &str) -> bool {
+    il.units.iter().any(|unit| {
+        unit.kind == UnitKind::Class
+            && unit
+                .name
+                .is_some_and(|name| interner.resolve(name) == expected)
+    })
 }
 
 fn binding_mutated(il: &Il, interner: &Interner, name: Symbol, defining_stmt: NodeId) -> bool {
@@ -251,7 +436,17 @@ fn field_mutates_binding(il: &Il, interner: &Interner, field: NodeId, name: Symb
 fn mutating_method_name(method: &str) -> bool {
     matches!(
         method,
-        "clear" | "pop" | "popitem" | "setdefault" | "update"
+        "clear"
+            | "delete"
+            | "insert"
+            | "pop"
+            | "popitem"
+            | "put"
+            | "putAll"
+            | "remove"
+            | "set"
+            | "setdefault"
+            | "update"
     )
 }
 
@@ -270,34 +465,119 @@ fn node_contains_symbol(il: &Il, node: NodeId, name: Symbol) -> bool {
             .any(|&child| node_contains_symbol(il, child, name))
 }
 
-fn python_module_hashes(path: &str) -> Vec<u64> {
-    let path = Path::new(path);
-    if path.extension().and_then(|ext| ext.to_str()) != Some("py") {
+fn file_module_hashes(il: &Il) -> Vec<u64> {
+    match il.meta.lang {
+        Lang::Python => module_hashes_from_path(&il.meta.path, &["py"], ".", false, true),
+        Lang::JavaScript | Lang::TypeScript => module_hashes_from_path(
+            &il.meta.path,
+            &["js", "jsx", "mjs", "cjs", "ts", "tsx", "mts", "cts"],
+            "/",
+            true,
+            false,
+        ),
+        Lang::Java => module_hashes_from_path(&il.meta.path, &["java"], ".", false, false),
+        Lang::Rust => {
+            let mut hashes = module_hashes_from_path(&il.meta.path, &["rs"], "::", false, false);
+            for module in module_names_from_path(&il.meta.path, &["rs"], "::", false) {
+                hashes.push(stable_symbol_hash(&format!("crate::{module}")));
+                hashes.push(stable_symbol_hash(&format!("self::{module}")));
+            }
+            dedupe_hashes(hashes)
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn java_class_module_hashes(il: &Il, interner: &Interner, class_name: Symbol) -> Vec<u64> {
+    let class_name = interner.resolve(class_name);
+    let mut hashes = vec![stable_symbol_hash(class_name)];
+    if let Some(mut parts) = path_parts_without_extension(&il.meta.path, &["java"]) {
+        if let Some(last) = parts.last_mut() {
+            *last = class_name.to_string();
+        }
+        for module in suffix_module_names(&parts, ".") {
+            hashes.push(stable_symbol_hash(&module));
+        }
+    }
+    dedupe_hashes(hashes)
+}
+
+fn module_hashes_from_path(
+    path: &str,
+    extensions: &[&str],
+    separator: &str,
+    include_relative_dot: bool,
+    drop_python_init: bool,
+) -> Vec<u64> {
+    let hashes = module_names_from_path(path, extensions, separator, drop_python_init)
+        .into_iter()
+        .flat_map(|module| {
+            if include_relative_dot {
+                vec![
+                    stable_symbol_hash(&module),
+                    stable_symbol_hash(&format!("./{module}")),
+                ]
+            } else {
+                vec![stable_symbol_hash(&module)]
+            }
+        })
+        .collect::<Vec<_>>();
+    dedupe_hashes(hashes)
+}
+
+fn module_names_from_path(
+    path: &str,
+    extensions: &[&str],
+    separator: &str,
+    drop_python_init: bool,
+) -> Vec<String> {
+    let Some(mut parts) = path_parts_without_extension(path, extensions) else {
         return Vec::new();
+    };
+    if drop_python_init && parts.last().is_some_and(|part| part == "__init__") {
+        parts.pop();
+    }
+    suffix_module_names(&parts, separator)
+}
+
+fn path_parts_without_extension(path: &str, extensions: &[&str]) -> Option<Vec<String>> {
+    let path = Path::new(path);
+    let ext = path.extension().and_then(|ext| ext.to_str())?;
+    if !extensions.contains(&ext) {
+        return None;
     }
     let mut parts: Vec<String> = path
         .components()
         .filter_map(|component| component.as_os_str().to_str())
-        .filter(|part| !part.is_empty())
+        .filter(|part| !part.is_empty() && *part != "/")
         .map(ToOwned::to_owned)
         .collect();
-    let Some(last) = parts.last_mut() else {
-        return Vec::new();
-    };
-    if let Some(stripped) = last.strip_suffix(".py") {
-        *last = stripped.to_string();
-    }
-    if last == "__init__" {
-        parts.pop();
-    }
+    let last = parts.last_mut()?;
+    let stem = Path::new(last)
+        .file_stem()
+        .and_then(|stem| stem.to_str())?
+        .to_string();
+    *last = stem;
+    Some(parts)
+}
+
+fn suffix_module_names(parts: &[String], separator: &str) -> Vec<String> {
     let mut out = Vec::new();
     for start in 0..parts.len() {
-        let module = parts[start..].join(".");
+        let module = parts[start..].join(separator);
         if !module.is_empty() {
-            out.push(stable_symbol_hash(&module));
+            out.push(module);
         }
     }
     out
+}
+
+fn dedupe_hashes(hashes: Vec<u64>) -> Vec<u64> {
+    let mut seen = FxHashSet::default();
+    hashes
+        .into_iter()
+        .filter(|hash| seen.insert(*hash))
+        .collect()
 }
 
 fn snapshot_subtree(il: &Il, root: NodeId) -> SubtreeSnapshot {

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -61,8 +61,10 @@ graph, and canonicalizations actually model:
 - literal map-default lookup through proven map/key/fallback coordinates, including
   Python `dict.get(key, fallback)` and Ruby literal `Hash#fetch(key, fallback)` or
   zero-arg pure fallback blocks such as `Hash#fetch(key) { fallback }`, plus Python
-  sibling-module `from module import LOOKUP` literal bindings when the provider binding is
-  unique, immutable, and unambiguous;
+  sibling-module `from module import LOOKUP` literal bindings, JS/TS named imports from
+  sibling `Map` exports, Java static imports from class `Map.of` fields, and Rust
+  `use` imports of const entry arrays consumed by `HashMap::from`/`BTreeMap::from` when
+  the provider binding is unique, immutable, and unambiguous;
 - `filter q (filter p) ↔ filter (p∧q)` (and the filtered comprehension / `.filter().filter()`
   chain / filtered builder loop);
 - guard-clause ↔ nested-if, ternary ↔ early-return, min/max idioms, commutativity +

--- a/docs/type4-adversarial-coverage.md
+++ b/docs/type4-adversarial-coverage.md
@@ -131,10 +131,13 @@ proof-backed min/max compositions, two-comparison ternaries, and proven numeric
 library clamp methods share `Clamp(x, lo, hi)`. Name-only lower/upper conventions,
 method names without numeric receiver proof, non-exiting checks, swapped bounds,
 and float domains must stay hard negatives.
-For map-default import rules, resolve only unambiguous Python sibling-module literal
-exports today: the provider must have one immutable literal binding, and provider mutation,
-importer mutation, duplicate providers, shadowing, unresolved imports, and non-Python
-module bridges remain hard-negative or successor work.
+For map-default import rules, resolve only unambiguous static imported bindings whose
+provider has one safe immutable literal or proven map-factory binding. The covered import
+slice includes Python sibling literals, JS/TS named imports from sibling map exports, Java
+static imports from class `Map.of` fields, and Rust `use` imports of const entry arrays
+consumed by `HashMap::from`/`BTreeMap::from`. Provider mutation, importer mutation,
+duplicate providers, shadowing, unresolved imports, unsupported coordinates, and changed
+receiver maps remain fail-closed hard negatives or successor work.
 
 ## Adversarial Cases
 


### PR DESCRIPTION
## selected item

- `map_default.non_python_import_bridge`

## implementation summary

- Generalized corpus-level imported immutable binding resolution beyond Python-only files.
- Added conservative provider module hashes for JS/TS path imports, Java class/static imports, and Rust module `use` imports.
- Allowed only safe map-oriented provider RHS shapes: Python/JS object/array-style literals, JS/TS `new Map([...])`, Java `Map.of`/`Map.ofEntries`, and Rust std map factories/const entry arrays.
- Kept provider mutation, importer mutation, duplicate providers, shadowing, unresolved imports, and wrong-map coordinates fail-closed.

## matrix/rule/case/docs changes

- Marked `map_default.non_python_import_bridge` covered with focused corpus evidence.
- Updated `proof.collection_provenance` and `idiom.map_default_lookup` positive cases and boundaries.
- Added `map_default_imported_rust_const_literal` and populated JS/TS, Java, Rust fixture evidence.
- Added `bench/type4/adversarial/cases/map_default_non_python_import` with positive and hard-negative cases.
- Updated `docs/type4-adversarial-coverage.md` and `docs/clone-types.md`.

## Successor Audit

1. Closed gap: non-Python imported map-default provenance for JS/TS named map exports, Java static imported `Map.of` fields, and Rust imported const entry arrays.
2. Newly revealed gap: Rust const-entry import evidence was not a first-class case handle, so this PR adds `map_default_imported_rust_const_literal`.
3. Successor cell/rule/case added: added the Rust positive case and merged the implementation into existing `proof.collection_provenance`; no new matrix cell or rule was added.
4. Why existing matrix is enough: remaining unsupported coordinates, mutation, shadowing, duplicate providers, and wrong maps are already the stated fail-closed boundaries under `map_default.non_python_import_bridge` / `proof.collection_provenance`.

## gates run

- `bench/type4/adversarial/scripts/type4-check --item map_default.non_python_import_bridge`
- `bench/type4/adversarial/scripts/type4-check`
- `cargo test -p nose-cli --test equivalence map_default`
- `cargo run -p nose-cli -- verify --max-violations 0 bench/type4/adversarial/cases/map_default_non_python_import`
- `awiki lint --root docs`
- `./scripts/check-duplication.sh`
- `./scripts/check-ci-local.sh --fast`

## type4-next --limit 3

```text
ID: hof.filter_map.rich_option_shapes
Score: 353
Status: candidate
Action: survey

ID: hof.flat_map.filtered_aggregate_bridge
Score: 349
Status: candidate
Action: survey

ID: perf.value_graph.hof_budget
Score: 223
Status: perf-blocked
Action: performance
```
