### PR TITLE
formal: de-ceremony the proof-obligation gate (drop redundant marker + markers field)

### DIFF
--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -18,6 +18,13 @@
 //! This is a *detection substrate*, not an IL rewrite: it returns a fingerprint
 //! the detector can use instead of (or alongside) subtree shapes.
 //!
+//! CONVENTION: a meaning-preserving *canonicalization* (a value rewrite) needs Lean evidence.
+//! Name it `canonicalize_*` and list it in an obligation's `[rust].symbols` — the formal
+//! obligation gate (`scripts/check-formal-obligations.py`) ENFORCES that every `canonicalize_*`
+//! fn is covered by some obligation (the name is the declaration; no separate marker needed). A
+//! canon under another name must be registered in that script's REQUIRED_OBLIGATIONS, or it
+//! skips the gate (the gap that let `.then`/`pure_inline` slip).
+//!
 //! proof-obligation: normalize.control_flow.guard_returns
 //! proof-obligation: normalize.value_graph.algebra
 //! proof-obligation: normalize.value_graph.bool_reduce

--- a/docs/formal-soundness.md
+++ b/docs/formal-soundness.md
@@ -31,7 +31,7 @@ namespaces such as:
 - `oracle.*` — behavioral-oracle independence contracts such as the normalization cutoff.
 
 The linter has a required-surface list for proof-sensitive areas whose omission would be
-easy to miss. Those obligations must list the expected Rust files, symbols, and markers in
+easy to miss. Those obligations must list the expected Rust files and symbols in
 `meta.toml`; otherwise CI fails even if a Lean file exists somewhere else.
 
 Every Rust-backed obligation must also be marked from the Rust side:
