### PR TITLE
Build semantic kernel pack foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,7 @@ dependencies = [
  "nose-frontend",
  "nose-il",
  "nose-normalize",
+ "nose-semantics",
  "rayon",
  "rustc-hash",
  "serde",
@@ -502,6 +503,7 @@ dependencies = [
  "anyhow",
  "ignore",
  "nose-il",
+ "nose-semantics",
  "rayon",
  "rustc-hash",
  "serde",
@@ -529,8 +531,16 @@ name = "nose-normalize"
 version = "0.5.0"
 dependencies = [
  "nose-il",
+ "nose-semantics",
  "rustc-hash",
  "serde",
+]
+
+[[package]]
+name = "nose-semantics"
+version = "0.5.0"
+dependencies = [
+ "nose-il",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/nose-il",
+    "crates/nose-semantics",
     "crates/nose-frontend",
     "crates/nose-normalize",
     "crates/nose-detect",
@@ -25,6 +26,7 @@ rust-version = "1.85"
 # Internal crates carry an explicit `version` (not just `path`) so the tree has no
 # wildcard deps and the crates stay publishable; `path` wins for local builds.
 nose-il = { path = "crates/nose-il", version = "0.5.0" }
+nose-semantics = { path = "crates/nose-semantics", version = "0.5.0" }
 nose-frontend = { path = "crates/nose-frontend", version = "0.5.0" }
 nose-normalize = { path = "crates/nose-normalize", version = "0.5.0" }
 nose-detect = { path = "crates/nose-detect", version = "0.5.0" }

--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -5546,8 +5546,8 @@ fn scan_mode_semantic_proves_collection_empty_checks() {
             && semantic_text.contains("rust_named.rs")
             && semantic_text.contains("java_size.java")
             && semantic_text.contains("java_named.java")
-            && semantic_text.contains("ruby_length.rb")
-            && semantic_text.contains("ruby_named.rb")
+            && !semantic_text.contains("ruby_length.rb")
+            && !semantic_text.contains("ruby_named.rb")
             && !semantic_text.contains("rust_threshold_negative.rs")
             && !semantic_text.contains("rust_receiver_negative.rs"),
         "semantic mode must prove collection-empty checks without merging boundaries: {semantic}"
@@ -5563,7 +5563,7 @@ fn scan_mode_semantic_proves_string_prefix_checks() {
     fs::create_dir_all(&dir).unwrap();
     fs::write(
         dir.join("prefix.py"),
-        "def prefix(value, other):\n    return value.startswith(\"pre\")\n",
+        "def prefix(value: str, other: str) -> bool:\n    return value.startswith(\"pre\")\n",
     )
     .unwrap();
     fs::write(
@@ -5635,12 +5635,10 @@ fn scan_mode_semantic_proves_string_prefix_checks() {
     let semantic_text = semantic_json.to_string();
     for expected in [
         "prefix.py",
-        "prefix.js",
         "prefix.ts",
         "prefix.go",
         "prefix.rs",
         "prefix.java",
-        "prefix.rb",
     ] {
         assert!(
             semantic_text.contains(expected),
@@ -5648,6 +5646,8 @@ fn scan_mode_semantic_proves_string_prefix_checks() {
         );
     }
     for unexpected in [
+        "prefix.js",
+        "prefix.rb",
         "affix_negative.py",
         "direction_negative.js",
         "receiver_negative.rs",
@@ -5662,7 +5662,7 @@ fn scan_mode_semantic_proves_string_prefix_checks() {
 }
 
 #[test]
-fn scan_mode_semantic_proves_rust_numeric_methods() {
+fn scan_mode_semantic_proves_rust_integer_methods() {
     let dir =
         std::env::temp_dir().join(format!("nose_rust_numeric_methods_{}", std::process::id()));
     let _ = fs::remove_dir_all(&dir);
@@ -5746,7 +5746,7 @@ fn scan_mode_semantic_proves_rust_numeric_methods() {
                 expected_pair.iter().all(|expected| text.contains(expected))
             })
             .unwrap_or_else(|| {
-                panic!("semantic mode should report numeric method family: {semantic}")
+                panic!("semantic mode should report integer method family: {semantic}")
             });
         let text = family.to_string();
         for unexpected in [
@@ -5757,7 +5757,7 @@ fn scan_mode_semantic_proves_rust_numeric_methods() {
         ] {
             assert!(
                 !text.contains(unexpected),
-                "semantic mode must preserve Rust numeric method boundaries: {semantic}"
+                "semantic mode must preserve Rust integer method boundaries: {semantic}"
             );
         }
     }
@@ -6278,8 +6278,6 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
         "python_deque_namespace.py",
         "python_module_tuple.py",
         "python_module_set.py",
-        "module_set.js",
-        "module_set.ts",
         "array_some.js",
         "array_some.ts",
         "array_indexof.js",
@@ -6294,11 +6292,11 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
         "array_every.ts",
         "array_filter_length_absence.js",
         "array_filter_length_absence.ts",
-        "module_list.java",
         "go_slices_package.go",
         "go_slices_alias.go",
         "go_slices_const.go",
         "go_slices_local.go",
+        "module_list.java",
         "java_local_list.java",
         "rust_local_array.rs",
         "rust_local_typed_array.rs",
@@ -6332,6 +6330,8 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
         "array_every_wrong_element.js",
         "array_every_wrong_collection.ts",
         "substring.rs",
+        "module_set.js",
+        "module_set.ts",
         "module_set_mutated.js",
         "python_module_mutated.py",
         "module_set_shadowed.ts",
@@ -6699,8 +6699,6 @@ fn scan_mode_semantic_proves_set_membership_when_receiver_is_proven() {
     let semantic_families = scan_families(&semantic_json);
     let expected_positive = [
         "literal.py",
-        "set_inline.js",
-        "set_local.js",
         "java_list_of.java",
         "java_set_of.java",
         "java_arrays_aslist.java",
@@ -6728,6 +6726,8 @@ fn scan_mode_semantic_proves_set_membership_when_receiver_is_proven() {
         });
     let typed_text = typed_family.to_string();
     for unexpected in [
+        "set_inline.js",
+        "set_local.js",
         "wrong_element.js",
         "wrong_collection.js",
         "untyped_receiver.ts",
@@ -6847,7 +6847,7 @@ fn scan_mode_semantic_proves_typed_typescript_map_key_membership() {
     fs::create_dir_all(&dir).unwrap();
     fs::write(
         dir.join("map_key.py"),
-        "def f(lookup, other_lookup, key, other):\n    return key in lookup\n",
+        "def f(lookup: dict[str, str], other_lookup: dict[str, str], key: str, other: str) -> bool:\n    return key in lookup\n",
     )
     .unwrap();
     fs::write(
@@ -7624,19 +7624,12 @@ fn scan_mode_semantic_proves_literal_map_default_lookup() {
         "map_default.py",
         "map_default.rb",
         "map_default_block.rb",
-        "map_default_inline.js",
-        "map_default_local.js",
-        "map_default_has_get.js",
-        "map_default_inline.ts",
         "map_default_java_of.java",
         "map_default_java_entries.java",
         "map_default_java_local.java",
-        "map_default_module.js",
-        "map_default_module.ts",
         "map_default_module.java",
         "map_default_rust_hashmap.rs",
         "map_default_rust_btreemap.rs",
-        "map_default_rust_local.rs",
         "map_default_go_inline.go",
         "map_default_go_local.go",
         "map_default_go_var.go",
@@ -7770,6 +7763,13 @@ fn scan_mode_semantic_proves_literal_map_default_lookup() {
         "wrong_map.py",
         "ruby_fetch_block_param.rb",
         "ruby_fetch_raise_block.rb",
+        "map_default_inline.js",
+        "map_default_local.js",
+        "map_default_has_get.js",
+        "map_default_inline.ts",
+        "map_default_module.js",
+        "map_default_module.ts",
+        "map_default_rust_local.rs",
         "wrong_js_key.js",
         "wrong_js_default.js",
         "wrong_js_map.js",
@@ -7888,7 +7888,6 @@ fn scan_mode_semantic_proves_null_presence_predicates() {
     for expected in [
         "none_compare.py",
         "null_compare.c",
-        "nil_method.rb",
         "none_method.rs",
         "iflet_none.rs",
     ] {
@@ -7897,7 +7896,7 @@ fn scan_mode_semantic_proves_null_presence_predicates() {
             "semantic mode should include {expected}: {semantic}"
         );
     }
-    for unexpected in ["some_method.rs", "wrong_value.py"] {
+    for unexpected in ["nil_method.rb", "some_method.rs", "wrong_value.py"] {
         assert!(
             !semantic_text.contains(unexpected),
             "semantic mode must preserve null-presence boundaries: {semantic}"
@@ -7914,13 +7913,13 @@ fn scan_mode_semantic_reports_flattened_guard_span_only() {
     fs::create_dir_all(&dir).unwrap();
 
     fs::write(
-        dir.join("large_branch.rb"),
-        "def table(rows, errors)\n  if rows.length == 0\n    return nil\n  else\n    title = \"Potential problems\"\n    if errors.length > 0\n      title = title.red\n    else\n      title = title.yellow\n    end\n    return Terminal::Table.new(title: title, rows: rows).to_s\n  end\nend\n",
+        dir.join("large_branch.ts"),
+        "export function table(rows: string[], errors: string[]) {\n  if (rows.length === 0) {\n    return null;\n  } else {\n    let title = \"Potential problems\";\n    if (errors.length > 0) {\n      title = title.toUpperCase();\n    } else {\n      title = title.toLowerCase();\n    }\n    return title + rows.join(\",\");\n  }\n}\n",
     )
     .unwrap();
     fs::write(
-        dir.join("small_guard.rb"),
-        "def payload(data)\n  return nil if data.empty?\n  data\nend\n",
+        dir.join("small_guard.ts"),
+        "export function payload(data: string[]) {\n  if (data.length === 0) return null;\n  return data;\n}\n",
     )
     .unwrap();
 
@@ -7942,7 +7941,7 @@ fn scan_mode_semantic_reports_flattened_guard_span_only() {
     let families = scan_families(&semantic_json);
     let text = semantic_json.to_string();
     assert!(
-        text.contains("large_branch.rb") && text.contains("small_guard.rb"),
+        text.contains("large_branch.ts") && text.contains("small_guard.ts"),
         "semantic mode should still report the strict guard-clause clone: {semantic}"
     );
     assert!(
@@ -7954,8 +7953,8 @@ fn scan_mode_semantic_reports_flattened_guard_span_only() {
                 let Some(file) = loc["file"].as_str() else {
                     return true;
                 };
-                !file.ends_with("large_branch.rb")
-                    || (loc["start_line"] == 2 && loc["end_line"] == 3)
+                !file.ends_with("large_branch.ts")
+                    || (loc["start_line"] == 2 && loc["end_line"] == 4)
             })
         }),
         "semantic mode must not report the flattened guard as the whole if/else span: {semantic}"

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -132,7 +132,8 @@ fn loop_converges_with_reduce_and_comprehension() {
     // SAME value fingerprint — they are the same fold.
     let i = Interner::new();
     let prod_loop = "def p(xs):\n    r = 1\n    for x in xs:\n        r = r * x\n    return r\n";
-    let prod_reduce = "def p(xs):\n    return reduce(lambda a, b: a * b, xs, 1)\n";
+    let prod_reduce =
+        "import functools\n\ndef p(xs):\n    return functools.reduce(lambda a, b: a * b, xs, 1)\n";
     assert_eq!(
         value_fp(&i, prod_loop, Lang::Python),
         value_fp(&i, prod_reduce, Lang::Python),
@@ -370,16 +371,16 @@ fn filtered_method_reduce_converges_with_guarded_loop() {
     // `if p(x) { acc = acc ⊕ x }`. The value graph must attach the filter predicate
     // to the reduce contribution, while the accumulator seed stays behavior-defining.
     let i = Interner::new();
-    let loop_js = "function f(xs){ let total = 0; for (const x of xs) { if (x > 0) { total += x; } } return total; }";
+    let loop_js = "function f(xs: number[]): number { let total = 0; for (const x of xs) { if (x > 0) { total += x; } } return total; }";
     let reduce_js =
-        "function f(xs){ return xs.filter(x => x > 0).reduce((total, x) => total + x, 0); }";
+        "function f(xs: number[]): number { return xs.filter(x => x > 0).reduce((total, x) => total + x, 0); }";
     let reduce_rs = "fn f(xs: &[i64]) -> i64 { xs.iter().copied().filter(|x| *x > 0).fold(0, |total, x| total + x) }";
     let bad_init =
-        "function f(xs){ return xs.filter(x => x > 0).reduce((total, x) => total + x, 1); }";
-    let loop_fp = value_fp(&i, loop_js, Lang::JavaScript);
+        "function f(xs: number[]): number { return xs.filter(x => x > 0).reduce((total, x) => total + x, 1); }";
+    let loop_fp = value_fp(&i, loop_js, Lang::TypeScript);
     assert_eq!(
         loop_fp,
-        value_fp(&i, reduce_js, Lang::JavaScript),
+        value_fp(&i, reduce_js, Lang::TypeScript),
         "JS filter().reduce(sum) should converge with the guarded loop"
     );
     assert_eq!(
@@ -389,41 +390,43 @@ fn filtered_method_reduce_converges_with_guarded_loop() {
     );
     assert_ne!(
         loop_fp,
-        value_fp(&i, bad_init, Lang::JavaScript),
+        value_fp(&i, bad_init, Lang::TypeScript),
         "changing the reduce seed is a hard negative"
     );
 }
 
 #[test]
 fn filtered_count_aggregates_converge_with_count_loop() {
-    // `filter(p).length`, `filter(p).count()`, and `count { p }` are all
-    // count-filter reductions: add 1 when the predicate holds, otherwise add 0.
+    // `filter(p).length` and Rust `filter(p).count()` are count-filter reductions:
+    // add 1 when the predicate holds, otherwise add 0. Ruby `count { p }` stays opaque
+    // until a pack/receiver proof can establish that `xs` is Ruby's collection protocol.
     let i = Interner::new();
-    let loop_js = "function f(xs){ let count = 0; for (const x of xs) { if (x > 0) { count += 1; } } return count; }";
-    let len_js = "function f(xs){ return xs.filter(x => x > 0).length; }";
+    let loop_js = "function f(xs: number[]): number { let count = 0; for (const x of xs) { if (x > 0) { count += 1; } } return count; }";
+    let len_js = "function f(xs: number[]): number { return xs.filter(x => x > 0).length; }";
     let count_rs =
         "fn f(xs: &[i64]) -> i64 { xs.iter().copied().filter(|x| *x > 0).count() as i64 }";
     let count_rb = "def f(xs)\n  xs.count { |x| x > 0 }\nend\n";
-    let bad_predicate = "function f(xs){ return xs.filter(x => x >= 0).length; }";
-    let loop_fp = value_fp(&i, loop_js, Lang::JavaScript);
+    let bad_predicate =
+        "function f(xs: number[]): number { return xs.filter(x => x >= 0).length; }";
+    let loop_fp = return_fp(&i, loop_js, Lang::TypeScript);
     assert_eq!(
         loop_fp,
-        value_fp(&i, len_js, Lang::JavaScript),
+        return_fp(&i, len_js, Lang::TypeScript),
         "JS filter().length should converge with a guarded count loop"
     );
     assert_eq!(
         loop_fp,
-        value_fp(&i, count_rs, Lang::Rust),
+        return_fp(&i, count_rs, Lang::Rust),
         "Rust filter().count() should converge through the same count reduce"
-    );
-    assert_eq!(
-        loop_fp,
-        value_fp(&i, count_rb, Lang::Ruby),
-        "Ruby count block should converge through the same count reduce"
     );
     assert_ne!(
         loop_fp,
-        value_fp(&i, bad_predicate, Lang::JavaScript),
+        return_fp(&i, count_rb, Lang::Ruby),
+        "Ruby count block must stay closed without a receiver/protocol proof"
+    );
+    assert_ne!(
+        loop_fp,
+        return_fp(&i, bad_predicate, Lang::TypeScript),
         "changing the count predicate is a hard negative"
     );
 }
@@ -447,8 +450,8 @@ fn java_stream_aggregates_converge_with_loops() {
     let sum_fp = value_fp(&i, sum_loop, Lang::Java);
     assert_eq!(sum_fp, value_fp(&i, sum_stream, Lang::Java));
     assert_eq!(
-        value_fp(&i, count_loop, Lang::Java),
-        value_fp(&i, count_stream, Lang::Java)
+        return_fp(&i, count_loop, Lang::Java),
+        return_fp(&i, count_stream, Lang::Java)
     );
     assert_eq!(
         value_fp(&i, any_loop, Lang::Java),
@@ -488,20 +491,20 @@ fn java_stream_flat_map_converges_with_python_comprehension() {
 }
 
 #[test]
-fn rust_vec_new_builder_loop_converges_with_flat_map() {
-    // `out = Vec::new()`-seeded builder loops now enter the exact channel like `[]`-seeded
-    // ones: `Vec::new()` is the empty vector (the value graph already models it as an empty
-    // Seq), so the exact-safe gate recognizes it. A nested flatten builder loop converges with
-    // `.flat_map(|xs| xs.iter().map(...))`; a changed inner element stays a hard negative.
+fn rust_vec_new_builder_loop_stays_distinct_from_flat_map_without_nested_element_proof() {
+    // `xss: &[Vec<_>]` proves the outer parameter is a collection, but the current semantic
+    // kernel does not yet carry the element-type proof needed to know that the lambda parameter
+    // `xs` is itself a collection. Keep the `.flat_map(|xs| xs.iter()...)` form fail-closed until
+    // nested collection receiver proofs exist.
     let i = Interner::new();
     let builder = "pub fn f(xss: &[Vec<i64>]) -> Vec<i64> { let mut out = Vec::new(); for xs in xss { for y in xs { out.push(*y); } } out }";
     let flat = "pub fn f(xss: &[Vec<i64>]) -> Vec<i64> { xss.iter().flat_map(|xs| xs.iter().map(|y| *y)).collect() }";
     let changed = "pub fn f(xss: &[Vec<i64>]) -> Vec<i64> { xss.iter().flat_map(|xs| xs.iter().map(|y| y + 1)).collect() }";
     let bfp = value_fp(&i, builder, Lang::Rust);
-    assert_eq!(
+    assert_ne!(
         bfp,
         value_fp(&i, flat, Lang::Rust),
-        "rust Vec::new() builder loop must converge with flat_map"
+        "nested flat_map must not converge without a nested element collection proof"
     );
     assert_ne!(
         bfp,
@@ -682,20 +685,19 @@ fn sub_dag_anchor_shared_when_units_share_a_heavy_computation() {
 }
 
 #[test]
-fn promise_then_chain_converges_with_await_sequential_code() {
-    // `p.then(r => body)` is a Promise continuation ≡ `const r = await p; body`. Beta-reducing
-    // the callback with the receiver makes a `.then`-chain's value fingerprint identical to the
-    // equivalent await/sequential code (the #1 real-world async Type-4 gap). A different
-    // continuation expression stays distinct.
+fn promise_then_chain_stays_opaque_without_receiver_proof() {
+    // A `.then` name is not itself proof of Promise/thenable semantics. Until the frontend or a
+    // semantic pack carries a resolved Promise-like receiver proof, exact value fingerprints must
+    // keep `.then` opaque rather than beta-reducing an arbitrary user method.
     let i = Interner::new();
     let await_form = "function f(id) {\n  const r = await db.get(id);\n  return r.x + 1;\n}\n";
     let then_form = "function f(id) {\n  return db.get(id).then(r => r.x + 1);\n}\n";
     let then_diff = "function f(id) {\n  return db.get(id).then(r => r.y - 1);\n}\n";
     let av = value_fp(&i, await_form, Lang::TypeScript);
-    assert_eq!(
+    assert_ne!(
         av,
         value_fp(&i, then_form, Lang::TypeScript),
-        "a `.then` continuation must converge with the equivalent await/sequential code"
+        "a `.then` continuation must not converge with await without receiver proof"
     );
     assert_ne!(
         av,
@@ -759,38 +761,40 @@ fn pure_method_recursion_converges_with_iteration() {
 }
 
 #[test]
-fn flatmap_identity_converges_with_inner_map_and_flatten_loop() {
-    // `xss.flatMap(xs => xs)` (identity inner) is `flatten`, equal to the explicit
-    // inner-identity-map `xss.flatMap(xs => xs.map(y => y))` and to the nested builder loop —
-    // the monad law `flatMap id = join` (`map id = id` on each sublist, so every emitted
-    // element is unchanged). A changed inner element stays a hard negative.
+fn flatmap_identity_converges_with_explicit_flatten_but_inner_map_stays_closed() {
+    // `xss.flatMap(xs => xs)` is a flatten semantically and converges with an explicit nested
+    // builder loop. The inner `xs.map(...)` form still stays closed until the kernel carries
+    // nested element collection proofs for `xs`.
     let i = Interner::new();
-    let identity = "function f(xss){ return xss.flatMap(xs => xs); }";
-    let inner_map = "function f(xss){ return xss.flatMap(xs => xs.map(y => y)); }";
-    let builder = "function f(xss){ const out = []; for (const xs of xss) { for (const y of xs) { out.push(y); } } return out; }";
-    let changed = "function f(xss){ return xss.flatMap(xs => xs.map(y => y + 1)); }";
-    let id_fp = value_fp(&i, identity, Lang::JavaScript);
-    assert_eq!(
+    let identity = "function f(xss: number[][]): number[] { return xss.flatMap(xs => xs); }";
+    let inner_map =
+        "function f(xss: number[][]): number[] { return xss.flatMap(xs => xs.map(y => y)); }";
+    let builder = "function f(xss: number[][]): number[] { const out: number[] = []; for (const xs of xss) { for (const y of xs) { out.push(y); } } return out; }";
+    let changed =
+        "function f(xss: number[][]): number[] { return xss.flatMap(xs => xs.map(y => y + 1)); }";
+    let id_fp = value_fp(&i, identity, Lang::TypeScript);
+    assert_ne!(
         id_fp,
-        value_fp(&i, inner_map, Lang::JavaScript),
-        "flatMap(id) must converge with flatMap(x => x.map(y => y))"
+        value_fp(&i, inner_map, Lang::TypeScript),
+        "inner map must stay closed without nested element collection proof"
     );
     assert_eq!(
         id_fp,
-        value_fp(&i, builder, Lang::JavaScript),
-        "flatMap(id) must converge with the nested builder loop (flatten)"
+        value_fp(&i, builder, Lang::TypeScript),
+        "flatMap(id) should converge with the explicit nested builder loop"
     );
     assert_ne!(
         id_fp,
-        value_fp(&i, changed, Lang::JavaScript),
+        value_fp(&i, changed, Lang::TypeScript),
         "a changed inner element (y + 1) must stay distinct (hard negative)"
     );
 }
 
 #[test]
 fn ruby_select_reduce_converges_with_guarded_loop() {
-    // Ruby `select { p }.reduce(init) { |a, x| ... }` is the same filtered fold as
-    // a guarded `each` accumulator loop. The changed seed remains a hard negative.
+    // Ruby `select { p }.reduce(init) { |a, x| ... }` is the same filtered fold only when
+    // `xs` is proven to be Ruby's collection protocol. With no receiver proof in this snippet,
+    // the method chain stays closed. The changed seed remains a hard negative.
     let i = Interner::new();
     let loop_rb = "def f(xs)\n  total = 0\n  xs.each do |x|\n    if x > 0\n      total += x\n    end\n  end\n  total\nend\n";
     let reduce_rb =
@@ -801,8 +805,8 @@ fn ruby_select_reduce_converges_with_guarded_loop() {
         "def f(xs)\n  xs.select { |x| x > 0 }.reduce(1) { |product, x| product * x }\nend\n";
     let bad_seed = "def f(xs)\n  xs.select { |x| x > 0 }.reduce(1) { |total, x| total + x }\nend\n";
     let sum_fp = value_fp(&i, loop_rb, Lang::Ruby);
-    assert_eq!(sum_fp, value_fp(&i, reduce_rb, Lang::Ruby));
-    assert_eq!(
+    assert_ne!(sum_fp, value_fp(&i, reduce_rb, Lang::Ruby));
+    assert_ne!(
         value_fp(&i, product_loop, Lang::Ruby),
         value_fp(&i, product_reduce, Lang::Ruby)
     );
@@ -818,8 +822,8 @@ fn ruby_any_all_predicates_converge_with_early_return_loops() {
     let all_call = "def f(xs)\n  xs.all? { |x| x >= 0 }\nend\n";
     let bad_predicate = "def f(xs)\n  xs.any? { |x| x >= 0 }\nend\n";
     let any_fp = value_fp(&i, any_loop, Lang::Ruby);
-    assert_eq!(any_fp, value_fp(&i, any_call, Lang::Ruby));
-    assert_eq!(
+    assert_ne!(any_fp, value_fp(&i, any_call, Lang::Ruby));
+    assert_ne!(
         value_fp(&i, all_loop, Lang::Ruby),
         value_fp(&i, all_call, Lang::Ruby)
     );
@@ -926,14 +930,15 @@ fn selection_reduction_loops_converge_cross_language() {
     let py_max = "def f(xs):\n    best = 0\n    for x in xs:\n        if x > best:\n            best = x\n    return best\n";
     let js_max =
         "function f(xs){ let best = 0; for (const x of xs) { if (x > best) { best = x; } } return best; }";
-    let reduce_js = "function f(xs){ return xs.reduce((best, x) => x > best ? x : best, 0); }";
+    let reduce_js =
+        "function f(xs: number[]): number { return xs.reduce((best, x) => x > best ? x : best, 0); }";
     let rust_max =
         "fn f(xs: &[i32]) -> i32 { let mut best = 0; for &x in xs { if x > best { best = x; } } best }";
     let rust_fold_max =
         "fn f(xs: &[i32]) -> i32 { xs.iter().copied().fold(0, |best, x| if x > best { x } else { best }) }";
     let py_min = "def f(xs):\n    best = 0\n    for x in xs:\n        if x < best:\n            best = x\n    return best\n";
     let reduce_py =
-        "def f(xs):\n    return reduce(lambda best, x: x if x < best else best, xs, 0)\n";
+        "import functools\n\ndef f(xs):\n    return functools.reduce(lambda best, x: x if x < best else best, xs, 0)\n";
     let rust_min =
         "fn f(xs: &[i32]) -> i32 { let mut best = 0; for &x in xs { if x < best { best = x; } } best }";
     let rust_fold_min =
@@ -942,7 +947,7 @@ fn selection_reduction_loops_converge_cross_language() {
 
     let max_fp = value_fp(&i, py_max, Lang::Python);
     assert_eq!(max_fp, value_fp(&i, js_max, Lang::JavaScript));
-    assert_eq!(max_fp, value_fp(&i, reduce_js, Lang::JavaScript));
+    assert_eq!(max_fp, value_fp(&i, reduce_js, Lang::TypeScript));
     assert_eq!(max_fp, value_fp(&i, rust_max, Lang::Rust));
     assert_eq!(max_fp, value_fp(&i, rust_fold_max, Lang::Rust));
     let min_fp = value_fp(&i, py_min, Lang::Python);
@@ -1012,8 +1017,11 @@ fn dot_product_converges_across_index_zip_and_enumerate() {
     assert_eq!(fp, value_fp(&i, rust_range, Lang::Rust));
     assert_eq!(fp, value_fp(&i, rust_zip, Lang::Rust));
     assert_eq!(fp, value_fp(&i, ruby_each, Lang::Ruby));
-    assert_eq!(fp, value_fp(&i, ruby_while, Lang::Ruby));
-    assert_eq!(fp, value_fp(&i, java_for, Lang::Java));
+    assert_ne!(fp, value_fp(&i, ruby_while, Lang::Ruby));
+    assert_eq!(
+        return_fp(&i, py_loop, Lang::Python),
+        return_fp(&i, java_for, Lang::Java)
+    );
     assert_eq!(fp, value_fp(&i, c_for, Lang::C));
     assert_ne!(fp, value_fp(&i, bad_pair_sum, Lang::Python));
 }
@@ -1071,16 +1079,20 @@ fn scalar_abs_builtins_converge_cross_language_with_shadow_boundary() {
         "pub fn f(value: i64, other: i64) -> i64 { let magnitude = value.abs(); magnitude + other }\n";
     let shadowed_js = "function f(Math, value, other) { const magnitude = Math.abs(value); return magnitude + other; }";
     let local_shadowed_js = "function f(value, other) { const Math = { abs: function(_value) { return 0; } }; const magnitude = Math.abs(value); return magnitude + other; }";
+    let ts_number_method_abs = "function f(value: number, other: number): number { const magnitude = value.abs(); return magnitude + other; }";
+    let rust_float_abs = "pub fn f(value: f64, other: f64) -> f64 { let magnitude = value.abs(); magnitude + other }\n";
     let custom_rust_abs = "struct Wrap(i64);\nimpl Wrap { fn abs(&self) -> i64 { 0 } }\npub fn f(value: Wrap) -> i64 { let magnitude = value.abs(); magnitude + 1 }\n";
     let fp = value_fp(&i, py, Lang::Python);
     assert_eq!(fp, value_fp(&i, js, Lang::JavaScript));
     assert_eq!(fp, value_fp(&i, ts, Lang::TypeScript));
     assert_eq!(fp, value_fp(&i, go, Lang::Go));
     assert_eq!(fp, value_fp(&i, java, Lang::Java));
-    assert_eq!(fp, value_fp(&i, ruby_abs, Lang::Ruby));
+    assert_ne!(fp, value_fp(&i, ruby_abs, Lang::Ruby));
     assert_eq!(fp, value_fp(&i, rust_abs, Lang::Rust));
     assert_ne!(fp, value_fp(&i, shadowed_js, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, local_shadowed_js, Lang::JavaScript));
+    assert_ne!(fp, value_fp(&i, ts_number_method_abs, Lang::TypeScript));
+    assert_ne!(fp, value_fp(&i, rust_float_abs, Lang::Rust));
     assert_ne!(fp, value_fp(&i, custom_rust_abs, Lang::Rust));
 }
 
@@ -1104,7 +1116,11 @@ fn scalar_minmax_builtins_converge_cross_language_with_shadow_boundary() {
     let rust_max = "pub fn f(left: i64, right: i64, other: i64) -> i64 { let selected = left.max(right); selected + other }\n";
     let py_wrong_value =
         "def f(left, right, other):\n    selected = min(left, other)\n    return selected + other\n";
+    let py_shadowed_min =
+        "def min(_left, _right):\n    return 0\n\ndef f(left, right, other):\n    selected = min(left, right)\n    return selected + other\n";
     let shadowed_js = "function f(left, right, other) { const Math = { min: function(_left, _right) { return 0; } }; const selected = Math.min(left, right); return selected + other; }";
+    let ts_number_method_min = "function f(left: number, right: number, other: number): number { const selected = left.min(right); return selected + other; }";
+    let rust_float_min = "pub fn f(left: f64, right: f64, other: f64) -> f64 { let selected = left.min(right); selected + other }\n";
     let custom_rust_min = "struct Wrap(i64);\nimpl Wrap { fn min(&self, _right: i64) -> i64 { 0 } }\npub fn f(left: Wrap, right: i64, other: i64) -> i64 { let selected = left.min(right); selected + other }\n";
     let custom_rust_max = "struct Wrap(i64);\nimpl Wrap { fn max(&self, _right: i64) -> i64 { 0 } }\npub fn f(left: Wrap, right: i64, other: i64) -> i64 { let selected = left.max(right); selected + other }\n";
 
@@ -1114,11 +1130,11 @@ fn scalar_minmax_builtins_converge_cross_language_with_shadow_boundary() {
     assert_eq!(fp, value_fp(&i, ts_min, Lang::TypeScript));
     assert_eq!(fp, value_fp(&i, go_min, Lang::Go));
     assert_eq!(fp, value_fp(&i, java_min, Lang::Java));
-    assert_eq!(fp, value_fp(&i, c_min, Lang::C));
-    assert_eq!(fp, value_fp(&i, ruby_min, Lang::Ruby));
+    assert_ne!(fp, value_fp(&i, c_min, Lang::C));
+    assert_ne!(fp, value_fp(&i, ruby_min, Lang::Ruby));
     assert_eq!(fp, value_fp(&i, rust_min, Lang::Rust));
     assert_ne!(fp, value_fp(&i, py_max, Lang::Python));
-    assert_eq!(
+    assert_ne!(
         value_fp(&i, py_max, Lang::Python),
         value_fp(&i, ruby_max, Lang::Ruby)
     );
@@ -1127,7 +1143,10 @@ fn scalar_minmax_builtins_converge_cross_language_with_shadow_boundary() {
         value_fp(&i, rust_max, Lang::Rust)
     );
     assert_ne!(fp, value_fp(&i, py_wrong_value, Lang::Python));
+    assert_ne!(fp, value_fp(&i, py_shadowed_min, Lang::Python));
     assert_ne!(fp, value_fp(&i, shadowed_js, Lang::JavaScript));
+    assert_ne!(fp, value_fp(&i, ts_number_method_min, Lang::TypeScript));
+    assert_ne!(fp, value_fp(&i, rust_float_min, Lang::Rust));
     assert_ne!(fp, value_fp(&i, custom_rust_min, Lang::Rust));
     assert_ne!(
         value_fp(&i, py_max, Lang::Python),
@@ -1185,6 +1204,8 @@ fn numeric_clamp_surface_bridge_requires_bound_proof() {
     let rust_guarded_clamp =
         "fn f(x: i64, lo: i64, hi: i64) -> i64 { if hi < lo { panic!(); } x.clamp(lo, hi) }";
     let rust_unproven_clamp = "fn f(x: i64, lo: i64, hi: i64) -> i64 { x.clamp(lo, hi) }";
+    let ts_number_method_clamp = "function f(x: number): number { return x.clamp(0, 10); }";
+    let rust_float_clamp = "fn f(x: f64) -> f64 { x.clamp(0.0, 10.0) }";
     let rust_custom_clamp = "struct Wrap(i64);\nimpl Wrap { fn clamp(&self, _lo: i64, _hi: i64) -> i64 { 0 } }\nfn f(x: Wrap) -> i64 { x.clamp(0, 10) }\n";
 
     let guarded_fp = value_fp(&i, minmax_guarded, Lang::Python);
@@ -1225,6 +1246,16 @@ fn numeric_clamp_surface_bridge_requires_bound_proof() {
     );
     assert_ne!(
         value_fp(&i, rust_literal_clamp, Lang::Rust),
+        value_fp(&i, ts_number_method_clamp, Lang::TypeScript),
+        "numeric method selectors outside a specific language/API contract must stay closed"
+    );
+    assert_ne!(
+        value_fp(&i, rust_literal_clamp, Lang::Rust),
+        value_fp(&i, rust_float_clamp, Lang::Rust),
+        "float/NaN-sensitive Rust clamp needs a separate contract and proof"
+    );
+    assert_ne!(
+        value_fp(&i, rust_literal_clamp, Lang::Rust),
         value_fp(&i, rust_custom_clamp, Lang::Rust),
         "custom clamp methods must stay outside the numeric library bridge"
     );
@@ -1238,7 +1269,7 @@ fn conditional_abs_reduction_converges_with_aggregate() {
     let py_loop = "def f(xs):\n    total = 0\n    for x in xs:\n        if x < 0:\n            total += -x\n        else:\n            total += x\n    return total\n";
     let py_sum = "def f(xs):\n    return sum(abs(x) for x in xs)\n";
     let js_reduce =
-        "function f(xs){ return xs.reduce((total, x) => total + (x < 0 ? -x : x), 0); }";
+        "function f(xs: number[]): number { return xs.reduce((total, x) => total + (x < 0 ? -x : x), 0); }";
     let rust_fold =
         "fn f(xs: &[i32]) -> i32 { xs.iter().copied().fold(0, |total, x| total + if x < 0 { -x } else { x }) }";
     let c_loop = "int f(int *xs, int n) { int total = 0; for (int i = 0; i < n; i++) { if (xs[i] < 0) { total += -xs[i]; } else { total += xs[i]; } } return total; }";
@@ -1246,7 +1277,7 @@ fn conditional_abs_reduction_converges_with_aggregate() {
         "def f(xs):\n    total = 0\n    for x in xs:\n        total += x\n    return total\n";
     let fp = value_fp(&i, py_loop, Lang::Python);
     assert_eq!(fp, value_fp(&i, py_sum, Lang::Python));
-    assert_eq!(fp, value_fp(&i, js_reduce, Lang::JavaScript));
+    assert_eq!(fp, value_fp(&i, js_reduce, Lang::TypeScript));
     assert_eq!(fp, value_fp(&i, rust_fold, Lang::Rust));
     assert_eq!(fp, value_fp(&i, c_loop, Lang::C));
     assert_ne!(fp, value_fp(&i, bad_sum, Lang::Python));
@@ -1444,11 +1475,11 @@ fn commutative_reconcile() {
 fn cross_language_summation_converges() {
     let i = Interner::new();
     let py = "def f(items):\n    total = 0\n    i = 0\n    while i < len(items):\n        total += items[i]\n        i = i + 1\n    return total\n";
-    let ts = "function f(items){ let total=0; for(let i=0;i<items.length;i++){ total += items[i]; } return total; }";
+    let ts = "function f(items: number[]): number { let total=0; for(let i=0;i<items.length;i++){ total += items[i]; } return total; }";
     let go = "package m\nfunc F(items []int) int {\n\ttotal := 0\n\tfor i := 0; i < len(items); i++ {\n\t\ttotal += items[i]\n\t}\n\treturn total\n}\n";
-    let hp = unit_hash(&i, py, Lang::Python);
-    assert_eq!(hp, unit_hash(&i, ts, Lang::TypeScript), "py == ts");
-    assert_eq!(hp, unit_hash(&i, go, Lang::Go), "py == go");
+    let hp = return_fp(&i, py, Lang::Python);
+    assert_eq!(hp, return_fp(&i, ts, Lang::TypeScript), "py == ts");
+    assert_eq!(hp, return_fp(&i, go, Lang::Go), "py == go");
 }
 
 #[test]
@@ -1734,10 +1765,10 @@ fn comprehension_converges_with_js_map() {
     // so the same transform written either way converges cross-language.
     let i = Interner::new();
     let py = "def f(items):\n    return [x * 2 for x in items]\n";
-    let js = "function g(items){\n  return items.map(x => x * 2);\n}\n";
+    let js = "function g(items: number[]): number[] {\n  return items.map(x => x * 2);\n}\n";
     assert_eq!(
         unit_hash(&i, py, Lang::Python),
-        unit_hash(&i, js, Lang::JavaScript),
+        unit_hash(&i, js, Lang::TypeScript),
         "comprehension == .map (HoF canonicalization)"
     );
 }
@@ -1880,7 +1911,7 @@ fn non_equivalent_swapped_params_differ() {
 fn comprehension_equals_js_map() {
     let i = Interner::new();
     let py = "def f(xs):\n    return [x * 2 for x in xs]\n";
-    let ts = "function f(xs){ return xs.map(x => x * 2); }";
+    let ts = "function f(xs: number[]): number[] { return xs.map(x => x * 2); }";
     assert_eq!(
         unit_hash(&i, py, Lang::Python),
         unit_hash(&i, ts, Lang::TypeScript)
@@ -1903,7 +1934,7 @@ fn print_builtin_converges_cross_language() {
     let i = Interner::new();
     let py = "def f(x):\n    print(x)\n";
     let js = "function f(x){ console.log(x); }";
-    let go = "package m\nfunc F(x int) {\n\tfmt.Println(x)\n}\n";
+    let go = "package m\n\nimport \"fmt\"\n\nfunc F(x int) {\n\tfmt.Println(x)\n}\n";
     let hp = unit_hash(&i, py, Lang::Python);
     assert_eq!(
         hp,
@@ -2136,8 +2167,8 @@ fn multi_clause_comprehension_converges_as_flat_map() {
     );
     let flat_map_js = value_fp(
         &i,
-        "function h(xs, ys){ return xs.flatMap(x => ys.map(y => x + y)); }",
-        Lang::JavaScript,
+        "function h(xs: number[], ys: number[]): number[] { return xs.flatMap(x => ys.map(y => x + y)); }",
+        Lang::TypeScript,
     );
     let nested_list = value_fp(
         &i,
@@ -2177,8 +2208,8 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
     );
     let sum_js = value_fp(
         &i,
-        "function h(xs, ys){ return xs.flatMap(x => ys.map(y => x + y)).reduce((a, v) => a + v, 0); }",
-        Lang::JavaScript,
+        "function h(xs: number[], ys: number[]): number { return xs.flatMap(x => ys.map(y => x + y)).reduce((a, v) => a + v, 0); }",
+        Lang::TypeScript,
     );
     let wrong_seed = value_fp(
         &i,
@@ -2242,8 +2273,8 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
     );
     let filtered_sum_js = value_fp(
         &i,
-        "function h(xs, ys){ return xs.filter(x => x > 0).flatMap(x => ys.filter(y => y < 10).map(y => x + y)).reduce((a, v) => a + v, 0); }",
-        Lang::JavaScript,
+        "function h(xs: number[], ys: number[]): number { return xs.filter(x => x > 0).flatMap(x => ys.filter(y => y < 10).map(y => x + y)).reduce((a, v) => a + v, 0); }",
+        Lang::TypeScript,
     );
     let filtered_sum_outer_changed = value_fp(
         &i,
@@ -2262,8 +2293,8 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
     );
     let filtered_any_js = value_fp(
         &i,
-        "function h(xs, ys){ return xs.filter(x => x > 0).flatMap(x => ys.filter(y => y < 10).map(y => x + y)).some(v => v > 0); }",
-        Lang::JavaScript,
+        "function h(xs: number[], ys: number[]): boolean { return xs.filter(x => x > 0).flatMap(x => ys.filter(y => y < 10).map(y => x + y)).some(v => v > 0); }",
+        Lang::TypeScript,
     );
     let filtered_any_loop = value_fp(
         &i,
@@ -2272,8 +2303,8 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
     );
     let filtered_any_terminal_changed = value_fp(
         &i,
-        "function h(xs, ys){ return xs.filter(x => x > 0).flatMap(x => ys.filter(y => y < 10).map(y => x + y)).some(v => false); }",
-        Lang::JavaScript,
+        "function h(xs: number[], ys: number[]): boolean { return xs.filter(x => x > 0).flatMap(x => ys.filter(y => y < 10).map(y => x + y)).some(v => false); }",
+        Lang::TypeScript,
     );
     let filtered_all_gen = value_fp(
         &i,
@@ -2282,8 +2313,8 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
     );
     let filtered_all_js = value_fp(
         &i,
-        "function h(xs, ys){ return xs.filter(x => x > 0).flatMap(x => ys.filter(y => y < 10).map(y => x + y)).every(v => v > 0); }",
-        Lang::JavaScript,
+        "function h(xs: number[], ys: number[]): boolean { return xs.filter(x => x > 0).flatMap(x => ys.filter(y => y < 10).map(y => x + y)).every(v => v > 0); }",
+        Lang::TypeScript,
     );
     let filtered_all_loop = value_fp(
         &i,
@@ -2292,8 +2323,8 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
     );
     let filtered_all_terminal_changed = value_fp(
         &i,
-        "function h(xs, ys){ return xs.filter(x => x > 0).flatMap(x => ys.filter(y => y < 10).map(y => x + y)).every(v => false); }",
-        Lang::JavaScript,
+        "function h(xs: number[], ys: number[]): boolean { return xs.filter(x => x > 0).flatMap(x => ys.filter(y => y < 10).map(y => x + y)).every(v => false); }",
+        Lang::TypeScript,
     );
 
     assert_eq!(
@@ -2387,8 +2418,8 @@ fn cross_language_any_all_converges() {
     );
     let any_js = value_fp(
         &i,
-        "function g(xs){ return xs.some(x => x > 0); }",
-        Lang::JavaScript,
+        "function g(xs: number[]): boolean { return xs.some(x => x > 0); }",
+        Lang::TypeScript,
     );
     let any_rs = value_fp(
         &i,
@@ -2402,8 +2433,8 @@ fn cross_language_any_all_converges() {
     );
     let all_js = value_fp(
         &i,
-        "function g(xs){ return xs.every(x => x > 0); }",
-        Lang::JavaScript,
+        "function g(xs: number[]): boolean { return xs.every(x => x > 0); }",
+        Lang::TypeScript,
     );
     assert_eq!(any_py, any_js, "Python any ≡ JS some");
     assert_eq!(any_py, any_rs, "Python any ≡ Rust any");
@@ -2485,8 +2516,23 @@ fn rust_filter_map_converges_with_filtered_map_and_guarded_builder() {
         "fn f(xs: &[i32]) -> Vec<i32> { xs.iter().copied().filter_map(|x| if x > 0 { Some(0) } else { None }).filter(|x| *x != 0).collect() }",
         Lang::Rust,
     );
+    let shadowed_some_rs = value_fp_named(
+        &i,
+        "fn Some(_value: i32) -> Option<i32> { None }\nfn f(xs: &[i32]) -> Vec<i32> { xs.iter().copied().filter_map(|x| if x > 0 { Some(x * 2) } else { None }).collect() }",
+        Lang::Rust,
+        "f",
+    );
+    let shadowed_vec_rs = value_fp_named(
+        &i,
+        "struct Vec;\nimpl Vec { fn new() -> Vec { Vec } fn push(&self, _value: i32) {} }\nfn f(xs: &[i32]) -> Vec { let out = Vec::new(); for x in xs { if *x > 0 { out.push(*x * 2); } } out }",
+        Lang::Rust,
+        "f",
+    );
 
-    assert_eq!(filtered_py, filtered_js, "filter+map surfaces should agree");
+    assert_ne!(
+        filtered_py, filtered_js,
+        "untyped JS parameter method calls lack a receiver proof and must stay opaque"
+    );
     assert_eq!(
         filtered_py, filtered_ts,
         "TypeScript filter+map surface should agree"
@@ -2531,6 +2577,14 @@ fn rust_filter_map_converges_with_filtered_map_and_guarded_builder() {
         falsey_rs, dropped_falsey_rs,
         "truthy filtering after emitting 0 must stay distinct"
     );
+    assert_ne!(
+        filtered_py, shadowed_some_rs,
+        "a local Rust Some definition must not be treated as Option::Some"
+    );
+    assert_ne!(
+        filtered_py, shadowed_vec_rs,
+        "a local Rust Vec definition must not be treated as std Vec::new"
+    );
 }
 
 /// Value-graph fingerprint of the first function unit.
@@ -2538,6 +2592,12 @@ fn value_fp(interner: &Interner, src: &str, lang: Lang) -> Vec<u64> {
     let il = nose_frontend::lower_source(FileId(0), "t", src.as_bytes(), lang, interner).unwrap();
     let n = normalize(&il, interner, &NormalizeOptions::default());
     nose_normalize::value_fingerprint(&n, first_func(&n), interner)
+}
+
+fn return_fp(interner: &Interner, src: &str, lang: Lang) -> Vec<u64> {
+    let il = nose_frontend::lower_source(FileId(0), "t", src.as_bytes(), lang, interner).unwrap();
+    let n = normalize(&il, interner, &NormalizeOptions::default());
+    nose_normalize::value_fingerprint_lits(&n, first_func(&n), interner).2
 }
 
 fn value_anchors(interner: &Interner, src: &str, lang: Lang) -> Vec<u64> {
@@ -3103,7 +3163,7 @@ fn value_graph_skips_try_handler_for_empty_static_hof_lambda_err() {
 fn value_graph_runs_try_handler_after_static_reduce_lambda_err() {
     let i = Interner::new();
     let try_err =
-        "def f():\n    try:\n        return reduce(lambda a, x: 1 / 0, [1], 0)\n    except Exception:\n        return 7\n";
+        "import functools\n\ndef f():\n    try:\n        return functools.reduce(lambda a, x: 1 / 0, [1], 0)\n    except Exception:\n        return 7\n";
     let plain_return = "def f():\n    return 7\n";
     assert_eq!(
         value_fp(&i, try_err, Lang::Python),
@@ -3116,7 +3176,7 @@ fn value_graph_runs_try_handler_after_static_reduce_lambda_err() {
 fn value_graph_skips_try_handler_for_empty_static_reduce_lambda_err() {
     let i = Interner::new();
     let empty_reduce =
-        "def f():\n    try:\n        return reduce(lambda a, x: 1 / 0, [], 0)\n    except Exception:\n        return 7\n";
+        "import functools\n\ndef f():\n    try:\n        return functools.reduce(lambda a, x: 1 / 0, [], 0)\n    except Exception:\n        return 7\n";
     let plain_return = "def f():\n    return 7\n";
     assert_ne!(
         value_fp(&i, empty_reduce, Lang::Python),
@@ -3253,7 +3313,7 @@ fn map_key_membership_converges_cross_language_with_boundaries() {
     let ts_array_from_values = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return Array.from(lookup.values()).includes(key); }";
 
     let fp = value_fp(&i, py, Lang::Python);
-    assert_eq!(fp, value_fp(&i, py_method, Lang::Python));
+    assert_ne!(fp, value_fp(&i, py_method, Lang::Python));
     assert_eq!(fp, value_fp(&i, py_keys_in, Lang::Python));
     assert_eq!(fp, value_fp(&i, py_keys_contains, Lang::Python));
     assert_eq!(fp, value_fp(&i, go, Lang::Go));
@@ -3261,8 +3321,8 @@ fn map_key_membership_converges_cross_language_with_boundaries() {
     assert_eq!(fp, value_fp(&i, java_key_set, Lang::Java));
     assert_eq!(fp, value_fp(&i, rust, Lang::Rust));
     assert_eq!(fp, value_fp(&i, rust_get, Lang::Rust));
-    assert_eq!(fp, value_fp(&i, ruby, Lang::Ruby));
-    assert_eq!(fp, value_fp(&i, ruby_has, Lang::Ruby));
+    assert_ne!(fp, value_fp(&i, ruby, Lang::Ruby));
+    assert_ne!(fp, value_fp(&i, ruby_has, Lang::Ruby));
     assert_eq!(fp, value_fp(&i, ts_array_from_keys, Lang::TypeScript));
     assert_ne!(fp, value_fp(&i, typed_set_same_names, Lang::TypeScript));
     assert_ne!(fp, value_fp(&i, wrong_key, Lang::Python));
@@ -3551,6 +3611,7 @@ fn collection_membership_set_construction_converges_with_boundaries() {
     let rust_std_wrong_element = "pub fn f(value: &str, other: &str) -> bool {\n    let values = std::collections::HashSet::from([\"red\", \"blue\"]);\n    values.contains(&other)\n}\n";
     let rust_std_wrong_collection = "pub fn f(value: &str, other: &str) -> bool {\n    let values = std::collections::BTreeSet::from([\"green\", \"blue\"]);\n    values.contains(&value)\n}\n";
     let rust_std_mutated = "pub fn f(value: &str, other: &str) -> bool {\n    let mut values = std::collections::HashSet::from([\"red\", \"blue\"]);\n    values.insert(\"green\");\n    values.contains(&value)\n}\n";
+    let rust_std_shadowed = "mod std { pub mod collections { pub struct HashSet; } }\npub fn f(value: &str, other: &str) -> bool {\n    let values = std::collections::HashSet::from([\"red\", \"blue\"]);\n    values.contains(&value)\n}\n";
     let ruby_set_wrong_element =
         "require \"set\"\n\ndef f(value, other)\n  Set.new([\"red\", \"blue\"]).include?(other)\nend\n";
     let ruby_set_wrong_collection =
@@ -3569,10 +3630,10 @@ fn collection_membership_set_construction_converges_with_boundaries() {
     assert_eq!(literal_fp, value_fp(&i, py_deque_namespace, Lang::Python));
     assert_eq!(literal_fp, value_fp(&i, py_module_tuple, Lang::Python));
     assert_eq!(literal_fp, value_fp(&i, py_module_set, Lang::Python));
-    assert_eq!(literal_fp, value_fp(&i, js_set_inline, Lang::JavaScript));
-    assert_eq!(literal_fp, value_fp(&i, js_set_local, Lang::JavaScript));
-    assert_eq!(literal_fp, value_fp(&i, js_module_set, Lang::JavaScript));
-    assert_eq!(literal_fp, value_fp(&i, ts_module_set, Lang::TypeScript));
+    assert_ne!(literal_fp, value_fp(&i, js_set_inline, Lang::JavaScript));
+    assert_ne!(literal_fp, value_fp(&i, js_set_local, Lang::JavaScript));
+    assert_ne!(literal_fp, value_fp(&i, js_module_set, Lang::JavaScript));
+    assert_ne!(literal_fp, value_fp(&i, ts_module_set, Lang::TypeScript));
     assert_eq!(literal_fp, value_fp(&i, js_array_some, Lang::JavaScript));
     assert_eq!(literal_fp, value_fp(&i, ts_array_some, Lang::TypeScript));
     assert_eq!(
@@ -3639,6 +3700,11 @@ fn collection_membership_set_construction_converges_with_boundaries() {
     assert_eq!(literal_fp, value_fp(&i, rust_std_hashset, Lang::Rust));
     assert_eq!(literal_fp, value_fp(&i, rust_std_btreeset, Lang::Rust));
     assert_eq!(literal_fp, value_fp(&i, rust_std_vecdeque, Lang::Rust));
+    assert_ne!(
+        literal_fp,
+        value_fp_named(&i, rust_std_shadowed, Lang::Rust, "f"),
+        "a local Rust std module must not be treated as the standard library"
+    );
     assert_eq!(literal_fp, value_fp(&i, ruby_member, Lang::Ruby));
     assert_eq!(literal_fp, value_fp(&i, ruby_set_new_include, Lang::Ruby));
     assert_eq!(literal_fp, value_fp(&i, ruby_set_new_member, Lang::Ruby));
@@ -3958,10 +4024,10 @@ fn literal_map_default_lookup_converges_with_js_map_construction_boundaries() {
 
     let fp = value_fp(&i, py_literal, Lang::Python);
     assert_eq!(fp, value_fp(&i, ruby_literal, Lang::Ruby));
-    assert_eq!(fp, value_fp(&i, js_inline, Lang::JavaScript));
-    assert_eq!(fp, value_fp(&i, js_local, Lang::JavaScript));
-    assert_eq!(fp, value_fp(&i, js_has_get, Lang::JavaScript));
-    assert_eq!(fp, value_fp(&i, ts_inline, Lang::TypeScript));
+    assert_ne!(fp, value_fp(&i, js_inline, Lang::JavaScript));
+    assert_ne!(fp, value_fp(&i, js_local, Lang::JavaScript));
+    assert_ne!(fp, value_fp(&i, js_has_get, Lang::JavaScript));
+    assert_ne!(fp, value_fp(&i, ts_inline, Lang::TypeScript));
     assert_ne!(fp, value_fp(&i, js_wrong_key, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, js_wrong_default, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, js_wrong_map, Lang::JavaScript));
@@ -4131,8 +4197,8 @@ fn literal_map_default_lookup_converges_with_module_map_bindings() {
     let java_shadowed = "class C { static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2); static int f(String key, String other) { return LOOKUP.getOrDefault(key, 0); } }\nclass Map { static java.util.Map<String, Integer> of(Object... values) { return java.util.Map.of(); } }\n";
 
     let fp = value_fp(&i, py_literal, Lang::Python);
-    assert_eq!(fp, value_fp(&i, js_module, Lang::JavaScript));
-    assert_eq!(fp, value_fp(&i, ts_module, Lang::TypeScript));
+    assert_ne!(fp, value_fp(&i, js_module, Lang::JavaScript));
+    assert_ne!(fp, value_fp(&i, ts_module, Lang::TypeScript));
     assert_eq!(fp, value_fp(&i, java_static, Lang::Java));
     assert_ne!(fp, value_fp(&i, js_wrong_key, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, ts_wrong_default, Lang::TypeScript));
@@ -4306,15 +4372,15 @@ fn literal_map_default_lookup_converges_with_non_python_imported_bindings() {
 
     let corpus = nose_frontend::lower_corpus_many(&[dir.as_path()]);
     let local = corpus_value_fp(&corpus, "local.py", "lookup");
-    assert_eq!(
+    assert_ne!(
         local,
         corpus_value_fp(&corpus, "js_imported.js", "lookup"),
-        "JS named import should prove the same literal map/default coordinates"
+        "JS imported Map bindings stay closed until constructor/provenance proof exists"
     );
-    assert_eq!(
+    assert_ne!(
         local,
         corpus_value_fp(&corpus, "ts_imported.ts", "lookup"),
-        "TS named import should prove the same literal map/default coordinates"
+        "TS imported Map bindings stay closed until constructor/provenance proof exists"
     );
     assert_eq!(
         local,
@@ -5051,7 +5117,7 @@ fn detection_smoke_groups_clones_excludes_decoy() {
     // Two clones (a sum loop in Python and TS) plus an unrelated decoy.
     let interner = Interner::new();
     let py = "def sum_list(items):\n    total = 0\n    i = 0\n    while i < len(items):\n        total += items[i]\n        i = i + 1\n    return total\n";
-    let ts = "function total(xs) {\n  let acc = 0;\n  for (let k = 0; k < xs.length; k++) {\n    acc += xs[k];\n  }\n  return acc;\n}\n";
+    let ts = "function total(xs: number[]): number {\n  let acc = 0;\n  for (const x of xs) {\n    acc += x;\n  }\n  return acc;\n}\n";
     let decoy = "def greet(name):\n    msg = 'hello ' + name\n    print(msg)\n    print(name)\n    return msg\n";
 
     let files = vec![
@@ -5184,8 +5250,8 @@ fn filter_fusion_converges() {
         ),
         value_fp(
             &i,
-            "function g(xs){ return xs.filter(x=>x>0).filter(x=>x<10); }",
-            Lang::JavaScript
+            "function g(xs: number[]): number[] { return xs.filter(x=>x>0).filter(x=>x<10); }",
+            Lang::TypeScript
         ),
         "Python two-filter comprehension should converge with JS chained .filter().filter()"
     );
@@ -5242,7 +5308,7 @@ fn reduce_lambda_selection_converges() {
     assert_eq!(
         value_fp(
             &i,
-            "def f(xs):\n    return reduce(lambda a,b: a if a>b else b, xs)\n",
+            "import functools\n\ndef f(xs):\n    return functools.reduce(lambda a,b: a if a>b else b, xs)\n",
             Lang::Python
         ),
         value_fp(&i, "def g(xs):\n    return max(xs)\n", Lang::Python),
@@ -5251,7 +5317,7 @@ fn reduce_lambda_selection_converges() {
     assert_eq!(
         value_fp(
             &i,
-            "def f(xs):\n    return reduce(lambda a,b: a if a<b else b, xs)\n",
+            "import functools\n\ndef f(xs):\n    return functools.reduce(lambda a,b: a if a<b else b, xs)\n",
             Lang::Python
         ),
         value_fp(&i, "def g(xs):\n    return min(xs)\n", Lang::Python),

--- a/crates/nose-detect/Cargo.toml
+++ b/crates/nose-detect/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 
 [dependencies]
 nose-il = { workspace = true }
+nose-semantics = { workspace = true }
 nose-normalize = { workspace = true }
 rustc-hash = { workspace = true }
 rayon = { workspace = true }

--- a/crates/nose-detect/src/fragment/conditional_guard.rs
+++ b/crates/nose-detect/src/fragment/conditional_guard.rs
@@ -9,7 +9,8 @@
 use super::contract::{Effect, EffectSite, FragmentContract};
 use super::oracle::free_input_cids;
 use super::{Exit, FragmentKind};
-use nose_il::{Builtin, Il, Interner, Lang, NodeId, NodeKind, Payload};
+use nose_il::{Builtin, Il, Interner, NodeId, NodeKind, Payload};
+use nose_semantics::{builder_append_method_contract, semantics};
 use rustc_hash::FxHashSet;
 
 pub(crate) fn recognize_conditional_guard(
@@ -71,7 +72,7 @@ fn branch_block(il: &Il, interner: &Interner, node: NodeId) -> Option<Summary> {
     if kids.is_empty() {
         return Some(Summary::default());
     }
-    if let Some(effects) = ordered_append_effect_sequence(il, node) {
+    if let Some(effects) = ordered_append_effect_sequence(il, interner, node) {
         return Some(Summary::exact(effects));
     }
     if let Some(effects) = ordered_index_assignment_effect_sequence(il, node) {
@@ -80,10 +81,10 @@ fn branch_block(il: &Il, interner: &Interner, node: NodeId) -> Option<Summary> {
     if let Some(effects) = ordered_self_field_assignment_sequence(il, interner, node) {
         return Some(Summary::exact(effects));
     }
-    if let Some(effects) = ordered_loop_effect_sequence(il, node) {
+    if let Some(effects) = ordered_loop_effect_sequence(il, interner, node) {
         return Some(Summary::exact(effects));
     }
-    if let Some(effects) = ordered_mixed_effect_sequence(il, node) {
+    if let Some(effects) = ordered_mixed_effect_sequence(il, interner, node) {
         return Some(Summary::exact(effects));
     }
     if let Some(effects) = ordered_conditional_effect_sequence(il, interner, node) {
@@ -99,12 +100,15 @@ fn branch_block(il: &Il, interner: &Interner, node: NodeId) -> Option<Summary> {
         return Some(Summary::exact(effects));
     }
     if kids.len() == 3 {
-        if let Some(effects) = temp_chain_consumed_by_statement(il, kids[0], kids[1], kids[2]) {
+        if let Some(effects) =
+            temp_chain_consumed_by_statement(il, interner, kids[0], kids[1], kids[2])
+        {
             return Some(Summary::exact(effects));
         }
     }
     if kids.len() == 2 {
-        if let Some(effects) = temp_assignment_consumed_by_statement(il, kids[0], kids[1]) {
+        if let Some(effects) = temp_assignment_consumed_by_statement(il, interner, kids[0], kids[1])
+        {
             return Some(Summary::exact(effects));
         }
     }
@@ -121,28 +125,38 @@ fn single_branch_statement(il: &Il, interner: &Interner, node: NodeId) -> Option
         NodeKind::Assign => {
             assignment_effect_site(il, interner, node).map(|site| Summary::exact(vec![site]))
         }
-        NodeKind::ExprStmt => expr_statement_site(il, node).map(|site| Summary::exact(vec![site])),
+        NodeKind::ExprStmt => {
+            expr_statement_site(il, interner, node).map(|site| Summary::exact(vec![site]))
+        }
         NodeKind::If => {
             let summary = conditional_summary(il, interner, node)?;
             summary.has_statement.then_some(summary)
         }
-        NodeKind::Loop => loop_effect_sites(il, node).map(Summary::exact),
+        NodeKind::Loop => loop_effect_sites(il, interner, node).map(Summary::exact),
         _ => None,
     }
 }
 
 // ---- ordered branch bodies --------------------------------------------------------------
 
-fn ordered_loop_effect_sequence(il: &Il, node: NodeId) -> Option<Vec<EffectSite>> {
+fn ordered_loop_effect_sequence(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<Vec<EffectSite>> {
     let kids = block_children_exact_len(il, node, 2)?;
     let mut effects = Vec::new();
     for &kid in kids {
-        effects.extend(loop_effect_sites(il, kid)?);
+        effects.extend(loop_effect_sites(il, interner, kid)?);
     }
     Some(effects)
 }
 
-fn ordered_mixed_effect_sequence(il: &Il, node: NodeId) -> Option<Vec<EffectSite>> {
+fn ordered_mixed_effect_sequence(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<Vec<EffectSite>> {
     let kids = block_children_exact_len(il, node, 2)?;
     if kids
         .iter()
@@ -163,8 +177,10 @@ fn ordered_mixed_effect_sequence(il: &Il, node: NodeId) -> Option<Vec<EffectSite
     let mut effects = Vec::new();
     for &kid in kids {
         match il.kind(kid) {
-            NodeKind::Loop => effects.extend(loop_effect_sites(il, kid)?),
-            NodeKind::ExprStmt | NodeKind::Assign => effects.push(direct_effect_site(il, kid)?),
+            NodeKind::Loop => effects.extend(loop_effect_sites(il, interner, kid)?),
+            NodeKind::ExprStmt | NodeKind::Assign => {
+                effects.push(direct_effect_site(il, interner, kid)?)
+            }
             _ => return None,
         }
     }
@@ -213,7 +229,9 @@ fn ordered_conditional_mixed_effect_sequence(
     for &kid in kids {
         match il.kind(kid) {
             NodeKind::If => effects.extend(conditional_direct_effect_sites(il, interner, kid)?),
-            NodeKind::ExprStmt | NodeKind::Assign => effects.push(direct_effect_site(il, kid)?),
+            NodeKind::ExprStmt | NodeKind::Assign => {
+                effects.push(direct_effect_site(il, interner, kid)?)
+            }
             _ => return None,
         }
     }
@@ -245,7 +263,7 @@ fn ordered_loop_conditional_effect_sequence(
     let mut effects = Vec::new();
     for &kid in kids {
         match il.kind(kid) {
-            NodeKind::Loop => effects.extend(loop_effect_sites(il, kid)?),
+            NodeKind::Loop => effects.extend(loop_effect_sites(il, interner, kid)?),
             NodeKind::If => effects.extend(conditional_direct_effect_sites(il, interner, kid)?),
             _ => return None,
         }
@@ -286,16 +304,22 @@ fn ordered_loop_conditional_mixed_effect_sequence(
     let mut effects = Vec::new();
     for &kid in kids {
         match il.kind(kid) {
-            NodeKind::Loop => effects.extend(loop_effect_sites(il, kid)?),
+            NodeKind::Loop => effects.extend(loop_effect_sites(il, interner, kid)?),
             NodeKind::If => effects.extend(conditional_direct_effect_sites(il, interner, kid)?),
-            NodeKind::ExprStmt | NodeKind::Assign => effects.push(direct_effect_site(il, kid)?),
+            NodeKind::ExprStmt | NodeKind::Assign => {
+                effects.push(direct_effect_site(il, interner, kid)?)
+            }
             _ => return None,
         }
     }
     Some(effects)
 }
 
-fn ordered_append_effect_sequence(il: &Il, node: NodeId) -> Option<Vec<EffectSite>> {
+fn ordered_append_effect_sequence(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<Vec<EffectSite>> {
     let kids = il.children(node);
     if il.kind(node) != NodeKind::Block || !(2..=5).contains(&kids.len()) {
         return None;
@@ -308,7 +332,7 @@ fn ordered_append_effect_sequence(il: &Il, node: NodeId) -> Option<Vec<EffectSit
     }
     let expected_effects = match kids
         .iter()
-        .filter(|&&kid| append_statement(il, kid))
+        .filter(|&&kid| append_statement(il, interner, kid))
         .count()
     {
         2 if kids.len() <= 4 => 2,
@@ -319,19 +343,20 @@ fn ordered_append_effect_sequence(il: &Il, node: NodeId) -> Option<Vec<EffectSit
     let mut idx = 0;
     while idx < kids.len() {
         if idx + 2 < kids.len()
-            && temp_chain_consumed_by_append(il, kids[idx], kids[idx + 1], kids[idx + 2])
+            && temp_chain_consumed_by_append(il, interner, kids[idx], kids[idx + 1], kids[idx + 2])
         {
             effects.push(EffectSite::observable(Effect::Append));
             idx += 3;
             continue;
         }
-        if idx + 1 < kids.len() && temp_assignment_consumed_by_append(il, kids[idx], kids[idx + 1])
+        if idx + 1 < kids.len()
+            && temp_assignment_consumed_by_append(il, interner, kids[idx], kids[idx + 1])
         {
             effects.push(EffectSite::observable(Effect::Append));
             idx += 2;
             continue;
         }
-        if append_statement(il, kids[idx]) {
+        if append_statement(il, interner, kids[idx]) {
             effects.push(EffectSite::observable(Effect::Append));
             idx += 1;
             continue;
@@ -342,7 +367,10 @@ fn ordered_append_effect_sequence(il: &Il, node: NodeId) -> Option<Vec<EffectSit
 }
 
 fn ordered_index_assignment_effect_sequence(il: &Il, node: NodeId) -> Option<Vec<EffectSite>> {
-    if !matches!(il.meta.lang, Lang::C | Lang::Go | Lang::Java) {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .non_overloadable_index_assignment()
+    {
         return None;
     }
     let kids = il.children(node);
@@ -393,7 +421,10 @@ fn ordered_self_field_assignment_sequence(
     interner: &Interner,
     node: NodeId,
 ) -> Option<Vec<EffectSite>> {
-    if il.meta.lang != Lang::Java {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+    {
         return None;
     }
     let kids = il.children(node);
@@ -409,7 +440,7 @@ fn ordered_self_field_assignment_sequence(
 
 fn conditional_direct_effect_sites(
     il: &Il,
-    _interner: &Interner,
+    interner: &Interner,
     node: NodeId,
 ) -> Option<Vec<EffectSite>> {
     if il.kind(node) != NodeKind::If {
@@ -422,7 +453,7 @@ fn conditional_direct_effect_sites(
     let mut has_effect = false;
     let mut effects = Vec::new();
     for &branch in kids.iter().skip(1) {
-        let branch_effect = empty_or_single_direct_effect_block(il, branch)?;
+        let branch_effect = empty_or_single_direct_effect_block(il, interner, branch)?;
         has_effect |= branch_effect.is_some();
         if let Some(site) = branch_effect {
             effects.push(site);
@@ -431,7 +462,11 @@ fn conditional_direct_effect_sites(
     has_effect.then_some(effects)
 }
 
-fn empty_or_single_direct_effect_block(il: &Il, node: NodeId) -> Option<Option<EffectSite>> {
+fn empty_or_single_direct_effect_block(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<Option<EffectSite>> {
     if il.kind(node) != NodeKind::Block {
         return None;
     }
@@ -442,12 +477,12 @@ fn empty_or_single_direct_effect_block(il: &Il, node: NodeId) -> Option<Option<E
     if kids.len() != 1 {
         return None;
     }
-    direct_effect_site(il, kids[0]).map(Some)
+    direct_effect_site(il, interner, kids[0]).map(Some)
 }
 
-fn direct_effect_site(il: &Il, node: NodeId) -> Option<EffectSite> {
+fn direct_effect_site(il: &Il, interner: &Interner, node: NodeId) -> Option<EffectSite> {
     match il.kind(node) {
-        NodeKind::ExprStmt if append_statement(il, node) => {
+        NodeKind::ExprStmt if append_statement(il, interner, node) => {
             Some(EffectSite::observable(Effect::Append))
         }
         NodeKind::Assign if index_assignment(il, node) => {
@@ -468,7 +503,12 @@ fn assignment_effect_site(il: &Il, interner: &Interner, node: NodeId) -> Option<
 
 fn self_field_assignment_site(il: &Il, interner: &Interner, node: NodeId) -> Option<EffectSite> {
     let kids = il.children(node);
-    if il.meta.lang == Lang::Java && kids.len() == 2 && is_java_this_field(il, interner, kids[0]) {
+    if semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        && kids.len() == 2
+        && is_java_this_field(il, interner, kids[0])
+    {
         let place = super::recognize::resolve_place(il, interner, kids[0]);
         return place
             .is_exact_safe()
@@ -477,7 +517,7 @@ fn self_field_assignment_site(il: &Il, interner: &Interner, node: NodeId) -> Opt
     None
 }
 
-fn expr_statement_site(il: &Il, node: NodeId) -> Option<EffectSite> {
+fn expr_statement_site(il: &Il, interner: &Interner, node: NodeId) -> Option<EffectSite> {
     if il.kind(node) != NodeKind::ExprStmt {
         return None;
     }
@@ -495,45 +535,49 @@ fn expr_statement_site(il: &Il, node: NodeId) -> Option<EffectSite> {
     {
         return None;
     }
-    if is_append_call(il, kids[0]) {
+    if is_append_call(il, interner, kids[0]) {
         Some(EffectSite::observable(Effect::Append))
     } else {
         Some(EffectSite::observable(Effect::Other))
     }
 }
 
-fn append_statement(il: &Il, stmt: NodeId) -> bool {
+fn append_statement(il: &Il, interner: &Interner, stmt: NodeId) -> bool {
     if il.kind(stmt) != NodeKind::ExprStmt {
         return false;
     }
     let kids = il.children(stmt);
-    kids.len() == 1 && is_append_call(il, kids[0])
+    kids.len() == 1 && is_append_call(il, interner, kids[0])
 }
 
 fn index_assignment(il: &Il, node: NodeId) -> bool {
-    matches!(il.meta.lang, Lang::C | Lang::Go | Lang::Java)
+    semantics(il.meta.lang)
+        .exact_fragments()
+        .non_overloadable_index_assignment()
         && il.kind(node) == NodeKind::Assign
         && il.children(node).len() == 2
         && il.kind(il.children(node)[0]) == NodeKind::Index
 }
 
-fn loop_effect_sites(il: &Il, node: NodeId) -> Option<Vec<EffectSite>> {
-    super::loop_effect::recognize_loop_effect(il, node).map(|contract| contract.effects)
+fn loop_effect_sites(il: &Il, interner: &Interner, node: NodeId) -> Option<Vec<EffectSite>> {
+    super::loop_effect::recognize_loop_effect(il, interner, node).map(|contract| contract.effects)
 }
 
 // ---- temp windows -----------------------------------------------------------------------
 
 fn temp_assignment_consumed_by_statement(
     il: &Il,
+    interner: &Interner,
     assign: NodeId,
     stmt: NodeId,
 ) -> Option<Vec<EffectSite>> {
     let (temp_cid, _) = local_nontrivial_assignment(il, assign)?;
-    statement_consumes_temp(il, stmt, temp_cid, None)
+    statement_consumes_temp(il, interner, stmt, temp_cid, None)
 }
 
 fn temp_chain_consumed_by_statement(
     il: &Il,
+    interner: &Interner,
     first_assign: NodeId,
     second_assign: NodeId,
     stmt: NodeId,
@@ -548,11 +592,12 @@ fn temp_chain_consumed_by_statement(
     if !mentions_any(il, second_rhs, &first) {
         return None;
     }
-    statement_consumes_temp(il, stmt, second_cid, Some(&first))
+    statement_consumes_temp(il, interner, stmt, second_cid, Some(&first))
 }
 
 fn statement_consumes_temp(
     il: &Il,
+    interner: &Interner,
     stmt: NodeId,
     temp_cid: u32,
     forbidden_cids: Option<&FxHashSet<u32>>,
@@ -580,7 +625,7 @@ fn statement_consumes_temp(
             {
                 return None;
             }
-            expr_statement_site(il, stmt).map(|site| vec![site])
+            expr_statement_site(il, interner, stmt).map(|site| vec![site])
         }
         NodeKind::Assign => index_assignment_consumes_temp(il, stmt, temp_cid, forbidden_cids)
             .then(|| vec![EffectSite::observable(Effect::IndexWrite)]),
@@ -588,7 +633,12 @@ fn statement_consumes_temp(
     }
 }
 
-fn temp_assignment_consumed_by_append(il: &Il, assign: NodeId, effect: NodeId) -> bool {
+fn temp_assignment_consumed_by_append(
+    il: &Il,
+    interner: &Interner,
+    assign: NodeId,
+    effect: NodeId,
+) -> bool {
     let Some((temp_cid, _)) = local_nontrivial_assignment(il, assign) else {
         return false;
     };
@@ -597,12 +647,13 @@ fn temp_assignment_consumed_by_append(il: &Il, assign: NodeId, effect: NodeId) -
     let empty = FxHashSet::default();
     il.kind(effect) == NodeKind::ExprStmt
         && il.children(effect).len() == 1
-        && is_append_call(il, il.children(effect)[0])
-        && append_consumes_temp(il, il.children(effect)[0], &empty, &temp_cids)
+        && is_append_call(il, interner, il.children(effect)[0])
+        && append_consumes_temp(il, interner, il.children(effect)[0], &empty, &temp_cids)
 }
 
 fn temp_chain_consumed_by_append(
     il: &Il,
+    interner: &Interner,
     first_assign: NodeId,
     second_assign: NodeId,
     effect: NodeId,
@@ -632,8 +683,15 @@ fn temp_chain_consumed_by_append(
     final_temp.insert(second_cid);
     il.kind(effect) == NodeKind::ExprStmt
         && il.children(effect).len() == 1
-        && is_append_call(il, il.children(effect)[0])
-        && append_consumes_chained_temp(il, il.children(effect)[0], &all_temps, &final_temp, &first)
+        && is_append_call(il, interner, il.children(effect)[0])
+        && append_consumes_chained_temp(
+            il,
+            interner,
+            il.children(effect)[0],
+            &all_temps,
+            &final_temp,
+            &first,
+        )
 }
 
 fn temp_assignment_consumed_by_index_assignment(il: &Il, assign: NodeId, effect: NodeId) -> bool {
@@ -699,11 +757,12 @@ fn index_assignment_consumes_temp(
 
 fn append_consumes_temp(
     il: &Il,
+    interner: &Interner,
     call: NodeId,
     forbidden_receiver_cids: &FxHashSet<u32>,
     temp_cids: &FxHashSet<u32>,
 ) -> bool {
-    let Some((receiver, value)) = append_call_args(il, call) else {
+    let Some((receiver, value)) = append_call_args(il, interner, call) else {
         return false;
     };
     !mentions_any(il, receiver, forbidden_receiver_cids)
@@ -713,12 +772,13 @@ fn append_consumes_temp(
 
 fn append_consumes_chained_temp(
     il: &Il,
+    interner: &Interner,
     call: NodeId,
     all_temp_cids: &FxHashSet<u32>,
     final_temp_cids: &FxHashSet<u32>,
     prior_temp_cids: &FxHashSet<u32>,
 ) -> bool {
-    let Some((receiver, value)) = append_call_args(il, call) else {
+    let Some((receiver, value)) = append_call_args(il, interner, call) else {
         return false;
     };
     !mentions_any(il, receiver, all_temp_cids)
@@ -732,18 +792,36 @@ fn block_children_exact_len(il: &Il, node: NodeId, len: usize) -> Option<&[NodeI
     (il.kind(node) == NodeKind::Block && il.children(node).len() == len).then(|| il.children(node))
 }
 
-fn append_call_args(il: &Il, node: NodeId) -> Option<(NodeId, NodeId)> {
-    if !is_append_call(il, node) {
+fn append_call_args(il: &Il, interner: &Interner, node: NodeId) -> Option<(NodeId, NodeId)> {
+    if !is_append_call(il, interner, node) {
         return None;
     }
     let kids = il.children(node);
-    Some((kids[0], kids[1]))
+    if matches!(il.node(node).payload, Payload::Builtin(Builtin::Append)) {
+        return Some((kids[0], kids[1]));
+    }
+    let receiver = *il.children(kids[0]).first()?;
+    Some((receiver, kids[1]))
 }
 
-fn is_append_call(il: &Il, node: NodeId) -> bool {
-    il.kind(node) == NodeKind::Call
-        && matches!(il.node(node).payload, Payload::Builtin(Builtin::Append))
-        && il.children(node).len() == 2
+fn is_append_call(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    if il.kind(node) != NodeKind::Call {
+        return false;
+    }
+    let kids = il.children(node);
+    if matches!(il.node(node).payload, Payload::Builtin(Builtin::Append)) {
+        return kids.len() == 2;
+    }
+    let Some((&callee, args)) = kids.split_first() else {
+        return false;
+    };
+    if args.len() != 1 || il.kind(callee) != NodeKind::Field {
+        return false;
+    }
+    let Payload::Name(method) = il.node(callee).payload else {
+        return false;
+    };
+    builder_append_method_contract(il.meta.lang, interner.resolve(method), args.len())
 }
 
 fn index_assignment_parts(il: &Il, node: NodeId) -> Option<(NodeId, Option<NodeId>, NodeId)> {
@@ -778,7 +856,11 @@ fn local_nontrivial_assignment(il: &Il, node: NodeId) -> Option<(u32, NodeId)> {
 }
 
 fn is_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if il.meta.lang != Lang::Java || il.kind(node) != NodeKind::Field {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        || il.kind(node) != NodeKind::Field
+    {
         return false;
     }
     if !matches!(il.node(node).payload, Payload::Name(_)) {
@@ -790,7 +872,9 @@ fn is_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
 }
 
 fn is_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    il.meta.lang == Lang::Java
+    semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
         && il.kind(node) == NodeKind::Var
         && matches!(il.node(node).payload, Payload::Name(name) if interner.resolve(name) == "this")
 }

--- a/crates/nose-detect/src/fragment/loop_effect.rs
+++ b/crates/nose-detect/src/fragment/loop_effect.rs
@@ -18,14 +18,19 @@
 use super::contract::{Effect, EffectSite, FragmentContract};
 use super::oracle::free_input_cids;
 use super::{Exit, FragmentKind};
-use nose_il::{Builtin, Il, Lang, LoopKind, NodeId, NodeKind, Payload};
+use nose_il::{Builtin, Il, Interner, LoopKind, NodeId, NodeKind, Payload};
+use nose_semantics::{builder_append_method_contract, semantics};
 use rustc_hash::FxHashSet;
 
 /// Recognize `node` as a `LoopEffect` contract, or `None` if it is not the shape.
 ///
 /// Independent of `units::exact_loop_effect_fragment_root`; the caller has already applied the
 /// shared span/context-safety gates (see [`super::recognize::recognize_contract`]).
-pub(crate) fn recognize_loop_effect(il: &Il, node: NodeId) -> Option<FragmentContract> {
+pub(crate) fn recognize_loop_effect(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<FragmentContract> {
     if !matches!(il.node(node).payload, Payload::Loop(LoopKind::ForEach)) {
         return None;
     }
@@ -42,7 +47,7 @@ pub(crate) fn recognize_loop_effect(il: &Il, node: NodeId) -> Option<FragmentCon
     }
 
     let mut effects = Vec::new();
-    if !body_depends_on_iter(il, kids[2], &iter_cids, &mut effects)? {
+    if !body_depends_on_iter(il, interner, kids[2], &iter_cids, &mut effects)? {
         return None;
     }
 
@@ -61,6 +66,7 @@ pub(crate) fn recognize_loop_effect(il: &Il, node: NodeId) -> Option<FragmentCon
 /// branch). Recognized effects are pushed onto `effects` in body order.
 fn body_depends_on_iter(
     il: &Il,
+    interner: &Interner,
     node: NodeId,
     iter_cids: &FxHashSet<u32>,
     effects: &mut Vec<EffectSite>,
@@ -75,6 +81,7 @@ fn body_depends_on_iter(
                 if idx + 2 < kids.len()
                     && temp_chain_consumed_by_effect(
                         il,
+                        interner,
                         kids[idx],
                         kids[idx + 1],
                         kids[idx + 2],
@@ -89,6 +96,7 @@ fn body_depends_on_iter(
                 if idx + 1 < kids.len()
                     && temp_assignment_consumed_by_effect(
                         il,
+                        interner,
                         kids[idx],
                         kids[idx + 1],
                         iter_cids,
@@ -99,14 +107,14 @@ fn body_depends_on_iter(
                     idx += 2;
                     continue;
                 }
-                has_effect |= body_depends_on_iter(il, kids[idx], iter_cids, effects)?;
+                has_effect |= body_depends_on_iter(il, interner, kids[idx], iter_cids, effects)?;
                 idx += 1;
             }
             Some(has_effect)
         }
         NodeKind::ExprStmt => {
             let kids = il.children(node);
-            if kids.len() == 1 && append_depends_on_iter(il, kids[0], iter_cids) {
+            if kids.len() == 1 && append_depends_on_iter(il, interner, kids[0], iter_cids) {
                 effects.push(EffectSite::observable(Effect::Append));
                 Some(true)
             } else {
@@ -131,7 +139,7 @@ fn body_depends_on_iter(
                 if il.kind(branch) != NodeKind::Block {
                     return None;
                 }
-                has_effect |= body_depends_on_iter(il, branch, iter_cids, effects)?;
+                has_effect |= body_depends_on_iter(il, interner, branch, iter_cids, effects)?;
             }
             Some(has_effect)
         }
@@ -143,8 +151,13 @@ fn body_depends_on_iter(
 
 /// `recv.append(value)` where the appended value depends on the loop var but the receiver
 /// (the appended-to collection) does not — so the receiver is loop-invariant.
-fn append_depends_on_iter(il: &Il, node: NodeId, iter_cids: &FxHashSet<u32>) -> bool {
-    let Some(kids) = append_call_args(il, node) else {
+fn append_depends_on_iter(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    iter_cids: &FxHashSet<u32>,
+) -> bool {
+    let Some(kids) = append_call_args(il, interner, node) else {
         return false;
     };
     !mentions_any(il, kids.0, iter_cids) && mentions_any(il, kids.1, iter_cids)
@@ -167,6 +180,7 @@ fn index_assignment_depends_on_iter(il: &Il, node: NodeId, iter_cids: &FxHashSet
 /// `t = <expr over iter>;  <effect consuming t>` over two adjacent statements.
 fn temp_assignment_consumed_by_effect(
     il: &Il,
+    interner: &Interner,
     assign: NodeId,
     effect: NodeId,
     iter_cids: &FxHashSet<u32>,
@@ -177,7 +191,7 @@ fn temp_assignment_consumed_by_effect(
     };
     let mut temp_cids = FxHashSet::default();
     temp_cids.insert(temp);
-    effect_consumes_temp(il, effect, iter_cids, &temp_cids, effects)
+    effect_consumes_temp(il, interner, effect, iter_cids, &temp_cids, effects)
 }
 
 /// A local `t = rhs` whose `rhs` is non-trivial, depends on the loop var, does not read `t`
@@ -197,6 +211,7 @@ fn iter_temp_assignment(il: &Il, node: NodeId, iter_cids: &FxHashSet<u32>) -> Op
 /// neither iter nor temp), or an index write whose key/value reads the temp.
 fn effect_consumes_temp(
     il: &Il,
+    interner: &Interner,
     node: NodeId,
     iter_cids: &FxHashSet<u32>,
     temp_cids: &FxHashSet<u32>,
@@ -205,7 +220,8 @@ fn effect_consumes_temp(
     match il.kind(node) {
         NodeKind::ExprStmt => {
             let kids = il.children(node);
-            if kids.len() == 1 && append_consumes_temp(il, kids[0], iter_cids, temp_cids) {
+            if kids.len() == 1 && append_consumes_temp(il, interner, kids[0], iter_cids, temp_cids)
+            {
                 effects.push(EffectSite::observable(Effect::Append));
                 return true;
             }
@@ -224,11 +240,12 @@ fn effect_consumes_temp(
 
 fn append_consumes_temp(
     il: &Il,
+    interner: &Interner,
     node: NodeId,
     iter_cids: &FxHashSet<u32>,
     temp_cids: &FxHashSet<u32>,
 ) -> bool {
-    let Some((recv, value)) = append_call_args(il, node) else {
+    let Some((recv, value)) = append_call_args(il, interner, node) else {
         return false;
     };
     !mentions_any(il, recv, iter_cids)
@@ -257,6 +274,7 @@ fn index_assignment_consumes_temp(
 /// adjacent statements.
 fn temp_chain_consumed_by_effect(
     il: &Il,
+    interner: &Interner,
     first: NodeId,
     second: NodeId,
     effect: NodeId,
@@ -286,6 +304,7 @@ fn temp_chain_consumed_by_effect(
     final_temp.insert(second_cid);
     effect_consumes_chained_temp(
         il,
+        interner,
         effect,
         iter_cids,
         &all_temps,
@@ -297,6 +316,7 @@ fn temp_chain_consumed_by_effect(
 
 fn effect_consumes_chained_temp(
     il: &Il,
+    interner: &Interner,
     node: NodeId,
     iter_cids: &FxHashSet<u32>,
     all_temps: &FxHashSet<u32>,
@@ -309,7 +329,7 @@ fn effect_consumes_chained_temp(
             let kids = il.children(node);
             if kids.len() == 1
                 && append_consumes_chained_temp(
-                    il, kids[0], iter_cids, all_temps, final_temp, prior_temp,
+                    il, interner, kids[0], iter_cids, all_temps, final_temp, prior_temp,
                 )
             {
                 effects.push(EffectSite::observable(Effect::Append));
@@ -332,13 +352,14 @@ fn effect_consumes_chained_temp(
 
 fn append_consumes_chained_temp(
     il: &Il,
+    interner: &Interner,
     node: NodeId,
     iter_cids: &FxHashSet<u32>,
     all_temps: &FxHashSet<u32>,
     final_temp: &FxHashSet<u32>,
     prior_temp: &FxHashSet<u32>,
 ) -> bool {
-    let Some((recv, value)) = append_call_args(il, node) else {
+    let Some((recv, value)) = append_call_args(il, interner, node) else {
         return false;
     };
     !mentions_any(il, recv, iter_cids)
@@ -371,20 +392,35 @@ fn index_assignment_consumes_chained_temp(
 // ---- shared structural readers (no acceptance semantics) ----------------------------------
 
 /// `(receiver, value)` of an `append`/`push` builtin call with exactly two children.
-fn append_call_args(il: &Il, node: NodeId) -> Option<(NodeId, NodeId)> {
-    if il.kind(node) != NodeKind::Call
-        || !matches!(il.node(node).payload, Payload::Builtin(Builtin::Append))
-    {
+fn append_call_args(il: &Il, interner: &Interner, node: NodeId) -> Option<(NodeId, NodeId)> {
+    if il.kind(node) != NodeKind::Call {
         return None;
     }
     let kids = il.children(node);
-    (kids.len() == 2).then(|| (kids[0], kids[1]))
+    if matches!(il.node(node).payload, Payload::Builtin(Builtin::Append)) {
+        return (kids.len() == 2).then(|| (kids[0], kids[1]));
+    }
+    let (&callee, args) = kids.split_first()?;
+    if args.len() != 1 || il.kind(callee) != NodeKind::Field {
+        return None;
+    }
+    let Payload::Name(method) = il.node(callee).payload else {
+        return None;
+    };
+    if !builder_append_method_contract(il.meta.lang, interner.resolve(method), args.len()) {
+        return None;
+    }
+    let receiver = *il.children(callee).first()?;
+    Some((receiver, args[0]))
 }
 
 /// `(receiver, key, value)` of a non-overloadable `recv[key] = value` index assignment
 /// (C/Go/Java only — the same surface the migrated `IndexAssignEffect` admits).
 fn index_assignment_parts(il: &Il, node: NodeId) -> Option<(NodeId, Option<NodeId>, NodeId)> {
-    if !matches!(il.meta.lang, Lang::C | Lang::Go | Lang::Java) {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .non_overloadable_index_assignment()
+    {
         return None;
     }
     let kids = il.children(node);

--- a/crates/nose-detect/src/fragment/oracle.rs
+++ b/crates/nose-detect/src/fragment/oracle.rs
@@ -16,15 +16,24 @@
 //! proof-obligation: detect.fragment.wrapper_synthesis
 //! proof-obligation: il.arena.deep_copy
 
-use super::contract::FragmentContract;
-use nose_il::{FileMeta, Il, IlBuilder, LoopKind, NodeId, NodeKind, Payload, Span, Unit, UnitKind};
+use super::contract::{Effect, FragmentContract};
+use nose_il::{
+    Builtin, FileMeta, Il, IlBuilder, Interner, LoopKind, NodeId, NodeKind, Payload, Span, Unit,
+    UnitKind,
+};
 use nose_normalize::{run_unit, Behavior, Value};
+use nose_semantics::builder_append_method_contract;
 
 /// Run the fragment described by `contract` on `args` (bound to its inputs in order) and
 /// return its observable [`Behavior`], or `None` if the wrapper cannot be synthesized or
 /// the interpreter cannot model the fragment.
-pub fn fragment_behavior(il: &Il, contract: &FragmentContract, args: &[Value]) -> Option<Behavior> {
-    let (synth, func) = synthesize_wrapper(il, contract)?;
+pub fn fragment_behavior(
+    il: &Il,
+    interner: &Interner,
+    contract: &FragmentContract,
+    args: &[Value],
+) -> Option<Behavior> {
+    let (synth, func) = synthesize_wrapper(il, interner, contract)?;
     run_unit(&synth, func, args)
 }
 
@@ -34,9 +43,19 @@ pub fn fragment_behavior(il: &Il, contract: &FragmentContract, args: &[Value]) -
 /// of fragment subtree> ] ]`. Parameters carry the fragment's free canonical ids so the
 /// deep-copied `Var` references resolve against them; the interpreter binds them
 /// positionally from `args`.
-pub fn synthesize_wrapper(il: &Il, contract: &FragmentContract) -> Option<(Il, NodeId)> {
+pub fn synthesize_wrapper(
+    il: &Il,
+    interner: &Interner,
+    contract: &FragmentContract,
+) -> Option<(Il, NodeId)> {
     let mut b = IlBuilder::new(il.file);
     let syn = Span::synthetic(il.file);
+    let policy = CopyPolicy {
+        canonicalize_append_effects: contract
+            .effects
+            .iter()
+            .any(|site| site.effect == Effect::Append),
+    };
 
     // Parameters: one per free input, in the contract's canonical order.
     let mut children: Vec<NodeId> = contract
@@ -54,10 +73,10 @@ pub fn synthesize_wrapper(il: &Il, contract: &FragmentContract) -> Option<(Il, N
         il.children(contract.root)
             .to_vec()
             .iter()
-            .map(|&s| copy_subtree(il, s, &mut b))
-            .collect()
+            .map(|&s| copy_subtree(il, interner, s, &mut b, policy))
+            .collect::<Option<Vec<_>>>()?
     } else {
-        vec![copy_subtree(il, contract.root, &mut b)]
+        vec![copy_subtree(il, interner, contract.root, &mut b, policy)?]
     };
     let body = b.add(NodeKind::Block, Payload::None, syn, &body_stmts);
     children.push(body);
@@ -80,18 +99,94 @@ pub fn synthesize_wrapper(il: &Il, contract: &FragmentContract) -> Option<(Il, N
     Some((synth, func))
 }
 
-/// Deep-copy the subtree rooted at `node` from `src` into `b`, preserving kind, payload,
-/// and span. Post-order: children are copied first so their fresh ids are known when the
-/// parent is added.
-fn copy_subtree(src: &Il, node: NodeId, b: &mut IlBuilder) -> NodeId {
+#[derive(Clone, Copy)]
+struct CopyPolicy {
+    canonicalize_append_effects: bool,
+}
+
+/// Deep-copy the subtree rooted at `node` from `src` into `b`, preserving kind, payload, and
+/// span unless the accepted contract needs an append effect surface made executable. That
+/// rewrite is deliberately local to wrapper synthesis: normal semantic normalization remains
+/// proof-gated and does not infer collection semantics from a method name alone.
+fn copy_subtree(
+    src: &Il,
+    interner: &Interner,
+    node: NodeId,
+    b: &mut IlBuilder,
+    policy: CopyPolicy,
+) -> Option<NodeId> {
+    if policy.canonicalize_append_effects {
+        if let Some((receiver, args)) = append_surface_parts(src, interner, node) {
+            let receiver_tag = append_receiver_tag(src, receiver)?;
+            let target = copy_subtree(src, interner, receiver, b, policy)?;
+            let mut kids = Vec::with_capacity(1 + args.len());
+            kids.push(target);
+            for &arg in args {
+                let value = copy_subtree(src, interner, arg, b, policy)?;
+                let tag = b.add(
+                    NodeKind::Lit,
+                    Payload::LitInt(receiver_tag),
+                    src.node(node).span,
+                    &[],
+                );
+                let tagged_value = b.add(
+                    NodeKind::Seq,
+                    Payload::None,
+                    src.node(node).span,
+                    &[tag, value],
+                );
+                kids.push(tagged_value);
+            }
+            return Some(b.add(
+                NodeKind::Call,
+                Payload::Builtin(Builtin::Append),
+                src.node(node).span,
+                &kids,
+            ));
+        }
+    }
+
     let kids: Vec<NodeId> = src
         .children(node)
         .to_vec()
         .iter()
-        .map(|&c| copy_subtree(src, c, b))
-        .collect();
+        .map(|&c| copy_subtree(src, interner, c, b, policy))
+        .collect::<Option<Vec<_>>>()?;
     let n = src.node(node);
-    b.add(n.kind, n.payload, n.span, &kids)
+    Some(b.add(n.kind, n.payload, n.span, &kids))
+}
+
+fn append_surface_parts<'a>(
+    src: &'a Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<(NodeId, &'a [NodeId])> {
+    if src.kind(node) != NodeKind::Call {
+        return None;
+    }
+    let kids = src.children(node);
+    if matches!(src.node(node).payload, Payload::Builtin(Builtin::Append)) {
+        return (kids.len() >= 2).then(|| (kids[0], &kids[1..]));
+    }
+    let (&callee, args) = kids.split_first()?;
+    if args.is_empty() || src.kind(callee) != NodeKind::Field {
+        return None;
+    }
+    let Payload::Name(method) = src.node(callee).payload else {
+        return None;
+    };
+    if !builder_append_method_contract(src.meta.lang, interner.resolve(method), args.len()) {
+        return None;
+    }
+    let receiver = *src.children(callee).first()?;
+    Some((receiver, args))
+}
+
+fn append_receiver_tag(src: &Il, receiver: NodeId) -> Option<i64> {
+    match (src.kind(receiver), src.node(receiver).payload) {
+        (NodeKind::Var, Payload::Cid(cid)) => Some(i64::from(cid)),
+        _ => None,
+    }
 }
 
 /// Collect the free canonical ids read in the subtree rooted at `node`, in ascending
@@ -230,11 +325,17 @@ mod tests {
             .collect()
     }
 
-    fn behavior_vector(il: &Il, c: &FragmentContract, battery: &[Vec<Value>]) -> Vec<Behavior> {
+    fn behavior_vector(
+        il: &Il,
+        interner: &Interner,
+        c: &FragmentContract,
+        battery: &[Vec<Value>],
+    ) -> Vec<Behavior> {
         battery
             .iter()
             .map(|row| {
-                fragment_behavior(il, c, row).expect("direct-return fragment must be interpretable")
+                fragment_behavior(il, interner, c, row)
+                    .expect("direct-return fragment must be interpretable")
             })
             .collect()
     }
@@ -247,7 +348,7 @@ mod tests {
         let contract = direct_return_contract(&il, root);
         assert_eq!(contract.arity(), 1, "one free input (the parameter)");
 
-        let (synth, func) = synthesize_wrapper(&il, &contract).expect("wrapper synthesizes");
+        let (synth, func) = synthesize_wrapper(&il, &i, &contract).expect("wrapper synthesizes");
         assert_eq!(synth.kind(func), NodeKind::Func);
         let b = run_unit(&synth, func, &[Value::Int(4)]).expect("interpretable");
         assert_eq!(b.ret, Value::Int(17), "4*4 + 1 = 17");
@@ -264,8 +365,8 @@ mod tests {
 
         let battery = battery_1();
         assert_eq!(
-            behavior_vector(&f, &cf, &battery),
-            behavior_vector(&g, &cg, &battery),
+            behavior_vector(&f, &i, &cf, &battery),
+            behavior_vector(&g, &i, &cg, &battery),
             "equivalent direct-return fragments must agree on every battery input"
         );
     }
@@ -280,8 +381,8 @@ mod tests {
 
         let battery = battery_1();
         assert_ne!(
-            behavior_vector(&f, &cf, &battery),
-            behavior_vector(&h, &ch, &battery),
+            behavior_vector(&f, &i, &cf, &battery),
+            behavior_vector(&h, &i, &ch, &battery),
             "behaviorally distinct fragments must diverge on the battery"
         );
     }
@@ -370,7 +471,9 @@ mod tests {
             assert_eq!(c.arity(), 2, "loop var excluded → arity 2");
             battery()
                 .iter()
-                .map(|row| fragment_behavior(&il, &c, row).expect("loop fragment interpretable"))
+                .map(|row| {
+                    fragment_behavior(&il, &i, &c, row).expect("loop fragment interpretable")
+                })
                 .collect()
         };
         let f = run("function f(out, xs){ for (const x of xs){ out.push(x); } }");
@@ -405,7 +508,7 @@ mod tests {
                 ],
             );
             assert_eq!(c.arity(), 1, "only `out` is free (literals are not inputs)");
-            fragment_behavior(&il, &c, &[Value::List(vec![])]).expect("interpretable")
+            fragment_behavior(&il, &i, &c, &[Value::List(vec![])]).expect("interpretable")
         };
         let fwd = run("function f(out){ out.push(1); out.push(2); }");
         let fwd2 = run("function h(out){ out.push(1); out.push(2); }");
@@ -413,5 +516,36 @@ mod tests {
         assert_eq!(fwd.effects.len(), 2, "both appends are recorded in order");
         assert_eq!(fwd, fwd2, "identical ordered bodies must agree");
         assert_ne!(fwd, rev, "swapping the append order must be observable");
+    }
+
+    #[test]
+    fn append_effect_wrapper_preserves_receiver_identity() {
+        let run = |src: &str| -> Behavior {
+            let i = Interner::new();
+            let il = norm(&i, src, Lang::JavaScript);
+            let body = first_func_body(&il);
+            let c = FragmentContract::ordered_effects(
+                FragmentKind::ExprEffect,
+                body,
+                free_input_cids(&il, body),
+                Exit::Normal,
+                vec![
+                    EffectSite::observable(Effect::Append),
+                    EffectSite::observable(Effect::Append),
+                ],
+            );
+            fragment_behavior(&il, &i, &c, &[Value::List(vec![]), Value::List(vec![])])
+                .expect("interpretable")
+        };
+
+        let same = run("function f(out, other){ out.push(1); other.push(2); }");
+        let renamed = run("function g(dst, aux){ dst.push(1); aux.push(2); }");
+        let swapped = run("function h(out, other){ other.push(1); out.push(2); }");
+
+        assert_eq!(same, renamed, "alpha-renamed receiver roles should agree");
+        assert_ne!(
+            same, swapped,
+            "append effects must preserve which receiver role was mutated"
+        );
     }
 }

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -17,7 +17,8 @@ use super::contract::{Effect, EffectSite, FragmentContract};
 use super::oracle::free_input_cids;
 use super::{Exit, FragmentKind, Place};
 use crate::units::{exact_java_this_field, exact_java_this_var};
-use nose_il::{stable_symbol_hash, Builtin, Il, Interner, Lang, NodeId, NodeKind, Payload};
+use nose_il::{stable_symbol_hash, Builtin, Il, Interner, NodeId, NodeKind, Payload};
+use nose_semantics::{builder_append_method_contract, semantics};
 
 /// Fragment kinds that have been migrated onto the contract path. The differential gate
 /// compares the predicate and contract paths over exactly this set; everything outside it
@@ -75,7 +76,7 @@ pub(crate) fn recognize_contract(
         )),
         NodeKind::Assign => recognize_assignment_effect(il, interner, node),
         NodeKind::ExprStmt if expr_effect_shape(il, kids) => {
-            let effect = if is_append_call(il, kids[0]) {
+            let effect = if is_append_call(il, interner, kids[0]) {
                 Effect::Append
             } else {
                 Effect::Other
@@ -88,7 +89,7 @@ pub(crate) fn recognize_contract(
             ))
         }
         NodeKind::If => super::conditional_guard::recognize_conditional_guard(il, interner, node),
-        NodeKind::Loop => super::loop_effect::recognize_loop_effect(il, node),
+        NodeKind::Loop => super::loop_effect::recognize_loop_effect(il, interner, node),
         _ => None,
     }
 }
@@ -105,7 +106,10 @@ fn recognize_assignment_effect(
         return None;
     }
     let target = kids[0];
-    if matches!(il.meta.lang, Lang::C | Lang::Go | Lang::Java) && il.kind(target) == NodeKind::Index
+    if semantics(il.meta.lang)
+        .exact_fragments()
+        .non_overloadable_index_assignment()
+        && il.kind(target) == NodeKind::Index
     {
         // An index write is observable in the effect trace (key and value are recorded), so
         // it carries no receiver-identity obligation and records no `Place` on the contract.
@@ -118,7 +122,11 @@ fn recognize_assignment_effect(
             EffectSite::observable(Effect::IndexWrite),
         ));
     }
-    if il.meta.lang == Lang::Java && exact_java_this_field(il, interner, target) {
+    if semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        && exact_java_this_field(il, interner, target)
+    {
         let place = resolve_place(il, interner, target);
         // Field writes do not observe their receiver in the oracle (the field-state map is
         // keyed by name only), so the write is exact-safe only with a proven receiver. The
@@ -152,9 +160,24 @@ fn expr_effect_shape(il: &Il, kids: &[NodeId]) -> bool {
         )
 }
 
-fn is_append_call(il: &Il, node: NodeId) -> bool {
-    il.kind(node) == NodeKind::Call
-        && matches!(il.node(node).payload, Payload::Builtin(Builtin::Append))
+fn is_append_call(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    if il.kind(node) != NodeKind::Call {
+        return false;
+    }
+    let kids = il.children(node);
+    if matches!(il.node(node).payload, Payload::Builtin(Builtin::Append)) {
+        return kids.len() == 2;
+    }
+    let Some((&callee, args)) = kids.split_first() else {
+        return false;
+    };
+    if args.len() != 1 || il.kind(callee) != NodeKind::Field {
+        return false;
+    }
+    let Payload::Name(method) = il.node(callee).payload else {
+        return false;
+    };
+    builder_append_method_contract(il.meta.lang, interner.resolve(method), args.len())
 }
 
 fn effect_contract(
@@ -579,7 +602,8 @@ mod tests {
             battery
                 .iter()
                 .map(|row| {
-                    fragment_behavior(&il, &c, row).expect("append fragment is interpretable")
+                    fragment_behavior(&il, &interner, &c, row)
+                        .expect("append fragment is interpretable")
                 })
                 .collect()
         };

--- a/crates/nose-detect/src/fragment/self_field_body.rs
+++ b/crates/nose-detect/src/fragment/self_field_body.rs
@@ -10,7 +10,8 @@
 use super::contract::{Effect, EffectSite, FragmentContract};
 use super::oracle::free_input_cids;
 use super::{Exit, FragmentKind};
-use nose_il::{Il, Interner, Lang, NodeId, NodeKind, Payload};
+use nose_il::{Il, Interner, NodeId, NodeKind, Payload};
+use nose_semantics::semantics;
 
 pub(crate) fn recognize_self_field_body(
     il: &Il,
@@ -18,7 +19,11 @@ pub(crate) fn recognize_self_field_body(
     parents: &[Option<NodeId>],
     node: NodeId,
 ) -> Option<FragmentContract> {
-    if il.meta.lang != Lang::Java || il.kind(node) != NodeKind::Block {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        || il.kind(node) != NodeKind::Block
+    {
         return None;
     }
     let func = parents.get(node.0 as usize).copied().flatten()?;
@@ -124,7 +129,11 @@ fn self_field_assign(
 }
 
 fn is_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if il.meta.lang != Lang::Java || il.kind(node) != NodeKind::Field {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        || il.kind(node) != NodeKind::Field
+    {
         return false;
     }
     if !matches!(il.node(node).payload, Payload::Name(_)) {
@@ -136,13 +145,19 @@ fn is_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
 }
 
 fn is_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    il.meta.lang == Lang::Java
+    semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
         && il.kind(node) == NodeKind::Var
         && matches!(il.node(node).payload, Payload::Name(name) if interner.resolve(name) == "this")
 }
 
 fn is_java_return_this(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if il.meta.lang != Lang::Java || il.kind(node) != NodeKind::Return {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        || il.kind(node) != NodeKind::Return
+    {
         return false;
     }
     let kids = il.children(node);

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -12,6 +12,9 @@ use nose_normalize::{
     module_facts::{collect_module_mutations, mutating_method_name},
     node_tag,
 };
+use nose_semantics::{
+    builder_append_method_contract, iterator_identity_adapter_contract, semantics,
+};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
 
@@ -590,12 +593,15 @@ pub(crate) fn extract(
 struct StrictFacts {
     immutable_names: FxHashSet<Symbol>,
     function_names: FxHashSet<Symbol>,
+    collection_cids: FxHashSet<u32>,
+    map_cids: FxHashSet<u32>,
 }
 
 impl StrictFacts {
     fn collect(il: &Il, interner: &Interner) -> Self {
         let mut facts = StrictFacts::default();
         facts.collect_immutable_bindings(il, interner);
+        facts.collect_local_container_bindings(il, interner);
         facts.collect_function_bindings(il, interner);
         facts
     }
@@ -664,6 +670,85 @@ impl StrictFacts {
             }
         }
     }
+
+    fn collect_local_container_bindings(&mut self, il: &Il, interner: &Interner) {
+        let mut counts: FxHashMap<u32, usize> = FxHashMap::default();
+        for (idx, node) in il.nodes.iter().enumerate() {
+            if node.kind != NodeKind::Assign {
+                continue;
+            }
+            let id = NodeId(idx as u32);
+            let kids = il.children(id);
+            if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Var {
+                continue;
+            }
+            if let Payload::Cid(cid) = il.node(kids[0]).payload {
+                *counts.entry(cid).or_insert(0) += 1;
+            }
+        }
+        let candidates: FxHashSet<u32> = counts
+            .iter()
+            .filter_map(|(&cid, &count)| (count == 1).then_some(cid))
+            .collect();
+        let mutated = collect_mutated_cids(il, interner, &candidates);
+        for (idx, node) in il.nodes.iter().enumerate() {
+            if node.kind != NodeKind::Assign {
+                continue;
+            }
+            let id = NodeId(idx as u32);
+            let kids = il.children(id);
+            if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Var {
+                continue;
+            }
+            let Payload::Cid(cid) = il.node(kids[0]).payload else {
+                continue;
+            };
+            if !candidates.contains(&cid) || mutated.contains(&cid) {
+                continue;
+            }
+            if strict_exact_local_collection_binding_safe(il, interner, self, kids[1]) {
+                self.collection_cids.insert(cid);
+            } else if strict_exact_local_map_binding_safe(il, interner, self, kids[1]) {
+                self.map_cids.insert(cid);
+            }
+        }
+    }
+}
+
+fn collect_mutated_cids(
+    il: &Il,
+    interner: &Interner,
+    candidates: &FxHashSet<u32>,
+) -> FxHashSet<u32> {
+    let mut mutated = FxHashSet::default();
+    for (idx, node) in il.nodes.iter().enumerate() {
+        if node.kind != NodeKind::Call {
+            continue;
+        }
+        let id = NodeId(idx as u32);
+        let kids = il.children(id);
+        let Some(&callee) = kids.first() else {
+            continue;
+        };
+        if il.kind(callee) != NodeKind::Field {
+            continue;
+        }
+        let Payload::Name(method) = il.node(callee).payload else {
+            continue;
+        };
+        if !mutating_method_name(interner.resolve(method)) {
+            continue;
+        }
+        let Some(&receiver) = il.children(callee).first() else {
+            continue;
+        };
+        if let (NodeKind::Var, Payload::Cid(cid)) = (il.kind(receiver), il.node(receiver).payload) {
+            if candidates.contains(&cid) {
+                mutated.insert(cid);
+            }
+        }
+    }
+    mutated
 }
 
 fn top_level_statements(il: &Il) -> Vec<NodeId> {
@@ -707,6 +792,32 @@ fn strict_exact_module_container_binding_safe(
         || strict_exact_rust_std_collection_factory_safe(il, interner, facts, node)
         || strict_exact_set_constructor_collection_safe(il, interner, facts, node)
         || strict_exact_java_collection_factory_safe(il, interner, facts, node)
+}
+
+fn strict_exact_local_collection_binding_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+) -> bool {
+    strict_exact_literal_collection_receiver_safe(il, interner, facts, node)
+        || strict_exact_python_collection_factory_safe(il, interner, facts, node)
+        || strict_exact_ruby_set_factory_safe(il, interner, facts, node)
+        || strict_exact_rust_vec_macro_collection_safe(il, interner, facts, node)
+        || strict_exact_rust_std_collection_factory_safe(il, interner, facts, node)
+        || strict_exact_rust_vec_new_safe(il, interner, node)
+        || strict_exact_java_collection_factory_safe(il, interner, facts, node)
+}
+
+fn strict_exact_local_map_binding_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+) -> bool {
+    strict_exact_java_map_factory_safe(il, interner, facts, node)
+        || strict_exact_rust_std_map_factory_safe(il, interner, facts, node)
+        || strict_exact_map_constructor_entries_safe(il, interner, facts, node)
 }
 
 fn immutable_binding_safe(
@@ -783,12 +894,57 @@ fn strict_exact_safe_tree(il: &Il, interner: &Interner, facts: &StrictFacts, nod
         NodeKind::BinOp if strict_exact_static_index_membership_safe(il, interner, facts, node) => {
             true
         }
+        NodeKind::BinOp if strict_exact_in_membership_safe(il, interner, facts, node) => true,
         NodeKind::Lit => exact_literal_safe(il, node),
         NodeKind::Var => strict_exact_safe_var(il, facts, node),
         _ => il
             .children(node)
             .iter()
             .all(|&c| strict_exact_safe_tree(il, interner, facts, c)),
+    }
+}
+
+fn strict_exact_in_membership_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+) -> bool {
+    let Payload::Op(Op::In) = il.node(node).payload else {
+        return false;
+    };
+    let kids = il.children(node);
+    kids.len() == 2
+        && strict_exact_safe_tree(il, interner, facts, kids[0])
+        && strict_exact_in_membership_collection_safe(il, interner, facts, kids[1])
+}
+
+fn strict_exact_in_membership_collection_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+) -> bool {
+    if strict_exact_proven_collection_receiver_safe(il, facts, node)
+        || strict_exact_proven_map_receiver_safe(il, facts, node)
+    {
+        return true;
+    }
+    match il.kind(node) {
+        NodeKind::Seq => strict_exact_membership_collection_safe(il, interner, facts, node),
+        NodeKind::Call => {
+            strict_exact_set_constructor_collection_safe(il, interner, facts, node)
+                || strict_exact_python_collection_factory_safe(il, interner, facts, node)
+                || strict_exact_ruby_set_factory_safe(il, interner, facts, node)
+                || strict_exact_rust_vec_macro_collection_safe(il, interner, facts, node)
+                || strict_exact_rust_std_collection_factory_safe(il, interner, facts, node)
+                || strict_exact_java_collection_factory_safe(il, interner, facts, node)
+                || strict_exact_map_key_view_collection_safe(il, interner, facts, node)
+        }
+        NodeKind::Var => {
+            matches!(il.node(node).payload, Payload::Name(name) if facts.proven_name(name))
+        }
+        _ => false,
     }
 }
 
@@ -1073,6 +1229,7 @@ fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, nod
             return false;
         };
         if strict_exact_literal_collection_receiver_safe(il, interner, facts, receiver)
+            || strict_exact_proven_collection_receiver_safe(il, facts, receiver)
             || strict_exact_python_collection_factory_safe(il, interner, facts, receiver)
             || strict_exact_ruby_set_factory_safe(il, interner, facts, receiver)
             || strict_exact_rust_vec_macro_collection_safe(il, interner, facts, receiver)
@@ -1083,12 +1240,34 @@ fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, nod
             return strict_exact_call_args_safe(il, interner, facts, node);
         }
     }
-    if matches!(method, "get" | "has" | "getOrDefault") {
+    if matches!(
+        method,
+        "get" | "has" | "getOrDefault" | "containsKey" | "contains_key" | "key?" | "has_key?"
+    ) {
         let Some(&receiver) = il.children(callee).first() else {
             return false;
         };
         if method == "get"
-            && strict_exact_typed_map_param_receiver_safe(il, receiver)
+            && strict_exact_proven_map_receiver_safe(il, facts, receiver)
+            && matches!(il.children(node).len(), 2 | 3)
+        {
+            return strict_exact_call_args_safe(il, interner, facts, node);
+        }
+        if method == "has"
+            && (strict_exact_proven_map_receiver_safe(il, facts, receiver)
+                || strict_exact_proven_collection_receiver_safe(il, facts, receiver))
+            && il.children(node).len() == 2
+        {
+            return strict_exact_call_args_safe(il, interner, facts, node);
+        }
+        if matches!(method, "containsKey" | "contains_key" | "key?" | "has_key?")
+            && strict_exact_proven_map_receiver_safe(il, facts, receiver)
+            && il.children(node).len() == 2
+        {
+            return strict_exact_call_args_safe(il, interner, facts, node);
+        }
+        if method == "getOrDefault"
+            && strict_exact_proven_map_receiver_safe(il, facts, receiver)
             && il.children(node).len() == 3
         {
             return strict_exact_call_args_safe(il, interner, facts, node);
@@ -1103,14 +1282,116 @@ fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, nod
             return strict_exact_call_args_safe(il, interner, facts, node);
         }
     }
-    if matches!(
-        method,
-        "iter" | "into_iter" | "iter_mut" | "collect" | "to_vec" | "copied" | "cloned"
-    ) {
-        return strict_exact_call_args_safe(il, interner, facts, node);
+    if strict_exact_iterator_identity_adapter_call_safe(il, interner, facts, node, callee, method) {
+        return true;
     }
+    // Opaque exact method identity: this keeps same-callee calls eligible as exact clones
+    // without assigning semantic meaning to the method name. Cross-language/builtin
+    // convergence still has to pass the proof-backed contracts above or in normalization.
     strict_exact_callee_identity(il, facts, callee)
         && strict_exact_call_args_safe(il, interner, facts, node)
+}
+
+fn strict_exact_iterator_identity_adapter_call_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+    callee: NodeId,
+    method: &str,
+) -> bool {
+    let kids = il.children(node);
+    let Some(arg_count) = kids.len().checked_sub(1) else {
+        return false;
+    };
+    if iterator_identity_adapter_contract(il.meta.lang, method, arg_count).is_none() {
+        return false;
+    }
+    if il.kind(callee) != NodeKind::Field {
+        return false;
+    }
+    let Some(&receiver) = il.children(callee).first() else {
+        return false;
+    };
+    strict_exact_iterator_receiver_safe(il, interner, facts, receiver)
+        && strict_exact_call_args_safe(il, interner, facts, node)
+}
+
+fn strict_exact_iterator_receiver_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    receiver: NodeId,
+) -> bool {
+    strict_exact_proven_collection_receiver_safe(il, facts, receiver)
+        || strict_exact_literal_collection_receiver_safe(il, interner, facts, receiver)
+        || strict_exact_rust_vec_macro_collection_safe(il, interner, facts, receiver)
+        || strict_exact_rust_std_collection_factory_safe(il, interner, facts, receiver)
+        || strict_exact_rust_vec_new_safe(il, interner, receiver)
+        || strict_exact_iterator_identity_adapter_node_safe(il, interner, facts, receiver)
+}
+
+fn strict_exact_iterator_identity_adapter_node_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+) -> bool {
+    if il.kind(node) != NodeKind::Call {
+        return false;
+    }
+    let kids = il.children(node);
+    let Some(&callee) = kids.first() else {
+        return false;
+    };
+    if il.kind(callee) != NodeKind::Field {
+        return false;
+    }
+    let Payload::Name(method) = il.node(callee).payload else {
+        return false;
+    };
+    strict_exact_iterator_identity_adapter_call_safe(
+        il,
+        interner,
+        facts,
+        node,
+        callee,
+        interner.resolve(method),
+    )
+}
+
+fn strict_exact_typed_collection_param_receiver_safe(il: &Il, receiver: NodeId) -> bool {
+    if il.kind(receiver) != NodeKind::Var {
+        return false;
+    }
+    let Payload::Cid(receiver_cid) = il.node(receiver).payload else {
+        return false;
+    };
+    il.nodes.iter().any(|node| {
+        node.kind == NodeKind::Param
+            && matches!(node.payload, Payload::Cid(param_cid) if param_cid == receiver_cid)
+            && il.param_type_facts.iter().any(|fact| {
+                fact.span == node.span
+                    && matches!(
+                        fact.semantic,
+                        ParamSemantic::Array | ParamSemantic::Collection | ParamSemantic::Set
+                    )
+            })
+    })
+}
+
+fn strict_exact_proven_collection_receiver_safe(
+    il: &Il,
+    facts: &StrictFacts,
+    receiver: NodeId,
+) -> bool {
+    if strict_exact_typed_collection_param_receiver_safe(il, receiver) {
+        return true;
+    }
+    matches!(
+        (il.kind(receiver), il.node(receiver).payload),
+        (NodeKind::Var, Payload::Cid(cid)) if facts.collection_cids.contains(&cid)
+    )
 }
 
 fn strict_exact_typed_map_param_receiver_safe(il: &Il, receiver: NodeId) -> bool {
@@ -1128,6 +1409,16 @@ fn strict_exact_typed_map_param_receiver_safe(il: &Il, receiver: NodeId) -> bool
                 .iter()
                 .any(|fact| fact.span == node.span && matches!(fact.semantic, ParamSemantic::Map))
     })
+}
+
+fn strict_exact_proven_map_receiver_safe(il: &Il, facts: &StrictFacts, receiver: NodeId) -> bool {
+    if strict_exact_typed_map_param_receiver_safe(il, receiver) {
+        return true;
+    }
+    matches!(
+        (il.kind(receiver), il.node(receiver).payload),
+        (NodeKind::Var, Payload::Cid(cid)) if facts.map_cids.contains(&cid)
+    )
 }
 
 fn strict_exact_map_key_view_safe(
@@ -1152,7 +1443,7 @@ fn strict_exact_map_key_view_safe(
     let Some(&receiver) = il.children(kids[0]).first() else {
         return false;
     };
-    strict_exact_typed_map_param_receiver_safe(il, receiver)
+    strict_exact_proven_map_receiver_safe(il, facts, receiver)
         || strict_exact_map_constructor_entries_safe(il, interner, facts, receiver)
         || strict_exact_java_map_factory_safe(il, interner, facts, receiver)
         || strict_exact_rust_std_map_factory_safe(il, interner, facts, receiver)
@@ -1214,6 +1505,11 @@ fn strict_exact_membership_collection_safe(
                 || strict_exact_java_collection_factory_safe(il, interner, facts, node)
                 || strict_exact_map_key_view_collection_safe(il, interner, facts, node);
         }
+        if strict_exact_proven_collection_receiver_safe(il, facts, node)
+            || strict_exact_proven_map_receiver_safe(il, facts, node)
+        {
+            return true;
+        }
         return strict_exact_safe_tree(il, interner, facts, node);
     }
     let tag_safe = match il.node(node).payload {
@@ -1232,19 +1528,14 @@ fn strict_exact_membership_collection_safe(
 }
 
 fn strict_exact_set_constructor_collection_safe(
-    il: &Il,
-    interner: &Interner,
-    facts: &StrictFacts,
-    node: NodeId,
+    _il: &Il,
+    _interner: &Interner,
+    _facts: &StrictFacts,
+    _node: NodeId,
 ) -> bool {
-    if il.kind(node) != NodeKind::Call {
-        return false;
-    }
-    let kids = il.children(node);
-    if kids.len() != 2 || !strict_exact_callee_name(il, interner, kids[0], "Set") {
-        return false;
-    }
-    strict_exact_membership_collection_safe(il, interner, facts, kids[1])
+    // JS `new Set(xs)` and plain `Set(xs)` currently lower to the same call
+    // shape, so exact constructor semantics must wait for a construct proof.
+    false
 }
 
 fn strict_exact_python_collection_factory_safe(
@@ -1253,7 +1544,11 @@ fn strict_exact_python_collection_factory_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    if il.meta.lang != Lang::Python || il.kind(node) != NodeKind::Call {
+    if !semantics(il.meta.lang)
+        .stdlib()
+        .python_collection_factories()
+        || il.kind(node) != NodeKind::Call
+    {
         return false;
     }
     let kids = il.children(node);
@@ -1377,7 +1672,7 @@ fn strict_exact_ruby_set_factory_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    if il.meta.lang != Lang::Ruby
+    if !semantics(il.meta.lang).stdlib().ruby_set_factory()
         || il.kind(node) != NodeKind::Call
         || !ruby_file_requires_module(il, interner, "set")
         || file_defines_name(il, interner, "Set")
@@ -1402,7 +1697,7 @@ fn strict_exact_ruby_set_factory_safe(
 }
 
 fn ruby_file_requires_module(il: &Il, interner: &Interner, module: &str) -> bool {
-    if il.meta.lang != Lang::Ruby {
+    if !semantics(il.meta.lang).stdlib().ruby_set_factory() {
         return false;
     }
     let expected = stable_symbol_hash(module);
@@ -1438,7 +1733,8 @@ fn strict_exact_rust_vec_macro_collection_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    if il.meta.lang != Lang::Rust || il.kind(node) != NodeKind::Call {
+    if !semantics(il.meta.lang).stdlib().rust_vec_macro_factory() || il.kind(node) != NodeKind::Call
+    {
         return false;
     }
     let kids = il.children(node);
@@ -1459,7 +1755,7 @@ fn strict_exact_rust_vec_macro_collection_safe(
 /// the exact channel like the `out = []` builder loops in Python/JS. Sound: it is a constant
 /// empty collection, no inputs or effects.
 fn strict_exact_rust_vec_new_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if il.meta.lang != Lang::Rust || il.kind(node) != NodeKind::Call {
+    if !semantics(il.meta.lang).stdlib().rust_vec_new_factory() || il.kind(node) != NodeKind::Call {
         return false;
     }
     let kids = il.children(node);
@@ -1469,8 +1765,16 @@ fn strict_exact_rust_vec_new_safe(il: &Il, interner: &Interner, node: NodeId) ->
     let Payload::Name(name) = il.node(kids[0]).payload else {
         return false;
     };
-    let text = interner.resolve(name);
-    text == "Vec::new" || text.ends_with("::Vec::new")
+    strict_exact_rust_vec_new_name(il, interner, interner.resolve(name))
+}
+
+fn strict_exact_rust_vec_new_name(il: &Il, interner: &Interner, text: &str) -> bool {
+    match text {
+        "Vec::new" => !file_defines_name(il, interner, "Vec"),
+        "std::vec::Vec::new" => !file_defines_name(il, interner, "std"),
+        "alloc::vec::Vec::new" => !file_defines_name(il, interner, "alloc"),
+        _ => false,
+    }
 }
 
 fn strict_exact_rust_std_collection_factory_safe(
@@ -1479,7 +1783,11 @@ fn strict_exact_rust_std_collection_factory_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    if il.meta.lang != Lang::Rust || il.kind(node) != NodeKind::Call {
+    if !semantics(il.meta.lang)
+        .stdlib()
+        .rust_std_collection_factories()
+        || il.kind(node) != NodeKind::Call
+    {
         return false;
     }
     let kids = il.children(node);
@@ -1497,6 +1805,9 @@ fn strict_exact_rust_std_collection_factory_safe(
     ) {
         return false;
     }
+    if file_defines_name(il, interner, "std") {
+        return false;
+    }
     strict_exact_membership_collection_safe(il, interner, facts, kids[1])
 }
 
@@ -1506,7 +1817,9 @@ fn strict_exact_java_collection_factory_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    if il.meta.lang != Lang::Java || il.kind(node) != NodeKind::Call {
+    if !semantics(il.meta.lang).stdlib().java_collection_factories()
+        || il.kind(node) != NodeKind::Call
+    {
         return false;
     }
     let kids = il.children(node);
@@ -1540,7 +1853,10 @@ fn strict_exact_java_collection_factory_safe(
 }
 
 fn java_file_defines_type_name(il: &Il, interner: &Interner, name: &str) -> bool {
-    if il.meta.lang != Lang::Java {
+    if !semantics(il.meta.lang)
+        .modules()
+        .java_type_declarations_shadow_stdlib()
+    {
         return false;
     }
     il.units.iter().any(|unit| {
@@ -1557,6 +1873,9 @@ fn file_defines_name(il: &Il, interner: &Interner, name: &str) -> bool {
     }) || il.units.iter().any(|unit| {
         unit.name
             .is_some_and(|symbol| interner.resolve(symbol) == name)
+    }) || il.nodes.iter().any(|node| {
+        matches!(node.kind, NodeKind::Module | NodeKind::Block)
+            && matches!(node.payload, Payload::Name(symbol) if interner.resolve(symbol) == name)
     })
 }
 
@@ -1582,7 +1901,7 @@ fn strict_exact_java_map_factory_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    if il.meta.lang != Lang::Java || il.kind(node) != NodeKind::Call {
+    if !semantics(il.meta.lang).stdlib().java_map_factories() || il.kind(node) != NodeKind::Call {
         return false;
     }
     let kids = il.children(node);
@@ -1644,19 +1963,14 @@ fn strict_exact_java_map_entry_safe(
 }
 
 fn strict_exact_map_constructor_entries_safe(
-    il: &Il,
-    interner: &Interner,
-    facts: &StrictFacts,
-    node: NodeId,
+    _il: &Il,
+    _interner: &Interner,
+    _facts: &StrictFacts,
+    _node: NodeId,
 ) -> bool {
-    if il.kind(node) != NodeKind::Call {
-        return false;
-    }
-    let kids = il.children(node);
-    if kids.len() != 2 || !strict_exact_callee_name(il, interner, kids[0], "Map") {
-        return false;
-    }
-    strict_exact_map_entries_safe(il, interner, facts, kids[1])
+    // JS `new Map(entries)` and plain `Map(entries)` currently lower to the same
+    // call shape, so exact constructor semantics must wait for a construct proof.
+    false
 }
 
 fn strict_exact_rust_std_map_factory_safe(
@@ -1665,7 +1979,8 @@ fn strict_exact_rust_std_map_factory_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    if il.meta.lang != Lang::Rust || il.kind(node) != NodeKind::Call {
+    if !semantics(il.meta.lang).stdlib().rust_std_map_factories() || il.kind(node) != NodeKind::Call
+    {
         return false;
     }
     let kids = il.children(node);
@@ -1679,6 +1994,9 @@ fn strict_exact_rust_std_map_factory_safe(
         interner.resolve(name),
         "std::collections::HashMap::from" | "std::collections::BTreeMap::from"
     ) {
+        return false;
+    }
+    if file_defines_name(il, interner, "std") {
         return false;
     }
     strict_exact_map_entries_safe(il, interner, facts, kids[1])
@@ -1715,7 +2033,11 @@ fn strict_exact_go_literal_zero_map_index_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    if il.meta.lang != Lang::Go || il.kind(node) != NodeKind::Index {
+    if !semantics(il.meta.lang)
+        .stdlib()
+        .go_literal_zero_map_lookup()
+        || il.kind(node) != NodeKind::Index
+    {
         return false;
     }
     let kids = il.children(node);
@@ -1984,7 +2306,7 @@ fn empty_or_single_direct_exact_statement_block(
     if kids.is_empty() {
         return Some(false);
     }
-    if exact_ordered_append_effect_sequence_block(il, node) {
+    if exact_ordered_append_effect_sequence_block(il, interner, node) {
         return Some(true);
     }
     if exact_ordered_index_assignment_effect_sequence_block(il, node) {
@@ -1999,10 +2321,10 @@ fn empty_or_single_direct_exact_statement_block(
     if exact_ordered_mixed_effect_sequence_block(il, interner, node) {
         return Some(true);
     }
-    if exact_ordered_conditional_effect_sequence_block(il, node) {
+    if exact_ordered_conditional_effect_sequence_block(il, interner, node) {
         return Some(true);
     }
-    if exact_ordered_conditional_mixed_effect_sequence_block(il, node) {
+    if exact_ordered_conditional_mixed_effect_sequence_block(il, interner, node) {
         return Some(true);
     }
     if exact_ordered_loop_conditional_effect_sequence_block(il, interner, node) {
@@ -2068,12 +2390,18 @@ fn exact_ordered_mixed_effect_sequence_block(il: &Il, interner: &Interner, node:
 fn exact_ordered_mixed_effect_sequence_item(il: &Il, interner: &Interner, node: NodeId) -> bool {
     match il.kind(node) {
         NodeKind::Loop => exact_loop_effect_fragment_root(il, interner, node),
-        NodeKind::ExprStmt | NodeKind::Assign => exact_direct_effect_statement_root(il, node),
+        NodeKind::ExprStmt | NodeKind::Assign => {
+            exact_direct_effect_statement_root(il, interner, node)
+        }
         _ => false,
     }
 }
 
-fn exact_ordered_conditional_effect_sequence_block(il: &Il, node: NodeId) -> bool {
+fn exact_ordered_conditional_effect_sequence_block(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> bool {
     if il.kind(node) != NodeKind::Block {
         return false;
     }
@@ -2082,17 +2410,23 @@ fn exact_ordered_conditional_effect_sequence_block(il: &Il, node: NodeId) -> boo
         && kids.iter().all(|&kid| il.kind(kid) == NodeKind::If)
         && kids
             .iter()
-            .all(|&kid| exact_conditional_direct_effect_fragment_root(il, kid))
+            .all(|&kid| exact_conditional_direct_effect_fragment_root(il, interner, kid))
 }
 
-fn exact_conditional_direct_effect_fragment_root(il: &Il, node: NodeId) -> bool {
+fn exact_conditional_direct_effect_fragment_root(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> bool {
     let kids = il.children(node);
     if il.kind(node) != NodeKind::If || !(kids.len() == 2 || kids.len() == 3) {
         return false;
     }
     let mut has_effect = false;
     for &branch in kids.iter().skip(1) {
-        let Some(branch_has_effect) = empty_or_single_direct_exact_effect_block(il, branch) else {
+        let Some(branch_has_effect) =
+            empty_or_single_direct_exact_effect_block(il, interner, branch)
+        else {
             return false;
         };
         has_effect |= branch_has_effect;
@@ -2100,7 +2434,11 @@ fn exact_conditional_direct_effect_fragment_root(il: &Il, node: NodeId) -> bool 
     has_effect
 }
 
-fn exact_ordered_conditional_mixed_effect_sequence_block(il: &Il, node: NodeId) -> bool {
+fn exact_ordered_conditional_mixed_effect_sequence_block(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> bool {
     if il.kind(node) != NodeKind::Block {
         return false;
     }
@@ -2120,8 +2458,10 @@ fn exact_ordered_conditional_mixed_effect_sequence_block(il: &Il, node: NodeId) 
         return false;
     }
     kids.iter().all(|&kid| match il.kind(kid) {
-        NodeKind::If => exact_conditional_direct_effect_fragment_root(il, kid),
-        NodeKind::ExprStmt | NodeKind::Assign => exact_direct_effect_statement_root(il, kid),
+        NodeKind::If => exact_conditional_direct_effect_fragment_root(il, interner, kid),
+        NodeKind::ExprStmt | NodeKind::Assign => {
+            exact_direct_effect_statement_root(il, interner, kid)
+        }
         _ => false,
     })
 }
@@ -2151,7 +2491,7 @@ fn exact_ordered_loop_conditional_effect_sequence_block(
     }
     kids.iter().all(|&kid| match il.kind(kid) {
         NodeKind::Loop => exact_loop_effect_fragment_root(il, interner, kid),
-        NodeKind::If => exact_conditional_direct_effect_fragment_root(il, kid),
+        NodeKind::If => exact_conditional_direct_effect_fragment_root(il, interner, kid),
         _ => false,
     })
 }
@@ -2185,13 +2525,19 @@ fn exact_ordered_loop_conditional_mixed_effect_sequence_block(
     }
     kids.iter().all(|&kid| match il.kind(kid) {
         NodeKind::Loop => exact_loop_effect_fragment_root(il, interner, kid),
-        NodeKind::If => exact_conditional_direct_effect_fragment_root(il, kid),
-        NodeKind::ExprStmt | NodeKind::Assign => exact_direct_effect_statement_root(il, kid),
+        NodeKind::If => exact_conditional_direct_effect_fragment_root(il, interner, kid),
+        NodeKind::ExprStmt | NodeKind::Assign => {
+            exact_direct_effect_statement_root(il, interner, kid)
+        }
         _ => false,
     })
 }
 
-fn empty_or_single_direct_exact_effect_block(il: &Il, node: NodeId) -> Option<bool> {
+fn empty_or_single_direct_exact_effect_block(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<bool> {
     if il.kind(node) != NodeKind::Block {
         return None;
     }
@@ -2202,18 +2548,18 @@ fn empty_or_single_direct_exact_effect_block(il: &Il, node: NodeId) -> Option<bo
     if kids.len() != 1 {
         return None;
     }
-    exact_direct_effect_statement_root(il, kids[0]).then_some(true)
+    exact_direct_effect_statement_root(il, interner, kids[0]).then_some(true)
 }
 
-fn exact_direct_effect_statement_root(il: &Il, node: NodeId) -> bool {
+fn exact_direct_effect_statement_root(il: &Il, interner: &Interner, node: NodeId) -> bool {
     match il.kind(node) {
-        NodeKind::ExprStmt => exact_append_effect_statement_root(il, node),
+        NodeKind::ExprStmt => exact_append_effect_statement_root(il, interner, node),
         NodeKind::Assign => exact_index_assignment_fragment_root(il, node),
         _ => false,
     }
 }
 
-fn exact_ordered_append_effect_sequence_block(il: &Il, node: NodeId) -> bool {
+fn exact_ordered_append_effect_sequence_block(il: &Il, interner: &Interner, node: NodeId) -> bool {
     if il.kind(node) != NodeKind::Block {
         return false;
     }
@@ -2229,7 +2575,7 @@ fn exact_ordered_append_effect_sequence_block(il: &Il, node: NodeId) -> bool {
     }
     let expected_effects = match kids
         .iter()
-        .filter(|&&kid| exact_append_effect_statement_root(il, kid))
+        .filter(|&&kid| exact_append_effect_statement_root(il, interner, kid))
         .count()
     {
         2 if kids.len() <= 4 => 2,
@@ -2242,6 +2588,7 @@ fn exact_ordered_append_effect_sequence_block(il: &Il, node: NodeId) -> bool {
         if idx + 2 < kids.len()
             && exact_temp_chain_consumed_by_append_effect(
                 il,
+                interner,
                 kids[idx],
                 kids[idx + 1],
                 kids[idx + 2],
@@ -2252,13 +2599,18 @@ fn exact_ordered_append_effect_sequence_block(il: &Il, node: NodeId) -> bool {
             continue;
         }
         if idx + 1 < kids.len()
-            && exact_temp_assignment_consumed_by_append_effect(il, kids[idx], kids[idx + 1])
+            && exact_temp_assignment_consumed_by_append_effect(
+                il,
+                interner,
+                kids[idx],
+                kids[idx + 1],
+            )
         {
             effects += 1;
             idx += 2;
             continue;
         }
-        if exact_append_effect_statement_root(il, kids[idx]) {
+        if exact_append_effect_statement_root(il, interner, kids[idx]) {
             effects += 1;
             idx += 1;
             continue;
@@ -2268,22 +2620,21 @@ fn exact_ordered_append_effect_sequence_block(il: &Il, node: NodeId) -> bool {
     effects == expected_effects
 }
 
-fn exact_append_effect_statement_root(il: &Il, stmt: NodeId) -> bool {
+fn exact_append_effect_statement_root(il: &Il, interner: &Interner, stmt: NodeId) -> bool {
     if il.kind(stmt) != NodeKind::ExprStmt {
         return false;
     }
     let kids = il.children(stmt);
-    kids.len() == 1 && exact_single_item_append_call(il, kids[0])
+    kids.len() == 1 && exact_single_item_append_call(il, interner, kids[0])
 }
 
-fn exact_single_item_append_call(il: &Il, call: NodeId) -> bool {
-    il.kind(call) == NodeKind::Call
-        && matches!(il.node(call).payload, Payload::Builtin(Builtin::Append))
-        && il.children(call).len() == 2
+fn exact_single_item_append_call(il: &Il, interner: &Interner, call: NodeId) -> bool {
+    append_call_args(il, interner, call).is_some()
 }
 
 fn exact_temp_assignment_consumed_by_append_effect(
     il: &Il,
+    interner: &Interner,
     assign: NodeId,
     effect: NodeId,
 ) -> bool {
@@ -2296,12 +2647,13 @@ fn exact_temp_assignment_consumed_by_append_effect(
     let kids = il.children(effect);
     il.kind(effect) == NodeKind::ExprStmt
         && kids.len() == 1
-        && exact_single_item_append_call(il, kids[0])
-        && append_effect_consumes_temp(il, kids[0], &empty, &temp_cids)
+        && exact_single_item_append_call(il, interner, kids[0])
+        && append_effect_consumes_temp(il, interner, kids[0], &empty, &temp_cids)
 }
 
 fn exact_temp_chain_consumed_by_append_effect(
     il: &Il,
+    interner: &Interner,
     first_assign: NodeId,
     second_assign: NodeId,
     effect: NodeId,
@@ -2333,9 +2685,10 @@ fn exact_temp_chain_consumed_by_append_effect(
     let kids = il.children(effect);
     il.kind(effect) == NodeKind::ExprStmt
         && kids.len() == 1
-        && exact_single_item_append_call(il, kids[0])
+        && exact_single_item_append_call(il, interner, kids[0])
         && append_effect_consumes_chained_temp(
             il,
+            interner,
             kids[0],
             &empty,
             &all_temps,
@@ -2345,7 +2698,10 @@ fn exact_temp_chain_consumed_by_append_effect(
 }
 
 fn exact_ordered_index_assignment_effect_sequence_block(il: &Il, node: NodeId) -> bool {
-    if !matches!(il.meta.lang, Lang::C | Lang::Go | Lang::Java) {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .non_overloadable_index_assignment()
+    {
         return false;
     }
     if il.kind(node) != NodeKind::Block {
@@ -2408,7 +2764,11 @@ fn exact_ordered_self_field_assignment_sequence_block(
     interner: &Interner,
     node: NodeId,
 ) -> bool {
-    if il.meta.lang != Lang::Java || il.kind(node) != NodeKind::Block {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        || il.kind(node) != NodeKind::Block
+    {
         return false;
     }
     let kids = il.children(node);
@@ -2614,7 +2974,10 @@ fn exact_assignment_fragment_kind(
 }
 
 fn exact_index_assignment_fragment_root(il: &Il, node: NodeId) -> bool {
-    if !matches!(il.meta.lang, Lang::C | Lang::Go | Lang::Java) {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .non_overloadable_index_assignment()
+    {
         return false;
     }
     let kids = il.children(node);
@@ -2625,7 +2988,11 @@ fn exact_index_assignment_fragment_root(il: &Il, node: NodeId) -> bool {
 // coordinate. Expose only Java's fixed `this.field = ...`; arbitrary receivers such as
 // `other.field = ...` need a receiver-aware proof fact before they can be exact fragments.
 fn exact_self_field_assignment_fragment_root(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if il.meta.lang != Lang::Java || il.kind(node) != NodeKind::Assign {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        || il.kind(node) != NodeKind::Assign
+    {
         return false;
     }
     let kids = il.children(node);
@@ -2633,7 +3000,11 @@ fn exact_self_field_assignment_fragment_root(il: &Il, interner: &Interner, node:
 }
 
 pub(crate) fn exact_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if il.meta.lang != Lang::Java || il.kind(node) != NodeKind::Field {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        || il.kind(node) != NodeKind::Field
+    {
         return false;
     }
     if !matches!(il.node(node).payload, Payload::Name(_)) {
@@ -2646,13 +3017,19 @@ pub(crate) fn exact_java_this_field(il: &Il, interner: &Interner, node: NodeId) 
 }
 
 pub(crate) fn exact_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    il.meta.lang == Lang::Java
+    semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
         && il.kind(node) == NodeKind::Var
         && matches!(il.node(node).payload, Payload::Name(name) if interner.resolve(name) == "this")
 }
 
 fn exact_java_return_this_fragment_root(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if il.meta.lang != Lang::Java || il.kind(node) != NodeKind::Return {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        || il.kind(node) != NodeKind::Return
+    {
         return false;
     }
     let kids = il.children(node);
@@ -2878,6 +3255,7 @@ fn foreach_effect_body_depends_on_iter(
                 if idx + 2 < kids.len()
                     && loop_temp_chain_consumed_by_effect(
                         il,
+                        interner,
                         kids[idx],
                         kids[idx + 1],
                         kids[idx + 2],
@@ -2891,6 +3269,7 @@ fn foreach_effect_body_depends_on_iter(
                 if idx + 1 < kids.len()
                     && loop_temp_assignment_consumed_by_effect(
                         il,
+                        interner,
                         kids[idx],
                         kids[idx + 1],
                         iter_cids,
@@ -2908,7 +3287,7 @@ fn foreach_effect_body_depends_on_iter(
         }
         NodeKind::ExprStmt => {
             let kids = il.children(node);
-            (kids.len() == 1 && append_effect_depends_on_iter(il, kids[0], iter_cids))
+            (kids.len() == 1 && append_effect_depends_on_iter(il, interner, kids[0], iter_cids))
                 .then_some(true)
         }
         NodeKind::Assign => {
@@ -2934,6 +3313,7 @@ fn foreach_effect_body_depends_on_iter(
 
 fn loop_temp_assignment_consumed_by_effect(
     il: &Il,
+    interner: &Interner,
     assign: NodeId,
     effect: NodeId,
     iter_cids: &FxHashSet<u32>,
@@ -2943,11 +3323,12 @@ fn loop_temp_assignment_consumed_by_effect(
     };
     let mut temp_cids = FxHashSet::default();
     temp_cids.insert(temp_cid);
-    loop_effect_consumes_temp(il, effect, iter_cids, &temp_cids)
+    loop_effect_consumes_temp(il, interner, effect, iter_cids, &temp_cids)
 }
 
 fn loop_temp_chain_consumed_by_effect(
     il: &Il,
+    interner: &Interner,
     first_assign: NodeId,
     second_assign: NodeId,
     effect: NodeId,
@@ -2976,7 +3357,15 @@ fn loop_temp_chain_consumed_by_effect(
     all_temps.insert(second_cid);
     let mut final_temp = FxHashSet::default();
     final_temp.insert(second_cid);
-    loop_effect_consumes_chained_temp(il, effect, iter_cids, &all_temps, &final_temp, &first_temp)
+    loop_effect_consumes_chained_temp(
+        il,
+        interner,
+        effect,
+        iter_cids,
+        &all_temps,
+        &final_temp,
+        &first_temp,
+    )
 }
 
 fn loop_local_iter_temp_assignment(
@@ -3012,6 +3401,7 @@ fn loop_local_iter_temp_assignment(
 
 fn loop_effect_consumes_temp(
     il: &Il,
+    interner: &Interner,
     node: NodeId,
     iter_cids: &FxHashSet<u32>,
     temp_cids: &FxHashSet<u32>,
@@ -3019,7 +3409,8 @@ fn loop_effect_consumes_temp(
     match il.kind(node) {
         NodeKind::ExprStmt => {
             let kids = il.children(node);
-            kids.len() == 1 && append_effect_consumes_temp(il, kids[0], iter_cids, temp_cids)
+            kids.len() == 1
+                && append_effect_consumes_temp(il, interner, kids[0], iter_cids, temp_cids)
         }
         NodeKind::Assign => index_assignment_effect_consumes_temp(il, node, iter_cids, temp_cids),
         _ => false,
@@ -3028,6 +3419,7 @@ fn loop_effect_consumes_temp(
 
 fn loop_effect_consumes_chained_temp(
     il: &Il,
+    interner: &Interner,
     node: NodeId,
     iter_cids: &FxHashSet<u32>,
     all_temp_cids: &FxHashSet<u32>,
@@ -3040,6 +3432,7 @@ fn loop_effect_consumes_chained_temp(
             kids.len() == 1
                 && append_effect_consumes_chained_temp(
                     il,
+                    interner,
                     kids[0],
                     iter_cids,
                     all_temp_cids,
@@ -3061,45 +3454,35 @@ fn loop_effect_consumes_chained_temp(
 
 fn append_effect_consumes_temp(
     il: &Il,
+    interner: &Interner,
     node: NodeId,
     iter_cids: &FxHashSet<u32>,
     temp_cids: &FxHashSet<u32>,
 ) -> bool {
-    if il.kind(node) != NodeKind::Call
-        || !matches!(il.node(node).payload, Payload::Builtin(Builtin::Append))
-    {
+    let Some((receiver, value)) = append_call_args(il, interner, node) else {
         return false;
-    }
-    let kids = il.children(node);
-    if kids.len() != 2 {
-        return false;
-    }
-    !node_mentions_any_cid(il, kids[0], iter_cids)
-        && !node_mentions_any_cid(il, kids[0], temp_cids)
-        && node_mentions_any_cid(il, kids[1], temp_cids)
+    };
+    !node_mentions_any_cid(il, receiver, iter_cids)
+        && !node_mentions_any_cid(il, receiver, temp_cids)
+        && node_mentions_any_cid(il, value, temp_cids)
 }
 
 fn append_effect_consumes_chained_temp(
     il: &Il,
+    interner: &Interner,
     node: NodeId,
     iter_cids: &FxHashSet<u32>,
     all_temp_cids: &FxHashSet<u32>,
     final_temp_cids: &FxHashSet<u32>,
     prior_temp_cids: &FxHashSet<u32>,
 ) -> bool {
-    if il.kind(node) != NodeKind::Call
-        || !matches!(il.node(node).payload, Payload::Builtin(Builtin::Append))
-    {
+    let Some((receiver, value)) = append_call_args(il, interner, node) else {
         return false;
-    }
-    let kids = il.children(node);
-    if kids.len() != 2 {
-        return false;
-    }
-    !node_mentions_any_cid(il, kids[0], iter_cids)
-        && !node_mentions_any_cid(il, kids[0], all_temp_cids)
-        && node_mentions_any_cid(il, kids[1], final_temp_cids)
-        && !node_mentions_any_cid(il, kids[1], prior_temp_cids)
+    };
+    !node_mentions_any_cid(il, receiver, iter_cids)
+        && !node_mentions_any_cid(il, receiver, all_temp_cids)
+        && node_mentions_any_cid(il, value, final_temp_cids)
+        && !node_mentions_any_cid(il, value, prior_temp_cids)
 }
 
 fn index_assignment_effect_consumes_temp(
@@ -3165,17 +3548,38 @@ fn index_assignment_effect_consumes_chained_temp(
     (key_uses_final || value_uses_final) && !key_uses_prior && !value_uses_prior
 }
 
-fn append_effect_depends_on_iter(il: &Il, node: NodeId, iter_cids: &FxHashSet<u32>) -> bool {
-    if il.kind(node) != NodeKind::Call
-        || !matches!(il.node(node).payload, Payload::Builtin(Builtin::Append))
-    {
+fn append_effect_depends_on_iter(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    iter_cids: &FxHashSet<u32>,
+) -> bool {
+    let Some((receiver, value)) = append_call_args(il, interner, node) else {
         return false;
+    };
+    !node_mentions_any_cid(il, receiver, iter_cids) && node_mentions_any_cid(il, value, iter_cids)
+}
+
+fn append_call_args(il: &Il, interner: &Interner, node: NodeId) -> Option<(NodeId, NodeId)> {
+    if il.kind(node) != NodeKind::Call {
+        return None;
     }
     let kids = il.children(node);
-    if kids.len() != 2 {
-        return false;
+    if matches!(il.node(node).payload, Payload::Builtin(Builtin::Append)) {
+        return (kids.len() == 2).then(|| (kids[0], kids[1]));
     }
-    !node_mentions_any_cid(il, kids[0], iter_cids) && node_mentions_any_cid(il, kids[1], iter_cids)
+    let (&callee, args) = kids.split_first()?;
+    if args.len() != 1 || il.kind(callee) != NodeKind::Field {
+        return None;
+    }
+    let Payload::Name(method) = il.node(callee).payload else {
+        return None;
+    };
+    if !builder_append_method_contract(il.meta.lang, interner.resolve(method), args.len()) {
+        return None;
+    }
+    let receiver = *il.children(callee).first()?;
+    Some((receiver, args[0]))
 }
 
 fn index_assignment_effect_depends_on_iter(
@@ -3295,6 +3699,9 @@ fn call_may_mutate_blocked_cid(
         return false;
     }
     let kids = il.children(node);
+    if let Some((receiver, _)) = append_call_args(il, interner, node) {
+        return node_mentions_any_cid(il, receiver, blocked);
+    }
     match il.node(node).payload {
         Payload::Builtin(Builtin::Append) => kids
             .first()

--- a/crates/nose-frontend/Cargo.toml
+++ b/crates/nose-frontend/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 
 [dependencies]
 nose-il = { workspace = true }
+nose-semantics = { workspace = true }
 rustc-hash = { workspace = true }
 rayon = { workspace = true }
 ignore = { workspace = true }

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -363,15 +363,18 @@ pub(crate) fn param_semantic_from_text(text: &str) -> Option<ParamSemantic> {
     {
         return Some(ParamSemantic::Map);
     }
+    if t.contains("option<") || t.contains("optional<") {
+        return Some(ParamSemantic::Option);
+    }
+    if t.contains("set[") || t.contains("set<") || t.contains("hashset<") || t.contains("btreeset<")
+    {
+        return Some(ParamSemantic::Set);
+    }
     if t.contains("[]")
         || t.contains(":&[")
         || t.contains("&[")
         || t.contains("list[")
         || t.contains("list<")
-        || t.contains("set[")
-        || t.contains("set<")
-        || t.contains("hashset<")
-        || t.contains("btreeset<")
         || t.contains("tuple[")
         || t.contains("container[")
         || t.contains("container<")
@@ -389,7 +392,12 @@ pub(crate) fn param_semantic_from_text(text: &str) -> Option<ParamSemantic> {
     {
         return Some(ParamSemantic::Collection);
     }
-    if t.contains("string") || t.contains(":str") || t.contains(":&str") {
+    if t.contains("string")
+        || t == "str"
+        || t == "&str"
+        || t.contains(":str")
+        || t.contains(":&str")
+    {
         return Some(ParamSemantic::String);
     }
     if is_integer_semantic_text(&t) {
@@ -472,17 +480,19 @@ pub(crate) fn stdlib_type_semantic(module: &str, exported: &str) -> Option<Param
         return Some(ParamSemantic::Map);
     }
     if matches!(module, "typing" | "collections.abc")
+        && matches!(exported, "FrozenSet" | "MutableSet" | "Set")
+    {
+        return Some(ParamSemantic::Set);
+    }
+    if matches!(module, "typing" | "collections.abc")
         && matches!(
             exported,
             "Collection"
                 | "Container"
                 | "Deque"
-                | "FrozenSet"
                 | "List"
                 | "MutableSequence"
-                | "MutableSet"
                 | "Sequence"
-                | "Set"
                 | "Tuple"
         )
     {

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -7,8 +7,9 @@
 //! module-binding seed can reuse its mutation and canonicalization logic.
 
 use nose_il::{
-    stable_symbol_hash, Il, Interner, Lang, Node, NodeId, NodeKind, Payload, Span, Symbol, UnitKind,
+    stable_symbol_hash, Il, Interner, Node, NodeId, NodeKind, Payload, Span, Symbol, UnitKind,
 };
+use nose_semantics::{semantics, ImportedMapFactoryContract};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::Path;
 
@@ -85,7 +86,10 @@ fn collect_literal_exports(
             );
         }
 
-        if il.meta.lang != Lang::Java {
+        if !semantics(il.meta.lang)
+            .modules()
+            .java_class_literal_exports()
+        {
             continue;
         }
         for unit in &il.units {
@@ -246,7 +250,7 @@ fn imported_literal_export_safe(il: &Il, interner: &Interner, node: NodeId) -> b
             let Payload::Name(tag) = il.node(node).payload else {
                 return false;
             };
-            if !imported_literal_seq_tag_safe(interner.resolve(tag)) {
+            if !nose_semantics::imported_literal_seq_tag_safe(interner.resolve(tag)) {
                 return false;
             }
             il.children(node)
@@ -280,31 +284,14 @@ fn literal_export_value_safe(il: &Il, interner: &Interner, node: NodeId) -> bool
     }
 }
 
-fn imported_literal_seq_tag_safe(tag: &str) -> bool {
-    matches!(
-        tag,
-        "dictionary" | "object" | "array" | "array_expression" | "tuple_expression"
-    )
-}
-
 fn imported_map_factory_call_safe(il: &Il, interner: &Interner, call: NodeId) -> bool {
-    match il.meta.lang {
-        Lang::JavaScript | Lang::TypeScript => js_map_constructor_call_safe(il, interner, call),
-        Lang::Java => java_map_factory_call_safe(il, interner, call),
-        Lang::Rust => rust_std_map_factory_call_safe(il, interner, call),
-        _ => false,
+    match semantics(il.meta.lang).stdlib().imported_map_factory() {
+        Some(ImportedMapFactoryContract::JavaMap) => java_map_factory_call_safe(il, interner, call),
+        Some(ImportedMapFactoryContract::RustStdMap) => {
+            rust_std_map_factory_call_safe(il, interner, call)
+        }
+        None => false,
     }
-}
-
-fn js_map_constructor_call_safe(il: &Il, interner: &Interner, call: NodeId) -> bool {
-    let kids = il.children(call);
-    if kids.len() != 2 || !var_named(il, interner, kids[0], "Map") {
-        return false;
-    }
-    if file_defines_symbol(il, interner, "Map") {
-        return false;
-    }
-    literal_export_value_safe(il, interner, kids[1])
 }
 
 fn java_map_factory_call_safe(il: &Il, interner: &Interner, call: NodeId) -> bool {
@@ -386,15 +373,6 @@ fn var_named(il: &Il, interner: &Interner, node: NodeId, expected: &str) -> bool
     matches!(il.node(node).payload, Payload::Name(name) if interner.resolve(name) == expected)
 }
 
-fn file_defines_symbol(il: &Il, interner: &Interner, expected: &str) -> bool {
-    il.units.iter().any(|unit| {
-        unit.name
-            .is_some_and(|name| interner.resolve(name) == expected)
-    }) || collect_top_level_statements(il).into_iter().any(|stmt| {
-        assignment_name(il, stmt).is_some_and(|name| interner.resolve(name) == expected)
-    })
-}
-
 fn java_file_defines_type_name(il: &Il, interner: &Interner, expected: &str) -> bool {
     il.units.iter().any(|unit| {
         unit.kind == UnitKind::Class
@@ -425,29 +403,12 @@ fn field_mutates_binding(il: &Il, interner: &Interner, field: NodeId, name: Symb
     let Payload::Name(method) = il.node(field).payload else {
         return false;
     };
-    if !mutating_method_name(interner.resolve(method)) {
+    if !nose_semantics::mutating_method_name(interner.resolve(method)) {
         return false;
     }
     il.children(field)
         .first()
         .is_some_and(|&receiver| node_refers_to_symbol(il, receiver, name))
-}
-
-fn mutating_method_name(method: &str) -> bool {
-    matches!(
-        method,
-        "clear"
-            | "delete"
-            | "insert"
-            | "pop"
-            | "popitem"
-            | "put"
-            | "putAll"
-            | "remove"
-            | "set"
-            | "setdefault"
-            | "update"
-    )
 }
 
 fn node_refers_to_symbol(il: &Il, node: NodeId, name: Symbol) -> bool {
@@ -466,26 +427,28 @@ fn node_contains_symbol(il: &Il, node: NodeId, name: Symbol) -> bool {
 }
 
 fn file_module_hashes(il: &Il) -> Vec<u64> {
-    match il.meta.lang {
-        Lang::Python => module_hashes_from_path(&il.meta.path, &["py"], ".", false, true),
-        Lang::JavaScript | Lang::TypeScript => module_hashes_from_path(
+    let Some(spec) = semantics(il.meta.lang).modules().path_spec() else {
+        return Vec::new();
+    };
+    let mut hashes = module_hashes_from_path(
+        &il.meta.path,
+        spec.extensions,
+        spec.separator,
+        spec.include_relative_dot,
+        spec.drop_init_file,
+    );
+    if spec.rust_crate_self_aliases {
+        for module in module_names_from_path(
             &il.meta.path,
-            &["js", "jsx", "mjs", "cjs", "ts", "tsx", "mts", "cts"],
-            "/",
-            true,
-            false,
-        ),
-        Lang::Java => module_hashes_from_path(&il.meta.path, &["java"], ".", false, false),
-        Lang::Rust => {
-            let mut hashes = module_hashes_from_path(&il.meta.path, &["rs"], "::", false, false);
-            for module in module_names_from_path(&il.meta.path, &["rs"], "::", false) {
-                hashes.push(stable_symbol_hash(&format!("crate::{module}")));
-                hashes.push(stable_symbol_hash(&format!("self::{module}")));
-            }
-            dedupe_hashes(hashes)
+            spec.extensions,
+            spec.separator,
+            spec.drop_init_file,
+        ) {
+            hashes.push(stable_symbol_hash(&format!("crate::{module}")));
+            hashes.push(stable_symbol_hash(&format!("self::{module}")));
         }
-        _ => Vec::new(),
     }
+    dedupe_hashes(hashes)
 }
 
 fn java_class_module_hashes(il: &Il, interner: &Interner, class_name: Symbol) -> Vec<u64> {

--- a/crates/nose-frontend/src/rust.rs
+++ b/crates/nose-frontend/src/rust.rs
@@ -10,7 +10,7 @@
 use crate::lower::Lowering;
 use nose_il::{
     Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload, Span,
-    UnitKind,
+    Symbol, UnitKind,
 };
 use tree_sitter::Node as TsNode;
 
@@ -42,7 +42,7 @@ fn lower_item(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
         "function_item" => Some(lower_func(lo, node, false)),
         "impl_item" | "trait_item" => Some(lower_type_block(lo, node, true)),
         "struct_item" | "enum_item" | "union_item" => Some(lower_type_block(lo, node, false)),
-        "mod_item" => node.child_by_field_name("body").map(|b| lower_items(lo, b)),
+        "mod_item" => Some(lower_mod_item(lo, node)),
         "const_item" | "static_item" => Some(lower_value_item(lo, node)),
         "use_declaration" | "extern_crate_declaration" => Some(
             lower_static_import(lo, node).unwrap_or_else(|| crate::lower::import_tokens(lo, node)),
@@ -88,7 +88,7 @@ fn lower_static_import(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
 /// also a unit) or field declarations, so similar types/impls cluster.
 fn lower_type_block(lo: &mut Lowering, node: TsNode, methods: bool) -> NodeId {
     let span = lo.span(node);
-    let name = node.child_by_field_name("name").map(|n| lo.sym(lo.text(n)));
+    let name = rust_item_name(lo, node);
     let body = node.child_by_field_name("body");
     let mut kids = Vec::new();
     if let Some(body) = body {
@@ -102,7 +102,8 @@ fn lower_type_block(lo: &mut Lowering, node: TsNode, methods: bool) -> NodeId {
             }
         }
     }
-    let block = lo.add(NodeKind::Block, Payload::None, span, &kids);
+    let payload = name.map(Payload::Name).unwrap_or(Payload::None);
+    let block = lo.add(NodeKind::Block, payload, span, &kids);
     // Only `impl`/`trait` blocks (which carry behavior) are detection units. Pure
     // data-type definitions (struct/enum/union) are NOT unit-ified: they have no
     // call/control/value signal, so any two same-arity types look "similar" and
@@ -111,6 +112,33 @@ fn lower_type_block(lo: &mut Lowering, node: TsNode, methods: bool) -> NodeId {
         lo.push_unit(block, UnitKind::Class, name);
     }
     block
+}
+
+fn lower_mod_item(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let payload = rust_item_name(lo, node)
+        .map(Payload::Name)
+        .unwrap_or(Payload::None);
+    let kids = node
+        .child_by_field_name("body")
+        .map(|body| {
+            Lowering::named_children(body)
+                .into_iter()
+                .filter_map(|child| lower_item(lo, child))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    lo.add(NodeKind::Module, payload, span, &kids)
+}
+
+fn rust_item_name(lo: &mut Lowering, node: TsNode) -> Option<Symbol> {
+    node.child_by_field_name("name")
+        .or_else(|| {
+            Lowering::named_children(node)
+                .into_iter()
+                .find(|child| matches!(child.kind(), "identifier" | "type_identifier"))
+        })
+        .map(|n| lo.sym(lo.text(n)))
 }
 
 /// A struct/enum field or enum variant → an `Assign(name, type-as-literal)` so the
@@ -196,7 +224,7 @@ fn push_pattern_params(lo: &mut Lowering, pat: TsNode, out: &mut Vec<NodeId>) {
 }
 
 /// Extract the binding identifier from a (simple) pattern.
-fn ident_of(lo: &Lowering, pat: TsNode) -> Option<nose_il::Symbol> {
+fn ident_of(lo: &Lowering, pat: TsNode) -> Option<Symbol> {
     match pat.kind() {
         "identifier" | "type_identifier" | "field_identifier" => Some(lo.sym(lo.text(pat))),
         // `mut x`, `ref x`, `&x`, `x: T` — descend to the inner identifier

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -134,6 +134,8 @@ pub enum ParamSemantic {
     Integer,
     Map,
     Number,
+    Option,
+    Set,
     String,
 }
 

--- a/crates/nose-normalize/src/desugar.rs
+++ b/crates/nose-normalize/src/desugar.rs
@@ -3,7 +3,7 @@
 //! - C-style loops rewritten to `while` (init hoisted before, update appended to
 //!   the body) so they converge with hand-written `while` loops;
 //! - cross-language builtins canonicalized (see [`crate::idioms`]);
-//! - `x.length` field reads folded to the `Len` builtin;
+//! - exact-safe `length` field reads folded to the `Len` builtin;
 //! - statement-position blocks flattened, empty blocks dropped;
 //! - (when `cfg_norm`) `if c { …; return } else { B }` flattened to
 //!   `if c { …; return } ; B`.
@@ -13,7 +13,7 @@
 
 use crate::idioms::{canon_call, CallCanon};
 use crate::NormalizeOptions;
-use nose_il::{Builtin, Il, IlBuilder, Interner, LoopKind, NodeId, NodeKind, Payload};
+use nose_il::{Il, IlBuilder, Interner, LoopKind, NodeId, NodeKind, ParamSemantic, Payload};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 pub(crate) fn run(old: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il {
@@ -230,18 +230,23 @@ impl Rebuilder<'_> {
         let n = *self.old.node(old_id);
         if let Payload::Name(s) = n.payload {
             let name = self.interner.resolve(s);
-            if name == "length" {
+            if let Some(builtin) =
+                nose_semantics::property_builtin_contract(self.old.meta.lang, name)
+            {
                 if let Some(&base) = self.old.children(old_id).first() {
+                    if !property_receiver_exact_safe(self.old, self.interner, base) {
+                        return self.generic(old_id);
+                    }
                     let new_base = self.go(base);
                     return self.b.add(
                         NodeKind::Call,
-                        Payload::Builtin(Builtin::Len),
+                        Payload::Builtin(builtin),
                         n.span,
                         &[new_base],
                     );
                 }
             }
-            if let Some(sync) = crate::idioms::async_to_sync(name) {
+            if let Some(sync) = crate::idioms::async_to_sync(self.old.meta.lang, name) {
                 let sym = self.interner.intern(sync);
                 let kids: Vec<NodeId> = self
                     .old
@@ -257,4 +262,68 @@ impl Rebuilder<'_> {
         }
         self.generic(old_id)
     }
+}
+
+fn property_receiver_exact_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    il.kind(node) == NodeKind::Seq
+        || matches!(
+            param_semantic_for_var(il, node),
+            Some(ParamSemantic::Array | ParamSemantic::Collection)
+        )
+        || property_receiver_exact_hof_node(il, interner, node)
+        || property_receiver_exact_hof_call(il, interner, node)
+}
+
+fn param_semantic_for_var(il: &Il, node: NodeId) -> Option<ParamSemantic> {
+    if il.kind(node) != NodeKind::Var {
+        return None;
+    }
+    let Payload::Cid(cid) = il.node(node).payload else {
+        return None;
+    };
+    let span = il.nodes.iter().find_map(|candidate| {
+        (candidate.kind == NodeKind::Param && candidate.payload == Payload::Cid(cid))
+            .then_some(candidate.span)
+    })?;
+    il.param_type_facts
+        .iter()
+        .find(|fact| fact.span == span)
+        .map(|fact| fact.semantic)
+}
+
+fn property_receiver_exact_hof_call(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    if il.kind(node) != NodeKind::Call {
+        return false;
+    }
+    let kids = il.children(node);
+    let Some(&callee) = kids.first() else {
+        return false;
+    };
+    if il.kind(callee) != NodeKind::Field {
+        return false;
+    }
+    let Payload::Name(method) = il.node(callee).payload else {
+        return false;
+    };
+    if kids.len() < 2 {
+        return false;
+    }
+    let Some(&receiver) = il.children(callee).first() else {
+        return false;
+    };
+    let method_text = interner.resolve(method);
+    nose_semantics::method_hof_contract(il.meta.lang, method_text).is_some()
+        && property_receiver_exact_safe(il, interner, receiver)
+}
+
+fn property_receiver_exact_hof_node(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    if il.kind(node) != NodeKind::HoF {
+        return false;
+    }
+    if !matches!(il.node(node).payload, Payload::HoF(_)) {
+        return false;
+    }
+    il.children(node)
+        .first()
+        .is_some_and(|&receiver| property_receiver_exact_safe(il, interner, receiver))
 }

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -7,7 +7,14 @@
 //! proof-obligation: normalize.value_graph.functor
 //! proof-obligation: normalize.value_graph.min_max
 
-use nose_il::{stable_symbol_hash, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
+use nose_il::{
+    stable_symbol_hash, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, ParamSemantic, Payload,
+};
+use nose_semantics::{
+    free_function_builtin_contract, iterator_identity_adapter_contract, method_call_contract,
+    method_hof_contract, BuiltinArgContract, MethodBuiltinArgs, MethodCallContract,
+    MethodReceiverContract, MethodSemanticContract,
+};
 
 /// The result of inspecting a `Call`: it canonicalizes to a builtin, to a
 /// higher-order op (`HoF`), or stays an ordinary call. The carried `NodeId`s are
@@ -55,30 +62,18 @@ pub(crate) fn canon_call(old: &Il, interner: &Interner, call_id: NodeId) -> Call
     match cn.kind {
         NodeKind::Var => {
             if let Payload::Name(s) = cn.payload {
-                match interner.resolve(s) {
-                    "len" if args.len() == 1 => builtin!(Builtin::Len, first),
-                    "print" => builtin!(Builtin::Print, all),
-                    // Go's builtin `append(xs, x...)`
-                    "append" => builtin!(Builtin::Append, all),
-                    "range" => builtin!(Builtin::Range, all),
-                    // `sum(xs)` / `sum(x for x in xs)` — additive reduction.
-                    "sum" if args.len() == 1 => builtin!(Builtin::Sum, first),
-                    // `functools.reduce(f, xs[, init])` — explicit fold.
-                    "reduce" if args.len() >= 2 => builtin!(Builtin::Reduce, all),
-                    // `min(iterable)` / `max(iterable)` — selection reduction.
-                    // `min(a, b)` / `max(a, b)` — scalar 2-way choice.
-                    "min" if args.len() == 1 || args.len() == 2 => builtin!(Builtin::Min, all),
-                    "max" if args.len() == 1 || args.len() == 2 => builtin!(Builtin::Max, all),
-                    "fmin" | "fminf" | "fminl" if args.len() == 2 => builtin!(Builtin::Min, all),
-                    "fmax" | "fmaxf" | "fmaxl" if args.len() == 2 => builtin!(Builtin::Max, all),
-                    "abs" | "fabs" if args.len() == 1 => builtin!(Builtin::Abs, first),
-                    "zip" if args.len() == 2 => builtin!(Builtin::Zip, all),
-                    "enumerate" if args.len() == 1 => builtin!(Builtin::Enumerate, first),
-                    // `any(gen)` / `all(gen)` — Python existential/universal reduction over
-                    // a generator (which lowers to a `Map`). One canonical arg (the Map).
-                    "any" if args.len() == 1 => builtin!(Builtin::Any, first),
-                    "all" if args.len() == 1 => builtin!(Builtin::All, first),
-                    _ => {}
+                if let Some(contract) =
+                    free_function_builtin_contract(old.meta.lang, interner.resolve(s), args.len())
+                {
+                    if contract.requires_unshadowed
+                        && file_defines_name(old, interner, interner.resolve(s))
+                    {
+                        return CallCanon::None;
+                    }
+                    match contract.args {
+                        BuiltinArgContract::First => builtin!(contract.builtin, first),
+                        BuiltinArgContract::All => builtin!(contract.builtin, all),
+                    }
                 }
             }
         }
@@ -86,335 +81,299 @@ pub(crate) fn canon_call(old: &Il, interner: &Interner, call_id: NodeId) -> Call
             if let Payload::Name(s) = cn.payload {
                 let fname = interner.resolve(s);
                 let base = old.children(callee).first().copied();
-                let base_name = base.and_then(|b| name_of(old, interner, b));
-                match fname {
-                    // xs.append(x) / xs.push(x)  →  Append[xs, args...]
-                    "append" | "push" => {
-                        let mut a = Vec::with_capacity(args.len() + 1);
-                        if let Some(b) = base {
-                            a.push(b);
-                        }
-                        a.extend_from_slice(args);
-                        return CallCanon::Builtin {
-                            op: Builtin::Append,
-                            arg_olds: a,
-                        };
-                    }
-                    "log" | "info" | "debug" if base_name == Some("console") => {
-                        return CallCanon::Builtin {
-                            op: Builtin::Print,
-                            arg_olds: args.to_vec(),
-                        }
-                    }
-                    "Println" | "Printf" | "Print" if base_name == Some("fmt") => {
-                        return CallCanon::Builtin {
-                            op: Builtin::Print,
-                            arg_olds: args.to_vec(),
-                        }
-                    }
-                    "Abs" if base_name == Some("math") && args.len() == 1 => {
-                        return CallCanon::Builtin {
-                            op: Builtin::Abs,
-                            arg_olds: vec![args[0]],
-                        }
-                    }
-                    "HasPrefix" | "HasSuffix"
-                        if base_name == Some("strings") && args.len() == 2 =>
-                    {
-                        return CallCanon::Builtin {
-                            op: if fname == "HasPrefix" {
-                                Builtin::StartsWith
-                            } else {
-                                Builtin::EndsWith
-                            },
-                            arg_olds: args.to_vec(),
-                        }
-                    }
-                    "Contains"
-                        if args.len() == 2
-                            && base.is_some_and(|b| {
-                                import_namespace_expr(old, interner, b, "slices")
-                            }) =>
-                    {
-                        return CallCanon::Builtin {
-                            op: Builtin::Contains,
-                            arg_olds: vec![args[1], args[0]],
-                        }
-                    }
-                    "len" | "length" | "size" if base.is_some() && args.is_empty() => {
-                        return CallCanon::Builtin {
-                            op: Builtin::Len,
-                            arg_olds: vec![base.unwrap()],
-                        }
-                    }
-                    "is_empty" | "isEmpty" | "empty?" if base.is_some() && args.is_empty() => {
-                        return CallCanon::Builtin {
-                            op: Builtin::IsEmpty,
-                            arg_olds: vec![base.unwrap()],
-                        }
-                    }
-                    "nil?" | "is_none" if base.is_some() && args.is_empty() => {
-                        return CallCanon::Builtin {
-                            op: Builtin::IsNull,
-                            arg_olds: vec![base.unwrap()],
-                        }
-                    }
-                    "is_some" if base.is_some() && args.is_empty() => {
-                        if let Some((map, key)) = map_get_call_parts(old, interner, base.unwrap()) {
-                            return CallCanon::Builtin {
-                                op: Builtin::Contains,
-                                arg_olds: vec![key, map],
-                            };
-                        }
-                        return CallCanon::Builtin {
-                            op: Builtin::IsNotNull,
-                            arg_olds: vec![base.unwrap()],
-                        };
-                    }
-                    "startsWith" | "startswith" | "starts_with" | "start_with?"
-                        if base.is_some() && args.len() == 1 =>
-                    {
-                        return CallCanon::Builtin {
-                            op: Builtin::StartsWith,
-                            arg_olds: vec![base.unwrap(), args[0]],
-                        }
-                    }
-                    "endsWith" | "endswith" | "ends_with" | "end_with?"
-                        if base.is_some() && args.len() == 1 =>
-                    {
-                        return CallCanon::Builtin {
-                            op: Builtin::EndsWith,
-                            arg_olds: vec![base.unwrap(), args[0]],
-                        }
-                    }
-                    "containsKey" | "contains_key" | "key?" | "has_key?" | "__contains__"
-                        if base.is_some() && args.len() == 1 =>
-                    {
-                        return CallCanon::Builtin {
-                            op: Builtin::Contains,
-                            arg_olds: vec![args[0], base.unwrap()],
-                        }
-                    }
-                    "includes" | "include?" | "contains" | "__contains__"
-                        if base.is_some()
-                            && args.len() == 1
-                            && (old.kind(base.unwrap()) == NodeKind::Seq
-                                || (fname == "contains"
-                                    && key_set_receiver(old, interner, base.unwrap())
-                                        .is_some())) =>
-                    {
-                        let collection = if fname == "contains" {
-                            key_set_receiver(old, interner, base.unwrap()).unwrap_or(base.unwrap())
-                        } else {
-                            base.unwrap()
-                        };
-                        return CallCanon::Builtin {
-                            op: Builtin::Contains,
-                            arg_olds: vec![args[0], collection],
-                        };
-                    }
-                    // Python `sep.join(xs)`: ordered string-builder fold. Keep this
-                    // restricted to a literal separator receiver; JavaScript/Ruby
-                    // `xs.join(sep)` have the collection as the receiver and are not this
-                    // surface shape.
-                    "join"
-                        if base.is_some()
-                            && args.len() == 1
-                            && matches!(
-                                old.node(base.unwrap()).payload,
-                                Payload::LitStr(_) | Payload::Lit(nose_il::LitClass::Str)
-                            ) =>
-                    {
-                        return CallCanon::Builtin {
-                            op: Builtin::Join,
-                            arg_olds: vec![base.unwrap(), args[0]],
-                        };
-                    }
-                    "get" | "fetch"
-                        if base.is_some()
-                            && args.len() == 2
-                            && map_like_literal(old, interner, base.unwrap()) =>
-                    {
-                        let fallback = if fname == "fetch" && old.kind(args[1]) == NodeKind::Lambda
-                        {
-                            let Some(fallback) = zero_arg_lambda_body_value(old, args[1]) else {
-                                return CallCanon::None;
-                            };
-                            fallback
-                        } else {
-                            args[1]
-                        };
-                        return CallCanon::Builtin {
-                            op: Builtin::GetOrDefault,
-                            arg_olds: vec![base.unwrap(), args[0], fallback],
-                        };
-                    }
-                    "getOrDefault" if base.is_some() && args.len() == 2 => {
-                        return CallCanon::Builtin {
-                            op: Builtin::GetOrDefault,
-                            arg_olds: vec![base.unwrap(), args[0], args[1]],
-                        }
-                    }
-                    "unwrap_or" if base.is_some() && args.len() == 1 => {
-                        if let Some((map, key)) = map_get_call_parts(old, interner, base.unwrap()) {
-                            return CallCanon::Builtin {
-                                op: Builtin::GetOrDefault,
-                                arg_olds: vec![map, key, args[0]],
-                            };
-                        }
-                        return CallCanon::Builtin {
-                            op: Builtin::ValueOrDefault,
-                            arg_olds: vec![base.unwrap(), args[0]],
-                        };
-                    }
-                    "unwrap_or_else" if base.is_some() && args.len() == 1 => {
-                        if let Some(fallback) = zero_arg_lambda_body(old, args[0]) {
-                            return CallCanon::Builtin {
-                                op: Builtin::ValueOrDefault,
-                                arg_olds: vec![base.unwrap(), fallback],
-                            };
-                        }
-                    }
-                    "map_or" if base.is_some() && args.len() == 2 => {
-                        if identity_lambda(old, args[1]) {
-                            return CallCanon::Builtin {
-                                op: Builtin::ValueOrDefault,
-                                arg_olds: vec![base.unwrap(), args[0]],
-                            };
-                        }
-                    }
-                    // `functools.reduce(f, xs[, init])` — here the *base* is the module
-                    // `functools`, not the collection, so it is an explicit fold over
-                    // `xs` (the same `Builtin::Reduce` as a bare `reduce(f, xs, init)`),
-                    // NOT a `xs.reduce(f)` method HoF. Without this it was read as a HoF
-                    // over `functools`, and a `functools.reduce` sum never converged with
-                    // its loop form.
-                    "reduce" if base_name == Some("functools") && args.len() >= 2 => {
-                        return CallCanon::Builtin {
-                            op: Builtin::Reduce,
-                            arg_olds: args.to_vec(),
-                        }
-                    }
-                    "Min" | "Max" if base_name == Some("math") && args.len() == 2 => {
-                        let op = if fname == "Min" {
-                            Builtin::Min
-                        } else {
-                            Builtin::Max
-                        };
-                        return CallCanon::Builtin {
-                            op,
-                            arg_olds: args.to_vec(),
-                        };
-                    }
-                    // Rust/iterator-style `a.iter().zip(b.iter())` is the same aligned
-                    // pair stream as Python `zip(a, b)`. Canonicalize it before outer
-                    // `.fold`/`.map` reasoning so tuple element bindings are shared.
-                    "zip" if base.is_some() && args.len() == 1 => {
-                        return CallCanon::Builtin {
-                            op: Builtin::Zip,
-                            arg_olds: vec![
-                                unwrap_iter(old, interner, base.unwrap()),
-                                unwrap_iter(old, interner, args[0]),
-                            ],
-                        }
-                    }
-                    // Folds across languages → one canonical `Reduce[fn, coll, init]`,
-                    // so a `.reduce`/`.inject`/`.fold` converges with an accumulator loop
-                    // (and with `functools.reduce`). The lambda is detected regardless of
-                    // arg order — JS `xs.reduce(fn, init)`, Ruby `xs.inject(init){fn}` /
-                    // `xs.reduce(init){fn}`, Rust `it.fold(init, fn)`. A Rust `.iter()` /
-                    // `.into_iter()` base is unwrapped to the underlying collection.
-                    "reduce" | "inject" | "fold" if base.is_some() && !args.is_empty() => {
-                        let (fn_old, init_old) = fold_fn_init(old, args);
-                        if let Some(fn_old) = fn_old {
-                            let coll = unwrap_iter(old, interner, base.unwrap());
-                            let mut a = vec![fn_old, coll];
-                            if let Some(init) = init_old {
-                                a.push(init);
-                            }
-                            return CallCanon::Builtin {
-                                op: Builtin::Reduce,
-                                arg_olds: a,
-                            };
-                        }
-                        // no lambda arg → not a recognizable fold; leave as a plain call.
-                    }
-                    // Existential/universal predicate reductions across languages → one
-                    // canonical `Any`/`All[coll, λ]`: JS `xs.some/every(p)`, Rust
-                    // `xs.iter().any/all(p)`, Java `stream.anyMatch/allMatch(p)`. The
-                    // iteration adapter base is unwrapped to the collection, so it
-                    // converges with Python `any(p(x) for x in xs)`.
-                    "some" | "any" | "any?" | "anyMatch" if base.is_some() && !args.is_empty() => {
-                        let coll = unwrap_iter(old, interner, base.unwrap());
-                        return CallCanon::Builtin {
-                            op: Builtin::Any,
-                            arg_olds: vec![coll, args[0]],
-                        };
-                    }
-                    "every" | "all" | "all?" | "allMatch" if base.is_some() && !args.is_empty() => {
-                        let coll = unwrap_iter(old, interner, base.unwrap());
-                        return CallCanon::Builtin {
-                            op: Builtin::All,
-                            arg_olds: vec![coll, args[0]],
-                        };
-                    }
-                    "map" | "collect" | "flatMap" | "flat_map" | "filter_map" | "filter"
-                    | "select"
-                        if base.is_some() && !args.is_empty() =>
-                    {
-                        let kind = match fname {
-                            "map" | "collect" => HoFKind::Map,
-                            "flatMap" | "flat_map" => HoFKind::FlatMap,
-                            "filter_map" => HoFKind::FilterMap,
-                            _ => HoFKind::Filter,
-                        };
-                        return CallCanon::HoF {
-                            kind,
-                            collection_old: unwrap_iter(old, interner, base.unwrap()),
-                            fn_old: args[0],
-                        };
-                    }
-                    "abs" if base.is_some() && args.is_empty() => {
-                        return CallCanon::Builtin {
-                            op: Builtin::Abs,
-                            arg_olds: vec![base.unwrap()],
-                        };
-                    }
-                    // Method-form iterator reductions (Rust `it.sum()/min()/max()/count()`,
-                    // taking no value args — the receiver IS the collection). Canonicalize to
-                    // the same builtin as the function form, unwrapping a `.iter()` base, so
-                    // `xs.iter().filter(p).sum()` converges with Python `sum(x for x in xs if p)`
-                    // and `.count()` with `len([… if p])` / `sum(1 for …)` (both via `Len`).
-                    "sum" | "min" | "max" | "count" if base.is_some() && args.is_empty() => {
-                        let op = match fname {
-                            "sum" => Builtin::Sum,
-                            "min" => Builtin::Min,
-                            "max" => Builtin::Max,
-                            _ => Builtin::Len, // count
-                        };
-                        let base_id = base.unwrap();
-                        if matches!(fname, "min" | "max") && old.kind(base_id) == NodeKind::Seq {
-                            let items = old.children(base_id);
-                            if items.len() == 2 {
-                                return CallCanon::Builtin {
-                                    op,
-                                    arg_olds: items.to_vec(),
-                                };
-                            }
-                        }
-                        let coll = unwrap_iter(old, interner, base_id);
-                        return CallCanon::Builtin {
-                            op,
-                            arg_olds: vec![coll],
-                        };
-                    }
-                    _ => {}
+                if let Some(contract) = method_call_contract(old.meta.lang, fname, args.len()) {
+                    let Some(base) = base else {
+                        return CallCanon::None;
+                    };
+                    let Some(proven) =
+                        prove_method_receiver(old, interner, contract.receiver, base, args)
+                    else {
+                        return CallCanon::None;
+                    };
+                    return apply_method_contract(old, interner, fname, contract, proven, args);
                 }
             }
         }
         _ => {}
     }
     CallCanon::None
+}
+
+#[derive(Clone, Copy)]
+enum ProvenReceiver {
+    Direct(NodeId),
+    MapGet { map: NodeId, key: NodeId },
+}
+
+fn prove_method_receiver(
+    old: &Il,
+    interner: &Interner,
+    contract: MethodReceiverContract,
+    base: NodeId,
+    args: &[NodeId],
+) -> Option<ProvenReceiver> {
+    match contract {
+        MethodReceiverContract::ExactCollection => {
+            exact_collection_receiver(old, interner, base).then_some(ProvenReceiver::Direct(base))
+        }
+        MethodReceiverContract::ExactProtocol => {
+            exact_protocol_receiver(old, interner, base).then_some(ProvenReceiver::Direct(base))
+        }
+        MethodReceiverContract::ExactProtocolPairArgument => {
+            (exact_protocol_receiver(old, interner, base)
+                && args
+                    .first()
+                    .is_some_and(|&arg| exact_protocol_receiver(old, interner, arg)))
+            .then_some(ProvenReceiver::Direct(base))
+        }
+        MethodReceiverContract::ExactOption => {
+            exact_option_receiver(old, interner, base).then_some(ProvenReceiver::Direct(base))
+        }
+        MethodReceiverContract::ExactString => {
+            exact_string_receiver(old, base).then_some(ProvenReceiver::Direct(base))
+        }
+        MethodReceiverContract::ExactInteger => {
+            exact_integer_receiver(old, base).then_some(ProvenReceiver::Direct(base))
+        }
+        MethodReceiverContract::ExactMap => {
+            exact_map_receiver(old, interner, base).then_some(ProvenReceiver::Direct(base))
+        }
+        MethodReceiverContract::ExactMapLiteral => {
+            map_like_literal(old, interner, base).then_some(ProvenReceiver::Direct(base))
+        }
+        MethodReceiverContract::ExactCollectionOrMap => {
+            (exact_collection_receiver(old, interner, base)
+                || exact_map_receiver(old, interner, base))
+            .then_some(ProvenReceiver::Direct(base))
+        }
+        MethodReceiverContract::ExactCollectionOrMapLiteral => {
+            (exact_collection_receiver(old, interner, base)
+                || map_like_literal(old, interner, base))
+            .then_some(ProvenReceiver::Direct(base))
+        }
+        MethodReceiverContract::ExactCollectionOrJavaKeySet => {
+            if exact_collection_receiver(old, interner, base) {
+                return Some(ProvenReceiver::Direct(base));
+            }
+            if old.meta.lang == nose_il::Lang::Java {
+                let map = key_set_receiver(old, interner, base)?;
+                return map_like_literal(old, interner, map).then_some(ProvenReceiver::Direct(map));
+            }
+            None
+        }
+        MethodReceiverContract::ExactSetOrMap => (exact_set_param(old, base)
+            || exact_map_param(old, base))
+        .then_some(ProvenReceiver::Direct(base)),
+        MethodReceiverContract::LiteralString => {
+            literal_string_receiver(old, base).then_some(ProvenReceiver::Direct(base))
+        }
+        MethodReceiverContract::UnshadowedGlobal(global) => (name_of(old, interner, base)
+            == Some(global)
+            && !file_defines_name(old, interner, global))
+        .then_some(ProvenReceiver::Direct(base)),
+        MethodReceiverContract::ImportedNamespace(module) => {
+            import_namespace_expr(old, interner, base, module)
+                .then_some(ProvenReceiver::Direct(base))
+        }
+        MethodReceiverContract::RustMapGetOrExactOption => {
+            if let Some((map, key)) = proven_map_get_call_parts(old, interner, base) {
+                Some(ProvenReceiver::MapGet { map, key })
+            } else {
+                exact_option_receiver(old, interner, base).then_some(ProvenReceiver::Direct(base))
+            }
+        }
+    }
+}
+
+fn apply_method_contract(
+    old: &Il,
+    interner: &Interner,
+    method: &str,
+    contract: MethodCallContract,
+    receiver: ProvenReceiver,
+    args: &[NodeId],
+) -> CallCanon {
+    let op = match contract.semantic {
+        MethodSemanticContract::Builtin(op) => op,
+        MethodSemanticContract::HoF(kind) => {
+            let ProvenReceiver::Direct(base) = receiver else {
+                return CallCanon::None;
+            };
+            return CallCanon::HoF {
+                kind,
+                collection_old: unwrap_iter(old, interner, base),
+                fn_old: args[0],
+            };
+        }
+    };
+
+    let direct = match receiver {
+        ProvenReceiver::Direct(node) => Some(node),
+        ProvenReceiver::MapGet { .. } => None,
+    };
+
+    match contract.args {
+        MethodBuiltinArgs::All => CallCanon::Builtin {
+            op,
+            arg_olds: args.to_vec(),
+        },
+        MethodBuiltinArgs::First => CallCanon::Builtin {
+            op,
+            arg_olds: vec![args[0]],
+        },
+        MethodBuiltinArgs::ReceiverOnly => {
+            if let ProvenReceiver::MapGet { map, key } = receiver {
+                if op == Builtin::IsNotNull {
+                    return CallCanon::Builtin {
+                        op: Builtin::Contains,
+                        arg_olds: vec![key, map],
+                    };
+                }
+                return CallCanon::None;
+            }
+            CallCanon::Builtin {
+                op,
+                arg_olds: vec![direct.unwrap()],
+            }
+        }
+        MethodBuiltinArgs::ReceiverThenAll => {
+            let Some(base) = direct else {
+                return CallCanon::None;
+            };
+            let mut a = Vec::with_capacity(args.len() + 1);
+            a.push(base);
+            a.extend_from_slice(args);
+            CallCanon::Builtin { op, arg_olds: a }
+        }
+        MethodBuiltinArgs::ReceiverAndFirst => {
+            let Some(base) = direct else {
+                return CallCanon::None;
+            };
+            CallCanon::Builtin {
+                op,
+                arg_olds: vec![base, args[0]],
+            }
+        }
+        MethodBuiltinArgs::FirstThenReceiver => {
+            let Some(base) = direct else {
+                return CallCanon::None;
+            };
+            CallCanon::Builtin {
+                op,
+                arg_olds: vec![args[0], base],
+            }
+        }
+        MethodBuiltinArgs::GoSliceContains => CallCanon::Builtin {
+            op,
+            arg_olds: vec![args[1], args[0]],
+        },
+        MethodBuiltinArgs::MapGetDefault => {
+            let Some(base) = direct else {
+                return CallCanon::None;
+            };
+            let fallback = if method == "fetch" && old.kind(args[1]) == NodeKind::Lambda {
+                let Some(fallback) = zero_arg_lambda_body_value(old, args[1]) else {
+                    return CallCanon::None;
+                };
+                fallback
+            } else {
+                args[1]
+            };
+            CallCanon::Builtin {
+                op,
+                arg_olds: vec![base, args[0], fallback],
+            }
+        }
+        MethodBuiltinArgs::RustMapGetOrOptionDefault => match receiver {
+            ProvenReceiver::MapGet { map, key } => CallCanon::Builtin {
+                op: Builtin::GetOrDefault,
+                arg_olds: vec![map, key, args[0]],
+            },
+            ProvenReceiver::Direct(base) => CallCanon::Builtin {
+                op,
+                arg_olds: vec![base, args[0]],
+            },
+        },
+        MethodBuiltinArgs::RustOptionDefaultLambda => {
+            let Some(base) = direct else {
+                return CallCanon::None;
+            };
+            if let Some(fallback) = zero_arg_lambda_body(old, args[0]) {
+                return CallCanon::Builtin {
+                    op,
+                    arg_olds: vec![base, fallback],
+                };
+            }
+            CallCanon::None
+        }
+        MethodBuiltinArgs::RustOptionMapOrIdentity => {
+            let Some(base) = direct else {
+                return CallCanon::None;
+            };
+            if identity_lambda(old, args[1]) {
+                return CallCanon::Builtin {
+                    op,
+                    arg_olds: vec![base, args[0]],
+                };
+            }
+            CallCanon::None
+        }
+        MethodBuiltinArgs::RustZip => {
+            let Some(base) = direct else {
+                return CallCanon::None;
+            };
+            CallCanon::Builtin {
+                op,
+                arg_olds: vec![
+                    unwrap_iter(old, interner, base),
+                    unwrap_iter(old, interner, args[0]),
+                ],
+            }
+        }
+        MethodBuiltinArgs::Fold => {
+            let Some(base) = direct else {
+                return CallCanon::None;
+            };
+            let (fn_old, init_old) = fold_fn_init(old, args);
+            let Some(fn_old) = fn_old else {
+                return CallCanon::None;
+            };
+            let coll = unwrap_iter(old, interner, base);
+            let mut a = vec![fn_old, coll];
+            if let Some(init) = init_old {
+                a.push(init);
+            }
+            CallCanon::Builtin { op, arg_olds: a }
+        }
+        MethodBuiltinArgs::BoolReduction => {
+            let Some(base) = direct else {
+                return CallCanon::None;
+            };
+            CallCanon::Builtin {
+                op,
+                arg_olds: vec![unwrap_iter(old, interner, base), args[0]],
+            }
+        }
+        MethodBuiltinArgs::Hof => CallCanon::None,
+        MethodBuiltinArgs::CollectionReduction => {
+            let Some(base) = direct else {
+                return CallCanon::None;
+            };
+            if matches!(op, Builtin::Min | Builtin::Max) && old.kind(base) == NodeKind::Seq {
+                let items = old.children(base);
+                if items.len() == 2 {
+                    return CallCanon::Builtin {
+                        op,
+                        arg_olds: items.to_vec(),
+                    };
+                }
+            }
+            CallCanon::Builtin {
+                op,
+                arg_olds: vec![unwrap_iter(old, interner, base)],
+            }
+        }
+    }
 }
 
 /// Classify a fold's args into `(fn, init)`: the lambda is the function (whatever its
@@ -432,12 +391,13 @@ fn fold_fn_init(old: &Il, args: &[NodeId]) -> (Option<NodeId>, Option<NodeId>) {
     (fn_old, init)
 }
 
-/// Peel a Rust iteration adapter — `xs.iter()` / `xs.into_iter()` / `xs.iter_mut()` —
-/// to the underlying collection, so a `xs.iter().fold(..)` iterates over `xs` (matching
-/// `for v in xs`). NOT `.keys()`/`.values()`, which change *what* is iterated.
+/// Peel a first-party Rust identity iterator adapter to the underlying collection, so
+/// `xs.iter().fold(..)` iterates over `xs` (matching `for v in xs`). NOT `.keys()`/`.values()`,
+/// which change *what* is iterated.
 fn unwrap_iter(old: &Il, interner: &Interner, node: NodeId) -> NodeId {
     if old.kind(node) == NodeKind::Call {
-        if let Some(&callee) = old.children(node).first() {
+        let call_kids = old.children(node);
+        if let Some(&callee) = call_kids.first() {
             if old.kind(callee) == NodeKind::Field {
                 if let Payload::Name(s) = old.node(callee).payload {
                     let method = interner.resolve(s);
@@ -452,9 +412,15 @@ fn unwrap_iter(old: &Il, interner: &Interner, node: NodeId) -> NodeId {
                             }
                         }
                     }
-                    if matches!(method, "iter" | "into_iter" | "iter_mut") {
+                    if iterator_identity_adapter_contract(
+                        old.meta.lang,
+                        method,
+                        call_kids.len() - 1,
+                    )
+                    .is_some()
+                    {
                         if let Some(&base) = old.children(callee).first() {
-                            return base;
+                            return unwrap_iter(old, interner, base);
                         }
                     }
                 }
@@ -464,35 +430,307 @@ fn unwrap_iter(old: &Il, interner: &Interner, node: NodeId) -> NodeId {
     node
 }
 
+fn exact_collection_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
+    exact_protocol_receiver(old, interner, node)
+}
+
+fn exact_protocol_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
+    if exact_collection_literal(old, interner, node) || exact_collection_param(old, node) {
+        return true;
+    }
+    if old.kind(node) != NodeKind::Call {
+        return false;
+    }
+    let kids = old.children(node);
+    let Some(&callee) = kids.first() else {
+        return false;
+    };
+    if old.kind(callee) != NodeKind::Field {
+        return false;
+    }
+    let Payload::Name(method) = old.node(callee).payload else {
+        return false;
+    };
+    let method = interner.resolve(method);
+    let Some(&receiver) = old.children(callee).first() else {
+        return false;
+    };
+    if matches!(method, "iter" | "into_iter" | "iter_mut") {
+        return exact_collection_receiver(old, interner, receiver);
+    }
+    if method == "stream" && name_of(old, interner, receiver) == Some("Arrays") {
+        return kids
+            .get(1)
+            .is_some_and(|&arg| exact_collection_receiver(old, interner, arg));
+    }
+    if method == "zip" && kids.len() == 2 {
+        return exact_protocol_receiver(old, interner, receiver)
+            && exact_protocol_receiver(old, interner, kids[1]);
+    }
+    if iterator_identity_adapter_contract(old.meta.lang, method, kids.len() - 1).is_some() {
+        return exact_protocol_receiver(old, interner, receiver);
+    }
+    if method_hof_contract(old.meta.lang, method).is_some() && kids.len() >= 2 {
+        return exact_protocol_receiver(old, interner, receiver);
+    }
+    false
+}
+
+fn exact_collection_param(old: &Il, node: NodeId) -> bool {
+    matches!(
+        param_semantic_for_var(old, node),
+        Some(ParamSemantic::Array | ParamSemantic::Collection | ParamSemantic::Set)
+    )
+}
+
+fn exact_set_param(old: &Il, node: NodeId) -> bool {
+    matches!(param_semantic_for_var(old, node), Some(ParamSemantic::Set))
+}
+
+fn exact_map_param(old: &Il, node: NodeId) -> bool {
+    matches!(param_semantic_for_var(old, node), Some(ParamSemantic::Map))
+}
+
+fn exact_map_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
+    exact_map_param(old, node) || map_like_literal(old, interner, node)
+}
+
+fn exact_option_param(old: &Il, node: NodeId) -> bool {
+    matches!(
+        param_semantic_for_var(old, node),
+        Some(ParamSemantic::Option)
+    )
+}
+
+fn param_semantic_for_var(old: &Il, node: NodeId) -> Option<ParamSemantic> {
+    if old.kind(node) != NodeKind::Var {
+        return None;
+    }
+    let param_span = match old.node(node).payload {
+        Payload::Cid(cid) => old.nodes.iter().find_map(|candidate| {
+            (candidate.kind == NodeKind::Param && candidate.payload == Payload::Cid(cid))
+                .then_some(candidate.span)
+        }),
+        Payload::Name(name) => {
+            let (scope, span) = nearest_named_param_scope(old, node, name)?;
+            if name_is_assigned_in_scope(old, name, scope) {
+                return None;
+            }
+            Some(span)
+        }
+        _ => None,
+    };
+    param_span.and_then(|span| {
+        old.param_type_facts
+            .iter()
+            .find(|fact| fact.span == span)
+            .map(|fact| fact.semantic)
+    })
+}
+
+fn nearest_named_param_scope(
+    old: &Il,
+    node: NodeId,
+    name: nose_il::Symbol,
+) -> Option<(NodeId, nose_il::Span)> {
+    let target = old.node(node).span;
+    let mut best: Option<(u32, NodeId, nose_il::Span)> = None;
+    for (idx, candidate) in old.nodes.iter().enumerate() {
+        if !matches!(candidate.kind, NodeKind::Func | NodeKind::Lambda) {
+            continue;
+        }
+        if !span_contains(candidate.span, target) {
+            continue;
+        }
+        let scope = NodeId(idx as u32);
+        let Some(param_span) = old.children(scope).iter().find_map(|&child| {
+            (old.kind(child) == NodeKind::Param && old.node(child).payload == Payload::Name(name))
+                .then_some(old.node(child).span)
+        }) else {
+            continue;
+        };
+        let width = candidate
+            .span
+            .end_byte
+            .saturating_sub(candidate.span.start_byte);
+        if best.is_none_or(|(best_width, _, _)| width < best_width) {
+            best = Some((width, scope, param_span));
+        }
+    }
+    best.map(|(_, scope, span)| (scope, span))
+}
+
+fn name_is_assigned_in_scope(old: &Il, name: nose_il::Symbol, scope: NodeId) -> bool {
+    old.nodes.iter().enumerate().any(|(idx, node)| {
+        if node.kind != NodeKind::Assign {
+            return false;
+        }
+        let id = NodeId(idx as u32);
+        if nearest_scope(old, id) != Some(scope) {
+            return false;
+        }
+        let Some(&lhs) = old.children(id).first() else {
+            return false;
+        };
+        old.kind(lhs) == NodeKind::Var && old.node(lhs).payload == Payload::Name(name)
+    })
+}
+
+fn nearest_scope(old: &Il, node: NodeId) -> Option<NodeId> {
+    let target = old.node(node).span;
+    let mut best: Option<(u32, NodeId)> = None;
+    for (idx, candidate) in old.nodes.iter().enumerate() {
+        if !matches!(candidate.kind, NodeKind::Func | NodeKind::Lambda) {
+            continue;
+        }
+        if !span_contains(candidate.span, target) {
+            continue;
+        }
+        let width = candidate
+            .span
+            .end_byte
+            .saturating_sub(candidate.span.start_byte);
+        if best.is_none_or(|(best_width, _)| width < best_width) {
+            best = Some((width, NodeId(idx as u32)));
+        }
+    }
+    best.map(|(_, scope)| scope)
+}
+
+fn span_contains(outer: nose_il::Span, inner: nose_il::Span) -> bool {
+    outer.file == inner.file
+        && outer.start_byte <= inner.start_byte
+        && outer.end_byte >= inner.end_byte
+}
+
+fn exact_collection_literal(old: &Il, interner: &Interner, node: NodeId) -> bool {
+    if old.kind(node) != NodeKind::Seq {
+        return false;
+    }
+    match old.node(node).payload {
+        Payload::None => true,
+        Payload::Name(name) => matches!(
+            interner.resolve(name),
+            "array" | "array_expression" | "list" | "tuple" | "tuple_expression"
+        ),
+        _ => false,
+    }
+}
+
+fn exact_option_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
+    if exact_option_param(old, node) {
+        return true;
+    }
+    if matches!(
+        old.node(node).payload,
+        Payload::Lit(nose_il::LitClass::Null)
+    ) {
+        return true;
+    }
+    if old.kind(node) != NodeKind::Call {
+        return false;
+    }
+    let kids = old.children(node);
+    if kids.len() != 2 || old.kind(kids[0]) != NodeKind::Var {
+        return false;
+    }
+    matches!(
+        old.node(kids[0]).payload,
+        Payload::Name(name) if rust_option_some_name(old, interner, interner.resolve(name))
+    )
+}
+
+fn exact_string_receiver(old: &Il, node: NodeId) -> bool {
+    matches!(
+        old.node(node).payload,
+        Payload::LitStr(_) | Payload::Lit(nose_il::LitClass::Str)
+    ) || matches!(
+        param_semantic_for_var(old, node),
+        Some(ParamSemantic::String)
+    )
+}
+
+fn literal_string_receiver(old: &Il, node: NodeId) -> bool {
+    exact_string_receiver(old, node)
+}
+
+fn exact_integer_receiver(old: &Il, node: NodeId) -> bool {
+    matches!(
+        old.node(node).payload,
+        Payload::LitInt(_) | Payload::Lit(nose_il::LitClass::Int)
+    ) || matches!(
+        param_semantic_for_var(old, node),
+        Some(ParamSemantic::Integer)
+    )
+}
+
+fn rust_option_some_name(old: &Il, interner: &Interner, text: &str) -> bool {
+    if old.meta.lang != nose_il::Lang::Rust {
+        return false;
+    }
+    match text {
+        "Some" => !file_defines_name(old, interner, "Some"),
+        "Option::Some" => !file_defines_name(old, interner, "Option"),
+        "std::option::Option::Some" => !file_defines_name(old, interner, "std"),
+        "core::option::Option::Some" => !file_defines_name(old, interner, "core"),
+        _ => false,
+    }
+}
+
+fn proven_map_get_call_parts(
+    old: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<(NodeId, NodeId)> {
+    let (map, key) = map_get_call_parts(old, interner, node)?;
+    source_map_expr(old, interner, map).then_some((map, key))
+}
+
+fn source_map_expr(old: &Il, interner: &Interner, node: NodeId) -> bool {
+    map_like_literal(old, interner, node) || rust_std_map_factory_call(old, interner, node)
+}
+
+fn rust_std_map_factory_call(old: &Il, interner: &Interner, node: NodeId) -> bool {
+    if old.kind(node) != NodeKind::Call {
+        return false;
+    }
+    let kids = old.children(node);
+    if kids.len() != 2 || old.kind(kids[0]) != NodeKind::Var || old.kind(kids[1]) != NodeKind::Seq {
+        return false;
+    }
+    let Payload::Name(callee) = old.node(kids[0]).payload else {
+        return false;
+    };
+    let callee = interner.resolve(callee);
+    nose_semantics::semantics(old.meta.lang)
+        .collections()
+        .free_name_map_factories()
+        .any(|factory| factory.names.iter().any(|name| *name == callee))
+}
+
 /// Canonical sync name for a known async counterpart, so behaviorally-equivalent
 /// sync/async twins (a frequent real Type-4 pattern, e.g. `__exit__`/`__aexit__`,
 /// `read`/`aread`) converge. Curated to high-confidence pairs only — generic
 /// `a`-prefixed names (`add`, `append`, `get`) are deliberately excluded.
-pub(crate) fn async_to_sync(name: &str) -> Option<&'static str> {
-    Some(match name {
-        // async dunder protocol methods
-        "__aenter__" => "__enter__",
-        "__aexit__" => "__exit__",
-        "__anext__" => "__next__",
-        "__aiter__" => "__iter__",
-        // async I/O / lifecycle method twins
-        "aread" => "read",
-        "areadline" => "readline",
-        "areadlines" => "readlines",
-        "awrite" => "write",
-        "aclose" => "close",
-        "asend" => "send",
-        "areceive" => "receive",
-        "aconnect" => "connect",
-        "adrain" => "drain",
-        "aflush" => "flush",
-        // async typing constructs
-        "AsyncIterable" => "Iterable",
-        "AsyncIterator" => "Iterator",
-        "AsyncGenerator" => "Generator",
-        "AsyncContextManager" => "ContextManager",
-        _ => return None,
-    })
+pub(crate) fn async_to_sync(lang: nose_il::Lang, name: &str) -> Option<&'static str> {
+    nose_semantics::async_to_sync_name(lang, name)
+}
+
+fn file_defines_name(old: &Il, interner: &Interner, name: &str) -> bool {
+    old.units
+        .iter()
+        .filter_map(|unit| unit.name)
+        .any(|symbol| interner.resolve(symbol) == name)
+        || old.nodes.iter().any(|node| match node.payload {
+            Payload::Cid(cid) => old
+                .cid_names
+                .get(cid as usize)
+                .is_some_and(|symbol| interner.resolve(*symbol) == name),
+            Payload::Name(symbol) if matches!(node.kind, NodeKind::Module | NodeKind::Block) => {
+                interner.resolve(symbol) == name
+            }
+            _ => false,
+        })
 }
 
 fn name_of<'a>(old: &Il, interner: &'a Interner, id: NodeId) -> Option<&'a str> {
@@ -660,5 +898,349 @@ fn identity_lambda(old: &Il, lambda: NodeId) -> bool {
         (Payload::Cid(a), Payload::Cid(b)) => a == b,
         (Payload::Name(a), Payload::Name(b)) => a == b,
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nose_il::{FileId, FileMeta, IlBuilder, Lang, ParamTypeFact, Span};
+
+    fn sp() -> Span {
+        Span::new(FileId(0), 1, 1, 1, 1)
+    }
+
+    fn free_call_il(lang: Lang, name: &str, shadow_name: bool) -> (Il, Interner, NodeId) {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let mut module_kids = Vec::new();
+        let mut cid_names = Vec::new();
+        if shadow_name {
+            let sym = interner.intern(name);
+            cid_names.push(sym);
+            module_kids.push(b.add(NodeKind::Param, Payload::Cid(0), sp(), &[]));
+        }
+        let callee = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern(name)),
+            sp(),
+            &[],
+        );
+        let arg = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("x")),
+            sp(),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(), &[callee, arg]);
+        module_kids.push(call);
+        let root = b.add(NodeKind::Module, Payload::None, sp(), &module_kids);
+        let il = b.finish(
+            root,
+            FileMeta {
+                path: "t".to_string(),
+                lang,
+            },
+            Vec::new(),
+            cid_names,
+        );
+        (il, interner, call)
+    }
+
+    fn method_call_il(lang: Lang, method: &str, literal_receiver: bool) -> (Il, Interner, NodeId) {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = if literal_receiver {
+            b.add(NodeKind::Seq, Payload::None, sp(), &[])
+        } else {
+            b.add(
+                NodeKind::Var,
+                Payload::Name(interner.intern("xs")),
+                sp(),
+                &[],
+            )
+        };
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern(method)),
+            sp(),
+            &[receiver],
+        );
+        let func = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("f")),
+            sp(),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(), &[field, func]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(), &[call]);
+        let il = b.finish(
+            root,
+            FileMeta {
+                path: "t".to_string(),
+                lang,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        (il, interner, call)
+    }
+
+    fn typed_method_call_il(
+        lang: Lang,
+        method: &str,
+        semantic: ParamSemantic,
+        duplicate_param_name: bool,
+    ) -> (Il, Interner, NodeId) {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let mut functions = Vec::new();
+        let param_span = sp();
+        let xs = interner.intern("xs");
+        let param = b.add(NodeKind::Param, Payload::Name(xs), param_span, &[]);
+        let receiver = b.add(NodeKind::Var, Payload::Name(xs), param_span, &[]);
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern(method)),
+            sp(),
+            &[receiver],
+        );
+        let func = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("f")),
+            sp(),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(), &[field, func]);
+        let body = b.add(NodeKind::Block, Payload::None, sp(), &[call]);
+        let function = b.add(NodeKind::Func, Payload::None, sp(), &[param, body]);
+        functions.push(function);
+        let duplicate_span = Span::new(FileId(0), 10, 11, 2, 2);
+        if duplicate_param_name {
+            let other_param = b.add(NodeKind::Param, Payload::Name(xs), duplicate_span, &[]);
+            let other_body = b.add(NodeKind::Block, Payload::None, duplicate_span, &[]);
+            let other_function = b.add(
+                NodeKind::Func,
+                Payload::None,
+                duplicate_span,
+                &[other_param, other_body],
+            );
+            functions.push(other_function);
+        }
+        let root = b.add(NodeKind::Module, Payload::None, sp(), &functions);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t".to_string(),
+                lang,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.param_type_facts.push(ParamTypeFact {
+            span: param_span,
+            semantic,
+        });
+        if duplicate_param_name {
+            il.param_type_facts.push(ParamTypeFact {
+                span: duplicate_span,
+                semantic,
+            });
+        }
+        (il, interner, call)
+    }
+
+    fn console_log_il(shadow_console: bool) -> (Il, Interner, NodeId) {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let mut module_kids = Vec::new();
+        let mut cid_names = Vec::new();
+        if shadow_console {
+            cid_names.push(interner.intern("console"));
+            module_kids.push(b.add(NodeKind::Param, Payload::Cid(0), sp(), &[]));
+        }
+        let receiver = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("console")),
+            sp(),
+            &[],
+        );
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("log")),
+            sp(),
+            &[receiver],
+        );
+        let arg = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("x")),
+            sp(),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(), &[field, arg]);
+        module_kids.push(call);
+        let root = b.add(NodeKind::Module, Payload::None, sp(), &module_kids);
+        let il = b.finish(
+            root,
+            FileMeta {
+                path: "t".to_string(),
+                lang: Lang::JavaScript,
+            },
+            Vec::new(),
+            cid_names,
+        );
+        (il, interner, call)
+    }
+
+    fn go_math_abs_il(with_import: bool) -> (Il, Interner, NodeId) {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let mut module_kids = Vec::new();
+        if with_import {
+            let lhs = b.add(
+                NodeKind::Var,
+                Payload::Name(interner.intern("math")),
+                sp(),
+                &[],
+            );
+            let module = b.add(
+                NodeKind::Lit,
+                Payload::LitStr(stable_symbol_hash("math")),
+                sp(),
+                &[],
+            );
+            let tag = interner.intern("import_namespace");
+            let rhs = b.add(NodeKind::Seq, Payload::Name(tag), sp(), &[module]);
+            module_kids.push(b.add(NodeKind::Assign, Payload::None, sp(), &[lhs, rhs]));
+        }
+        let receiver = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("math")),
+            sp(),
+            &[],
+        );
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("Abs")),
+            sp(),
+            &[receiver],
+        );
+        let arg = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("x")),
+            sp(),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(), &[field, arg]);
+        module_kids.push(call);
+        let root = b.add(NodeKind::Module, Payload::None, sp(), &module_kids);
+        let il = b.finish(
+            root,
+            FileMeta {
+                path: "t".to_string(),
+                lang: Lang::Go,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        (il, interner, call)
+    }
+
+    #[test]
+    fn free_name_builtin_requires_language_contract() {
+        let (il, interner, call) = free_call_il(Lang::JavaScript, "len", false);
+        assert!(matches!(canon_call(&il, &interner, call), CallCanon::None));
+    }
+
+    #[test]
+    fn free_name_builtin_requires_no_shadowing() {
+        let (il, interner, call) = free_call_il(Lang::Python, "len", true);
+        assert!(matches!(canon_call(&il, &interner, call), CallCanon::None));
+    }
+
+    #[test]
+    fn python_unshadowed_builtin_is_admitted() {
+        let (il, interner, call) = free_call_il(Lang::Python, "len", false);
+        assert!(matches!(
+            canon_call(&il, &interner, call),
+            CallCanon::Builtin {
+                op: Builtin::Len,
+                arg_olds
+            } if arg_olds.len() == 1
+        ));
+    }
+
+    #[test]
+    fn method_hof_requires_exact_receiver() {
+        let (il, interner, call) = method_call_il(Lang::JavaScript, "map", false);
+        assert!(matches!(canon_call(&il, &interner, call), CallCanon::None));
+    }
+
+    #[test]
+    fn method_hof_allows_literal_sequence_receiver() {
+        let (il, interner, call) = method_call_il(Lang::JavaScript, "map", true);
+        assert!(matches!(
+            canon_call(&il, &interner, call),
+            CallCanon::HoF {
+                kind: HoFKind::Map,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn method_bool_reduction_allows_typed_collection_receiver() {
+        let (il, interner, call) =
+            typed_method_call_il(Lang::TypeScript, "some", ParamSemantic::Collection, false);
+        assert!(matches!(
+            canon_call(&il, &interner, call),
+            CallCanon::Builtin {
+                op: Builtin::Any,
+                arg_olds
+            } if arg_olds.len() == 2
+        ));
+    }
+
+    #[test]
+    fn method_bool_reduction_uses_lexical_param_scope() {
+        let (il, interner, call) =
+            typed_method_call_il(Lang::TypeScript, "some", ParamSemantic::Collection, true);
+        assert!(matches!(
+            canon_call(&il, &interner, call),
+            CallCanon::Builtin {
+                op: Builtin::Any,
+                arg_olds
+            } if arg_olds.len() == 2
+        ));
+    }
+
+    #[test]
+    fn js_console_print_requires_no_shadowing() {
+        let (il, interner, call) = console_log_il(true);
+        assert!(matches!(canon_call(&il, &interner, call), CallCanon::None));
+
+        let (il, interner, call) = console_log_il(false);
+        assert!(matches!(
+            canon_call(&il, &interner, call),
+            CallCanon::Builtin {
+                op: Builtin::Print,
+                arg_olds
+            } if arg_olds.len() == 1
+        ));
+    }
+
+    #[test]
+    fn go_stdlib_method_requires_import_namespace_proof() {
+        let (il, interner, call) = go_math_abs_il(false);
+        assert!(matches!(canon_call(&il, &interner, call), CallCanon::None));
+
+        let (il, interner, call) = go_math_abs_il(true);
+        assert!(matches!(
+            canon_call(&il, &interner, call),
+            CallCanon::Builtin {
+                op: Builtin::Abs,
+                arg_olds
+            } if arg_olds.len() == 1
+        ));
     }
 }

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -18,7 +18,11 @@
 //! proof-obligation: normalize.value_graph.field_writes
 //! proof-obligation: normalize.value_graph.free_monoid
 
-use nose_il::{Builtin, HoFKind, Il, LoopKind, NodeId, NodeKind, Op, Payload, Symbol};
+use nose_il::{Builtin, Il, LoopKind, NodeId, NodeKind, Op, Payload, Symbol};
+use nose_semantics::{
+    builtin_demand, eager_builtin_contract, hof_contract, BuiltinDemand, EagerBuiltinContract,
+    HofContract,
+};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 /// A runtime value. `List` is nested so `zip`/`enumerate` can yield pairs.
@@ -569,21 +573,14 @@ impl<'a> Interp<'a> {
         };
         let kids = self.il.children(node).to_vec();
         let mut args = Vec::new();
-        // `reduce(f, xs, init)` carries a lambda; evaluate it specially.
-        if matches!(b, Builtin::Reduce) {
-            return self.eval_reduce_call(&kids, env);
-        }
-        // `any`/`all` short-circuit over a (possibly predicate-mapped) collection. The
-        // method form `xs.some(λ)` carries a lambda; the generator form `any(p for x in xs)`
-        // is a pre-mapped list of predicate values.
-        if matches!(b, Builtin::Any | Builtin::All) {
-            return self.eval_any_all_call(matches!(b, Builtin::All), &kids, env);
-        }
-        if matches!(b, Builtin::Append) {
-            return self.eval_append(&kids, env);
-        }
-        if matches!(b, Builtin::ValueOrDefault) {
-            return self.eval_value_or_default_call(&kids, env);
+        match builtin_demand(b) {
+            BuiltinDemand::Reduce => return self.eval_reduce_call(&kids, env),
+            BuiltinDemand::AnyAll { all } => return self.eval_any_all_call(all, &kids, env),
+            BuiltinDemand::Append => return self.eval_append(&kids, env),
+            BuiltinDemand::ValueOrDefault => {
+                return self.eval_value_or_default_call(&kids, env);
+            }
+            BuiltinDemand::Eager => {}
         }
         for &k in &kids {
             let arg = self.eval(k, env)?;
@@ -592,8 +589,8 @@ impl<'a> Interp<'a> {
             }
             args.push(arg);
         }
-        match b {
-            Builtin::Len => match args.first() {
+        match eager_builtin_contract(b).ok_or(Unsupported)? {
+            EagerBuiltinContract::Len => match args.first() {
                 Some(Value::List(xs)) => Ok(Value::Int(xs.len() as i64)),
                 // A string is the free monoid over opaque piece hashes; its character
                 // length is unknown (piece count ≠ char count), so `len` stays `Err` —
@@ -601,40 +598,40 @@ impl<'a> Interp<'a> {
                 // `Int(1)` falsely equated `len(any_string)` with the literal `1`.
                 _ => Ok(Value::Err),
             },
-            Builtin::IsEmpty => match args.first() {
+            EagerBuiltinContract::IsEmpty => match args.first() {
                 Some(Value::List(xs)) => Ok(Value::Bool(xs.is_empty())),
                 _ => Ok(Value::Err),
             },
-            Builtin::IsNull => match args.first() {
+            EagerBuiltinContract::IsNull => match args.first() {
                 Some(value) => Ok(Value::Bool(matches!(value, Value::Null))),
                 _ => Ok(Value::Err),
             },
-            Builtin::IsNotNull => match args.first() {
+            EagerBuiltinContract::IsNotNull => match args.first() {
                 Some(value) => Ok(Value::Bool(!matches!(value, Value::Null))),
                 _ => Ok(Value::Err),
             },
-            Builtin::StartsWith => Ok(string_affix(args.first(), args.get(1), true)),
-            Builtin::EndsWith => Ok(string_affix(args.first(), args.get(1), false)),
-            Builtin::Contains => match (args.first(), args.get(1)) {
+            EagerBuiltinContract::StartsWith => Ok(string_affix(args.first(), args.get(1), true)),
+            EagerBuiltinContract::EndsWith => Ok(string_affix(args.first(), args.get(1), false)),
+            EagerBuiltinContract::Contains => match (args.first(), args.get(1)) {
                 (Some(element), Some(Value::List(items))) => Ok(Value::Bool(
                     items.iter().any(|candidate| candidate == element),
                 )),
                 _ => Ok(Value::Err),
             },
-            Builtin::Join => Ok(join_strings(args.first(), args.get(1))),
-            Builtin::Abs => match args.first() {
+            EagerBuiltinContract::Join => Ok(join_strings(args.first(), args.get(1))),
+            EagerBuiltinContract::Abs => match args.first() {
                 Some(Value::Int(v)) => Ok(Value::Int(v.abs())),
                 _ => Ok(Value::Err),
             },
-            Builtin::UnsignedCast32 => match args.first() {
+            EagerBuiltinContract::UnsignedCast32 => match args.first() {
                 Some(Value::Int(v)) => Ok(Value::Int(v.rem_euclid(1_i64 << 32))),
                 _ => Ok(Value::Err),
             },
-            Builtin::Sum => Ok(fold_ints(args.first(), 0, |a, x| a + x)),
-            Builtin::Min => Ok(fold_opt(args.first(), |a, x| a.min(x))),
-            Builtin::Max => Ok(fold_opt(args.first(), |a, x| a.max(x))),
-            Builtin::Range => range_values(&args),
-            Builtin::Zip => match (args.first(), args.get(1)) {
+            EagerBuiltinContract::Sum => Ok(fold_ints(args.first(), 0, |a, x| a + x)),
+            EagerBuiltinContract::Min => Ok(fold_opt(args.first(), |a, x| a.min(x))),
+            EagerBuiltinContract::Max => Ok(fold_opt(args.first(), |a, x| a.max(x))),
+            EagerBuiltinContract::Range => range_values(&args),
+            EagerBuiltinContract::Zip => match (args.first(), args.get(1)) {
                 (Some(Value::List(a)), Some(Value::List(b))) => Ok(Value::List(
                     a.iter()
                         .zip(b.iter())
@@ -643,7 +640,7 @@ impl<'a> Interp<'a> {
                 )),
                 _ => Ok(Value::Err),
             },
-            Builtin::Enumerate => match args.first() {
+            EagerBuiltinContract::Enumerate => match args.first() {
                 Some(Value::List(xs)) => Ok(Value::List(
                     xs.iter()
                         .enumerate()
@@ -654,14 +651,13 @@ impl<'a> Interp<'a> {
             },
             // `for (x in list)` iterates the indices 0..n-1 (keys). Objects aren't
             // modeled → Err (so such loops are non-interpretable, not falsely merged).
-            Builtin::Keys => match args.first() {
+            EagerBuiltinContract::Keys => match args.first() {
                 Some(Value::List(xs)) => {
                     Ok(Value::List((0..xs.len() as i64).map(Value::Int).collect()))
                 }
                 _ => Ok(Value::Err),
             },
-            Builtin::Append => unreachable!("handled by eval_append before arg eval"),
-            Builtin::Print => {
+            EagerBuiltinContract::Print => {
                 for a in &args {
                     self.effects.push(a.clone());
                 }
@@ -670,10 +666,8 @@ impl<'a> Interp<'a> {
             // Dicts are not modeled — a `DictEntry` makes its unit non-interpretable (Err),
             // so dict-building units are excluded from the oracle rather than risk a false
             // merge. Their convergence rests on the DistinctEntry-vs-tuple representation.
-            Builtin::DictEntry => Ok(Value::Err),
-            Builtin::GetOrDefault => Ok(Value::Err),
-            Builtin::ValueOrDefault => unreachable!("handled before eager arg eval"),
-            Builtin::Reduce | Builtin::Any | Builtin::All => unreachable!(),
+            EagerBuiltinContract::DictEntry => Ok(Value::Err),
+            EagerBuiltinContract::GetOrDefault => Ok(Value::Err),
         }
     }
 
@@ -914,8 +908,8 @@ impl<'a> Interp<'a> {
             _ => return Ok(Value::Err),
         };
         let f = kids[1];
-        match kind {
-            HoFKind::Map => {
+        match hof_contract(kind) {
+            HofContract::Map => {
                 let mut out = Vec::new();
                 for x in coll {
                     let value = self.apply(f, &[x], env)?;
@@ -926,7 +920,7 @@ impl<'a> Interp<'a> {
                 }
                 Ok(Value::List(out))
             }
-            HoFKind::FlatMap => {
+            HofContract::FlatMap => {
                 let mut out = Vec::new();
                 for x in coll {
                     match self.apply(f, &[x], env)? {
@@ -937,7 +931,7 @@ impl<'a> Interp<'a> {
                 }
                 Ok(Value::List(out))
             }
-            HoFKind::FilterMap => {
+            HofContract::FilterMap => {
                 let mut out = Vec::new();
                 for x in coll {
                     match self.apply(f, &[x], env)? {
@@ -948,7 +942,7 @@ impl<'a> Interp<'a> {
                 }
                 Ok(Value::List(out))
             }
-            HoFKind::Filter => {
+            HofContract::Filter => {
                 let mut out = Vec::new();
                 for x in coll {
                     let keep = self.apply(f, std::slice::from_ref(&x), env)?;
@@ -961,7 +955,7 @@ impl<'a> Interp<'a> {
                 }
                 Ok(Value::List(out))
             }
-            HoFKind::Reduce => {
+            HofContract::Reduce => {
                 let mut it = coll.into_iter();
                 let mut acc = match it.next() {
                     Some(v) => v,
@@ -1241,7 +1235,9 @@ fn un(op: Op, a: &Value) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_il::{FileId, FileMeta, IlBuilder, Interner, Lang, LitClass, Span, Unit, UnitKind};
+    use nose_il::{
+        FileId, FileMeta, HoFKind, IlBuilder, Interner, Lang, LitClass, Span, Unit, UnitKind,
+    };
 
     /// Build `fn() { return len(<str literal>) }` and run it.
     fn run_len_of_string() -> Value {

--- a/crates/nose-normalize/src/module_facts.rs
+++ b/crates/nose-normalize/src/module_facts.rs
@@ -1,4 +1,6 @@
-use nose_il::{Builtin, Il, Interner, Lang, NodeId, NodeKind, Payload, Symbol};
+use nose_il::{Builtin, Il, Interner, NodeId, NodeKind, Payload, Symbol};
+pub use nose_semantics::module_binding_mutating_method_name as mutating_method_name;
+use nose_semantics::semantics;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 pub fn top_level_statements_for(il: &Il) -> Vec<NodeId> {
@@ -152,36 +154,6 @@ pub(crate) fn shadowed_js_like_module_binding_nodes_for_symbol_in_scope(
         .collect()
 }
 
-pub fn mutating_method_name(method: &str) -> bool {
-    matches!(
-        method,
-        "add"
-            | "addAll"
-            | "append"
-            | "delete"
-            | "clear"
-            | "compute"
-            | "computeIfAbsent"
-            | "computeIfPresent"
-            | "merge"
-            | "pop"
-            | "push"
-            | "put"
-            | "putAll"
-            | "remove"
-            | "removeAll"
-            | "removeIf"
-            | "replace"
-            | "replaceAll"
-            | "retainAll"
-            | "shift"
-            | "sort"
-            | "splice"
-            | "unshift"
-            | "set"
-    )
-}
-
 fn mark_direct_symbol(
     il: &Il,
     node: NodeId,
@@ -221,7 +193,11 @@ fn shadowed_js_like_module_binding_nodes(
     local_scope: &[bool],
 ) -> FxHashMap<NodeId, FxHashSet<Symbol>> {
     let mut out = FxHashMap::default();
-    if candidates.is_empty() || !js_like_lang(il.meta.lang) {
+    if candidates.is_empty()
+        || !semantics(il.meta.lang)
+            .modules()
+            .js_like_shadowed_module_bindings()
+    {
         return out;
     }
     collect_shadowed_js_like_module_binding_nodes(
@@ -271,13 +247,6 @@ fn collect_shadowed_js_like_module_binding_nodes(
     }
 }
 
-fn js_like_lang(lang: Lang) -> bool {
-    matches!(
-        lang,
-        Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html
-    )
-}
-
 #[cfg(test)]
 fn node_symbol_in(il: &Il, node: NodeId) -> Option<Symbol> {
     let local_scope = local_scope_nodes(il);
@@ -318,7 +287,7 @@ fn cid_is_module_scoped(node: NodeId, local_scope: &[bool]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_il::{FileId, FileMeta, IlBuilder, Span, Unit, UnitKind};
+    use nose_il::{FileId, FileMeta, IlBuilder, Lang, Span, Unit, UnitKind};
 
     fn sp(line: u32) -> Span {
         Span::new(FileId(0), line, line, line, line)

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -48,55 +48,16 @@ use nose_il::{
     stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LoopKind, NodeId, NodeKind, Op,
     ParamSemantic, Payload, Span, Symbol, UnitKind,
 };
+use nose_semantics::{
+    builder_append_method_contract, builtin_tag, iterator_identity_adapter_contract,
+    method_call_contract, reduction_builtin_contract, scalar_integer_method_contract, semantics,
+    IteratorAdapterReceiverContract, MethodBuiltinArgs, MethodReceiverContract,
+    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
+};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
 
 const LARGE_AC_EXPR_OPERANDS: usize = 64;
-
-/// Free function/path names that construct a collection from a single sequence literal
-/// (`factory(<seq>)`), driving [`Builder::proven_free_name_collection_factory`]. Each row is
-/// `(language gate | None = any, the constructor names, shadow-guard)`: when the guard is true a
-/// same-named local definition (`file_defines_name`) shadows the builtin and the row does not
-/// match. This data table replaces the formerly-separate per-language `Set` / python-builtin /
-/// rust-`::from` recognizers, whose identical skeletons nose's own duplication gate flagged.
-type CollectionFactoryRow = (Option<Lang>, &'static [&'static str], bool);
-const FREE_NAME_COLLECTION_FACTORIES: &[CollectionFactoryRow] = &[
-    (None, &["Set"], false),
-    (
-        Some(Lang::Python),
-        &["list", "set", "frozenset", "tuple"],
-        true,
-    ),
-    (
-        Some(Lang::Rust),
-        &[
-            "std::collections::HashSet::from",
-            "std::collections::BTreeSet::from",
-            "std::collections::VecDeque::from",
-        ],
-        false,
-    ),
-];
-
-/// Free function/path names that construct a MAP from a single sequence literal of key/value
-/// entries (`factory([<entry>, …])`), driving [`Builder::proven_free_name_map_factory`]. Each row
-/// is `(language gate | None = any, the constructor names, the entry literal's `Seq` tag)`: JS
-/// `new Map([[k, v], …])` nests each entry as a `Seq(1)` array, Rust `HashMap::from([(k, v), …])`
-/// as a `Seq(2)` tuple — the only difference between two otherwise-identical skeletons. This data
-/// table replaces the separate `proven_map_constructor_entries` / `proven_rust_std_map_factory_*`
-/// recognizers. (Java `Map.of`/`ofEntries` and Go map literals have different shapes — kept apart.)
-type MapFactoryRow = (Option<Lang>, &'static [&'static str], u64);
-const FREE_NAME_MAP_FACTORIES: &[MapFactoryRow] = &[
-    (None, &["Map"], 1),
-    (
-        Some(Lang::Rust),
-        &[
-            "std::collections::HashMap::from",
-            "std::collections::BTreeMap::from",
-        ],
-        2,
-    ),
-];
 
 /// A heavy sub-DAG anchor: a shared sub-computation's structural `hash`, its `weight` (sub-DAG
 /// size), and the source line range (`line_start..=line_end`) of the IL subtree that produced it —
@@ -115,13 +76,6 @@ pub type Anchors = Vec<Anchor>;
 /// One value-graph build's fingerprints: `(value, literal, return)` hash multisets plus the
 /// heavy sub-DAG [`Anchors`].
 pub type FingerprintBundle = (Vec<u64>, Vec<u64>, Vec<u64>, Anchors);
-
-/// The [`ValOp::Call`] tag for a known builtin: its discriminant + 1. The `+1` reserves tag
-/// `0` for an opaque (non-builtin) callee — see [`ValOp::Call`]'s definition. Centralizes
-/// that encoding so the reserved-zero invariant lives in one place.
-fn builtin_tag(b: Builtin) -> u32 {
-    b as u32 + 1
-}
 
 /// Public entry: the value-graph fingerprint of the unit rooted at `root`
 /// (sorted multiset of `u64` value hashes). Equivalent computations → equal
@@ -807,7 +761,7 @@ impl<'a> Builder<'a> {
     fn is_collection_param_expr(&self, expr: NodeId) -> bool {
         matches!(
             self.param_semantic_of_expr(expr),
-            Some(ParamSemantic::Collection)
+            Some(ParamSemantic::Collection | ParamSemantic::Set)
         )
     }
 
@@ -815,10 +769,10 @@ impl<'a> Builder<'a> {
         matches!(self.param_semantic_of_expr(expr), Some(ParamSemantic::Map))
     }
 
-    fn is_number_param_expr(&self, expr: NodeId) -> bool {
+    fn is_integer_param_expr(&self, expr: NodeId) -> bool {
         matches!(
             self.param_semantic_of_expr(expr),
-            Some(ParamSemantic::Integer | ParamSemantic::Number)
+            Some(ParamSemantic::Integer)
         )
     }
 
@@ -841,17 +795,18 @@ impl<'a> Builder<'a> {
         };
         match self.param_semantic.get(&cid).copied() {
             Some(ParamSemantic::Array) => self.mk(ValOp::ArrayParam, vec![value]),
-            Some(ParamSemantic::Collection) => self.mk(ValOp::CollectionParam, vec![value]),
+            Some(ParamSemantic::Collection | ParamSemantic::Set) => {
+                self.mk(ValOp::CollectionParam, vec![value])
+            }
             Some(ParamSemantic::String) => self.mk(ValOp::StringParam, vec![value]),
             _ => value,
         }
     }
 
     fn is_js_like_lang(&self) -> bool {
-        matches!(
-            self.il.meta.lang,
-            Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html
-        )
+        semantics(self.il.meta.lang)
+            .modules()
+            .js_like_shadowed_module_bindings()
     }
 
     fn free_name_input_key(&self, name: &str) -> u32 {
@@ -887,26 +842,41 @@ impl<'a> Builder<'a> {
     }
 
     /// `factory(<seq>)` where `factory` is a free function/path name that constructs a collection
-    /// from a single sequence literal. Data-driven by [`FREE_NAME_COLLECTION_FACTORIES`]: each row
-    /// is `(language | any, the constructor names, whether a same-named local definition shadows
-    /// it)`. Replaces the per-language `Set` / python-builtin / rust-`::from` recognizers.
+    /// from a single sequence literal. Data-driven by the first-party collection contracts in
+    /// `nose-semantics`; each row carries the names and whether a same-named local definition
+    /// shadows the builtin.
     fn proven_free_name_collection_factory(&self, value: ValueId) -> Option<ValueId> {
-        let lang = self.il.meta.lang;
         self.collection_factory_seq(value, |s, callee| {
-            FREE_NAME_COLLECTION_FACTORIES
-                .iter()
-                .filter(|(want, _, _)| want.is_none_or(|l| l == lang))
-                .flat_map(|(_, names, guard)| names.iter().map(move |n| (*n, *guard)))
+            semantics(s.il.meta.lang)
+                .collections()
+                .free_name_collection_factories()
+                .flat_map(|factory| {
+                    factory
+                        .names
+                        .iter()
+                        .map(move |name| (*name, factory.shadow_guard))
+                })
                 .any(|(name, guard)| {
-                    s.is_free_name_value(callee, name) && (!guard || !s.file_defines_name(name))
+                    s.is_free_name_value(callee, name)
+                        && s.free_name_factory_shadow_safe(name, guard)
                 })
         })
+    }
+
+    fn free_name_factory_shadow_safe(&self, name: &str, shadow_guard: bool) -> bool {
+        if shadow_guard {
+            return !self.file_defines_name(name);
+        }
+        if self.il.meta.lang == Lang::Rust && name.starts_with("std::") {
+            return !self.file_defines_name("std");
+        }
+        true
     }
 
     /// Python `from collections import deque; deque(<seq>)` — the imported-stdlib collection
     /// factory (the non-free-name part of the former python recognizer).
     fn proven_python_deque_collection_value(&self, value: ValueId) -> Option<ValueId> {
-        if self.il.meta.lang != Lang::Python {
+        if !semantics(self.il.meta.lang).stdlib().python_deque_factory() {
             return None;
         }
         self.collection_factory_seq(value, |s, callee| {
@@ -915,7 +885,10 @@ impl<'a> Builder<'a> {
     }
 
     fn proven_java_collection_factory_value(&mut self, value: ValueId) -> Option<ValueId> {
-        if self.il.meta.lang != Lang::Java {
+        if !semantics(self.il.meta.lang)
+            .stdlib()
+            .java_collection_factories()
+        {
             return None;
         }
         let node = &self.nodes[value as usize];
@@ -960,7 +933,7 @@ impl<'a> Builder<'a> {
     }
 
     fn proven_ruby_set_factory_value(&self, value: ValueId) -> Option<ValueId> {
-        if self.il.meta.lang != Lang::Ruby
+        if !semantics(self.il.meta.lang).stdlib().ruby_set_factory()
             || !self.ruby_file_requires_module("set")
             || self.file_defines_name("Set")
         {
@@ -975,7 +948,10 @@ impl<'a> Builder<'a> {
     }
 
     fn proven_rust_vec_macro_collection_value(&mut self, value: ValueId) -> Option<ValueId> {
-        if self.il.meta.lang != Lang::Rust {
+        if !semantics(self.il.meta.lang)
+            .stdlib()
+            .rust_vec_macro_factory()
+        {
             return None;
         }
         let node = &self.nodes[value as usize];
@@ -1029,7 +1005,10 @@ impl<'a> Builder<'a> {
     }
 
     fn file_imports_namespace(&self, expr: NodeId, module: &str) -> bool {
-        if self.il.meta.lang != Lang::Go {
+        if !semantics(self.il.meta.lang)
+            .modules()
+            .go_import_namespace_facts()
+        {
             return false;
         }
         let Some(alias) = self.node_symbol(expr) else {
@@ -1060,7 +1039,10 @@ impl<'a> Builder<'a> {
     }
 
     fn java_file_defines_type_name(&self, name: &str) -> bool {
-        if self.il.meta.lang != Lang::Java {
+        if !semantics(self.il.meta.lang)
+            .modules()
+            .java_type_declarations_shadow_stdlib()
+        {
             return false;
         }
         self.il.units.iter().any(|unit| {
@@ -1078,11 +1060,14 @@ impl<'a> Builder<'a> {
         }) || self.il.units.iter().any(|unit| {
             unit.name
                 .is_some_and(|symbol| self.interner.resolve(symbol) == name)
+        }) || self.il.nodes.iter().any(|node| {
+            matches!(node.kind, NodeKind::Module | NodeKind::Block)
+                && matches!(node.payload, Payload::Name(symbol) if self.interner.resolve(symbol) == name)
         })
     }
 
     fn ruby_file_requires_module(&self, module: &str) -> bool {
-        if self.il.meta.lang != Lang::Ruby {
+        if !semantics(self.il.meta.lang).stdlib().ruby_set_factory() {
             return false;
         }
         let expected = stable_symbol_hash(module);
@@ -1117,7 +1102,9 @@ impl<'a> Builder<'a> {
             return Some(value);
         }
         if matches!(self.nodes[value as usize].op, ValOp::Seq(2))
-            || (self.il.meta.lang == Lang::Python
+            || (semantics(self.il.meta.lang)
+                .collections()
+                .empty_sequence_is_collection()
                 && matches!(self.nodes[value as usize].op, ValOp::Seq(0)))
         {
             let items = self.nodes[value as usize].args.clone();
@@ -1224,9 +1211,8 @@ impl<'a> Builder<'a> {
     }
 
     /// `factory([<entry>, …])` where `factory` is a free name that builds a map from a sequence of
-    /// 2-element key/value entries. Data-driven by [`FREE_NAME_MAP_FACTORIES`]; the matched row's
-    /// `Seq` tag says how each entry is shaped (JS array vs Rust tuple). Replaces the per-language
-    /// JS-`Map` and Rust-`::from` map recognizers (identical skeletons but for the entry tag).
+    /// 2-element key/value entries. Data-driven by first-party map contracts in `nose-semantics`;
+    /// the matched row's `Seq` tag says how each entry is shaped (JS array vs Rust tuple).
     fn proven_free_name_map_factory(&mut self, value: ValueId) -> Option<ValueId> {
         let node = &self.nodes[value as usize];
         if !matches!(node.op, ValOp::Call(0)) || node.args.len() != 2 {
@@ -1236,12 +1222,16 @@ impl<'a> Builder<'a> {
         if !matches!(self.nodes[seq as usize].op, ValOp::Seq(1)) {
             return None;
         }
-        let lang = self.il.meta.lang;
-        let entry_tag = FREE_NAME_MAP_FACTORIES
-            .iter()
-            .filter(|(want, _, _)| want.is_none_or(|l| l == lang))
-            .find(|(_, names, _)| names.iter().any(|n| self.is_free_name_value(callee, n)))
-            .map(|(_, _, tag)| *tag)?;
+        let entry_tag = semantics(self.il.meta.lang)
+            .collections()
+            .free_name_map_factories()
+            .find(|factory| {
+                factory.names.iter().any(|name| {
+                    self.is_free_name_value(callee, name)
+                        && self.free_name_factory_shadow_safe(name, false)
+                })
+            })
+            .map(|factory| factory.entry_seq_tag)?;
         self.map_factory_from_seq(seq, entry_tag)
     }
 
@@ -1265,7 +1255,7 @@ impl<'a> Builder<'a> {
     }
 
     fn proven_java_map_factory_entries(&mut self, value: ValueId) -> Option<ValueId> {
-        if self.il.meta.lang != Lang::Java {
+        if !semantics(self.il.meta.lang).stdlib().java_map_factories() {
             return None;
         }
         let node = &self.nodes[value as usize];
@@ -1333,7 +1323,10 @@ impl<'a> Builder<'a> {
         expr: NodeId,
         args: &[ValueId],
     ) -> Option<ValueId> {
-        if self.il.meta.lang != Lang::Go {
+        if !semantics(self.il.meta.lang)
+            .stdlib()
+            .go_literal_zero_map_lookup()
+        {
             return None;
         }
         let Payload::Name(name) = self.il.node(expr).payload else {
@@ -1448,9 +1441,14 @@ impl<'a> Builder<'a> {
         let args = node.args.clone();
         if args.len() == 1 {
             let callee = &self.nodes[args[0] as usize];
-            if !matches!(callee.op, ValOp::Field(name) if name == stable_symbol_hash("keys"))
-                || callee.args.len() != 1
-            {
+            let key_view = matches!(
+                callee.op,
+                ValOp::Field(name)
+                    if name == stable_symbol_hash("keys")
+                        || (self.il.meta.lang == Lang::Java
+                            && name == stable_symbol_hash("keySet"))
+            );
+            if !key_view || callee.args.len() != 1 {
                 return None;
             }
             let map = callee.args[0];
@@ -1568,8 +1566,7 @@ impl<'a> Builder<'a> {
         let map = if self.is_map_param_expr(receiver) {
             receiver_value
         } else {
-            self.proven_map_value(receiver_value)
-                .or_else(|| map_specific_method.then_some(receiver_value))?
+            self.proven_map_value(receiver_value)?
         };
         Some(self.mk(ValOp::Bin(Op::In as u32), vec![key, map]))
     }
@@ -1589,7 +1586,7 @@ impl<'a> Builder<'a> {
         let Payload::Name(name) = self.il.node(callee).payload else {
             return None;
         };
-        if self.interner.resolve(name) != "get" {
+        if !matches!(self.interner.resolve(name), "get" | "getOrDefault") {
             return None;
         }
         let receiver = self.il.children(callee).first().copied()?;
@@ -1607,19 +1604,11 @@ impl<'a> Builder<'a> {
         ))
     }
 
-    fn eval_proven_numeric_method_call(
+    fn eval_proven_integer_method_call(
         &mut self,
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
-        #[derive(Clone, Copy)]
-        enum NumericMethod {
-            Abs,
-            Min(NodeId),
-            Max(NodeId),
-            Clamp(NodeId, NodeId),
-        }
-
         let &callee = kids.first()?;
         if self.il.kind(callee) != NodeKind::Field {
             return None;
@@ -1628,43 +1617,93 @@ impl<'a> Builder<'a> {
             return None;
         };
         let method = self.interner.resolve(name);
-        let numeric_op = match (method, kids.len()) {
-            ("abs", 1) => Some(NumericMethod::Abs),
-            ("min", 2) => kids.get(1).copied().map(NumericMethod::Min),
-            ("max", 2) => kids.get(1).copied().map(NumericMethod::Max),
-            ("clamp", 3) => Some(NumericMethod::Clamp(kids[1], kids[2])),
-            _ => None,
-        }?;
+        let contract = scalar_integer_method_contract(
+            self.il.meta.lang,
+            method,
+            kids.len().saturating_sub(1),
+        )?;
+        if contract.receiver != MethodReceiverContract::ExactInteger {
+            return None;
+        }
         let receiver = self.il.children(callee).first().copied()?;
-        let receiver_value = self.eval_proven_numeric_expr(receiver, env)?;
-        match numeric_op {
-            NumericMethod::Abs => Some(self.mk(ValOp::Un(ABS_CODE), vec![receiver_value])),
-            NumericMethod::Min(rhs) => {
-                let rhs = self.eval(rhs, env);
-                Some(self.mk(ValOp::Bin(MIN_CODE), vec![receiver_value, rhs]))
+        let receiver_value = self.eval_proven_integer_expr(receiver, env)?;
+        match contract.semantic {
+            ScalarIntegerMethod::Abs => Some(self.mk(ValOp::Un(ABS_CODE), vec![receiver_value])),
+            ScalarIntegerMethod::Min => {
+                let rhs = self.eval(*kids.get(1)?, env);
+                self.eval_proven_integer_minmax_method_call(MIN_CODE, receiver_value, rhs)
             }
-            NumericMethod::Max(rhs) => {
-                let rhs = self.eval(rhs, env);
-                Some(self.mk(ValOp::Bin(MAX_CODE), vec![receiver_value, rhs]))
+            ScalarIntegerMethod::Max => {
+                let rhs = self.eval(*kids.get(1)?, env);
+                self.eval_proven_integer_minmax_method_call(MAX_CODE, receiver_value, rhs)
             }
-            NumericMethod::Clamp(lo, hi) => {
-                let lo = self.eval(lo, env);
-                let hi = self.eval(hi, env);
-                self.proof_backed_clamp_value(receiver_value, lo, hi)
+            ScalarIntegerMethod::Clamp => {
+                let lo = self.eval(*kids.get(1)?, env);
+                let hi = self.eval(*kids.get(2)?, env);
+                self.eval_proven_integer_clamp_method_call(receiver_value, lo, hi)
             }
         }
     }
 
-    fn eval_proven_numeric_expr(
+    fn eval_proven_integer_minmax_method_call(
+        &mut self,
+        op: u32,
+        receiver: ValueId,
+        rhs: ValueId,
+    ) -> Option<ValueId> {
+        if !self.is_integer_domain_value(rhs) {
+            return None;
+        }
+        Some(self.mk(ValOp::Bin(op), vec![receiver, rhs]))
+    }
+
+    fn eval_proven_integer_clamp_method_call(
+        &mut self,
+        receiver: ValueId,
+        lo: ValueId,
+        hi: ValueId,
+    ) -> Option<ValueId> {
+        if !self.is_integer_domain_value(lo) || !self.is_integer_domain_value(hi) {
+            return None;
+        }
+        self.proof_backed_clamp_value(receiver, lo, hi)
+    }
+
+    fn eval_proven_integer_expr(
         &mut self,
         expr: NodeId,
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
         let value = self.eval(expr, env);
         if self.il.kind(expr) == NodeKind::Var {
-            return self.is_number_param_expr(expr).then_some(value);
+            return self.is_integer_param_expr(expr).then_some(value);
         }
-        (self.vty(value) == Ty::Num).then_some(value)
+        self.is_integer_domain_value(value).then_some(value)
+    }
+
+    fn is_integer_domain_value(&self, value: ValueId) -> bool {
+        if self.int_const_value(value).is_some()
+            || self.is_param_value(value, ParamSemantic::Integer)
+        {
+            return true;
+        }
+        let node = &self.nodes[value as usize];
+        match node.op {
+            ValOp::Un(op) if op == ABS_CODE && node.args.len() == 1 => {
+                self.is_integer_domain_value(node.args[0])
+            }
+            ValOp::Bin(op) if (op == MIN_CODE || op == MAX_CODE) && node.args.len() == 2 => node
+                .args
+                .iter()
+                .copied()
+                .all(|arg| self.is_integer_domain_value(arg)),
+            ValOp::Clamp if node.args.len() == 3 => node
+                .args
+                .iter()
+                .copied()
+                .all(|arg| self.is_integer_domain_value(arg)),
+            _ => false,
+        }
     }
 
     /// Push an effect sink, tagged with the current path condition — so a *conditional*
@@ -2195,7 +2234,9 @@ impl<'a> Builder<'a> {
     }
 
     fn has_primitive_order_comparisons(&self) -> bool {
-        matches!(self.il.meta.lang, Lang::C | Lang::Go | Lang::Java)
+        semantics(self.il.meta.lang)
+            .operators()
+            .primitive_order_comparisons()
     }
 
     /// `(x < y) ∧ (x ≤ y) → x < y`. Guard-clause lowering accumulates path conditions
@@ -3011,7 +3052,9 @@ impl<'a> Builder<'a> {
         // Ruby `r << item` appends to a list (`<<` lowers to `Shl`, a BinOp not a Call). Scoped
         // to Ruby and — via `builder_candidates`' empty-Seq-seed gate — to a `[]`-seeded builder,
         // so integer `a << b` shift (`a` is not a list-builder) never enters the Map build.
-        if self.il.meta.lang == Lang::Ruby
+        if semantics(self.il.meta.lang)
+            .collections()
+            .ruby_shovel_list_append()
             && self.il.kind(e) == NodeKind::BinOp
             && matches!(self.il.node(e).payload, Payload::Op(Op::Shl))
         {
@@ -3039,7 +3082,11 @@ impl<'a> Builder<'a> {
         }
         if self.il.kind(first) == NodeKind::Field {
             if let Payload::Name(s) = self.il.node(first).payload {
-                if self.interner.resolve(s) == "add" {
+                if builder_append_method_contract(
+                    self.il.meta.lang,
+                    self.interner.resolve(s),
+                    kids.len() - 1,
+                ) {
                     if let Some(&recv) = self.il.children(first).first() {
                         if let (NodeKind::Var, Payload::Cid(c)) =
                             (self.il.kind(recv), self.il.node(recv).payload)
@@ -5042,7 +5089,9 @@ impl<'a> Builder<'a> {
     }
 
     fn has_java_primitive_integer_ops(&self) -> bool {
-        self.il.meta.lang == Lang::Java
+        semantics(self.il.meta.lang)
+            .stdlib()
+            .java_primitive_integer_ops()
     }
 
     fn parity_zero_condition(&self, cond: ValueId) -> Option<(ValueId, bool)> {
@@ -5113,7 +5162,10 @@ impl<'a> Builder<'a> {
     }
 
     fn c_u16_be_byte_pack_pattern(&mut self, left: ValueId, right: ValueId) -> Option<ValueId> {
-        if self.il.meta.lang != Lang::C {
+        if !semantics(self.il.meta.lang)
+            .operators()
+            .c_integer_byte_pack_contracts()
+        {
             return None;
         }
         for (shifted, low) in [(left, right), (right, left)] {
@@ -5139,7 +5191,11 @@ impl<'a> Builder<'a> {
     }
 
     fn c_u32_be_byte_pack_pattern(&mut self, operands: &[ValueId]) -> Option<ValueId> {
-        if self.il.meta.lang != Lang::C || operands.len() != 4 {
+        if !semantics(self.il.meta.lang)
+            .operators()
+            .c_integer_byte_pack_contracts()
+            || operands.len() != 4
+        {
             return None;
         }
         let mut base = None;
@@ -5250,6 +5306,13 @@ impl<'a> Builder<'a> {
         let ValOp::Const(key) = self.nodes[value as usize].op else {
             return None;
         };
+        // `LitInt(v)` is keyed as `0x1000_0000 + v as u32`, so retained
+        // negative integers sit below the positive range. Exclude only the
+        // small `LitClass` discriminants; strings/floats/bools live in their
+        // own higher ranges and must never count as integer-bound proofs.
+        if !(0x0000_0006..=0x1FFF_FFFF).contains(&key) {
+            return None;
+        }
         Some(key.wrapping_sub(0x1000_0000) as i32 as i64)
     }
 
@@ -5519,15 +5582,15 @@ impl<'a> Builder<'a> {
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
-        match b {
-            Builtin::Len => {
+        match reduction_builtin_contract(b)? {
+            ReductionBuiltinContract::Len => {
                 if kids.len() == 1 {
                     self.eval_len_builtin(kids[0], env)
                 } else {
                     None
                 }
             }
-            Builtin::Sum => {
+            ReductionBuiltinContract::Sum => {
                 let av = self.eval(*kids.first()?, env);
                 // `sum(map)` → the mapped stream's per-element contribution; a filtered
                 // map/flat-map carries a predicate and becomes `pred ? contrib : 0`,
@@ -5543,7 +5606,7 @@ impl<'a> Builder<'a> {
                 let init = self.int_const(0);
                 Some(self.mk(ValOp::Reduce(Op::Add as u32), vec![init, contrib]))
             }
-            Builtin::Reduce => {
+            ReductionBuiltinContract::ExplicitFold => {
                 if kids.len() < 2 {
                     return None;
                 }
@@ -5579,8 +5642,8 @@ impl<'a> Builder<'a> {
                 };
                 Some(self.mk(ValOp::Reduce(op), args))
             }
-            Builtin::Min | Builtin::Max => {
-                let (reduce_code, choice_code) = if matches!(b, Builtin::Max) {
+            ReductionBuiltinContract::Selection { max } => {
+                let (reduce_code, choice_code) = if max {
                     (REDUCE_MAX, MAX_CODE)
                 } else {
                     (REDUCE_MIN, MIN_CODE)
@@ -5604,12 +5667,8 @@ impl<'a> Builder<'a> {
                 };
                 Some(self.mk(ValOp::Reduce(reduce_code), vec![contrib]))
             }
-            Builtin::Any | Builtin::All => {
-                let code = if matches!(b, Builtin::All) {
-                    REDUCE_ALL
-                } else {
-                    REDUCE_ANY
-                };
+            ReductionBuiltinContract::Bool { all } => {
+                let code = if all { REDUCE_ALL } else { REDUCE_ANY };
                 // `xs.some(p)` / `xs.any(p)` — method form `[coll, λ]`: the per-element
                 // contribution is `p(Elem coll)`. `any(p(x) for x in xs)` — generator form
                 // `[Map]`: the mapped predicate value; a *filtered* generator carries its
@@ -5660,7 +5719,7 @@ impl<'a> Builder<'a> {
                 };
                 Some(self.mk(ValOp::Reduce(code), vec![contrib]))
             }
-            Builtin::Join => {
+            ReductionBuiltinContract::Join => {
                 if kids.len() != 2 {
                     return None;
                 }
@@ -5669,7 +5728,6 @@ impl<'a> Builder<'a> {
                 let elem = self.elem(coll);
                 Some(self.mk(ValOp::Reduce(ORDERED_STRING_JOIN), vec![sep, elem]))
             }
-            _ => None,
         }
     }
 
@@ -5679,8 +5737,12 @@ impl<'a> Builder<'a> {
         }
 
         let av = self.eval(arg, env);
+        self.eval_len_value(av)
+    }
+
+    fn eval_len_value(&mut self, value: ValueId) -> Option<ValueId> {
         let (op, args) = {
-            let n = &self.nodes[av as usize];
+            let n = &self.nodes[value as usize];
             (n.op.clone(), n.args.clone())
         };
         let ValOp::Hof(k) = op else { return None };
@@ -6261,17 +6323,28 @@ impl<'a> Builder<'a> {
         let Payload::Name(name) = self.il.node(callee).payload else {
             return None;
         };
-        if self.interner.resolve(name) != "count" {
+        let contract = method_call_contract(
+            self.il.meta.lang,
+            self.interner.resolve(name),
+            kids.len().saturating_sub(1),
+        )?;
+        if contract.semantic != MethodSemanticContract::Builtin(Builtin::Len)
+            || contract.receiver != MethodReceiverContract::ExactProtocol
+            || contract.args != MethodBuiltinArgs::CollectionReduction
+        {
             return None;
         }
         let base = *self.il.children(callee).first()?;
+        let base_value = self.eval(base, env);
+        if !matches!(
+            self.nodes[base_value as usize].op,
+            ValOp::Seq(_) | ValOp::ArrayParam | ValOp::CollectionParam | ValOp::Hof(_)
+        ) {
+            return None;
+        }
         match kids {
             // Rust-style `iter.filter(p).count()`.
             [_] => self.eval_filter_count(base, env),
-            // Ruby-style `xs.count { |x| p(x) }`.
-            [_, predicate] if self.il.kind(*predicate) == NodeKind::Lambda => {
-                self.eval_predicate_count(base, *predicate, env)
-            }
             _ => None,
         }
     }
@@ -6316,6 +6389,93 @@ impl<'a> Builder<'a> {
             .map(|&i| self.eval(i, env))
             .unwrap_or_else(|| self.int_const(1));
         Some(self.mk(ValOp::Reduce(Op::Mul as u32), vec![init, contrib]))
+    }
+
+    fn eval_iterator_identity_adapter(
+        &mut self,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if kids.len() != 1 || self.il.kind(kids[0]) != NodeKind::Field {
+            return None;
+        }
+        let Payload::Name(method) = self.il.node(kids[0]).payload else {
+            return None;
+        };
+        let contract = iterator_identity_adapter_contract(
+            self.il.meta.lang,
+            self.interner.resolve(method),
+            0,
+        )?;
+        let base = *self.il.children(kids[0]).first()?;
+        let value = self.eval(base, env);
+        let value = self.param_domain_value(value);
+        self.iterator_adapter_receiver_proven(contract.receiver, value)
+            .then_some(value)
+    }
+
+    fn iterator_adapter_receiver_proven(
+        &self,
+        receiver: IteratorAdapterReceiverContract,
+        value: ValueId,
+    ) -> bool {
+        match receiver {
+            IteratorAdapterReceiverContract::ExactIterableValue => matches!(
+                self.nodes[value as usize].op,
+                ValOp::Seq(_) | ValOp::ArrayParam | ValOp::CollectionParam | ValOp::Hof(_)
+            ),
+        }
+    }
+
+    fn eval_rust_map_get_unwrap_or_call(
+        &mut self,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if kids.len() != 2 || self.il.kind(kids[0]) != NodeKind::Field {
+            return None;
+        }
+        let Payload::Name(method) = self.il.node(kids[0]).payload else {
+            return None;
+        };
+        let contract = method_call_contract(self.il.meta.lang, self.interner.resolve(method), 1)?;
+        if contract.receiver != MethodReceiverContract::RustMapGetOrExactOption
+            || contract.args != MethodBuiltinArgs::RustMapGetOrOptionDefault
+        {
+            return None;
+        }
+        let receiver = *self.il.children(kids[0]).first()?;
+        let value = self.eval(receiver, env);
+        let (map, key) = self.proven_map_get_value(value)?;
+        let default = self.eval(kids[1], env);
+        Some(self.mk(
+            ValOp::Call(builtin_tag(Builtin::GetOrDefault)),
+            vec![map, key, default],
+        ))
+    }
+
+    fn eval_rust_map_get_is_some_call(
+        &mut self,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if kids.len() != 1 || self.il.kind(kids[0]) != NodeKind::Field {
+            return None;
+        }
+        let Payload::Name(method) = self.il.node(kids[0]).payload else {
+            return None;
+        };
+        let contract = method_call_contract(self.il.meta.lang, self.interner.resolve(method), 0)?;
+        if contract.receiver != MethodReceiverContract::RustMapGetOrExactOption
+            || contract.args != MethodBuiltinArgs::ReceiverOnly
+            || contract.semantic != MethodSemanticContract::Builtin(Builtin::IsNotNull)
+        {
+            return None;
+        }
+        let receiver = *self.il.children(kids[0]).first()?;
+        let value = self.eval(receiver, env);
+        let (map, key) = self.proven_map_get_value(value)?;
+        Some(self.mk(ValOp::Bin(Op::In as u32), vec![key, map]))
     }
 
     /// The element value(s) a map lambda binds to, plus any predicate CARRIED by the
@@ -6600,12 +6760,16 @@ impl<'a> Builder<'a> {
         else {
             return None;
         };
-        let text = self.interner.resolve(name);
-        (text == "Some" || text.ends_with("::Some")).then_some(kids[1])
+        self.rust_option_some_name(self.interner.resolve(name))
+            .then_some(kids[1])
     }
 
     fn rust_option_and_then_call_parts(&self, node: NodeId) -> Option<(NodeId, NodeId)> {
-        if self.il.meta.lang != Lang::Rust || self.il.kind(node) != NodeKind::Call {
+        if !semantics(self.il.meta.lang)
+            .stdlib()
+            .rust_filter_map_option_contract()
+            || self.il.kind(node) != NodeKind::Call
+        {
             return None;
         }
         let kids = self.il.children(node);
@@ -6628,8 +6792,32 @@ impl<'a> Builder<'a> {
         else {
             return false;
         };
-        let text = self.interner.resolve(name);
-        text == "Vec::new" || text.ends_with("::Vec::new")
+        self.rust_vec_new_name(self.interner.resolve(name))
+    }
+
+    fn rust_option_some_name(&self, text: &str) -> bool {
+        if self.il.meta.lang != Lang::Rust {
+            return false;
+        }
+        match text {
+            "Some" => !self.file_defines_name("Some"),
+            "Option::Some" => !self.file_defines_name("Option"),
+            "std::option::Option::Some" => !self.file_defines_name("std"),
+            "core::option::Option::Some" => !self.file_defines_name("core"),
+            _ => false,
+        }
+    }
+
+    fn rust_vec_new_name(&self, text: &str) -> bool {
+        if self.il.meta.lang != Lang::Rust {
+            return false;
+        }
+        match text {
+            "Vec::new" => !self.file_defines_name("Vec"),
+            "std::vec::Vec::new" => !self.file_defines_name("std"),
+            "alloc::vec::Vec::new" => !self.file_defines_name("alloc"),
+            _ => false,
+        }
     }
 
     fn is_null_literal(&self, node: NodeId) -> bool {
@@ -6892,6 +7080,21 @@ impl<'a> Builder<'a> {
                 };
                 if a.len() == 1 {
                     if let Payload::Name(s) = node.payload {
+                        if nose_semantics::property_builtin_contract(
+                            self.il.meta.lang,
+                            self.interner.resolve(s),
+                        ) == Some(Builtin::Len)
+                        {
+                            if let Some(len) = self.eval_len_value(a[0]) {
+                                return len;
+                            }
+                            if matches!(
+                                self.param_semantic_of_expr(kids[0]),
+                                Some(ParamSemantic::Array | ParamSemantic::Collection)
+                            ) {
+                                return self.mk(ValOp::Call(builtin_tag(Builtin::Len)), a);
+                            }
+                        }
                         let receiver = &self.nodes[a[0] as usize];
                         if matches!(receiver.op, ValOp::Seq(6)) && receiver.args.len() == 1 {
                             let module = receiver.args[0];
@@ -6923,8 +7126,9 @@ impl<'a> Builder<'a> {
             }
             NodeKind::Call => {
                 let kids = self.il.children(expr).to_vec();
-                // `p.then(λr. body)` is a Promise continuation ≡ `const r = await p; body` — a
-                // value-graph canon proved in `rules::promise_then` (the #1 real-world async gap).
+                // Promise continuation beta-reduction is exact only when a semantic pack can
+                // prove the receiver is Promise-like; otherwise arbitrary `.then` methods stay
+                // opaque.
                 if let Some(v) = rules::promise_then::apply(self, expr, env) {
                     return v;
                 }
@@ -6995,34 +7199,20 @@ impl<'a> Builder<'a> {
                 if let Some(r) = self.eval_product_call(&kids, env) {
                     return r;
                 }
-                if let Some(r) = self.eval_proven_numeric_method_call(&kids, env) {
+                if let Some(r) = self.eval_proven_integer_method_call(&kids, env) {
+                    return r;
+                }
+                if let Some(r) = self.eval_rust_map_get_unwrap_or_call(&kids, env) {
+                    return r;
+                }
+                if let Some(r) = self.eval_rust_map_get_is_some_call(&kids, env) {
                     return r;
                 }
                 if kids.len() == 1 && self.is_rust_vec_new_call(kids[0]) {
                     return self.mk(ValOp::Seq(1), vec![]);
                 }
-                // Iteration-identity adapters: `xs.iter()` / `.into_iter()` / `.collect()`
-                // / `.to_vec()` / `.copied()` / `.cloned()` don't change *what* is iterated
-                // or produced, so peel them — `xs.iter().map(f).collect()` (Rust) converges
-                // with `[f(x) for x in xs]` (Python). The callee is a `Field` whose base is
-                // the receiver; the call has no value arguments.
-                if kids.len() == 1 && self.il.kind(kids[0]) == NodeKind::Field {
-                    if let Payload::Name(s) = self.il.node(kids[0]).payload {
-                        if matches!(
-                            self.interner.resolve(s),
-                            "iter"
-                                | "into_iter"
-                                | "iter_mut"
-                                | "collect"
-                                | "to_vec"
-                                | "copied"
-                                | "cloned"
-                        ) {
-                            if let Some(&base) = self.il.children(kids[0]).first() {
-                                return self.eval(base, env);
-                            }
-                        }
-                    }
+                if let Some(v) = self.eval_iterator_identity_adapter(&kids, env) {
+                    return v;
                 }
                 // 2-way `min(x, y)` / `max(x, y)` → canonical Min/Max, converging with the
                 // ternary idiom `x if x<y else y`. (1-arg `min(iterable)` is a reduction,
@@ -7031,15 +7221,18 @@ impl<'a> Builder<'a> {
                     if let (NodeKind::Var, Payload::Name(s)) =
                         (self.il.kind(kids[0]), self.il.node(kids[0]).payload)
                     {
-                        let code = match self.interner.resolve(s) {
+                        let method = self.interner.resolve(s);
+                        let code = match method {
                             "min" => Some(MIN_CODE),
                             "max" => Some(MAX_CODE),
                             _ => None,
                         };
                         if let Some(c) = code {
-                            let x = self.eval(kids[1], env);
-                            let y = self.eval(kids[2], env);
-                            return self.mk(ValOp::Bin(c), vec![x, y]);
+                            if !self.file_defines_name(method) {
+                                let x = self.eval(kids[1], env);
+                                let y = self.eval(kids[2], env);
+                                return self.mk(ValOp::Bin(c), vec![x, y]);
+                            }
                         }
                     }
                 }
@@ -7208,7 +7401,7 @@ impl<'a> Builder<'a> {
                 self.mk(ValOp::Phi, a)
             }
             NodeKind::Lambda => {
-                let hash = self.subtree_hash(expr);
+                let hash = self.valued_subtree_hash(expr);
                 self.mk(ValOp::Lambda(hash), vec![])
             }
             // Any unlowered / unhandled construct — notably `Raw`, which wraps a
@@ -7671,7 +7864,7 @@ fn stable_float_const_key(value: &str) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_il::{FileId, FileMeta, IlBuilder, ParamTypeFact, Span, Unit, UnitKind};
+    use nose_il::{FileId, FileMeta, IlBuilder, Lang, ParamTypeFact, Span, Unit, UnitKind};
 
     fn sp(line: u32) -> Span {
         Span::new(FileId(0), line, line, line, line)

--- a/crates/nose-normalize/src/value_graph/rules/promise_then.rs
+++ b/crates/nose-normalize/src/value_graph/rules/promise_then.rs
@@ -1,17 +1,15 @@
 //! Promise `.then` continuation canonicalization.
 //!
-//! A settled Promise is modeled by its resolved value (the value graph strips `await` to its
-//! operand), so `p.then(λr. body)` is the continuation applied to that value — exactly what
-//! `let r = await p; body` computes. Beta-reduce the single-argument `.then` callback over the
-//! receiver, so a `.then`-chain converges with the equivalent await / sequential code. Chains
-//! reduce recursively (evaluating the receiver triggers the inner `.then`). `.then(fnRef)` (no
-//! lambda body), the two-argument `.then(onOk, onErr)`, and `.catch`/`.finally` (error/cleanup
-//! continuations whose parameter is the error, not the resolved value) are left opaque.
+//! The surface contract exists for JS-like `.then(lambda)` calls, but exact beta-reduction is
+//! admitted only when a pack-provided receiver proof establishes Promise/thenable semantics.
+//! Current IL does not carry that proof, so this rule is fail-closed until the async protocol
+//! extension point can validate the receiver.
 //!
 //! proof-obligation: normalize.value_graph.promise_then
 
 use super::super::{Builder, ValueId};
 use nose_il::{NodeId, NodeKind, Payload};
+use nose_semantics::{promise_then_contract, AsyncReceiverContract};
 use rustc_hash::FxHashMap;
 
 pub(in super::super) fn apply(
@@ -30,14 +28,27 @@ pub(in super::super) fn apply(
     let Payload::Name(s) = builder.il.node(callee).payload else {
         return None;
     };
-    if builder.interner.resolve(s) != "then" {
-        return None;
-    }
+    let contract = promise_then_contract(builder.il.meta.lang, builder.interner.resolve(s), 1)?;
     let cb = kids[1];
     if builder.il.kind(cb) != NodeKind::Lambda {
         return None;
     }
     let &recv = builder.il.children(callee).first()?;
+    if !promise_receiver_proven(builder, contract.receiver, recv) {
+        return None;
+    }
     let recv_v = builder.eval(recv, env);
     builder.eval_lambda_body(cb, &[recv_v], env)
+}
+
+fn promise_receiver_proven(
+    _builder: &Builder<'_>,
+    receiver: AsyncReceiverContract,
+    _recv: NodeId,
+) -> bool {
+    match receiver {
+        // The current IL does not retain a resolved Promise/thenable type or constructor fact.
+        // Until a language pack can provide that proof, exact `.then` beta-reduction is closed.
+        AsyncReceiverContract::ExactPromiseLike => false,
+    }
 }

--- a/crates/nose-semantics/Cargo.toml
+++ b/crates/nose-semantics/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "nose-normalize"
+name = "nose-semantics"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -7,9 +7,6 @@ rust-version.workspace = true
 
 [dependencies]
 nose-il = { workspace = true }
-nose-semantics = { workspace = true }
-rustc-hash = { workspace = true }
-serde = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -1,0 +1,1487 @@
+//! Semantic contracts for language and library facts used by exact matching.
+//!
+//! This crate is the first-party semantic-kernel facade. The initial migration is
+//! deliberately behavior-preserving: it names the semantic assumptions that were
+//! previously encoded as scattered `Lang` matches. Future pack loading should
+//! extend this contract surface rather than letting packs mint fingerprints or
+//! approve exact clone matches directly.
+
+use nose_il::{Builtin, HoFKind, Lang};
+
+/// Stable pack id for the first-party language/stdlib contracts compiled into nose.
+pub const FIRST_PARTY_PACK_ID: &str = "nose.first_party";
+
+/// Channel a semantic fact or contract is safe to influence.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ChannelEligibility {
+    SyntaxOnly,
+    NearOnly,
+    ExactEmpirical,
+    ExactProven,
+    FirstParty,
+}
+
+/// A first-party language profile. Keep this cheap and copyable; callers use it as a
+/// named semantic boundary around currently-supported language behavior.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LanguageProfile {
+    lang: Lang,
+}
+
+pub fn semantics(lang: Lang) -> LanguageProfile {
+    LanguageProfile { lang }
+}
+
+impl LanguageProfile {
+    pub fn lang(self) -> Lang {
+        self.lang
+    }
+
+    pub fn pack_id(self) -> &'static str {
+        FIRST_PARTY_PACK_ID
+    }
+
+    pub fn eligibility(self) -> ChannelEligibility {
+        ChannelEligibility::FirstParty
+    }
+
+    pub fn operators(self) -> OperatorSemantics {
+        OperatorSemantics { lang: self.lang }
+    }
+
+    pub fn effects(self) -> EffectSemantics {
+        EffectSemantics { lang: self.lang }
+    }
+
+    pub fn modules(self) -> ModuleSemantics {
+        ModuleSemantics { lang: self.lang }
+    }
+
+    pub fn stdlib(self) -> StdlibSemantics {
+        StdlibSemantics { lang: self.lang }
+    }
+
+    pub fn collections(self) -> CollectionSemantics {
+        CollectionSemantics { lang: self.lang }
+    }
+
+    pub fn exact_fragments(self) -> FragmentSemantics {
+        FragmentSemantics { lang: self.lang }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct OperatorSemantics {
+    lang: Lang,
+}
+
+impl OperatorSemantics {
+    /// Source comparison operators are primitive total-order comparisons rather
+    /// than receiver-overloadable/user-dispatched comparisons. This gates lattice
+    /// comparison absorption rules.
+    pub fn primitive_order_comparisons(self) -> bool {
+        matches!(self.lang, Lang::C | Lang::Go | Lang::Java)
+    }
+
+    /// C unsigned byte/word packing contracts are currently first-party only for
+    /// the C lowering, where explicit unsigned facts are recovered by the frontend.
+    pub fn c_integer_byte_pack_contracts(self) -> bool {
+        self.lang == Lang::C
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct EffectSemantics {
+    lang: Lang,
+}
+
+impl EffectSemantics {
+    /// `target[key] = value` is modeled as a non-overloadable observable index
+    /// write. Languages with user-dispatched index assignment must stay fail-closed
+    /// unless a future pack emits a stronger receiver proof.
+    pub fn non_overloadable_index_assignment(self) -> bool {
+        matches!(self.lang, Lang::C | Lang::Go | Lang::Java)
+    }
+
+    /// Exact field-write fragments currently require Java's fixed `this.field`
+    /// receiver proof.
+    pub fn java_this_field_place(self) -> bool {
+        self.lang == Lang::Java
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct FragmentSemantics {
+    lang: Lang,
+}
+
+impl FragmentSemantics {
+    pub fn non_overloadable_index_assignment(self) -> bool {
+        EffectSemantics { lang: self.lang }.non_overloadable_index_assignment()
+    }
+
+    pub fn java_this_field_place(self) -> bool {
+        EffectSemantics { lang: self.lang }.java_this_field_place()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ModuleSemantics {
+    lang: Lang,
+}
+
+impl ModuleSemantics {
+    /// JavaScript-like lexical scopes can shadow imported module bindings with a
+    /// local definition of the same name.
+    pub fn js_like_shadowed_module_bindings(self) -> bool {
+        matches!(
+            self.lang,
+            Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html
+        )
+    }
+
+    /// Sibling-module immutable literal export resolution is modeled for these
+    /// first-party module systems.
+    pub fn sibling_literal_exports(self) -> bool {
+        self.path_spec().is_some()
+    }
+
+    /// Java class bodies also contribute static literal bindings keyed by class
+    /// names and path-derived class module names.
+    pub fn java_class_literal_exports(self) -> bool {
+        self.lang == Lang::Java
+    }
+
+    /// Java class/type declarations can shadow standard type names such as
+    /// `Map`, `List`, `Set`, and `Arrays` in first-party stdlib contracts.
+    pub fn java_type_declarations_shadow_stdlib(self) -> bool {
+        self.lang == Lang::Java
+    }
+
+    /// Go static imports are lowered as namespace facts that can prove package
+    /// aliases for selected stdlib-style recognizers.
+    pub fn go_import_namespace_facts(self) -> bool {
+        self.lang == Lang::Go
+    }
+
+    pub fn path_spec(self) -> Option<ModulePathSpec> {
+        match self.lang {
+            Lang::Python => Some(ModulePathSpec {
+                extensions: &["py"],
+                separator: ".",
+                include_relative_dot: false,
+                drop_init_file: true,
+                rust_crate_self_aliases: false,
+            }),
+            Lang::JavaScript | Lang::TypeScript => Some(ModulePathSpec {
+                extensions: &["js", "jsx", "mjs", "cjs", "ts", "tsx", "mts", "cts"],
+                separator: "/",
+                include_relative_dot: true,
+                drop_init_file: false,
+                rust_crate_self_aliases: false,
+            }),
+            Lang::Java => Some(ModulePathSpec {
+                extensions: &["java"],
+                separator: ".",
+                include_relative_dot: false,
+                drop_init_file: false,
+                rust_crate_self_aliases: false,
+            }),
+            Lang::Rust => Some(ModulePathSpec {
+                extensions: &["rs"],
+                separator: "::",
+                include_relative_dot: false,
+                drop_init_file: false,
+                rust_crate_self_aliases: true,
+            }),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ModulePathSpec {
+    pub extensions: &'static [&'static str],
+    pub separator: &'static str,
+    pub include_relative_dot: bool,
+    pub drop_init_file: bool,
+    pub rust_crate_self_aliases: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct StdlibSemantics {
+    lang: Lang,
+}
+
+impl StdlibSemantics {
+    pub fn python_collection_factories(self) -> bool {
+        self.lang == Lang::Python
+    }
+
+    pub fn python_deque_factory(self) -> bool {
+        self.lang == Lang::Python
+    }
+
+    pub fn java_collection_factories(self) -> bool {
+        self.lang == Lang::Java
+    }
+
+    pub fn java_map_factories(self) -> bool {
+        self.lang == Lang::Java
+    }
+
+    pub fn java_primitive_integer_ops(self) -> bool {
+        self.lang == Lang::Java
+    }
+
+    pub fn ruby_set_factory(self) -> bool {
+        self.lang == Lang::Ruby
+    }
+
+    pub fn rust_vec_macro_factory(self) -> bool {
+        self.lang == Lang::Rust
+    }
+
+    pub fn rust_vec_new_factory(self) -> bool {
+        self.lang == Lang::Rust
+    }
+
+    pub fn rust_std_collection_factories(self) -> bool {
+        self.lang == Lang::Rust
+    }
+
+    pub fn rust_std_map_factories(self) -> bool {
+        self.lang == Lang::Rust
+    }
+
+    pub fn go_literal_zero_map_lookup(self) -> bool {
+        self.lang == Lang::Go
+    }
+
+    pub fn rust_filter_map_option_contract(self) -> bool {
+        self.lang == Lang::Rust
+    }
+
+    pub fn imported_map_factory(self) -> Option<ImportedMapFactoryContract> {
+        match self.lang {
+            Lang::Java => Some(ImportedMapFactoryContract::JavaMap),
+            Lang::Rust => Some(ImportedMapFactoryContract::RustStdMap),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ImportedMapFactoryContract {
+    JavaMap,
+    RustStdMap,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum BuiltinDemand {
+    Eager,
+    Reduce,
+    AnyAll { all: bool },
+    Append,
+    ValueOrDefault,
+}
+
+pub fn builtin_demand(builtin: Builtin) -> BuiltinDemand {
+    match builtin {
+        Builtin::Reduce => BuiltinDemand::Reduce,
+        Builtin::Any => BuiltinDemand::AnyAll { all: false },
+        Builtin::All => BuiltinDemand::AnyAll { all: true },
+        Builtin::Append => BuiltinDemand::Append,
+        Builtin::ValueOrDefault => BuiltinDemand::ValueOrDefault,
+        _ => BuiltinDemand::Eager,
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum EagerBuiltinContract {
+    Len,
+    IsEmpty,
+    IsNull,
+    IsNotNull,
+    StartsWith,
+    EndsWith,
+    Contains,
+    Join,
+    Abs,
+    UnsignedCast32,
+    Sum,
+    Min,
+    Max,
+    Range,
+    Zip,
+    Enumerate,
+    Keys,
+    Print,
+    DictEntry,
+    GetOrDefault,
+}
+
+pub fn eager_builtin_contract(builtin: Builtin) -> Option<EagerBuiltinContract> {
+    Some(match builtin {
+        Builtin::Len => EagerBuiltinContract::Len,
+        Builtin::IsEmpty => EagerBuiltinContract::IsEmpty,
+        Builtin::IsNull => EagerBuiltinContract::IsNull,
+        Builtin::IsNotNull => EagerBuiltinContract::IsNotNull,
+        Builtin::StartsWith => EagerBuiltinContract::StartsWith,
+        Builtin::EndsWith => EagerBuiltinContract::EndsWith,
+        Builtin::Contains => EagerBuiltinContract::Contains,
+        Builtin::Join => EagerBuiltinContract::Join,
+        Builtin::Abs => EagerBuiltinContract::Abs,
+        Builtin::UnsignedCast32 => EagerBuiltinContract::UnsignedCast32,
+        Builtin::Sum => EagerBuiltinContract::Sum,
+        Builtin::Min => EagerBuiltinContract::Min,
+        Builtin::Max => EagerBuiltinContract::Max,
+        Builtin::Range => EagerBuiltinContract::Range,
+        Builtin::Zip => EagerBuiltinContract::Zip,
+        Builtin::Enumerate => EagerBuiltinContract::Enumerate,
+        Builtin::Keys => EagerBuiltinContract::Keys,
+        Builtin::Print => EagerBuiltinContract::Print,
+        Builtin::DictEntry => EagerBuiltinContract::DictEntry,
+        Builtin::GetOrDefault => EagerBuiltinContract::GetOrDefault,
+        Builtin::Reduce
+        | Builtin::Any
+        | Builtin::All
+        | Builtin::Append
+        | Builtin::ValueOrDefault => return None,
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ReductionBuiltinContract {
+    Len,
+    Sum,
+    ExplicitFold,
+    Selection { max: bool },
+    Bool { all: bool },
+    Join,
+}
+
+pub fn reduction_builtin_contract(builtin: Builtin) -> Option<ReductionBuiltinContract> {
+    Some(match builtin {
+        Builtin::Len => ReductionBuiltinContract::Len,
+        Builtin::Sum => ReductionBuiltinContract::Sum,
+        Builtin::Reduce => ReductionBuiltinContract::ExplicitFold,
+        Builtin::Min => ReductionBuiltinContract::Selection { max: false },
+        Builtin::Max => ReductionBuiltinContract::Selection { max: true },
+        Builtin::Any => ReductionBuiltinContract::Bool { all: false },
+        Builtin::All => ReductionBuiltinContract::Bool { all: true },
+        Builtin::Join => ReductionBuiltinContract::Join,
+        _ => return None,
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum HofContract {
+    Map,
+    FlatMap,
+    FilterMap,
+    Filter,
+    Reduce,
+}
+
+pub fn hof_contract(kind: HoFKind) -> HofContract {
+    match kind {
+        HoFKind::Map => HofContract::Map,
+        HoFKind::FlatMap => HofContract::FlatMap,
+        HoFKind::FilterMap => HofContract::FilterMap,
+        HoFKind::Filter => HofContract::Filter,
+        HoFKind::Reduce => HofContract::Reduce,
+    }
+}
+
+/// The value-graph call tag for a canonical builtin. Tag `0` is reserved for
+/// opaque calls, so kernel-owned builtin contracts start at `1`.
+pub fn builtin_tag(builtin: Builtin) -> u32 {
+    builtin as u32 + 1
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum BuiltinArgContract {
+    First,
+    All,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct FreeFunctionBuiltinContract {
+    pub builtin: Builtin,
+    pub args: BuiltinArgContract,
+    pub requires_unshadowed: bool,
+}
+
+pub fn free_function_builtin_contract(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<FreeFunctionBuiltinContract> {
+    let contract = match name {
+        "len" if matches!(lang, Lang::Python | Lang::Go) && arg_count == 1 => {
+            (Builtin::Len, BuiltinArgContract::First)
+        }
+        "append" if lang == Lang::Go && arg_count >= 2 => {
+            (Builtin::Append, BuiltinArgContract::All)
+        }
+        "print" if lang == Lang::Python => (Builtin::Print, BuiltinArgContract::All),
+        "range" if lang == Lang::Python => (Builtin::Range, BuiltinArgContract::All),
+        "sum" if lang == Lang::Python && arg_count == 1 => {
+            (Builtin::Sum, BuiltinArgContract::First)
+        }
+        "min" if lang == Lang::Python && (arg_count == 1 || arg_count == 2) => {
+            (Builtin::Min, BuiltinArgContract::All)
+        }
+        "max" if lang == Lang::Python && (arg_count == 1 || arg_count == 2) => {
+            (Builtin::Max, BuiltinArgContract::All)
+        }
+        "abs" if lang == Lang::Python && arg_count == 1 => {
+            (Builtin::Abs, BuiltinArgContract::First)
+        }
+        "zip" if lang == Lang::Python && arg_count == 2 => (Builtin::Zip, BuiltinArgContract::All),
+        "enumerate" if lang == Lang::Python && arg_count == 1 => {
+            (Builtin::Enumerate, BuiltinArgContract::First)
+        }
+        "any" if lang == Lang::Python && arg_count == 1 => {
+            (Builtin::Any, BuiltinArgContract::First)
+        }
+        "all" if lang == Lang::Python && arg_count == 1 => {
+            (Builtin::All, BuiltinArgContract::First)
+        }
+        _ => return None,
+    };
+    Some(FreeFunctionBuiltinContract {
+        builtin: contract.0,
+        args: contract.1,
+        requires_unshadowed: true,
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MethodReceiverContract {
+    ExactCollection,
+    ExactProtocol,
+    ExactProtocolPairArgument,
+    ExactOption,
+    ExactString,
+    ExactInteger,
+    ExactMap,
+    ExactMapLiteral,
+    ExactCollectionOrMap,
+    ExactCollectionOrMapLiteral,
+    ExactCollectionOrJavaKeySet,
+    ExactSetOrMap,
+    LiteralString,
+    UnshadowedGlobal(&'static str),
+    ImportedNamespace(&'static str),
+    RustMapGetOrExactOption,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MethodBuiltinArgs {
+    All,
+    First,
+    ReceiverOnly,
+    ReceiverThenAll,
+    ReceiverAndFirst,
+    FirstThenReceiver,
+    GoSliceContains,
+    MapGetDefault,
+    RustMapGetOrOptionDefault,
+    RustOptionDefaultLambda,
+    RustOptionMapOrIdentity,
+    RustZip,
+    Fold,
+    BoolReduction,
+    Hof,
+    CollectionReduction,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MethodSemanticContract {
+    Builtin(Builtin),
+    HoF(HoFKind),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct MethodCallContract {
+    pub semantic: MethodSemanticContract,
+    pub receiver: MethodReceiverContract,
+    pub args: MethodBuiltinArgs,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ScalarIntegerMethod {
+    Abs,
+    Min,
+    Max,
+    Clamp,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ScalarIntegerMethodContract {
+    pub semantic: ScalarIntegerMethod,
+    pub receiver: MethodReceiverContract,
+}
+
+pub fn scalar_integer_method_contract(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<ScalarIntegerMethodContract> {
+    use ScalarIntegerMethod as Method;
+
+    let semantic = match (lang, name, arg_count) {
+        (Lang::Rust, "abs", 0) => Method::Abs,
+        (Lang::Rust, "min", 1) => Method::Min,
+        (Lang::Rust, "max", 1) => Method::Max,
+        (Lang::Rust, "clamp", 2) => Method::Clamp,
+        _ => return None,
+    };
+    Some(ScalarIntegerMethodContract {
+        semantic,
+        receiver: MethodReceiverContract::ExactInteger,
+    })
+}
+
+pub fn method_call_contract(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<MethodCallContract> {
+    use MethodBuiltinArgs as Args;
+    use MethodReceiverContract as Receiver;
+    use MethodSemanticContract as Semantic;
+
+    let contract = match (lang, name, arg_count) {
+        (Lang::Python, "append", 1) => (
+            Builtin::Append,
+            Receiver::ExactCollection,
+            Args::ReceiverThenAll,
+        ),
+        (
+            Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html,
+            "push",
+            1..,
+        ) => (
+            Builtin::Append,
+            Receiver::ExactCollection,
+            Args::ReceiverThenAll,
+        ),
+
+        (
+            Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html,
+            "log" | "info" | "debug",
+            _,
+        ) => (
+            Builtin::Print,
+            Receiver::UnshadowedGlobal("console"),
+            Args::All,
+        ),
+        (Lang::Go, "Println" | "Printf" | "Print", _) => (
+            Builtin::Print,
+            Receiver::ImportedNamespace("fmt"),
+            Args::All,
+        ),
+        (Lang::Go, "Abs", 1) => (
+            Builtin::Abs,
+            Receiver::ImportedNamespace("math"),
+            Args::First,
+        ),
+        (Lang::Go, "HasPrefix", 2) => (
+            Builtin::StartsWith,
+            Receiver::ImportedNamespace("strings"),
+            Args::All,
+        ),
+        (Lang::Go, "HasSuffix", 2) => (
+            Builtin::EndsWith,
+            Receiver::ImportedNamespace("strings"),
+            Args::All,
+        ),
+        (Lang::Go, "Contains", 2) => (
+            Builtin::Contains,
+            Receiver::ImportedNamespace("slices"),
+            Args::GoSliceContains,
+        ),
+
+        (Lang::Rust, "len", 0) | (Lang::Java, "size", 0) => {
+            (Builtin::Len, Receiver::ExactCollection, Args::ReceiverOnly)
+        }
+        (
+            Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html,
+            "length",
+            0,
+        ) => (Builtin::Len, Receiver::ExactCollection, Args::ReceiverOnly),
+        (Lang::Rust, "is_empty", 0) | (Lang::Java, "isEmpty", 0) | (Lang::Ruby, "empty?", 0) => (
+            Builtin::IsEmpty,
+            Receiver::ExactCollection,
+            Args::ReceiverOnly,
+        ),
+        (Lang::Ruby, "nil?", 0) | (Lang::Rust, "is_none", 0) => {
+            (Builtin::IsNull, Receiver::ExactOption, Args::ReceiverOnly)
+        }
+        (Lang::Rust, "is_some", 0) => (
+            Builtin::IsNotNull,
+            Receiver::RustMapGetOrExactOption,
+            Args::ReceiverOnly,
+        ),
+
+        (
+            Lang::JavaScript
+            | Lang::TypeScript
+            | Lang::Vue
+            | Lang::Svelte
+            | Lang::Html
+            | Lang::Java,
+            "startsWith",
+            1,
+        )
+        | (Lang::Python, "startswith", 1)
+        | (Lang::Rust, "starts_with", 1)
+        | (Lang::Ruby, "start_with?", 1) => (
+            Builtin::StartsWith,
+            Receiver::ExactString,
+            Args::ReceiverAndFirst,
+        ),
+        (
+            Lang::JavaScript
+            | Lang::TypeScript
+            | Lang::Vue
+            | Lang::Svelte
+            | Lang::Html
+            | Lang::Java,
+            "endsWith",
+            1,
+        )
+        | (Lang::Python, "endswith", 1)
+        | (Lang::Rust, "ends_with", 1)
+        | (Lang::Ruby, "end_with?", 1) => (
+            Builtin::EndsWith,
+            Receiver::ExactString,
+            Args::ReceiverAndFirst,
+        ),
+
+        (Lang::Java, "containsKey", 1)
+        | (Lang::Rust, "contains_key", 1)
+        | (Lang::Ruby, "key?" | "has_key?", 1) => (
+            Builtin::Contains,
+            Receiver::ExactMap,
+            Args::FirstThenReceiver,
+        ),
+        (Lang::Python, "__contains__", 1) => (
+            Builtin::Contains,
+            Receiver::ExactCollectionOrMap,
+            Args::FirstThenReceiver,
+        ),
+        (
+            Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html,
+            "includes",
+            1,
+        )
+        | (Lang::Ruby, "include?", 1)
+        | (Lang::Java | Lang::Rust, "contains", 1) => (
+            Builtin::Contains,
+            Receiver::ExactCollectionOrJavaKeySet,
+            Args::FirstThenReceiver,
+        ),
+        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "has", 1) => {
+            (
+                Builtin::Contains,
+                Receiver::ExactSetOrMap,
+                Args::FirstThenReceiver,
+            )
+        }
+
+        (Lang::Python, "join", 1) => (
+            Builtin::Join,
+            Receiver::LiteralString,
+            Args::ReceiverAndFirst,
+        ),
+        (Lang::Python, "get", 2) | (Lang::Ruby, "fetch", 2) => (
+            Builtin::GetOrDefault,
+            Receiver::ExactMap,
+            Args::MapGetDefault,
+        ),
+        (Lang::Java, "getOrDefault", 2) => (
+            Builtin::GetOrDefault,
+            Receiver::ExactMap,
+            Args::MapGetDefault,
+        ),
+        (Lang::Rust, "unwrap_or", 1) => (
+            Builtin::ValueOrDefault,
+            Receiver::RustMapGetOrExactOption,
+            Args::RustMapGetOrOptionDefault,
+        ),
+        (Lang::Rust, "unwrap_or_else", 1) => (
+            Builtin::ValueOrDefault,
+            Receiver::ExactOption,
+            Args::RustOptionDefaultLambda,
+        ),
+        (Lang::Rust, "map_or", 2) => (
+            Builtin::ValueOrDefault,
+            Receiver::ExactOption,
+            Args::RustOptionMapOrIdentity,
+        ),
+
+        (Lang::Python, "reduce", 2..) => (
+            Builtin::Reduce,
+            Receiver::ImportedNamespace("functools"),
+            Args::All,
+        ),
+        (Lang::Go, "Min", 2) => (Builtin::Min, Receiver::ImportedNamespace("math"), Args::All),
+        (Lang::Go, "Max", 2) => (Builtin::Max, Receiver::ImportedNamespace("math"), Args::All),
+        (Lang::Rust, "zip", 1) => (
+            Builtin::Zip,
+            Receiver::ExactProtocolPairArgument,
+            Args::RustZip,
+        ),
+
+        _ if method_fold_name(lang, name) && arg_count > 0 => {
+            (Builtin::Reduce, Receiver::ExactProtocol, Args::Fold)
+        }
+        _ if method_bool_reduction_builtin(lang, name).is_some() && arg_count > 0 => (
+            method_bool_reduction_builtin(lang, name).unwrap(),
+            Receiver::ExactProtocol,
+            Args::BoolReduction,
+        ),
+        _ if method_collection_reduction_builtin(lang, name).is_some() && arg_count == 0 => (
+            method_collection_reduction_builtin(lang, name).unwrap(),
+            Receiver::ExactProtocol,
+            Args::CollectionReduction,
+        ),
+        _ if method_hof_contract(lang, name).is_some() && arg_count > 0 => {
+            return Some(MethodCallContract {
+                semantic: Semantic::HoF(method_hof_contract(lang, name).unwrap()),
+                receiver: Receiver::ExactProtocol,
+                args: Args::Hof,
+            });
+        }
+        (Lang::Rust, "abs", 0) => (Builtin::Abs, Receiver::ExactInteger, Args::ReceiverOnly),
+        _ => return None,
+    };
+
+    Some(MethodCallContract {
+        semantic: Semantic::Builtin(contract.0),
+        receiver: contract.1,
+        args: contract.2,
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum AsyncReceiverContract {
+    ExactPromiseLike,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct PromiseThenContract {
+    pub receiver: AsyncReceiverContract,
+}
+
+pub fn promise_then_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<PromiseThenContract> {
+    if matches!(
+        lang,
+        Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html
+    ) && method == "then"
+        && arg_count == 1
+    {
+        Some(PromiseThenContract {
+            receiver: AsyncReceiverContract::ExactPromiseLike,
+        })
+    } else {
+        None
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum IteratorAdapterReceiverContract {
+    ExactIterableValue,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct IteratorIdentityAdapterContract {
+    pub receiver: IteratorAdapterReceiverContract,
+}
+
+pub fn iterator_identity_adapter_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<IteratorIdentityAdapterContract> {
+    if lang == Lang::Rust
+        && arg_count == 0
+        && matches!(
+            method,
+            "iter" | "into_iter" | "iter_mut" | "collect" | "to_vec" | "copied" | "cloned"
+        )
+    {
+        Some(IteratorIdentityAdapterContract {
+            receiver: IteratorAdapterReceiverContract::ExactIterableValue,
+        })
+    } else {
+        None
+    }
+}
+
+pub fn builder_append_method_contract(lang: Lang, method: &str, arg_count: usize) -> bool {
+    matches!(
+        (lang, method, arg_count),
+        (Lang::Python, "append", 1)
+            | (
+                Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html,
+                "push",
+                1
+            )
+            | (Lang::Java, "add", 1)
+            | (Lang::Rust, "push", 1)
+    )
+}
+
+pub fn method_fold_name(lang: Lang, name: &str) -> bool {
+    matches!(
+        (lang, name),
+        (
+            Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html,
+            "reduce"
+        ) | (Lang::Ruby, "inject" | "reduce")
+            | (Lang::Rust, "fold")
+            | (Lang::Java, "reduce")
+    )
+}
+
+pub fn method_bool_reduction_builtin(lang: Lang, name: &str) -> Option<Builtin> {
+    Some(match (lang, name) {
+        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "some") => {
+            Builtin::Any
+        }
+        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "every") => {
+            Builtin::All
+        }
+        (Lang::Rust, "any") | (Lang::Ruby, "any?") | (Lang::Java, "anyMatch") => Builtin::Any,
+        (Lang::Rust, "all") | (Lang::Ruby, "all?") | (Lang::Java, "allMatch") => Builtin::All,
+        _ => return None,
+    })
+}
+
+pub fn method_hof_contract(lang: Lang, name: &str) -> Option<HoFKind> {
+    Some(match (lang, name) {
+        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "map")
+        | (Lang::Rust, "map")
+        | (Lang::Java, "map")
+        | (Lang::Ruby, "map" | "collect") => HoFKind::Map,
+        (
+            Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html,
+            "flatMap",
+        )
+        | (Lang::Rust, "flat_map")
+        | (Lang::Java, "flatMap") => HoFKind::FlatMap,
+        (Lang::Rust, "filter_map") => HoFKind::FilterMap,
+        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "filter")
+        | (Lang::Rust, "filter")
+        | (Lang::Java, "filter")
+        | (Lang::Ruby, "filter" | "select") => HoFKind::Filter,
+        _ => return None,
+    })
+}
+
+pub fn method_collection_reduction_builtin(lang: Lang, name: &str) -> Option<Builtin> {
+    Some(match (lang, name) {
+        (Lang::Rust, "sum") => Builtin::Sum,
+        (Lang::Rust, "min") => Builtin::Min,
+        (Lang::Rust, "max") => Builtin::Max,
+        (Lang::Rust, "count") => Builtin::Len,
+        (Lang::Java, "count") => Builtin::Len,
+        _ => return None,
+    })
+}
+
+pub fn property_builtin_contract(lang: Lang, name: &str) -> Option<Builtin> {
+    Some(match (lang, name) {
+        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "length") => {
+            Builtin::Len
+        }
+        (Lang::Java, "length") => Builtin::Len,
+        _ => return None,
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct CollectionSemantics {
+    lang: Lang,
+}
+
+impl CollectionSemantics {
+    /// Python's empty `Seq(0)` literal is a collection value for first-party exact
+    /// collection contracts.
+    pub fn empty_sequence_is_collection(self) -> bool {
+        self.lang == Lang::Python
+    }
+
+    pub fn ruby_shovel_list_append(self) -> bool {
+        self.lang == Lang::Ruby
+    }
+
+    pub fn free_name_collection_factories(self) -> impl Iterator<Item = FreeNameCollectionFactory> {
+        FREE_NAME_COLLECTION_FACTORIES
+            .iter()
+            .copied()
+            .filter(move |row| row.lang.is_none_or(|lang| lang == self.lang))
+    }
+
+    pub fn free_name_map_factories(self) -> impl Iterator<Item = FreeNameMapFactory> {
+        FREE_NAME_MAP_FACTORIES
+            .iter()
+            .copied()
+            .filter(move |row| row.lang.is_none_or(|lang| lang == self.lang))
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct FreeNameCollectionFactory {
+    pub lang: Option<Lang>,
+    pub names: &'static [&'static str],
+    pub shadow_guard: bool,
+}
+
+const FREE_NAME_COLLECTION_FACTORIES: &[FreeNameCollectionFactory] = &[
+    FreeNameCollectionFactory {
+        lang: Some(Lang::Python),
+        names: &["list", "set", "frozenset", "tuple"],
+        shadow_guard: true,
+    },
+    FreeNameCollectionFactory {
+        lang: Some(Lang::Rust),
+        names: &[
+            "std::collections::HashSet::from",
+            "std::collections::BTreeSet::from",
+            "std::collections::VecDeque::from",
+        ],
+        shadow_guard: false,
+    },
+];
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct FreeNameMapFactory {
+    pub lang: Option<Lang>,
+    pub names: &'static [&'static str],
+    pub entry_seq_tag: u64,
+}
+
+const FREE_NAME_MAP_FACTORIES: &[FreeNameMapFactory] = &[FreeNameMapFactory {
+    lang: Some(Lang::Rust),
+    names: &[
+        "std::collections::HashMap::from",
+        "std::collections::BTreeMap::from",
+    ],
+    entry_seq_tag: 2,
+}];
+
+pub fn imported_literal_seq_tag_safe(tag: &str) -> bool {
+    matches!(
+        tag,
+        "dictionary" | "object" | "array" | "array_expression" | "tuple_expression"
+    )
+}
+
+pub fn mutating_method_name(method: &str) -> bool {
+    matches!(
+        method,
+        "clear"
+            | "delete"
+            | "insert"
+            | "pop"
+            | "popitem"
+            | "put"
+            | "putAll"
+            | "remove"
+            | "set"
+            | "setdefault"
+            | "update"
+    )
+}
+
+pub fn module_binding_mutating_method_name(method: &str) -> bool {
+    matches!(
+        method,
+        "add"
+            | "addAll"
+            | "append"
+            | "delete"
+            | "clear"
+            | "compute"
+            | "computeIfAbsent"
+            | "computeIfPresent"
+            | "merge"
+            | "pop"
+            | "push"
+            | "put"
+            | "putAll"
+            | "remove"
+            | "removeAll"
+            | "removeIf"
+            | "replace"
+            | "replaceAll"
+            | "retainAll"
+            | "shift"
+            | "sort"
+            | "splice"
+            | "unshift"
+            | "set"
+    )
+}
+
+pub fn async_to_sync_name(lang: Lang, name: &str) -> Option<&'static str> {
+    if lang != Lang::Python {
+        return None;
+    }
+    Some(match name {
+        "__aenter__" => "__enter__",
+        "__aexit__" => "__exit__",
+        "__anext__" => "__next__",
+        "__aiter__" => "__iter__",
+        "aread" => "read",
+        "areadline" => "readline",
+        "areadlines" => "readlines",
+        "awrite" => "write",
+        "aclose" => "close",
+        "asend" => "send",
+        "areceive" => "receive",
+        "aconnect" => "connect",
+        "adrain" => "drain",
+        "aflush" => "flush",
+        "AsyncIterable" => "Iterable",
+        "AsyncIterator" => "Iterator",
+        "AsyncGenerator" => "Generator",
+        "AsyncContextManager" => "ContextManager",
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_LANGS: &[Lang] = &[
+        Lang::Python,
+        Lang::JavaScript,
+        Lang::TypeScript,
+        Lang::Go,
+        Lang::Rust,
+        Lang::Java,
+        Lang::C,
+        Lang::Ruby,
+        Lang::Vue,
+        Lang::Svelte,
+        Lang::Html,
+    ];
+
+    const ALL_BUILTINS: &[Builtin] = &[
+        Builtin::Len,
+        Builtin::Print,
+        Builtin::Append,
+        Builtin::Range,
+        Builtin::Sum,
+        Builtin::Reduce,
+        Builtin::Min,
+        Builtin::Max,
+        Builtin::Abs,
+        Builtin::Zip,
+        Builtin::Enumerate,
+        Builtin::Keys,
+        Builtin::Any,
+        Builtin::All,
+        Builtin::DictEntry,
+        Builtin::IsEmpty,
+        Builtin::StartsWith,
+        Builtin::EndsWith,
+        Builtin::Contains,
+        Builtin::GetOrDefault,
+        Builtin::ValueOrDefault,
+        Builtin::IsNull,
+        Builtin::IsNotNull,
+        Builtin::Join,
+        Builtin::UnsignedCast32,
+    ];
+
+    #[test]
+    fn first_party_profile_wraps_each_language() {
+        for &lang in ALL_LANGS {
+            let profile = semantics(lang);
+            assert_eq!(profile.lang(), lang);
+            assert_eq!(profile.pack_id(), FIRST_PARTY_PACK_ID);
+            assert_eq!(profile.eligibility(), ChannelEligibility::FirstParty);
+        }
+    }
+
+    #[test]
+    fn language_predicates_preserve_existing_gates() {
+        for &lang in ALL_LANGS {
+            let profile = semantics(lang);
+            assert_eq!(
+                profile.operators().primitive_order_comparisons(),
+                matches!(lang, Lang::C | Lang::Go | Lang::Java)
+            );
+            assert_eq!(
+                profile.operators().c_integer_byte_pack_contracts(),
+                lang == Lang::C
+            );
+            assert_eq!(
+                profile.effects().non_overloadable_index_assignment(),
+                matches!(lang, Lang::C | Lang::Go | Lang::Java)
+            );
+            assert_eq!(
+                profile.effects().java_this_field_place(),
+                lang == Lang::Java
+            );
+            assert_eq!(
+                profile.modules().js_like_shadowed_module_bindings(),
+                matches!(
+                    lang,
+                    Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html
+                )
+            );
+            assert_eq!(
+                profile.modules().java_class_literal_exports(),
+                lang == Lang::Java
+            );
+            assert_eq!(
+                profile.modules().java_type_declarations_shadow_stdlib(),
+                lang == Lang::Java
+            );
+            assert_eq!(
+                profile.modules().go_import_namespace_facts(),
+                lang == Lang::Go
+            );
+        }
+    }
+
+    #[test]
+    fn stdlib_predicates_preserve_existing_gates() {
+        for &lang in ALL_LANGS {
+            let stdlib = semantics(lang).stdlib();
+            assert_eq!(stdlib.python_collection_factories(), lang == Lang::Python);
+            assert_eq!(stdlib.python_deque_factory(), lang == Lang::Python);
+            assert_eq!(stdlib.java_collection_factories(), lang == Lang::Java);
+            assert_eq!(stdlib.java_map_factories(), lang == Lang::Java);
+            assert_eq!(stdlib.java_primitive_integer_ops(), lang == Lang::Java);
+            assert_eq!(stdlib.ruby_set_factory(), lang == Lang::Ruby);
+            assert_eq!(stdlib.rust_vec_macro_factory(), lang == Lang::Rust);
+            assert_eq!(stdlib.rust_vec_new_factory(), lang == Lang::Rust);
+            assert_eq!(stdlib.rust_std_collection_factories(), lang == Lang::Rust);
+            assert_eq!(stdlib.rust_std_map_factories(), lang == Lang::Rust);
+            assert_eq!(stdlib.go_literal_zero_map_lookup(), lang == Lang::Go);
+            assert_eq!(stdlib.rust_filter_map_option_contract(), lang == Lang::Rust);
+        }
+    }
+
+    #[test]
+    fn free_name_contracts_are_behavior_equivalent_tables() {
+        let py_names: Vec<_> = semantics(Lang::Python)
+            .collections()
+            .free_name_collection_factories()
+            .flat_map(|factory| factory.names.iter().copied())
+            .collect();
+        assert!(py_names.contains(&"list"));
+        assert!(py_names.contains(&"frozenset"));
+        assert!(!py_names.contains(&"Set"));
+
+        let rust_map_tags: Vec<_> = semantics(Lang::Rust)
+            .collections()
+            .free_name_map_factories()
+            .map(|factory| factory.entry_seq_tag)
+            .collect();
+        assert_eq!(rust_map_tags, vec![2]);
+
+        let js_map_tags: Vec<_> = semantics(Lang::JavaScript)
+            .collections()
+            .free_name_map_factories()
+            .map(|factory| factory.entry_seq_tag)
+            .collect();
+        assert!(js_map_tags.is_empty());
+    }
+
+    #[test]
+    fn mutating_method_sets_stay_distinct() {
+        assert!(mutating_method_name("put"));
+        assert!(!mutating_method_name("push"));
+        assert!(module_binding_mutating_method_name("push"));
+        assert!(module_binding_mutating_method_name("addAll"));
+    }
+
+    #[test]
+    fn builtin_contracts_preserve_current_special_demand_split() {
+        for &builtin in ALL_BUILTINS {
+            assert_eq!(builtin_tag(builtin), builtin as u32 + 1);
+        }
+        assert_eq!(builtin_demand(Builtin::Reduce), BuiltinDemand::Reduce);
+        assert_eq!(
+            builtin_demand(Builtin::Any),
+            BuiltinDemand::AnyAll { all: false }
+        );
+        assert_eq!(
+            builtin_demand(Builtin::All),
+            BuiltinDemand::AnyAll { all: true }
+        );
+        assert_eq!(builtin_demand(Builtin::Append), BuiltinDemand::Append);
+        assert_eq!(
+            builtin_demand(Builtin::ValueOrDefault),
+            BuiltinDemand::ValueOrDefault
+        );
+        assert_eq!(builtin_demand(Builtin::Len), BuiltinDemand::Eager);
+        assert_eq!(
+            eager_builtin_contract(Builtin::Len),
+            Some(EagerBuiltinContract::Len)
+        );
+        assert_eq!(eager_builtin_contract(Builtin::Append), None);
+        assert_eq!(
+            reduction_builtin_contract(Builtin::Max),
+            Some(ReductionBuiltinContract::Selection { max: true })
+        );
+        assert_eq!(
+            reduction_builtin_contract(Builtin::Any),
+            Some(ReductionBuiltinContract::Bool { all: false })
+        );
+        assert_eq!(reduction_builtin_contract(Builtin::Print), None);
+        assert_eq!(hof_contract(HoFKind::FilterMap), HofContract::FilterMap);
+    }
+
+    #[test]
+    fn free_function_builtin_contracts_are_language_and_shadow_constrained() {
+        assert_eq!(
+            free_function_builtin_contract(Lang::Python, "len", 1),
+            Some(FreeFunctionBuiltinContract {
+                builtin: Builtin::Len,
+                args: BuiltinArgContract::First,
+                requires_unshadowed: true,
+            })
+        );
+        assert_eq!(free_function_builtin_contract(Lang::Python, "len", 2), None);
+        assert_eq!(
+            free_function_builtin_contract(Lang::JavaScript, "len", 1),
+            None
+        );
+        assert_eq!(
+            free_function_builtin_contract(Lang::Python, "print", 3),
+            Some(FreeFunctionBuiltinContract {
+                builtin: Builtin::Print,
+                args: BuiltinArgContract::All,
+                requires_unshadowed: true,
+            })
+        );
+        assert_eq!(
+            free_function_builtin_contract(Lang::Go, "append", 2),
+            Some(FreeFunctionBuiltinContract {
+                builtin: Builtin::Append,
+                args: BuiltinArgContract::All,
+                requires_unshadowed: true,
+            })
+        );
+        assert_eq!(free_function_builtin_contract(Lang::Go, "append", 1), None);
+        assert_eq!(free_function_builtin_contract(Lang::C, "fmaxf", 2), None);
+        assert_eq!(
+            free_function_builtin_contract(Lang::Python, "fmaxf", 2),
+            None
+        );
+        assert_eq!(
+            free_function_builtin_contract(Lang::Python, "max", 2),
+            Some(FreeFunctionBuiltinContract {
+                builtin: Builtin::Max,
+                args: BuiltinArgContract::All,
+                requires_unshadowed: true,
+            })
+        );
+        assert_eq!(free_function_builtin_contract(Lang::Python, "any", 2), None);
+    }
+
+    #[test]
+    fn method_protocol_contracts_are_language_constrained() {
+        assert!(method_fold_name(Lang::Ruby, "inject"));
+        assert!(!method_fold_name(Lang::Python, "inject"));
+        assert!(!method_fold_name(Lang::Ruby, "map"));
+        assert_eq!(
+            method_bool_reduction_builtin(Lang::Java, "anyMatch"),
+            Some(Builtin::Any)
+        );
+        assert_eq!(
+            method_bool_reduction_builtin(Lang::JavaScript, "every"),
+            Some(Builtin::All)
+        );
+        assert_eq!(method_bool_reduction_builtin(Lang::Python, "every"), None);
+        assert_eq!(
+            method_hof_contract(Lang::Ruby, "collect"),
+            Some(HoFKind::Map)
+        );
+        assert_eq!(
+            method_hof_contract(Lang::Rust, "flat_map"),
+            Some(HoFKind::FlatMap)
+        );
+        assert_eq!(
+            method_hof_contract(Lang::Ruby, "select"),
+            Some(HoFKind::Filter)
+        );
+        assert_eq!(method_hof_contract(Lang::Python, "select"), None);
+        assert_eq!(
+            method_collection_reduction_builtin(Lang::Rust, "count"),
+            Some(Builtin::Len)
+        );
+        assert_eq!(
+            method_collection_reduction_builtin(Lang::Java, "count"),
+            Some(Builtin::Len)
+        );
+        assert_eq!(
+            method_collection_reduction_builtin(Lang::JavaScript, "count"),
+            None
+        );
+        assert_eq!(
+            property_builtin_contract(Lang::JavaScript, "length"),
+            Some(Builtin::Len)
+        );
+        assert_eq!(property_builtin_contract(Lang::Python, "length"), None);
+    }
+
+    #[test]
+    fn method_call_contracts_carry_receiver_and_resolution_obligations() {
+        assert_eq!(
+            method_call_contract(Lang::Python, "append", 1),
+            Some(MethodCallContract {
+                semantic: MethodSemanticContract::Builtin(Builtin::Append),
+                receiver: MethodReceiverContract::ExactCollection,
+                args: MethodBuiltinArgs::ReceiverThenAll,
+            })
+        );
+        assert_eq!(method_call_contract(Lang::Python, "append", 0), None);
+        assert_eq!(
+            method_call_contract(Lang::JavaScript, "log", 1),
+            Some(MethodCallContract {
+                semantic: MethodSemanticContract::Builtin(Builtin::Print),
+                receiver: MethodReceiverContract::UnshadowedGlobal("console"),
+                args: MethodBuiltinArgs::All,
+            })
+        );
+        assert_eq!(
+            method_call_contract(Lang::Go, "Abs", 1),
+            Some(MethodCallContract {
+                semantic: MethodSemanticContract::Builtin(Builtin::Abs),
+                receiver: MethodReceiverContract::ImportedNamespace("math"),
+                args: MethodBuiltinArgs::First,
+            })
+        );
+        assert_eq!(
+            method_call_contract(Lang::Python, "__contains__", 1),
+            Some(MethodCallContract {
+                semantic: MethodSemanticContract::Builtin(Builtin::Contains),
+                receiver: MethodReceiverContract::ExactCollectionOrMap,
+                args: MethodBuiltinArgs::FirstThenReceiver,
+            })
+        );
+        assert_eq!(
+            method_call_contract(Lang::TypeScript, "has", 1),
+            Some(MethodCallContract {
+                semantic: MethodSemanticContract::Builtin(Builtin::Contains),
+                receiver: MethodReceiverContract::ExactSetOrMap,
+                args: MethodBuiltinArgs::FirstThenReceiver,
+            })
+        );
+        assert_eq!(
+            method_call_contract(Lang::Java, "getOrDefault", 2),
+            Some(MethodCallContract {
+                semantic: MethodSemanticContract::Builtin(Builtin::GetOrDefault),
+                receiver: MethodReceiverContract::ExactMap,
+                args: MethodBuiltinArgs::MapGetDefault,
+            })
+        );
+        assert_eq!(method_call_contract(Lang::JavaScript, "abs", 0), None);
+    }
+
+    #[test]
+    fn scalar_integer_methods_are_language_and_signature_constrained() {
+        assert_eq!(
+            scalar_integer_method_contract(Lang::Rust, "clamp", 2),
+            Some(ScalarIntegerMethodContract {
+                semantic: ScalarIntegerMethod::Clamp,
+                receiver: MethodReceiverContract::ExactInteger,
+            })
+        );
+        assert_eq!(
+            scalar_integer_method_contract(Lang::Rust, "min", 1),
+            Some(ScalarIntegerMethodContract {
+                semantic: ScalarIntegerMethod::Min,
+                receiver: MethodReceiverContract::ExactInteger,
+            })
+        );
+        assert_eq!(scalar_integer_method_contract(Lang::Rust, "clamp", 1), None);
+        assert_eq!(
+            scalar_integer_method_contract(Lang::TypeScript, "clamp", 2),
+            None
+        );
+        assert_eq!(
+            scalar_integer_method_contract(Lang::JavaScript, "abs", 0),
+            None
+        );
+    }
+
+    #[test]
+    fn async_to_sync_contracts_are_python_constrained() {
+        assert_eq!(
+            async_to_sync_name(Lang::Python, "__aenter__"),
+            Some("__enter__")
+        );
+        assert_eq!(async_to_sync_name(Lang::Python, "aread"), Some("read"));
+        assert_eq!(
+            async_to_sync_name(Lang::Python, "AsyncIterator"),
+            Some("Iterator")
+        );
+        assert_eq!(async_to_sync_name(Lang::JavaScript, "aread"), None);
+        assert_eq!(async_to_sync_name(Lang::Python, "append"), None);
+    }
+
+    #[test]
+    fn promise_then_contract_requires_js_like_surface_and_receiver_proof() {
+        assert_eq!(
+            promise_then_contract(Lang::TypeScript, "then", 1),
+            Some(PromiseThenContract {
+                receiver: AsyncReceiverContract::ExactPromiseLike,
+            })
+        );
+        assert_eq!(promise_then_contract(Lang::TypeScript, "then", 2), None);
+        assert_eq!(promise_then_contract(Lang::Python, "then", 1), None);
+    }
+
+    #[test]
+    fn iterator_identity_adapters_are_rust_and_receiver_proof_constrained() {
+        assert_eq!(
+            iterator_identity_adapter_contract(Lang::Rust, "iter", 0),
+            Some(IteratorIdentityAdapterContract {
+                receiver: IteratorAdapterReceiverContract::ExactIterableValue,
+            })
+        );
+        assert_eq!(
+            iterator_identity_adapter_contract(Lang::Rust, "collect", 0),
+            Some(IteratorIdentityAdapterContract {
+                receiver: IteratorAdapterReceiverContract::ExactIterableValue,
+            })
+        );
+        assert_eq!(
+            iterator_identity_adapter_contract(Lang::JavaScript, "collect", 0),
+            None
+        );
+        assert_eq!(
+            iterator_identity_adapter_contract(Lang::Rust, "collect", 1),
+            None
+        );
+    }
+
+    #[test]
+    fn builder_append_contracts_are_language_and_arity_constrained() {
+        assert!(builder_append_method_contract(Lang::Rust, "push", 1));
+        assert!(!builder_append_method_contract(Lang::Rust, "push", 2));
+        assert!(builder_append_method_contract(Lang::Java, "add", 1));
+        assert!(builder_append_method_contract(Lang::JavaScript, "push", 1));
+        assert!(builder_append_method_contract(Lang::Python, "append", 1));
+        assert!(!builder_append_method_contract(Lang::Ruby, "push", 1));
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,6 +5,13 @@ designed so that semantically-equivalent code converges toward identical
 structure, then finds and ranks duplication on top of it. The IL is **not** the
 deliverable — it's the substrate.
 
+The long-term boundary for language and library meaning is the
+[semantic-kernel](semantic-kernel.md): a pack-based semantic contract layer that
+makes evaluation strategy, effects, library APIs, laws, and proof status explicit
+instead of scattering semantic assumptions across the engine. The first internal
+facade is in `nose-semantics`; the pipeline below describes the current mixed
+state while migration continues.
+
 ## North star
 
 nose's exact Type-4 goal is **not** to guess arbitrary semantic similarity. It is
@@ -68,11 +75,15 @@ A Cargo workspace; data flows left-to-right through them.
 | crate | role |
 |---|---|
 | `nose-il` | arena IL model (`Vec<Node>`, `NodeId(u32)`, out-of-line edges), provenance spans, interner, serialization, IR verifier |
+| `nose-semantics` | first-party semantic facade: language profiles, effect/operator/module/stdlib predicates, API contracts, and exact-channel proof obligations |
 | `nose-frontend` | tree-sitter parse + per-language CST→IL lowering (one module per language; embedded `<script>` extraction) |
 | `nose-normalize` | the normalization passes + the value graph (GVN) |
 | `nose-detect` | unit/feature extraction, MinHash/LSH, scoring, clustering, refactor ranking |
 | `nose-eval` | benchmark scoring (precision/recall, pooled, stratified) — see [benchmark](benchmark.md) |
 | `nose-cli` | the `nose` binary, config loading, baselines, caching |
+
+The current semantic assumptions these crates share are summarized in
+[semantic-kernel-snapshot](semantic-kernel-snapshot.md).
 
 ## Design choices worth knowing
 

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -54,19 +54,21 @@ This is nose's distinguishing capability, but it is **bounded, not total** — a
 semantic equivalence is undecidable. nose converges the equivalence classes its IL, value
 graph, and canonicalizations actually model:
 
-- loop ↔ `reduce`/`sum` ↔ comprehension ↔ `.append`/`.map` builder loop; nested list
-  builders ↔ Python multi-clause comprehensions ↔ `.flatMap(... .map(...))`; an `any`/`all`
-  loop ↔ the functional form; pure aggregate consumers over flat-map streams ↔ nested
+- loop ↔ `reduce`/`sum` ↔ comprehension ↔ proof-backed `.append`/`.map` builder loop;
+  nested list builders ↔ Python multi-clause comprehensions ↔ proven flat-map
+  surfaces; inner method chains such as `xs.map(...)` require nested element
+  collection proof before they enter exact matching; an `any`/`all` loop ↔ the
+  functional form; pure aggregate consumers over flat-map streams ↔ nested
   reduction loops; a `reduce`-lambda min/max ↔ `max`/`min`;
   `len([… if p]) ↔ Σ(p?1:0)`; a dict-building loop `d={}; for x: d[k]=v` ↔ the dict
   comprehension `{k: v for x in xs}`;
 - literal map-default lookup through proven map/key/fallback coordinates, including
   Python `dict.get(key, fallback)` and Ruby literal `Hash#fetch(key, fallback)` or
   zero-arg pure fallback blocks such as `Hash#fetch(key) { fallback }`, plus Python
-  sibling-module `from module import LOOKUP` literal bindings, JS/TS named imports from
-  sibling `Map` exports, Java static imports from class `Map.of` fields, and Rust
-  `use` imports of const entry arrays consumed by `HashMap::from`/`BTreeMap::from` when
-  the provider binding is unique, immutable, and unambiguous;
+  sibling-module `from module import LOOKUP` literal bindings, Java static imports from
+  class `Map.of` fields, and Rust `use` imports of const entry arrays consumed by
+  `HashMap::from`/`BTreeMap::from` when the provider binding is unique, immutable, and
+  unambiguous;
 - `filter q (filter p) ↔ filter (p∧q)` (and the filtered comprehension / `.filter().filter()`
   chain / filtered builder loop), plus the direct Rust `filter_map` / guarded-builder slice
   where `None` means absence and emitted falsey values remain values;
@@ -74,8 +76,10 @@ graph, and canonicalizations actually model:
   idioms, commutativity +
   associativity (AC-canonical operands), distribution `a·c + b·c ≡ (a+b)·c` (numeric),
   `a − b ≡ a + (−b)`, De Morgan, short-circuit `and`/`or`;
-- the same algorithm written in a **different language** (incl. Rust `it.iter().filter(p).sum()`
-  ↔ Python `sum(x for x in xs if p)`).
+- the same algorithm written in a **different language** when the relevant API
+  contracts and receiver domains are proven (for example Rust
+  `it.iter().filter(p).sum()` ↔ Python `sum(x for x in xs if p)` under a collection
+  proof).
 
 For the classes it captures, equal fingerprint -> equal behavior is the design invariant:
 guarded by the hidden `nose verify` oracle, regression tests, and Lean obligations for the
@@ -90,7 +94,10 @@ core canonicalizations, but not a per-scan or whole-pipeline proof. See
 - **General collection flattening** — depth-parameterized flattening such as
   `Array.prototype.flat(depth)` is not canonicalized. The modeled flattening is the
   one-level flat-map shape (`FlatMap[A, λa. Map[B, λb. e]]`) used by Python multi-clause
-  comprehensions, JS `.flatMap`, and equivalent nested builder loops.
+  comprehensions, proof-backed JS `.flatMap`, and equivalent nested builder loops.
+- **Name-only library semantics** are not accepted. A method named `map`, `then`,
+  `collect`, or `contains` is exact only when the language, symbol/receiver,
+  shadowing/import, arity, and effect/demand obligations for that API are proven.
 - **Recursion ↔ iteration** is partially modeled — a bounded subset converges (see
   [normalization](normalization.md)); general recursion↔iteration remains out of scope.
 - The behavioral *proof* (`nose verify`) covers only interpretable (≈ pure) units; detection

--- a/docs/formal-soundness.md
+++ b/docs/formal-soundness.md
@@ -14,6 +14,11 @@ should not depend only on corpus coverage. The registry lives under
 - `Counterexamples.lean` — optional boundary proof for rewrites or missing preconditions that
   must stay closed.
 
+The planned [semantic-kernel](semantic-kernel.md) keeps this registry as the
+first-party proof boundary for exact laws. External semantic packs may declare
+their own evidence status, but nose does not certify external packs; providers
+and users own those claims unless the pack is adopted as first-party.
+
 The obligation id must match its path. For example,
 `formal/obligations/normalize/value_graph/factor_distribute/meta.toml` declares
 `normalize.value_graph.factor_distribute`.

--- a/docs/home.md
+++ b/docs/home.md
@@ -51,6 +51,9 @@ You want to *change* nose or understand how it works inside.
 - [design & direction](design.md) — the *why* behind the roadmap: the sound core as the moat, the two (non-human) consumers, and what that decides. **Check roadmap calls against this.**
 - [architecture](architecture.md) — the crates and the lower → normalize → detect → rank pipeline.
 - [normalization](normalization.md) — the passes that make behaviorally-equivalent code converge (the hard part).
+- [semantic-kernel](semantic-kernel.md) — semantic-kernel and pack architecture: language/library semantics, extension boundaries, responsibility model, and exact-channel eligibility.
+- [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
+- [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.
 - [fragment-contracts](fragment-contracts.md) — how exact sub-function fragments are modeled: classification, contract, the wrapper-synthesis behavior oracle, the effect algebra, and fail-closed receiver identity.
 - [formal-soundness](formal-soundness.md) — Lean 4 proof-obligation registry for proof-sensitive IL, normalization, fragment, and oracle contracts.
 - [hazard-ranking](hazard-ranking.md) — the evidence base for the experimental `--sort hazard` (a divergence-*propensity* signal; **not** a validated harm ranker — it ranks actual harm near chance) and the honest evaluation trail.

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -4,6 +4,11 @@ nose parses each language with tree-sitter and lowers it into one shared IL, so
 clones are found *across* languages, not just within one. The lowering machinery is
 described in [architecture](architecture.md).
 
+The current language frontends are first-party code. The direction is for both
+first-party and external languages to enter through the same pack extension
+boundary described in [semantic-kernel](semantic-kernel.md), while keeping exact
+semantic matching fail-closed unless the required facts and contracts are present.
+
 ## Supported languages
 
 Eight base languages, each with its own CST→IL lowering:
@@ -63,4 +68,7 @@ lowering to expression if-chains instead of `Raw`, or Ruby scrutinee-less `case`
 its `when` predicates directly while preserving the `else` arm) is how a language becomes a
 first-class citizen —
 see the [experiments](experiments.md) log and the convergence-test discipline in
-[CONTRIBUTING](../CONTRIBUTING.md).
+[`CONTRIBUTING`](../CONTRIBUTING.md).
+
+For the planned pack-based language onboarding model, see
+[semantic-kernel-roadmap](semantic-kernel-roadmap.md).

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -15,14 +15,18 @@ experiments that validated these passes are in [experiments](experiments.md).
 > Later additions on the value graph: a purpose-fit **type inference** (`types.rs`, now a
 > fixpoint over subexpression result types) gating the type-dependent canons, free-monoid
 > strings, map **and filter** fusion (a filter is the element-carrying `Hof(Map,[Elem,p])`,
-> so nested filters fuse to `p∧q`), Rust **filter-map** selection for direct
-> `Some(value)`/`None` callbacks and guarded `Vec::new()`/`push` builders, first-class
+> so nested filters fuse to `p∧q` when the collection/protocol receiver is proven), Rust
+> **filter-map** selection for direct `Some(value)`/`None` callbacks and proof-backed
+> guarded `Vec::new()`/`push` builders, first-class
 > **flat-map** modeling for Python
-> multi-clause comprehensions, JS `.flatMap`, pure Java `Arrays.stream(...).flatMap(...map...)`,
-> equivalent nested list-builder loops, **identity flat-map `flatMap(λx. x)` canonicalized to
+> multi-clause comprehensions, proof-backed JS `.flatMap`, pure Java
+> `Arrays.stream(...).flatMap(...map...)`, equivalent nested list-builder loops,
+> **identity flat-map `flatMap(λx. x)` canonicalized to
 > the modeled element-stream inner (the monad law `flatMap id = join`; proven in
-> `normalize.value_graph.flatmap_identity`), so it converges with the nested builder loop and
-> the explicit inner-identity-map form**, and pure inner-Map aggregate consumers such as
+> `normalize.value_graph.flatmap_identity`), so it converges with explicit nested
+> builder loops**. Inner method chains such as `xs.map(...)` still require nested
+> element collection proof before they enter the exact channel. Pure inner-Map
+> aggregate consumers such as
 > sum/max/any over flat-map streams versus nested reduction loops when the contribution
 > uses the outer element (kept distinct from nested-list comprehensions, Java stream
 > `map` returning streams, wrong reduction seeds, outer-cardinality-only cases, and
@@ -33,8 +37,10 @@ experiments that validated these passes are in [experiments](experiments.md).
 > min/max and any/all reductions (cross-language), simple **flag+break existence/universal
 > loops** (`found=false; if p { found=true; break }` / the dual `all` form),
 > **reduce-lambda selection** (`reduce(λ. a if a>b else b)≡max`), **count-of-filter**
-> (`len([…if p])≡Σ(p?1:0)`), method-form iterator reductions (Rust
-> `.sum()/.min()/.max()/.count()`), **dict-builder ≡ dict comprehension**
+> (`len([…if p])≡Σ(p?1:0)`, including proof-backed JS/TS `filter(...).length`),
+> method-form iterator/stream reductions (Rust `.sum()/.min()/.max()/.count()`
+> and Java `Stream.count()` when receiver/protocol proof exists),
+> **dict-builder ≡ dict comprehension**
 > (`d={}; for x: d[k]=v` ≡ `{k:v for x}` via a `DictEntry`-distinct rep that cannot collide
 > with a list of tuples), ternary-return decomposition, negated-comparison canon,
 > equality-chain literal membership (`x=="a" || x=="b"`), stricter record-shape guard

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -164,6 +164,7 @@ Each `locations[]` item has:
 | `sem` | integer | Value-graph size for the site. |
 | `span_lines` | integer | Inclusive source-line span for this location. |
 | `span_tokens` | integer | Normalized-token span used by the detector's size gates. |
+| `shared_subdag` | array, optional | `[start_line, end_line]` inclusive range of the heavy shared computation at this site when the family is grouped by a shared sub-DAG. |
 | `is_fragment` | boolean | `true` when this location is an exact sub-function fragment; `false` for whole units and syntax-channel copy-paste spans. |
 | `fragment_kind` | string, optional | Exact fragment proof shape, present only when `is_fragment` is `true`; examples include `direct-return`, `conditional-guard`, and `self-field-body`. |
 | `reason_code` | string, optional | Stable exact-fragment proof reason derived from `fragment_kind`, present only when `is_fragment` is `true`; examples include `exact-direct-return` and `exact-conditional-guard`. |

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -1,0 +1,190 @@
+# Semantic kernel roadmap
+
+Back to [semantic-kernel](semantic-kernel.md). Current code shape is recorded in
+[semantic-kernel-snapshot](semantic-kernel-snapshot.md).
+
+This page tracks decisions, history, and remaining work for the semantic kernel
+and pack ecosystem.
+
+## Decisions
+
+1. **All language and library semantics should eventually enter through packs.**
+   First-party languages are not special at the API boundary; they may be compiled
+   into nose, but they should use the same pack contracts as external languages.
+
+2. **nose certifies only first-party packs.** External pack providers own their
+   semantic claims. Users own the decision to enable them. nose owns the extension
+   contract, validation of pack structure, fail-closed execution, and provenance
+   reporting.
+
+3. **Packs emit evidence, not verdicts.** A pack can emit facts, contracts, and
+   protocol operations. It cannot mint fingerprints, bypass laws, or approve exact
+   clones.
+
+4. **Language core and library semantics are separate layers.** Evaluation order,
+   truthiness, overloadability, and exception behavior belong to language core.
+   `sum`, `Iterator::map`, `Array.prototype.map`, RxJS `Observable.map`, and NumPy
+   vector operations belong to stdlib/library packs mapped onto protocols.
+
+5. **Demand and effect are first-class.** Lazy evaluation, short-circuiting,
+   iterators, async/futures, and observables cannot be accurately modeled with a
+   simple purity flag. Exact laws need demand and effect preconditions.
+
+6. **Unknown stays fail-closed.** Missing type, receiver, symbol, version,
+   shadowing, or effect evidence must block exact semantic acceptance. It may
+   still inform `near` scoring.
+
+7. **Selectors are not proof.** A function or method name is only a selector.
+   Exact contracts must also declare and check the language, symbol/namespace,
+   arity, receiver/protocol, shadowing, import, version, overload, demand, and
+   effect obligations that make that selector mean the claimed operation.
+
+## History
+
+- The original architecture lowered every supported language into one shared IL,
+  then normalized toward common fingerprints.
+- The value graph became the behavioral fingerprint substrate, separating exact
+  semantic matching from fuzzy structural candidate generation.
+- The independent interpreter oracle was added to test fingerprint-equal units
+  against concrete behavior and catch behavior-changing canonicalizations.
+- Lean proof obligations were added for proof-sensitive rules.
+- Exact fragments gained explicit contracts, effect classifications, and
+  fail-closed receiver/place boundaries.
+- Dogfooding surfaced repeated per-language frontend shapes; safe common helpers
+  moved into `lower.rs`, while grammar-specific parallelism remained explicit.
+- Documentation review in PR #89 clarified the current limits: exact Type-4 is a
+  modeled subset, not arbitrary semantic equivalence.
+- The semantic-kernel direction was chosen to make language and library semantics
+  an explicit extension boundary rather than scattered engine code.
+- The first internal facade landed as `nose-semantics`, wrapping first-party
+  language/profile predicates and API contracts while the rest of the pipeline is
+  migrated.
+- Name-only contracts were narrowed: JS/TS `Map`/`Set` constructors, JS-like
+  `.then`, untyped JS collection methods, and Rust iterator adapters now require
+  explicit proof or remain exact-closed.
+- Additional call surfaces moved behind proof-gated contracts: JS/TS
+  `filter(...).length`, Rust `get(key).is_some()`, Java `keySet().contains`,
+  and Java `Stream.count()` require receiver/protocol or map proof. Ruby untyped
+  `Enumerable` and scalar/array numeric helpers remain closed until comparable
+  proof facts exist.
+- New value-graph rewrites began moving into named `rules/*` modules with
+  mechanical formal-obligation pairing; `clamp` is the current proof-backed
+  example.
+- Per-semantic parameter recognizers were folded into `is_param_value`, making
+  `ParamSemantic` the current internal vocabulary for receiver/domain proof
+  facts until packs provide versioned evidence records.
+- Rust scalar integer methods (`abs`, `min`, `max`, `clamp`) now consume a
+  language-, signature-, and integer-domain-constrained first-party contract
+  instead of a bare method-name recognizer. Float/NaN-sensitive methods remain a
+  separate future contract.
+
+## Phase 0: documentation and vocabulary
+
+- Define semantic-kernel goals, non-goals, responsibility model, and pack kinds.
+- Record the current implementation snapshot separately from the roadmap.
+- Link the direction from home, architecture, languages, and formal-soundness.
+- Keep docs honest: this is planned architecture, not current user-facing
+  capability.
+
+## Phase 1: kernel facade and fail-closed migration
+
+- Add a `nose-semantics` crate or module with stable internal types for language
+  profile, semantic facts, evaluation rules, effect summaries, protocol ops, API
+  contracts, law ids, and proof status.
+- Implement first-party built-in profiles by wrapping existing `Lang` matches.
+- Replace direct semantic `Lang` checks with named predicates where behavior is
+  already sound.
+- Tighten old name-only recognizers when the required proof does not exist yet,
+  even when this changes old convergence behavior.
+- Add tests proving language/arity/shadowing/receiver obligations for the facade.
+- Keep parser/lowering dispatch unchanged in this phase.
+
+## Phase 2: shared contracts for duplicated gates
+
+- Move primitive comparison gates behind `OperatorSemantics`.
+- Move index assignment and Java self-field exact gates behind `EffectSemantics`.
+- Move collection/map factory recognition into `LibraryApiContract` records.
+- Make value-graph and strict exact gates consume the same contract source.
+- Turn named value-graph rule modules into LawPack-facing law ids/contracts while
+  retaining formal-obligation metadata as the first-party proof boundary.
+- Add construct/call distinction facts so constructor-only contracts such as
+  JS/TS `new Map` and `new Set` can be reopened safely.
+- Add receiver/place facts so field read/write and property contracts are not
+  field-name-only.
+- Add provenance fields internally before exposing them in scan JSON.
+
+## Phase 3: first-party packs
+
+- Convert Python, JavaScript/TypeScript, Go, Rust, Java, C, Ruby, and embedded
+  JS/TS containers into first-party compiled packs.
+- Split stdlib knowledge into first-party `StdlibPack`s.
+- Define conformance manifests for each pack: positive convergence cases, hard
+  negatives, Raw coverage expectations, oracle coverage, and proof obligations.
+- Ensure existing docs and capabilities are generated from or checked against pack
+  metadata.
+
+## Phase 4: external pack contract
+
+- Define a versioned pack manifest schema.
+- Start with data-only external packs for simple APIs.
+- Add restricted recognizer hooks only after the manifest path is stable.
+- Require pack metadata: provider, license, version range, supported analysis
+  channels, evidence status, conformance commands, and semantic provenance ids.
+- Document the pack conformance checklist as part of the extension schema; make
+  clear that conformance evidence is provider/user responsibility unless the pack
+  is first-party.
+- Add user configuration for enabling external packs explicitly.
+- Report which external packs influenced `near` candidates and exact matches.
+
+The external schema must make proof obligations first-class. For example, a pack
+claiming `pkg.Foo.map` maps to the `Map` protocol must say how `pkg.Foo` is
+resolved, which versions it covers, how callback demand works, whether effects
+are delayed or eager, and which hard negatives distinguish it from same-named but
+different APIs.
+
+## Phase 5: demand-aware semantics
+
+- Model child demand: always, never, conditional, per-element pull,
+  short-circuit-until, maybe repeated, and call-by-need memoized.
+- Model effect visibility under demand: skipped effects, delayed effects,
+  per-element callback effects, async scheduling, yields, and stream emissions.
+- Refactor oracle and value graph to consume demand rules instead of local
+  hard-coded evaluation behavior.
+- Add lazy iterator/generator hard negatives before enabling new exact laws.
+
+## Phase 6: ecosystem packs
+
+- Add high-value first-party or community packs only when their contracts are
+  narrow and testable.
+- Candidate areas: Lodash, RxJS, NumPy, pandas, Java Streams/Guava, Rust Iterator
+  ecosystem helpers, Tokio futures, Rails ActiveSupport collection helpers.
+- Keep exact eligibility narrow. Many APIs should stay `near-only` because
+  versioning, mutability, callback effects, or dynamic dispatch make exact
+  equivalence too risky.
+
+## Open questions
+
+- How much of a pack should be data-only, and when is a restricted recognizer hook
+  justified?
+- Should external recognizers run as compiled Rust, WASM, or a sandboxed DSL?
+- What is the minimum provenance that scan JSON must expose without making reports
+  noisy?
+- How should users pin pack versions in CI?
+- How should conflicting packs or overlapping API contracts be resolved?
+- What conformance score is enough for a first-party pack to enter the default
+  exact channel?
+- Should a pack be able to express language-specific proof-producing lowering
+  extensions before the general construct/import/type fact model is complete?
+
+## Near-term acceptance criteria
+
+The first implementation PR should be considered successful if it:
+
+- introduces the semantic-kernel vocabulary and first compiled facade;
+- replaces proof-sensitive `Lang`/name matches with named semantic predicates or
+  fail-closed contracts;
+- records intentional old-behavior changes where missing evidence blocks exact
+  convergence;
+- keeps tests and docs checks green;
+- documents the first-party/external responsibility boundary;
+- makes it easier to explain why an exact match was accepted.

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -1,0 +1,156 @@
+# Semantic kernel snapshot
+
+Back to [semantic-kernel](semantic-kernel.md). This page records the current
+implementation shape; planned work and decision history live in
+[semantic-kernel-roadmap](semantic-kernel-roadmap.md).
+
+Snapshot date: 2026-06-07, `feature/semantic-kernel-packs` worktree against
+`origin/main`.
+
+## What exists today
+
+nose now has a first internal semantic-kernel facade, but most of the engine is
+still being migrated toward it.
+
+- `nose-il` defines a compact shared IL, `Lang`, `Builtin`, `HoFKind`, operators,
+  literals, source spans, units, and parameter semantic facts.
+- `nose-semantics` defines the first-party semantic profile facade: language,
+  operator, effect, fragment, module, stdlib, builtin, method-call, property,
+  async, iterator-adapter, builder-append, and factory contracts.
+- `nose-frontend` owns tree-sitter parsing, per-language lowering, embedded
+  `<script>` extraction, import facts, and Raw-node coverage.
+- `nose-normalize` owns desugaring, alpha-renaming, recursion normalization,
+  dataflow, CFG/algebra normalization, type-gated value-graph rules, and the
+  interpreter oracle.
+- proof-sensitive value-graph laws are starting to move into named rule modules
+  under `crates/nose-normalize/src/value_graph/rules/`; `clamp` and
+  `promise_then` are the current examples.
+- `nose-detect` owns unit extraction, exact fragment contracts, effect fragments,
+  value/shape features, candidate generation, clustering, and ranking.
+- `formal/obligations` records proof obligations for proof-sensitive rules.
+
+The current model already enforces the main product principle: exact semantic
+matches must be fail-closed and false merges are bugs.
+
+## Implemented facade contracts
+
+The current facade is compiled Rust, not an external manifest schema. It is
+intended to make the future pack extension boundary explicit while behavior is
+migrated.
+
+- Free-function builtin contracts are language- and arity-constrained and require
+  unshadowed builtin/global proof before exact lowering.
+- Method contracts carry receiver obligations such as exact collection, exact
+  protocol, exact option, exact string, exact primitive integer, exact map literal,
+  imported namespace, or unshadowed global.
+- Property builtin contracts are language-constrained; a selector such as
+  `length` is not enough without receiver proof. JS/TS `filter(...).length`
+  is admitted only after the receiver has already entered a proven collection/HOF
+  value.
+- Promise `.then` has a JS-like surface contract, but exact beta-reduction is
+  closed until a pack/frontend can prove a Promise-like receiver.
+- Rust iterator identity adapters (`iter`, `into_iter`, `collect`, `to_vec`,
+  `copied`, `cloned`) are language-, arity-, and receiver-proof constrained.
+- Builder append contracts are separate from arbitrary method calls: Java `add`
+  and Rust `push` are admitted only for active builder proofs.
+- Collection reductions such as Rust `Iterator::count()` and Java
+  `Stream.count()` are admitted through exact protocol receiver contracts, not
+  through a bare method-name check.
+- Map-key membership contracts now require map receiver proof. Examples include
+  Java `Map.containsKey`, Java `keySet().contains`, Rust `contains_key`, Rust
+  `get(key).is_some()`, and TypeScript `Array.from(map.keys()).includes(key)`
+  when the receiver is a typed/proven map.
+- JS/TS `new Map(...)` and `new Set(...)` remain closed because lowering does not
+  yet retain a constructor proof distinct from ordinary `Map(...)`/`Set(...)`.
+
+## Scattered semantic knowledge
+
+Semantic knowledge still appears in several forms outside the facade:
+
+- direct `Lang` checks and local recognizers in strict exact gates and value-graph
+  rules that have not yet been expressed as shared contracts;
+- factory recognizers such as Python collection factories, Ruby `Set.new`, Rust
+  `Vec::new`, Java `List.of`, and Java/Rust map factories;
+- module/import proof logic for immutable sibling-module literal bindings;
+- type facts and coarse type inference used to gate numeric and collection laws;
+- named value-graph rule modules that still consume internal `Builder` facts
+  instead of versioned `LawPack` records;
+- hard-coded oracle evaluation rules for eager calls, short-circuit operators,
+  HOFs, nullish defaulting, recursion, and effect traces;
+- duplicated strict exact gates in value-graph and unit/fragment extraction paths.
+
+These are valuable, but they do not yet share one complete semantic contract
+language.
+
+## Current strengths
+
+- Exact matching is conservative by design.
+- The value graph already separates behavioral fingerprints from fuzzy candidate
+  structure.
+- The oracle models return values, ordered effects, final field state, `Err`
+  behavior, short-circuit `and`/`or`, `any`/`all`, HOFs, recursion, and selected
+  interprocedural calls.
+- Proof-sensitive normalization already has named rule modules and a Lean
+  obligation registry.
+- Raw-node coverage gives a practical measure of lowering gaps.
+- Convergence tests and hard negatives catch many semantic boundary mistakes.
+
+## Current limits
+
+- Language semantics are not first-class. Many rules ask "which language is this?"
+  instead of "which semantic capability has been proven?"
+- Library semantics are embedded in engine code rather than declared as versioned
+  API contracts.
+- Evaluation strategy is not a shared model. Eager, short-circuit, pull-lazy,
+  call-by-need, async, and observable behavior are not represented by a common
+  demand/effect abstraction.
+- External extension points do not exist. New languages and libraries must be
+  added inside the main crates.
+- Report output does not yet expose semantic provenance such as pack id, contract
+  id, law id, or proof status.
+- First-party and external responsibility boundaries are not represented because
+  there are no loadable external packs yet.
+
+## Current fail-closed choices
+
+Several older convergence expectations are intentionally disabled or narrowed in
+this worktree because the required evidence is not yet modeled:
+
+- JS-like `.then(lambda)` does not converge with `await` code until Promise-like
+  receiver proof exists.
+- Plain JS/TS `Map` and `Set` constructor semantics do not enter exact matching
+  until constructor-vs-call proof exists.
+- Untyped JS/TS array method chains do not enter exact higher-order contracts
+  unless the receiver is a literal/proven collection surface.
+- Nested element method chains such as `xs.map(...)` inside a flat-map callback
+  stay closed unless the nested element collection proof is available. Explicit
+  nested builder loops can still converge with identity flat-map when their loop
+  structure proves the emitted elements.
+- Ruby untyped `Enumerable` methods, Ruby scalar/array `abs`/`min`/`max`, and C
+  `fmin`/`fmax` remain closed until the relevant receiver, stdlib, and overload
+  facts are modeled as contracts.
+- Rust scalar `.abs`, `.min`, `.max`, and `.clamp` are admitted only for the
+  current first-party primitive-integer domain. Rust float methods need a separate
+  float/NaN contract and proof before they can enter exact matching.
+
+These reduce recall in affected cases, but they are the correct precision trade
+until packs can emit the missing facts.
+
+## Known migration targets
+
+The first high-value targets for semantic-kernel extraction are:
+
+- field/place identity for field reads and writes, replacing field-name-only
+  state with receiver-aware proof;
+- constructor facts for JS/TS `new Map` and `new Set`;
+- resolved symbol facts for Java/Rust stdlib factories instead of path/name
+  heuristics;
+- nested collection element proofs for iterator chains and builder convergence;
+- Promise/future/thenable receiver facts;
+- demand/error contracts for language-core oracle behavior such as non-iterable
+  `for`/`foreach` evaluation;
+- LawPack-facing ids for named value-graph rules, with the existing formal
+  obligation metadata kept as the first-party proof boundary;
+- module export visibility, path resolution, and mutation proof;
+- provenance fields in scan JSON for pack id, contract id, law id, and evidence
+  status.

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -1,0 +1,287 @@
+# Semantic kernel and packs
+
+Back to [home](home.md). Current implementation status is in
+[semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and remaining
+work are tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md).
+
+## Context
+
+nose's long-term moat is not "more parsers". It is a precise, extensible model of
+what code means across many languages and libraries, strong enough to support exact
+semantic clone detection while still practical enough to run on real repositories.
+
+The current engine already has the right instincts: fail-closed exact matching,
+language-specific lowering, a value graph, an interpreter oracle, hard negatives,
+and Lean proof obligations for the most sensitive rewrites. The missing foundation
+is a single semantic boundary. Today, facts about language and library behavior
+are spread across frontends, normalization, fragment recognition, import proof
+logic, and the oracle. That makes new language work harder than it should be and
+makes soundness depend on scattered `Lang` checks.
+
+The semantic kernel is the boundary that all exact semantic reasoning must cross.
+The first internal facade now lives in `nose-semantics`; it is still a compiled
+first-party implementation, not a loadable external pack runtime.
+
+## Goal
+
+Build a research-grade, practical semantic kernel that:
+
+- represents language semantics explicitly: evaluation order, demand/laziness,
+  truthiness, nullability, exceptions, mutation, operator dispatch, overloadability,
+  and effect observability;
+- represents library semantics through versioned packs, not ad hoc builtin
+  recognizers;
+- lets first-party and external packs add language and library knowledge through
+  well-defined extension points;
+- keeps the exact `semantic` channel fail-closed unless the required semantic facts
+  and contracts are present;
+- keeps fuzzy or uncertain knowledge useful in candidate generation and `near`
+  ranking without letting it approve exact fingerprint equality;
+- records why a semantic match was accepted: which pack, contract, semantic facts,
+  laws, and proof or test status were involved.
+
+The standard is: a pack contributes semantic evidence; the kernel validates the
+evidence shape and decides whether it is admissible for a given analysis channel
+under the user's configured trust policy.
+
+## Non-goals
+
+- Do not make packs arbitrary plugins that can generate fingerprints or approve
+  exact equivalence directly.
+- Do not require nose to certify every external pack. nose validates the pack
+  format and runs fail-closed, but external pack correctness is the responsibility
+  of the pack provider and the user who enables it.
+- Do not merge language core semantics and library semantics into one table.
+  Python call-by-value, JavaScript `Array.prototype.map`, Rust `Iterator::map`,
+  RxJS `Observable.map`, and NumPy vector operations are different layers.
+- Do not make all library knowledge exact by default. Unresolved symbols,
+  monkey-patching, shadowing, overloads, dynamic imports, version uncertainty,
+  or missing hard negatives must demote a contract to `near` or reject it.
+- Do not hide semantic assumptions inside lowering. Lowering may emit facts, but
+  exact semantic acceptance must be decided by the kernel and its contracts.
+
+## Responsibility model
+
+There are two responsibility classes.
+
+**First-party packs** ship with nose and are maintained by this project. Their
+exact contracts must be covered by the same quality gates as the engine: regression
+tests, hard negatives, the interpreter oracle where applicable, benchmark checks,
+and Lean obligations for proof-sensitive laws.
+
+The first-party packs enabled by the default nose distribution are the **default
+packs**; nose owns their review, validation, and release quality.
+
+**External packs** are not approved or certified by nose. The provider owns their
+semantic claims, version constraints, tests, and documentation. The user owns the
+decision to enable them. nose's responsibility is to define the extension
+contract, validate that a pack declares its claims in that contract, keep exact
+analysis fail-closed when evidence is missing, and surface provenance in reports.
+
+This is similar in spirit to a "DefinitelyTyped for semantics" ecosystem, but the
+trust boundary is stricter: a type declaration can be wrong and still compile;
+an exact semantic contract can create a false merge. External packs therefore need
+clear conformance criteria, and users need visible provenance.
+
+## Pack kinds
+
+Every language and library, including the built-in ones, should eventually enter
+through the same extension points.
+
+| pack kind | purpose |
+|---|---|
+| `LanguagePack` | file detection, parser binding, surface lowering, core language semantics, and language-level proof facts |
+| `StdlibPack` | standard library APIs for a specific language/version |
+| `LibraryPack` | ecosystem APIs such as Lodash, RxJS, NumPy, Guava, Tokio, or Rails |
+| `ProtocolPack` | language-neutral semantic protocols such as `Iterable`, `Iterator`, `Stream`, `Option`, `Result`, `Map`, `Set`, `Future`, `Promise`, `Observable`, and `Tensor` |
+| `LawPack` | reusable semantic laws such as map fusion, filter fusion, monoid folds, short-circuit reductions, and nullish defaulting |
+
+First-party packs may be compiled Rust. External packs should start as data-only
+manifests for simple APIs, with restricted recognizer hooks added later for cases
+that require code. In both cases, packs emit kernel-defined facts and contracts,
+not private value-graph operations.
+
+Current named value-graph rule modules such as `value_graph/rules/clamp.rs` are
+the internal precursor to `LawPack` law ids. External packs may declare evidence
+and API facts that make a law applicable, but they must not bypass the first-party
+law registry or emit private canonical value-graph nodes.
+
+## Extension boundary
+
+Packs may:
+
+- lower source constructs to kernel-defined surface IR;
+- emit semantic facts such as proven type domains, non-shadowed builtins, unique
+  immutable imports, primitive array places, pure callbacks, pull iterators, or
+  memoized thunks;
+- declare API contracts that map resolved symbols to protocol operations;
+- declare evaluation and demand behavior for constructs and APIs;
+- declare effect summaries and exact/near eligibility;
+- provide conformance fixtures, hard negatives, and proof-obligation links.
+
+Packs may not:
+
+- mint arbitrary value fingerprints;
+- bypass the law registry;
+- mark a pair of units as exact clones;
+- assume symbol identity without the required resolution or shadowing proof;
+- turn uncertain dynamic behavior into exact facts;
+- mutate global kernel behavior outside their declared contracts.
+
+## Contract shape
+
+An API contract is not a name match. A contract must identify the surface it
+claims and the evidence required to admit it.
+
+At minimum, exact-capable contracts need:
+
+- a language or language-family constraint;
+- a symbol identity constraint: fully resolved symbol, imported namespace, proven
+  receiver protocol/type, or a language-defined unshadowed builtin/global;
+- signature constraints: arity, parameter roles, receiver position, overload
+  identity, and call shape, including whether the operation is a function,
+  method, constructor, property, operator, or macro-like surface;
+- shadowing, import, receiver, version, and overload preconditions;
+- argument demand, callback demand, effect summary, and return/protocol mapping;
+- channel eligibility and provenance ids.
+
+For example, "method named `map`" is not a semantic fact. `JavaScript
+Array.prototype.map`, `Rust Iterator::map`, `Ruby Enumerable#map`, and RxJS
+`Observable.map` have different demand and effect behavior. A pack may connect
+one of those surfaces to the common `Map` protocol only after it proves the
+surface is that API. If the current IL cannot prove the surface, the exact
+channel stays closed until the pack or frontend adds the missing fact.
+
+## Semantic axes
+
+The kernel needs first-class axes instead of language-name checks.
+
+### Evaluation and demand
+
+Lazy evaluation and short-circuiting cannot be modeled as a boolean. The kernel
+must represent when each child is demanded, how often it can be demanded, whether
+results are memoized, and in which order effects become observable.
+
+Examples:
+
+- eager call-by-value arguments, usually left-to-right;
+- conditional demand for `&&`, `||`, ternary, nullish defaulting, and exception
+  handlers;
+- pull-based iterator pipelines, where `map` and `filter` callbacks run only
+  when a terminal consumer demands elements;
+- call-by-need thunks with memoization;
+- async, promise, future, and observable APIs whose construction and observation
+  happen at different times.
+
+### Values and domains
+
+Algebraic laws are valid only inside the right value domain. Numeric `+`,
+string/list concatenation, overloaded operators, floating NaN, integer overflow,
+and tensor broadcasting cannot share one undifferentiated `Add`.
+
+The kernel should model domains such as numeric, boolean, string/free-monoid,
+sequence, map, set, option/nullish, result/error, future/promise, observable, and
+domain-specific collection types. Unknown stays top: exact rewrites fire only
+when a required domain is proven.
+
+### Effects and observations
+
+Behavior is not just a return value. The kernel must distinguish ordered effects,
+final state by place, local-only mutation, emitted streams, exceptions, async
+scheduling, yields, allocation identity when relevant, and opaque calls.
+
+For example, swapping two appends is observable, while writing two distinct
+constructor fields may be equivalent if the observable is final object state.
+Those are different effect equivalence classes.
+
+### Symbol and module facts
+
+Library semantics require reliable symbol identity. A pack contract for `sum`,
+`Array.prototype.map`, `Iterator::map`, or `Observable.map` is admissible only when
+resolution, receiver type, version, and shadowing rules prove that the call is the
+API the contract describes.
+
+### Laws and proof status
+
+Rewrites should be registered as semantic laws with explicit preconditions:
+required domains, effect conditions, demand conditions, and proof status.
+
+Proof statuses mirror [formal-soundness](formal-soundness.md): `proven`,
+`covered`, `missing`, `empirical-only`, and `rejected-counterexample`. First-party
+exact laws need project-owned evidence. External laws may declare evidence, but
+nose does not certify it unless the law ships as first-party.
+
+## Channel eligibility
+
+The same semantic knowledge can be safe for one channel and unsafe for another.
+
+| eligibility | use |
+|---|---|
+| `syntax-only` | parsing/lowering/reporting only |
+| `near-only` | candidate generation and review-oriented scoring |
+| `exact-empirical` | exact channel when required tests, hard negatives, and oracle coverage are present |
+| `exact-proven` | exact channel with proof obligations for the core law |
+| `first-party` | maintained and gated by the nose project |
+
+External packs may declare their intended eligibility, but users choose whether
+to trust that declaration. The default nose distribution should enable exact
+matching only for first-party packs and any external packs the user explicitly
+opts into.
+
+## Pack conformance
+
+The extension contract must define what a pack provider is expected to publish.
+Meeting these criteria is not nose certification; it is the minimum shape that
+lets users and tools evaluate whether a pack is trustworthy enough for their use.
+
+Every pack should declare:
+
+- stable pack id, provider, license, source repository, and support contact;
+- language, runtime, package, and version ranges it claims to model;
+- supported channels: `syntax-only`, `near-only`, `exact-empirical`, or
+  `exact-proven`;
+- semantic contracts with stable ids, including symbol/receiver constraints,
+  evaluation rules, effect summaries, return/protocol mapping, and exact
+  eligibility;
+- required facts for each exact contract, such as non-shadowing, resolved import,
+  receiver type, immutable binding, pure callback, or primitive operator proof;
+- conformance fixtures: positive convergence cases and hard negatives;
+- known unsound or unsupported boundaries;
+- proof status and links for any claimed `exact-proven` law;
+- provenance labels that can appear in reports.
+
+Packs that claim exact eligibility should also provide a reproducible conformance
+command. First-party packs must run that command in nose CI. External packs should
+ship it so users can run it, but nose does not promise to execute or approve it
+unless the pack is adopted as first-party.
+
+## Practical architecture
+
+The target shape is:
+
+```text
+source
+  -> LanguagePack parser/lowering
+  -> surface semantic IR + facts
+  -> kernel validation
+  -> core semantic IR
+  -> protocol/law normalization
+  -> value graph + oracle
+  -> detection/ranking/report provenance
+```
+
+This does not require a flag-day rewrite. The migration can start with wrappers
+around existing behavior: replace `Lang` checks with semantic predicates, then
+move duplicated library recognizers and strict gates behind shared contracts.
+
+## Design rule
+
+If a future contributor asks "can this exact match be accepted?", the answer
+should not be "because the file is Java" or "because this recognizer says so".
+It should be:
+
+1. which pack emitted the relevant facts;
+2. which API or construct contract matched;
+3. which semantic law applied;
+4. which domains, demand rules, and effect conditions were proven;
+5. which channel eligibility admitted the result.

--- a/formal/obligations/normalize/value_graph/clamp/meta.toml
+++ b/formal/obligations/normalize/value_graph/clamp/meta.toml
@@ -8,8 +8,21 @@ rule_module = true
 files = [
   "crates/nose-normalize/src/value_graph/rules/clamp.rs",
   "crates/nose-normalize/src/value_graph.rs",
+  "crates/nose-semantics/src/lib.rs",
 ]
-symbols = ["apply", "minmax_pattern"]
+symbols = [
+  "apply",
+  "minmax_pattern",
+  "clamp_ternary_pattern",
+  "eval_proven_integer_clamp_method_call",
+  "clamp_minmax_candidates",
+  "is_integer_domain_value",
+  "scalar_integer_method_contract",
+  "ScalarIntegerMethod",
+  "is_safe_clamp_integer_value",
+  "has_bound_order_fact",
+  "proof_backed_clamp_value",
+]
 
 [lean]
 proof = "Proof.lean"

--- a/formal/obligations/normalize/value_graph/min_max/meta.toml
+++ b/formal/obligations/normalize/value_graph/min_max/meta.toml
@@ -4,8 +4,20 @@ kind = "soundness"
 summary = "Min/max select idioms and accumulator reductions are commutative and associative over Int."
 
 [rust]
-files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/idioms.rs"]
-symbols = ["minmax_pattern", "MIN_CODE", "MAX_CODE"]
+files = [
+  "crates/nose-normalize/src/value_graph.rs",
+  "crates/nose-normalize/src/idioms.rs",
+  "crates/nose-semantics/src/lib.rs",
+]
+symbols = [
+  "minmax_pattern",
+  "eval_proven_integer_minmax_method_call",
+  "is_integer_domain_value",
+  "scalar_integer_method_contract",
+  "ScalarIntegerMethod",
+  "MIN_CODE",
+  "MAX_CODE",
+]
 
 [lean]
 proof = "Proof.lean"


### PR DESCRIPTION
## Summary
- add `nose-semantics` as the first-party semantic-kernel facade for language/profile/API contracts
- tighten exact semantic lowering around language, arity, receiver, shadowing, import, integer-domain, and append-effect evidence
- document semantic-kernel packs, snapshot, roadmap, responsibility boundaries, and latest-main adaptations

## Latest main review
- #93 deterministic family dedup: no semantic-pack change needed
- #94 shared sub-DAG lines: documented `locations[].shared_subdag` in scan JSON
- #95 clamp rule module: expanded formal metadata and tied named rule modules to future LawPack ids
- #96 non-iterable foreach Err: recorded as future language-core demand/error contract work
- #97 `is_param_value`: kept as internal proof-gate vocabulary until packs emit versioned evidence

## Verification
- `cargo fmt --check`
- `cargo check -p nose-semantics -p nose-normalize -p nose-frontend -p nose-detect --locked`
- `cargo test -p nose-semantics -p nose-normalize --locked -- --nocapture`
- `cargo test -p nose-detect --locked -- --nocapture`
- `cargo test -p nose-cli --test equivalence --locked -- --nocapture`
- `cargo test -p nose-cli --test cli --locked -- --nocapture`
- `python3 scripts/check-formal-obligations.py`
- `awiki lint --root docs`
- `./scripts/check-docs.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 의미 계약(semantic contracts) 시스템을 도입하여 언어별 라이브러리 의미를 일관되게 처리
  * 프로토콜, 이터레이터, 빌더 등 복잡한 언어 구조에 대한 정확한 인식 개선

* **Documentation**
  * 시맨틱 커널(semantic kernel) 아키텍처 및 로드맵 문서 추가
  * 채널별 인정 기준과 팩 확장성에 대한 설명 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->