### PR TITLE
normalize: migrate promise_then canon to a rules/ module (directory gate auto-requires it)

### DIFF
--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -6417,43 +6417,8 @@ impl<'a> Builder<'a> {
 
     /// Evaluate a lambda's body with its positional parameters bound to `params`,
     /// returning the value of its first `return` (intermediate assignments update the
-    /// local env). Used to unfold a `map`/`reduce` lambda over a canonical `Elem`.
-    /// `p.then(λr. body)` ≡ `const r = await p; body`. With `await` already stripped, beta-reduce
-    /// the single-argument continuation callback with the receiver promise's value, so a
-    /// `.then`-chain converges with the equivalent `await`/sequential form. Only the one-argument
-    /// `.then(λr. …)` shape is reduced: `.then(fnRef)` (no lambda body to inline), the
-    /// two-argument `.then(onOk, onErr)`, and `.catch`/`.finally` (error/cleanup continuations
-    /// whose parameter is the error, not the resolved value) are left opaque. Promises wrap
-    /// external async values, so this is a NEAR-channel recall extension, never an exact merge.
-    // proof-obligation: normalize.value_graph.promise_then
-    fn eval_promise_then(
-        &mut self,
-        expr: NodeId,
-        env: &FxHashMap<u32, ValueId>,
-    ) -> Option<ValueId> {
-        let kids = self.il.children(expr).to_vec();
-        if kids.len() != 2 {
-            return None;
-        }
-        let callee = kids[0];
-        if self.il.kind(callee) != NodeKind::Field {
-            return None;
-        }
-        let Payload::Name(s) = self.il.node(callee).payload else {
-            return None;
-        };
-        if self.interner.resolve(s) != "then" {
-            return None;
-        }
-        let cb = kids[1];
-        if self.il.kind(cb) != NodeKind::Lambda {
-            return None;
-        }
-        let &recv = self.il.children(callee).first()?;
-        let recv_v = self.eval(recv, env);
-        self.eval_lambda_body(cb, &[recv_v], env)
-    }
-
+    /// local env). Used to unfold a `map`/`reduce` lambda over a canonical `Elem`, and the
+    /// `.then` continuation callback (see `rules::promise_then`).
     fn eval_lambda_body(
         &mut self,
         lambda: NodeId,
@@ -6972,12 +6937,9 @@ impl<'a> Builder<'a> {
             }
             NodeKind::Call => {
                 let kids = self.il.children(expr).to_vec();
-                // `p.then(λr. body)` is a Promise continuation ≡ `const r = await p; body`.
-                // Since `await` is already stripped to its operand, beta-reduce the callback
-                // with the receiver's value so a `.then`-chain converges with the equivalent
-                // await / sequential code (the #1 real-world async Type-4 gap). Chains reduce
-                // recursively (evaluating the receiver triggers the inner `.then`).
-                if let Some(v) = self.eval_promise_then(expr, env) {
+                // `p.then(λr. body)` is a Promise continuation ≡ `const r = await p; body` — a
+                // value-graph canon proved in `rules::promise_then` (the #1 real-world async gap).
+                if let Some(v) = rules::promise_then::apply(self, expr, env) {
                     return v;
                 }
                 // Reduction builtins fold a collection to one value — canonicalize to

--- a/crates/nose-normalize/src/value_graph/rules.rs
+++ b/crates/nose-normalize/src/value_graph/rules.rs
@@ -5,3 +5,4 @@
 //! formal-obligation linter checks that directory/file pairing mechanically.
 
 pub(super) mod factor_distribute;
+pub(super) mod promise_then;

--- a/crates/nose-normalize/src/value_graph/rules/promise_then.rs
+++ b/crates/nose-normalize/src/value_graph/rules/promise_then.rs
@@ -1,0 +1,43 @@
+//! Promise `.then` continuation canonicalization.
+//!
+//! A settled Promise is modeled by its resolved value (the value graph strips `await` to its
+//! operand), so `p.then(λr. body)` is the continuation applied to that value — exactly what
+//! `let r = await p; body` computes. Beta-reduce the single-argument `.then` callback over the
+//! receiver, so a `.then`-chain converges with the equivalent await / sequential code. Chains
+//! reduce recursively (evaluating the receiver triggers the inner `.then`). `.then(fnRef)` (no
+//! lambda body), the two-argument `.then(onOk, onErr)`, and `.catch`/`.finally` (error/cleanup
+//! continuations whose parameter is the error, not the resolved value) are left opaque.
+//!
+//! proof-obligation: normalize.value_graph.promise_then
+
+use super::super::{Builder, ValueId};
+use nose_il::{NodeId, NodeKind, Payload};
+use rustc_hash::FxHashMap;
+
+pub(in super::super) fn apply(
+    builder: &mut Builder<'_>,
+    expr: NodeId,
+    env: &FxHashMap<u32, ValueId>,
+) -> Option<ValueId> {
+    let kids = builder.il.children(expr).to_vec();
+    if kids.len() != 2 {
+        return None;
+    }
+    let callee = kids[0];
+    if builder.il.kind(callee) != NodeKind::Field {
+        return None;
+    }
+    let Payload::Name(s) = builder.il.node(callee).payload else {
+        return None;
+    };
+    if builder.interner.resolve(s) != "then" {
+        return None;
+    }
+    let cb = kids[1];
+    if builder.il.kind(cb) != NodeKind::Lambda {
+        return None;
+    }
+    let &recv = builder.il.children(callee).first()?;
+    let recv_v = builder.eval(recv, env);
+    builder.eval_lambda_body(cb, &[recv_v], env)
+}

--- a/formal/obligations/normalize/value_graph/promise_then/meta.toml
+++ b/formal/obligations/normalize/value_graph/promise_then/meta.toml
@@ -4,8 +4,9 @@ kind = "soundness"
 summary = "A settled Promise is modeled by its resolved value (the value graph strips `await` to its operand), so `p.then(λr. body r)` is the continuation applied to that value — `let r = await p; body r`. Beta-reducing the `.then` callback over the receiver is therefore meaning-preserving, and a `.then`-chain equals the nested sequential-await composition."
 
 [rust]
-files = ["crates/nose-normalize/src/value_graph.rs"]
-symbols = ["eval_promise_then"]
+rule_module = true
+files = ["crates/nose-normalize/src/value_graph/rules/promise_then.rs"]
+symbols = ["apply"]
 
 [lean]
 proof = "Proof.lean"

--- a/scripts/check-formal-obligations.py
+++ b/scripts/check-formal-obligations.py
@@ -102,15 +102,12 @@ REQUIRED_OBLIGATIONS = (
         ("crates/nose-normalize/src/lib.rs",),
         ("NormalizeOptions", "oracle", "recursion::run"),
     ),
-    # Semantic canons that live INLINE in value_graph.rs (not in the `value_graph/rules/`
+    # Semantic canons that still live INLINE in value_graph.rs (not in the `value_graph/rules/`
     # directory the RULE_ROOTS convention auto-requires) — registered here so the gate enforces
-    # their Lean evidence and marker exactly like a rule module. Without this, a canon added
-    # inline carries no proof obligation and the gate stays silent (the gap this PR closes).
-    RequiredObligation(
-        "normalize.value_graph.promise_then",
-        ("crates/nose-normalize/src/value_graph.rs",),
-        ("eval_promise_then",),
-    ),
+    # their Lean evidence and marker exactly like a rule module. PREFER making a new canon a rule
+    # module (auto-required by the directory convention): `promise_then` was migrated there;
+    # `pure_inline` stays here because it carries Builder state (the inline registry), which a
+    # stateless rule module can't hold.
     RequiredObligation(
         "normalize.value_graph.pure_inline",
         ("crates/nose-normalize/src/value_graph.rs",),


### PR DESCRIPTION
Moves an inline canon onto the **robust** coverage path. The `value_graph/rules/<name>.rs` directory convention auto-requires `normalize.value_graph.<name>` — no manual `REQUIRED_OBLIGATIONS` entry, no naming-convention lint needed. (Rule modules are child modules of `value_graph`, so they reach the Builder's private `eval`/`eval_lambda_body`/`il`/`interner` with no visibility changes.)

- `eval_promise_then` → `rules::promise_then::apply`; the obligation meta now points at the rule module (`rule_module = true`), and `promise_then` is **dropped from `REQUIRED_OBLIGATIONS`** — the directory pairing enforces it (verified: deleting the obligation now fails with "missing matching obligation").
- `pure_inline` stays in `REQUIRED_OBLIGATIONS` — it carries Builder state (the inline registry) and can't be a stateless rule module. Documented.

This establishes `rules/` as the demonstrated home for value-graph canons: a new one added there is auto-required. Behavior-preserving — async `.then` still converges; full suite (204 equiv) + clippy + formal lint (21 obligations) green.

(Honest limit: a canon added *inline* under an arbitrary name still isn't auto-detected — the eval helpers aren't structurally distinguishable. The convention "new canon → `rules/` module" + the `canonicalize_*` naming lint + `REQUIRED_OBLIGATIONS` are the layered mitigations.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Promise 연속(continuation) 처리 로직을 전용 규칙 모듈로 재구성하여 값 그래프 정규화 코드베이스를 정리했습니다. 이제 Promise `.then` 연산자 처리가 더 모듈화되고 유지보수하기 쉬운 구조로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->