### PR TITLE
type4: cover filtered flatmap aggregate predicates

### DIFF
--- a/bench/type4/adversarial/cases/cases.v1.json
+++ b/bench/type4/adversarial/cases/cases.v1.json
@@ -176,15 +176,39 @@
       "kind": "positive",
       "semantic_family": "hof.flat_map",
       "claim": "A filtered flat-map aggregate may converge with an equivalent nested guarded reduction when outer and inner predicates are preserved.",
-      "evidence": "Successor candidate; the current aggregate bridge intentionally covers pure inner Map FlatMap streams only."
+      "fixtures": [
+        "bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered_flat.py",
+        "bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered_loop.py",
+        "bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered.js",
+        "bench/type4/adversarial/cases/flat_map_aggregate/any_filtered_flat.py",
+        "bench/type4/adversarial/cases/flat_map_aggregate/any_filtered.js"
+      ],
+      "evidence": "Focused equivalence test converges Python filtered flat-map sum, Python nested guarded sum loop, JS filtered flatMap().reduce(), and JS method-terminal .some() with the equivalent Python filtered any generator."
     },
     {
       "id": "flat_map_aggregate_filter_predicate_change",
       "kind": "hard-negative",
       "semantic_family": "hof.flat_map",
       "claim": "Changing an outer or inner FlatMap aggregate predicate changes behavior.",
-      "mutation": "outer/inner filter predicate changed while contribution stays the same",
-      "evidence": "Successor boundary for hof.flat_map.filtered_aggregate_bridge."
+      "mutation": "outer/inner/terminal predicate changed to a static false predicate while contribution stays the same",
+      "fixtures": [
+        "bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered_outer_changed.py",
+        "bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered_inner_changed.py",
+        "bench/type4/adversarial/cases/flat_map_aggregate/any_filtered_terminal_changed.js"
+      ],
+      "evidence": "Focused equivalence test keeps static-false outer predicates, inner predicates, and method-terminal predicates distinct from the covered filtered FlatMap aggregate."
+    },
+    {
+      "id": "any_filtered_flat_map_early_return_loop",
+      "kind": "positive",
+      "semantic_family": "hof.flat_map",
+      "claim": "A filtered FlatMap any/existence aggregate may converge with the equivalent nested guarded early-return loop.",
+      "fixtures": [
+        "bench/type4/adversarial/cases/flat_map_aggregate/any_filtered_flat.py",
+        "bench/type4/adversarial/cases/flat_map_aggregate/any_filtered.js",
+        "bench/type4/adversarial/cases/flat_map_aggregate/any_filtered_loop.py"
+      ],
+      "evidence": "Successor audit from hof.flat_map.filtered_aggregate_bridge: Python filtered any generator and JS filtered flatMap().some() converge, but the equivalent nested guarded early-return loop remains under-merged."
     },
     {
       "id": "java_stream_flat_map_py_comp",

--- a/bench/type4/adversarial/cases/flat_map_aggregate/any_filtered.js
+++ b/bench/type4/adversarial/cases/flat_map_aggregate/any_filtered.js
@@ -1,0 +1,6 @@
+function anyFiltered(xs, ys) {
+  return xs
+    .filter((x) => x > 0)
+    .flatMap((x) => ys.filter((y) => y < 10).map((y) => x + y))
+    .some((v) => v > 0);
+}

--- a/bench/type4/adversarial/cases/flat_map_aggregate/any_filtered_flat.py
+++ b/bench/type4/adversarial/cases/flat_map_aggregate/any_filtered_flat.py
@@ -1,0 +1,2 @@
+def any_filtered_flat(xs, ys):
+    return any(x + y > 0 for x in xs if x > 0 for y in ys if y < 10)

--- a/bench/type4/adversarial/cases/flat_map_aggregate/any_filtered_loop.py
+++ b/bench/type4/adversarial/cases/flat_map_aggregate/any_filtered_loop.py
@@ -1,0 +1,7 @@
+def any_filtered_loop(xs, ys):
+    for x in xs:
+        if x > 0:
+            for y in ys:
+                if y < 10 and x + y > 0:
+                    return True
+    return False

--- a/bench/type4/adversarial/cases/flat_map_aggregate/any_filtered_terminal_changed.js
+++ b/bench/type4/adversarial/cases/flat_map_aggregate/any_filtered_terminal_changed.js
@@ -1,0 +1,6 @@
+function anyFilteredTerminalChanged(xs, ys) {
+  return xs
+    .filter((x) => x > 0)
+    .flatMap((x) => ys.filter((y) => y < 10).map((y) => x + y))
+    .some((v) => false);
+}

--- a/bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered.js
+++ b/bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered.js
@@ -1,0 +1,6 @@
+function sumFiltered(xs, ys) {
+  return xs
+    .filter((x) => x > 0)
+    .flatMap((x) => ys.filter((y) => y < 10).map((y) => x + y))
+    .reduce((a, v) => a + v, 0);
+}

--- a/bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered_flat.py
+++ b/bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered_flat.py
@@ -1,0 +1,2 @@
+def sum_filtered_flat(xs, ys):
+    return sum(x + y for x in xs if x > 0 for y in ys if y < 10)

--- a/bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered_inner_changed.py
+++ b/bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered_inner_changed.py
@@ -1,0 +1,2 @@
+def sum_filtered_inner_changed(xs, ys):
+    return sum(x + y for x in xs if x > 0 for y in ys if False)

--- a/bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered_loop.py
+++ b/bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered_loop.py
@@ -1,0 +1,8 @@
+def sum_filtered_loop(xs, ys):
+    total = 0
+    for x in xs:
+        if x > 0:
+            for y in ys:
+                if y < 10:
+                    total = total + x + y
+    return total

--- a/bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered_outer_changed.py
+++ b/bench/type4/adversarial/cases/flat_map_aggregate/sum_filtered_outer_changed.py
@@ -1,0 +1,2 @@
+def sum_filtered_outer_changed(xs, ys):
+    return sum(x + y for x in xs if False for y in ys if y < 10)

--- a/bench/type4/adversarial/coverage_matrix.v1.json
+++ b/bench/type4/adversarial/coverage_matrix.v1.json
@@ -77,7 +77,7 @@
       "rule_ids": ["hof.flat_map", "hof.aggregate_bridge", "oracle.hof.flat_map"],
       "positive_cases": ["sum_flat_map_nested_loop", "max_flat_map_nested_loop", "any_flat_map_nested_loop"],
       "adversarial_cases": ["sum_flat_map_wrong_seed", "sum_flat_map_nested_list", "any_flat_map_wrong_predicate", "flat_map_aggregate_outer_cardinality_boundary"],
-      "evidence": "Pure FlatMap aggregates now consume the emitted inner Map value explicitly instead of treating FlatMap's [outer, inner] args like filtered Map's [contrib, pred] layout. Nested reduction loops that carry an accumulator through an inner Reduce converge with sum/max/any flat-map generators and JS flatMap().reduce(); wrong seed, nested-list aggregation, changed any predicate, and outer-cardinality-dependent aggregates stay split. Successor audit: filtered/carry-predicate FlatMap aggregates and method terminal predicate forms remain separate frontier work.",
+      "evidence": "Pure FlatMap aggregates now consume the emitted inner Map value explicitly instead of treating FlatMap's [outer, inner] args like filtered Map's [contrib, pred] layout. Nested reduction loops that carry an accumulator through an inner Reduce converge with sum/max/any flat-map generators and JS flatMap().reduce(); wrong seed, nested-list aggregation, changed any predicate, and outer-cardinality-dependent aggregates stay split. Successor audit: filtered Sum/Reduce FlatMap aggregates and method terminal predicates are covered by hof.flat_map.filtered_aggregate_bridge; filtered nested early-return any/all loops remain separate frontier work.",
       "agent_task": "Monitor pure FlatMap aggregate consumers. Filtered FlatMap aggregate or terminal-method gaps should attach to hof.flat_map.filtered_aggregate_bridge.",
       "required_gates": [
         "bench/type4/adversarial/scripts/type4-check --item hof.flat_map.aggregate_bridge",
@@ -91,20 +91,41 @@
       "id": "hof.flat_map.filtered_aggregate_bridge",
       "semantic_family": "hof.flat_map",
       "title": "Filtered FlatMap aggregate consumers preserve carried predicates",
-      "status": "candidate",
-      "next_action": "survey",
-      "priority": 54,
+      "status": "covered",
+      "next_action": "monitor",
+      "priority": 0,
       "languages": ["python", "javascript", "rust"],
       "representations": ["filtered_flat_map_chain", "nested_guarded_reduction_loop", "method_terminal_predicate"],
       "rule_ids": ["hof.flat_map", "hof.aggregate_bridge", "oracle.hof.flat_map"],
       "positive_cases": ["sum_filtered_flat_map_nested_loop"],
       "adversarial_cases": ["flat_map_aggregate_filter_predicate_change", "flat_map_vs_nested_list"],
-      "evidence": "The covered aggregate bridge is intentionally limited to pure inner Map FlatMap streams. Aggregates where FlatMap carries an outer or inner filter predicate, or method terminals apply a fresh predicate to the flattened stream, still need focused reproduction before the bridge can widen.",
-      "agent_task": "Survey filtered flat-map aggregate consumers and add hard negatives for changed outer/inner predicates before broadening aggregate predicate handling.",
+      "evidence": "Filtered FlatMap Sum/Reduce consumers now carry outer and inner filter predicates into the reduction identity branch, so Python filtered flat-map sums converge with equivalent nested guarded reduction loops and JS filtered flatMap().reduce(). JS method-terminal .some() over a filtered FlatMap also converges with the equivalent Python filtered any generator while changed outer, inner, and terminal predicates stay split. Successor audit: filtered nested early-return any/all loops remain under-merged and are tracked by hof.flat_map.filtered_any_early_return_loop.",
+      "agent_task": "Monitor filtered FlatMap aggregate consumers. Predicate-carrying Sum/Reduce and method-terminal Any/All are covered; nested early-return existence loops should attach to hof.flat_map.filtered_any_early_return_loop.",
       "required_gates": [
         "bench/type4/adversarial/scripts/type4-check --item hof.flat_map.filtered_aggregate_bridge",
         "cargo test -p nose-cli --test equivalence flat_map",
-        "cargo run -p nose-cli -- verify --max-violations 0 <focused-filtered-flatmap-aggregate-corpus>"
+        "cargo run -p nose-cli -- verify --max-violations 0 bench/type4/adversarial/cases/flat_map_aggregate"
+      ],
+      "docs": ["docs/type4-adversarial-coverage.md", "docs/normalization.md"]
+    },
+    {
+      "id": "hof.flat_map.filtered_any_early_return_loop",
+      "semantic_family": "hof.flat_map",
+      "title": "Filtered FlatMap any loops converge with method/generator aggregates",
+      "status": "under-merged",
+      "next_action": "engine",
+      "priority": 57,
+      "languages": ["python", "javascript"],
+      "representations": ["filtered_flat_map_generator", "nested_guarded_early_return_loop", "method_terminal_predicate"],
+      "rule_ids": ["hof.flat_map", "hof.aggregate_bridge", "oracle.hof.flat_map"],
+      "positive_cases": ["any_filtered_flat_map_early_return_loop"],
+      "adversarial_cases": ["flat_map_aggregate_filter_predicate_change", "flat_map_vs_nested_list"],
+      "evidence": "Successor audit from hof.flat_map.filtered_aggregate_bridge: Python filtered any generator and JS filtered flatMap().some() converge, but the equivalent Python nested guarded early-return loop remains split because existence-loop reduction does not yet normalize stacked FlatMap filter guards into the same method-terminal predicate shape.",
+      "agent_task": "Extend existence-loop/any-all normalization for nested filtered FlatMap early-return loops without dropping outer or inner filter predicates; keep changed predicate and nested-list hard negatives split.",
+      "required_gates": [
+        "bench/type4/adversarial/scripts/type4-check --item hof.flat_map.filtered_any_early_return_loop",
+        "cargo test -p nose-cli --test equivalence flat_map",
+        "cargo run -p nose-cli -- verify --max-violations 0 bench/type4/adversarial/cases/flat_map_aggregate"
       ],
       "docs": ["docs/type4-adversarial-coverage.md", "docs/normalization.md"]
     },

--- a/bench/type4/adversarial/rule_registry.v1.json
+++ b/bench/type4/adversarial/rule_registry.v1.json
@@ -46,9 +46,9 @@
       "status": "landed",
       "summary": "Aggregate consumers read pure FlatMap emitted values without confusing FlatMap and filtered Map argument layouts.",
       "implementation": ["crates/nose-normalize/src/value_graph.rs"],
-      "positive_cases": ["sum_flat_map_nested_loop", "max_flat_map_nested_loop", "any_flat_map_nested_loop", "sum_filtered_flat_map_nested_loop"],
+      "positive_cases": ["sum_flat_map_nested_loop", "max_flat_map_nested_loop", "any_flat_map_nested_loop", "sum_filtered_flat_map_nested_loop", "any_filtered_flat_map_early_return_loop"],
       "hard_negatives": ["sum_flat_map_wrong_seed", "sum_flat_map_nested_list", "any_flat_map_wrong_predicate", "flat_map_aggregate_outer_cardinality_boundary", "flat_map_aggregate_filter_predicate_change"],
-      "boundaries": ["Map and FlatMap argument layouts are different; aggregate code must match the HoF kind explicitly.", "The landed bridge covers pure inner Map FlatMap streams and nested inner Reduce loops only when the emitted contribution depends on the outer element.", "Filtered/carry-predicate FlatMap aggregates and method terminal predicate forms remain successor work."],
+      "boundaries": ["Map and FlatMap argument layouts are different; aggregate code must match the HoF kind explicitly.", "The landed bridge covers pure inner Map FlatMap streams, filtered Sum/Reduce FlatMap streams, and method-terminal Any/All predicates over filtered FlatMap streams when the emitted contribution depends on the outer element.", "Filtered nested early-return any/all loops and outer-ignored FlatMap aggregates remain successor work."],
       "docs": ["docs/type4-adversarial-coverage.md", "docs/normalization.md"]
     },
     {

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -1854,6 +1854,46 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
         "def h(xs, ys):\n    return sum(y for y in ys)\n",
         Lang::Python,
     );
