### PR TITLE
detect: surface the shared sub-DAG's source lines at the family level (#91 follow-up)

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3070,7 +3070,17 @@ fn print_refactor_human(
                 .as_deref()
                 .map(|n| format!("  {n}"))
                 .unwrap_or_default();
-            println!("    {}:{}-{}{}", l.file, l.start_line, l.end_line, name);
+            // For a partial / sub-DAG clone, point at where the shared computation sits here.
+            let shared = match l.shared_subdag {
+                Some((s, e)) if (s, e) != (l.start_line, l.end_line) => {
+                    format!("  (shared computation: lines {s}-{e})")
+                }
+                _ => String::new(),
+            };
+            println!(
+                "    {}:{}-{}{}{}",
+                l.file, l.start_line, l.end_line, name, shared
+            );
         }
         if f.locations.len() > SITE_CAP {
             println!(

--- a/crates/nose-cli/tests/detection.rs
+++ b/crates/nose-cli/tests/detection.rs
@@ -93,6 +93,44 @@ fn rust_clones_group_decoy_excluded() {
 }
 
 #[test]
+fn sub_dag_family_annotates_each_site_with_shared_computation_lines() {
+    // Two functions that share a heavy computation but differ elsewhere — a partial / sub-DAG
+    // clone caught by the anchor (near) channel. Each site must report ITS OWN source range for
+    // the shared computation, so the report can point at where the shared logic lives in each copy.
+    let a = "function reportA(items) {\n  const totals = items.map(i => i.price * i.qty).reduce((s, x) => s + x, 0);\n  const tax = totals * 0.1;\n  const grand = totals + tax;\n  logA(grand);\n  return grand;\n}\n";
+    let b = "function reportB(items) {\n  warmup();\n  warmup2();\n  const totals = items.map(i => i.price * i.qty).reduce((s, x) => s + x, 0);\n  const tax = totals * 0.1;\n  const grand = totals + tax;\n  saveB(grand);\n  notifyB(grand);\n}\n";
+    let corpus = build(&[("a.ts", a, Lang::TypeScript), ("b.ts", b, Lang::TypeScript)]);
+    let opts = DetectOptions {
+        threshold: 0.70,
+        min_tokens: 1,
+        ..Default::default()
+    };
+    let report = detect(
+        &corpus,
+        &opts,
+        &StructuralDetector::candidates(opts.jaccard_weight),
+    );
+    let families = rank_families(&report);
+    let fam = families
+        .iter()
+        .find(|f| f.locations.iter().any(|l| l.shared_subdag.is_some()))
+        .expect("a sub-DAG family annotated with shared-computation lines must exist");
+    let site = |file: &str| {
+        fam.locations
+            .iter()
+            .find(|l| l.file == file)
+            .and_then(|l| l.shared_subdag)
+    };
+    let sa = site("a.ts").expect("a.ts site is annotated");
+    let sb = site("b.ts").expect("b.ts site is annotated");
+    assert_eq!(
+        sb.0,
+        sa.0 + 2,
+        "each site reports the shared computation at its OWN location (b is two lines lower)",
+    );
+}
+
+#[test]
 fn cross_language_family_groups_six_languages() {
     // The same guarded-accumulator loop, written idiomatically in all six
     // foreach-convergent languages, must land in ONE cross-language family — the

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -460,6 +460,12 @@ pub struct Loc {
     pub reason_code: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enclosing_unit: Option<EnclosingUnit>,
+    /// For a sub-DAG (partial) clone, the inclusive source line range AT THIS SITE of the heavy
+    /// shared computation the family is grouped on (the anchor present in every member). `None`
+    /// when the family shares no heavy sub-DAG, or the anchor carries no source span. Lets a
+    /// partial clone point at *where* the shared computation lives in each copy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shared_subdag: Option<(u32, u32)>,
 }
 
 /// Inclusive source-line range used to construct a [`Loc`].
@@ -533,6 +539,7 @@ impl Loc {
             fragment_kind: None,
             reason_code: None,
             enclosing_unit: None,
+            shared_subdag: None,
         }
     }
 }
@@ -934,12 +941,25 @@ pub fn detect_from_units(
                 .copied()
                 .unwrap_or((0.0, 0));
             let score = if n == 0 { 0.0 } else { sum / n as f64 };
+            let mut locs: Vec<Loc> = members
+                .iter()
+                .map(|&m| loc_of(&units[m], enclosing[m].clone()))
+                .collect();
+            // If every member shares a heavy sub-DAG (a partial / sub-DAG clone), annotate each
+            // site with its OWN source range for that shared computation — so the report can point
+            // at where the shared logic lives in each copy, not just that one exists.
+            if let Some(hash) = shared_subdag_hash(members, &units) {
+                for (&m, loc) in members.iter().zip(locs.iter_mut()) {
+                    if let Some(a) = units[m].anchors.iter().find(|a| a.hash == hash) {
+                        if a.line_start > 0 || a.line_end > 0 {
+                            loc.shared_subdag = Some((a.line_start, a.line_end));
+                        }
+                    }
+                }
+            }
             Group {
                 score: round3(score),
-                members: members
-                    .iter()
-                    .map(|&m| loc_of(&units[m], enclosing[m].clone()))
-                    .collect(),
+                members: locs,
             }
         })
         .collect();
