### PR TITLE
docs: align user-facing docs with current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,88 +1,12 @@
 # nose
 
-**Find code clone families across Python, JavaScript, TypeScript (incl. JSX/TSX),
-Go, Rust, Java, C, and Ruby — plus the `<script>` logic inside Vue, Svelte, and
-HTML** — in one self-contained Rust binary.
+**nose** finds refactoring candidates and semantic code clone families across Python,
+JavaScript, TypeScript, Go, Rust, Java, C, Ruby, and embedded `<script>` logic in Vue,
+Svelte, and HTML.
 
-*The name: a **nose** sniffs out code smells — the duplication worth refactoring away, even
-when it's been renamed or restructured (and, occasionally, rewritten in another language).*
-
-## See it
-
-These three functions compute the same thing — **sum a list** — in three languages and three
-styles. A token-based copy-paste detector sees three unrelated files.
-**nose reports them as one clone family**, because it matches on *what the code computes*:
-
-```python
-# Python — explicit loop
-def total(xs):
-    s = 0
-    for x in xs:
-        s += x
-    return s
-```
-```javascript
-// JavaScript — reduce
-const total = xs => xs.reduce((a, b) => a + b, 0);
-```
-```go
-// Go — indexed loop
-func Total(xs []int) int {
-    n := 0
-    for i := 0; i < len(xs); i++ { n += xs[i] }
-    return n
-}
-```
-
-Same logic, three languages, **zero shared tokens**. nose sees through renamed variables,
-reordered statements, and loop ↔ `reduce` ↔ comprehension rewrites — so it finds the
-duplicated *logic* worth refactoring, not just literal copy-paste. (Cross-*language*
-matches like this one are real but uncommon in practice; the everyday win is the same
-logic renamed or restructured **within** a language.) And the match isn't a guess: an
-equal fingerprint is **sound by intent** — *fingerprint-equal ⟹ behavior-equal* (see
-[How it works](#how-it-works)).
-
-## How it works
-
-nose parses each language with tree-sitter and lowers it into a single normalized
-**intermediate language (IL)** designed so that semantically-equivalent code converges
-to (near-)identical structure: identifiers alpha-renamed, loops unified, surface sugar
-desugared, operators/idioms canonicalized, plus a hash-consed **value graph** (GVN) that
-captures *what the code computes* (invariant to temporaries, statement order, and common
-subexpressions). On top of the IL it detects clones and ranks **design-level refactoring
-opportunities**. Every IL node carries inline provenance, so every match traces back to
-its source span.
-
-The value graph is **sound by intent** — two fragments sharing a fingerprint should
-compute the same thing. That contract is checked by a differential interpreter oracle
-(it interprets the *pre-canonicalization* IL so a rewrite can't mask its own bug) and by
-machine-checked **Lean proofs** of the core canonicalizations (`formal/`). It is a design
-contract and an internal test discipline, not a whole-pipeline proof. See
-[docs/architecture.md](docs/architecture.md) and Experiments §AJ/§AX.
-
-## Clone types
-
-Against the standard taxonomy (Roy, Cordy & Koschke, 2009):
-
-- **Type-1** (identical except whitespace/comments) — caught by the `syntax` CPD floor.
-- **Type-2** (renamed identifiers/types/literals) — identifiers/types converge in the
-  normalized unit channels; literal changes are handled by `near`.
-- **Type-3** (statements added / removed / changed) — opt in with `--mode near`.
-- **Type-4** (same computation, different syntax) — exact modeled equivalence in `semantic`
-  (loop ↔ reduce ↔ comprehension, control-flow forms, commutativity, cross-language), sound by
-  intent — **not** arbitrary algorithmic equivalence.
-
-See [docs/clone-types.md](docs/clone-types.md) for the precise per-type scope and limits.
-
-## What it does
-
-`nose scan <paths>` finds clone families across files, modules, and languages and
-ranks them by **how cleanly each one extracts** into a shared helper, so you review
-the duplication you can actually act on first (`--sort value` for raw volume instead).
-By default it runs `syntax,semantic`: CPD-style syntax copy-paste plus exact
-value-fingerprint Type-4 clones. If you pass `--mode`, that replaces the default
-with exactly the channels you list: `syntax`, `semantic`, `near`, or a comma-list
-such as `--mode syntax,semantic,near`.
+It ships as one self-contained Rust binary. By default, `nose scan` combines a
+same-language copy-paste floor with exact modeled semantic matches, then ranks clone
+families by how cleanly they can be extracted.
 
 ## Install
 
@@ -94,175 +18,46 @@ brew install corca-ai/tap/nose
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/corca-ai/nose/releases/latest/download/nose-cli-installer.sh | sh
 ```
 
-Prebuilt binaries for macOS (Apple Silicon + Intel) and Linux (x86_64 + arm64)
-are attached to every [release](https://github.com/corca-ai/nose/releases).
-
-## Quick start
+To build from source:
 
 ```sh
-# Build from source (requires the Rust toolchain):
 cargo build --release
-
-# Default: syntax CPD floor + exact semantic Type-4 clones:
-./target/release/nose scan path/to/project
-
-# Markdown report (for a PR / issue):
-./target/release/nose scan src --format markdown > REFACTOR.md
-
-# JSON (machine-readable), top 50 families:
-./target/release/nose scan src --format json --top 50
-
-# jscpd-style copy-paste gate:
-./target/release/nose scan src --mode syntax --fail-on any
-
-# Exact semantic-only audit:
-./target/release/nose scan src --mode semantic
-
-# Include Type-3 near-duplicates (near takes an inline acceptance threshold):
-./target/release/nose scan src --mode syntax,semantic,near:0.70
+./target/release/nose scan examples --min-size 8
 ```
 
-### Example
+## First Scan
 
-```
-$ nose scan examples --min-size 8
-scanned 3 files · go 1 · python 1 · typescript 1
-1 clone family, ranked by extractability (cleanest to fold into one helper)  ·  ~30 duplicated lines  (showing 1)
-
-#1  id b658f483dcc2b097 · 6 copies · same logic in 3 languages (go, python, typescript) · ~30 lines removable
-    → local duplication — extract a helper (cross-language)
-    examples/sum.go:3-9  SumFor
-    examples/sum.go:11-17  SumRange
-    examples/sum.py:1-7  sum_while
-    examples/sum.ts:1-7  sumFor
-    examples/sum.ts:9-15  sumOf
-    examples/sum.py:10-14  sum_for
+```sh
+nose scan path/to/project
+nose scan src --format markdown > REFACTOR.md
+nose scan src --format json --top 50
+nose scan src --mode syntax --fail-on any
+nose review --base origin/main --fail
 ```
 
-(Runs on the repo's own `examples/` — six tiny sum routines across three languages and
-several loop forms, all one family. `--min-size 8` because the demo functions are tiny;
-the default minimum is 24 IL tokens.)
-
-Each family is described in plain language — how many copies, how much is actually
-shared vs varies, how many lines you could remove — and **every site is listed** so you
-can go act on it. The one-line **hint** (`→`) is grounded in the facts (a shared symbol
-name, cross-language spread, how many modules it touches), never a guess about
-semantics. For same-language families the description reads `N of M lines identical, K
-spots differ`; add `--show proposal` to see the extracted helper and `--show diff` to see
-exactly what varies.
-
-Each **family** is one refactoring decision (extract a shared helper / base class /
-data table). By default families are ranked by **extractability** — the *invariant*
-lines you'd actually fold into one helper (`N/M shared`), weighted by how much of each
-copy is invariant and dampened by how many parameters that helper needs — so a tight,
-cleanly-extractable pair outranks a big block whose copies merely look similar.
-`--sort hazard` is an experimental *divergence-propensity* view (see
-[hazard-ranking](docs/hazard-ranking.md)); `--sort value` ranks by raw duplicated
-volume; `--sort sites` by copy count.
-
-## Pipeline
-
-```
-source ──tree-sitter──▶ raw IL ──normalize──▶ canonical IL ──▶ units + features
-                                                                      │
-                                       MinHash + LSH candidate gen ◀──┘
-                                                  │
-                          structural + value-graph scoring ──▶ clusters ──▶ ranked families
-```
-
-Normalization (the `normalize` stage above) is covered in [How it works](#how-it-works)
-and [docs/normalization.md](docs/normalization.md). **Detection** (`nose-detect`) then
-runs three selectable channels feeding one ranking:
-
-- *Syntax* — a Rabin-Karp scan over each file's IL token stream that finds duplicated
-  runs regardless of unit boundaries: the jscpd-style Type-1/2 floor.
-- *Semantic* — exact value-fingerprint matches: modeled Type-4 equivalence with the
-  fingerprint-equal ⇒ behavior-equal contract.
-- *Near* — shape-candidate Type-3 near-duplicates scored by structural/value overlap
-  and RANSAC alignment; opt in with `--mode near` or a comma-list containing `near`.
-
-## CLI
-
-- `nose scan <paths…>` — ranked clone families.
-  - rank/filter/shape: `--sort extractability|value|sites|hazard` (default
-    `extractability`), `--top N`, `--min-members N`, `--min-value V`,
-    `--min-size N`,
-    `--mode syntax|semantic|near` (comma-list/repeatable; omitted = `syntax,semantic`),
-    `--exclude <glob>` (gitignore-syntax; `.gitignore` is respected automatically,
-    even outside a git repo).
-  - review: `--show diff|proposal|hotspots` (repeatable/comma-list) — `diff` shows each
-    family as a unified diff of its two copies, `proposal` the shared skeleton with varying
-    spots as `⟨param N⟩`, `hotspots` directories ranked by duplicated lines;
-    `--format human|json|markdown|sarif`.
-  - workflow: `nose.toml` config (`[scan]`), `--baseline <file>`,
-    `--write-baseline`, `--fail-on any|new` (CI gate),
-    `--cache-dir <dir>` (fast re-runs).
-  - inline `// nose-ignore` marks a clone as intentionally kept.
-- `nose review [paths…] --base <ref>` — flag clones **changed inconsistently** in a diff
-  (a copy edited, its siblings missed — a likely un-propagated change). Needs a git repo;
-  shares `scan`'s detection flags, adds `--fail` as a CI gate. See
-  [docs/review.md](docs/review.md).
-- `nose il <file> [--normalized] [--no-cfg-norm] [--format sexpr|json]` — inspect the IL.
-- `nose stats <paths…>` — IL lowering coverage per language.
-- `nose capabilities` — JSON contract for integrations that need supported commands,
-  formats, config keys, and scan capability flags.
-
-`nose behavioral-gate` is a visible experimental Type-4 benchmark command, not a
-stable integration surface. Hidden `detect`, `verify`, `features`, `eval`, and
-`ceiling` commands exist for strict/research workflows; `scan` is the command for
-everyday use.
+`nose scan` respects `.gitignore` files inside scanned trees. Use `--mode semantic` for
+exact semantic-only findings, or `--mode syntax,semantic,near:0.70` to include fuzzy
+near-duplicates.
 
 ## Documentation
 
-New to nose? **[Getting started](docs/getting-started.md)** walks through your first
-scan and how to read the report. The full [`docs/`](docs/home.md) wiki is grouped by
-what you're here to do:
-
-- **Using nose** — [Usage](docs/usage.md), [Configuration](docs/configuration.md),
-  [Continuous-Integration](docs/continuous-integration.md),
-  [Structured-Ignores](docs/structured-ignores.md),
-  [Clone-Types](docs/clone-types.md), [Languages](docs/languages.md).
-- **Integrating nose** — [Capabilities](docs/capabilities.md),
-  [Scan-JSON](docs/scan-json.md).
-- **Contributing** — [Architecture](docs/architecture.md),
-  [Normalization](docs/normalization.md), [Experiments](docs/experiments.md),
-  [Benchmark](docs/benchmark.md), [Field-Evaluation](docs/field-evaluation.md),
-  [Dogfooding](docs/dogfooding.md).
-
-## Crates
-
-| crate | role |
-|---|---|
-| `nose-il` | arena IL model, provenance spans, interner, serialization |
-| `nose-frontend` | tree-sitter parse + per-language CST→IL lowering |
-| `nose-normalize` | normalization passes + value graph (GVN) |
-| `nose-detect` | fingerprints, LSH, scoring, clustering, refactor ranking |
-| `nose-eval` | benchmark scoring (precision/recall, pooled, stratified) |
-| `nose-cli` | the `nose` binary |
+- [Documentation home](docs/home.md) — entry point for using, integrating, and contributing.
+- [Getting started](docs/getting-started.md) — first scan and how to read the report.
+- [Usage](docs/usage.md) — command and flag reference.
+- [Configuration](docs/configuration.md) — `nose.toml`, excludes, modes, thresholds, ignores.
+- [Contributing](CONTRIBUTING.md) — development workflow and quality gates.
+- [Agent instructions](AGENTS.md) — repository-specific instructions for coding agents.
 
 ## Status
 
-Pre-1.0. Languages: Python, JavaScript, TypeScript (with JSX/TSX), Go, Rust, Java, C, Ruby,
-and the embedded `<script>` of Vue/Svelte/HTML (IL lowering coverage ≈ 99.99% — Raw-node
-ratio < 0.01% on the vendored corpus). Output is **deterministic** — byte-identical
-across runs, thread counts, *and* machines. The pipeline is parallel and frontend-bound
-(parse+lower scales ~11.6× across cores); per-file throughput is corpus-dependent —
-reproduce with `NOSE_TIME=1 nose scan <path>` (≈19.5k files/sec warm; see
-[experiments](docs/experiments.md) §T).
+Pre-1.0. Current capability, language, JSON, benchmark, and soundness details live in the
+wiki so claims have one source of truth:
 
-Correctness is anchored by **cross-language convergence tests**: the same algorithm written
-in different languages (and equivalent forms — `for`/`while`, ternary/`switch`, comprehension/`.map`,
-f-string/template/interpolation, guard clauses, De Morgan) must normalize to one IL hash, while
-behaviorally different code (sum vs product) must not. See `docs/experiments.md` for the
-methodology and the bugs this discipline caught (§S).
-
-## Quality gates
-
-`./scripts/check-ci-local.sh --fast` is the PR/push preflight: rustfmt, clippy
-(`-D warnings`), `nose-cli` tests, and docs wiki lint. `./scripts/check.sh` is the
-full local CI mirror, including release build/tests, supply-chain checks, MSRV,
-Lean proofs, and the self-hosted duplication gate. Lint policy lives once in
-`[workspace.lints]`. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
+- [Languages](docs/languages.md)
+- [Clone types](docs/clone-types.md)
+- [Benchmark](docs/benchmark.md)
+- [Architecture](docs/architecture.md)
+- [Scan JSON schema](docs/scan-json.md)
 
 ## License
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -29,11 +29,19 @@ bench/setup_repos.sh                      # clone the pinned corpus into bench/r
 python3 bench/labels/eval_by_language.py  # P@10 + worthy-recall, per language, dev/held-out, 95% CIs
 ```
 
-**Headline (current):** precision@10 ≈ **60% dev / 54% held-out**, worthy-**recall ≈ 99%**.
-The per-language CIs are wide (bounded by #repos×10), which is the point — they tell you
-whether a per-language difference is real or noise. The standing finding (experiments §AV)
-is that the residual precision loss is *judgment-deep* (genuinely-ambiguous, parallel-by-
-design families), not a detector signal gap.
+`eval_by_language.py` still prints its historical `value` baseline and
+anti-unification re-rank columns. The current default `extractability` order is the native
+`nose scan --format json` family order; the snapshot below uses that same label matching
+with the native order kept.
+
+**Current reproducible snapshot:** with the current default `extractability` order, an
+audit run over the checked-out `bench/repos` corpus measured overall precision@10 at about
+**65% dev / 58% held-out**. The same scan re-sorted by raw `value` measured about
+**58% dev / 56% held-out**. Worthy-recall in that run was roughly **86% dev / 88%
+held-out**. The per-language CIs are wide (bounded by #repos×10), which is the point —
+they tell you whether a per-language difference is real or noise. The standing finding
+(experiments §AV) is that much residual precision loss is *judgment-deep*
+(genuinely-ambiguous, parallel-by-design families), not a simple detector signal gap.
 
 ## Soundness — the behavioral oracle
 
@@ -51,10 +59,11 @@ nose verify bench/repos   # SOUND / canon PRESERVED, + a completeness ratio
 
 ## Throughput
 
-The detector is parallel at every stage and deterministic across runs, threads, and
-machines. On the pinned corpus it sustains **~19,500 files/sec** (warm, full pipeline);
-the frontend (tree-sitter parse + lower, ~65%) dominates and scales ~11.6× on 18 cores.
-`NOSE_TIME=1 nose scan <path> --top 0` prints the per-stage breakdown. Add
+The detector is parallel at every stage and designed for deterministic output; tests cover
+repeat runs and thread-count variation on the local platform. The archived §T run measured
+about **19,500 files/sec** warm on its pinned corpus/hardware, with frontend parse+lower
+dominating and scaling about 11.6x on 18 cores. `NOSE_TIME=1 nose scan <path> --top 0`
+prints the per-stage breakdown for your machine. Add
 `--mode syntax,semantic,near` when measuring the full review surface. See
 experiments §T for the throughput work.
 

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -21,7 +21,8 @@ the engine is in [architecture](architecture.md).
 ## Type-1 — fully
 
 Whitespace, layout, and comments never enter the IL, so Type-1 fragments produce identical
-fingerprints. They are caught by the `syntax` CPD floor and by the unit fingerprints.
+fingerprints. They are caught by the same-language `syntax` CPD floor and by the unit
+fingerprints.
 
 ## Type-2 — identifiers and types fully; literals on a two-axis split
 
@@ -34,10 +35,10 @@ fingerprints. They are caught by the `syntax` CPD floor and by the unit fingerpr
   their class. So a Type-2 clone that differs only in literal values is matched by
   `--mode near`, but deliberately kept distinct by exact `--mode semantic`.
 
-`--mode syntax` is intentionally the CPD floor: it is excellent for copied runs that a
-token detector should catch, including runs that cross function boundaries, but it is not
-the whole renamed-Type-2 story by itself. Use the default or add `near` when renamed or
-literal-varied copies matter.
+`--mode syntax` is intentionally the CPD floor: it is excellent for same-language copied
+runs that a token detector should catch, including runs that cross function boundaries, but
+it is not the renamed/literal-varied Type-2 story by itself. Use the default or add `near`
+when renamed or literal-varied copies matter.
 
 ## Type-3 — near-duplicate via similarity (the primary use)
 
@@ -76,9 +77,10 @@ graph, and canonicalizations actually model:
 - the same algorithm written in a **different language** (incl. Rust `it.iter().filter(p).sum()`
   ↔ Python `sum(x for x in xs if p)`).
 
-For the classes it captures, the match carries a **soundness guarantee**: equal fingerprint
-⟹ equal behavior, enforced by an interpreter oracle (`nose verify`) and machine-checked in
-Lean (`formal/`). See [normalization](normalization.md) for the full pass list.
+For the classes it captures, equal fingerprint -> equal behavior is the design invariant:
+guarded by the hidden `nose verify` oracle, regression tests, and Lean obligations for the
+core canonicalizations, but not a per-scan or whole-pipeline proof. See
+[normalization](normalization.md) for the full pass list.
 
 ### What nose does *not* do (no overclaim)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,9 +2,9 @@
 
 Real projects shouldn't carry 200-character command lines. Put a `nose.toml`
 (or `.nose.toml`) in the directory where you invoke nose and it is read
-automatically. CLI flags from [usage](usage.md) always win; the config supplies
-defaults for supported scan settings; anything unset falls back to the built-in
-default. Back to [home](home.md).
+automatically. The config supplies defaults for supported scan settings; most CLI flags
+override those defaults, while `exclude` globs are additive. Anything unset falls back to
+the built-in default. Back to [home](home.md).
 
 ## `nose.toml`
 
@@ -31,7 +31,7 @@ the built-in default". Keys are kebab-case and live under the `[scan]` table.
 | key | type | default | same as flag |
 |---|---|---|---|
 | `exclude` | list of globs | `[]` | `--exclude` |
-| `mode` | list of `syntax`\|`semantic`\|`near` | `["syntax", "semantic"]` | `--mode` |
+| `mode` | list of `syntax`\|`semantic`\|`near[:T]` | `["syntax", "semantic"]` | `--mode` |
 | `sort` | `extractability`\|`value`\|`sites`\|`hazard` | `extractability` | `--sort` |
 | `min-value` | float | `0.0` | `--min-value` |
 | `min-members` | int | `2` | `--min-members` |
@@ -68,8 +68,10 @@ command line are combined. Globs use gitignore syntax (`tests/**`,
 `**/*.test.ts`, `vendor/**`) and are applied *during the directory walk*, so an
 excluded directory is pruned, not just filtered out afterward.
 
-`.gitignore` is always respected automatically, so vendored dependencies, build
-output, and the like are skipped without any configuration.
+`.gitignore` files inside each scanned tree are respected automatically, even when that
+tree is not a git checkout, so vendored dependencies, build output, and the like are
+skipped without any configuration. Parent ignore files above the scanned root are not
+applied; pointing nose at an ignored subdirectory intentionally still scans it.
 
 ## Structured ignores
 
@@ -91,10 +93,11 @@ The file format, selector semantics, and expiry behavior are documented in
 
 ## Inline suppression
 
-To mark one specific clone as intentionally kept, put `// nose-ignore` on or
-just above the unit (function/class/block). nose drops that unit from
-detection, so it never shows up as a family. Use this for a duplicate you've
-consciously decided to live with, rather than excluding the whole file.
+To mark one site as intentionally kept, put a `nose-ignore` marker in a comment on the
+unit's first line or immediately above it (`# nose-ignore`, `// nose-ignore`, and similar
+comment syntax all work). nose drops that unit from detection, so that site cannot form a
+family. Use this for a duplicate you've consciously decided to live with, rather than
+excluding the whole file.
 
 For a finding that should stay visible to audit tooling, prefer a structured
 ignore entry. For accepting *all* of today's existing duplication at once — so

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -603,13 +603,13 @@ correctives the prototype lacked — **tightness** (shared/total, so a 22/384 di
 outrank a 15/15 pair), a **parameter penalty** (a 30-hole "helper" is scaffolding), and an **IDF
 idiom-gate** (pervasive lines like `if err != nil {` contribute ~0) — plus zero-invariant-line
 families score 0 (the structural-only `sim 1.00` pathology) and a type-def/generated discount;
-cross-language families fall back to the structural estimate. **It is the first ranking change to
-move the held-out number, and it moves it the right way:** held-out +6pp (54% → 60%), dev flat, no
-recall cost (reordering only). Gains are broad (Java 42% → 71%, C 24% → 35%), not one-language. The
-lesson: **a re-rank built from what actually extracts (tight, few-param, non-idiom shared lines)
-generalizes, where one built from raw structural abstractness did not.** `--sort value` is retained
-for raw-volume triage; detection is unchanged (same families, only order and the `N/M shared · Pp`
-cell differ).
+cross-language families fall back to the structural estimate. In the historical §AZ slice it was
+the first ranking change to move the held-out number in the right direction (held-out +6pp,
+dev flat, no recall cost, reordering only). The durable lesson is that a re-rank built from
+what actually extracts (tight, few-param, non-idiom shared lines) generalized where one built
+from raw structural abstractness did not. For current reproducible P@10/recall numbers, use
+[benchmark](benchmark.md); `--sort value` is retained for raw-volume triage, and detection is
+unchanged (same families, only order and the `N/M shared · Pp` cell differ).
 
 ## BA. Exact-Type-4 convergence push — stronger types, Lean-backed algebra, filter fusion
 

--- a/docs/field-evaluation.md
+++ b/docs/field-evaluation.md
@@ -106,9 +106,9 @@ similarity cell replaced by an honest `N/M shared · Pp`. Same-language families
 that share *no* invariant lines (a language idiom, or two unrelated type literals
 of the same shape) now sink instead of topping the list. `--sort value` retains
 the raw-volume ranking. This is not the abstractness re-rank §AU/§AV rejected:
-measured on the v5 labelset it holds dev P@10 (61%) and lifts the **held-out**
-split +6pp (54%→60%) with no recall cost -- it generalizes where the prototype
-did not. See [experiments](experiments.md) §AZ.
+the historical §AZ run recorded a held-out lift for extractability. The current
+reproducible v5 evaluator and its confidence intervals are summarized in
+[benchmark](benchmark.md).
 
 The same pass drove four detector fixes (all landed): the contiguous copy-paste
 channel is same-language by construction (no cross-language false merges), a

--- a/docs/fragment-contracts.md
+++ b/docs/fragment-contracts.md
@@ -50,12 +50,12 @@ resolve to a proven [`Place`] (an append/index write carries no such obligation)
 
 ### 3. The oracle — wrapper synthesis
 
-A fragment is verified through the *same* independent behavior check as a whole function. We
-do **not** add a new interpreter path. Instead the contract is lowered into a synthetic
-single-function IL — free inputs become parameters, the fragment subtree is deep-copied into
-the body — and handed to the existing [`run_unit`](architecture.md) interpreter. We reuse
-its `Behavior` (returned value + ordered effect trace + final field state) and the same input
-battery whole functions use.
+The contract path can verify a fragment through the *same* independent behavior machinery as
+a whole function. It does **not** add a new interpreter path. Instead the contract is lowered
+into a synthetic single-function IL — free inputs become parameters, the fragment subtree is
+deep-copied into the body — and handed to the existing [`run_unit`](architecture.md)
+interpreter. The production scan still uses the predicate path described below; the contract
+path is kept in lockstep by differential tests and proof obligations.
 
 Because `Behavior` already records effects and field state, **effects are preserved as
 observable behavior for free**: appending to a parameter list shows up in the effect trace,
@@ -113,11 +113,11 @@ resolves to `Field(This, …)`, and the recognizer asserts the place is exact-sa
 The recognizers are migrated onto the contract path one family at a time. An independent
 contract recognizer (`fragment::recognize`) re-expresses each migrated shape, reusing only the
 shared invalidation gates (span containment + context safety) rather than the per-shape
-predicates. A test asserts that over a multi-language corpus the predicate path and the
-contract path accept **exactly the same `(span, kind)` set** for migrated kinds, and a
+predicates. Tests assert that over representative multi-language snippets the predicate path
+and the contract path accept **exactly the same `(span, kind)` set** for migrated kinds, and a
 `debug_assert` in the collector cross-checks the forward direction on every accepted fragment
-across the whole fixture corpus. A migration step that changes which fragments are accepted
-fails the gate — that is what keeps the re-expression behavior-invariant.
+while collecting units. A migration step that changes which fragments are accepted fails the
+gate — that is what keeps the re-expression behavior-invariant.
 
 ## Output surfaces
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,8 +27,8 @@ instead, see [usage → Install](usage.md#install).
 
 ## Your first scan
 
-Run `nose scan` on any file or directory. It recurses, respects `.gitignore`, and
-prints the duplication it found, most worth-refactoring first:
+Run `nose scan` on any file or directory. It recurses, respects `.gitignore` files inside
+the scanned tree, and prints the duplication it found, most worth-refactoring first:
 
 ```sh
 nose scan path/to/project

--- a/docs/home.md
+++ b/docs/home.md
@@ -6,9 +6,9 @@ lowering every language into one normalized intermediate language (IL) and
 ranking duplicated code by how much it's worth refactoring. The repository
 [`README`](../README.md) is the one-screen overview; this wiki is the full guide.
 
-Every page lives in `docs/` and links to its neighbours with relative links, so the
-docs browse cleanly on GitHub and in any Markdown viewer. The pages are grouped by
-what you're here to do.
+Every wiki page lives in `docs/` and links to its neighbours with relative links, so the
+docs browse cleanly on GitHub and in any Markdown viewer. Root project docs are linked
+where relevant. The pages are grouped by what you're here to do.
 
 ## Start here
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -39,7 +39,8 @@ shows up as one cross-container family (confirmed on real projects in
 
 Lowering quality is measured by the **Raw-node ratio** — the fraction of CST
 nodes that fall through to an opaque `Raw` IL node instead of a real one. Lower
-is better; the vendored corpus sits below 0.01%. Check it per language with:
+is better; on the current pinned `bench/repos` corpus the overall ratio is about
+0.57%, with language-specific gaps visible in `nose stats`. Check it per language with:
 
 ```sh
 nose stats <paths…>

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -186,8 +186,9 @@ via bounded equality saturation over a fixed rule set:
   negation normalization (De Morgan,
   double-negation `!!x` cancelled only on Bool, negated-comparison `!(a<=b)`→`a>b`);
   comparison-direction canonicalization; short-circuit `and`/`or` to the value-`Phi`.
-  Distribution (e.g. `a*c+b*c`) is intentionally NOT applied — it is unsound for strings
-  (`("x"+"y")*2` ≠ `"xx"+"yy"`) and the operands can't be proven numeric.
+  Distribution/factoring (e.g. `a*c+b*c -> (a+b)*c`) is applied only through the
+  value-graph rule when the operands are proven numeric. String/list repetition and other
+  overloadable or unproven domains stay closed.
 Extract a canonical term by a cost function. Self-contained; strong on
 expression-level Type-4. Hard parts: rule confluence, termination, choosing the
 canonical extraction, integer/float/overflow caveats (kept approximate).

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -50,12 +50,14 @@ pin a release.
 > any truncation explicit; pass **`--top 0`** to emit every family. `ranking.total_families`
 > is always the complete post-filter count regardless of `--top`.
 
-The JSON report intentionally keeps diagnostic families that the default human,
-Markdown, SARIF, and `--fail-on` surfaces omit: hidden proof-only fragments,
-review-surface fragments, and families wholly inside files with generated-code
-headers. Consumers that want the same first-screen surface as humans should filter
-for `recommended_surface == "default"` and drop generated-header files according
-to their own source metadata.
+The JSON report intentionally keeps diagnostic families that survive ranking but are
+omitted from the default human, Markdown, SARIF, and `--fail-on` surfaces: hidden
+proof-only fragments, review-surface fragments, and families wholly inside files with
+generated-code headers. It is not raw detector output: families wholly in
+vendored/generated-looking paths may already have been pruned before serialization.
+Consumers that want the same first-screen surface as humans should filter for
+`recommended_surface == "default"` and drop generated-header files according to their own
+source metadata.
 
 ## Top-level fields
 
@@ -66,7 +68,7 @@ to their own source metadata.
 | `scope.files` | integer | Number of supported source files scanned after ignores and excludes. |
 | `scope.languages` | array | Per-language file counts, largest first. |
 | `ranking.sort` | string | Sort key used for `families`: `extractability` (default), `value`, `sites`, or `hazard`. |
-| `ranking.total_families` | integer | Active families remaining after filters, baseline suppression, and structured ignores, before `--top`. |
+| `ranking.total_families` | integer | Active families remaining after rank-time pruning, filters, baseline suppression, and structured ignores, before `--top`. |
 | `ranking.shown_families` | integer | Families present in `families`. |
 | `ranking.limit` | integer or null | The `--top` limit; `null` means `--top 0` showed every family. |
 | `baseline` | object, optional | Baseline comparison summary when `--baseline` is active. |

--- a/docs/type4-adversarial-coverage.md
+++ b/docs/type4-adversarial-coverage.md
@@ -16,14 +16,14 @@ frontier_platform.py
 
 `bench/type4/adversarial` is no longer the source of truth for next work. The former
 adversarial ledger was retired after each entry had a current gate in tests, `type4-smoke`,
-`nose verify`, or `scan_regression`.
+focused verifier checks, or `scan_regression`.
 
 What remains is intentionally smaller:
 
 | file | role |
 |---|---|
 | `cases/cases.v1.json` | focused positive and hard-negative case handles |
-| `cases/**` | small fixture corpora used by focused `scan` / `verify` gates |
+| `cases/**` | small fixture corpora used by focused `scan` gates, focused verifier checks, or boundary documentation |
 | `scripts/type4-check` | validate target packets, real-frontier links, and focused cases |
 | `scripts/type4-next` | print next task cards from `frontier_target_packets.v1.json` |
 | `scripts/type4-report` | summarize target packets and focused case coverage |
@@ -59,7 +59,9 @@ real frontier evidence. Important cases should be promoted into an automatic gat
 
 - Rust or CLI equivalence tests for stable semantic rules;
 - `scripts/type4-smoke.sh` focused gates for generated positives and hard negatives;
-- `nose verify --max-violations 0 <focused-corpus>` for oracle-backed behavior checks;
+- `nose verify --max-violations 0 <focused-corpus>` for named oracle-backed behavior
+  checks; not every directory under `cases/**` is intended to pass as a standalone
+  zero-violation verifier corpus;
 - `scan_regression compare` for product output/runtime and HoF value-graph budget checks;
 - formal obligations where a proof precondition is the boundary.
 

--- a/docs/type4-benchmark.md
+++ b/docs/type4-benchmark.md
@@ -289,27 +289,25 @@ when the focused/compact gates have closed.
 The bridge is candidate mining: v5 families seed generator templates and hard-negatives, but
 only evidence-backed pairs enter the Type-4 gold set.
 
-## Initial implementation shape
+## Current implementation shape
 
-The seed lives in `bench/type4/`:
+The detailed file inventory lives in [`bench/type4/README.md`](../bench/type4/README.md).
+The stable roles are:
 
-- `proposals.v1.json` — LLM-planned semantic proposal cards;
-- `capabilities.v1.json` — current surface-by-surface proof-fact capability matrix;
-- `ITERATIONS.md` — compact decision log for coverage expansion, real-corpus batches,
-  fragment-unit work, smoke results, and remaining frontier;
-- `generate.py` — deterministic source/manifest generator for all supported surfaces;
-- `select_cases.py` — coverage-preserving compaction for routine gates;
-- `eval_manifest.py` — compares `nose scan --mode semantic` output against the manifest;
-- `schema.json` — pair-level manifest schema;
-- `scan_regression/` — the repeatable product-scan runtime/output-drift harness
-  (`nose scan --mode semantic --format json --top 0`), with its own subset, recorded
-  baseline, fragment/reason-code/surface bucket drift, enclosing-unit recovery metrics,
-  generated HoF value-graph budget smoke, and threshold docs; see
-  `bench/type4/scan_regression/README.md`;
-- `adversarial/` — focused Type-4 case handles, verifier-lead draft tooling, and target
-  packet task scripts; see
+- synthetic generation and manifest evaluation:
+  `generate.py`, `select_cases.py`, `eval_manifest.py`, and `schema.json`;
+- coverage matrix and proof-fact capability tracking:
+  `coverage_matrix.v1.json`, `coverage_evidence.v1.json`, `coverage_matrix.py`, and
+  `capabilities.v1.json`;
+- real-corpus frontier evidence and next-work packets:
+  `real_frontier.v1.json`, `frontier_target_packets.v1.json`, `frontier_platform.py`, and
+  `frontier_axes.py`, summarized in [frontier-platform](frontier-platform.md);
+- focused adversarial cases and verifier-lead draft tooling:
+  `adversarial/`, summarized in
   [type4-adversarial-coverage](type4-adversarial-coverage.md);
-- `README.md` — commands and current smoke numbers.
+- product semantic-scan regression:
+  `scan_regression/`, which guards runtime, output drift, fragment/reason-code/surface
+  buckets, enclosing-unit recovery, and HoF value-graph budget behavior.
 
 The long-term direction is an adversarial semantic test factory: the generator creates
 frontier cases, the verifier proves or refutes them, detector failures become minimal

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,8 +25,8 @@ from-source `./target/release/nose`.
 ## `nose scan`
 
 `nose scan <paths…>` scans one or more files/directories (recursively, respecting
-`.gitignore`), groups duplicated code into **families**, and ranks them by
-**extractability** — how cleanly each family folds into one shared helper — so the
+`.gitignore` files inside each scanned tree), groups duplicated code into **families**, and
+ranks them by **extractability** — how cleanly each family folds into one shared helper — so the
 duplication you can actually act on surfaces first. With no `--mode`, it runs
 `syntax,semantic`: CPD-style syntax runs plus exact semantic Type-4 clones.
 
@@ -40,7 +40,8 @@ breakdown, scope tags, and the `→` hint — is covered in
 The default human, Markdown, SARIF, and `--fail-on` surfaces show only
 action-oriented findings. Tiny proof-only fragments, review-only fragments, and
 families wholly inside files with generated-code headers are omitted with a short
-count line; `--format json --top 0` keeps the full diagnostic family set.
+count line; `--format json --top 0` keeps the post-ranking diagnostic families that
+survive rank-time pruning.
 
 ### Flags
 
@@ -56,7 +57,7 @@ Grouped by what they do. Config-backed scan defaults are listed in
 | `--min-members N` | only families with at least N duplicated sites (default 2) |
 | `--min-value V` | hide families below this refactoring value (noise floor on large repos) |
 | `--min-size N` | ignore units or syntax copy-paste runs smaller than this size, in IL tokens (default 24) |
-| `--mode MODE` | one or more of `syntax`, `semantic`, `near`; comma-list or repeatable; when present, replaces the default |
+| `--mode MODE` | one or more of `syntax`, `semantic`, `near[:T]`; comma-list or repeatable; when present, replaces the default |
 | `--exclude <glob>` | skip paths matching a gitignore-syntax glob (repeatable) |
 | `--ignore-file <file>` | suppress reviewed families using a structured ignore file with reason/owner/expiry metadata |
 
@@ -111,7 +112,7 @@ the standard Type-1–4 taxonomy.
 
 | mode | clone type | detector channel | use when |
 |---|---|---|---|
-| `syntax` | Type-1/2 floor | jscpd-style contiguous copy-paste runs | replacing jscpd / blocking copy-paste clones in CI |
+| `syntax` | Type-1 / exact token-run floor | same-language jscpd-style contiguous copy-paste runs | replacing jscpd / blocking copy-paste clones in CI |
 | `semantic` | Type-4 | exact value-fingerprint matches | high-confidence semantic clones with no fuzzy threshold |
 | `near` | Type-3 | shape candidates + fuzzy structural/value scoring | finding near-duplicates for review |
 
@@ -129,44 +130,19 @@ nose scan src --mode syntax --mode semantic    # same as --mode syntax,semantic
 The `near` channel takes its acceptance threshold inline — `--mode near:0.8` (default
 `0.70`). `syntax` and `semantic` are exact channels and take no threshold.
 
-The `syntax` channel is the CPD floor: it finds duplicated token runs even when they
-start or end in the middle of a function. The normalized unit channels (`semantic` and
-`near`) are where renamed identifiers, cross-language convergence, and Type-3 edits are
-handled.
+The `syntax` channel is the CPD floor: it finds same-language duplicated token runs even
+when they start or end in the middle of a function. The normalized unit channels
+(`semantic` and `near`) are where renamed identifiers, literal-varied Type-2 cases,
+cross-language convergence, and Type-3 edits are handled.
 
 `semantic` is still unit-bounded rather than an arbitrary-fragment equivalence search.
-By default, sub-function units include bounded control-flow blocks and exact-safe
-single-statement fragments such as return/throw expressions and simple
-conditional return/throw/effect guards, including bare returns, explicit empty no-op
-branches, and nested branches whose only non-empty statement is another exact conditional,
-a single exact ForEach effect loop, or exactly two ordered exact effect items drawn from
-ForEach effect loops, append effects, conditional direct effects, and non-overloadable
-C/Go/Java index assignments.
-Conditional branches may also assign one local temporary, or a two-temporary linear chain,
-and immediately consume the final value in a direct return/throw/effect statement or a
-non-overloadable C/Go/Java index assignment whose receiver does not depend on the
-temporary.
-They may contain exactly two or three ordered single-item append effects when each
-appended item is direct or is immediately produced by a branch-local temporary or linear
-temp chain.
-They may also contain exactly two or three ordered non-overloadable C/Go/Java
-index-assignment effects when each assignment is direct or immediately consumes a
-branch-local temporary or linear temp chain.
-They also include ForEach append-effect loops whose only loop-body effects append values
-that depend on the iteration binding, plus C/Go/Java index-assignment effects where index
-assignment is not receiver-overloadable, and Java `this.field = value` self-field
-assignments whose receiver is the language-fixed `this` object. Java function-body blocks
-can also become exact fragments when every body statement is one of those direct or
-conditional `this.field` assignments, optionally followed by a terminal `return this`.
-Conditional branches may also contain exactly two or three ordered Java fixed-`this`
-field assignments; this is admitted only because each write resolves to a proven
-`this.field` place and the oracle observes the resulting field state.
-General field writes such as `other.field = value`, implicit field assignments such as
-`field = value`, `return other`, mixed-effect bodies, arbitrary statement windows, and
-dynamic-property languages remain outside this exact fragment set. Those fragments are
-reported only when the whole value subtree stays inside the displayed source span, the
-fragment is `exact_safe`, and the value fingerprint is large enough for the exact semantic
-gate.
+Besides whole functions/classes/blocks, it admits only exact-safe sub-function fragments
+whose inputs, exits, and ordered effects are self-contained: direct return/throw values,
+bounded conditional guards, selected for-each append/index effects, and fixed-`this` Java
+field writes. General statement windows, dynamic receiver writes, mixed unproven effects,
+and arbitrary field/property mutation stay closed. The exact fragment contract and JSON
+metadata are documented in [fragment-contracts](fragment-contracts.md) and
+[scan-json](scan-json.md#fragment-metadata).
 
 ## Integrating with nose
 
@@ -186,8 +162,9 @@ and may change to improve readability. The stable contract is documented in
 
 ## Other commands
 
-- `nose review [paths…] --base <ref>` — flag clones changed inconsistently in a diff (a
-  copy edited, its siblings missed). The git-aware companion to `scan`; full guide in
+- `nose review [paths…] [--base <ref>]` — flag clones changed inconsistently in a diff (a
+  copy edited, its siblings missed). Defaults to `HEAD` for uncommitted local changes;
+  use `--base origin/main` for a PR branch. The git-aware companion to `scan`; full guide in
   [review](review.md).
 - `nose stats <paths…> [--top N] [--json]` — per-language IL lowering coverage (the
   Raw-node ratio), with the top unhandled surface kinds (`--top`, default 30; `--json`


### PR DESCRIPTION
## Summary
- keep README minimal and point readers to AGENTS.md and the docs wiki
- correct CLI/user-doc claims for review defaults, .gitignore scope, inline suppressions, JSON diagnostic output, and syntax/Type-2 scope
- update benchmark/language/status wording to match current local evidence and clarify historical Type-4/fragment docs

## Verification
- ./scripts/check-ci-local.sh --fast
- ./scripts/check-docs.sh
- git diff --check
- cargo run -q -p nose-cli -- capabilities
- cargo run -q -p nose-cli -- scan examples --min-size 8 --format json --top 0

Notes:
- Raw-node ratio checked from the original workspace with bench/repos present: cargo run --release -q -p nose-cli -- stats bench/repos --json -> raw_ratio 0.00574.
- Current default extractability P@10 was checked with a native-order labelset audit over bench/repos: ~65% dev / 58% held-out.