### PR TITLE
normalize: widen interprocedural inline to multi-statement pure bodies

### DIFF
--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -576,6 +576,29 @@ fn go_functional_append_builder_loop_converges_with_comprehension() {
 }
 
 #[test]
+fn interprocedural_inline_handles_multi_statement_pure_helper() {
+    // A pure helper with LOCAL temporaries (`sub = …; disc = …; return sub - disc`) inlines just
+    // like a single-`return` one — the multi-statement body is a pure value computation, so a
+    // caller of it converges with the same logic written inline. An effectful (field-writing)
+    // helper still does NOT inline (its effect can't be dropped).
+    let i = Interner::new();
+    let helper = "def base(item):\n    sub = item.price * item.qty\n    disc = sub * 0.1\n    return sub - disc\n\ndef total(item):\n    return base(item) + 5\n";
+    let inline = "def total(item):\n    sub = item.price * item.qty\n    disc = sub * 0.1\n    return (sub - disc) + 5\n";
+    assert_eq!(
+        value_fp_named(&i, helper, Lang::Python, "total"),
+        value_fp_named(&i, inline, Lang::Python, "total"),
+        "a multi-statement pure helper must inline like a single-return one",
+    );
+    let eff = "def bump(box, x):\n    box.count = box.count + 1\n    return x * 2\n\ndef use(box, x):\n    return bump(box, x) + 5\n";
+    let eff_free = "def use(box, x):\n    return x * 2 + 5\n";
+    assert_ne!(
+        value_fp_named(&i, eff, Lang::Python, "use"),
+        value_fp_named(&i, eff_free, Lang::Python, "use"),
+        "an effectful (field-writing) helper must not be inlined",
+    );
+}
+
+#[test]
 fn interprocedural_pure_inline_converges_extract_method() {
     // A function whose body inlines a computation converges with one that calls a PURE extracted
     // helper for it — `f(args)` is β-reduced to the helper's body (interprocedural summary), the

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -2547,12 +2547,13 @@ impl<'a> Builder<'a> {
             if !self.function_binding_safe(unit.root, unit.root) {
                 continue;
             }
-            // SOUNDNESS: only inline a function whose body is a single `return <expr>` — a pure
-            // value with NO statement effects. `function_binding_safe` alone is too weak here: it
-            // admits field/index writes (an effect the value-only inline would silently drop,
-            // which the oracle — blind to cross-function calls — could not catch). A lone return
-            // has no other statements, so there is nothing to drop.
-            let Some(ret_expr) = self.single_return_expr(unit.root) else {
+            // SOUNDNESS: only inline an EFFECT-FREE body — a `return <expr>` or a straight-line
+            // block of LOCAL bindings ending in a `return`. `function_binding_safe` alone is too
+            // weak: it admits field/index WRITES (an effect the value-only inline would silently
+            // drop). `inline_pure_body` gates the statement level so nothing observable is dropped.
+            // (The interp oracle now interprets cross-function calls, so the inline is also checked
+            // end-to-end by `nose verify` — but the gate stays conservative by construction.)
+            let Some(body) = self.inline_pure_body(unit.root) else {
                 continue;
             };
             let kids = self.il.children(unit.root);
@@ -2563,7 +2564,7 @@ impl<'a> Builder<'a> {
                     _ => None,
                 })
                 .collect();
-            self.inline_fns.insert(name, (params, ret_expr));
+            self.inline_fns.insert(name, (params, body));
         }
     }
 
@@ -2585,7 +2586,7 @@ impl<'a> Builder<'a> {
         let Payload::Name(fname) = self.il.node(callee).payload else {
             return None;
         };
-        let (params, ret_expr) = self.inline_fns.get(&fname)?.clone();
+        let (params, body) = self.inline_fns.get(&fname)?.clone();
         if params.len() != kids.len() - 1 {
             return None;
         }
@@ -2594,23 +2595,38 @@ impl<'a> Builder<'a> {
             let av = self.eval(kids[pi + 1], env);
             fenv.insert(pc, av);
         }
-        Some(self.eval(ret_expr, &fenv))
+        // Evaluate the body to its return value, binding any local `let`s along the way — the same
+        // sink-free evaluator used for lambda bodies, so locals thread through but no effect sink
+        // is emitted (the body is effect-free by `inline_pure_body`).
+        self.eval_block_return(body, &mut fenv)
     }
 
-    /// The single `return <expr>` of a function body, or `None` if the body is anything else
-    /// (locals, multiple statements, effects, control flow) — so only an effect-free pure value
-    /// qualifies for value-only inlining. Accepts `{ return e; }` and a bare `return e`.
-    fn single_return_expr(&self, root: NodeId) -> Option<NodeId> {
+    /// The body of a function that qualifies for value-only inlining: a bare `return <expr>`, or a
+    /// straight-line block of LOCAL bindings (`let x = …`, an `Assign` to a `Var`) ending in a
+    /// `return`. Returns `None` for any STATEMENT effect — a field/index write, a bare effect
+    /// expression, or control flow — which a value-only inline would silently drop.
+    /// `function_binding_safe` already vetted the expressions; this gates the statement level.
+    fn inline_pure_body(&self, root: NodeId) -> Option<NodeId> {
         let &body = self.il.children(root).last()?;
-        let ret = match self.il.kind(body) {
-            NodeKind::Return => body,
-            NodeKind::Block => match self.il.children(body) {
-                [only] if self.il.kind(*only) == NodeKind::Return => *only,
-                _ => return None,
-            },
-            _ => return None,
-        };
-        self.il.children(ret).first().copied()
+        match self.il.kind(body) {
+            NodeKind::Return => Some(body),
+            NodeKind::Block => {
+                let (last, prefix) = self.il.children(body).split_last()?;
+                if self.il.kind(*last) != NodeKind::Return {
+                    return None;
+                }
+                let local_binding = |&s: &NodeId| {
+                    self.il.kind(s) == NodeKind::Assign
+                        && self
+                            .il
+                            .children(s)
+                            .first()
+                            .is_some_and(|&t| self.il.kind(t) == NodeKind::Var)
+                };
+                prefix.iter().all(local_binding).then_some(body)
+            }
+            _ => None,
+        }
     }
 
     fn function_binding_safe(&self, root: NodeId, node: NodeId) -> bool {


### PR DESCRIPTION
The inline canon (PR #82) only handled a single `return <expr>`. Widen it to the common extract-method shape — a helper with local temporaries:

```python
def base(item):
    sub = item.price * item.qty
    disc = sub * 0.1
    return sub - disc
```

`inline_pure_body` (replacing `single_return_expr`) accepts a bare return OR a Block whose non-final statements are all LOCAL `Assign`s to a `Var` (no field/index writes, no bare effect expressions, no control flow); `eval_inlined_call` evaluates it with the sink-free `eval_block_return` (binds locals, emits no effect).

**Now safe to widen** because the interp oracle interprets cross-function calls (#85) — the inline is *checked* end-to-end by `nose verify`, not just argued by construction. An effectful (field-writing) helper is still excluded.

Validated: test `interprocedural_inline_handles_multi_statement_pure_helper` (+ effectful hard negative); full suite (204 equiv) + clippy green; **`nose verify crates --max-violations 0` → SOUND, 0 false merges** (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)