+    let filtered_sum_gen = value_fp(
+        &i,
+        "def f(xs, ys):\n    return sum(x + y for x in xs if x > 0 for y in ys if y < 10)\n",
+        Lang::Python,
+    );
+    let filtered_sum_loop = value_fp(
+        &i,
+        "def g(xs, ys):\n    total = 0\n    for x in xs:\n        if x > 0:\n            for y in ys:\n                if y < 10:\n                    total = total + x + y\n    return total\n",
+        Lang::Python,
+    );
+    let filtered_sum_js = value_fp(
+        &i,
+        "function h(xs, ys){ return xs.filter(x => x > 0).flatMap(x => ys.filter(y => y < 10).map(y => x + y)).reduce((a, v) => a + v, 0); }",
+        Lang::JavaScript,
+    );
+    let filtered_sum_outer_changed = value_fp(
+        &i,
+        "def bad(xs, ys):\n    return sum(x + y for x in xs if False for y in ys if y < 10)\n",
+        Lang::Python,
+    );
+    let filtered_sum_inner_changed = value_fp(
+        &i,
+        "def bad(xs, ys):\n    return sum(x + y for x in xs if x > 0 for y in ys if False)\n",
+        Lang::Python,
+    );
+    let filtered_any_gen = value_fp(
+        &i,
+        "def f(xs, ys):\n    return any(x + y > 0 for x in xs if x > 0 for y in ys if y < 10)\n",
+        Lang::Python,
+    );
+    let filtered_any_js = value_fp(
+        &i,
+        "function h(xs, ys){ return xs.filter(x => x > 0).flatMap(x => ys.filter(y => y < 10).map(y => x + y)).some(v => v > 0); }",
+        Lang::JavaScript,
+    );
+    let filtered_any_terminal_changed = value_fp(
+        &i,
+        "function h(xs, ys){ return xs.filter(x => x > 0).flatMap(x => ys.filter(y => y < 10).map(y => x + y)).some(v => false); }",
+        Lang::JavaScript,
+    );
 
     assert_eq!(
         sum_gen, sum_loop,
@@ -1890,6 +1930,30 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
     assert_ne!(
         outer_independent_loop, direct_inner_sum,
         "a nested loop that ignores the outer value still depends on outer cardinality"
+    );
+    assert_eq!(
+        filtered_sum_gen, filtered_sum_loop,
+        "filtered flat-map sums should match equivalent nested guarded reductions"
+    );
+    assert_eq!(
+        filtered_sum_gen, filtered_sum_js,
+        "filtered flatMap().reduce() should preserve carried outer and inner predicates"
+    );
+    assert_ne!(
+        filtered_sum_gen, filtered_sum_outer_changed,
+        "changing the outer flat-map aggregate predicate changes behavior"
+    );
+    assert_ne!(
+        filtered_sum_gen, filtered_sum_inner_changed,
+        "changing the inner flat-map aggregate predicate changes behavior"
+    );
+    assert_eq!(
+        filtered_any_gen, filtered_any_js,
+        "method terminal predicates over filtered flatMap should preserve carried predicates"
+    );
+    assert_ne!(
+        filtered_any_gen, filtered_any_terminal_changed,
+        "changing the terminal method predicate changes behavior"
     );
 }
 

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -1848,6 +1848,10 @@ impl<'a> Builder<'a> {
                 if let Some(v) = self.value_default_pattern(args[0], args[1], args[2]) {
                     return v;
                 }
+                if let Some(v) = self.flatten_nested_guarded_identity_phi(args[0], args[1], args[2])
+                {
+                    return v;
+                }
             }
         }
         // Full ASSOCIATIVE-COMMUTATIVE canonicalization: flatten a `+`/`*`/`&`/`|`/`^`