@@ -40,9 +40,11 @@ Every Rust-backed obligation must also be marked from the Rust side:
 //! proof-obligation: normalize.recursion.structural_fold
 ```
 
-The linter checks both directions. A marker without a matching `meta.toml` fails, and a
-`meta.toml` whose `rust.markers` entry is not present in one of its `rust.files` fails. This
-keeps proof-sensitive code from drifting away from the registry.
+The linter checks both directions. A marker without a matching `meta.toml` fails, and an
+obligation whose `// proof-obligation: <id>` marker is absent from its `rust.files` fails. The
+marker IS the obligation id — there is no `rust.markers` field to repeat it (a `canonicalize_*`
+fn is likewise required to appear in some obligation's `rust.symbols`). This keeps
+proof-sensitive code from drifting away from the registry.
 
 ## Named rule modules
 

--- a/formal/README.md
+++ b/formal/README.md
@@ -33,8 +33,9 @@ Some semantic surfaces are required even when they are not one-file rule modules
 currently requires obligations for IL arena validity/deep-copy, recursion rewrites, exact
 fragment effect/place and wrapper contracts, and the oracle cutoff.
 
-Every Rust-backed obligation must list `rust.markers = ["<obligation id>"]`, and one of the
-listed Rust files must contain the matching comment marker:
+Every Rust-backed obligation must carry a comment marker — `// proof-obligation: <obligation id>`
+— in one of its listed Rust files. The marker IS the obligation id, so there is no separate
+`rust.markers` field (the linter derives the expected marker from the id):
 
 ```rust
 //! proof-obligation: detect.fragment.effect_place

--- a/formal/obligations/detect/fragment/effect_place/meta.toml
+++ b/formal/obligations/detect/fragment/effect_place/meta.toml
@@ -6,7 +6,6 @@ summary = "Append and index effects are directly observed; field writes require 
 [rust]
 files = ["crates/nose-detect/src/fragment/contract.rs"]
 symbols = ["Effect", "Place", "writes_proven"]
-markers = ["detect.fragment.effect_place"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/detect/fragment/free_inputs/meta.toml
+++ b/formal/obligations/detect/fragment/free_inputs/meta.toml
@@ -6,7 +6,6 @@ summary = "Fragment wrapper inputs are exactly reads from the enclosing scope wi
 [rust]
 files = ["crates/nose-detect/src/fragment/oracle.rs"]
 symbols = ["free_input_cids", "collect_bound_cids", "collect_binding_targets"]
-markers = ["detect.fragment.free_inputs"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/detect/fragment/wrapper_synthesis/meta.toml
+++ b/formal/obligations/detect/fragment/wrapper_synthesis/meta.toml
@@ -6,7 +6,6 @@ summary = "A fragment wrapper exposes one parameter per free input and keeps the
 [rust]
 files = ["crates/nose-detect/src/fragment/oracle.rs"]
 symbols = ["fragment_behavior", "synthesize_wrapper", "run_unit"]
-markers = ["detect.fragment.wrapper_synthesis"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/il/arena/deep_copy/meta.toml
+++ b/formal/obligations/il/arena/deep_copy/meta.toml
@@ -6,7 +6,6 @@ summary = "Deep-copying a subtree into a fresh IL builder keeps old ids valid an
 [rust]
 files = ["crates/nose-detect/src/fragment/oracle.rs"]
 symbols = ["copy_subtree", "synthesize_wrapper"]
-markers = ["il.arena.deep_copy"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/il/arena/validity/meta.toml
+++ b/formal/obligations/il/arena/validity/meta.toml
@@ -6,7 +6,6 @@ summary = "IL validation requires root, unit roots, and child edges to stay insi
 [rust]
 files = ["crates/nose-il/src/lib.rs"]
 symbols = ["validate", "IlBuilder"]
-markers = ["il.arena.validity"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/control_flow/guard_returns/meta.toml
+++ b/formal/obligations/normalize/control_flow/guard_returns/meta.toml
@@ -6,7 +6,6 @@ summary = "Guard-return, dead-code-after-return, and ternary-return control-flow
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/cfg_norm.rs"]
 symbols = ["guarded", "process_block"]
-markers = ["normalize.control_flow.guard_returns"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/recursion/structural_fold/meta.toml
+++ b/formal/obligations/normalize/recursion/structural_fold/meta.toml
@@ -6,7 +6,6 @@ summary = "Numeric structural recursion can be emitted as an accumulator fold fo
 [rust]
 files = ["crates/nose-normalize/src/recursion/structural_fold.rs"]
 symbols = ["recognize", "build_body"]
-markers = ["normalize.recursion.structural_fold"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/recursion/tail/meta.toml
+++ b/formal/obligations/normalize/recursion/tail/meta.toml
@@ -6,7 +6,6 @@ summary = "Tail-recursive self calls and their emitted while loop reach the same
 [rust]
 files = ["crates/nose-normalize/src/recursion/tail.rs"]
 symbols = ["recognize", "build_body"]
-markers = ["normalize.recursion.tail"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/algebra/meta.toml
+++ b/formal/obligations/normalize/value_graph/algebra/meta.toml
@@ -6,7 +6,6 @@ summary = "Associative-commutative numeric algebra and subtraction/negation cano
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/algebra.rs"]
 symbols = ["flatten_into", "intern_ac_chain", "collect_add_sub_expr_operands"]
-markers = ["normalize.value_graph.algebra"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/bool_reduce/meta.toml
+++ b/formal/obligations/normalize/value_graph/bool_reduce/meta.toml
@@ -6,7 +6,6 @@ summary = "Any/all reductions are well-defined Bool folds for cross-language pre
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/idioms.rs"]
 symbols = ["recognize_existence_reduction", "REDUCE_ANY", "REDUCE_ALL"]
-markers = ["normalize.value_graph.bool_reduce"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/clamp/meta.toml
+++ b/formal/obligations/normalize/value_graph/clamp/meta.toml
@@ -5,8 +5,7 @@ summary = "Clamp min/max compositions and two-comparison forms agree only under 
 
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs"]
-symbols = ["minmax_pattern"]
-markers = ["normalize.value_graph.clamp"]
+symbols = ["minmax_pattern", "canonicalize_proof_backed_clamp"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/compare/meta.toml
+++ b/formal/obligations/normalize/value_graph/compare/meta.toml
@@ -6,7 +6,6 @@ summary = "Comparison direction, negated comparisons, and total-order lattice ca
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/algebra.rs"]
 symbols = ["negate_cmp_code", "lattice_le_ne_to_lt", "lattice_lt_eq_to_le"]
-markers = ["normalize.value_graph.compare"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/factor_distribute/meta.toml
+++ b/formal/obligations/normalize/value_graph/factor_distribute/meta.toml
@@ -7,7 +7,6 @@ summary = "The named factor_distribute rule preserves Int denotation and is gate
 rule_module = true
 files = ["crates/nose-normalize/src/value_graph/rules/factor_distribute.rs"]
 symbols = ["apply"]
-markers = ["normalize.value_graph.factor_distribute"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/field_writes/meta.toml
+++ b/formal/obligations/normalize/value_graph/field_writes/meta.toml
@@ -6,7 +6,6 @@ summary = "Field writes are interpreted as final field state with last-write-win
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/interp.rs"]
 symbols = ["flush_fields", "field_env"]
-markers = ["normalize.value_graph.field_writes"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/flatmap_identity/meta.toml
+++ b/formal/obligations/normalize/value_graph/flatmap_identity/meta.toml
@@ -6,7 +6,6 @@ summary = "Identity flat-map (flatMap id) canonicalizes to flatten; the modeled 
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs"]
 symbols = ["HoFKind::FlatMap"]
-markers = ["normalize.value_graph.flatmap_identity"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/free_monoid/meta.toml
+++ b/formal/obligations/normalize/value_graph/free_monoid/meta.toml
@@ -6,7 +6,6 @@ summary = "String/list builder semantics are ordered free-monoid concatenation, 
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/interp.rs"]
 symbols = ["is_concat_ty", "join_strings"]
-markers = ["normalize.value_graph.free_monoid"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/functor/meta.toml
+++ b/formal/obligations/normalize/value_graph/functor/meta.toml
@@ -6,7 +6,6 @@ summary = "Map/filter fusion and count-of-filter normalization preserve List den
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/idioms.rs"]
 symbols = ["HoFKind::Map", "HoFKind::Filter", "and_preds"]
-markers = ["normalize.value_graph.functor"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/min_max/meta.toml
+++ b/formal/obligations/normalize/value_graph/min_max/meta.toml
@@ -6,7 +6,6 @@ summary = "Min/max select idioms and accumulator reductions are commutative and 
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/idioms.rs"]
 symbols = ["minmax_pattern", "MIN_CODE", "MAX_CODE"]
-markers = ["normalize.value_graph.min_max"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/promise_then/meta.toml
+++ b/formal/obligations/normalize/value_graph/promise_then/meta.toml
@@ -6,7 +6,6 @@ summary = "A settled Promise is modeled by its resolved value (the value graph s
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs"]
 symbols = ["eval_promise_then"]
-markers = ["normalize.value_graph.promise_then"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/pure_inline/meta.toml
+++ b/formal/obligations/normalize/value_graph/pure_inline/meta.toml
@@ -6,7 +6,6 @@ summary = "Inlining a call to a PURE, single-`return` function is beta-substitut
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs"]
 symbols = ["eval_inlined_call"]
-markers = ["normalize.value_graph.pure_inline"]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/oracle/cutoff/meta.toml
+++ b/formal/obligations/oracle/cutoff/meta.toml
@@ -6,7 +6,6 @@ summary = "Oracle-mode normalization stops after desugar and alpha, excluding se
 [rust]
 files = ["crates/nose-normalize/src/lib.rs"]
 symbols = ["NormalizeOptions", "oracle", "recursion::run"]
-markers = ["oracle.cutoff"]
 
 [lean]
 proof = "Proof.lean"

--- a/scripts/check-formal-obligations.py
+++ b/scripts/check-formal-obligations.py
@@ -260,6 +260,42 @@ def collect_rust_markers() -> dict[str, set[str]]:
     return markers
 
 
+# A `fn canonicalize_*` is, by convention, a value-graph CANONICALIZATION — a meaning-preserving
+# rewrite that needs Lean evidence. This catches the failure mode that let `.then`/`pure_inline`
+# slip (a new canon added inline with no obligation): name a canon `canonicalize_*` and the gate
+# *forces* a proof-obligation marker on it. (An arbitrarily-named canon still needs author
+# discipline — register it in REQUIRED_OBLIGATIONS — but the conventional name is now enforced.)
+CANON_FN_RE = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?fn\s+(canonicalize_[A-Za-z0-9_]+)\b")
+
+
+def lint_canon_naming(obligations: dict[str, "Obligation"], errors: list[str]) -> None:
+    # The function NAME `canonicalize_*` already declares "this is a canonicalization"; no extra
+    # marker is needed. Require only that it is covered by an obligation — i.e. its name appears in
+    # some obligation's `[rust].symbols` (the registry obligations already declare). One
+    # declaration, where it belongs (the obligation), not a redundant source comment.
+    declared_symbols: set[str] = set()
+    for ob in obligations.values():
+        rust = ob.meta.get("rust", {})
+        if isinstance(rust, dict):
+            for sym in rust.get("symbols", []) or []:
+                if isinstance(sym, str):
+                    declared_symbols.add(sym)
+    for root in RUST_ROOTS:
+        if not root.exists():
+            continue
+        for rust_file in sorted(root.rglob("*.rs")):
+            rel = str(rust_file.relative_to(ROOT))
+            for i, line in enumerate(rust_file.read_text(encoding="utf-8").splitlines()):
+                m = CANON_FN_RE.match(line)
+                if m and m.group(1) not in declared_symbols:
+                    error(
+                        errors,
+                        f"{rel}:{i + 1}: `fn {m.group(1)}` is a canonicalization (by naming "
+                        f"convention) with no Lean obligation — add `{m.group(1)}` to some "
+                        f"obligation's `[rust].symbols`, or register it in REQUIRED_OBLIGATIONS.",
+                    )
+
+
 def lint_meta(
     obligation: Obligation,
     all_ids: set[str],
@@ -293,16 +329,16 @@ def lint_meta(
         for symbol in symbols:
             if re.search(rf"\b{re.escape(symbol)}\b", contents) is None:
                 error(errors, f"{where}: rust symbol `{symbol}` was not found in listed files")
-    markers = as_list(rust.get("markers", []), "rust.markers", errors, where)
-    if rust_files and not markers:
-        error(errors, f"{where}: rust-backed obligations must list at least one `rust.markers` entry")
+    # The source marker IS the obligation id (the lint always required `marker == id`), so a
+    # `[rust].markers` field just repeats the id — redundant. Forbid it and derive the expected
+    # source marker from the id: a rust-backed obligation must carry `// proof-obligation: <id>`
+    # in a listed file.
+    if rust.get("markers") is not None:
+        error(errors, f"{where}: drop the redundant `[rust].markers` field — the source marker is the obligation id `{obligation.id}`, checked automatically")
     if rust_files and rust_markers is not None:
-        for marker in markers:
-            if marker != obligation.id:
-                error(errors, f"{where}: rust marker `{marker}` must match obligation id `{obligation.id}`")
-            found_files = rust_markers.get(marker, set())
-            if not any(rust_file in found_files for rust_file in rust_files):
-                error(errors, f"{where}: rust marker `{marker}` was not found in listed rust files")
+        found_files = rust_markers.get(obligation.id, set())
+        if not any(rust_file in found_files for rust_file in rust_files):
+            error(errors, f"{where}: source marker `// proof-obligation: {obligation.id}` was not found in listed rust files")
 
     if rust.get("rule_module", False) is True:
         matching_prefix = next((prefix for prefix in RULE_ROOTS if obligation.id.startswith(prefix + ".")), None)
@@ -450,9 +486,6 @@ def lint_required_obligations(
         rust_symbols = rust.get("symbols", [])
         if not isinstance(rust_symbols, list):
             rust_symbols = []
-        rust_markers = rust.get("markers", [])
-        if not isinstance(rust_markers, list):
-            rust_markers = []
 
         for rust_file in item.rust_files:
             if rust_file not in rust_files:
@@ -460,8 +493,7 @@ def lint_required_obligations(
         for symbol in item.rust_symbols:
             if symbol not in rust_symbols:
                 error(errors, f"{where}: required surface must list rust symbol `{symbol}`")
-        if item.id not in rust_markers:
-            error(errors, f"{where}: required surface must list rust marker `{item.id}`")
+        # The source marker (`// proof-obligation: <id>`) is checked by lint_meta, not re-declared.
 
 
 def lint_lean_layout(errors: list[str]) -> None:
@@ -568,28 +600,24 @@ def run_self_tests() -> int:
                 "`lean.counterexample_theorems`",
             ),
             (
-                "rust-backed obligation without marker list",
+                "rust-backed obligation with redundant markers field",
+                {
+                    **base_meta("proven"),
+                    "rust": {"files": ["required.rs"], "symbols": [], "markers": ["self_test"]},
+                    "lean": {"proof": "Proof.lean", "theorems": ["SelfTest.ok"]},
+                },
+                True,
+                "drop the redundant `[rust].markers` field",
+            ),
+            (
+                "rust-backed obligation with missing marker",
                 {
                     **base_meta("proven"),
                     "rust": {"files": ["required.rs"], "symbols": []},
                     "lean": {"proof": "Proof.lean", "theorems": ["SelfTest.ok"]},
                 },
                 True,
-                "rust-backed obligations must list at least one `rust.markers` entry",
-            ),
-            (
-                "rust-backed obligation with missing marker",
-                {
-                    **base_meta("proven"),
-                    "rust": {
-                        "files": ["required.rs"],
-                        "symbols": [],
-                        "markers": ["self_test"],
-                    },
-                    "lean": {"proof": "Proof.lean", "theorems": ["SelfTest.ok"]},
-                },
-                True,
-                "rust marker `self_test` was not found in listed rust files",
+                "source marker `// proof-obligation: self_test` was not found in listed rust files",
             ),
         ]
 
@@ -629,25 +657,6 @@ def run_self_tests() -> int:
                 },
                 "required surface must list rust symbol `required_symbol`",
             ),
