### PR TITLE
formal: backfill Lean obligations for async .then + pure inline (close gate gap)

### DIFF
--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -2556,6 +2556,7 @@ impl<'a> Builder<'a> {
     /// function, so `f(args)` ≡ the function's body with `args` substituted (the extract-method /
     /// interprocedural-summary equivalence). Returns `None` for non-direct calls, unknown/
     /// ambiguous callees, or arity mismatch — leaving the opaque-call fallback to run.
+    // proof-obligation: normalize.value_graph.pure_inline
     fn eval_inlined_call(
         &mut self,
         kids: &[NodeId],
@@ -6385,6 +6386,7 @@ impl<'a> Builder<'a> {
     /// two-argument `.then(onOk, onErr)`, and `.catch`/`.finally` (error/cleanup continuations
     /// whose parameter is the error, not the resolved value) are left opaque. Promises wrap
     /// external async values, so this is a NEAR-channel recall extension, never an exact merge.
+    // proof-obligation: normalize.value_graph.promise_then
     fn eval_promise_then(
         &mut self,
         expr: NodeId,

--- a/formal/obligations/normalize/value_graph/promise_then/Proof.lean
+++ b/formal/obligations/normalize/value_graph/promise_then/Proof.lean
@@ -1,0 +1,34 @@
+/-
+Soundness of nose's Promise `.then` continuation canonicalization.
+
+The value graph already strips `await e` to its operand `e`, i.e. it models a *settled* Promise
+by its resolved value (an eager / identity-monad model — sound for clone detection, where the
+two forms compute the same result and the scheduling difference is irrelevant). Under that model
+`p.then(λr. body r)` is just the continuation applied to the resolved value, which is exactly
+what `let r = await p; body r` computes. So the value graph beta-reduces the `.then` callback
+over the receiver (`eval_promise_then`), and a `.then`-chain is the nested await composition.
+
+This file proves those two equalities for the model. Self-contained; checked by the formal
+obligation CI gate.
+-/
+
+namespace NosePromiseThen
+
+/-- `await p` on a settled promise: the value graph models a settled `Promise α` by its resolved
+    value `α`, so awaiting is the identity. -/
+def awaitP (p : α) : α := p
+
+/-- `p.then(f)` on a settled promise: run the continuation on the resolved value. -/
+def thenP (p : α) (f : α → β) : β := f p
+
+/-- The rewrite `eval_promise_then` performs: `p.then(λr. body r)` ≡ `let r = await p; body r`.
+    Beta-reducing the callback over the receiver is meaning-preserving. -/
+theorem then_eq_await_bind (p : α) (f : α → β) : thenP p f = f (awaitP p) := rfl
+
+/-- A `.then`-chain is the nested sequential composition of the continuations — so
+    `p.then(f).then(g)` converges with `let r = await p; let s = await f(r); g(s)`. This is why
+    chains reduce recursively (evaluating the receiver triggers the inner `.then`). -/
+theorem then_chain (p : α) (f : α → β) (g : β → γ) :
+    thenP (thenP p f) g = thenP p (fun r => g (f r)) := rfl
+
+end NosePromiseThen

--- a/formal/obligations/normalize/value_graph/promise_then/meta.toml
+++ b/formal/obligations/normalize/value_graph/promise_then/meta.toml
@@ -1,0 +1,16 @@
+id = "normalize.value_graph.promise_then"
+status = "proven"
+kind = "soundness"
+summary = "A settled Promise is modeled by its resolved value (the value graph strips `await` to its operand), so `p.then(λr. body r)` is the continuation applied to that value — `let r = await p; body r`. Beta-reducing the `.then` callback over the receiver is therefore meaning-preserving, and a `.then`-chain equals the nested sequential-await composition."
+
+[rust]
+files = ["crates/nose-normalize/src/value_graph.rs"]
+symbols = ["eval_promise_then"]
+markers = ["normalize.value_graph.promise_then"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NosePromiseThen.then_eq_await_bind",
+  "NosePromiseThen.then_chain",
+]

--- a/formal/obligations/normalize/value_graph/pure_inline/Proof.lean
+++ b/formal/obligations/normalize/value_graph/pure_inline/Proof.lean
@@ -1,0 +1,37 @@
+/-
+Soundness of nose's interprocedural pure-inline canonicalization.
+
+The value graph inlines a call `f(args)` to a PURE, file-local, single-`return` function by
+binding the parameters to the (caller-evaluated) arguments and evaluating the function's return
+expression (`eval_inlined_call`). This is beta-substitution. Soundness rests on the function
+being EFFECT-FREE: the Rust gate admits only a lone `return <expr>` that is
+`function_binding_safe` (no loops, throws, lambdas, user calls, or — because there is no second
+statement — field/index writes), so an effect-free function is modeled here as a total
+mathematical function `body : α → β`, and its observable result is exactly `body arg`.
+
+This file proves that beta-substitution is meaning-preserving for such a function (the inlined
+value equals the call's value), in the single- and two-argument forms, and that inlining a helper
+into a caller equals inlining the composed whole. Self-contained; checked by the formal
+obligation CI gate.
+-/
+
+namespace NosePureInline
+
+/-- A pure single-`return` function is modeled by its body, a total function `body : α → β`.
+    Calling it is applying the body; inlining substitutes the argument into the body. -/
+def callP (body : α → β) (arg : α) : β := body arg
+
+/-- BETA: inlining `f(arg)` to `body arg` is exactly the call's value — substitution preserves
+    meaning for an effect-free function. -/
+theorem inline_beta (body : α → β) (arg : α) : callP body arg = body arg := rfl
+
+/-- Positional binding for a two-parameter helper: each parameter is bound to its argument. -/
+theorem inline_beta2 (body : α → β → γ) (a : α) (b : β) :
+    (fun x y => body x y) a b = body a b := rfl
+
+/-- Inlining a pure helper `f` into a caller `g(f(arg))` equals inlining the composed whole — so
+    the caller converges with the same logic written inline (the extract-method equivalence). -/
+theorem inline_compose (g : β → γ) (f : α → β) (arg : α) :
+    g (callP f arg) = (fun x => g (f x)) arg := rfl
+
+end NosePureInline

--- a/formal/obligations/normalize/value_graph/pure_inline/meta.toml
+++ b/formal/obligations/normalize/value_graph/pure_inline/meta.toml
@@ -1,0 +1,17 @@
+id = "normalize.value_graph.pure_inline"
+status = "proven"
+kind = "soundness"
+summary = "Inlining a call to a PURE, single-`return` function is beta-substitution: `f(args)` ≡ the function's body with the parameters bound to the arguments. For an effect-free function (modeled as a total mathematical function) this preserves meaning — nothing observable is dropped — so the interprocedural inline (`eval_inlined_call`) is sound. The Rust side enforces the effect-free precondition (a lone `return <expr>` that is `function_binding_safe`), which is why only a pure body may be inlined."
+
+[rust]
+files = ["crates/nose-normalize/src/value_graph.rs"]
+symbols = ["eval_inlined_call"]
+markers = ["normalize.value_graph.pure_inline"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NosePureInline.inline_beta",
+  "NosePureInline.inline_beta2",
+  "NosePureInline.inline_compose",
+]

--- a/scripts/check-formal-obligations.py
+++ b/scripts/check-formal-obligations.py
@@ -102,6 +102,20 @@ REQUIRED_OBLIGATIONS = (
         ("crates/nose-normalize/src/lib.rs",),
         ("NormalizeOptions", "oracle", "recursion::run"),
     ),
+    # Semantic canons that live INLINE in value_graph.rs (not in the `value_graph/rules/`
+    # directory the RULE_ROOTS convention auto-requires) — registered here so the gate enforces
+    # their Lean evidence and marker exactly like a rule module. Without this, a canon added
+    # inline carries no proof obligation and the gate stays silent (the gap this PR closes).
+    RequiredObligation(
+        "normalize.value_graph.promise_then",
+        ("crates/nose-normalize/src/value_graph.rs",),
+        ("eval_promise_then",),
+    ),
+    RequiredObligation(
+        "normalize.value_graph.pure_inline",
+        ("crates/nose-normalize/src/value_graph.rs",),
+        ("eval_inlined_call",),
+    ),
 )
 
 


### PR DESCRIPTION
PR #82 introduced two semantic canonicalizations (Promise `.then` continuation, interprocedural pure inline) without the Lean evidence the project's discipline requires. This backfills both and closes the enforcement gap that let them slip.

## Obligations added (both `proven`, Lean compiles in CI)
- **`normalize.value_graph.promise_then`** — a settled Promise is modeled by its resolved value (the value graph strips `await`), so `p.then(λr. body)` ≡ `let r = await p; body` and a `.then`-chain is the nested await composition. Theorems `then_eq_await_bind`, `then_chain`.
- **`normalize.value_graph.pure_inline`** — inlining a pure single-`return` function is meaning-preserving β-substitution (`f(args)` ≡ body with params bound). Theorems `inline_beta`, `inline_beta2`, `inline_compose`. The effect-free precondition is enforced Rust-side (lone `return` + `function_binding_safe`).

## Why they were missed — and the fix
The obligation gate auto-requires Lean evidence only for (a) rule modules under `value_graph/rules/` (a directory-shaped convention) and (b) a hardcoded `REQUIRED_OBLIGATIONS` list. **Both new canons live INLINE in `value_graph.rs`**, so neither path required them; and the marker lint only validates markers that *exist* (marker → obligation), so it can't detect a canon that *should* have one. Registering both in `REQUIRED_OBLIGATIONS` (with their symbols + markers) makes the gate enforce their proof + marker exactly like a rule module going forward.

Validated: `check-formal-obligations.py` passes (21 obligations); `check-lean-proofs.sh` compiles all proofs incl. the two new; markers added at `eval_promise_then` / `eval_inlined_call`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)