@@ -1899,6 +1903,23 @@ impl<'a> Builder<'a> {
         self.vty.push(ty);
         self.intern.insert(key, id);
         id
+    }
+
+    fn flatten_nested_guarded_identity_phi(
+        &mut self,
+        cond: ValueId,
+        then_v: ValueId,
+        else_v: ValueId,
+    ) -> Option<ValueId> {
+        let inner_args = {
+            let inner = &self.nodes[then_v as usize];
+            if !matches!(inner.op, ValOp::Phi) || inner.args.len() != 3 || inner.args[2] != else_v {
+                return None;
+            }
+            inner.args.clone()
+        };
+        let both = self.mk(ValOp::Bin(Op::And as u32), vec![cond, inner_args[0]]);
+        Some(self.mk(ValOp::Phi, vec![both, inner_args[1], else_v]))
     }
 
     fn intern_ac_chain(&mut self, opc: u32, operands: &[ValueId]) -> ValueId {
@@ -4391,7 +4412,10 @@ impl<'a> Builder<'a> {
             let args = self.nodes[val as usize].args.clone();
             if args.len() == 3 && args[2] == loopv {
                 // (a) guarded accumulation: `if cond { acc = acc ⊕ contrib }`.
-                if let Some((op, contrib)) = self.as_reduction_cached(args[1], loopv, cache) {
+                if let Some((op, contrib)) = self
+                    .as_reduction_cached(args[1], loopv, cache)
+                    .or_else(|| self.nested_reduce_step(args[1], loopv, cache))
+                {
                     if let Some(id) = identity_of(op) {
                         let ident = self.int_const(id);
                         let guarded = self.mk(ValOp::Phi, vec![args[0], contrib, ident]);
@@ -4415,7 +4439,10 @@ impl<'a> Builder<'a> {
             // it with the negated guard so it converges with the loop form `if v>0:
             // acc+=v` (whose single-branch guard stays positive).
             if args.len() == 3 && args[1] == loopv {
-                if let Some((op, contrib)) = self.as_reduction_cached(args[2], loopv, cache) {
+                if let Some((op, contrib)) = self
+                    .as_reduction_cached(args[2], loopv, cache)
+                    .or_else(|| self.nested_reduce_step(args[2], loopv, cache))
+                {
                     if let Some(id) = identity_of(op) {
                         let ident = self.int_const(id);
                         let ncond = self.negate_guard(args[0]);
@@ -4490,6 +4517,22 @@ impl<'a> Builder<'a> {
             acc = self.mk(ValOp::Bin(op), vec![acc, o]);
         }
         Some((op, acc))
+    }
+
+    fn nested_reduce_step(
+        &mut self,
+        val: ValueId,
+        loopv: ValueId,
+        cache: &mut ReductionCache,
+    ) -> Option<(u32, ValueId)> {
+        let ValOp::Reduce(op) = self.nodes[val as usize].op else {
+            return None;
+        };
+        let args = self.nodes[val as usize].args.clone();
+        if args.len() == 2 && args[0] == loopv && !self.references_cached(args[1], loopv, cache) {
+            return Some((op, args[1]));
+        }
+        None
     }
 
     /// The canonical negation of a guard value: a comparison flips to its complement
@@ -5017,10 +5060,26 @@ impl<'a> Builder<'a> {
         if let Some(value) = self.hof_emitted_elem(coll) {
             return value;
         }
-        self.mk(ValOp::Elem(self.vhash[coll as usize]), vec![coll])
+        self.raw_elem(coll)
     }
 
     fn hof_emitted_elem(&mut self, coll: ValueId) -> Option<ValueId> {
+        let (emitted, predicate) = self.hof_emitted_elem_with_pred(coll)?;
+        predicate.is_none().then_some(emitted)
+    }
+
+    fn raw_elem(&mut self, coll: ValueId) -> ValueId {
+        self.mk(ValOp::Elem(self.vhash[coll as usize]), vec![coll])
+    }
+
+    fn collection_elem_with_pred(&mut self, coll: ValueId) -> (ValueId, Option<ValueId>) {
+        if let Some(parts) = self.hof_emitted_elem_with_pred(coll) {
+            return parts;
+        }
+        (self.raw_elem(coll), None)
+    }
+
+    fn hof_emitted_elem_with_pred(&mut self, coll: ValueId) -> Option<(ValueId, Option<ValueId>)> {
         // FUNCTOR LAW / map fusion: an element drawn from `map(f, c)` is `f` applied to an
         // element of `c`, and a pure Map node's `contrib` (args[0]) already *is* that
         // per-element value. So `Elem(Map(f, c)) -> contrib`, which fuses nested maps:
@@ -5037,10 +5096,23 @@ impl<'a> Builder<'a> {
             (n.op.clone(), n.args.clone())
         };
         match op {
-            ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() == 1 => Some(args[0]),
-            ValOp::Hof(k) if k == HoFKind::FlatMap as u32 && args.len() == 2 => self
-                .hof_emitted_elem(args[1])
-                .filter(|&emitted| self.references(emitted, args[0])),
+            ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() == 1 => Some((args[0], None)),
+            ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() == 2 => {
+                Some((args[0], Some(args[1])))
+            }
+            ValOp::Hof(k)
+                if k == HoFKind::FlatMap as u32 && (args.len() == 2 || args.len() == 3) =>
+            {
+                let outer = args[0];
+                let inner = args[1];
+                let outer_predicate = args.get(2).copied();
+                let (emitted, inner_predicate) = self.hof_emitted_elem_with_pred(inner)?;
+                if !self.references(emitted, outer) {
+                    return None;
+                }
+                let predicate = self.and_preds(outer_predicate, inner_predicate);
+                Some((emitted, predicate))
+            }
             _ => None,
         }
     }
@@ -5133,20 +5205,16 @@ impl<'a> Builder<'a> {
             }
             Builtin::Sum => {
                 let av = self.eval(*kids.first()?, env);
-                // `sum(map)` → the mapped stream's per-element contribution; a *filtered*
-                // map `Hof(Map, [contrib, pred])` → `pred ? contrib : 0`, matching a
-                // guarded loop `if pred: acc += contrib`; `sum(xs)` → the raw element.
-                let (op, args) = {
-                    let n = &self.nodes[av as usize];
-                    (n.op.clone(), n.args.clone())
-                };
-                let contrib = match op {
-                    ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() >= 2 => {
-                        let zero = self.int_const(0);
-                        self.mk(ValOp::Phi, vec![args[1], args[0], zero])
-                    }
-                    ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() == 1 => args[0],
-                    _ => self.elem(av),
+                // `sum(map)` → the mapped stream's per-element contribution; a filtered
+                // map/flat-map carries a predicate and becomes `pred ? contrib : 0`,
+                // matching a guarded loop `if pred: acc += contrib`; `sum(xs)` → the raw
+                // element.
+                let zero = self.int_const(0);
+                let (contrib, predicate) = self.collection_elem_with_pred(av);
+                let contrib = if let Some(predicate) = predicate {
+                    self.mk(ValOp::Phi, vec![predicate, contrib, zero])
+                } else {
+                    contrib
                 };
                 let init = self.int_const(0);
                 Some(self.mk(ValOp::Reduce(Op::Add as u32), vec![init, contrib]))
@@ -5162,7 +5230,7 @@ impl<'a> Builder<'a> {
                     let guard = self.eval_lambda_body(predicate, &[elem], env)?;
                     (vec![elem], Some(guard))
                 } else {
-                    (self.elem_bindings(kids.get(1).copied(), env), None)
+                    self.elem_bindings_with_pred(kids.get(1).copied(), env)
                 };
                 let acc = self.fresh_opaque();
                 let mut params = Vec::with_capacity(elems.len() + 1);
@@ -5224,9 +5292,12 @@ impl<'a> Builder<'a> {
                 // predicate, guarded by the OR/AND identity (false for any, true for all).
                 let contrib = if kids.len() >= 2 && self.il.kind(kids[1]) == NodeKind::Lambda {
                     let coll = self.eval(kids[0], env);
-                    let elem = self.elem(coll);
+                    let (elem, carried_guard) = self.collection_elem_with_pred(coll);
                     let pred = self.eval_lambda_body(kids[1], &[elem], env)?;
-                    if code == REDUCE_ANY && self.is_static_non_float_collection_expr(kids[0]) {
+                    if carried_guard.is_none()
+                        && code == REDUCE_ANY
+                        && self.is_static_non_float_collection_expr(kids[0])
+                    {
                         if let Some((element, collection)) =
                             self.static_literal_membership_predicate(pred)
                         {
@@ -5235,7 +5306,10 @@ impl<'a> Builder<'a> {
                             );
                         }
                     }
-                    if code == REDUCE_ALL && self.is_static_non_float_collection_expr(kids[0]) {
+                    if carried_guard.is_none()
+                        && code == REDUCE_ALL
+                        && self.is_static_non_float_collection_expr(kids[0])
+                    {
                         if let Some((element, collection)) =
                             self.static_literal_absence_predicate(pred)
                         {
@@ -5244,21 +5318,20 @@ impl<'a> Builder<'a> {
                             return Some(self.mk(ValOp::Un(Op::Not as u32), vec![membership]));
                         }
                     }
-                    pred
+                    if let Some(carried_guard) = carried_guard {
+                        let ident = self.mk(ValOp::Const(0x3000_0001 + code - REDUCE_ANY), vec![]);
+                        self.mk(ValOp::Phi, vec![carried_guard, pred, ident])
+                    } else {
+                        pred
+                    }
                 } else {
                     let av = self.eval(*kids.first()?, env);
-                    let (op, args) = {
-                        let n = &self.nodes[av as usize];
-                        (n.op.clone(), n.args.clone())
-                    };
-                    match op {
-                        ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() >= 2 => {
-                            let ident =
-                                self.mk(ValOp::Const(0x3000_0001 + code - REDUCE_ANY), vec![]);
-                            self.mk(ValOp::Phi, vec![args[1], args[0], ident])
-                        }
-                        ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() == 1 => args[0],
-                        _ => self.elem(av),
+                    let (contrib, predicate) = self.collection_elem_with_pred(av);
+                    if let Some(predicate) = predicate {
+                        let ident = self.mk(ValOp::Const(0x3000_0001 + code - REDUCE_ANY), vec![]);
+                        self.mk(ValOp::Phi, vec![predicate, contrib, ident])
+                    } else {
+                        contrib
                     }
                 };
                 Some(self.mk(ValOp::Reduce(code), vec![contrib]))
@@ -5967,8 +6040,16 @@ impl<'a> Builder<'a> {
         coll_node: Option<NodeId>,
         env: &FxHashMap<u32, ValueId>,
     ) -> Vec<ValueId> {
+        self.elem_bindings_with_pred(coll_node, env).0
+    }
+
+    fn elem_bindings_with_pred(
+        &mut self,
+        coll_node: Option<NodeId>,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> (Vec<ValueId>, Option<ValueId>) {
         let Some(c) = coll_node else {
-            return Vec::new();
+            return (Vec::new(), None);
         };
         if self.il.kind(c) == NodeKind::Call
             && matches!(self.il.node(c).payload, Payload::Builtin(Builtin::Zip))
@@ -5978,10 +6059,11 @@ impl<'a> Builder<'a> {
                 let v = self.eval(k, env);
                 out.push(self.elem(v));
             }
-            return out;
+            return (out, None);
         }
         let cv = self.eval(c, env);
-        vec![self.elem(cv)]
+        let (elem, predicate) = self.collection_elem_with_pred(cv);
+        (vec![elem], predicate)
     }
 
     /// Evaluate a lambda's body with its positional parameters bound to `params`,

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -24,8 +24,9 @@
 > sum/max/any over flat-map streams versus nested reduction loops when the contribution
 > uses the outer element (kept distinct from nested-list comprehensions, Java stream
 > `map` returning streams, wrong reduction seeds, outer-cardinality-only cases, and
-> changed flattened predicates; filtered/carry-predicate FlatMap aggregates remain
-> successor work), full **AC flatten+sort in the value graph itself** (not
+> changed flattened predicates; filtered Sum/Reduce FlatMap aggregates and method-terminal
+> Any/All predicates preserve carried outer/inner predicates, while filtered nested
+> early-return any/all loops remain successor work), full **AC flatten+sort in the value graph itself** (not
 > only the `algebra` IL pass), **distribution/factoring** `a*c+b*c→(a+b)*c` (Num-gated),
 > min/max and any/all reductions (cross-language), simple **flag+break existence/universal
 > loops** (`found=false; if p { found=true; break }` / the dual `all` form),

--- a/docs/type4-adversarial-coverage.md
+++ b/docs/type4-adversarial-coverage.md
@@ -127,7 +127,9 @@ layout: pure `FlatMap[outer, Map[contrib]]` streams and equivalent nested inner
 element, but the bridge must not read FlatMap's `[outer, inner]` arguments as
 filtered Map's `[contrib, pred]`. Wrong sum seeds, nested-list aggregation,
 outer-cardinality-only cases, and changed flattened predicates remain hard
-negatives; filtered/carry-predicate FlatMap aggregates are successor work.
+negatives; filtered Sum/Reduce FlatMap aggregates and method-terminal Any/All
+predicates preserve carried outer/inner predicates, while filtered nested
+early-return any/all loops remain successor work.
 For numeric clamp rules, require a concrete integer-domain and `lo <= hi` proof;
 proof-backed min/max compositions, two-comparison ternaries, and proven numeric
 library clamp methods share `Clamp(x, lo, hi)`. Name-only lower/upper conventions,


### PR DESCRIPTION
## Selected item

- `hof.flat_map.filtered_aggregate_bridge`

## Implementation summary

- Carry filtered FlatMap predicates into aggregate consumers instead of peeling filtered collection elements unguarded.
- Normalize filtered `Sum`/`Reduce` contributions as guarded identity `Phi` values, including nested guarded loop reductions.
- Bridge method-terminal `Any`/`All` consumers over filtered FlatMap emitted values while keeping changed terminal predicates split.
- Keep filtered collection `Elem(...)` fail-closed when there is no predicate-aware consumer.

## Matrix/rule/case/docs changes

- Marked `hof.flat_map.filtered_aggregate_bridge` covered with updated evidence and focused verify corpus gate.
- Added successor cell `hof.flat_map.filtered_any_early_return_loop` for nested guarded early-return any/all loops.
- Added filtered FlatMap sum/any positive and hard-negative fixtures under `bench/type4/adversarial/cases/flat_map_aggregate`.
- Updated `cases.v1.json`, `rule_registry.v1.json`, and docs in `docs/type4-adversarial-coverage.md` and `docs/normalization.md`.

## Successor Audit

1. Closed gap: filtered FlatMap aggregate consumers now preserve carried outer/inner predicates for Python filtered sums, equivalent nested guarded sum loops, JS `flatMap(...).reduce(...)`, and JS/Python method/generator any shapes.
2. Newly exposed gap: the equivalent Python nested guarded early-return any loop still under-merges against the filtered generator/method-terminal shape.
3. Successor added: yes, `hof.flat_map.filtered_any_early_return_loop`, with positive case `any_filtered_flat_map_early_return_loop` and existing hard negatives for predicate changes and nested-list boundaries.
4. Existing matrix alone was not sufficient because the early-return loop gap is a distinct existence-loop normalization frontier, so it is tracked as a new successor cell.

## Gates run

- `bench/type4/adversarial/scripts/type4-check --item hof.flat_map.filtered_aggregate_bridge`
- `bench/type4/adversarial/scripts/type4-check`
- `cargo test -p nose-cli --test equivalence flat_map`
- `cargo run -p nose-cli -- verify --max-violations 0 bench/type4/adversarial/cases/flat_map_aggregate`
- `cargo run -p nose-cli -- scan bench/type4/adversarial/cases/flat_map_aggregate --mode semantic --min-lines 1 --min-size 1 --format json --top 0`
- `awiki lint --root docs`
- `./scripts/check-ci-local.sh --fast`

## `type4-next --limit 3`

```text
ID: hof.flat_map.filtered_any_early_return_loop
Score: 647
Status: under-merged
Action: engine

ID: perf.value_graph.hof_budget
Score: 223
Status: perf-blocked
Action: performance
```