-            (
-                "required obligation missing rust marker",
-                {
-                    "self_test": Obligation(
-                        "self_test",
-                        obligation_path,
-                        {
-                            **base_meta("proven"),
-                            "rust": {
-                                "files": ["required.rs"],
-                                "symbols": ["required_symbol"],
-                                "markers": [],
-                            },
-                            "lean": {"proof": "Proof.lean", "theorems": ["SelfTest.ok"]},
-                        },
-                    )
-                },
-                "required surface must list rust marker `self_test`",
-            ),
         ]
 
         marker_index_cases = [
@@ -665,11 +674,7 @@ def run_self_tests() -> int:
                         obligation_path,
                         {
                             **base_meta("proven"),
-                            "rust": {
-                                "files": ["other.rs"],
-                                "symbols": [],
-                                "markers": ["self_test"],
-                            },
+                            "rust": {"files": ["other.rs"], "symbols": []},
                             "lean": {"proof": "Proof.lean", "theorems": ["SelfTest.ok"]},
                         },
                     )
@@ -724,6 +729,7 @@ def main() -> int:
     lint_rule_modules(obligations, errors)
     lint_rust_marker_index(obligations, rust_markers, errors)
     lint_required_obligations(obligations, errors)
+    lint_canon_naming(obligations, errors)
     lint_lean_layout(errors)
 
     if errors:


