### PR TITLE
detect: record source line range per sub-DAG anchor (shared-line provenance)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,7 @@ version = "0.5.0"
 dependencies = [
  "nose-il",
  "rustc-hash",
+ "serde",
 ]
 
 [[package]]

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -2510,12 +2510,59 @@ fn value_anchors(interner: &Interner, src: &str, lang: Lang) -> Vec<u64> {
     let n = normalize(&il, interner, &NormalizeOptions::default());
     nose_normalize::value_anchors(&n, first_func(&n), interner)
         .into_iter()
-        .map(|(hash, _weight)| hash)
+        .map(|anchor| anchor.hash)
         .collect()
 }
 
 fn shares_any(a: &[u64], b: &[u64]) -> bool {
     a.iter().any(|x| b.contains(x))
+}
+
+fn full_anchors(interner: &Interner, src: &str, lang: Lang) -> Vec<nose_normalize::Anchor> {
+    let il = nose_frontend::lower_source(FileId(0), "t", src.as_bytes(), lang, interner).unwrap();
+    let n = normalize(&il, interner, &NormalizeOptions::default());
+    nose_normalize::value_anchors(&n, first_func(&n), interner)
+}
+
+#[test]
+fn sub_dag_anchor_carries_source_line_range_of_the_shared_computation() {
+    // A heavy sub-DAG anchor records WHERE its computation lives (line range), so a partial clone
+    // can report the shared lines. The SAME computation placed on different lines in two functions
+    // yields the same anchor hash but each unit's own line range.
+    let i = Interner::new();
+    let body = |head: &str| {
+        format!(
+            "{head}\n  const totals = items.map(i => i.price * i.qty).reduce((s, x) => s + x, 0);\n  const tax = totals * 0.1;\n  const shipping = totals > 100 ? 0 : 15;\n  const grand = totals + tax + shipping;\n  log(grand);\n  return grand;\n}}\n"
+        )
+    };
+    // Same heavy computation, but two extra lines push it down in `g`.
+    let a = body("function f(items) {");
+    let b = body("function g(items) {\n  log(1);\n  log(2);");
+    let aa = full_anchors(&i, &a, Lang::TypeScript);
+    let bb = full_anchors(&i, &b, Lang::TypeScript);
+    // At least one anchor carries a real (non-zero) line range.
+    assert!(
+        aa.iter().any(|x| x.line_start > 0),
+        "an anchor should record its source line range, got {aa:?}",
+    );
+    // The shared computation produces the same hash in both, on each unit's own line.
+    let sh = aa
+        .iter()
+        .filter(|x| bb.iter().any(|y| y.hash == x.hash))
+        .max_by_key(|x| x.weight)
+        .expect("the shared computation should produce a common anchor hash");
+    let in_b = bb.iter().find(|y| y.hash == sh.hash).unwrap();
+    // Each unit reports the shared computation at ITS OWN location: the two leading `log` lines in
+    // `g` shift every line down by exactly 2.
+    assert!(
+        sh.line_start > 0 && in_b.line_start > 0,
+        "both carry a real line: {sh:?} / {in_b:?}"
+    );
+    assert_eq!(
+        in_b.line_start,
+        sh.line_start + 2,
+        "g's shared computation is 2 lines below f's (the two extra `log` lines)",
+    );
 }
 
 fn value_fp_named(interner: &Interner, src: &str, lang: Lang, name: &str) -> Vec<u64> {

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -1042,8 +1042,8 @@ const ANCHOR_PAIR_CAP: usize = 64;
 fn anchor_candidates(units: &[UnitFeat]) -> Vec<(usize, usize)> {
     let mut buckets: HashMap<u64, Vec<usize>> = HashMap::new();
     for (idx, unit) in units.iter().enumerate() {
-        for &(hash, _weight) in &unit.anchors {
-            buckets.entry(hash).or_default().push(idx);
+        for a in &unit.anchors {
+            buckets.entry(a.hash).or_default().push(idx);
         }
     }
     let max_df = anchor_max_df();
@@ -1069,14 +1069,14 @@ fn anchor_candidates(units: &[UnitFeat]) -> Vec<(usize, usize)> {
 /// The weight of the LARGEST sub-DAG the two units share (0 if none) — a shared anchor is a
 /// shared extractable sub-computation, and a bigger one is a stronger partial-clone signal.
 /// Both anchor lists are sorted by hash, so this is a linear merge.
-fn shared_anchor_weight(a: &[(u64, u32)], b: &[(u64, u32)]) -> u32 {
+fn shared_anchor_weight(a: &[nose_normalize::Anchor], b: &[nose_normalize::Anchor]) -> u32 {
     let (mut i, mut j, mut best) = (0, 0, 0);
     while i < a.len() && j < b.len() {
-        match a[i].0.cmp(&b[j].0) {
+        match a[i].hash.cmp(&b[j].hash) {
             std::cmp::Ordering::Less => i += 1,
             std::cmp::Ordering::Greater => j += 1,
             std::cmp::Ordering::Equal => {
-                best = best.max(a[i].1.min(b[j].1));
+                best = best.max(a[i].weight.min(b[j].weight));
                 i += 1;
                 j += 1;
             }

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -49,13 +49,13 @@ pub struct UnitFeat {
     /// clones return the same computed values; used to demote near-identical units
     /// that differ only in their result (`<` vs `<=`, an extra effect).
     pub returns: Vec<u64>,
-    /// The unit's heavy sub-DAG ANCHORS as `(hash, weight)`, sorted/deduped by hash
-    /// (sub-computations of ≥ `ANCHOR_MIN_WEIGHT` value-nodes). Two units sharing a rare anchor
-    /// share an extractable common sub-computation — a partial / sub-DAG clone that whole-unit
-    /// Jaccard misses; the weight (sub-DAG size) lets the candidate (`near`) channel RANK a
-    /// shared sub-DAG by how big the shared computation is.
+    /// The unit's heavy sub-DAG ANCHORS (sub-computations of ≥ `ANCHOR_MIN_WEIGHT` value-nodes),
+    /// sorted/deduped by hash. Two units sharing a rare anchor share an extractable common
+    /// sub-computation — a partial / sub-DAG clone that whole-unit Jaccard misses. Each carries
+    /// its weight (to RANK the shared sub-DAG by size) and the source line range (to SHOW where
+    /// the shared computation lives).
     #[serde(default)]
-    pub anchors: Vec<(u64, u32)>,
+    pub anchors: Vec<nose_normalize::Anchor>,
     /// Whether the value fingerprint is safe to use as a strict semantic proof.
     ///
     /// `semantic` mode must not report units whose fingerprint passed through lossy

--- a/crates/nose-normalize/Cargo.toml
+++ b/crates/nose-normalize/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 [dependencies]
 nose-il = { workspace = true }
 rustc-hash = { workspace = true }
+serde = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -33,8 +33,8 @@ pub use interp::{run_unit, Behavior, Value};
 pub use value_graph::{
     value_anchors, value_fingerprint, value_fingerprint_and_contracts, value_fingerprint_contracts,
     value_fingerprint_lits, value_fingerprint_lits_anchors,
-    value_fingerprint_lits_anchors_with_context, value_fingerprint_lits_with_context, Anchors,
-    FingerprintBundle, ValueFingerprintContext, ANCHOR_MIN_WEIGHT,
+    value_fingerprint_lits_anchors_with_context, value_fingerprint_lits_with_context, Anchor,
+    Anchors, FingerprintBundle, ValueFingerprintContext, ANCHOR_MIN_WEIGHT,
 };
 
 use nose_il::{FileMeta, Il, IlBuilder, Interner, NodeId, NodeKind, Payload, Symbol, Unit};

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -46,7 +46,7 @@ use crate::module_facts::{
 use crate::types::Ty;
 use nose_il::{
     stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LoopKind, NodeId, NodeKind, Op,
-    ParamSemantic, Payload, Symbol, UnitKind,
+    ParamSemantic, Payload, Span, Symbol, UnitKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -78,8 +78,19 @@ const FREE_NAME_COLLECTION_FACTORIES: &[CollectionFactoryRow] = &[
     ),
 ];
 
-/// A unit's heavy sub-DAG anchors as `(structural hash, sub-DAG weight)`, sorted/deduped by hash.
-pub type Anchors = Vec<(u64, u32)>;
+/// A heavy sub-DAG anchor: a shared sub-computation's structural `hash`, its `weight` (sub-DAG
+/// size), and the source line range (`line_start..=line_end`) of the IL subtree that produced it —
+/// so a partial / sub-DAG clone can report WHERE the shared computation lives in each unit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Anchor {
+    pub hash: u64,
+    pub weight: u32,
+    pub line_start: u32,
+    pub line_end: u32,
+}
+
+/// A unit's heavy sub-DAG anchors, sorted/deduped by hash.
+pub type Anchors = Vec<Anchor>;
 
 /// One value-graph build's fingerprints: `(value, literal, return)` hash multisets plus the
 /// heavy sub-DAG [`Anchors`].
@@ -376,6 +387,13 @@ struct Builder<'a> {
     nodes: Vec<ValNode>,
     /// Structural hash per value node, kept in lockstep with `nodes`.
     vhash: Vec<u64>,
+    /// Source span of the IL subtree that produced each value node (lockstep with `nodes`), so a
+    /// sub-DAG anchor can report WHERE the shared computation lives. Stamped at creation from
+    /// `cur_span` (the enclosing expression being evaluated).
+    node_span: Vec<Option<Span>>,
+    /// The source span of the expression currently being evaluated (set by `eval`), used to stamp
+    /// `node_span` for every node `mk` creates while evaluating it.
+    cur_span: Option<Span>,
     intern: FxHashMap<(ValOp, Vec<ValueId>), ValueId>,
     sinks: Vec<Sink>,
     opaque_ctr: u32,
@@ -500,6 +518,8 @@ impl<'a> Builder<'a> {
             interner,
             nodes: Vec::new(),
             vhash: Vec::new(),
+            node_span: Vec::new(),
+            cur_span: None,
             intern: FxHashMap::default(),
             sinks: Vec::new(),
             opaque_ctr: 0,
@@ -1993,6 +2013,7 @@ impl<'a> Builder<'a> {
         self.nodes.push(ValNode { op, args });
         self.vhash.push(h);
         self.vty.push(ty);
+        self.node_span.push(self.cur_span);
         self.intern.insert(key, id);
         id
     }
@@ -6745,6 +6766,17 @@ impl<'a> Builder<'a> {
     }
 
     fn eval(&mut self, expr: NodeId, env: &FxHashMap<u32, ValueId>) -> ValueId {
+        // Track the enclosing source expression so EVERY node created while evaluating it (the top
+        // node AND the intermediate nodes a reduce/map unfolds via `mk`) is stamped with its span
+        // at creation — those intermediates are exactly what a heavy sub-DAG anchor points at.
+        let prev = self.cur_span;
+        self.cur_span = Some(self.il.node(expr).span);
+        let v = self.eval_inner(expr, env);
+        self.cur_span = prev;
+        v
+    }
+
+    fn eval_inner(&mut self, expr: NodeId, env: &FxHashMap<u32, ValueId>) -> ValueId {
         let node = *self.il.node(expr);
         match node.kind {
             NodeKind::Var => match node.payload {
@@ -7276,7 +7308,7 @@ impl<'a> Builder<'a> {
             }
             weight[i] = w.min(WEIGHT_CAP);
         }
-        let mut out: Vec<(u64, u32)> = Vec::new();
+        let mut out: Anchors = Vec::new();
         for i in 0..n {
             if reachable[i]
                 && weight[i] >= min_weight
@@ -7285,13 +7317,24 @@ impl<'a> Builder<'a> {
                     ValOp::Const(_) | ValOp::Input(_) | ValOp::Elem(_)
                 )
             {
-                out.push((self.vhash[i], weight[i]));
+                let (line_start, line_end) = self
+                    .node_span
+                    .get(i)
+                    .copied()
+                    .flatten()
+                    .map_or((0, 0), |s| (s.start_line, s.end_line));
+                out.push(Anchor {
+                    hash: self.vhash[i],
+                    weight: weight[i],
+                    line_start,
+                    line_end,
+                });
             }
         }
         // Dedup by hash (a given sub-DAG hash has a deterministic weight); sort hash-asc,
         // weight-desc so the kept entry is the largest if a hash ever recurs.
-        out.sort_unstable_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
-        out.dedup_by_key(|&mut (h, _)| h);
+        out.sort_unstable_by(|a, b| a.hash.cmp(&b.hash).then(b.weight.cmp(&a.weight)));
+        out.dedup_by_key(|a| a.hash);
         out
     }
 

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -101,3 +101,12 @@ source — chiefly the per-grammar frontend helpers and the `proven_*` value-gra
 factories (genuinely parallel functions, like the frontend parallelism already accepted here).
 These are dedup candidates, not duplication introduced by the PR. The gate budget is re-baselined
 to 20 so it keeps ratcheting against NEW duplication on top of the stronger detector.
+
+## Budget 20 → 21 and sub-DAG anchors with line ranges
+
+A later PR weight-grades the sub-DAG score (a larger shared computation scores higher), which
+lifts one pre-existing partial-clone family past the substantial threshold — budget re-baselined
+20 → 21. Each sub-DAG anchor also now carries the **source line range** of the shared computation
+(stamped from the enclosing expression during value-graph evaluation), exposed per unit in
+`nose features --format json` (`anchors[].line_start` / `line_end`) — so a partial / sub-DAG clone
+can point at *where* the shared computation lives in each member, not just that one exists.


### PR DESCRIPTION
A sub-DAG partial clone could report that two units share a heavy computation, but not **where**. This tracks value-node→source provenance so each anchor carries the line range of the shared computation.

- `value_graph`: a `cur_span` (the expression being evaluated, set by an `eval` wrapper) stamps `node_span` for every node `mk` creates — **including the intermediate nodes a reduce/map unfolds**, which are exactly what a heavy anchor points at. `anchors()` returns `Anchor { hash, weight, line_start, line_end }` (was a bare `(hash, weight)` tuple).
- The line range rides through `UnitFeat.anchors` into `nose features --format json` per unit. The detector's anchor pairing / weight ranking are unchanged (hash + weight).
- Each unit reports the shared computation at its **own** location (test: the same computation two lines lower in a sibling function reports a line range shifted by exactly two).

No measurable scan-time cost (eval-wrapper overhead is in the noise on nose's own crates). Full suite (205 equiv, +1) + clippy + dup-gate (21) green. `nose-normalize` gains a `serde` dep for the serializable `Anchor`.

**Honest scope:** delivers the shared-line **data** per unit. A turnkey family-level "shared lines X–Y in each member" annotation needs anchors plumbed into `Report`/groups (`rank_families` only sees location clusters today) — left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)