### PR TITLE
interp: iterating a non-iterable is Err (oracle now covers foreach-accumulators)

### DIFF
--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -25,6 +25,41 @@ fn first_func(il: &nose_il::Il) -> NodeId {
 }
 
 #[test]
+fn foreach_accumulator_is_interpretable_iterating_a_nonlist_is_err_not_unsupported() {
+    // The headline foreach-accumulator: iterating a LIST computes; iterating a non-iterable
+    // (a scalar) is a runtime TYPE ERROR (`Err`), NOT an unmodelable construct. So the unit stays
+    // interpretable on every battery row (list → value, scalar → Err) and the oracle can check it
+    // instead of excluding it. Before this, the scalar case returned `Unsupported` (None), which
+    // dropped the whole unit from the oracle.
+    let i = Interner::new();
+    let il = nose_frontend::lower_source(
+        FileId(0),
+        "t",
+        b"def sum_pos(xs):\n    t = 0\n    for x in xs:\n        if x > 0:\n            t = t + x\n    return t\n",
+        Lang::Python,
+        &i,
+    )
+    .unwrap();
+    let n = normalize(&il, &i, &NormalizeOptions::default());
+    let f = first_func(&n);
+    use nose_normalize::{run_unit, Value};
+    let list = Value::List(vec![Value::Int(2), Value::Int(-1), Value::Int(5)]);
+    assert_eq!(
+        run_unit(&n, f, &[list])
+            .expect("list input is interpretable")
+            .ret,
+        Value::Int(7),
+        "summing the positives of [2,-1,5] is 7",
+    );
+    let scalar = run_unit(&n, f, &[Value::Int(3)]).expect("scalar input stays interpretable (Err)");
+    assert_eq!(
+        scalar.ret,
+        Value::Err,
+        "iterating a scalar is a runtime type error (Err), not Unsupported",
+    );
+}
+
+#[test]
 fn loop_unification_cfor_equals_while() {
     let i = Interner::new();
     let cfor = "function f(xs){ let t=0; for(let k=0;k<xs.length;k++){ t+=xs[k]; } return t; }";

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -293,7 +293,13 @@ impl<'a> Interp<'a> {
                 let seq = match self.eval(kids[1], env)? {
                     Value::List(xs) => xs,
                     Value::Err => return Ok(Flow::Err),
-                    _ => return Err(Unsupported),
+                    // Iterating a non-iterable (int/bool/null/string) is a runtime TYPE ERROR in
+                    // every modeled language (Python/JS `TypeError`, …), not an unmodelable
+                    // construct — so it is `Err` behavior, NOT `Unsupported`. This keeps a
+                    // foreach-accumulator (the headline cross-language Type-4 pattern) interpretable
+                    // even on the battery's scalar rows: it `Err`s there and computes on the list
+                    // rows, so the oracle CHECKS it instead of excluding the whole unit.
+                    _ => return Ok(Flow::Err),
                 };
                 for item in seq {
                     self.tick()?;

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -400,7 +400,9 @@ plus a checker (`nose verify`) that groups units by value fingerprint and assert
 **fingerprint-equal ⟹ behavior-equal on every input** (a battery of input vectors per
 interpretable function). It is intentionally *partial*: any unmodeled construct (opaque call,
 field access, exception) makes the whole unit uninterpretable and it is excluded — never
-guessed. It **need not match any language exactly, only be self-consistent**: a genuinely
+guessed. (A genuine runtime *type error*, though, is behavior, not an unmodeled construct: e.g.
+iterating a non-iterable — a scalar where the battery feeds one to a `for`-each — yields `Err`,
+so a foreach-accumulator stays interpretable across the battery instead of being dropped.) It **need not match any language exactly, only be self-consistent**: a genuinely
 equivalent pair agrees under any consistent semantics, so a merge the interpreter contradicts is
 a real bug. This sets the asymmetry that defines the instrument: **soundness violations are
 proofs (every one a real bug); completeness misses are leads (some real, some battery


### PR DESCRIPTION
The interpreter dropped a whole unit to `Unsupported` when a `for`-each's iteree wasn't a list. But iterating a non-iterable is a runtime **type error** in every modeled language (Python/JS `TypeError`, …) — i.e. `Err` *behavior*, not an unmodelable construct. Since the verify battery feeds each parameter a mix of lists **and** scalars, a foreach-accumulator (the headline cross-language Type-4 pattern) hit a scalar row, returned `Unsupported`, and was **excluded from the oracle entirely**.

Return `Err` there instead → a foreach-accumulator stays interpretable on every battery row (list → value, scalar → `Err`), so the oracle **checks** the headline pattern instead of skipping it.

**Effect:** a 3-function foreach-accumulator corpus goes 0 → 3 interpretable; nose's own crates 28 → 29. Soundness preserved: `nose verify crates --max-violations 0` → SOUND, 0 false merges.

Test: `sum_pos(xs)` = 7 on `[2,-1,5]` and `Err` on a scalar (interpretable both ways, not dropped). Full suite (206 equiv) + clippy + dup-gate (21) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)