### PR DESCRIPTION
Two redundancies in the proof-obligation registry — both the **same shape** you flagged (a hand-typed declaration that just repeats info already present), surfaced after `.then`/`pure_inline` slipped the gate without proofs.

## 1. The `[rust].markers` field always repeated the obligation id
All 21 obligations had `markers = ["<id>"]`, and the lint already required `marker == id` — so the field carried zero information. **Removed it from every `meta.toml`**; the lint now derives the expected source marker from the obligation id and **forbids** the field. A rust-backed obligation still must carry `// proof-obligation: <id>` in a listed file.

## 2. The canon gate required a redundant marker
The first cut of `lint_canon_naming` required a separate `// proof-obligation:` marker on every `canonicalize_*` fn — but the name *already* declares "this is a canon" (your point). Replaced with: a `canonicalize_*` fn must appear in some obligation's `[rust].symbols`. One declaration, where it belongs.

Net: the gate catches a new canonicalization shipped without Lean evidence, with **no busywork** — name it `canonicalize_*` + list it in symbols, or register in `REQUIRED_OBLIGATIONS`. Documented in the value-graph header, `formal/README.md`, `docs/formal-soundness.md`.

Validated: self-test + real lint pass (21 obligations); each check BITES (re-adding a `markers` field, removing a source marker, or an unregistered `canonicalize_*` all fail with the exact error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)