### PR TITLE
normalize: migrate the clamp canon to a rules/ module (directory gate auto-requires it)

### DIFF
--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -1996,7 +1996,7 @@ impl<'a> Builder<'a> {
             }
         }
         let id = self.intern_node(op, args);
-        self.canonicalize_proof_backed_clamp(id).unwrap_or(id)
+        rules::clamp::apply(self, id).unwrap_or(id)
     }
 
     /// Intern a value node by `(op, args)` (hash-consing), computing its structural hash
@@ -3325,35 +3325,6 @@ impl<'a> Builder<'a> {
         } else {
             None
         }
-    }
-
-    fn canonicalize_proof_backed_clamp(&mut self, value: ValueId) -> Option<ValueId> {
-        if !matches!(self.nodes[value as usize].op, ValOp::Bin(o) if o == MIN_CODE || o == MAX_CODE)
-        {
-            return None;
-        }
-        let candidates = self.clamp_minmax_candidates(value);
-        if candidates.is_empty() {
-            return None;
-        }
-        self.clamp_candidate_count += 1;
-        let mut proven: Vec<_> = candidates
-            .into_iter()
-            .filter(|&(x, lo, hi)| {
-                self.is_safe_clamp_integer_value(x)
-                    && self.is_safe_clamp_integer_value(lo)
-                    && self.is_safe_clamp_integer_value(hi)
-                    && self.has_bound_order_fact(lo, hi)
-            })
-            .collect();
-        proven.sort_unstable();
-        proven.dedup();
-        if proven.len() != 1 {
-            return None;
-        }
-        self.clamp_proof_backed_candidate_count += 1;
-        let (x, lo, hi) = proven[0];
-        self.proof_backed_clamp_value(x, lo, hi)
     }
 
     fn clamp_minmax_candidates(&self, value: ValueId) -> Vec<(ValueId, ValueId, ValueId)> {

--- a/crates/nose-normalize/src/value_graph/rules.rs
+++ b/crates/nose-normalize/src/value_graph/rules.rs
@@ -4,5 +4,6 @@
 //! `formal/obligations/normalize/value_graph/<rule>/meta.toml` entry. The
 //! formal-obligation linter checks that directory/file pairing mechanically.
 
+pub(super) mod clamp;
 pub(super) mod factor_distribute;
 pub(super) mod promise_then;

--- a/crates/nose-normalize/src/value_graph/rules/clamp.rs
+++ b/crates/nose-normalize/src/value_graph/rules/clamp.rs
@@ -1,0 +1,38 @@
+//! Proof-backed clamp canonicalization: `min(max(x, lo), hi)` / `max(min(x, hi), lo)` → a single
+//! canonical clamp, but ONLY when the bound order `lo ≤ hi` is a proven fact and every operand is a
+//! safe clamp integer. Distribution of the nested min/max is unsound without `lo ≤ hi` (it would
+//! reorder the saturation), so the order fact is part of the proof obligation; the operands must be
+//! integers because the float min/max NaN semantics differ.
+//!
+//! proof-obligation: normalize.value_graph.clamp
+
+use super::super::{Builder, ValOp, ValueId, MAX_CODE, MIN_CODE};
+
+pub(in super::super) fn apply(builder: &mut Builder<'_>, value: ValueId) -> Option<ValueId> {
+    if !matches!(builder.nodes[value as usize].op, ValOp::Bin(o) if o == MIN_CODE || o == MAX_CODE)
+    {
+        return None;
+    }
+    let candidates = builder.clamp_minmax_candidates(value);
+    if candidates.is_empty() {
+        return None;
+    }
+    builder.clamp_candidate_count += 1;
+    let mut proven: Vec<_> = candidates
+        .into_iter()
+        .filter(|&(x, lo, hi)| {
+            builder.is_safe_clamp_integer_value(x)
+                && builder.is_safe_clamp_integer_value(lo)
+                && builder.is_safe_clamp_integer_value(hi)
+                && builder.has_bound_order_fact(lo, hi)
+        })
+        .collect();
+    proven.sort_unstable();
+    proven.dedup();
+    if proven.len() != 1 {
+        return None;
+    }
+    builder.clamp_proof_backed_candidate_count += 1;
+    let (x, lo, hi) = proven[0];
+    builder.proof_backed_clamp_value(x, lo, hi)
+}

--- a/formal/obligations/normalize/value_graph/clamp/meta.toml
+++ b/formal/obligations/normalize/value_graph/clamp/meta.toml
@@ -4,8 +4,12 @@ kind = "soundness"
 summary = "Clamp min/max compositions and two-comparison forms agree only under the lo <= hi precondition."
 
 [rust]
-files = ["crates/nose-normalize/src/value_graph.rs"]
-symbols = ["minmax_pattern", "canonicalize_proof_backed_clamp"]
+rule_module = true
+files = [
+  "crates/nose-normalize/src/value_graph/rules/clamp.rs",
+  "crates/nose-normalize/src/value_graph.rs",
+]
+symbols = ["apply", "minmax_pattern"]
 
 [lean]
 proof = "Proof.lean"


### PR DESCRIPTION
Continues moving inline value-graph canons onto the robust path (after `promise_then` in #90): the proof-backed clamp recognizer now lives in `value_graph/rules/clamp.rs`, so the directory convention auto-requires `normalize.value_graph.clamp` — no `canonicalize_*` naming special-case needed.

- `canonicalize_proof_backed_clamp` → `rules::clamp::apply(builder, value)`, calling the Builder's clamp helpers + counter fields (reachable because a rule module is a *child* module of `value_graph`). Call site updated.
- Obligation meta → `rule_module = true`, files `[rules/clamp.rs, value_graph.rs]` (the `minmax_pattern` helper stays), symbols `["apply", "minmax_pattern"]`.

Behavior-preserving: scan JSON **byte-identical** to main on an external clamp corpus (the `crates` self-scan changes only because nose's own source moved). Verified the directory convention now **bites** (deleting the obligation fails the gate). Full suite (205 equiv) + clippy + formal lint (21) + dup-gate (21) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)