@@ -1064,6 +1084,25 @@ fn anchor_candidates(units: &[UnitFeat]) -> Vec<(usize, usize)> {
         }
     }
     out
+}
+
+/// The heaviest sub-DAG anchor present in EVERY member of a group (`None` if none is shared by
+/// all) — the shared computation the report annotates each site with. For a 2-member partial clone
+/// this is the shared anchor; for a larger family it is the common heavy computation.
+fn shared_subdag_hash(members: &[usize], units: &[UnitFeat]) -> Option<u64> {
+    if members.len() < 2 {
+        return None;
+    }
+    units[members[0]]
+        .anchors
+        .iter()
+        .filter(|a| {
+            members[1..]
+                .iter()
+                .all(|&m| units[m].anchors.iter().any(|b| b.hash == a.hash))
+        })
+        .max_by_key(|a| a.weight)
+        .map(|a| a.hash)
 }
 
 /// The weight of the LARGEST sub-DAG the two units share (0 if none) — a shared anchor is a

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -106,5 +106,10 @@ A later PR weight-grades the sub-DAG score (a larger shared computation scores h
 lifts one pre-existing partial-clone family past the substantial threshold — budget re-baselined
 20 → 21. Each sub-DAG anchor also now carries the **source line range** of the shared computation
 (stamped from the enclosing expression during value-graph evaluation), exposed per unit in
-`nose features --format json` (`anchors[].line_start` / `line_end`) — so a partial / sub-DAG clone
-can point at *where* the shared computation lives in each member, not just that one exists.
+`nose features --format json` (`anchors[].line_start` / `line_end`).
+
+Those line ranges are now surfaced at the **family** level too: when every member of a clone family
+shares a heavy sub-DAG, each site in the report carries `locations[].shared_subdag = [start, end]`
+— its OWN source range for the shared computation — and `nose scan`'s text output appends
+`(shared computation: lines X-Y)` to each site. So a partial / sub-DAG clone points at *where* the
+shared logic lives in every copy, not just that one exists.


### PR DESCRIPTION
#91 recorded each anchor's source line range per unit; this plumbs it into the **family** report so a partial / sub-DAG clone shows **where** the shared computation lives in each copy (the deferred piece from #91).

- New `Loc.shared_subdag: Option<(start, end)>`: at group construction, find the heaviest anchor hash present in **every** member (`shared_subdag_hash`) and stamp each site with its OWN line range for that computation.
- `nose scan` text output appends `(shared computation: lines X-Y)` to each site; the range also rides into `--format json` as `locations[].shared_subdag` (serde-skipped when absent).
- Only annotates when the range differs from the whole-site span (a genuine sub-region).

Test: a partial clone whose shared computation sits two lines lower in the sibling file reports a line range shifted by exactly two per site. Full suite + clippy + dup-gate (21) green; docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 복제 코드 검출 결과에 공유 계산 범위 정보가 추가되었습니다. 각 복제 위치에서 공유되는 계산 부분이 어느 라인에 위치하는지 명확하게 표시됩니다.

* **테스트**
  * 공유 계산 주석 처리 기능의 정확성을 검증하는 테스트가 추가되었습니다.

* **문서**
  * 공유 sub-DAG 라인 범위 표시 방식에 대한 설명이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->