### PR TITLE
detect: make family dedup a deterministic total order (dup-gate robustness)

### DIFF
--- a/crates/nose-detect/src/report.rs
+++ b/crates/nose-detect/src/report.rs
@@ -503,10 +503,17 @@ pub fn rank_families(report: &Report) -> Vec<RefactorFamily> {
     // — leaving its enclosing family *also* in the list: the same OAuth test-server or
     // design-verifier function reported as several overlapping entries. The caller
     // re-sorts the survivors by the chosen key, so this order only governs dedup.)
+    // Sort LARGEST span first (then value), with a min-location final tie-break so this is a TOTAL
+    // order: families that tie on span AND value still sort deterministically by source position,
+    // not by upstream group-iteration order. Without it, two equal-span/value families could be
+    // deduped in either direction depending on map-iteration order, making the kept set (and so the
+    // dup-gate count) sensitive to incidental ordering. (The gate is otherwise fully deterministic:
+    // FxHash and IEEE `+−×÷`/`sqrt` are platform-independent, so CI and local agree exactly.)
     fams.sort_by(|a, b| {
         total_span(b)
             .cmp(&total_span(a))
             .then(b.value.total_cmp(&a.value))
+            .then_with(|| family_min_loc(a).cmp(&family_min_loc(b)))
     });
     // Keep a family unless an already-kept (larger) one subsumes it. `subsumes(k, f)`
     // requires `k` to have a site in the file of *every* `f` site — so any subsumer must
@@ -535,6 +542,16 @@ pub fn rank_families(report: &Report) -> Vec<RefactorFamily> {
 /// Total source lines a family spans across all its sites — its "size" for dedup.
 fn total_span(f: &RefactorFamily) -> u32 {
     f.locations.iter().map(span_lines).sum()
+}
+
+/// A family's lexicographically smallest site `(file, start_line, end_line)` — a stable identity
+/// used only as the final dedup-sort tie-break, so equal-span/value families order deterministically
+/// by source position rather than by incidental group-iteration order.
+fn family_min_loc(f: &RefactorFamily) -> Option<(&str, u32, u32)> {
+    f.locations
+        .iter()
+        .map(|l| (l.file.as_str(), l.start_line, l.end_line))
+        .min()
 }
 
 /// Does family `outer` subsume `inner` — i.e. every `inner` site lands on (mostly
@@ -887,6 +904,35 @@ mod tests {
         assert_eq!(
             fams[0].mean_lines, 31,
             "the surviving family is the outer one"
+        );
+    }
+
+    #[test]
+    fn dedup_order_is_independent_of_group_input_order() {
+        // Two families that tie on span AND value but live in different files. The dedup sort's
+        // min-location tie-break must order them deterministically by source position, NOT by
+        // group-iteration order — otherwise the kept set (and so the dup-gate count) would be
+        // sensitive to incidental ordering.
+        let mk = |f1: &'static str, f2: &'static str| Group {
+            score: 1.0,
+            members: vec![loc(f1, 1, 20, "rust"), loc(f2, 1, 20, "rust")],
+        };
+        let keys = |groups| {
+            rank_families(&report(groups))
+                .iter()
+                .map(|f| family_min_loc(f).map(|(file, s, e)| (file.to_string(), s, e)))
+                .collect::<Vec<_>>()
+        };
+        let forward = keys(vec![mk("a.rs", "a2.rs"), mk("b.rs", "b2.rs")]);
+        let reversed = keys(vec![mk("b.rs", "b2.rs"), mk("a.rs", "a2.rs")]);
+        assert_eq!(
+            forward, reversed,
+            "dedup result must not depend on group input order"
+        );
+        assert_eq!(
+            forward[0].as_ref().unwrap().0,
+            "a.rs",
+            "tied families order by source position",
         );
     }
 

--- a/scripts/check-duplication.sh
+++ b/scripts/check-duplication.sh
@@ -10,6 +10,13 @@
 # Runs only the `near` channel: this gate is about *design-level* Type-3 duplication
 # (families worth extracting), not the syntax copy-paste floor — which always surfaces
 # the reviewed-and-accepted per-grammar frontend parallelism (see docs/dogfooding.md).
+#
+# DETERMINISM: the count is reproducible run-to-run AND across platforms — nose hashes with
+# FxHash (no random seed) and ranks with IEEE correctly-rounded ops only (+ - * / sqrt), and the
+# family dedup sorts by a TOTAL order (span, value, then min source location). So CI and a local
+# run report the SAME number; a count change is a real detection change (new duplication or a
+# grammar/parse difference), never platform jitter. If they ever disagree, suspect a stale binary
+# or a tree-sitter grammar version skew — not nondeterminism.
 set -euo pipefail
 
 MIN_VALUE=40   # ignore small/incidental similarity; gate only on substantial families


### PR DESCRIPTION
**Investigation (your "±1 local-vs-CI" concern):** the dup-gate is *already* deterministic — nose hashes with FxHash (no random seed) and ranks with IEEE correctly-rounded ops only (`+ − × ÷ sqrt`), so CI and local agree exactly (both **21**; run-to-run output is byte-identical). The earlier "CI 20 vs local 21" was a stale-binary measurement artifact during the #88 cycle (a grading-enabled worktree binary vs pre-grading CI main), **not** platform jitter.

**Latent fragility found + fixed:** the family dedup sort broke ties only by `(span, value)`, falling back to upstream group-iteration order — so a tied **peer** family could be dropped or kept depending on incidental ordering. Added a min-source-location final tie-break → the dedup is now a **total order**, independent of input order.

**Effect:** canonicalizes one previously order-dependent outcome — a tied peer pair (`c.rs` ↔ `java.rs` frontend near-dup) that was being dropped is now correctly kept (full family list 264 → 265). The **gated count (value ≥ 40) is unchanged at 21**; the surfaced family is sub-threshold. A correctness fix (peers shouldn't be dedup'd by coin-flip), not a regression.

- `family_min_loc` + tie-break in `rank_families`.
- Regression test: `rank_families` invariant to group input order.
- Determinism guarantees documented in `check-duplication.sh`.

Full suite + clippy + dup-gate (21) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)