### PR TITLE
Build proof-gated semantic kernel foundation

### DIFF
--- a/crates/nose-cli/tests/detection.rs
+++ b/crates/nose-cli/tests/detection.rs
@@ -131,11 +131,10 @@ fn sub_dag_family_annotates_each_site_with_shared_computation_lines() {
 }
 
 #[test]
-fn cross_language_family_groups_six_languages() {
-    // The same guarded-accumulator loop, written idiomatically in all six
-    // foreach-convergent languages, must land in ONE cross-language family — the
-    // headline capability. (C is excluded: it has no foreach, so its indexed loop
-    // converges to a different — and correctly distinct — IL shape.)
+fn cross_language_family_groups_proven_foreach_languages() {
+    // The same guarded-accumulator loop, written idiomatically in languages with proven foreach
+    // semantics, must land in ONE cross-language family. Ruby `.each` is present as a hard
+    // negative: it stays closed until a pack supplies receiver/protocol proof for `items`.
     let py = "def f(items):\n    total = 0\n    for x in items:\n        if x > 0:\n            total = total + x\n    return total\n";
     let ts = "function g(xs: number[]): number {\n    let acc = 0;\n    for (const v of xs) {\n        if (v > 0) {\n            acc = acc + v;\n        }\n    }\n    return acc;\n}\n";
     let go = "package m\nfunc H(items []int) int {\n\tsum := 0\n\tfor _, e := range items {\n\t\tif e > 0 {\n\t\t\tsum = sum + e\n\t\t}\n\t}\n\treturn sum\n}\n";
@@ -168,14 +167,17 @@ fn cross_language_family_groups_six_languages() {
         .find(|f| f.languages >= 2)
         .expect("a cross-language family must exist");
     assert!(
-        xlang.languages == 6 && xlang.members == 6,
-        "py/ts/go/rust/java/ruby accumulators form one 6-language, 6-site family (got {} langs, {} sites)",
+        xlang.languages == 5 && xlang.members == 5,
+        "py/ts/go/rust/java accumulators form one 5-language, 5-site family (got {} langs, {} sites)",
         xlang.languages,
         xlang.members
     );
     assert!(
-        xlang.locations.iter().all(|l| l.file != "decoy.py"),
-        "the decoy must not join the family"
+        xlang
+            .locations
+            .iter()
+            .all(|l| l.file != "decoy.py" && l.file != "acc.rb"),
+        "ruby each and the decoy must not join the proven foreach family"
     );
 }
 

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -2539,6 +2539,12 @@ fn rust_filter_map_converges_with_filtered_map_and_guarded_builder() {
         Lang::Rust,
         "f",
     );
+    let shadowed_none_rs = value_fp_named(
+        &i,
+        "const None: Option<i32> = Some(0);\nfn f(xs: &[i32]) -> Vec<i32> { xs.iter().copied().filter_map(|x| if x > 0 { Some(x * 2) } else { None }).collect() }",
+        Lang::Rust,
+        "f",
+    );
     let shadowed_vec_rs = value_fp_named(
         &i,
         "struct Vec;\nimpl Vec { fn new() -> Vec { Vec } fn push(&self, _value: i32) {} }\nfn f(xs: &[i32]) -> Vec { let out = Vec::new(); for x in xs { if *x > 0 { out.push(*x * 2); } } out }",
@@ -2597,6 +2603,10 @@ fn rust_filter_map_converges_with_filtered_map_and_guarded_builder() {
     assert_ne!(
         filtered_py, shadowed_some_rs,
         "a local Rust Some definition must not be treated as Option::Some"
+    );
+    assert_ne!(
+        filtered_py, shadowed_none_rs,
+        "a local Rust None definition must not be treated as Option::None"
     );
     assert_ne!(
         filtered_py, shadowed_vec_rs,
@@ -4617,6 +4627,7 @@ fn rust_if_let_option_presence_converges_with_option_predicates() {
     let if_some = "pub fn f(value: Option<i32>) -> bool {\n    if let Some(_) = value { true } else { false }\n}\n";
     let is_some = "pub fn g(value: Option<i32>) -> bool {\n    value.is_some()\n}\n";
     let if_none = "pub fn h(value: Option<i32>) -> bool {\n    if let None = value { true } else { false }\n}\n";
+    let shadowed_some_pattern = "struct Some<T>(T);\npub fn f(value: Some<i32>) -> bool {\n    if let Some(_) = value { true } else { false }\n}\n";
     assert_eq!(
         value_fp(&i, if_some, Lang::Rust),
         value_fp(&i, is_some, Lang::Rust),
@@ -4626,6 +4637,11 @@ fn rust_if_let_option_presence_converges_with_option_predicates() {
         value_fp(&i, if_some, Lang::Rust),
         value_fp(&i, if_none, Lang::Rust),
         "if let Some(_) must stay distinct from if let None"
+    );
+    assert_ne!(
+        value_fp(&i, if_some, Lang::Rust),
+        value_fp_named(&i, shadowed_some_pattern, Lang::Rust, "f"),
+        "a local Rust Some pattern must not be treated as Option::Some"
     );
 }
 

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -4583,6 +4583,7 @@ fn option_defaulting_converges_with_nullish_default_boundaries() {
     let wrong_value = "pub fn f(value: Option<i32>, fallback: i32, other: Option<i32>, other_default: i32) -> i32 { other.unwrap_or(fallback) }\n";
     let truthy_or =
         "function f(value, fallback, other, otherDefault) { return value || fallback; }";
+    let shadowed_undefined = "function f(value, fallback, other, otherDefault, undefined) { return value === undefined ? fallback : value; }";
 
     let fp = value_fp(&i, js, Lang::JavaScript);
     assert_eq!(fp, value_fp(&i, js_guard, Lang::JavaScript));
@@ -4594,6 +4595,7 @@ fn option_defaulting_converges_with_nullish_default_boundaries() {
     assert_ne!(fp, value_fp(&i, wrong_default, Lang::Rust));
     assert_ne!(fp, value_fp(&i, wrong_value, Lang::Rust));
     assert_ne!(fp, value_fp(&i, truthy_or, Lang::JavaScript));
+    assert_ne!(fp, value_fp(&i, shadowed_undefined, Lang::JavaScript));
 }
 
 #[test]

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -549,22 +549,22 @@ fn rust_recursion_converges_with_iteration_via_return_unwrap() {
 }
 
 #[test]
-fn ruby_shovel_builder_loop_converges_with_comprehension() {
-    // Ruby builds a list with `out = []; xs.each { |x| out << e }` — `<<` lowers to `Shl`.
-    // Recognizing `out << e` as the per-element build (scoped to Ruby AND the empty-Seq seed,
-    // so integer `a << b` shift never enters) makes it converge with the Python comprehension.
+fn ruby_shovel_builder_each_stays_closed_without_receiver_proof() {
+    // Ruby `xs.each { ... }` stays an ordinary block call until a pack supplies receiver/protocol
+    // proof for `xs`. The Ruby `<<` builder signal is still retained inside the opaque call body,
+    // but the default analyzer must not infer Enumerable semantics from the method name alone.
     let i = Interner::new();
     let py_comp = "def f(xs):\n    return [x * x for x in xs]\n";
     let ruby_build = "def f(xs)\n  out = []\n  xs.each { |x| out << x * x }\n  out\nend\n";
     let ruby_diff = "def f(xs)\n  out = []\n  xs.each { |x| out << x + 1 }\n  out\nend\n";
     let comp_fp = value_fp(&i, py_comp, Lang::Python);
-    assert_eq!(
-        comp_fp,
-        value_fp(&i, ruby_build, Lang::Ruby),
-        "ruby << builder loop must converge with the python comprehension"
-    );
     assert_ne!(
         comp_fp,
+        value_fp(&i, ruby_build, Lang::Ruby),
+        "ruby each builder must stay closed without receiver/protocol proof"
+    );
+    assert_ne!(
+        value_fp(&i, ruby_build, Lang::Ruby),
         value_fp(&i, ruby_diff, Lang::Ruby),
         "a different per-element contribution must stay distinct"
     );
@@ -908,7 +908,11 @@ fn c_pointer_length_contract_converges_cross_language() {
 
     let c_fp = value_fp(&i, c, Lang::C);
     assert_eq!(c_fp, value_fp(&i, java, Lang::Java));
-    assert_eq!(c_fp, value_fp(&i, ruby, Lang::Ruby));
+    assert_ne!(
+        c_fp,
+        value_fp(&i, ruby, Lang::Ruby),
+        "ruby each must stay closed until receiver/protocol proof exists"
+    );
     assert_ne!(c_fp, value_fp(&i, param_order_not_contract, Lang::C));
     assert_ne!(c_fp, value_fp(&i, inclusive, Lang::C));
 }
@@ -927,7 +931,11 @@ fn c_integer_boolean_any_all_converge_cross_language() {
     let non_bool_return = "int f(int *xs, int n) { for (int i = 0; i < n; i++) { if (xs[i] == 0) { return 2; } } return 0; }";
 
     let any_fp = value_fp(&i, c_any, Lang::C);
-    assert_eq!(any_fp, value_fp(&i, ruby_any, Lang::Ruby));
+    assert_ne!(
+        any_fp,
+        value_fp(&i, ruby_any, Lang::Ruby),
+        "ruby each must stay closed until receiver/protocol proof exists"
+    );
     assert_eq!(any_fp, value_fp(&i, java_any, Lang::Java));
     assert_eq!(
         value_fp(&i, c_all, Lang::C),
@@ -1028,7 +1036,11 @@ fn dot_product_converges_across_index_zip_and_enumerate() {
     assert_eq!(fp, value_fp(&i, go_for, Lang::Go));
     assert_eq!(fp, value_fp(&i, rust_range, Lang::Rust));
     assert_eq!(fp, value_fp(&i, rust_zip, Lang::Rust));
-    assert_eq!(fp, value_fp(&i, ruby_each, Lang::Ruby));
+    assert_ne!(
+        fp,
+        value_fp(&i, ruby_each, Lang::Ruby),
+        "ruby each_with_index must stay closed until receiver/protocol proof exists"
+    );
     assert_ne!(fp, value_fp(&i, ruby_while, Lang::Ruby));
     assert_eq!(
         return_fp(&i, py_loop, Lang::Python),
@@ -1796,7 +1808,7 @@ fn comprehension_converges_with_js_map() {
 }
 
 #[test]
-fn find_max_converges_py_rust_ruby() {
+fn find_max_converges_py_rust_but_ruby_each_stays_closed() {
     // A second algorithm shape (index `items[0]`, compare, branch-assign) converges
     // across languages — guards against shape-specific convergence over-fitting.
     let i = Interner::new();
@@ -1809,10 +1821,10 @@ fn find_max_converges_py_rust_ruby() {
         unit_hash(&i, rs, Lang::Rust),
         "python == rust (find-max)"
     );
-    assert_eq!(
+    assert_ne!(
         h,
         unit_hash(&i, rb, Lang::Ruby),
-        "python == ruby (find-max)"
+        "ruby each must stay closed until receiver/protocol proof exists"
     );
 }
 
@@ -1858,17 +1870,18 @@ fn c_non_equivalent_different_op_differ() {
 }
 
 #[test]
-fn ruby_each_converges_with_python_foreach() {
-    // Ruby `xs.each { |x| … }` and a Python `for x in xs` loop share IL shape.
+fn ruby_each_stays_closed_without_receiver_proof() {
+    // Ruby `xs.each { |x| ... }` is just a method call unless a pack proves that `xs` has
+    // Ruby Enumerable semantics. The analyzer must not infer a foreach loop from the name `each`.
     let i = Interner::new();
     let rb =
         "def f(items)\n  total = 0\n  items.each do |x|\n    total += x\n  end\n  total\nend\n";
     let py =
         "def f(items):\n    total = 0\n    for x in items:\n        total += x\n    return total\n";
-    assert_eq!(
+    assert_ne!(
         unit_hash(&i, rb, Lang::Ruby),
         unit_hash(&i, py, Lang::Python),
-        "ruby each == python for"
+        "ruby each must stay closed without receiver/protocol proof"
     );
 }
 

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -1086,6 +1086,7 @@ fn scalar_abs_builtins_converge_cross_language_with_shadow_boundary() {
         "pub fn f(value: i64, other: i64) -> i64 { let magnitude = value.abs(); magnitude + other }\n";
     let shadowed_js = "function f(Math, value, other) { const magnitude = Math.abs(value); return magnitude + other; }";
     let local_shadowed_js = "function f(value, other) { const Math = { abs: function(_value) { return 0; } }; const magnitude = Math.abs(value); return magnitude + other; }";
+    let java_shadowed_math_param = "class Math { int abs(int value) { return 0; } }\nclass C { static int f(Math Math, int value, int other) { int magnitude = Math.abs(value); return magnitude + other; } }\n";
     let ts_number_method_abs = "function f(value: number, other: number): number { const magnitude = value.abs(); return magnitude + other; }";
     let rust_float_abs = "pub fn f(value: f64, other: f64) -> f64 { let magnitude = value.abs(); magnitude + other }\n";
     let custom_rust_abs = "struct Wrap(i64);\nimpl Wrap { fn abs(&self) -> i64 { 0 } }\npub fn f(value: Wrap) -> i64 { let magnitude = value.abs(); magnitude + 1 }\n";
@@ -1098,6 +1099,10 @@ fn scalar_abs_builtins_converge_cross_language_with_shadow_boundary() {
     assert_eq!(fp, value_fp(&i, rust_abs, Lang::Rust));
     assert_ne!(fp, value_fp(&i, shadowed_js, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, local_shadowed_js, Lang::JavaScript));
+    assert_ne!(
+        fp,
+        value_fp_named(&i, java_shadowed_math_param, Lang::Java, "f")
+    );
     assert_ne!(fp, value_fp(&i, ts_number_method_abs, Lang::TypeScript));
     assert_ne!(fp, value_fp(&i, rust_float_abs, Lang::Rust));
     assert_ne!(fp, value_fp(&i, custom_rust_abs, Lang::Rust));
@@ -1126,6 +1131,7 @@ fn scalar_minmax_builtins_converge_cross_language_with_shadow_boundary() {
     let py_shadowed_min =
         "def min(_left, _right):\n    return 0\n\ndef f(left, right, other):\n    selected = min(left, right)\n    return selected + other\n";
     let shadowed_js = "function f(left, right, other) { const Math = { min: function(_left, _right) { return 0; } }; const selected = Math.min(left, right); return selected + other; }";
+    let java_shadowed_math_type = "class C { static int f(int left, int right, int other) { int selected = Math.min(left, right); return selected + other; } }\nclass Math { static int min(int left, int right) { return 0; } }\n";
     let ts_number_method_min = "function f(left: number, right: number, other: number): number { const selected = left.min(right); return selected + other; }";
     let rust_float_min = "pub fn f(left: f64, right: f64, other: f64) -> f64 { let selected = left.min(right); selected + other }\n";
     let custom_rust_min = "struct Wrap(i64);\nimpl Wrap { fn min(&self, _right: i64) -> i64 { 0 } }\npub fn f(left: Wrap, right: i64, other: i64) -> i64 { let selected = left.min(right); selected + other }\n";
@@ -1152,6 +1158,10 @@ fn scalar_minmax_builtins_converge_cross_language_with_shadow_boundary() {
     assert_ne!(fp, value_fp(&i, py_wrong_value, Lang::Python));
     assert_ne!(fp, value_fp(&i, py_shadowed_min, Lang::Python));
     assert_ne!(fp, value_fp(&i, shadowed_js, Lang::JavaScript));
+    assert_ne!(
+        fp,
+        value_fp_named(&i, java_shadowed_math_type, Lang::Java, "f")
+    );
     assert_ne!(fp, value_fp(&i, ts_number_method_min, Lang::TypeScript));
     assert_ne!(fp, value_fp(&i, rust_float_min, Lang::Rust));
     assert_ne!(fp, value_fp(&i, custom_rust_min, Lang::Rust));

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -3298,6 +3298,7 @@ fn map_key_membership_converges_cross_language_with_boundaries() {
     let ruby = "def f(lookup, other_lookup, key, other)\n  lookup.key?(key)\nend\n";
     let ruby_has = "def f(lookup, other_lookup, key, other)\n  lookup.has_key?(key)\nend\n";
     let ts_array_from_keys = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return Array.from(lookup.keys()).includes(key); }";
+    let ts_direct_keys_includes = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return lookup.keys().includes(key); }";
     let typed_set_same_names = "function f(lookup: Set<string>, other_lookup: Set<string>, key: string, other: string): boolean { return lookup.has(key); }";
     let wrong_key =
         "def f(lookup, other_lookup, key, other):\n    return lookup.__contains__(other)\n";
@@ -3324,6 +3325,11 @@ fn map_key_membership_converges_cross_language_with_boundaries() {
     assert_ne!(fp, value_fp(&i, ruby, Lang::Ruby));
     assert_ne!(fp, value_fp(&i, ruby_has, Lang::Ruby));
     assert_eq!(fp, value_fp(&i, ts_array_from_keys, Lang::TypeScript));
+    assert_ne!(
+        fp,
+        value_fp(&i, ts_direct_keys_includes, Lang::TypeScript),
+        "Map.keys() is an iterator view; direct .includes is not a proven key-view collection"
+    );
     assert_ne!(fp, value_fp(&i, typed_set_same_names, Lang::TypeScript));
     assert_ne!(fp, value_fp(&i, wrong_key, Lang::Python));
     assert_ne!(fp, value_fp(&i, wrong_map, Lang::Python));

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -447,6 +447,9 @@ fn java_stream_aggregates_converge_with_loops() {
     let all_stream = "import java.util.Arrays; class C { static boolean f(int[] xs) { return Arrays.stream(xs).allMatch(x -> x >= 0); } }";
     let bad_seed =
         "import java.util.Arrays; class C { static int f(int[] xs) { return Arrays.stream(xs).filter(x -> x > 0).reduce(1, (total, x) -> total + x); } }";
+    let missing_arrays_import = "class C { static int f(int[] xs) { return Arrays.stream(xs).filter(x -> x > 0).reduce(0, (total, x) -> total + x); } }";
+    let shadowed_arrays =
+        "import java.util.Arrays; class Arrays {} class C { static int f(int[] xs) { return Arrays.stream(xs).filter(x -> x > 0).reduce(0, (total, x) -> total + x); } }";
     let sum_fp = value_fp(&i, sum_loop, Lang::Java);
     assert_eq!(sum_fp, value_fp(&i, sum_stream, Lang::Java));
     assert_eq!(
@@ -462,6 +465,8 @@ fn java_stream_aggregates_converge_with_loops() {
         value_fp(&i, all_stream, Lang::Java)
     );
     assert_ne!(sum_fp, value_fp(&i, bad_seed, Lang::Java));
+    assert_ne!(sum_fp, value_fp(&i, missing_arrays_import, Lang::Java));
+    assert_ne!(sum_fp, value_fp(&i, shadowed_arrays, Lang::Java));
 }
 
 #[test]

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -854,11 +854,18 @@ fn python_math_prod_converges_with_product_loop() {
     let loop_py = "def f(xs):\n    product = 1\n    for x in xs:\n        if x > 0:\n            product *= x\n    return product\n";
     let prod_py =
         "import math\n\ndef f(xs):\n    return math.prod((x for x in xs if x > 0), start=1)\n";
+    let aliased_prod_py =
+        "import math as m\n\ndef f(xs):\n    return m.prod((x for x in xs if x > 0), start=1)\n";
     let bad_seed =
         "import math\n\ndef f(xs):\n    return math.prod((x for x in xs if x > 0), start=2)\n";
+    let missing_import = "def f(xs):\n    return math.prod((x for x in xs if x > 0), start=1)\n";
+    let shadowed_math = "import math\nmath = object()\n\ndef f(xs):\n    return math.prod((x for x in xs if x > 0), start=1)\n";
     let loop_fp = value_fp(&i, loop_py, Lang::Python);
     assert_eq!(loop_fp, value_fp(&i, prod_py, Lang::Python));
+    assert_eq!(loop_fp, value_fp(&i, aliased_prod_py, Lang::Python));
     assert_ne!(loop_fp, value_fp(&i, bad_seed, Lang::Python));
+    assert_ne!(loop_fp, value_fp(&i, missing_import, Lang::Python));
+    assert_ne!(loop_fp, value_fp(&i, shadowed_math, Lang::Python));
 }
 
 #[test]

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -3486,6 +3486,8 @@ fn collection_membership_set_construction_converges_with_boundaries() {
     let js_module_set =
         "const VALUES = new Set([\"red\", \"blue\"]);\nfunction f(value, other) { return VALUES.has(value); }";
     let ts_module_set = "const VALUES = new Set<string>([\"red\", \"blue\"]);\nfunction f(value: string, other: string): boolean { return VALUES.has(value); }";
+    let js_array_contains =
+        "function f(value, other) { return [\"red\", \"blue\"].contains(value); }";
     let js_array_some =
         "function f(value, other) { return [\"red\", \"blue\"].some((item) => item === value); }";
     let ts_array_some = "function f(value: string, other: string): boolean { return [\"red\", \"blue\"].some((item: string) => item === value); }";
@@ -3634,6 +3636,11 @@ fn collection_membership_set_construction_converges_with_boundaries() {
     assert_ne!(literal_fp, value_fp(&i, js_set_local, Lang::JavaScript));
     assert_ne!(literal_fp, value_fp(&i, js_module_set, Lang::JavaScript));
     assert_ne!(literal_fp, value_fp(&i, ts_module_set, Lang::TypeScript));
+    assert_ne!(
+        literal_fp,
+        value_fp(&i, js_array_contains, Lang::JavaScript),
+        "JavaScript .contains is not a standard array membership contract"
+    );
     assert_eq!(literal_fp, value_fp(&i, js_array_some, Lang::JavaScript));
     assert_eq!(literal_fp, value_fp(&i, ts_array_some, Lang::TypeScript));
     assert_eq!(
@@ -4360,6 +4367,11 @@ fn literal_map_default_lookup_converges_with_non_python_imported_bindings() {
     )
     .unwrap();
     std::fs::write(
+        dir.join("rust_imported_shadowed_std.rs"),
+        "use tables::LOOKUP;\n\nmod std { pub mod collections { pub struct HashMap; } }\n\npub fn lookup(key: &str, other: &str) -> i32 {\n    *std::collections::HashMap::from(LOOKUP).get(key).unwrap_or(&0)\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
         dir.join("wrong_tables.rs"),
         "pub const LOOKUP: [(&str, i32); 2] = [(\"red\", 9), (\"blue\", 2)];\n",
     )
@@ -4391,6 +4403,11 @@ fn literal_map_default_lookup_converges_with_non_python_imported_bindings() {
         local,
         corpus_value_fp(&corpus, "rust_imported.rs", "lookup"),
         "Rust use-imported const entries should prove the same map/default coordinates"
+    );
+    assert_ne!(
+        local,
+        corpus_value_fp(&corpus, "rust_imported_shadowed_std.rs", "lookup"),
+        "a local Rust std module must block imported std map factory provenance"
     );
     assert_ne!(
         local,

--- a/crates/nose-detect/src/fragment/conditional_guard.rs
+++ b/crates/nose-detect/src/fragment/conditional_guard.rs
@@ -9,8 +9,11 @@
 use super::contract::{Effect, EffectSite, FragmentContract};
 use super::oracle::free_input_cids;
 use super::{Exit, FragmentKind};
-use nose_il::{Builtin, Il, Interner, NodeId, NodeKind, Payload};
-use nose_semantics::{builder_append_method_contract, semantics};
+use nose_il::{Il, Interner, NodeId, NodeKind, Payload};
+use nose_semantics::{
+    builder_append_call_args, exact_java_this_field, exact_non_overloadable_index_assignment,
+    exact_non_overloadable_index_assignment_parts, semantics,
+};
 use rustc_hash::FxHashSet;
 
 pub(crate) fn recognize_conditional_guard(
@@ -507,7 +510,7 @@ fn self_field_assignment_site(il: &Il, interner: &Interner, node: NodeId) -> Opt
         .exact_fragments()
         .java_this_field_place()
         && kids.len() == 2
-        && is_java_this_field(il, interner, kids[0])
+        && exact_java_this_field(il, interner, kids[0])
     {
         let place = super::recognize::resolve_place(il, interner, kids[0]);
         return place
@@ -551,12 +554,7 @@ fn append_statement(il: &Il, interner: &Interner, stmt: NodeId) -> bool {
 }
 
 fn index_assignment(il: &Il, node: NodeId) -> bool {
-    semantics(il.meta.lang)
-        .exact_fragments()
-        .non_overloadable_index_assignment()
-        && il.kind(node) == NodeKind::Assign
-        && il.children(node).len() == 2
-        && il.kind(il.children(node)[0]) == NodeKind::Index
+    exact_non_overloadable_index_assignment(il, node)
 }
 
 fn loop_effect_sites(il: &Il, interner: &Interner, node: NodeId) -> Option<Vec<EffectSite>> {
@@ -793,44 +791,15 @@ fn block_children_exact_len(il: &Il, node: NodeId, len: usize) -> Option<&[NodeI
 }
 
 fn append_call_args(il: &Il, interner: &Interner, node: NodeId) -> Option<(NodeId, NodeId)> {
-    if !is_append_call(il, interner, node) {
-        return None;
-    }
-    let kids = il.children(node);
-    if matches!(il.node(node).payload, Payload::Builtin(Builtin::Append)) {
-        return Some((kids[0], kids[1]));
-    }
-    let receiver = *il.children(kids[0]).first()?;
-    Some((receiver, kids[1]))
+    builder_append_call_args(il, interner, node)
 }
 
 fn is_append_call(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if il.kind(node) != NodeKind::Call {
-        return false;
-    }
-    let kids = il.children(node);
-    if matches!(il.node(node).payload, Payload::Builtin(Builtin::Append)) {
-        return kids.len() == 2;
-    }
-    let Some((&callee, args)) = kids.split_first() else {
-        return false;
-    };
-    if args.len() != 1 || il.kind(callee) != NodeKind::Field {
-        return false;
-    }
-    let Payload::Name(method) = il.node(callee).payload else {
-        return false;
-    };
-    builder_append_method_contract(il.meta.lang, interner.resolve(method), args.len())
+    builder_append_call_args(il, interner, node).is_some()
 }
 
 fn index_assignment_parts(il: &Il, node: NodeId) -> Option<(NodeId, Option<NodeId>, NodeId)> {
-    if !index_assignment(il, node) {
-        return None;
-    }
-    let kids = il.children(node);
-    let target = il.children(kids[0]);
-    Some((*target.first()?, target.get(1).copied(), kids[1]))
+    exact_non_overloadable_index_assignment_parts(il, node)
 }
 
 fn local_nontrivial_assignment(il: &Il, node: NodeId) -> Option<(u32, NodeId)> {
@@ -853,30 +822,6 @@ fn local_nontrivial_assignment(il: &Il, node: NodeId) -> Option<(u32, NodeId)> {
         return None;
     }
     Some((cid, kids[1]))
-}
-
-fn is_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        || il.kind(node) != NodeKind::Field
-    {
-        return false;
-    }
-    if !matches!(il.node(node).payload, Payload::Name(_)) {
-        return false;
-    }
-    il.children(node)
-        .first()
-        .is_some_and(|&receiver| is_java_this_var(il, interner, receiver))
-}
-
-fn is_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        && il.kind(node) == NodeKind::Var
-        && matches!(il.node(node).payload, Payload::Name(name) if interner.resolve(name) == "this")
 }
 
 fn mentions_any(il: &Il, node: NodeId, cids: &FxHashSet<u32>) -> bool {

--- a/crates/nose-detect/src/fragment/loop_effect.rs
+++ b/crates/nose-detect/src/fragment/loop_effect.rs
@@ -18,8 +18,8 @@
 use super::contract::{Effect, EffectSite, FragmentContract};
 use super::oracle::free_input_cids;
 use super::{Exit, FragmentKind};
-use nose_il::{Builtin, Il, Interner, LoopKind, NodeId, NodeKind, Payload};
-use nose_semantics::{builder_append_method_contract, semantics};
+use nose_il::{Il, Interner, LoopKind, NodeId, NodeKind, Payload};
+use nose_semantics::{builder_append_call_args, exact_non_overloadable_index_assignment_parts};
 use rustc_hash::FxHashSet;
 
 /// Recognize `node` as a `LoopEffect` contract, or `None` if it is not the shape.
@@ -393,43 +393,13 @@ fn index_assignment_consumes_chained_temp(
 
 /// `(receiver, value)` of an `append`/`push` builtin call with exactly two children.
 fn append_call_args(il: &Il, interner: &Interner, node: NodeId) -> Option<(NodeId, NodeId)> {
-    if il.kind(node) != NodeKind::Call {
-        return None;
-    }
-    let kids = il.children(node);
-    if matches!(il.node(node).payload, Payload::Builtin(Builtin::Append)) {
-        return (kids.len() == 2).then(|| (kids[0], kids[1]));
-    }
-    let (&callee, args) = kids.split_first()?;
-    if args.len() != 1 || il.kind(callee) != NodeKind::Field {
-        return None;
-    }
-    let Payload::Name(method) = il.node(callee).payload else {
-        return None;
-    };
-    if !builder_append_method_contract(il.meta.lang, interner.resolve(method), args.len()) {
-        return None;
-    }
-    let receiver = *il.children(callee).first()?;
-    Some((receiver, args[0]))
+    builder_append_call_args(il, interner, node)
 }
 
 /// `(receiver, key, value)` of a non-overloadable `recv[key] = value` index assignment
 /// (C/Go/Java only — the same surface the migrated `IndexAssignEffect` admits).
 fn index_assignment_parts(il: &Il, node: NodeId) -> Option<(NodeId, Option<NodeId>, NodeId)> {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .non_overloadable_index_assignment()
-    {
-        return None;
-    }
-    let kids = il.children(node);
-    if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Index {
-        return None;
-    }
-    let target = il.children(kids[0]);
-    let receiver = *target.first()?;
-    Some((receiver, target.get(1).copied(), kids[1]))
+    exact_non_overloadable_index_assignment_parts(il, node)
 }
 
 /// A local `var = rhs` where `rhs` is not a bare var/lit and does not read the target itself.

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -16,9 +16,8 @@
 use super::contract::{Effect, EffectSite, FragmentContract};
 use super::oracle::free_input_cids;
 use super::{Exit, FragmentKind, Place};
-use crate::units::{exact_java_this_field, exact_java_this_var};
-use nose_il::{stable_symbol_hash, Builtin, Il, Interner, NodeId, NodeKind, Payload};
-use nose_semantics::{builder_append_method_contract, semantics};
+use nose_il::{stable_symbol_hash, Il, Interner, NodeId, NodeKind, Payload};
+use nose_semantics::{builder_append_call, exact_java_this_field, exact_java_this_var, semantics};
 
 /// Fragment kinds that have been migrated onto the contract path. The differential gate
 /// compares the predicate and contract paths over exactly this set; everything outside it
@@ -161,23 +160,7 @@ fn expr_effect_shape(il: &Il, kids: &[NodeId]) -> bool {
 }
 
 fn is_append_call(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if il.kind(node) != NodeKind::Call {
-        return false;
-    }
-    let kids = il.children(node);
-    if matches!(il.node(node).payload, Payload::Builtin(Builtin::Append)) {
-        return kids.len() == 2;
-    }
-    let Some((&callee, args)) = kids.split_first() else {
-        return false;
-    };
-    if args.len() != 1 || il.kind(callee) != NodeKind::Field {
-        return false;
-    }
-    let Payload::Name(method) = il.node(callee).payload else {
-        return false;
-    };
-    builder_append_method_contract(il.meta.lang, interner.resolve(method), args.len())
+    builder_append_call(il, interner, node)
 }
 
 fn effect_contract(

--- a/crates/nose-detect/src/fragment/self_field_body.rs
+++ b/crates/nose-detect/src/fragment/self_field_body.rs
@@ -10,8 +10,8 @@
 use super::contract::{Effect, EffectSite, FragmentContract};
 use super::oracle::free_input_cids;
 use super::{Exit, FragmentKind};
-use nose_il::{Il, Interner, NodeId, NodeKind, Payload};
-use nose_semantics::semantics;
+use nose_il::{Il, Interner, NodeId, NodeKind};
+use nose_semantics::{exact_java_return_this, exact_java_this_field, semantics};
 
 pub(crate) fn recognize_self_field_body(
     il: &Il,
@@ -38,7 +38,7 @@ pub(crate) fn recognize_self_field_body(
     let mut effects = Vec::new();
     let mut has_field_effect = false;
     for (idx, &child) in kids.iter().enumerate() {
-        if is_java_return_this(il, interner, child) {
+        if exact_java_return_this(il, interner, child) {
             if idx + 1 != kids.len() {
                 return None;
             }
@@ -117,7 +117,7 @@ fn self_field_assign(
     effects: &mut Vec<EffectSite>,
 ) -> Option<()> {
     let kids = il.children(node);
-    if kids.len() != 2 || !is_java_this_field(il, interner, kids[0]) {
+    if kids.len() != 2 || !exact_java_this_field(il, interner, kids[0]) {
         return None;
     }
     let place = super::recognize::resolve_place(il, interner, kids[0]);
@@ -126,40 +126,4 @@ fn self_field_assign(
     }
     effects.push(EffectSite::at(Effect::FieldWrite, place));
     Some(())
-}
-
-fn is_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        || il.kind(node) != NodeKind::Field
-    {
-        return false;
-    }
-    if !matches!(il.node(node).payload, Payload::Name(_)) {
-        return false;
-    }
-    il.children(node)
-        .first()
-        .is_some_and(|&receiver| is_java_this_var(il, interner, receiver))
-}
-
-fn is_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        && il.kind(node) == NodeKind::Var
-        && matches!(il.node(node).payload, Payload::Name(name) if interner.resolve(name) == "this")
-}
-
-fn is_java_return_this(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        || il.kind(node) != NodeKind::Return
-    {
-        return false;
-    }
-    let kids = il.children(node);
-    kids.len() == 1 && is_java_this_var(il, interner, kids[0])
 }

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -16,7 +16,10 @@ use nose_semantics::{
     builder_append_call_args, domain_evidence_from_param_semantic, exact_java_return_this,
     exact_java_this_field, exact_non_overloadable_index_assignment,
     exact_non_overloadable_index_assignment_parts, iterator_identity_adapter_contract,
-    rust_vec_new_factory_contract, semantics,
+    java_collection_factory_contract, java_map_entry_contract, java_map_factory_contract,
+    js_like_map_constructor_contract, js_like_set_constructor_contract, method_call_contract,
+    ruby_set_factory_contract, rust_vec_new_factory_contract, semantics, JavaMapFactoryKind,
+    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1224,48 +1227,19 @@ fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, nod
         return strict_exact_field_receiver_name(il, interner, callee, "Array")
             && strict_exact_call_args_safe(il, interner, facts, node);
     }
-    if matches!(
-        method,
-        "contains" | "__contains__" | "include?" | "member?" | "includes"
-    ) {
-        let Some(&receiver) = il.children(callee).first() else {
-            return false;
-        };
-        if strict_exact_literal_collection_receiver_safe(il, interner, facts, receiver)
-            || strict_exact_proven_collection_receiver_safe(il, facts, receiver)
-            || strict_exact_python_collection_factory_safe(il, interner, facts, receiver)
-            || strict_exact_ruby_set_factory_safe(il, interner, facts, receiver)
-            || strict_exact_rust_vec_macro_collection_safe(il, interner, facts, receiver)
-            || strict_exact_rust_std_collection_factory_safe(il, interner, facts, receiver)
-            || strict_exact_java_collection_factory_safe(il, interner, facts, receiver)
-            || strict_exact_map_key_view_collection_safe(il, interner, facts, receiver)
-        {
-            return strict_exact_call_args_safe(il, interner, facts, node);
-        }
+    if strict_exact_collection_contains_call_safe(il, interner, facts, node, callee, method) {
+        return true;
     }
-    if matches!(
-        method,
-        "get" | "has" | "getOrDefault" | "containsKey" | "contains_key" | "key?" | "has_key?"
-    ) {
+    if strict_exact_map_contains_call_safe(il, interner, facts, node, callee, method) {
+        return true;
+    }
+    if matches!(method, "get" | "getOrDefault") {
         let Some(&receiver) = il.children(callee).first() else {
             return false;
         };
         if method == "get"
             && strict_exact_proven_map_receiver_safe(il, facts, receiver)
             && matches!(il.children(node).len(), 2 | 3)
-        {
-            return strict_exact_call_args_safe(il, interner, facts, node);
-        }
-        if method == "has"
-            && (strict_exact_proven_map_receiver_safe(il, facts, receiver)
-                || strict_exact_proven_collection_receiver_safe(il, facts, receiver))
-            && il.children(node).len() == 2
-        {
-            return strict_exact_call_args_safe(il, interner, facts, node);
-        }
-        if matches!(method, "containsKey" | "contains_key" | "key?" | "has_key?")
-            && strict_exact_proven_map_receiver_safe(il, facts, receiver)
-            && il.children(node).len() == 2
         {
             return strict_exact_call_args_safe(il, interner, facts, node);
         }
@@ -1292,6 +1266,89 @@ fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, nod
     // without assigning semantic meaning to the method name. Cross-language/builtin
     // convergence still has to pass the proof-backed contracts above or in normalization.
     strict_exact_callee_identity(il, facts, callee)
+        && strict_exact_call_args_safe(il, interner, facts, node)
+}
+
+fn strict_exact_collection_contains_call_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+    callee: NodeId,
+    method: &str,
+) -> bool {
+    let Some(contract) = method_call_contract(
+        il.meta.lang,
+        method,
+        il.children(node).len().saturating_sub(1),
+    ) else {
+        return false;
+    };
+    if contract.semantic != MethodSemanticContract::Builtin(Builtin::Contains)
+        || contract.args != MethodBuiltinArgs::FirstThenReceiver
+    {
+        return false;
+    }
+    let receiver_safe = match contract.receiver {
+        MethodReceiverContract::ExactCollection
+        | MethodReceiverContract::ExactCollectionOrMap
+        | MethodReceiverContract::ExactCollectionOrJavaKeySet => {
+            let Some(&receiver) = il.children(callee).first() else {
+                return false;
+            };
+            strict_exact_literal_collection_receiver_safe(il, interner, facts, receiver)
+                || strict_exact_proven_collection_receiver_safe(il, facts, receiver)
+                || strict_exact_python_collection_factory_safe(il, interner, facts, receiver)
+                || strict_exact_ruby_set_factory_safe(il, interner, facts, receiver)
+                || strict_exact_rust_vec_macro_collection_safe(il, interner, facts, receiver)
+                || strict_exact_rust_std_collection_factory_safe(il, interner, facts, receiver)
+                || strict_exact_java_collection_factory_safe(il, interner, facts, receiver)
+                || strict_exact_map_key_view_collection_safe(il, interner, facts, receiver)
+        }
+        MethodReceiverContract::ExactSetOrMap => {
+            let Some(&receiver) = il.children(callee).first() else {
+                return false;
+            };
+            strict_exact_typed_set_param_receiver_safe(il, receiver)
+        }
+        _ => false,
+    };
+    receiver_safe && strict_exact_call_args_safe(il, interner, facts, node)
+}
+
+fn strict_exact_map_contains_call_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+    callee: NodeId,
+    method: &str,
+) -> bool {
+    let Some(contract) = method_call_contract(
+        il.meta.lang,
+        method,
+        il.children(node).len().saturating_sub(1),
+    ) else {
+        return false;
+    };
+    if contract.semantic != MethodSemanticContract::Builtin(Builtin::Contains)
+        || contract.args != MethodBuiltinArgs::FirstThenReceiver
+        || !matches!(
+            contract.receiver,
+            MethodReceiverContract::ExactMap
+                | MethodReceiverContract::ExactCollectionOrMap
+                | MethodReceiverContract::ExactSetOrMap
+        )
+    {
+        return false;
+    }
+    let Some(&receiver) = il.children(callee).first() else {
+        return false;
+    };
+    (strict_exact_proven_map_receiver_safe(il, facts, receiver)
+        || strict_exact_java_map_factory_safe(il, interner, facts, receiver)
+        || strict_exact_rust_std_map_factory_safe(il, interner, facts, receiver)
+        || strict_exact_map_constructor_entries_safe(il, interner, facts, receiver))
         && strict_exact_call_args_safe(il, interner, facts, node)
 }
 
@@ -1361,6 +1418,23 @@ fn strict_exact_iterator_identity_adapter_node_safe(
         callee,
         interner.resolve(method),
     )
+}
+
+fn strict_exact_typed_set_param_receiver_safe(il: &Il, receiver: NodeId) -> bool {
+    if il.kind(receiver) != NodeKind::Var {
+        return false;
+    }
+    let Payload::Cid(receiver_cid) = il.node(receiver).payload else {
+        return false;
+    };
+    il.nodes.iter().any(|node| {
+        node.kind == NodeKind::Param
+            && matches!(node.payload, Payload::Cid(param_cid) if param_cid == receiver_cid)
+            && il.param_type_facts.iter().any(|fact| {
+                fact.span == node.span
+                    && domain_evidence_from_param_semantic(fact.semantic).is_set()
+            })
+    })
 }
 
 fn strict_exact_typed_collection_param_receiver_safe(il: &Il, receiver: NodeId) -> bool {
@@ -1529,13 +1603,16 @@ fn strict_exact_membership_collection_safe(
 }
 
 fn strict_exact_set_constructor_collection_safe(
-    _il: &Il,
+    il: &Il,
     _interner: &Interner,
     _facts: &StrictFacts,
     _node: NodeId,
 ) -> bool {
     // JS `new Set(xs)` and plain `Set(xs)` currently lower to the same call
     // shape, so exact constructor semantics must wait for a construct proof.
+    if js_like_set_constructor_contract(il.meta.lang, "Set").is_none() {
+        return false;
+    }
     false
 }
 
@@ -1561,13 +1638,33 @@ fn strict_exact_python_collection_factory_safe(
             return false;
         };
         let name = interner.resolve(name);
-        matches!(name, "list" | "set" | "frozenset" | "tuple")
-            && !file_defines_name(il, interner, name)
+        semantics(il.meta.lang)
+            .collections()
+            .free_name_collection_factories()
+            .any(|factory| {
+                factory.names.contains(&name)
+                    && strict_exact_free_name_factory_shadow_safe(
+                        il,
+                        interner,
+                        name,
+                        factory.shadow_guard,
+                    )
+            })
     } else {
         false
     };
-    let imported_stdlib_factory =
-        strict_exact_python_imported_factory_name(il, interner, kids[0], "collections", "deque");
+    let imported_stdlib_factory = semantics(il.meta.lang)
+        .collections()
+        .imported_collection_factories()
+        .any(|factory| {
+            strict_exact_python_imported_factory_name(
+                il,
+                interner,
+                kids[0],
+                factory.module,
+                factory.exported,
+            )
+        });
     (builtin || imported_stdlib_factory)
         && strict_exact_membership_collection_safe(il, interner, facts, kids[1])
 }
@@ -1673,11 +1770,7 @@ fn strict_exact_ruby_set_factory_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    if !semantics(il.meta.lang).stdlib().ruby_set_factory()
-        || il.kind(node) != NodeKind::Call
-        || !ruby_file_requires_module(il, interner, "set")
-        || file_defines_name(il, interner, "Set")
-    {
+    if il.kind(node) != NodeKind::Call {
         return false;
     }
     let kids = il.children(node);
@@ -1687,13 +1780,23 @@ fn strict_exact_ruby_set_factory_safe(
     let Payload::Name(method) = il.node(kids[0]).payload else {
         return false;
     };
-    if interner.resolve(method) != "new" {
-        return false;
-    }
+    let method = interner.resolve(method);
     let Some(&receiver) = il.children(kids[0]).first() else {
         return false;
     };
-    strict_exact_callee_name(il, interner, receiver, "Set")
+    if il.kind(receiver) != NodeKind::Var {
+        return false;
+    }
+    let Payload::Name(receiver_name) = il.node(receiver).payload else {
+        return false;
+    };
+    let receiver_name = interner.resolve(receiver_name);
+    let Some(contract) = ruby_set_factory_contract(il.meta.lang, receiver_name, method, 1) else {
+        return false;
+    };
+    ruby_file_requires_module(il, interner, contract.required_module)
+        && !file_defines_name(il, interner, contract.shadow_root)
+        && strict_exact_callee_name(il, interner, receiver, contract.receiver)
         && strict_exact_membership_collection_safe(il, interner, facts, kids[1])
 }
 
@@ -1794,15 +1897,15 @@ fn strict_exact_rust_std_collection_factory_safe(
     let Payload::Name(name) = il.node(kids[0]).payload else {
         return false;
     };
-    if !matches!(
-        interner.resolve(name),
-        "std::collections::HashSet::from"
-            | "std::collections::BTreeSet::from"
-            | "std::collections::VecDeque::from"
-    ) {
+    let name = interner.resolve(name);
+    let factory = semantics(il.meta.lang)
+        .collections()
+        .free_name_collection_factories()
+        .find(|factory| factory.names.contains(&name));
+    let Some(factory) = factory else {
         return false;
-    }
-    if file_defines_name(il, interner, "std") {
+    };
+    if !strict_exact_free_name_factory_shadow_safe(il, interner, name, factory.shadow_guard) {
         return false;
     }
     strict_exact_membership_collection_safe(il, interner, facts, kids[1])
@@ -1837,12 +1940,11 @@ fn strict_exact_java_collection_factory_safe(
     };
     let method = interner.resolve(method);
     let receiver_name = interner.resolve(receiver_name);
-    let standard_factory = matches!(
-        (receiver_name, method),
-        ("List" | "Set", "of") | ("Arrays", "asList")
-    );
-    standard_factory
-        && !java_file_defines_type_name(il, interner, receiver_name)
+    let Some(contract) = java_collection_factory_contract(il.meta.lang, receiver_name, method)
+    else {
+        return false;
+    };
+    !java_file_defines_type_name(il, interner, contract.receiver)
         && kids
             .iter()
             .skip(1)
@@ -1911,22 +2013,25 @@ fn strict_exact_java_map_factory_safe(
     let Some(&receiver) = il.children(kids[0]).first() else {
         return false;
     };
-    if !strict_exact_java_std_var_name(il, interner, receiver, "Map") {
+    let method = interner.resolve(method);
+    let Some(contract) = java_map_factory_contract(il.meta.lang, "Map", method) else {
+        return false;
+    };
+    if !strict_exact_java_std_var_name(il, interner, receiver, contract.receiver) {
         return false;
     }
-    match interner.resolve(method) {
-        "of" => {
+    match contract.kind {
+        JavaMapFactoryKind::Of => {
             let entries = &kids[1..];
             entries.len() % 2 == 0
                 && entries
                     .iter()
                     .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
         }
-        "ofEntries" => kids
+        JavaMapFactoryKind::OfEntries => kids
             .iter()
             .skip(1)
             .all(|&entry| strict_exact_java_map_entry_safe(il, interner, facts, entry)),
-        _ => false,
     }
 }
 
@@ -1946,13 +2051,12 @@ fn strict_exact_java_map_entry_safe(
     let Payload::Name(method) = il.node(kids[0]).payload else {
         return false;
     };
-    if interner.resolve(method) != "entry" {
-        return false;
-    }
+    let method = interner.resolve(method);
     let Some(&receiver) = il.children(kids[0]).first() else {
         return false;
     };
-    strict_exact_java_std_var_name(il, interner, receiver, "Map")
+    java_map_entry_contract(il.meta.lang, "Map", method)
+        && strict_exact_java_std_var_name(il, interner, receiver, "Map")
         && kids
             .iter()
             .skip(1)
@@ -1960,13 +2064,16 @@ fn strict_exact_java_map_entry_safe(
 }
 
 fn strict_exact_map_constructor_entries_safe(
-    _il: &Il,
+    il: &Il,
     _interner: &Interner,
     _facts: &StrictFacts,
     _node: NodeId,
 ) -> bool {
     // JS `new Map(entries)` and plain `Map(entries)` currently lower to the same
     // call shape, so exact constructor semantics must wait for a construct proof.
+    if js_like_map_constructor_contract(il.meta.lang, "Map").is_none() {
+        return false;
+    }
     false
 }
 
@@ -1987,16 +2094,33 @@ fn strict_exact_rust_std_map_factory_safe(
     let Payload::Name(name) = il.node(kids[0]).payload else {
         return false;
     };
-    if !matches!(
-        interner.resolve(name),
-        "std::collections::HashMap::from" | "std::collections::BTreeMap::from"
-    ) {
+    let name = interner.resolve(name);
+    let factory = semantics(il.meta.lang)
+        .collections()
+        .free_name_map_factories()
+        .find(|factory| factory.names.contains(&name));
+    if factory.is_none() {
         return false;
     }
-    if file_defines_name(il, interner, "std") {
+    if !strict_exact_free_name_factory_shadow_safe(il, interner, name, false) {
         return false;
     }
     strict_exact_map_entries_safe(il, interner, facts, kids[1])
+}
+
+fn strict_exact_free_name_factory_shadow_safe(
+    il: &Il,
+    interner: &Interner,
+    name: &str,
+    shadow_guard: bool,
+) -> bool {
+    if shadow_guard {
+        return !file_defines_name(il, interner, name);
+    }
+    if il.meta.lang == Lang::Rust && name.starts_with("std::") {
+        return !file_defines_name(il, interner, "std");
+    }
+    true
 }
 
 fn strict_exact_map_entries_safe(

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -18,10 +18,10 @@ use nose_semantics::{
     exact_non_overloadable_index_assignment_parts, go_zero_map_default_kind,
     go_zero_map_lookup_contract, iterator_identity_adapter_contract,
     java_collection_factory_contract, java_map_entry_contract, java_map_factory_contract,
-    js_like_map_constructor_contract, js_like_set_constructor_contract, map_key_view_contract,
-    map_key_view_wrapper_contract, method_call_contract, ruby_set_factory_contract,
-    rust_vec_new_factory_contract, semantics, JavaMapFactoryKind, MapKeyViewKind,
-    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
+    js_like_map_constructor_contract, js_like_set_constructor_contract, map_get_contract,
+    map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
+    ruby_set_factory_contract, rust_vec_new_factory_contract, semantics, JavaMapFactoryKind,
+    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1235,31 +1235,11 @@ fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, nod
     if strict_exact_map_contains_call_safe(il, interner, facts, node, callee, method) {
         return true;
     }
-    if matches!(method, "get" | "getOrDefault") {
-        let Some(&receiver) = il.children(callee).first() else {
-            return false;
-        };
-        if method == "get"
-            && strict_exact_proven_map_receiver_safe(il, facts, receiver)
-            && matches!(il.children(node).len(), 2 | 3)
-        {
-            return strict_exact_call_args_safe(il, interner, facts, node);
-        }
-        if method == "getOrDefault"
-            && strict_exact_proven_map_receiver_safe(il, facts, receiver)
-            && il.children(node).len() == 3
-        {
-            return strict_exact_call_args_safe(il, interner, facts, node);
-        }
-        if strict_exact_set_constructor_collection_safe(il, interner, facts, receiver) {
-            return strict_exact_call_args_safe(il, interner, facts, node);
-        }
-        if strict_exact_java_map_factory_safe(il, interner, facts, receiver) {
-            return strict_exact_call_args_safe(il, interner, facts, node);
-        }
-        if strict_exact_map_constructor_entries_safe(il, interner, facts, receiver) {
-            return strict_exact_call_args_safe(il, interner, facts, node);
-        }
+    if strict_exact_map_get_call_safe(il, interner, facts, node, callee, method) {
+        return true;
+    }
+    if strict_exact_map_get_default_call_safe(il, interner, facts, node, callee, method) {
+        return true;
     }
     if strict_exact_iterator_identity_adapter_call_safe(il, interner, facts, node, callee, method) {
         return true;
@@ -1350,6 +1330,62 @@ fn strict_exact_map_contains_call_safe(
     (strict_exact_proven_map_receiver_safe(il, facts, receiver)
         || strict_exact_java_map_factory_safe(il, interner, facts, receiver)
         || strict_exact_rust_std_map_factory_safe(il, interner, facts, receiver)
+        || strict_exact_map_constructor_entries_safe(il, interner, facts, receiver))
+        && strict_exact_call_args_safe(il, interner, facts, node)
+}
+
+fn strict_exact_map_get_call_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+    callee: NodeId,
+    method: &str,
+) -> bool {
+    if map_get_contract(
+        il.meta.lang,
+        method,
+        il.children(node).len().saturating_sub(1),
+    )
+    .is_none()
+    {
+        return false;
+    }
+    let Some(&receiver) = il.children(callee).first() else {
+        return false;
+    };
+    (strict_exact_proven_map_receiver_safe(il, facts, receiver)
+        || strict_exact_java_map_factory_safe(il, interner, facts, receiver)
+        || strict_exact_map_constructor_entries_safe(il, interner, facts, receiver))
+        && strict_exact_call_args_safe(il, interner, facts, node)
+}
+
+fn strict_exact_map_get_default_call_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+    callee: NodeId,
+    method: &str,
+) -> bool {
+    let Some(contract) = method_call_contract(
+        il.meta.lang,
+        method,
+        il.children(node).len().saturating_sub(1),
+    ) else {
+        return false;
+    };
+    if contract.semantic != MethodSemanticContract::Builtin(Builtin::GetOrDefault)
+        || contract.receiver != MethodReceiverContract::ExactMap
+        || contract.args != MethodBuiltinArgs::MapGetDefault
+    {
+        return false;
+    }
+    let Some(&receiver) = il.children(callee).first() else {
+        return false;
+    };
+    (strict_exact_proven_map_receiver_safe(il, facts, receiver)
+        || strict_exact_java_map_factory_safe(il, interner, facts, receiver)
         || strict_exact_map_constructor_entries_safe(il, interner, facts, receiver))
         && strict_exact_call_args_safe(il, interner, facts, node)
 }

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -16,12 +16,13 @@ use nose_semantics::{
     builder_append_call_args, domain_evidence_from_param_semantic, exact_java_return_this,
     exact_java_this_field, exact_non_overloadable_index_assignment,
     exact_non_overloadable_index_assignment_parts, go_zero_map_default_kind,
-    go_zero_map_lookup_contract, iterator_identity_adapter_contract,
-    java_collection_factory_contract, java_map_entry_contract, java_map_factory_contract,
-    js_like_map_constructor_contract, js_like_set_constructor_contract, map_get_contract,
-    map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
-    ruby_set_factory_contract, rust_vec_new_factory_contract, semantics, JavaMapFactoryKind,
-    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
+    go_zero_map_lookup_contract, index_membership_threshold_contract,
+    iterator_identity_adapter_contract, java_collection_factory_contract, java_map_entry_contract,
+    java_map_factory_contract, js_like_map_constructor_contract, js_like_set_constructor_contract,
+    map_get_contract, map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
+    ruby_set_factory_contract, rust_vec_new_factory_contract, semantics,
+    static_index_membership_contract, IndexMembershipThreshold, JavaMapFactoryKind, MapKeyViewKind,
+    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1020,14 +1021,14 @@ fn strict_exact_static_index_membership_parts(
     if !strict_exact_static_non_float_collection(il, receiver) {
         return None;
     }
-    if method == "indexOf" {
-        return Some((kids[1], receiver));
+    let contract = static_index_membership_contract(il.meta.lang, method, kids.len() - 1)?;
+    match contract.kind {
+        StaticIndexMembershipKind::IndexOf => Some((kids[1], receiver)),
+        StaticIndexMembershipKind::FindIndex => {
+            let element = strict_exact_lambda_eq_param_element(il, interner, facts, kids[1])?;
+            Some((element, receiver))
+        }
     }
-    if method == "findIndex" {
-        let element = strict_exact_lambda_eq_param_element(il, interner, facts, kids[1])?;
-        return Some((element, receiver));
-    }
-    None
 }
 
 fn strict_exact_index_membership_threshold(
@@ -1037,12 +1038,18 @@ fn strict_exact_index_membership_threshold(
     threshold: NodeId,
 ) -> bool {
     if strict_exact_minus_one_literal(il, threshold) {
-        return op == Op::Ne
-            || (!index_call_on_right && op == Op::Gt)
-            || (index_call_on_right && op == Op::Lt);
+        return index_membership_threshold_contract(
+            op,
+            index_call_on_right,
+            IndexMembershipThreshold::MinusOne,
+        );
     }
     if matches!(il.node(threshold).payload, Payload::LitInt(0)) {
-        return (!index_call_on_right && op == Op::Ge) || (index_call_on_right && op == Op::Le);
+        return index_membership_threshold_contract(
+            op,
+            index_call_on_right,
+            IndexMembershipThreshold::Zero,
+        );
     }
     false
 }

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -6,16 +6,16 @@
 use crate::fragment::{FragmentKind, ProofFacts};
 use nose_il::{
     stable_symbol_hash, Builtin, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op,
-    ParamSemantic, Payload, Symbol, UnitKind,
+    Payload, Symbol, UnitKind,
 };
 use nose_normalize::{
     module_facts::{collect_module_mutations, mutating_method_name},
     node_tag,
 };
 use nose_semantics::{
-    builder_append_call_args, exact_java_return_this, exact_java_this_field,
-    exact_non_overloadable_index_assignment, exact_non_overloadable_index_assignment_parts,
-    iterator_identity_adapter_contract, semantics,
+    builder_append_call_args, domain_evidence_from_param_semantic, exact_java_return_this,
+    exact_java_this_field, exact_non_overloadable_index_assignment,
+    exact_non_overloadable_index_assignment_parts, iterator_identity_adapter_contract, semantics,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1374,10 +1374,8 @@ fn strict_exact_typed_collection_param_receiver_safe(il: &Il, receiver: NodeId) 
             && matches!(node.payload, Payload::Cid(param_cid) if param_cid == receiver_cid)
             && il.param_type_facts.iter().any(|fact| {
                 fact.span == node.span
-                    && matches!(
-                        fact.semantic,
-                        ParamSemantic::Array | ParamSemantic::Collection | ParamSemantic::Set
-                    )
+                    && domain_evidence_from_param_semantic(fact.semantic)
+                        .is_array_collection_or_set()
             })
     })
 }
@@ -1406,10 +1404,10 @@ fn strict_exact_typed_map_param_receiver_safe(il: &Il, receiver: NodeId) -> bool
     il.nodes.iter().any(|node| {
         node.kind == NodeKind::Param
             && matches!(node.payload, Payload::Cid(param_cid) if param_cid == receiver_cid)
-            && il
-                .param_type_facts
-                .iter()
-                .any(|fact| fact.span == node.span && matches!(fact.semantic, ParamSemantic::Map))
+            && il.param_type_facts.iter().any(|fact| {
+                fact.span == node.span
+                    && domain_evidence_from_param_semantic(fact.semantic).is_map()
+            })
     })
 }
 

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -15,7 +15,8 @@ use nose_normalize::{
 use nose_semantics::{
     builder_append_call_args, domain_evidence_from_param_semantic, exact_java_return_this,
     exact_java_this_field, exact_non_overloadable_index_assignment,
-    exact_non_overloadable_index_assignment_parts, iterator_identity_adapter_contract, semantics,
+    exact_non_overloadable_index_assignment_parts, iterator_identity_adapter_contract,
+    rust_vec_new_factory_contract, semantics,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1769,12 +1770,8 @@ fn strict_exact_rust_vec_new_safe(il: &Il, interner: &Interner, node: NodeId) ->
 }
 
 fn strict_exact_rust_vec_new_name(il: &Il, interner: &Interner, text: &str) -> bool {
-    match text {
-        "Vec::new" => !file_defines_name(il, interner, "Vec"),
-        "std::vec::Vec::new" => !file_defines_name(il, interner, "std"),
-        "alloc::vec::Vec::new" => !file_defines_name(il, interner, "alloc"),
-        _ => false,
-    }
+    rust_vec_new_factory_contract(il.meta.lang, text)
+        .is_some_and(|contract| !file_defines_name(il, interner, contract.shadow_root))
 }
 
 fn strict_exact_rust_std_collection_factory_safe(

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -13,7 +13,9 @@ use nose_normalize::{
     node_tag,
 };
 use nose_semantics::{
-    builder_append_method_contract, iterator_identity_adapter_contract, semantics,
+    builder_append_call_args, exact_java_return_this, exact_java_this_field,
+    exact_non_overloadable_index_assignment, exact_non_overloadable_index_assignment_parts,
+    iterator_identity_adapter_contract, semantics,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -2914,15 +2916,8 @@ fn exact_index_assignment_consumes_temp(
     temp_cid: u32,
     forbidden_cids: Option<&FxHashSet<u32>>,
 ) -> bool {
-    if !exact_index_assignment_fragment_root(il, stmt) {
-        return false;
-    }
-    let kids = il.children(stmt);
-    if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Index {
-        return false;
-    }
-    let target_kids = il.children(kids[0]);
-    let Some(&receiver) = target_kids.first() else {
+    let Some((receiver, key, value)) = exact_non_overloadable_index_assignment_parts(il, stmt)
+    else {
         return false;
     };
 
@@ -2934,19 +2929,15 @@ fn exact_index_assignment_consumes_temp(
         return false;
     }
 
-    let key_uses_temp = target_kids
-        .get(1)
-        .is_some_and(|&key| node_mentions_any_cid(il, key, &temp));
-    let value_uses_temp = node_mentions_any_cid(il, kids[1], &temp);
+    let key_uses_temp = key.is_some_and(|key| node_mentions_any_cid(il, key, &temp));
+    let value_uses_temp = node_mentions_any_cid(il, value, &temp);
     if !(key_uses_temp || value_uses_temp) {
         return false;
     }
     match forbidden_cids {
         Some(cids) => {
-            !target_kids
-                .get(1)
-                .is_some_and(|&key| node_mentions_any_cid(il, key, cids))
-                && !node_mentions_any_cid(il, kids[1], cids)
+            !key.is_some_and(|key| node_mentions_any_cid(il, key, cids))
+                && !node_mentions_any_cid(il, value, cids)
         }
         None => true,
     }
@@ -2974,14 +2965,7 @@ fn exact_assignment_fragment_kind(
 }
 
 fn exact_index_assignment_fragment_root(il: &Il, node: NodeId) -> bool {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .non_overloadable_index_assignment()
-    {
-        return false;
-    }
-    let kids = il.children(node);
-    kids.len() == 2 && il.kind(kids[0]) == NodeKind::Index
+    exact_non_overloadable_index_assignment(il, node)
 }
 
 // Field-write fingerprints intentionally model final self-field state without a receiver
@@ -2999,41 +2983,8 @@ fn exact_self_field_assignment_fragment_root(il: &Il, interner: &Interner, node:
     kids.len() == 2 && exact_java_this_field(il, interner, kids[0])
 }
 
-pub(crate) fn exact_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        || il.kind(node) != NodeKind::Field
-    {
-        return false;
-    }
-    if !matches!(il.node(node).payload, Payload::Name(_)) {
-        return false;
-    }
-    let Some(&receiver) = il.children(node).first() else {
-        return false;
-    };
-    exact_java_this_var(il, interner, receiver)
-}
-
-pub(crate) fn exact_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        && il.kind(node) == NodeKind::Var
-        && matches!(il.node(node).payload, Payload::Name(name) if interner.resolve(name) == "this")
-}
-
 fn exact_java_return_this_fragment_root(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        || il.kind(node) != NodeKind::Return
-    {
-        return false;
-    }
-    let kids = il.children(node);
-    kids.len() == 1 && exact_java_this_var(il, interner, kids[0])
+    exact_java_return_this(il, interner, node)
 }
 
 fn exact_function_body_self_field_fragment_root(
@@ -3491,15 +3442,8 @@ fn index_assignment_effect_consumes_temp(
     iter_cids: &FxHashSet<u32>,
     temp_cids: &FxHashSet<u32>,
 ) -> bool {
-    if !exact_index_assignment_fragment_root(il, node) {
-        return false;
-    }
-    let kids = il.children(node);
-    if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Index {
-        return false;
-    }
-    let target_kids = il.children(kids[0]);
-    let Some(&receiver) = target_kids.first() else {
+    let Some((receiver, key, value)) = exact_non_overloadable_index_assignment_parts(il, node)
+    else {
         return false;
     };
     if node_mentions_any_cid(il, receiver, iter_cids)
@@ -3507,10 +3451,8 @@ fn index_assignment_effect_consumes_temp(
     {
         return false;
     }
-    target_kids
-        .get(1)
-        .is_some_and(|&key| node_mentions_any_cid(il, key, temp_cids))
-        || node_mentions_any_cid(il, kids[1], temp_cids)
+    key.is_some_and(|key| node_mentions_any_cid(il, key, temp_cids))
+        || node_mentions_any_cid(il, value, temp_cids)
 }
 
 fn index_assignment_effect_consumes_chained_temp(
@@ -3521,15 +3463,8 @@ fn index_assignment_effect_consumes_chained_temp(
     final_temp_cids: &FxHashSet<u32>,
     prior_temp_cids: &FxHashSet<u32>,
 ) -> bool {
-    if !exact_index_assignment_fragment_root(il, node) {
-        return false;
-    }
-    let kids = il.children(node);
-    if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Index {
-        return false;
-    }
-    let target_kids = il.children(kids[0]);
-    let Some(&receiver) = target_kids.first() else {
+    let Some((receiver, key, value)) = exact_non_overloadable_index_assignment_parts(il, node)
+    else {
         return false;
     };
     if node_mentions_any_cid(il, receiver, iter_cids)
@@ -3537,14 +3472,10 @@ fn index_assignment_effect_consumes_chained_temp(
     {
         return false;
     }
-    let key_uses_final = target_kids
-        .get(1)
-        .is_some_and(|&key| node_mentions_any_cid(il, key, final_temp_cids));
-    let key_uses_prior = target_kids
-        .get(1)
-        .is_some_and(|&key| node_mentions_any_cid(il, key, prior_temp_cids));
-    let value_uses_final = node_mentions_any_cid(il, kids[1], final_temp_cids);
-    let value_uses_prior = node_mentions_any_cid(il, kids[1], prior_temp_cids);
+    let key_uses_final = key.is_some_and(|key| node_mentions_any_cid(il, key, final_temp_cids));
+    let key_uses_prior = key.is_some_and(|key| node_mentions_any_cid(il, key, prior_temp_cids));
+    let value_uses_final = node_mentions_any_cid(il, value, final_temp_cids);
+    let value_uses_prior = node_mentions_any_cid(il, value, prior_temp_cids);
     (key_uses_final || value_uses_final) && !key_uses_prior && !value_uses_prior
 }
 
@@ -3561,25 +3492,7 @@ fn append_effect_depends_on_iter(
 }
 
 fn append_call_args(il: &Il, interner: &Interner, node: NodeId) -> Option<(NodeId, NodeId)> {
-    if il.kind(node) != NodeKind::Call {
-        return None;
-    }
-    let kids = il.children(node);
-    if matches!(il.node(node).payload, Payload::Builtin(Builtin::Append)) {
-        return (kids.len() == 2).then(|| (kids[0], kids[1]));
-    }
-    let (&callee, args) = kids.split_first()?;
-    if args.len() != 1 || il.kind(callee) != NodeKind::Field {
-        return None;
-    }
-    let Payload::Name(method) = il.node(callee).payload else {
-        return None;
-    };
-    if !builder_append_method_contract(il.meta.lang, interner.resolve(method), args.len()) {
-        return None;
-    }
-    let receiver = *il.children(callee).first()?;
-    Some((receiver, args[0]))
+    builder_append_call_args(il, interner, node)
 }
 
 fn index_assignment_effect_depends_on_iter(
@@ -3588,24 +3501,15 @@ fn index_assignment_effect_depends_on_iter(
     node: NodeId,
     iter_cids: &FxHashSet<u32>,
 ) -> bool {
-    if !exact_index_assignment_fragment_root(il, node) {
-        return false;
-    }
-    let kids = il.children(node);
-    if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Index {
-        return false;
-    }
-    let target_kids = il.children(kids[0]);
-    let Some(&receiver) = target_kids.first() else {
+    let Some((receiver, key, value)) = exact_non_overloadable_index_assignment_parts(il, node)
+    else {
         return false;
     };
     if node_mentions_any_cid(il, receiver, iter_cids) {
         return false;
     }
-    target_kids
-        .get(1)
-        .is_some_and(|&key| node_mentions_any_cid(il, key, iter_cids))
-        || node_mentions_any_cid(il, kids[1], iter_cids)
+    key.is_some_and(|key| node_mentions_any_cid(il, key, iter_cids))
+        || node_mentions_any_cid(il, value, iter_cids)
 }
 
 pub(crate) fn top_level_statement_fragment_context_safe(

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -15,7 +15,8 @@ use nose_normalize::{
 use nose_semantics::{
     builder_append_call_args, domain_evidence_from_param_semantic, exact_java_return_this,
     exact_java_this_field, exact_non_overloadable_index_assignment,
-    exact_non_overloadable_index_assignment_parts, iterator_identity_adapter_contract,
+    exact_non_overloadable_index_assignment_parts, go_zero_map_default_kind,
+    go_zero_map_lookup_contract, iterator_identity_adapter_contract,
     java_collection_factory_contract, java_map_entry_contract, java_map_factory_contract,
     js_like_map_constructor_contract, js_like_set_constructor_contract, map_key_view_contract,
     map_key_view_wrapper_contract, method_call_contract, ruby_set_factory_contract,
@@ -2174,11 +2175,7 @@ fn strict_exact_go_literal_zero_map_index_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    if !semantics(il.meta.lang)
-        .stdlib()
-        .go_literal_zero_map_lookup()
-        || il.kind(node) != NodeKind::Index
-    {
+    if go_zero_map_lookup_contract(il.meta.lang).is_none() || il.kind(node) != NodeKind::Index {
         return false;
     }
     let kids = il.children(node);
@@ -2193,13 +2190,16 @@ fn strict_exact_go_literal_zero_map_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
+    let Some(contract) = go_zero_map_lookup_contract(il.meta.lang) else {
+        return false;
+    };
     if il.kind(node) != NodeKind::Seq {
         return false;
     }
     let Payload::Name(name) = il.node(node).payload else {
         return false;
     };
-    if interner.resolve(name) != "composite_literal" || il.children(node).is_empty() {
+    if interner.resolve(name) != contract.map_literal_tag || il.children(node).is_empty() {
         return false;
     }
     let mut value_kind = None;
@@ -2211,14 +2211,14 @@ fn strict_exact_go_literal_zero_map_safe(
             return false;
         };
         let kv = il.children(entry);
-        if interner.resolve(entry_name) != "keyed_element"
+        if interner.resolve(entry_name) != contract.entry_tag
             || kv.len() != 2
             || !matches!(il.node(kv[0]).payload, Payload::LitStr(_))
             || !strict_exact_safe_tree(il, interner, facts, kv[0])
         {
             return false;
         }
-        let Some(kind) = strict_exact_go_zero_value_kind(il.node(kv[1]).payload) else {
+        let Some(kind) = go_zero_map_default_kind(il.meta.lang, il.node(kv[1]).payload) else {
             return false;
         };
         match value_kind {
@@ -2230,17 +2230,6 @@ fn strict_exact_go_literal_zero_map_safe(
             }
         }
     })
-}
-
-fn strict_exact_go_zero_value_kind(payload: Payload) -> Option<u8> {
-    match payload {
-        Payload::LitInt(_) => Some(1),
-        Payload::LitStr(_) => Some(2),
-        Payload::LitBool(_) => Some(3),
-        Payload::LitFloat(_) => Some(4),
-        Payload::Lit(LitClass::Null) => Some(5),
-        _ => None,
-    }
 }
 
 fn strict_exact_call_args_safe(

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -17,8 +17,9 @@ use nose_semantics::{
     exact_java_this_field, exact_non_overloadable_index_assignment,
     exact_non_overloadable_index_assignment_parts, iterator_identity_adapter_contract,
     java_collection_factory_contract, java_map_entry_contract, java_map_factory_contract,
-    js_like_map_constructor_contract, js_like_set_constructor_contract, method_call_contract,
-    ruby_set_factory_contract, rust_vec_new_factory_contract, semantics, JavaMapFactoryKind,
+    js_like_map_constructor_contract, js_like_set_constructor_contract, map_key_view_contract,
+    map_key_view_wrapper_contract, method_call_contract, ruby_set_factory_contract,
+    rust_vec_new_factory_contract, semantics, JavaMapFactoryKind, MapKeyViewKind,
     MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1502,6 +1503,18 @@ fn strict_exact_map_key_view_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
+    strict_exact_map_key_view_safe_matching(il, interner, facts, node, |kind| {
+        kind == MapKeyViewKind::Collection
+    })
+}
+
+fn strict_exact_map_key_view_safe_matching(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+    accepts: impl Fn(MapKeyViewKind) -> bool + Copy,
+) -> bool {
     if il.kind(node) != NodeKind::Call {
         return false;
     }
@@ -1512,7 +1525,10 @@ fn strict_exact_map_key_view_safe(
     let Payload::Name(method) = il.node(kids[0]).payload else {
         return false;
     };
-    if interner.resolve(method) != "keys" {
+    let Some(contract) = map_key_view_contract(il.meta.lang, interner.resolve(method), 0) else {
+        return false;
+    };
+    if !accepts(contract.kind) {
         return false;
     }
     let Some(&receiver) = il.children(kids[0]).first() else {
@@ -1543,15 +1559,19 @@ fn strict_exact_map_key_view_collection_safe(
     let Payload::Name(method) = il.node(kids[0]).payload else {
         return false;
     };
-    if interner.resolve(method) != "from" {
+    let Some(contract) =
+        map_key_view_wrapper_contract(il.meta.lang, "Array", interner.resolve(method), 1)
+    else {
         return false;
-    }
+    };
     let Some(&receiver) = il.children(kids[0]).first() else {
         return false;
     };
-    strict_exact_callee_name(il, interner, receiver, "Array")
-        && !file_defines_name(il, interner, "Array")
-        && strict_exact_map_key_view_safe(il, interner, facts, kids[1])
+    strict_exact_callee_name(il, interner, receiver, contract.receiver)
+        && !file_defines_name(il, interner, contract.receiver)
+        && strict_exact_map_key_view_safe_matching(il, interner, facts, kids[1], |kind| {
+            kind == MapKeyViewKind::Iterator
+        })
 }
 
 fn strict_exact_literal_collection_receiver_safe(

--- a/crates/nose-frontend/src/java.rs
+++ b/crates/nose-frontend/src/java.rs
@@ -44,19 +44,33 @@ fn lower_item(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
         | "annotation_type_declaration" => Some(lower_type(lo, node)),
         "method_declaration" | "constructor_declaration" => Some(lower_method(lo, node)),
         "field_declaration" => Some(lower_field(lo, node)),
-        "import_declaration" => Some(
-            lower_static_import(lo, node).unwrap_or_else(|| crate::lower::import_tokens(lo, node)),
-        ),
+        "import_declaration" => {
+            Some(lower_import(lo, node).unwrap_or_else(|| crate::lower::import_tokens(lo, node)))
+        }
         "package_declaration" => Some(crate::lower::import_tokens(lo, node)),
         "line_comment" | "block_comment" => None,
         _ => lower_stmt(lo, node),
     }
 }
 
-fn lower_static_import(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
+fn lower_import(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     let span = lo.span(node);
     let text = lo.text(node).trim().trim_end_matches(';').trim();
-    let path = text.strip_prefix("import static ")?.trim();
+    if let Some(path) = text.strip_prefix("import static ") {
+        let path = path.trim();
+        if path.ends_with(".*") {
+            return None;
+        }
+        let (module, exported) = path.rsplit_once('.')?;
+        return Some(crate::lower::import_binding(
+            lo,
+            span,
+            exported.trim(),
+            module.trim(),
+            exported.trim(),
+        ));
+    }
+    let path = text.strip_prefix("import ")?.trim();
     if path.ends_with(".*") {
         return None;
     }

--- a/crates/nose-frontend/src/java.rs
+++ b/crates/nose-frontend/src/java.rs
@@ -8,8 +8,8 @@
 
 use crate::lower::{common_bin_op, Lowering};
 use nose_il::{
-    Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, ParamSemantic,
-    Payload, Span, UnitKind,
+    FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, ParamSemantic, Payload,
+    Span, UnitKind,
 };
 use tree_sitter::Node as TsNode;
 
@@ -754,25 +754,6 @@ fn lower_binary(lo: &mut Lowering, node: TsNode) -> NodeId {
 fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
     let name_node = node.child_by_field_name("name");
-    let object_node = node.child_by_field_name("object");
-    let math_builtin = name_node
-        .and_then(|n| match lo.text(n) {
-            "abs" => Some((Builtin::Abs, 1)),
-            "min" => Some((Builtin::Min, 2)),
-            "max" => Some((Builtin::Max, 2)),
-            _ => None,
-        })
-        .filter(|_| object_node.is_some_and(|o| lo.text(o) == "Math"));
-    if let Some((builtin, arity)) = math_builtin {
-        if let Some(args) = node.child_by_field_name("arguments") {
-            let args = Lowering::named_children(args);
-            if args.len() == arity {
-                let lowered: Vec<NodeId> =
-                    args.into_iter().map(|arg| lower_expr(lo, arg)).collect();
-                return lo.add(NodeKind::Call, Payload::Builtin(builtin), span, &lowered);
-            }
-        }
-    }
     let name = name_node.map(|n| lo.sym(lo.text(n)));
     let callee = match node.child_by_field_name("object") {
         Some(o) => {

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -327,7 +327,7 @@ fn lower_field(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
 
 fn lower_params(lo: &mut Lowering, params: TsNode, out: &mut Vec<NodeId>) {
     // A single-identifier arrow param arrives as the identifier itself.
-    if params.kind() == "identifier" {
+    if matches!(params.kind(), "identifier" | "undefined") {
         let span = lo.span(params);
         let sym = lo.sym(lo.text(params));
         out.push(lo.add(NodeKind::Param, Payload::Name(sym), span, &[]));
@@ -349,7 +349,7 @@ fn lower_params(lo: &mut Lowering, params: TsNode, out: &mut Vec<NodeId>) {
 
 fn param_name<'a>(lo: &Lowering<'a>, p: TsNode<'a>) -> Option<&'a str> {
     match p.kind() {
-        "identifier" | "shorthand_property_identifier_pattern" => Some(lo.text(p)),
+        "identifier" | "shorthand_property_identifier_pattern" | "undefined" => Some(lo.text(p)),
         "required_parameter" | "optional_parameter" => p
             .child_by_field_name("pattern")
             .or_else(|| p.named_child(0))
@@ -828,7 +828,8 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         "template_string" => lower_template(lo, node),
         "true" => lo.add(NodeKind::Lit, Payload::LitBool(true), span, &[]),
         "false" => lo.add(NodeKind::Lit, Payload::LitBool(false), span, &[]),
-        "null" | "undefined" => lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[]),
+        "null" => lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[]),
+        "undefined" => lo.var("undefined", span),
         "regex" => lo.str_lit(lo.text(node), span),
         "call_expression" => lower_call(lo, node),
         "new_expression" => lower_new(lo, node),

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -16,9 +16,10 @@ use nose_semantics::{
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::Path;
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct ExportedBinding {
     file_idx: usize,
+    deps: Vec<SubtreeSnapshot>,
     rhs: NodeId,
 }
 
@@ -42,7 +43,7 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
         return;
     }
 
-    let replacements: Vec<Vec<(NodeId, SubtreeSnapshot)>> = files
+    let replacements: Vec<Vec<(NodeId, Vec<SubtreeSnapshot>, SubtreeSnapshot)>> = files
         .iter()
         .enumerate()
         .map(|(file_idx, il)| {
@@ -54,14 +55,22 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
                     if export.file_idx == file_idx {
                         return None;
                     }
-                    Some((stmt, snapshot_subtree(&files[export.file_idx], export.rhs)))
+                    Some((
+                        stmt,
+                        export.deps.clone(),
+                        snapshot_subtree(&files[export.file_idx], export.rhs),
+                    ))
                 })
                 .collect()
         })
         .collect();
 
     for (file_idx, file_replacements) in replacements.into_iter().enumerate() {
-        for (stmt, snapshot) in file_replacements {
+        for (stmt, deps, snapshot) in file_replacements {
+            for dep in deps {
+                let dep_stmt = append_snapshot(&mut files[file_idx], &dep);
+                prepend_root_statement(&mut files[file_idx], dep_stmt);
+            }
             let rhs = append_snapshot(&mut files[file_idx], &snapshot);
             replace_assignment_rhs(&mut files[file_idx], stmt, rhs);
         }
@@ -156,16 +165,40 @@ fn collect_statement_exports(
             continue;
         }
         let exported = stable_symbol_hash(interner.resolve(name));
+        let deps = import_dependency_snapshots(il, interner, rhs);
         for &module in module_hashes {
             let key = (module, exported);
             if exports
-                .insert(key, ExportedBinding { file_idx, rhs })
+                .insert(
+                    key,
+                    ExportedBinding {
+                        file_idx,
+                        deps: deps.clone(),
+                        rhs,
+                    },
+                )
                 .is_some()
             {
                 ambiguous.insert(key);
             }
         }
     }
+}
+
+fn import_dependency_snapshots(il: &Il, interner: &Interner, rhs: NodeId) -> Vec<SubtreeSnapshot> {
+    collect_top_level_statements(il)
+        .into_iter()
+        .filter(|&stmt| {
+            assignment_rhs(il, stmt).is_some_and(|dep_rhs| {
+                import_binding_key(il, interner, stmt).is_some()
+                    && il.kind(dep_rhs) == NodeKind::Seq
+            })
+        })
+        .filter(|&stmt| {
+            assignment_name(il, stmt).is_some_and(|name| node_contains_symbol(il, rhs, name))
+        })
+        .map(|stmt| snapshot_subtree(il, stmt))
+        .collect()
 }
 
 fn collect_top_level_statements(il: &Il) -> Vec<NodeId> {
@@ -649,4 +682,23 @@ fn replace_assignment_rhs(il: &mut Il, stmt: NodeId, rhs: NodeId) {
     if let Some(slot) = il.edges.get_mut(rhs_slot) {
         *slot = rhs;
     }
+}
+
+fn prepend_root_statement(il: &mut Il, stmt: NodeId) {
+    let old_root = il.root;
+    let old_root_node = *il.node(old_root);
+    let mut children = Vec::with_capacity(il.children(old_root).len() + 1);
+    children.push(stmt);
+    children.extend_from_slice(il.children(old_root));
+    let child_start = il.edges.len() as u32;
+    il.edges.extend_from_slice(&children);
+    let new_root = NodeId(il.nodes.len() as u32);
+    il.nodes.push(Node {
+        kind: old_root_node.kind,
+        payload: old_root_node.payload,
+        span: old_root_node.span,
+        child_start,
+        child_len: children.len() as u32,
+    });
+    il.root = new_root;
 }

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -9,7 +9,10 @@
 use nose_il::{
     stable_symbol_hash, Il, Interner, Node, NodeId, NodeKind, Payload, Span, Symbol, UnitKind,
 };
-use nose_semantics::{semantics, ImportedMapFactoryContract};
+use nose_semantics::{
+    java_map_entry_contract, java_map_factory_contract, semantics, ImportedMapFactoryContract,
+    JavaMapFactoryKind,
+};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::Path;
 
@@ -302,20 +305,22 @@ fn java_map_factory_call_safe(il: &Il, interner: &Interner, call: NodeId) -> boo
     let Some(method) = field_method_on_var(il, interner, callee, "Map") else {
         return false;
     };
-    if java_file_defines_type_name(il, interner, "Map") {
+    let Some(contract) = java_map_factory_contract(il.meta.lang, "Map", method) else {
+        return false;
+    };
+    if java_file_defines_type_name(il, interner, contract.receiver) {
         return false;
     }
-    match method {
-        "of" => {
+    match contract.kind {
+        JavaMapFactoryKind::Of => {
             args.len() % 2 == 0
                 && args
                     .iter()
                     .all(|&arg| literal_export_value_safe(il, interner, arg))
         }
-        "ofEntries" => args
+        JavaMapFactoryKind::OfEntries => args
             .iter()
             .all(|&arg| java_map_entry_call_safe(il, interner, arg)),
-        _ => false,
     }
 }
 
@@ -327,7 +332,10 @@ fn java_map_entry_call_safe(il: &Il, interner: &Interner, call: NodeId) -> bool 
     if kids.len() != 3 {
         return false;
     }
-    if field_method_on_var(il, interner, kids[0], "Map") != Some("entry") {
+    let Some(method) = field_method_on_var(il, interner, kids[0], "Map") else {
+        return false;
+    };
+    if !java_map_entry_contract(il.meta.lang, "Map", method) {
         return false;
     }
     if java_file_defines_type_name(il, interner, "Map") {
@@ -342,9 +350,14 @@ fn rust_std_map_factory_call_safe(il: &Il, interner: &Interner, call: NodeId) ->
     if kids.len() != 2 {
         return false;
     }
-    if !var_named(il, interner, kids[0], "std::collections::HashMap::from")
-        && !var_named(il, interner, kids[0], "std::collections::BTreeMap::from")
-    {
+    let Some(name) = var_text(il, interner, kids[0]) else {
+        return false;
+    };
+    let factory = semantics(il.meta.lang)
+        .collections()
+        .free_name_map_factories()
+        .find(|factory| factory.names.contains(&name));
+    if factory.is_none() || !free_name_factory_shadow_safe(il, interner, name, false) {
         return false;
     }
     literal_export_value_safe(il, interner, kids[1])
@@ -367,10 +380,44 @@ fn field_method_on_var<'a>(
 }
 
 fn var_named(il: &Il, interner: &Interner, node: NodeId, expected: &str) -> bool {
+    var_text(il, interner, node).is_some_and(|name| name == expected)
+}
+
+fn var_text<'a>(il: &Il, interner: &'a Interner, node: NodeId) -> Option<&'a str> {
     if il.kind(node) != NodeKind::Var {
-        return false;
+        return None;
     }
-    matches!(il.node(node).payload, Payload::Name(name) if interner.resolve(name) == expected)
+    let Payload::Name(name) = il.node(node).payload else {
+        return None;
+    };
+    Some(interner.resolve(name))
+}
+
+fn free_name_factory_shadow_safe(
+    il: &Il,
+    interner: &Interner,
+    name: &str,
+    shadow_guard: bool,
+) -> bool {
+    if shadow_guard {
+        return !file_defines_name(il, interner, name);
+    }
+    if il.meta.lang == nose_il::Lang::Rust && name.starts_with("std::") {
+        return !file_defines_name(il, interner, "std");
+    }
+    true
+}
+
+fn file_defines_name(il: &Il, interner: &Interner, expected: &str) -> bool {
+    collect_top_level_statements(il).iter().any(|&stmt| {
+        assignment_name(il, stmt).is_some_and(|symbol| interner.resolve(symbol) == expected)
+    }) || il.units.iter().any(|unit| {
+        unit.name
+            .is_some_and(|symbol| interner.resolve(symbol) == expected)
+    }) || il.nodes.iter().any(|node| {
+        matches!(node.kind, NodeKind::Module | NodeKind::Block)
+            && matches!(node.payload, Payload::Name(symbol) if interner.resolve(symbol) == expected)
+    })
 }
 
 fn java_file_defines_type_name(il: &Il, interner: &Interner, expected: &str) -> bool {

--- a/crates/nose-frontend/src/ruby.rs
+++ b/crates/nose-frontend/src/ruby.rs
@@ -2,14 +2,14 @@
 //!
 //! Convergence-friendly lowering: `def` → function unit, `class`/`module` →
 //! class-like unit; `if`/`unless`/`while`/`until`/`case` map to `If`/`Loop`;
-//! `xs.each { |x| … }` and `for x in xs` map to a `ForEach` loop; `x op= y`
-//! desugars to an assignment; method calls → `Field`-call form. Ruby's implicit
+//! `for x in xs` maps to a `ForEach` loop; `x op= y` desugars to an assignment;
+//! method calls → `Field`-call form. Ruby's implicit
 //! last-expression return is wrapped in `Return` to converge with explicit returns.
 
 use crate::lower::{common_bin_op, Lowering};
 use nose_il::{
-    Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload, Span,
-    Symbol, UnitKind,
+    FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload, Span, Symbol,
+    UnitKind,
 };
 use tree_sitter::Node as TsNode;
 
@@ -105,15 +105,9 @@ fn lower_stmt(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
         // converge with the block forms and other languages' guards.
         "if_modifier" | "unless_modifier" => Some(lower_modifier(lo, node)),
         "assignment" | "operator_assignment" => Some(lower_assign(lo, node)),
-        // `xs.each { … }` as a statement is a loop, not an expr-statement — emit it
-        // bare so it converges with a `for x in xs` loop in other languages.
         "call" | "method_call" => {
-            if let Some(loop_node) = try_each_loop(lo, node) {
-                Some(loop_node)
-            } else {
-                let e = lower_call(lo, node);
-                Some(lo.add(NodeKind::ExprStmt, Payload::None, span, &[e]))
-            }
+            let e = lower_call(lo, node);
+            Some(lo.add(NodeKind::ExprStmt, Payload::None, span, &[e]))
         }
         _ => {
             let e = lower_expr(lo, node);
@@ -574,76 +568,8 @@ fn raw_kids(lo: &mut Lowering, node: TsNode) -> NodeId {
     lo.raw(node.kind(), span, &kids)
 }
 
-/// `recv.method(args) { block }` → `Call(Field(method, recv), args…, block?)`.
-/// An iteration like `xs.each { |x| … }` becomes a `ForEach` loop for convergence.
-/// `xs.each { |x| body }` / `xs.each do |x| body end` → `ForEach(x, xs, body)`,
-/// so Ruby iteration converges with a `for x in xs` loop in other languages.
-fn try_each_loop(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
-    let span = lo.span(node);
-    let m = node
-        .child_by_field_name("method")
-        .map(|m| lo.text(m).to_string())?;
-    let r = node.child_by_field_name("receiver")?;
-    let b = Lowering::named_children(node)
-        .into_iter()
-        .find(|c| matches!(c.kind(), "block" | "do_block"))?;
-    if !matches!(m.as_str(), "each" | "each_with_index") {
-        return None;
-    }
-    let mut iter = lower_expr(lo, r);
-    let params = b
-        .child_by_field_name("parameters")
-        .map(Lowering::named_children)
-        .unwrap_or_default();
-    let pat = if m.as_str() == "each_with_index" {
-        let mut params = params;
-        if params.len() >= 2 {
-            // Ruby yields `(element, index)`, while the shared Enumerate lowering
-            // expects pattern order `(index, element)`.
-            params.swap(0, 1);
-        }
-        let vars: Vec<NodeId> = params
-            .into_iter()
-            .map(|p| lower_block_param_var(lo, p, span))
-            .collect();
-        iter = lo.add(
-            NodeKind::Call,
-            Payload::Builtin(Builtin::Enumerate),
-            span,
-            &[iter],
-        );
-        lo.add(NodeKind::Seq, Payload::None, span, &vars)
-    } else {
-        params
-            .into_iter()
-            .next()
-            .and_then(|p| param_name(lo, p))
-            .map(|s| lo.add(NodeKind::Var, Payload::Name(s), span, &[]))
-            .unwrap_or_else(|| lo.empty_block(span))
-    };
-    let body = block_body(lo, b);
-    Some(lo.add(
-        NodeKind::Loop,
-        Payload::Loop(LoopKind::ForEach),
-        span,
-        &[pat, iter, body],
-    ))
-}
-
-fn lower_block_param_var(lo: &mut Lowering, node: TsNode, span: Span) -> NodeId {
-    if lo.text(node) == "_" {
-        return lo.empty_block(span);
-    }
-    param_name(lo, node)
-        .map(|s| lo.add(NodeKind::Var, Payload::Name(s), span, &[]))
-        .unwrap_or_else(|| lo.empty_block(span))
-}
-
 fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
-    if let Some(loop_node) = try_each_loop(lo, node) {
-        return loop_node;
-    }
     let method = node
         .child_by_field_name("method")
         .map(|m| lo.sym(lo.text(m)));

--- a/crates/nose-frontend/src/rust.rs
+++ b/crates/nose-frontend/src/rust.rs
@@ -473,11 +473,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
     match node.kind() {
         "identifier" | "type_identifier" | "field_identifier" | "scoped_identifier" => {
-            if lo.text(node) == "None" {
-                lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[])
-            } else {
-                lo.var(lo.text(node), span)
-            }
+            lo.var(lo.text(node), span)
         }
         "self" => lo.var("self", span),
         "integer_literal" => {
@@ -898,9 +894,9 @@ fn lower_let_condition(lo: &mut Lowering, node: TsNode) -> NodeId {
         return lower_expr(lo, node);
     };
     let text = lo.text(node).trim();
-    let op = if text.starts_with("let Some") {
+    let op = if text.starts_with("let Some") && !rust_file_defines_name(lo, "Some") {
         Some(Builtin::IsNotNull)
-    } else if text.starts_with("let None") {
+    } else if text.starts_with("let None") && !rust_file_defines_name(lo, "None") {
         Some(Builtin::IsNull)
     } else {
         None
@@ -910,6 +906,51 @@ fn lower_let_condition(lo: &mut Lowering, node: TsNode) -> NodeId {
         return lo.add(NodeKind::Call, Payload::Builtin(op), span, &[value]);
     }
     lower_expr(lo, value_node)
+}
+
+fn rust_file_defines_name(lo: &Lowering, name: &str) -> bool {
+    let Ok(src) = std::str::from_utf8(lo.src) else {
+        return false;
+    };
+    rust_item_declares_name(src, name)
+}
+
+fn rust_item_declares_name(src: &str, name: &str) -> bool {
+    const ITEM_PREFIXES: &[&str] = &[
+        "const", "static", "fn", "struct", "enum", "union", "type", "mod", "trait",
+    ];
+    src.lines()
+        .map(strip_rust_line_comment)
+        .map(rust_identifier_tokens)
+        .any(|tokens| rust_tokens_declare_name(&tokens, ITEM_PREFIXES, name))
+}
+
+fn strip_rust_line_comment(line: &str) -> &str {
+    line.split_once("//").map(|(code, _)| code).unwrap_or(line)
+}
+
+fn rust_identifier_tokens(line: &str) -> Vec<&str> {
+    line.split(|ch: char| !(ch == '_' || ch.is_ascii_alphanumeric()))
+        .filter(|token| !token.is_empty())
+        .collect()
+}
+
+fn rust_tokens_declare_name(tokens: &[&str], item_prefixes: &[&str], name: &str) -> bool {
+    tokens.iter().enumerate().any(|(idx, token)| {
+        if !item_prefixes.contains(token) {
+            return false;
+        }
+        tokens
+            .get(idx + 1)
+            .is_some_and(|candidate| !rust_item_qualifier_token(candidate) && *candidate == name)
+    })
+}
+
+fn rust_item_qualifier_token(token: &str) -> bool {
+    matches!(
+        token,
+        "pub" | "crate" | "super" | "self" | "unsafe" | "async" | "extern" | "const" | "fn"
+    )
 }
 
 /// `match e { p1 => b1, p2 => b2, … }` → nested `if`/`else` chain, each arm's
@@ -1247,6 +1288,26 @@ mod tests {
             il.nodes.iter().any(|node| node.kind == NodeKind::Throw),
             "panic! should lower to a Throw node so guard clauses are path-narrowing exits"
         );
+    }
+
+    #[test]
+    fn rust_item_shadow_scan_handles_visibility_and_qualifiers() {
+        assert!(rust_item_declares_name(
+            "pub(crate) struct Some<T>(T);",
+            "Some"
+        ));
+        assert!(rust_item_declares_name(
+            "pub const None: Option<i32> = Some(0);",
+            "None"
+        ));
+        assert!(rust_item_declares_name(
+            "pub const fn Some(value: i32) -> Option<i32> { None }",
+            "Some"
+        ));
+        assert!(!rust_item_declares_name(
+            "if let Some(_) = value { true } else { false }",
+            "Some"
+        ));
     }
 
     #[test]

--- a/crates/nose-normalize/src/desugar.rs
+++ b/crates/nose-normalize/src/desugar.rs
@@ -13,7 +13,8 @@
 
 use crate::idioms::{canon_call, CallCanon};
 use crate::NormalizeOptions;
-use nose_il::{Il, IlBuilder, Interner, LoopKind, NodeId, NodeKind, ParamSemantic, Payload};
+use nose_il::{Il, IlBuilder, Interner, LoopKind, NodeId, NodeKind, Payload};
+use nose_semantics::{domain_evidence_from_param_semantic, DomainEvidence};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 pub(crate) fn run(old: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il {
@@ -266,15 +267,12 @@ impl Rebuilder<'_> {
 
 fn property_receiver_exact_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
     il.kind(node) == NodeKind::Seq
-        || matches!(
-            param_semantic_for_var(il, node),
-            Some(ParamSemantic::Array | ParamSemantic::Collection)
-        )
+        || domain_evidence_for_var(il, node).is_some_and(DomainEvidence::is_array_or_collection)
         || property_receiver_exact_hof_node(il, interner, node)
         || property_receiver_exact_hof_call(il, interner, node)
 }
 
-fn param_semantic_for_var(il: &Il, node: NodeId) -> Option<ParamSemantic> {
+fn domain_evidence_for_var(il: &Il, node: NodeId) -> Option<DomainEvidence> {
     if il.kind(node) != NodeKind::Var {
         return None;
     }
@@ -288,7 +286,7 @@ fn param_semantic_for_var(il: &Il, node: NodeId) -> Option<ParamSemantic> {
     il.param_type_facts
         .iter()
         .find(|fact| fact.span == span)
-        .map(|fact| fact.semantic)
+        .map(|fact| domain_evidence_from_param_semantic(fact.semantic))
 }
 
 fn property_receiver_exact_hof_call(il: &Il, interner: &Interner, node: NodeId) -> bool {

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -12,8 +12,8 @@ use nose_semantics::{
     domain_evidence_from_param_semantic, free_function_builtin_contract,
     iterator_identity_adapter_contract, map_get_contract, map_key_view_contract,
     method_call_contract, method_hof_contract, rust_option_some_constructor_contract,
-    BuiltinArgContract, DomainEvidence, MapKeyViewKind, MethodBuiltinArgs, MethodCallContract,
-    MethodReceiverContract, MethodSemanticContract,
+    static_collection_adapter_contract, BuiltinArgContract, DomainEvidence, MapKeyViewKind,
+    MethodBuiltinArgs, MethodCallContract, MethodReceiverContract, MethodSemanticContract,
 };
 
 /// The result of inspecting a `Call`: it canonicalizes to a builtin, to a
@@ -391,8 +391,8 @@ fn fold_fn_init(old: &Il, args: &[NodeId]) -> (Option<NodeId>, Option<NodeId>) {
     (fn_old, init)
 }
 
-/// Peel a first-party Rust identity iterator adapter to the underlying collection, so
-/// `xs.iter().fold(..)` iterates over `xs` (matching `for v in xs`). NOT `.keys()`/`.values()`,
+/// Peel a first-party identity iterator adapter to the underlying collection, so
+/// `xs.iter().fold(..)` / `xs.stream().map(..)` iterate over `xs`. NOT `.keys()`/`.values()`,
 /// which change *what* is iterated.
 fn unwrap_iter(old: &Il, interner: &Interner, node: NodeId) -> NodeId {
     if old.kind(node) == NodeKind::Call {
@@ -401,15 +401,11 @@ fn unwrap_iter(old: &Il, interner: &Interner, node: NodeId) -> NodeId {
             if old.kind(callee) == NodeKind::Field {
                 if let Payload::Name(s) = old.node(callee).payload {
                     let method = interner.resolve(s);
-                    if method == "stream" {
-                        if let Some(&base) = old.children(callee).first() {
-                            if name_of(old, interner, base) == Some("Arrays") {
-                                if let Some(&arg) = old.children(node).get(1) {
-                                    return arg;
-                                }
-                            } else {
-                                return base;
-                            }
+                    if let Some(&base) = old.children(callee).first() {
+                        if let Some(arg) =
+                            static_collection_adapter_arg(old, interner, base, method, call_kids)
+                        {
+                            return arg;
                         }
                     }
                     if iterator_identity_adapter_contract(
@@ -458,10 +454,8 @@ fn exact_protocol_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool 
     if matches!(method, "iter" | "into_iter" | "iter_mut") {
         return exact_collection_receiver(old, interner, receiver);
     }
-    if method == "stream" && name_of(old, interner, receiver) == Some("Arrays") {
-        return kids
-            .get(1)
-            .is_some_and(|&arg| exact_collection_receiver(old, interner, arg));
+    if let Some(arg) = static_collection_adapter_arg(old, interner, receiver, method, kids) {
+        return exact_collection_receiver(old, interner, arg);
     }
     if method == "zip" && kids.len() == 2 {
         return exact_protocol_receiver(old, interner, receiver)
@@ -478,6 +472,28 @@ fn exact_protocol_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool 
 
 fn exact_collection_param(old: &Il, node: NodeId) -> bool {
     domain_evidence_for_var(old, node).is_some_and(DomainEvidence::is_array_collection_or_set)
+}
+
+fn static_collection_adapter_arg(
+    old: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+    method: &str,
+    call_kids: &[NodeId],
+) -> Option<NodeId> {
+    let receiver_name = name_of(old, interner, receiver)?;
+    let contract = static_collection_adapter_contract(
+        old.meta.lang,
+        receiver_name,
+        method,
+        call_kids.len().saturating_sub(1),
+    )?;
+    if file_defines_type_name(old, interner, receiver_name)
+        || !import_binding_expr(old, interner, receiver, contract.module, contract.exported)
+    {
+        return None;
+    }
+    call_kids.get(1).copied()
 }
 
 fn exact_set_param(old: &Il, node: NodeId) -> bool {
@@ -719,6 +735,14 @@ fn file_defines_name(old: &Il, interner: &Interner, name: &str) -> bool {
         })
 }
 
+fn file_defines_type_name(old: &Il, interner: &Interner, name: &str) -> bool {
+    old.units
+        .iter()
+        .filter(|unit| matches!(unit.kind, nose_il::UnitKind::Class))
+        .filter_map(|unit| unit.name)
+        .any(|symbol| interner.resolve(symbol) == name)
+}
+
 fn name_of<'a>(old: &Il, interner: &'a Interner, id: NodeId) -> Option<&'a str> {
     let n = old.node(id);
     if n.kind == NodeKind::Var {
@@ -741,6 +765,62 @@ fn import_namespace_expr(old: &Il, interner: &Interner, id: NodeId, module: &str
                     .iter()
                     .any(|&child| import_namespace_assignment(old, interner, child, alias, module)))
     })
+}
+
+fn import_binding_expr(
+    old: &Il,
+    interner: &Interner,
+    id: NodeId,
+    module: &str,
+    exported: &str,
+) -> bool {
+    let Some(alias) = name_of(old, interner, id) else {
+        return false;
+    };
+    old.children(old.root).iter().any(|&stmt| {
+        import_binding_assignment(old, interner, stmt, alias, module, exported)
+            || (old.kind(stmt) == NodeKind::Block
+                && old.children(stmt).iter().any(|&child| {
+                    import_binding_assignment(old, interner, child, alias, module, exported)
+                }))
+    })
+}
+
+fn import_binding_assignment(
+    old: &Il,
+    interner: &Interner,
+    stmt: NodeId,
+    alias: &str,
+    module: &str,
+    exported: &str,
+) -> bool {
+    if old.kind(stmt) != NodeKind::Assign {
+        return false;
+    }
+    let kids = old.children(stmt);
+    if kids.len() != 2 || assignment_alias_name(old, interner, kids[0]) != Some(alias) {
+        return false;
+    }
+    if old.kind(kids[1]) != NodeKind::Seq {
+        return false;
+    }
+    let Payload::Name(seq_name) = old.node(kids[1]).payload else {
+        return false;
+    };
+    if interner.resolve(seq_name) != "import_binding" {
+        return false;
+    }
+    let coords = old.children(kids[1]);
+    if coords.len() != 2 {
+        return false;
+    }
+    matches!(
+        old.node(coords[0]).payload,
+        Payload::LitStr(hash) if hash == stable_symbol_hash(module)
+    ) && matches!(
+        old.node(coords[1]).payload,
+        Payload::LitStr(hash) if hash == stable_symbol_hash(exported)
+    )
 }
 
 fn import_namespace_assignment(

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -10,10 +10,10 @@
 use nose_il::{stable_symbol_hash, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
 use nose_semantics::{
     domain_evidence_from_param_semantic, free_function_builtin_contract,
-    iterator_identity_adapter_contract, map_key_view_contract, method_call_contract,
-    method_hof_contract, rust_option_some_constructor_contract, BuiltinArgContract, DomainEvidence,
-    MapKeyViewKind, MethodBuiltinArgs, MethodCallContract, MethodReceiverContract,
-    MethodSemanticContract,
+    iterator_identity_adapter_contract, map_get_contract, map_key_view_contract,
+    method_call_contract, method_hof_contract, rust_option_some_constructor_contract,
+    BuiltinArgContract, DomainEvidence, MapKeyViewKind, MethodBuiltinArgs, MethodCallContract,
+    MethodReceiverContract, MethodSemanticContract,
 };
 
 /// The result of inspecting a `Call`: it canonicalizes to a builtin, to a
@@ -810,9 +810,7 @@ fn map_get_call_parts(old: &Il, interner: &Interner, id: NodeId) -> Option<(Node
     let Payload::Name(method) = old.node(kids[0]).payload else {
         return None;
     };
-    if interner.resolve(method) != "get" {
-        return None;
-    }
+    map_get_contract(old.meta.lang, interner.resolve(method), 1)?;
     let receiver = *old.children(kids[0]).first()?;
     Some((receiver, kids[1]))
 }

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -11,8 +11,8 @@ use nose_il::{stable_symbol_hash, Builtin, HoFKind, Il, Interner, NodeId, NodeKi
 use nose_semantics::{
     domain_evidence_from_param_semantic, free_function_builtin_contract,
     iterator_identity_adapter_contract, method_call_contract, method_hof_contract,
-    BuiltinArgContract, DomainEvidence, MethodBuiltinArgs, MethodCallContract,
-    MethodReceiverContract, MethodSemanticContract,
+    rust_option_some_constructor_contract, BuiltinArgContract, DomainEvidence, MethodBuiltinArgs,
+    MethodCallContract, MethodReceiverContract, MethodSemanticContract,
 };
 
 /// The result of inspecting a `Call`: it canonicalizes to a builtin, to a
@@ -658,16 +658,8 @@ fn exact_integer_receiver(old: &Il, node: NodeId) -> bool {
 }
 
 fn rust_option_some_name(old: &Il, interner: &Interner, text: &str) -> bool {
-    if old.meta.lang != nose_il::Lang::Rust {
-        return false;
-    }
-    match text {
-        "Some" => !file_defines_name(old, interner, "Some"),
-        "Option::Some" => !file_defines_name(old, interner, "Option"),
-        "std::option::Option::Some" => !file_defines_name(old, interner, "std"),
-        "core::option::Option::Some" => !file_defines_name(old, interner, "core"),
-        _ => false,
-    }
+    rust_option_some_constructor_contract(old.meta.lang, text)
+        .is_some_and(|contract| !file_defines_name(old, interner, contract.shadow_root))
 }
 
 fn proven_map_get_call_parts(

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -7,12 +7,11 @@
 //! proof-obligation: normalize.value_graph.functor
 //! proof-obligation: normalize.value_graph.min_max
 
-use nose_il::{
-    stable_symbol_hash, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, ParamSemantic, Payload,
-};
+use nose_il::{stable_symbol_hash, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
 use nose_semantics::{
-    free_function_builtin_contract, iterator_identity_adapter_contract, method_call_contract,
-    method_hof_contract, BuiltinArgContract, MethodBuiltinArgs, MethodCallContract,
+    domain_evidence_from_param_semantic, free_function_builtin_contract,
+    iterator_identity_adapter_contract, method_call_contract, method_hof_contract,
+    BuiltinArgContract, DomainEvidence, MethodBuiltinArgs, MethodCallContract,
     MethodReceiverContract, MethodSemanticContract,
 };
 
@@ -477,18 +476,15 @@ fn exact_protocol_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool 
 }
 
 fn exact_collection_param(old: &Il, node: NodeId) -> bool {
-    matches!(
-        param_semantic_for_var(old, node),
-        Some(ParamSemantic::Array | ParamSemantic::Collection | ParamSemantic::Set)
-    )
+    domain_evidence_for_var(old, node).is_some_and(DomainEvidence::is_array_collection_or_set)
 }
 
 fn exact_set_param(old: &Il, node: NodeId) -> bool {
-    matches!(param_semantic_for_var(old, node), Some(ParamSemantic::Set))
+    domain_evidence_for_var(old, node).is_some_and(DomainEvidence::is_set)
 }
 
 fn exact_map_param(old: &Il, node: NodeId) -> bool {
-    matches!(param_semantic_for_var(old, node), Some(ParamSemantic::Map))
+    domain_evidence_for_var(old, node).is_some_and(DomainEvidence::is_map)
 }
 
 fn exact_map_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
@@ -496,13 +492,10 @@ fn exact_map_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
 }
 
 fn exact_option_param(old: &Il, node: NodeId) -> bool {
-    matches!(
-        param_semantic_for_var(old, node),
-        Some(ParamSemantic::Option)
-    )
+    domain_evidence_for_var(old, node).is_some_and(DomainEvidence::is_option)
 }
 
-fn param_semantic_for_var(old: &Il, node: NodeId) -> Option<ParamSemantic> {
+fn domain_evidence_for_var(old: &Il, node: NodeId) -> Option<DomainEvidence> {
     if old.kind(node) != NodeKind::Var {
         return None;
     }
@@ -524,7 +517,7 @@ fn param_semantic_for_var(old: &Il, node: NodeId) -> Option<ParamSemantic> {
         old.param_type_facts
             .iter()
             .find(|fact| fact.span == span)
-            .map(|fact| fact.semantic)
+            .map(|fact| domain_evidence_from_param_semantic(fact.semantic))
     })
 }
 
@@ -645,8 +638,8 @@ fn exact_string_receiver(old: &Il, node: NodeId) -> bool {
         old.node(node).payload,
         Payload::LitStr(_) | Payload::Lit(nose_il::LitClass::Str)
     ) || matches!(
-        param_semantic_for_var(old, node),
-        Some(ParamSemantic::String)
+        domain_evidence_for_var(old, node),
+        Some(domain) if domain.is_string()
     )
 }
 
@@ -659,8 +652,8 @@ fn exact_integer_receiver(old: &Il, node: NodeId) -> bool {
         old.node(node).payload,
         Payload::LitInt(_) | Payload::Lit(nose_il::LitClass::Int)
     ) || matches!(
-        param_semantic_for_var(old, node),
-        Some(ParamSemantic::Integer)
+        domain_evidence_for_var(old, node),
+        Some(domain) if domain.is_integer()
     )
 }
 
@@ -904,7 +897,7 @@ fn identity_lambda(old: &Il, lambda: NodeId) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_il::{FileId, FileMeta, IlBuilder, Lang, ParamTypeFact, Span};
+    use nose_il::{FileId, FileMeta, IlBuilder, Lang, ParamSemantic, ParamTypeFact, Span};
 
     fn sp() -> Span {
         Span::new(FileId(0), 1, 1, 1, 1)

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -10,9 +10,10 @@
 use nose_il::{stable_symbol_hash, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
 use nose_semantics::{
     domain_evidence_from_param_semantic, free_function_builtin_contract,
-    iterator_identity_adapter_contract, method_call_contract, method_hof_contract,
-    rust_option_some_constructor_contract, BuiltinArgContract, DomainEvidence, MethodBuiltinArgs,
-    MethodCallContract, MethodReceiverContract, MethodSemanticContract,
+    iterator_identity_adapter_contract, map_key_view_contract, method_call_contract,
+    method_hof_contract, rust_option_some_constructor_contract, BuiltinArgContract, DomainEvidence,
+    MapKeyViewKind, MethodBuiltinArgs, MethodCallContract, MethodReceiverContract,
+    MethodSemanticContract,
 };
 
 /// The result of inspecting a `Call`: it canonicalizes to a builtin, to a
@@ -827,7 +828,8 @@ fn key_set_receiver(old: &Il, interner: &Interner, id: NodeId) -> Option<NodeId>
     let Payload::Name(method) = old.node(kids[0]).payload else {
         return None;
     };
-    if interner.resolve(method) != "keySet" {
+    let contract = map_key_view_contract(old.meta.lang, interner.resolve(method), 0)?;
+    if contract.kind != MapKeyViewKind::Collection {
         return None;
     }
     old.children(kids[0]).first().copied()

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -54,8 +54,8 @@ use nose_semantics::{
     index_membership_threshold_contract, iterator_identity_adapter_contract,
     java_collection_factory_contract_by_hash, java_map_entry_contract_by_hash,
     java_map_factory_contract_by_hash, map_get_contract_by_hash, map_key_view_contract_by_hash,
-    map_key_view_wrapper_contract_by_hash, method_call_contract, reduction_builtin_contract,
-    ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
+    map_key_view_wrapper_contract_by_hash, method_call_contract, nullish_global_contract,
+    reduction_builtin_contract, ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
     rust_option_some_constructor_contract, rust_vec_new_factory_contract,
     scalar_integer_method_contract, semantics, static_index_membership_contract, DomainEvidence,
     GoZeroMapDefaultKind, ImportedNamespaceFunctionSemantic, IndexMembershipThreshold,
@@ -6994,6 +6994,12 @@ impl<'a> Builder<'a> {
                 Payload::Name(s) => {
                     if let Some(&v) = self.global_env.get(&s) {
                         return v;
+                    }
+                    let name = self.interner.resolve(s);
+                    if let Some(contract) = nullish_global_contract(self.il.meta.lang, name) {
+                        if !contract.requires_unshadowed || !self.file_defines_name(contract.name) {
+                            return self.null_const();
+                        }
                     }
                     let key = 0x8000_0000u32 | (self.interner.symbol_hash(s) as u32);
                     self.mk(ValOp::Input(key), vec![])

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -56,11 +56,12 @@ use nose_semantics::{
     java_map_factory_contract_by_hash, map_get_contract_by_hash, map_key_view_contract_by_hash,
     map_key_view_wrapper_contract_by_hash, method_call_contract, nullish_global_contract,
     reduction_builtin_contract, ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
-    rust_option_some_constructor_contract, rust_vec_new_factory_contract,
-    scalar_integer_method_contract, semantics, static_index_membership_contract, DomainEvidence,
-    GoZeroMapDefaultKind, ImportedNamespaceFunctionSemantic, IndexMembershipThreshold,
-    IteratorAdapterReceiverContract, JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs,
-    MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
+    rust_option_none_sentinel_contract, rust_option_some_constructor_contract,
+    rust_vec_new_factory_contract, scalar_integer_method_contract, semantics,
+    static_index_membership_contract, DomainEvidence, GoZeroMapDefaultKind,
+    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
+    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
+    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
     StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -6728,6 +6729,7 @@ impl<'a> Builder<'a> {
             }
             NodeKind::If => self.eval_filter_map_if(node, env),
             NodeKind::Lit if self.is_null_literal(node) => Some(FilterMapResult::Drop),
+            NodeKind::Var if self.is_rust_option_none_node(node) => Some(FilterMapResult::Drop),
             NodeKind::Call => {
                 if let Some((receiver, lambda)) = self.rust_option_and_then_call_parts(node) {
                     return self.eval_filter_map_and_then(receiver, lambda, env);
@@ -6876,6 +6878,19 @@ impl<'a> Builder<'a> {
             .is_some_and(|contract| !self.file_defines_name(contract.shadow_root))
     }
 
+    fn rust_option_none_name(&self, text: &str) -> bool {
+        rust_option_none_sentinel_contract(self.il.meta.lang, text)
+            .is_some_and(|contract| !self.file_defines_name(contract.shadow_root))
+    }
+
+    fn is_rust_option_none_node(&self, node: NodeId) -> bool {
+        let (NodeKind::Var, Payload::Name(name)) = (self.il.kind(node), self.il.node(node).payload)
+        else {
+            return false;
+        };
+        self.rust_option_none_name(self.interner.resolve(name))
+    }
+
     fn rust_vec_new_name(&self, text: &str) -> bool {
         rust_vec_new_factory_contract(self.il.meta.lang, text)
             .is_some_and(|contract| !self.file_defines_name(contract.shadow_root))
@@ -6996,6 +7011,9 @@ impl<'a> Builder<'a> {
                         return v;
                     }
                     let name = self.interner.resolve(s);
+                    if self.rust_option_none_name(name) {
+                        return self.null_const();
+                    }
                     if let Some(contract) = nullish_global_contract(self.il.meta.lang, name) {
                         if !contract.requires_unshadowed || !self.file_defines_name(contract.name) {
                             return self.null_const();

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -52,7 +52,7 @@ use nose_semantics::{
     builder_append_method_contract, builtin_tag, domain_evidence_from_param_semantic,
     go_zero_map_default_kind, go_zero_map_lookup_contract, iterator_identity_adapter_contract,
     java_collection_factory_contract_by_hash, java_map_entry_contract_by_hash,
-    java_map_factory_contract_by_hash, map_key_view_contract_by_hash,
+    java_map_factory_contract_by_hash, map_get_contract_by_hash, map_key_view_contract_by_hash,
     map_key_view_wrapper_contract_by_hash, method_call_contract, reduction_builtin_contract,
     ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
     rust_option_some_constructor_contract, rust_vec_new_factory_contract,
@@ -1429,9 +1429,11 @@ impl<'a> Builder<'a> {
         }
         let args = node.args.clone();
         let callee = &self.nodes[node.args[0] as usize];
-        if !matches!(callee.op, ValOp::Field(name) if name == stable_symbol_hash("get"))
-            || callee.args.len() != 1
-        {
+        let ValOp::Field(method) = callee.op else {
+            return None;
+        };
+        map_get_contract_by_hash(self.il.meta.lang, method, args.len().saturating_sub(1))?;
+        if callee.args.len() != 1 {
             return None;
         }
         let map = callee.args[0];
@@ -1637,7 +1639,15 @@ impl<'a> Builder<'a> {
         let Payload::Name(name) = self.il.node(callee).payload else {
             return None;
         };
-        if !matches!(self.interner.resolve(name), "get" | "getOrDefault") {
+        let contract = method_call_contract(
+            self.il.meta.lang,
+            self.interner.resolve(name),
+            kids.len().saturating_sub(1),
+        )?;
+        if contract.semantic != MethodSemanticContract::Builtin(Builtin::GetOrDefault)
+            || contract.receiver != MethodReceiverContract::ExactMap
+            || contract.args != MethodBuiltinArgs::MapGetDefault
+        {
             return None;
         }
         let receiver = self.il.children(callee).first().copied()?;
@@ -6228,7 +6238,10 @@ impl<'a> Builder<'a> {
             return false;
         }
         let callee = &self.nodes[args[0] as usize];
-        if !matches!(callee.op, ValOp::Field(name) if name == stable_symbol_hash("get"))
+        let ValOp::Field(method) = callee.op else {
+            return false;
+        };
+        if map_get_contract_by_hash(self.il.meta.lang, method, 1).is_none()
             || callee.args.len() != 1
         {
             return false;

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -46,13 +46,14 @@ use crate::module_facts::{
 use crate::types::Ty;
 use nose_il::{
     stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LoopKind, NodeId, NodeKind, Op,
-    ParamSemantic, Payload, Span, Symbol, UnitKind,
+    Payload, Span, Symbol, UnitKind,
 };
 use nose_semantics::{
-    builder_append_method_contract, builtin_tag, iterator_identity_adapter_contract,
-    method_call_contract, reduction_builtin_contract, scalar_integer_method_contract, semantics,
-    IteratorAdapterReceiverContract, MethodBuiltinArgs, MethodReceiverContract,
-    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
+    builder_append_method_contract, builtin_tag, domain_evidence_from_param_semantic,
+    iterator_identity_adapter_contract, method_call_contract, reduction_builtin_contract,
+    scalar_integer_method_contract, semantics, DomainEvidence, IteratorAdapterReceiverContract,
+    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract,
+    ScalarIntegerMethod,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -399,9 +400,8 @@ struct Builder<'a> {
     /// Inferred parameter types by position (from `types::infer_param_types`), seeding the
     /// type of each `Input` node.
     param_ty: Vec<Ty>,
-    /// Explicit source-level parameter semantic facts keyed by the alpha-renamed cid
-    /// currently in scope.
-    param_semantic: FxHashMap<u32, ParamSemantic>,
+    /// Kernel domain evidence keyed by the alpha-renamed cid currently in scope.
+    param_domain: FxHashMap<u32, DomainEvidence>,
     /// The branch conditions currently in effect (each a `cond` or `Not(cond)`). A
     /// `return`/`throw` reached under a non-empty path is tagged with that condition,
     /// so `if c {return A} else {return B}` and the branch-swapped `if c {return B}
@@ -503,7 +503,7 @@ impl<'a> Builder<'a> {
             valued_subtree_hash: None,
             vty: Vec::new(),
             param_ty: Vec::new(),
-            param_semantic: FxHashMap::default(),
+            param_domain: FxHashMap::default(),
             path: Vec::new(),
             bound_order_facts: Vec::new(),
             effect_slot: 0,
@@ -703,30 +703,30 @@ impl<'a> Builder<'a> {
         )
     }
 
-    fn param_semantic_for_param(&self, param: NodeId) -> Option<ParamSemantic> {
+    fn domain_evidence_for_param(&self, param: NodeId) -> Option<DomainEvidence> {
         let span = self.il.node(param).span;
         self.il
             .param_type_facts
             .iter()
             .find(|fact| fact.span == span)
-            .map(|fact| fact.semantic)
+            .map(|fact| domain_evidence_from_param_semantic(fact.semantic))
     }
 
-    fn seed_param_semantics(&mut self, root: NodeId) {
-        let scope = self.param_semantic_scope(root).unwrap_or(root);
+    fn seed_param_domains(&mut self, root: NodeId) {
+        let scope = self.param_domain_scope(root).unwrap_or(root);
         for &k in self.il.children(scope) {
             if self.il.kind(k) != NodeKind::Param {
                 continue;
             }
-            if let (Payload::Cid(cid), Some(semantic)) =
-                (self.il.node(k).payload, self.param_semantic_for_param(k))
+            if let (Payload::Cid(cid), Some(domain)) =
+                (self.il.node(k).payload, self.domain_evidence_for_param(k))
             {
-                self.param_semantic.insert(cid, semantic);
+                self.param_domain.insert(cid, domain);
             }
         }
     }
 
-    fn param_semantic_scope(&self, root: NodeId) -> Option<NodeId> {
+    fn param_domain_scope(&self, root: NodeId) -> Option<NodeId> {
         if self.il.kind(root) == NodeKind::Func {
             return Some(root);
         }
@@ -748,57 +748,53 @@ impl<'a> Builder<'a> {
         best.map(|(_, node)| node)
     }
 
-    fn param_semantic_of_expr(&self, expr: NodeId) -> Option<ParamSemantic> {
+    fn domain_evidence_of_expr(&self, expr: NodeId) -> Option<DomainEvidence> {
         if self.il.kind(expr) != NodeKind::Var {
             return None;
         }
         let Payload::Cid(cid) = self.il.node(expr).payload else {
             return None;
         };
-        self.param_semantic.get(&cid).copied()
+        self.param_domain.get(&cid).copied()
     }
 
     fn is_collection_param_expr(&self, expr: NodeId) -> bool {
-        matches!(
-            self.param_semantic_of_expr(expr),
-            Some(ParamSemantic::Collection | ParamSemantic::Set)
-        )
+        self.domain_evidence_of_expr(expr)
+            .is_some_and(DomainEvidence::is_collection_or_set)
     }
 
     fn is_map_param_expr(&self, expr: NodeId) -> bool {
-        matches!(self.param_semantic_of_expr(expr), Some(ParamSemantic::Map))
+        self.domain_evidence_of_expr(expr)
+            .is_some_and(DomainEvidence::is_map)
     }
 
     fn is_integer_param_expr(&self, expr: NodeId) -> bool {
-        matches!(
-            self.param_semantic_of_expr(expr),
-            Some(ParamSemantic::Integer)
-        )
+        self.domain_evidence_of_expr(expr)
+            .is_some_and(DomainEvidence::is_integer)
     }
 
-    /// Whether `value` is a parameter (an `Input`) carrying the given proof-gate semantic. Replaces
-    /// the per-semantic `is_map`/`is_integer`/`is_byte_array` recognizers (identical but for the
-    /// variant). `is_array` adds the `ArrayParam` op on top.
-    fn is_param_value(&self, value: ValueId, sem: ParamSemantic) -> bool {
+    /// Whether `value` is a parameter (an `Input`) carrying the given proof-gate domain.
+    /// `is_array` adds the `ArrayParam` op on top.
+    fn is_param_value(&self, value: ValueId, domain: DomainEvidence) -> bool {
         matches!(self.nodes[value as usize].op, ValOp::Input(cid)
-            if self.param_semantic.get(&cid) == Some(&sem))
+            if self.param_domain.get(&cid) == Some(&domain))
     }
 
     fn is_array_param_value(&self, value: ValueId) -> bool {
         matches!(self.nodes[value as usize].op, ValOp::ArrayParam)
-            || self.is_param_value(value, ParamSemantic::Array)
+            || self.is_param_value(value, DomainEvidence::Array)
     }
 
     fn param_domain_value(&mut self, value: ValueId) -> ValueId {
         let ValOp::Input(cid) = self.nodes[value as usize].op else {
             return value;
         };
-        match self.param_semantic.get(&cid).copied() {
-            Some(ParamSemantic::Array) => self.mk(ValOp::ArrayParam, vec![value]),
-            Some(ParamSemantic::Collection | ParamSemantic::Set) => {
+        match self.param_domain.get(&cid).copied() {
+            Some(domain) if domain.is_array() => self.mk(ValOp::ArrayParam, vec![value]),
+            Some(domain) if domain.is_collection_or_set() => {
                 self.mk(ValOp::CollectionParam, vec![value])
             }
-            Some(ParamSemantic::String) => self.mk(ValOp::StringParam, vec![value]),
+            Some(domain) if domain.is_string() => self.mk(ValOp::StringParam, vec![value]),
             _ => value,
         }
     }
@@ -1425,7 +1421,7 @@ impl<'a> Builder<'a> {
             return None;
         }
         let map = callee.args[0];
-        let map = if self.is_param_value(map, ParamSemantic::Map) {
+        let map = if self.is_param_value(map, DomainEvidence::Map) {
             map
         } else {
             self.proven_map_value(map)?
@@ -1452,7 +1448,7 @@ impl<'a> Builder<'a> {
                 return None;
             }
             let map = callee.args[0];
-            return if self.is_param_value(map, ParamSemantic::Map) {
+            return if self.is_param_value(map, DomainEvidence::Map) {
                 Some(map)
             } else {
                 self.proven_map_value(map)
@@ -1683,7 +1679,7 @@ impl<'a> Builder<'a> {
 
     fn is_integer_domain_value(&self, value: ValueId) -> bool {
         if self.int_const_value(value).is_some()
-            || self.is_param_value(value, ParamSemantic::Integer)
+            || self.is_param_value(value, DomainEvidence::Integer)
         {
             return true;
         }
@@ -2274,8 +2270,8 @@ impl<'a> Builder<'a> {
 
     fn build_unit_with_context(&mut self, root: NodeId, context: Option<&ValueFingerprintContext>) {
         self.param_ty = crate::types::infer_param_types(self.il, root);
-        self.param_semantic.clear();
-        self.seed_param_semantics(root);
+        self.param_domain.clear();
+        self.seed_param_domains(root);
         self.seed_immutable_bindings(root, context);
         self.build_inline_registry(root);
         let mut env: FxHashMap<u32, ValueId> = FxHashMap::default();
@@ -2291,8 +2287,8 @@ impl<'a> Builder<'a> {
                     if self.il.kind(k) == NodeKind::Param {
                         if let Payload::Cid(c) = self.il.node(k).payload {
                             if matches!(
-                                self.param_semantic.get(&c),
-                                Some(ParamSemantic::Integer | ParamSemantic::Number)
+                                self.param_domain.get(&c).copied(),
+                                Some(domain) if domain.is_integer_or_number()
                             ) {
                                 let pos_idx = pos as usize;
                                 if self.param_ty.len() <= pos_idx {
@@ -3343,7 +3339,7 @@ impl<'a> Builder<'a> {
     }
 
     fn is_safe_clamp_integer_value(&self, value: ValueId) -> bool {
-        self.int_const_value(value).is_some() || self.is_param_value(value, ParamSemantic::Integer)
+        self.int_const_value(value).is_some() || self.is_param_value(value, DomainEvidence::Integer)
     }
 
     fn proof_backed_clamp_value(
@@ -3775,9 +3771,9 @@ impl<'a> Builder<'a> {
                 NodeKind::Func => {
                     let kids = self.il.children(c).to_vec();
                     let mut menv = env.clone();
-                    let saved_param_semantic = self.param_semantic.clone();
-                    self.param_semantic.clear();
-                    self.seed_param_semantics(c);
+                    let saved_param_domain = self.param_domain.clone();
+                    self.param_domain.clear();
+                    self.seed_param_domains(c);
                     let mut pos = 0u32;
                     for &k in &kids {
                         if self.il.kind(k) == NodeKind::Param {
@@ -3791,7 +3787,7 @@ impl<'a> Builder<'a> {
                     if let Some(&body) = kids.last() {
                         self.process_stmt(body, &mut menv);
                     }
-                    self.param_semantic = saved_param_semantic;
+                    self.param_domain = saved_param_domain;
                 }
                 NodeKind::Block => self.process_container(c, env),
                 _ => self.process_stmt(c, env),
@@ -5180,7 +5176,7 @@ impl<'a> Builder<'a> {
             if base == low_base
                 && high_index == 0
                 && low_index == 1
-                && self.is_param_value(base, ParamSemantic::ByteArray)
+                && self.is_param_value(base, DomainEvidence::ByteArray)
             {
                 let zero = self.int_const(0);
                 let one = self.int_const(1);
@@ -5224,7 +5220,7 @@ impl<'a> Builder<'a> {
             return None;
         }
         let base = base?;
-        if !self.is_param_value(base, ParamSemantic::ByteArray) {
+        if !self.is_param_value(base, DomainEvidence::ByteArray) {
             return None;
         }
         let zero = self.int_const(0);
@@ -7088,10 +7084,10 @@ impl<'a> Builder<'a> {
                             if let Some(len) = self.eval_len_value(a[0]) {
                                 return len;
                             }
-                            if matches!(
-                                self.param_semantic_of_expr(kids[0]),
-                                Some(ParamSemantic::Array | ParamSemantic::Collection)
-                            ) {
+                            if self
+                                .domain_evidence_of_expr(kids[0])
+                                .is_some_and(DomainEvidence::is_array_or_collection)
+                            {
                                 return self.mk(ValOp::Call(builtin_tag(Builtin::Len)), a);
                             }
                         }
@@ -7864,7 +7860,9 @@ fn stable_float_const_key(value: &str) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_il::{FileId, FileMeta, IlBuilder, Lang, ParamTypeFact, Span, Unit, UnitKind};
+    use nose_il::{
+        FileId, FileMeta, IlBuilder, Lang, ParamSemantic, ParamTypeFact, Span, Unit, UnitKind,
+    };
 
     fn sp(line: u32) -> Span {
         Span::new(FileId(0), line, line, line, line)

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -922,7 +922,7 @@ impl<'a> Builder<'a> {
                     receiver_name,
                     method,
                 )?;
-                self.is_free_java_std_name(receiver, contract.receiver)
+                self.is_imported_java_util_name(receiver, contract.receiver)
                     .then_some(contract)
             })?;
         // A single argument to a varargs collection factory (`Arrays.asList(x)`,
@@ -978,8 +978,9 @@ impl<'a> Builder<'a> {
         Some(self.mk(ValOp::Seq(1), args[1..].to_vec()))
     }
 
-    fn is_free_java_std_name(&self, value: ValueId, name: &str) -> bool {
-        self.is_free_name_value(value, name) && !self.java_file_defines_type_name(name)
+    fn is_imported_java_util_name(&self, value: ValueId, name: &str) -> bool {
+        !self.java_file_defines_type_name(name)
+            && self.is_import_binding_value(value, "java.util", name)
     }
 
     fn is_import_namespace_expr(
@@ -1284,7 +1285,7 @@ impl<'a> Builder<'a> {
             return None;
         }
         let contract = java_map_factory_contract_by_hash(self.il.meta.lang, "Map", method)?;
-        if !self.is_free_java_std_name(callee.args[0], contract.receiver) {
+        if !self.is_imported_java_util_name(callee.args[0], contract.receiver) {
             return None;
         }
         if contract.kind == JavaMapFactoryKind::Of {
@@ -1321,7 +1322,7 @@ impl<'a> Builder<'a> {
         };
         if callee.args.len() != 1
             || !java_map_entry_contract_by_hash(self.il.meta.lang, "Map", method)
-            || !self.is_free_java_std_name(callee.args[0], "Map")
+            || !self.is_imported_java_util_name(callee.args[0], "Map")
         {
             return None;
         }

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -51,9 +51,10 @@ use nose_il::{
 use nose_semantics::{
     builder_append_method_contract, builtin_tag, domain_evidence_from_param_semantic,
     iterator_identity_adapter_contract, method_call_contract, reduction_builtin_contract,
-    scalar_integer_method_contract, semantics, DomainEvidence, IteratorAdapterReceiverContract,
-    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract,
-    ScalarIntegerMethod,
+    rust_option_and_then_contract, rust_option_some_constructor_contract,
+    rust_vec_new_factory_contract, scalar_integer_method_contract, semantics, DomainEvidence,
+    IteratorAdapterReceiverContract, MethodBuiltinArgs, MethodReceiverContract,
+    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -6775,7 +6776,7 @@ impl<'a> Builder<'a> {
         let Payload::Name(method) = self.il.node(kids[0]).payload else {
             return None;
         };
-        if self.interner.resolve(method) != "and_then" {
+        if !rust_option_and_then_contract(self.il.meta.lang, self.interner.resolve(method), 1) {
             return None;
         }
         let receiver = *self.il.children(kids[0]).first()?;
@@ -6792,28 +6793,13 @@ impl<'a> Builder<'a> {
     }
 
     fn rust_option_some_name(&self, text: &str) -> bool {
-        if self.il.meta.lang != Lang::Rust {
-            return false;
-        }
-        match text {
-            "Some" => !self.file_defines_name("Some"),
-            "Option::Some" => !self.file_defines_name("Option"),
-            "std::option::Option::Some" => !self.file_defines_name("std"),
-            "core::option::Option::Some" => !self.file_defines_name("core"),
-            _ => false,
-        }
+        rust_option_some_constructor_contract(self.il.meta.lang, text)
+            .is_some_and(|contract| !self.file_defines_name(contract.shadow_root))
     }
 
     fn rust_vec_new_name(&self, text: &str) -> bool {
-        if self.il.meta.lang != Lang::Rust {
-            return false;
-        }
-        match text {
-            "Vec::new" => !self.file_defines_name("Vec"),
-            "std::vec::Vec::new" => !self.file_defines_name("std"),
-            "alloc::vec::Vec::new" => !self.file_defines_name("alloc"),
-            _ => false,
-        }
+        rust_vec_new_factory_contract(self.il.meta.lang, text)
+            .is_some_and(|contract| !self.file_defines_name(contract.shadow_root))
     }
 
     fn is_null_literal(&self, node: NodeId) -> bool {

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -51,12 +51,13 @@ use nose_il::{
 use nose_semantics::{
     builder_append_method_contract, builtin_tag, domain_evidence_from_param_semantic,
     iterator_identity_adapter_contract, java_collection_factory_contract_by_hash,
-    java_map_entry_contract_by_hash, java_map_factory_contract_by_hash, method_call_contract,
+    java_map_entry_contract_by_hash, java_map_factory_contract_by_hash,
+    map_key_view_contract_by_hash, map_key_view_wrapper_contract_by_hash, method_call_contract,
     reduction_builtin_contract, ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
     rust_option_some_constructor_contract, rust_vec_new_factory_contract,
     scalar_integer_method_contract, semantics, DomainEvidence, IteratorAdapterReceiverContract,
-    JavaMapFactoryKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
-    ReductionBuiltinContract, ScalarIntegerMethod,
+    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
+    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -1448,6 +1449,14 @@ impl<'a> Builder<'a> {
     }
 
     fn proven_map_key_view_value(&mut self, value: ValueId) -> Option<ValueId> {
+        self.proven_map_key_view_value_matching(value, MapKeyViewKind::Collection)
+    }
+
+    fn proven_map_key_view_value_matching(
+        &mut self,
+        value: ValueId,
+        accepted: MapKeyViewKind,
+    ) -> Option<ValueId> {
         let node = &self.nodes[value as usize];
         if !matches!(node.op, ValOp::Call(0)) {
             return None;
@@ -1455,14 +1464,11 @@ impl<'a> Builder<'a> {
         let args = node.args.clone();
         if args.len() == 1 {
             let callee = &self.nodes[args[0] as usize];
-            let key_view = matches!(
-                callee.op,
-                ValOp::Field(name)
-                    if name == stable_symbol_hash("keys")
-                        || (self.il.meta.lang == Lang::Java
-                            && name == stable_symbol_hash("keySet"))
-            );
-            if !key_view || callee.args.len() != 1 {
+            let ValOp::Field(method) = callee.op else {
+                return None;
+            };
+            let contract = map_key_view_contract_by_hash(self.il.meta.lang, method, 0)?;
+            if contract.kind != accepted || callee.args.len() != 1 {
                 return None;
             }
             let map = callee.args[0];
@@ -1474,13 +1480,19 @@ impl<'a> Builder<'a> {
         }
         if args.len() == 2 {
             let callee = &self.nodes[args[0] as usize];
-            if !matches!(callee.op, ValOp::Field(name) if name == stable_symbol_hash("from"))
+            let ValOp::Field(method) = callee.op else {
+                return None;
+            };
+            let contract =
+                map_key_view_wrapper_contract_by_hash(self.il.meta.lang, "Array", method, 1)?;
+            if accepted != MapKeyViewKind::Collection
                 || callee.args.len() != 1
-                || !self.is_free_name_value(callee.args[0], "Array")
+                || !self.is_free_name_value(callee.args[0], contract.receiver)
+                || self.file_defines_name(contract.receiver)
             {
                 return None;
             }
-            return self.proven_map_key_view_value(args[1]);
+            return self.proven_map_key_view_value_matching(args[1], MapKeyViewKind::Iterator);
         }
         None
     }

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -50,16 +50,17 @@ use nose_il::{
 };
 use nose_semantics::{
     builder_append_method_contract, builtin_tag, domain_evidence_from_param_semantic,
-    go_zero_map_default_kind, go_zero_map_lookup_contract, index_membership_threshold_contract,
-    iterator_identity_adapter_contract, java_collection_factory_contract_by_hash,
-    java_map_entry_contract_by_hash, java_map_factory_contract_by_hash, map_get_contract_by_hash,
-    map_key_view_contract_by_hash, map_key_view_wrapper_contract_by_hash, method_call_contract,
-    reduction_builtin_contract, ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
+    go_zero_map_default_kind, go_zero_map_lookup_contract, imported_namespace_function_contract,
+    index_membership_threshold_contract, iterator_identity_adapter_contract,
+    java_collection_factory_contract_by_hash, java_map_entry_contract_by_hash,
+    java_map_factory_contract_by_hash, map_get_contract_by_hash, map_key_view_contract_by_hash,
+    map_key_view_wrapper_contract_by_hash, method_call_contract, reduction_builtin_contract,
+    ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
     rust_option_some_constructor_contract, rust_vec_new_factory_contract,
     scalar_integer_method_contract, semantics, static_index_membership_contract, DomainEvidence,
-    GoZeroMapDefaultKind, IndexMembershipThreshold, IteratorAdapterReceiverContract,
-    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
-    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
+    GoZeroMapDefaultKind, ImportedNamespaceFunctionSemantic, IndexMembershipThreshold,
+    IteratorAdapterReceiverContract, JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs,
+    MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
     StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -6435,22 +6436,23 @@ impl<'a> Builder<'a> {
         let Payload::Name(name) = self.il.node(callee).payload else {
             return None;
         };
-        if self.interner.resolve(name) != "prod" {
-            return None;
-        }
+        let contract = imported_namespace_function_contract(
+            self.il.meta.lang,
+            self.interner.resolve(name),
+            kids.len().saturating_sub(1),
+        )?;
         let base = *self.il.children(callee).first()?;
-        if !matches!(
-            (self.il.kind(base), self.il.node(base).payload),
-            (NodeKind::Var, Payload::Name(s)) if self.interner.resolve(s) == "math"
-        ) {
+        if !self.is_import_namespace_expr(base, contract.module, env) {
             return None;
         }
+        let ImportedNamespaceFunctionSemantic::ProductReduction { op, identity } =
+            contract.semantic;
         let coll = self.eval(*kids.get(1)?, env);
-        let (op, args) = {
+        let (coll_op, args) = {
             let n = &self.nodes[coll as usize];
             (n.op.clone(), n.args.clone())
         };
-        let contrib = match op {
+        let contrib = match coll_op {
             ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() >= 2 => {
                 let one = self.int_const(1);
                 self.mk(ValOp::Phi, vec![args[1], args[0], one])
@@ -6461,8 +6463,8 @@ impl<'a> Builder<'a> {
         let init = kids
             .get(2)
             .map(|&i| self.eval(i, env))
-            .unwrap_or_else(|| self.int_const(1));
-        Some(self.mk(ValOp::Reduce(Op::Mul as u32), vec![init, contrib]))
+            .unwrap_or_else(|| self.int_const(identity));
+        Some(self.mk(ValOp::Reduce(op as u32), vec![init, contrib]))
     }
 
     fn eval_iterator_identity_adapter(

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -50,15 +50,17 @@ use nose_il::{
 };
 use nose_semantics::{
     builder_append_method_contract, builtin_tag, domain_evidence_from_param_semantic,
-    go_zero_map_default_kind, go_zero_map_lookup_contract, iterator_identity_adapter_contract,
-    java_collection_factory_contract_by_hash, java_map_entry_contract_by_hash,
-    java_map_factory_contract_by_hash, map_get_contract_by_hash, map_key_view_contract_by_hash,
-    map_key_view_wrapper_contract_by_hash, method_call_contract, reduction_builtin_contract,
-    ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
+    go_zero_map_default_kind, go_zero_map_lookup_contract, index_membership_threshold_contract,
+    iterator_identity_adapter_contract, java_collection_factory_contract_by_hash,
+    java_map_entry_contract_by_hash, java_map_factory_contract_by_hash, map_get_contract_by_hash,
+    map_key_view_contract_by_hash, map_key_view_wrapper_contract_by_hash, method_call_contract,
+    reduction_builtin_contract, ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
     rust_option_some_constructor_contract, rust_vec_new_factory_contract,
-    scalar_integer_method_contract, semantics, DomainEvidence, GoZeroMapDefaultKind,
-    IteratorAdapterReceiverContract, JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs,
-    MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
+    scalar_integer_method_contract, semantics, static_index_membership_contract, DomainEvidence,
+    GoZeroMapDefaultKind, IndexMembershipThreshold, IteratorAdapterReceiverContract,
+    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
+    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
+    StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -5926,7 +5928,7 @@ impl<'a> Builder<'a> {
 
     fn eval_static_index_membership_comparison(
         &mut self,
-        op: u32,
+        op: Op,
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
@@ -5966,34 +5968,42 @@ impl<'a> Builder<'a> {
         if !self.is_static_non_float_collection_expr(receiver) {
             return None;
         }
-        if method == "indexOf" {
-            let element = self.eval(kids[1], env);
-            let collection = self.eval_membership_collection(receiver, env);
-            return Some((element, collection));
+        let contract = static_index_membership_contract(self.il.meta.lang, method, kids.len() - 1)?;
+        match contract.kind {
+            StaticIndexMembershipKind::IndexOf => {
+                let element = self.eval(kids[1], env);
+                let collection = self.eval_membership_collection(receiver, env);
+                Some((element, collection))
+            }
+            StaticIndexMembershipKind::FindIndex if self.il.kind(kids[1]) == NodeKind::Lambda => {
+                let collection = self.eval(receiver, env);
+                let elem = self.elem(collection);
+                let pred = self.eval_lambda_body(kids[1], &[elem], env)?;
+                self.static_literal_membership_predicate(pred)
+            }
+            StaticIndexMembershipKind::FindIndex => None,
         }
-        if method == "findIndex" && self.il.kind(kids[1]) == NodeKind::Lambda {
-            let collection = self.eval(receiver, env);
-            let elem = self.elem(collection);
-            let pred = self.eval_lambda_body(kids[1], &[elem], env)?;
-            return self.static_literal_membership_predicate(pred);
-        }
-        None
     }
 
     fn is_index_membership_threshold(
         &self,
-        op: u32,
+        op: Op,
         index_call_on_right: bool,
         threshold: NodeId,
     ) -> bool {
         if self.is_minus_one_literal(threshold) {
-            return op == Op::Ne as u32
-                || (!index_call_on_right && op == Op::Gt as u32)
-                || (index_call_on_right && op == Op::Lt as u32);
+            return index_membership_threshold_contract(
+                op,
+                index_call_on_right,
+                IndexMembershipThreshold::MinusOne,
+            );
         }
         if self.is_zero_literal(threshold) {
-            return (!index_call_on_right && op == Op::Ge as u32)
-                || (index_call_on_right && op == Op::Le as u32);
+            return index_membership_threshold_contract(
+                op,
+                index_call_on_right,
+                IndexMembershipThreshold::Zero,
+            );
         }
         false
     }
@@ -7027,8 +7037,12 @@ impl<'a> Builder<'a> {
                 if let Some(v) = self.eval_len_zero_comparison(op, &kids, env) {
                     return v;
                 }
-                if let Some(v) = self.eval_static_index_membership_comparison(op, &kids, env) {
-                    return v;
+                if let Payload::Op(op_kind) = node.payload {
+                    if let Some(v) =
+                        self.eval_static_index_membership_comparison(op_kind, &kids, env)
+                    {
+                        return v;
+                    }
                 }
                 if op == Op::Add as u32 || op == Op::Sub as u32 {
                     let mut operands = Vec::new();

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -50,14 +50,15 @@ use nose_il::{
 };
 use nose_semantics::{
     builder_append_method_contract, builtin_tag, domain_evidence_from_param_semantic,
-    iterator_identity_adapter_contract, java_collection_factory_contract_by_hash,
-    java_map_entry_contract_by_hash, java_map_factory_contract_by_hash,
-    map_key_view_contract_by_hash, map_key_view_wrapper_contract_by_hash, method_call_contract,
-    reduction_builtin_contract, ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
+    go_zero_map_default_kind, go_zero_map_lookup_contract, iterator_identity_adapter_contract,
+    java_collection_factory_contract_by_hash, java_map_entry_contract_by_hash,
+    java_map_factory_contract_by_hash, map_key_view_contract_by_hash,
+    map_key_view_wrapper_contract_by_hash, method_call_contract, reduction_builtin_contract,
+    ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
     rust_option_some_constructor_contract, rust_vec_new_factory_contract,
-    scalar_integer_method_contract, semantics, DomainEvidence, IteratorAdapterReceiverContract,
-    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
-    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
+    scalar_integer_method_contract, semantics, DomainEvidence, GoZeroMapDefaultKind,
+    IteratorAdapterReceiverContract, JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs,
+    MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -1324,8 +1325,9 @@ impl<'a> Builder<'a> {
     }
 
     fn proven_go_literal_zero_map_value(&self, value: ValueId) -> Option<(ValueId, ValueId)> {
+        let contract = go_zero_map_lookup_contract(self.il.meta.lang)?;
         let node = &self.nodes[value as usize];
-        if !matches!(node.op, ValOp::Seq(tag) if tag == stable_symbol_hash("go_literal_zero_map"))
+        if !matches!(node.op, ValOp::Seq(tag) if tag == stable_symbol_hash(contract.canonical_value_tag))
             || node.args.len() != 2
         {
             return None;
@@ -1338,16 +1340,11 @@ impl<'a> Builder<'a> {
         expr: NodeId,
         args: &[ValueId],
     ) -> Option<ValueId> {
-        if !semantics(self.il.meta.lang)
-            .stdlib()
-            .go_literal_zero_map_lookup()
-        {
-            return None;
-        }
+        let contract = go_zero_map_lookup_contract(self.il.meta.lang)?;
         let Payload::Name(name) = self.il.node(expr).payload else {
             return None;
         };
-        if self.interner.resolve(name) != "composite_literal" || args.is_empty() {
+        if self.interner.resolve(name) != contract.map_literal_tag || args.is_empty() {
             return None;
         }
         let entry_nodes = self.il.children(expr).to_vec();
@@ -1364,7 +1361,7 @@ impl<'a> Builder<'a> {
             let Payload::Name(entry_name) = self.il.node(entry_node_id).payload else {
                 return None;
             };
-            if self.interner.resolve(entry_name) != "keyed_element" {
+            if self.interner.resolve(entry_name) != contract.entry_tag {
                 return None;
             }
             let kv_nodes = self.il.children(entry_node_id);
@@ -1373,8 +1370,9 @@ impl<'a> Builder<'a> {
             {
                 return None;
             }
-            let (kind, value_default) =
-                self.go_literal_zero_default_from_payload(self.il.node(kv_nodes[1]).payload)?;
+            let kind =
+                go_zero_map_default_kind(self.il.meta.lang, self.il.node(kv_nodes[1]).payload)?;
+            let value_default = self.go_literal_zero_default_value(kind);
             match value_kind {
                 Some(current_kind) if current_kind != kind => return None,
                 Some(_) => {}
@@ -1384,7 +1382,7 @@ impl<'a> Builder<'a> {
                 }
             }
             let entry_value_node = &self.nodes[entry_value as usize];
-            if !matches!(entry_value_node.op, ValOp::Seq(tag) if tag == stable_symbol_hash("keyed_element"))
+            if !matches!(entry_value_node.op, ValOp::Seq(tag) if tag == stable_symbol_hash(contract.entry_tag))
                 || entry_value_node.args.len() != 2
             {
                 return None;
@@ -1393,25 +1391,22 @@ impl<'a> Builder<'a> {
         }
         let map = self.mk(ValOp::Seq(3), canonical_entries);
         Some(self.mk(
-            ValOp::Seq(stable_symbol_hash("go_literal_zero_map")),
+            ValOp::Seq(stable_symbol_hash(contract.canonical_value_tag)),
             vec![default?, map],
         ))
     }
 
-    fn go_literal_zero_default_from_payload(&mut self, payload: Payload) -> Option<(u8, ValueId)> {
-        match payload {
-            Payload::LitInt(_) => Some((1, self.int_const(0))),
-            Payload::LitStr(_) => Some((
-                2,
-                self.mk(ValOp::Const(stable_string_const_key("")), vec![]),
-            )),
-            Payload::LitBool(_) => Some((3, self.mk(ValOp::Const(0x3000_0001), vec![]))),
-            Payload::LitFloat(_) => Some((
-                4,
-                self.mk(ValOp::Const(stable_float_const_key("0.0")), vec![]),
-            )),
-            Payload::Lit(nose_il::LitClass::Null) => Some((5, self.null_const())),
-            _ => None,
+    fn go_literal_zero_default_value(&mut self, kind: GoZeroMapDefaultKind) -> ValueId {
+        match kind {
+            GoZeroMapDefaultKind::Int => self.int_const(0),
+            GoZeroMapDefaultKind::String => {
+                self.mk(ValOp::Const(stable_string_const_key("")), vec![])
+            }
+            GoZeroMapDefaultKind::Bool => self.mk(ValOp::Const(0x3000_0001), vec![]),
+            GoZeroMapDefaultKind::Float => {
+                self.mk(ValOp::Const(stable_float_const_key("0.0")), vec![])
+            }
+            GoZeroMapDefaultKind::Null => self.null_const(),
         }
     }
 

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -50,11 +50,13 @@ use nose_il::{
 };
 use nose_semantics::{
     builder_append_method_contract, builtin_tag, domain_evidence_from_param_semantic,
-    iterator_identity_adapter_contract, method_call_contract, reduction_builtin_contract,
-    rust_option_and_then_contract, rust_option_some_constructor_contract,
-    rust_vec_new_factory_contract, scalar_integer_method_contract, semantics, DomainEvidence,
-    IteratorAdapterReceiverContract, MethodBuiltinArgs, MethodReceiverContract,
-    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
+    iterator_identity_adapter_contract, java_collection_factory_contract_by_hash,
+    java_map_entry_contract_by_hash, java_map_factory_contract_by_hash, method_call_contract,
+    reduction_builtin_contract, ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
+    rust_option_some_constructor_contract, rust_vec_new_factory_contract,
+    scalar_integer_method_contract, semantics, DomainEvidence, IteratorAdapterReceiverContract,
+    JavaMapFactoryKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
+    ReductionBuiltinContract, ScalarIntegerMethod,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -764,6 +766,11 @@ impl<'a> Builder<'a> {
             .is_some_and(DomainEvidence::is_collection_or_set)
     }
 
+    fn is_set_param_expr(&self, expr: NodeId) -> bool {
+        self.domain_evidence_of_expr(expr)
+            .is_some_and(DomainEvidence::is_set)
+    }
+
     fn is_map_param_expr(&self, expr: NodeId) -> bool {
         self.domain_evidence_of_expr(expr)
             .is_some_and(DomainEvidence::is_map)
@@ -873,11 +880,11 @@ impl<'a> Builder<'a> {
     /// Python `from collections import deque; deque(<seq>)` — the imported-stdlib collection
     /// factory (the non-free-name part of the former python recognizer).
     fn proven_python_deque_collection_value(&self, value: ValueId) -> Option<ValueId> {
-        if !semantics(self.il.meta.lang).stdlib().python_deque_factory() {
-            return None;
-        }
         self.collection_factory_seq(value, |s, callee| {
-            s.is_import_binding_value(callee, "collections", "deque")
+            semantics(s.il.meta.lang)
+                .collections()
+                .imported_collection_factories()
+                .any(|factory| s.is_import_binding_value(callee, factory.module, factory.exported))
         })
     }
 
@@ -901,17 +908,17 @@ impl<'a> Builder<'a> {
             return None;
         }
         let receiver = callee.args[0];
-        let is_standard_factory = if method == stable_symbol_hash("of") {
-            self.is_free_java_std_name(receiver, "List")
-                || self.is_free_java_std_name(receiver, "Set")
-        } else if method == stable_symbol_hash("asList") {
-            self.is_free_java_std_name(receiver, "Arrays")
-        } else {
-            false
-        };
-        if !is_standard_factory {
-            return None;
-        }
+        let contract = ["List", "Set", "Arrays"]
+            .into_iter()
+            .find_map(|receiver_name| {
+                let contract = java_collection_factory_contract_by_hash(
+                    self.il.meta.lang,
+                    receiver_name,
+                    method,
+                )?;
+                self.is_free_java_std_name(receiver, contract.receiver)
+                    .then_some(contract)
+            })?;
         // A single argument to a varargs collection factory (`Arrays.asList(x)`,
         // `List.of(x)`, `Set.of(x)`) is ambiguous: when `x` is an array it is spread
         // into the element list, but when `x` is a single object it is the sole
@@ -921,7 +928,7 @@ impl<'a> Builder<'a> {
         // must refuse, or an array-typed field and a list-typed field of the same name
         // would false-merge. Multi-argument factories are always a literal element list.
         if args.len() == 2 {
-            if method == stable_symbol_hash("asList") && self.is_array_param_value(args[1]) {
+            if contract.single_arg_spreads_array && self.is_array_param_value(args[1]) {
                 return Some(self.mk(ValOp::ArrayParam, vec![args[1]]));
             }
             return None;
@@ -930,17 +937,20 @@ impl<'a> Builder<'a> {
     }
 
     fn proven_ruby_set_factory_value(&self, value: ValueId) -> Option<ValueId> {
-        if !semantics(self.il.meta.lang).stdlib().ruby_set_factory()
-            || !self.ruby_file_requires_module("set")
-            || self.file_defines_name("Set")
-        {
-            return None;
-        }
         self.collection_factory_seq(value, |s, callee| {
             let callee = &s.nodes[callee as usize];
-            matches!(callee.op, ValOp::Field(method) if method == stable_symbol_hash("new"))
-                && callee.args.len() == 1
-                && s.is_free_name_value(callee.args[0], "Set")
+            let ValOp::Field(method) = callee.op else {
+                return false;
+            };
+            let Some(contract) =
+                ruby_set_factory_contract_by_hash(s.il.meta.lang, "Set", method, 1)
+            else {
+                return false;
+            };
+            callee.args.len() == 1
+                && s.ruby_file_requires_module(contract.required_module)
+                && !s.file_defines_name(contract.shadow_root)
+                && s.is_free_name_value(callee.args[0], contract.receiver)
         })
     }
 
@@ -1264,10 +1274,14 @@ impl<'a> Builder<'a> {
         let ValOp::Field(method) = callee.op else {
             return None;
         };
-        if callee.args.len() != 1 || !self.is_free_java_std_name(callee.args[0], "Map") {
+        if callee.args.len() != 1 {
             return None;
         }
-        if method == stable_symbol_hash("of") {
+        let contract = java_map_factory_contract_by_hash(self.il.meta.lang, "Map", method)?;
+        if !self.is_free_java_std_name(callee.args[0], contract.receiver) {
+            return None;
+        }
+        if contract.kind == JavaMapFactoryKind::Of {
             let entries = &args[1..];
             if entries.len() % 2 != 0 {
                 return None;
@@ -1278,7 +1292,7 @@ impl<'a> Builder<'a> {
             }
             return Some(self.mk(ValOp::Seq(3), canonical_entries));
         }
-        if method == stable_symbol_hash("ofEntries") {
+        if contract.kind == JavaMapFactoryKind::OfEntries {
             let mut canonical_entries = Vec::with_capacity(args.len().saturating_sub(1));
             for entry in args.iter().skip(1).copied() {
                 let kv = self.proven_java_map_entry_pair(entry)?;
@@ -1296,8 +1310,11 @@ impl<'a> Builder<'a> {
         }
         let args = node.args.clone();
         let callee = &self.nodes[args[0] as usize];
-        if !matches!(callee.op, ValOp::Field(name) if name == stable_symbol_hash("entry"))
-            || callee.args.len() != 1
+        let ValOp::Field(method) = callee.op else {
+            return None;
+        };
+        if callee.args.len() != 1
+            || !java_map_entry_contract_by_hash(self.il.meta.lang, "Map", method)
             || !self.is_free_java_std_name(callee.args[0], "Map")
         {
             return None;
@@ -1493,30 +1510,53 @@ impl<'a> Builder<'a> {
         let callee_kids = self.il.children(callee);
         let receiver = callee_kids.first().copied();
 
-        if matches!(
-            method,
-            "contains" | "includes" | "include?" | "member?" | "__contains__" | "has"
-        ) && kids.len() == 2
+        let contract =
+            method_call_contract(self.il.meta.lang, method, kids.len().saturating_sub(1))?;
+        if contract.semantic != MethodSemanticContract::Builtin(Builtin::Contains) {
+            return None;
+        }
+
+        if contract.args == MethodBuiltinArgs::FirstThenReceiver
+            && matches!(
+                contract.receiver,
+                MethodReceiverContract::ExactCollection
+                    | MethodReceiverContract::ExactCollectionOrMap
+                    | MethodReceiverContract::ExactCollectionOrJavaKeySet
+                    | MethodReceiverContract::ExactSetOrMap
+            )
+            && kids.len() == 2
         {
             let receiver = receiver?;
             let element = self.eval(kids[1], env);
-            if let Some(map) = self.proven_map_key_view_expr(receiver, env) {
-                return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, map]));
+            if matches!(
+                contract.receiver,
+                MethodReceiverContract::ExactCollectionOrMap
+                    | MethodReceiverContract::ExactCollectionOrJavaKeySet
+            ) {
+                if let Some(map) = self.proven_map_key_view_expr(receiver, env) {
+                    return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, map]));
+                }
             }
-            if self.is_collection_param_expr(receiver) {
+            let receiver_param_safe = match contract.receiver {
+                MethodReceiverContract::ExactSetOrMap => self.is_set_param_expr(receiver),
+                _ => self.is_collection_param_expr(receiver),
+            };
+            if receiver_param_safe {
                 let collection = self.eval_membership_collection(receiver, env);
                 return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
             }
             let receiver_value = self.eval(receiver, env);
-            if let Some(collection) = self
-                .proven_collection_value(receiver_value)
-                .or_else(|| self.proven_local_collection_binding_value(receiver, env))
-            {
-                let collection = self.canonical_membership_collection_value(collection);
-                return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
+            if contract.receiver != MethodReceiverContract::ExactSetOrMap {
+                if let Some(collection) = self
+                    .proven_collection_value(receiver_value)
+                    .or_else(|| self.proven_local_collection_binding_value(receiver, env))
+                {
+                    let collection = self.canonical_membership_collection_value(collection);
+                    return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
+                }
             }
             None
-        } else if method == "Contains" && kids.len() == 3 {
+        } else if contract.args == MethodBuiltinArgs::GoSliceContains && kids.len() == 3 {
             let receiver = receiver?;
             if !self.is_import_namespace_expr(receiver, "slices", env)
                 && !self.file_imports_namespace(receiver, "slices")
@@ -1552,9 +1592,16 @@ impl<'a> Builder<'a> {
             return None;
         };
         let method = self.interner.resolve(name);
-        let map_specific_method =
-            matches!(method, "containsKey" | "contains_key" | "key?" | "has_key?");
-        if !matches!(method, "has" | "__contains__") && !map_specific_method {
+        let contract = method_call_contract(self.il.meta.lang, method, 1)?;
+        if contract.semantic != MethodSemanticContract::Builtin(Builtin::Contains)
+            || contract.args != MethodBuiltinArgs::FirstThenReceiver
+            || !matches!(
+                contract.receiver,
+                MethodReceiverContract::ExactMap
+                    | MethodReceiverContract::ExactCollectionOrMap
+                    | MethodReceiverContract::ExactSetOrMap
+            )
+        {
             return None;
         }
         let receiver = self.il.children(callee).first().copied()?;

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -977,6 +977,45 @@ pub fn iterator_identity_adapter_contract(
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ShadowedPathContract {
+    pub shadow_root: &'static str,
+}
+
+pub fn rust_option_some_constructor_contract(
+    lang: Lang,
+    name: &str,
+) -> Option<ShadowedPathContract> {
+    if lang != Lang::Rust {
+        return None;
+    }
+    let shadow_root = match name {
+        "Some" => "Some",
+        "Option::Some" => "Option",
+        "std::option::Option::Some" => "std",
+        "core::option::Option::Some" => "core",
+        _ => return None,
+    };
+    Some(ShadowedPathContract { shadow_root })
+}
+
+pub fn rust_vec_new_factory_contract(lang: Lang, name: &str) -> Option<ShadowedPathContract> {
+    if lang != Lang::Rust {
+        return None;
+    }
+    let shadow_root = match name {
+        "Vec::new" => "Vec",
+        "std::vec::Vec::new" => "std",
+        "alloc::vec::Vec::new" => "alloc",
+        _ => return None,
+    };
+    Some(ShadowedPathContract { shadow_root })
+}
+
+pub fn rust_option_and_then_contract(lang: Lang, method: &str, arg_count: usize) -> bool {
+    lang == Lang::Rust && method == "and_then" && arg_count == 1
+}
+
 pub fn builder_append_method_contract(lang: Lang, method: &str, arg_count: usize) -> bool {
     matches!(
         (lang, method, arg_count),
@@ -1697,6 +1736,41 @@ mod tests {
             iterator_identity_adapter_contract(Lang::Rust, "collect", 1),
             None
         );
+    }
+
+    #[test]
+    fn rust_std_path_contracts_carry_shadow_roots() {
+        assert_eq!(
+            rust_option_some_constructor_contract(Lang::Rust, "Option::Some"),
+            Some(ShadowedPathContract {
+                shadow_root: "Option",
+            })
+        );
+        assert_eq!(
+            rust_option_some_constructor_contract(Lang::Rust, "std::option::Option::Some"),
+            Some(ShadowedPathContract { shadow_root: "std" })
+        );
+        assert_eq!(
+            rust_option_some_constructor_contract(Lang::Python, "Some"),
+            None
+        );
+        assert_eq!(
+            rust_vec_new_factory_contract(Lang::Rust, "alloc::vec::Vec::new"),
+            Some(ShadowedPathContract {
+                shadow_root: "alloc",
+            })
+        );
+        assert_eq!(
+            rust_vec_new_factory_contract(Lang::Rust, "Vec::with_capacity"),
+            None
+        );
+        assert!(rust_option_and_then_contract(Lang::Rust, "and_then", 1));
+        assert!(!rust_option_and_then_contract(Lang::Rust, "and_then", 0));
+        assert!(!rust_option_and_then_contract(
+            Lang::JavaScript,
+            "and_then",
+            1
+        ));
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -7,7 +7,7 @@
 //! approve exact clone matches directly.
 
 use nose_il::{
-    stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LitClass, NodeId, NodeKind,
+    stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LitClass, NodeId, NodeKind, Op,
     ParamSemantic, Payload,
 };
 
@@ -1357,6 +1357,62 @@ pub fn map_get_contract_by_hash(
         .flatten()
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum StaticIndexMembershipKind {
+    IndexOf,
+    FindIndex,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct StaticIndexMembershipContract {
+    pub method: &'static str,
+    pub kind: StaticIndexMembershipKind,
+}
+
+pub fn static_index_membership_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<StaticIndexMembershipContract> {
+    if !js_like_lang(lang) || arg_count != 1 {
+        return None;
+    }
+    Some(match method {
+        "indexOf" => StaticIndexMembershipContract {
+            method: "indexOf",
+            kind: StaticIndexMembershipKind::IndexOf,
+        },
+        "findIndex" => StaticIndexMembershipContract {
+            method: "findIndex",
+            kind: StaticIndexMembershipKind::FindIndex,
+        },
+        _ => return None,
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum IndexMembershipThreshold {
+    MinusOne,
+    Zero,
+}
+
+pub fn index_membership_threshold_contract(
+    op: Op,
+    index_call_on_right: bool,
+    threshold: IndexMembershipThreshold,
+) -> bool {
+    match threshold {
+        IndexMembershipThreshold::MinusOne => {
+            op == Op::Ne
+                || (!index_call_on_right && op == Op::Gt)
+                || (index_call_on_right && op == Op::Lt)
+        }
+        IndexMembershipThreshold::Zero => {
+            (!index_call_on_right && op == Op::Ge) || (index_call_on_right && op == Op::Le)
+        }
+    }
+}
+
 pub fn builder_append_method_contract(lang: Lang, method: &str, arg_count: usize) -> bool {
     matches!(
         (lang, method, arg_count),
@@ -2345,6 +2401,51 @@ mod tests {
         assert_eq!(map_get_contract(Lang::Python, "get", 1), None);
         assert_eq!(map_get_contract(Lang::Rust, "get", 2), None);
         assert_eq!(map_get_contract(Lang::Java, "getOrDefault", 1), None);
+    }
+
+    #[test]
+    fn static_index_membership_contracts_are_js_like_and_threshold_constrained() {
+        assert_eq!(
+            static_index_membership_contract(Lang::JavaScript, "indexOf", 1),
+            Some(StaticIndexMembershipContract {
+                method: "indexOf",
+                kind: StaticIndexMembershipKind::IndexOf,
+            })
+        );
+        assert_eq!(
+            static_index_membership_contract(Lang::TypeScript, "findIndex", 1),
+            Some(StaticIndexMembershipContract {
+                method: "findIndex",
+                kind: StaticIndexMembershipKind::FindIndex,
+            })
+        );
+        assert_eq!(
+            static_index_membership_contract(Lang::Python, "indexOf", 1),
+            None
+        );
+        assert_eq!(
+            static_index_membership_contract(Lang::JavaScript, "indexOf", 2),
+            None
+        );
+        assert_eq!(
+            static_index_membership_contract(Lang::JavaScript, "includes", 1),
+            None
+        );
+        assert!(index_membership_threshold_contract(
+            Op::Ne,
+            false,
+            IndexMembershipThreshold::MinusOne
+        ));
+        assert!(index_membership_threshold_contract(
+            Op::Le,
+            true,
+            IndexMembershipThreshold::Zero
+        ));
+        assert!(!index_membership_threshold_contract(
+            Op::Eq,
+            false,
+            IndexMembershipThreshold::MinusOne
+        ));
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -1326,6 +1326,37 @@ pub fn go_zero_map_default_kind(lang: Lang, payload: Payload) -> Option<GoZeroMa
     })
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct MapGetContract {
+    pub method: &'static str,
+}
+
+pub fn map_get_contract(lang: Lang, method: &str, arg_count: usize) -> Option<MapGetContract> {
+    matches!(
+        lang,
+        Lang::Java
+            | Lang::Rust
+            | Lang::JavaScript
+            | Lang::TypeScript
+            | Lang::Vue
+            | Lang::Svelte
+            | Lang::Html
+    )
+    .then_some(())
+    .filter(|_| method == "get" && arg_count == 1)
+    .map(|_| MapGetContract { method: "get" })
+}
+
+pub fn map_get_contract_by_hash(
+    lang: Lang,
+    method_hash: u64,
+    arg_count: usize,
+) -> Option<MapGetContract> {
+    (method_hash == stable_symbol_hash("get"))
+        .then(|| map_get_contract(lang, "get", arg_count))
+        .flatten()
+}
+
 pub fn builder_append_method_contract(lang: Lang, method: &str, arg_count: usize) -> bool {
     matches!(
         (lang, method, arg_count),
@@ -2295,6 +2326,25 @@ mod tests {
             None
         );
         assert_eq!(go_zero_map_default_kind(Lang::Go, Payload::None), None);
+    }
+
+    #[test]
+    fn map_get_contracts_are_language_and_arity_constrained() {
+        assert_eq!(
+            map_get_contract(Lang::Rust, "get", 1),
+            Some(MapGetContract { method: "get" })
+        );
+        assert_eq!(
+            map_get_contract_by_hash(Lang::Java, stable_symbol_hash("get"), 1),
+            Some(MapGetContract { method: "get" })
+        );
+        assert_eq!(
+            map_get_contract(Lang::TypeScript, "get", 1),
+            Some(MapGetContract { method: "get" })
+        );
+        assert_eq!(map_get_contract(Lang::Python, "get", 1), None);
+        assert_eq!(map_get_contract(Lang::Rust, "get", 2), None);
+        assert_eq!(map_get_contract(Lang::Java, "getOrDefault", 1), None);
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -891,6 +891,13 @@ pub fn method_call_contract(
         ),
         (Lang::Go, "Min", 2) => (Builtin::Min, Receiver::ImportedNamespace("math"), Args::All),
         (Lang::Go, "Max", 2) => (Builtin::Max, Receiver::ImportedNamespace("math"), Args::All),
+        (Lang::Java, "abs", 1) => (
+            Builtin::Abs,
+            Receiver::UnshadowedGlobal("Math"),
+            Args::First,
+        ),
+        (Lang::Java, "min", 2) => (Builtin::Min, Receiver::UnshadowedGlobal("Math"), Args::All),
+        (Lang::Java, "max", 2) => (Builtin::Max, Receiver::UnshadowedGlobal("Math"), Args::All),
         (Lang::Rust, "zip", 1) => (
             Builtin::Zip,
             Receiver::ExactProtocolPairArgument,
@@ -2106,6 +2113,22 @@ mod tests {
                 semantic: MethodSemanticContract::Builtin(Builtin::Abs),
                 receiver: MethodReceiverContract::ImportedNamespace("math"),
                 args: MethodBuiltinArgs::First,
+            })
+        );
+        assert_eq!(
+            method_call_contract(Lang::Java, "abs", 1),
+            Some(MethodCallContract {
+                semantic: MethodSemanticContract::Builtin(Builtin::Abs),
+                receiver: MethodReceiverContract::UnshadowedGlobal("Math"),
+                args: MethodBuiltinArgs::First,
+            })
+        );
+        assert_eq!(
+            method_call_contract(Lang::Java, "min", 2),
+            Some(MethodCallContract {
+                semantic: MethodSemanticContract::Builtin(Builtin::Min),
+                receiver: MethodReceiverContract::UnshadowedGlobal("Math"),
+                args: MethodBuiltinArgs::All,
             })
         );
         assert_eq!(

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -6,7 +6,7 @@
 //! extend this contract surface rather than letting packs mint fingerprints or
 //! approve exact clone matches directly.
 
-use nose_il::{Builtin, HoFKind, Il, Interner, Lang, NodeId, NodeKind, Payload};
+use nose_il::{Builtin, HoFKind, Il, Interner, Lang, NodeId, NodeKind, ParamSemantic, Payload};
 
 /// Stable pack id for the first-party language/stdlib contracts compiled into nose.
 pub const FIRST_PARTY_PACK_ID: &str = "nose.first_party";
@@ -19,6 +19,91 @@ pub enum ChannelEligibility {
     ExactEmpirical,
     ExactProven,
     FirstParty,
+}
+
+/// Kernel-facing domain evidence recovered from source facts, type inference, or future packs.
+///
+/// `nose-il::ParamSemantic` is the current frontend storage format for source-level parameter
+/// annotations. Exact gates should consume this semantic-kernel vocabulary instead, so future
+/// packs can provide equivalent evidence without becoming coupled to frontend syntax facts.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum DomainEvidence {
+    Array,
+    ByteArray,
+    Collection,
+    Integer,
+    Map,
+    Number,
+    Option,
+    Set,
+    String,
+}
+
+impl DomainEvidence {
+    pub fn from_param_semantic(semantic: ParamSemantic) -> Self {
+        match semantic {
+            ParamSemantic::Array => DomainEvidence::Array,
+            ParamSemantic::ByteArray => DomainEvidence::ByteArray,
+            ParamSemantic::Collection => DomainEvidence::Collection,
+            ParamSemantic::Integer => DomainEvidence::Integer,
+            ParamSemantic::Map => DomainEvidence::Map,
+            ParamSemantic::Number => DomainEvidence::Number,
+            ParamSemantic::Option => DomainEvidence::Option,
+            ParamSemantic::Set => DomainEvidence::Set,
+            ParamSemantic::String => DomainEvidence::String,
+        }
+    }
+
+    pub fn is_array(self) -> bool {
+        self == DomainEvidence::Array
+    }
+
+    pub fn is_byte_array(self) -> bool {
+        self == DomainEvidence::ByteArray
+    }
+
+    pub fn is_collection_or_set(self) -> bool {
+        matches!(self, DomainEvidence::Collection | DomainEvidence::Set)
+    }
+
+    pub fn is_array_or_collection(self) -> bool {
+        matches!(self, DomainEvidence::Array | DomainEvidence::Collection)
+    }
+
+    pub fn is_array_collection_or_set(self) -> bool {
+        matches!(
+            self,
+            DomainEvidence::Array | DomainEvidence::Collection | DomainEvidence::Set
+        )
+    }
+
+    pub fn is_set(self) -> bool {
+        self == DomainEvidence::Set
+    }
+
+    pub fn is_map(self) -> bool {
+        self == DomainEvidence::Map
+    }
+
+    pub fn is_option(self) -> bool {
+        self == DomainEvidence::Option
+    }
+
+    pub fn is_string(self) -> bool {
+        self == DomainEvidence::String
+    }
+
+    pub fn is_integer(self) -> bool {
+        self == DomainEvidence::Integer
+    }
+
+    pub fn is_integer_or_number(self) -> bool {
+        matches!(self, DomainEvidence::Integer | DomainEvidence::Number)
+    }
+}
+
+pub fn domain_evidence_from_param_semantic(semantic: ParamSemantic) -> DomainEvidence {
+    DomainEvidence::from_param_semantic(semantic)
 }
 
 /// A first-party language profile. Keep this cheap and copyable; callers use it as a
@@ -1161,7 +1246,7 @@ pub fn async_to_sync_name(lang: Lang, name: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_il::{FileId, FileMeta, IlBuilder, Span, Unit, UnitKind};
+    use nose_il::{FileId, FileMeta, IlBuilder, ParamSemantic, Span, Unit, UnitKind};
 
     const ALL_LANGS: &[Lang] = &[
         Lang::Python,
@@ -1233,6 +1318,27 @@ mod tests {
             assert_eq!(profile.pack_id(), FIRST_PARTY_PACK_ID);
             assert_eq!(profile.eligibility(), ChannelEligibility::FirstParty);
         }
+    }
+
+    #[test]
+    fn domain_evidence_preserves_param_semantic_boundaries() {
+        assert_eq!(
+            domain_evidence_from_param_semantic(ParamSemantic::Array),
+            DomainEvidence::Array
+        );
+        assert!(DomainEvidence::Array.is_array_collection_or_set());
+        assert!(DomainEvidence::Collection.is_array_or_collection());
+        assert!(DomainEvidence::Set.is_collection_or_set());
+        assert!(DomainEvidence::Map.is_map());
+        assert!(DomainEvidence::Option.is_option());
+        assert!(DomainEvidence::String.is_string());
+        assert!(DomainEvidence::ByteArray.is_byte_array());
+        assert!(DomainEvidence::Integer.is_integer());
+        assert!(DomainEvidence::Number.is_integer_or_number());
+        assert!(DomainEvidence::Integer.is_integer_or_number());
+        assert!(!DomainEvidence::Number.is_integer());
+        assert!(!DomainEvidence::Array.is_collection_or_set());
+        assert!(!DomainEvidence::Set.is_array_or_collection());
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -6,7 +6,7 @@
 //! extend this contract surface rather than letting packs mint fingerprints or
 //! approve exact clone matches directly.
 
-use nose_il::{Builtin, HoFKind, Lang};
+use nose_il::{Builtin, HoFKind, Il, Interner, Lang, NodeId, NodeKind, Payload};
 
 /// Stable pack id for the first-party language/stdlib contracts compiled into nose.
 pub const FIRST_PARTY_PACK_ID: &str = "nose.first_party";
@@ -123,6 +123,71 @@ impl FragmentSemantics {
     pub fn java_this_field_place(self) -> bool {
         EffectSemantics { lang: self.lang }.java_this_field_place()
     }
+}
+
+/// Exact Java `this` receiver proof for first-party self-field fragments.
+pub fn exact_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        && il.kind(node) == NodeKind::Var
+        && matches!(il.node(node).payload, Payload::Name(name) if interner.resolve(name) == "this")
+}
+
+/// Exact Java `this.field` place proof for receiver-free field-write fingerprints.
+pub fn exact_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        || il.kind(node) != NodeKind::Field
+    {
+        return false;
+    }
+    if !matches!(il.node(node).payload, Payload::Name(_)) {
+        return false;
+    }
+    il.children(node)
+        .first()
+        .is_some_and(|&receiver| exact_java_this_var(il, interner, receiver))
+}
+
+/// Exact Java `return this` proof used by self-field body fragments.
+pub fn exact_java_return_this(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        || il.kind(node) != NodeKind::Return
+    {
+        return false;
+    }
+    let kids = il.children(node);
+    kids.len() == 1 && exact_java_this_var(il, interner, kids[0])
+}
+
+/// `(receiver, key, value)` of a first-party exact-safe index assignment.
+///
+/// This is intentionally language-gated: languages with overloadable/user-dispatched index
+/// assignment remain fail-closed until a pack supplies a stronger receiver proof.
+pub fn exact_non_overloadable_index_assignment_parts(
+    il: &Il,
+    node: NodeId,
+) -> Option<(NodeId, Option<NodeId>, NodeId)> {
+    if !semantics(il.meta.lang)
+        .exact_fragments()
+        .non_overloadable_index_assignment()
+    {
+        return None;
+    }
+    let kids = il.children(node);
+    if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Index {
+        return None;
+    }
+    let target = il.children(kids[0]);
+    Some((*target.first()?, target.get(1).copied(), kids[1]))
+}
+
+pub fn exact_non_overloadable_index_assignment(il: &Il, node: NodeId) -> bool {
+    exact_non_overloadable_index_assignment_parts(il, node).is_some()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -841,6 +906,38 @@ pub fn builder_append_method_contract(lang: Lang, method: &str, arg_count: usize
     )
 }
 
+/// `(receiver, value)` of a single-item append-like builder call admitted by first-party
+/// language/library contracts.
+pub fn builder_append_call_args(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<(NodeId, NodeId)> {
+    if il.kind(node) != NodeKind::Call {
+        return None;
+    }
+    let kids = il.children(node);
+    if matches!(il.node(node).payload, Payload::Builtin(Builtin::Append)) {
+        return (kids.len() == 2).then(|| (kids[0], kids[1]));
+    }
+    let (&callee, args) = kids.split_first()?;
+    if args.len() != 1 || il.kind(callee) != NodeKind::Field {
+        return None;
+    }
+    let Payload::Name(method) = il.node(callee).payload else {
+        return None;
+    };
+    if !builder_append_method_contract(il.meta.lang, interner.resolve(method), args.len()) {
+        return None;
+    }
+    let receiver = *il.children(callee).first()?;
+    Some((receiver, args[0]))
+}
+
+pub fn builder_append_call(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    builder_append_call_args(il, interner, node).is_some()
+}
+
 pub fn method_fold_name(lang: Lang, name: &str) -> bool {
     matches!(
         (lang, name),
@@ -1064,6 +1161,7 @@ pub fn async_to_sync_name(lang: Lang, name: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nose_il::{FileId, FileMeta, IlBuilder, Span, Unit, UnitKind};
 
     const ALL_LANGS: &[Lang] = &[
         Lang::Python,
@@ -1106,6 +1204,26 @@ mod tests {
         Builtin::Join,
         Builtin::UnsignedCast32,
     ];
+
+    fn sp(line: u32) -> Span {
+        Span::new(FileId(0), line, line, 1, 1)
+    }
+
+    fn finish_il(builder: IlBuilder, root: NodeId, lang: Lang) -> Il {
+        builder.finish(
+            root,
+            FileMeta {
+                path: "t".into(),
+                lang,
+            },
+            vec![Unit {
+                root,
+                kind: UnitKind::Function,
+                name: None,
+            }],
+            Vec::new(),
+        )
+    }
 
     #[test]
     fn first_party_profile_wraps_each_language() {
@@ -1483,5 +1601,102 @@ mod tests {
         assert!(builder_append_method_contract(Lang::JavaScript, "push", 1));
         assert!(builder_append_method_contract(Lang::Python, "append", 1));
         assert!(!builder_append_method_contract(Lang::Ruby, "push", 1));
+    }
+
+    #[test]
+    fn exact_java_this_helpers_are_language_and_shape_constrained() {
+        let interner = Interner::default();
+        let this = interner.intern("this");
+        let field_name = interner.intern("value");
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(NodeKind::Var, Payload::Name(this), sp(1), &[]);
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(field_name),
+            sp(1),
+            &[receiver],
+        );
+        let ret = b.add(NodeKind::Return, Payload::None, sp(2), &[receiver]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(1), &[field, ret]);
+        let il = finish_il(b, root, Lang::Java);
+
+        assert!(exact_java_this_var(&il, &interner, receiver));
+        assert!(exact_java_this_field(&il, &interner, field));
+        assert!(exact_java_return_this(&il, &interner, ret));
+
+        let mut js_il = il.clone();
+        js_il.meta.lang = Lang::JavaScript;
+        assert!(!exact_java_this_var(&js_il, &interner, receiver));
+        assert!(!exact_java_this_field(&js_il, &interner, field));
+        assert!(!exact_java_return_this(&js_il, &interner, ret));
+    }
+
+    #[test]
+    fn exact_index_assignment_parts_are_language_constrained() {
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(NodeKind::Var, Payload::Cid(1), sp(1), &[]);
+        let key = b.add(NodeKind::Var, Payload::Cid(2), sp(1), &[]);
+        let target = b.add(NodeKind::Index, Payload::None, sp(1), &[receiver, key]);
+        let value = b.add(NodeKind::Var, Payload::Cid(3), sp(1), &[]);
+        let assign = b.add(NodeKind::Assign, Payload::None, sp(1), &[target, value]);
+        let il = finish_il(b, assign, Lang::Go);
+
+        assert_eq!(
+            exact_non_overloadable_index_assignment_parts(&il, assign),
+            Some((receiver, Some(key), value))
+        );
+        assert!(exact_non_overloadable_index_assignment(&il, assign));
+
+        let mut ruby_il = il.clone();
+        ruby_il.meta.lang = Lang::Ruby;
+        assert_eq!(
+            exact_non_overloadable_index_assignment_parts(&ruby_il, assign),
+            None
+        );
+        assert!(!exact_non_overloadable_index_assignment(&ruby_il, assign));
+    }
+
+    #[test]
+    fn builder_append_call_args_are_language_arity_and_receiver_constrained() {
+        let interner = Interner::default();
+        let append = interner.intern("append");
+        let push = interner.intern("push");
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(NodeKind::Var, Payload::Cid(1), sp(1), &[]);
+        let value = b.add(NodeKind::Var, Payload::Cid(2), sp(1), &[]);
+        let builtin = b.add(
+            NodeKind::Call,
+            Payload::Builtin(Builtin::Append),
+            sp(1),
+            &[receiver, value],
+        );
+        let method = b.add(NodeKind::Field, Payload::Name(append), sp(2), &[receiver]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(2), &[method, value]);
+        let push_method = b.add(NodeKind::Field, Payload::Name(push), sp(3), &[receiver]);
+        let push_call = b.add(NodeKind::Call, Payload::None, sp(3), &[push_method, value]);
+        let root = b.add(
+            NodeKind::Block,
+            Payload::None,
+            sp(1),
+            &[builtin, call, push_call],
+        );
+        let il = finish_il(b, root, Lang::Python);
+
+        assert_eq!(
+            builder_append_call_args(&il, &interner, builtin),
+            Some((receiver, value))
+        );
+        assert_eq!(
+            builder_append_call_args(&il, &interner, call),
+            Some((receiver, value))
+        );
+        assert_eq!(builder_append_call_args(&il, &interner, push_call), None);
+
+        let mut rust_il = il.clone();
+        rust_il.meta.lang = Lang::Rust;
+        assert_eq!(
+            builder_append_call_args(&rust_il, &interner, push_call),
+            Some((receiver, value))
+        );
     }
 }

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -985,6 +985,7 @@ pub fn iterator_identity_adapter_contract(
             method,
             "iter" | "into_iter" | "iter_mut" | "collect" | "to_vec" | "copied" | "cloned"
         )
+        || lang == Lang::Java && method == "stream" && arg_count == 0
     {
         Some(IteratorIdentityAdapterContract {
             receiver: IteratorAdapterReceiverContract::ExactIterableValue,
@@ -992,6 +993,26 @@ pub fn iterator_identity_adapter_contract(
     } else {
         None
     }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct StaticCollectionAdapterContract {
+    pub module: &'static str,
+    pub exported: &'static str,
+}
+
+pub fn static_collection_adapter_contract(
+    lang: Lang,
+    receiver: &str,
+    method: &str,
+    arg_count: usize,
+) -> Option<StaticCollectionAdapterContract> {
+    (lang == Lang::Java && receiver == "Arrays" && method == "stream" && arg_count == 1).then_some(
+        StaticCollectionAdapterContract {
+            module: "java.util",
+            exported: "Arrays",
+        },
+    )
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -2263,11 +2284,36 @@ mod tests {
             })
         );
         assert_eq!(
+            iterator_identity_adapter_contract(Lang::Java, "stream", 0),
+            Some(IteratorIdentityAdapterContract {
+                receiver: IteratorAdapterReceiverContract::ExactIterableValue,
+            })
+        );
+        assert_eq!(
             iterator_identity_adapter_contract(Lang::JavaScript, "collect", 0),
             None
         );
         assert_eq!(
             iterator_identity_adapter_contract(Lang::Rust, "collect", 1),
+            None
+        );
+    }
+
+    #[test]
+    fn static_collection_adapters_are_import_binding_constrained() {
+        assert_eq!(
+            static_collection_adapter_contract(Lang::Java, "Arrays", "stream", 1),
+            Some(StaticCollectionAdapterContract {
+                module: "java.util",
+                exported: "Arrays",
+            })
+        );
+        assert_eq!(
+            static_collection_adapter_contract(Lang::Java, "Arrays", "stream", 0),
+            None
+        );
+        assert_eq!(
+            static_collection_adapter_contract(Lang::JavaScript, "Arrays", "stream", 1),
             None
         );
     }

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -6,7 +6,10 @@
 //! extend this contract surface rather than letting packs mint fingerprints or
 //! approve exact clone matches directly.
 
-use nose_il::{Builtin, HoFKind, Il, Interner, Lang, NodeId, NodeKind, ParamSemantic, Payload};
+use nose_il::{
+    stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, NodeId, NodeKind, ParamSemantic,
+    Payload,
+};
 
 /// Stable pack id for the first-party language/stdlib contracts compiled into nose.
 pub const FIRST_PARTY_PACK_ID: &str = "nose.first_party";
@@ -829,7 +832,7 @@ pub fn method_call_contract(
             "includes",
             1,
         )
-        | (Lang::Ruby, "include?", 1)
+        | (Lang::Ruby, "include?" | "member?", 1)
         | (Lang::Java | Lang::Rust, "contains", 1) => (
             Builtin::Contains,
             Receiver::ExactCollectionOrJavaKeySet,
@@ -1016,6 +1019,193 @@ pub fn rust_option_and_then_contract(lang: Lang, method: &str, arg_count: usize)
     lang == Lang::Rust && method == "and_then" && arg_count == 1
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum JavaCollectionFactoryKind {
+    ListOf,
+    SetOf,
+    ArraysAsList,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct JavaCollectionFactoryContract {
+    pub receiver: &'static str,
+    pub method: &'static str,
+    pub kind: JavaCollectionFactoryKind,
+    pub single_arg_spreads_array: bool,
+}
+
+pub fn java_collection_factory_contract(
+    lang: Lang,
+    receiver: &str,
+    method: &str,
+) -> Option<JavaCollectionFactoryContract> {
+    if lang != Lang::Java {
+        return None;
+    }
+    Some(match (receiver, method) {
+        ("List", "of") => JavaCollectionFactoryContract {
+            receiver: "List",
+            method: "of",
+            kind: JavaCollectionFactoryKind::ListOf,
+            single_arg_spreads_array: false,
+        },
+        ("Set", "of") => JavaCollectionFactoryContract {
+            receiver: "Set",
+            method: "of",
+            kind: JavaCollectionFactoryKind::SetOf,
+            single_arg_spreads_array: false,
+        },
+        ("Arrays", "asList") => JavaCollectionFactoryContract {
+            receiver: "Arrays",
+            method: "asList",
+            kind: JavaCollectionFactoryKind::ArraysAsList,
+            single_arg_spreads_array: true,
+        },
+        _ => return None,
+    })
+}
+
+pub fn java_collection_factory_contract_by_hash(
+    lang: Lang,
+    receiver: &str,
+    method_hash: u64,
+) -> Option<JavaCollectionFactoryContract> {
+    ["of", "asList"].into_iter().find_map(|method| {
+        (stable_symbol_hash(method) == method_hash)
+            .then(|| java_collection_factory_contract(lang, receiver, method))
+            .flatten()
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum JavaMapFactoryKind {
+    Of,
+    OfEntries,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct JavaMapFactoryContract {
+    pub receiver: &'static str,
+    pub method: &'static str,
+    pub kind: JavaMapFactoryKind,
+}
+
+pub fn java_map_factory_contract(
+    lang: Lang,
+    receiver: &str,
+    method: &str,
+) -> Option<JavaMapFactoryContract> {
+    if lang != Lang::Java || receiver != "Map" {
+        return None;
+    }
+    Some(match method {
+        "of" => JavaMapFactoryContract {
+            receiver: "Map",
+            method: "of",
+            kind: JavaMapFactoryKind::Of,
+        },
+        "ofEntries" => JavaMapFactoryContract {
+            receiver: "Map",
+            method: "ofEntries",
+            kind: JavaMapFactoryKind::OfEntries,
+        },
+        _ => return None,
+    })
+}
+
+pub fn java_map_factory_contract_by_hash(
+    lang: Lang,
+    receiver: &str,
+    method_hash: u64,
+) -> Option<JavaMapFactoryContract> {
+    ["of", "ofEntries"].into_iter().find_map(|method| {
+        (stable_symbol_hash(method) == method_hash)
+            .then(|| java_map_factory_contract(lang, receiver, method))
+            .flatten()
+    })
+}
+
+pub fn java_map_entry_contract(lang: Lang, receiver: &str, method: &str) -> bool {
+    lang == Lang::Java && receiver == "Map" && method == "entry"
+}
+
+pub fn java_map_entry_contract_by_hash(lang: Lang, receiver: &str, method_hash: u64) -> bool {
+    java_map_entry_contract(lang, receiver, "entry") && method_hash == stable_symbol_hash("entry")
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct RubySetFactoryContract {
+    pub receiver: &'static str,
+    pub method: &'static str,
+    pub required_module: &'static str,
+    pub shadow_root: &'static str,
+}
+
+pub fn ruby_set_factory_contract(
+    lang: Lang,
+    receiver: &str,
+    method: &str,
+    arg_count: usize,
+) -> Option<RubySetFactoryContract> {
+    (lang == Lang::Ruby && receiver == "Set" && method == "new" && arg_count == 1).then_some(
+        RubySetFactoryContract {
+            receiver: "Set",
+            method: "new",
+            required_module: "set",
+            shadow_root: "Set",
+        },
+    )
+}
+
+pub fn ruby_set_factory_contract_by_hash(
+    lang: Lang,
+    receiver: &str,
+    method_hash: u64,
+    arg_count: usize,
+) -> Option<RubySetFactoryContract> {
+    (method_hash == stable_symbol_hash("new"))
+        .then(|| ruby_set_factory_contract(lang, receiver, "new", arg_count))
+        .flatten()
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ConstructorProofRequirement {
+    ConstructSyntax,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ClosedConstructorContract {
+    pub receiver: &'static str,
+    pub required_proof: ConstructorProofRequirement,
+}
+
+pub fn js_like_set_constructor_contract(
+    lang: Lang,
+    receiver: &str,
+) -> Option<ClosedConstructorContract> {
+    (js_like_lang(lang) && receiver == "Set").then_some(ClosedConstructorContract {
+        receiver: "Set",
+        required_proof: ConstructorProofRequirement::ConstructSyntax,
+    })
+}
+
+pub fn js_like_map_constructor_contract(
+    lang: Lang,
+    receiver: &str,
+) -> Option<ClosedConstructorContract> {
+    (js_like_lang(lang) && receiver == "Map").then_some(ClosedConstructorContract {
+        receiver: "Map",
+        required_proof: ConstructorProofRequirement::ConstructSyntax,
+    })
+}
+
+fn js_like_lang(lang: Lang) -> bool {
+    matches!(
+        lang,
+        Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html
+    )
+}
+
 pub fn builder_append_method_contract(lang: Lang, method: &str, arg_count: usize) -> bool {
     matches!(
         (lang, method, arg_count),
@@ -1159,6 +1349,13 @@ impl CollectionSemantics {
             .copied()
             .filter(move |row| row.lang.is_none_or(|lang| lang == self.lang))
     }
+
+    pub fn imported_collection_factories(self) -> impl Iterator<Item = ImportedCollectionFactory> {
+        IMPORTED_COLLECTION_FACTORIES
+            .iter()
+            .copied()
+            .filter(move |row| row.lang.is_none_or(|lang| lang == self.lang))
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -1199,6 +1396,19 @@ const FREE_NAME_MAP_FACTORIES: &[FreeNameMapFactory] = &[FreeNameMapFactory {
         "std::collections::BTreeMap::from",
     ],
     entry_seq_tag: 2,
+}];
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ImportedCollectionFactory {
+    pub lang: Option<Lang>,
+    pub module: &'static str,
+    pub exported: &'static str,
+}
+
+const IMPORTED_COLLECTION_FACTORIES: &[ImportedCollectionFactory] = &[ImportedCollectionFactory {
+    lang: Some(Lang::Python),
+    module: "collections",
+    exported: "deque",
 }];
 
 pub fn imported_literal_seq_tag_safe(tag: &str) -> bool {
@@ -1452,6 +1662,13 @@ mod tests {
         assert!(py_names.contains(&"frozenset"));
         assert!(!py_names.contains(&"Set"));
 
+        let imported_py_names: Vec<_> = semantics(Lang::Python)
+            .collections()
+            .imported_collection_factories()
+            .map(|factory| (factory.module, factory.exported))
+            .collect();
+        assert_eq!(imported_py_names, vec![("collections", "deque")]);
+
         let rust_map_tags: Vec<_> = semantics(Lang::Rust)
             .collections()
             .free_name_map_factories()
@@ -1650,6 +1867,15 @@ mod tests {
             })
         );
         assert_eq!(
+            method_call_contract(Lang::Ruby, "member?", 1),
+            Some(MethodCallContract {
+                semantic: MethodSemanticContract::Builtin(Builtin::Contains),
+                receiver: MethodReceiverContract::ExactCollectionOrJavaKeySet,
+                args: MethodBuiltinArgs::FirstThenReceiver,
+            })
+        );
+        assert_eq!(method_call_contract(Lang::JavaScript, "contains", 1), None);
+        assert_eq!(
             method_call_contract(Lang::Java, "getOrDefault", 2),
             Some(MethodCallContract {
                 semantic: MethodSemanticContract::Builtin(Builtin::GetOrDefault),
@@ -1771,6 +1997,104 @@ mod tests {
             "and_then",
             1
         ));
+    }
+
+    #[test]
+    fn java_factory_contracts_are_language_receiver_and_selector_constrained() {
+        assert_eq!(
+            java_collection_factory_contract(Lang::Java, "List", "of"),
+            Some(JavaCollectionFactoryContract {
+                receiver: "List",
+                method: "of",
+                kind: JavaCollectionFactoryKind::ListOf,
+                single_arg_spreads_array: false,
+            })
+        );
+        assert_eq!(
+            java_collection_factory_contract(Lang::Java, "Arrays", "asList"),
+            Some(JavaCollectionFactoryContract {
+                receiver: "Arrays",
+                method: "asList",
+                kind: JavaCollectionFactoryKind::ArraysAsList,
+                single_arg_spreads_array: true,
+            })
+        );
+        assert_eq!(
+            java_collection_factory_contract(Lang::JavaScript, "List", "of"),
+            None
+        );
+        assert_eq!(
+            java_collection_factory_contract(Lang::Java, "Map", "of"),
+            None
+        );
+        assert_eq!(
+            java_map_factory_contract(Lang::Java, "Map", "ofEntries"),
+            Some(JavaMapFactoryContract {
+                receiver: "Map",
+                method: "ofEntries",
+                kind: JavaMapFactoryKind::OfEntries,
+            })
+        );
+        assert_eq!(java_map_factory_contract(Lang::Java, "List", "of"), None);
+        assert!(java_map_entry_contract(Lang::Java, "Map", "entry"));
+        assert!(!java_map_entry_contract(Lang::Java, "Entry", "entry"));
+        assert_eq!(
+            java_collection_factory_contract_by_hash(Lang::Java, "Set", stable_symbol_hash("of"))
+                .map(|contract| contract.kind),
+            Some(JavaCollectionFactoryKind::SetOf)
+        );
+        assert_eq!(
+            java_map_factory_contract_by_hash(Lang::Java, "Map", stable_symbol_hash("of"))
+                .map(|contract| contract.kind),
+            Some(JavaMapFactoryKind::Of)
+        );
+        assert!(java_map_entry_contract_by_hash(
+            Lang::Java,
+            "Map",
+            stable_symbol_hash("entry")
+        ));
+    }
+
+    #[test]
+    fn ruby_and_closed_js_like_factory_contracts_keep_proof_obligations_explicit() {
+        assert_eq!(
+            ruby_set_factory_contract(Lang::Ruby, "Set", "new", 1),
+            Some(RubySetFactoryContract {
+                receiver: "Set",
+                method: "new",
+                required_module: "set",
+                shadow_root: "Set",
+            })
+        );
+        assert_eq!(ruby_set_factory_contract(Lang::Ruby, "Set", "new", 2), None);
+        assert_eq!(
+            ruby_set_factory_contract(Lang::Python, "Set", "new", 1),
+            None
+        );
+        assert!(
+            ruby_set_factory_contract_by_hash(Lang::Ruby, "Set", stable_symbol_hash("new"), 1)
+                .is_some()
+        );
+
+        assert_eq!(
+            js_like_set_constructor_contract(Lang::TypeScript, "Set"),
+            Some(ClosedConstructorContract {
+                receiver: "Set",
+                required_proof: ConstructorProofRequirement::ConstructSyntax,
+            })
+        );
+        assert_eq!(
+            js_like_map_constructor_contract(Lang::JavaScript, "Map"),
+            Some(ClosedConstructorContract {
+                receiver: "Map",
+                required_proof: ConstructorProofRequirement::ConstructSyntax,
+            })
+        );
+        assert_eq!(js_like_map_constructor_contract(Lang::Java, "Map"), None);
+        assert_eq!(
+            js_like_set_constructor_contract(Lang::JavaScript, "WeakSet"),
+            None
+        );
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -1206,6 +1206,88 @@ fn js_like_lang(lang: Lang) -> bool {
     )
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MapKeyViewKind {
+    Collection,
+    Iterator,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct MapKeyViewContract {
+    pub method: &'static str,
+    pub kind: MapKeyViewKind,
+}
+
+pub fn map_key_view_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<MapKeyViewContract> {
+    if arg_count != 0 {
+        return None;
+    }
+    Some(match (lang, method) {
+        (Lang::Python | Lang::Ruby, "keys") => MapKeyViewContract {
+            method: "keys",
+            kind: MapKeyViewKind::Collection,
+        },
+        (Lang::Java, "keySet") => MapKeyViewContract {
+            method: "keySet",
+            kind: MapKeyViewKind::Collection,
+        },
+        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "keys") => {
+            MapKeyViewContract {
+                method: "keys",
+                kind: MapKeyViewKind::Iterator,
+            }
+        }
+        _ => return None,
+    })
+}
+
+pub fn map_key_view_contract_by_hash(
+    lang: Lang,
+    method_hash: u64,
+    arg_count: usize,
+) -> Option<MapKeyViewContract> {
+    ["keys", "keySet"].into_iter().find_map(|method| {
+        (stable_symbol_hash(method) == method_hash)
+            .then(|| map_key_view_contract(lang, method, arg_count))
+            .flatten()
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct MapKeyViewWrapperContract {
+    pub receiver: &'static str,
+    pub method: &'static str,
+}
+
+pub fn map_key_view_wrapper_contract(
+    lang: Lang,
+    receiver: &str,
+    method: &str,
+    arg_count: usize,
+) -> Option<MapKeyViewWrapperContract> {
+    (js_like_lang(lang) && receiver == "Array" && method == "from" && arg_count == 1).then_some(
+        MapKeyViewWrapperContract {
+            receiver: "Array",
+            method: "from",
+        },
+    )
+}
+
+pub fn map_key_view_wrapper_contract_by_hash(
+    lang: Lang,
+    receiver: &str,
+    method_hash: u64,
+    arg_count: usize,
+) -> Option<MapKeyViewWrapperContract> {
+    (method_hash == stable_symbol_hash("from"))
+        .then(|| map_key_view_wrapper_contract(lang, receiver, "from", arg_count))
+        .flatten()
+}
+
 pub fn builder_append_method_contract(lang: Lang, method: &str, arg_count: usize) -> bool {
     matches!(
         (lang, method, arg_count),
@@ -2095,6 +2177,56 @@ mod tests {
             js_like_set_constructor_contract(Lang::JavaScript, "WeakSet"),
             None
         );
+    }
+
+    #[test]
+    fn map_key_view_contracts_distinguish_collection_and_iterator_views() {
+        assert_eq!(
+            map_key_view_contract(Lang::Python, "keys", 0),
+            Some(MapKeyViewContract {
+                method: "keys",
+                kind: MapKeyViewKind::Collection,
+            })
+        );
+        assert_eq!(
+            map_key_view_contract(Lang::Java, "keySet", 0),
+            Some(MapKeyViewContract {
+                method: "keySet",
+                kind: MapKeyViewKind::Collection,
+            })
+        );
+        assert_eq!(
+            map_key_view_contract(Lang::TypeScript, "keys", 0),
+            Some(MapKeyViewContract {
+                method: "keys",
+                kind: MapKeyViewKind::Iterator,
+            })
+        );
+        assert_eq!(map_key_view_contract(Lang::JavaScript, "keySet", 0), None);
+        assert_eq!(map_key_view_contract(Lang::Python, "keys", 1), None);
+        assert_eq!(
+            map_key_view_wrapper_contract(Lang::JavaScript, "Array", "from", 1),
+            Some(MapKeyViewWrapperContract {
+                receiver: "Array",
+                method: "from",
+            })
+        );
+        assert_eq!(
+            map_key_view_wrapper_contract(Lang::Python, "Array", "from", 1),
+            None
+        );
+        assert_eq!(
+            map_key_view_contract_by_hash(Lang::Java, stable_symbol_hash("keySet"), 0)
+                .map(|contract| contract.kind),
+            Some(MapKeyViewKind::Collection)
+        );
+        assert!(map_key_view_wrapper_contract_by_hash(
+            Lang::TypeScript,
+            "Array",
+            stable_symbol_hash("from"),
+            1,
+        )
+        .is_some());
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -1471,6 +1471,19 @@ pub fn imported_namespace_function_contract(
     })
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct NullishGlobalContract {
+    pub name: &'static str,
+    pub requires_unshadowed: bool,
+}
+
+pub fn nullish_global_contract(lang: Lang, name: &str) -> Option<NullishGlobalContract> {
+    (js_like_lang(lang) && name == "undefined").then_some(NullishGlobalContract {
+        name: "undefined",
+        requires_unshadowed: true,
+    })
+}
+
 pub fn builder_append_method_contract(lang: Lang, method: &str, arg_count: usize) -> bool {
     matches!(
         (lang, method, arg_count),
@@ -2567,6 +2580,26 @@ mod tests {
             imported_namespace_function_contract(Lang::Python, "sum", 1),
             None
         );
+    }
+
+    #[test]
+    fn nullish_global_contracts_are_js_like_and_unshadowed() {
+        assert_eq!(
+            nullish_global_contract(Lang::JavaScript, "undefined"),
+            Some(NullishGlobalContract {
+                name: "undefined",
+                requires_unshadowed: true,
+            })
+        );
+        assert_eq!(
+            nullish_global_contract(Lang::TypeScript, "undefined"),
+            Some(NullishGlobalContract {
+                name: "undefined",
+                requires_unshadowed: true,
+            })
+        );
+        assert_eq!(nullish_global_contract(Lang::Python, "undefined"), None);
+        assert_eq!(nullish_global_contract(Lang::JavaScript, "null"), None);
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -1432,6 +1432,38 @@ pub fn index_membership_threshold_contract(
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ImportedNamespaceFunctionSemantic {
+    ProductReduction { op: Op, identity: u32 },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ImportedNamespaceFunctionContract {
+    pub module: &'static str,
+    pub function: &'static str,
+    pub receiver: MethodReceiverContract,
+    pub semantic: ImportedNamespaceFunctionSemantic,
+}
+
+pub fn imported_namespace_function_contract(
+    lang: Lang,
+    function: &str,
+    arg_count: usize,
+) -> Option<ImportedNamespaceFunctionContract> {
+    Some(match (lang, function, arg_count) {
+        (Lang::Python, "prod", 1 | 2) => ImportedNamespaceFunctionContract {
+            module: "math",
+            function: "prod",
+            receiver: MethodReceiverContract::ImportedNamespace("math"),
+            semantic: ImportedNamespaceFunctionSemantic::ProductReduction {
+                op: Op::Mul,
+                identity: 1,
+            },
+        },
+        _ => return None,
+    })
+}
+
 pub fn builder_append_method_contract(lang: Lang, method: &str, arg_count: usize) -> bool {
     matches!(
         (lang, method, arg_count),
@@ -2476,6 +2508,42 @@ mod tests {
             false,
             IndexMembershipThreshold::MinusOne
         ));
+    }
+
+    #[test]
+    fn imported_namespace_function_contracts_carry_module_and_receiver_proof() {
+        assert_eq!(
+            imported_namespace_function_contract(Lang::Python, "prod", 1),
+            Some(ImportedNamespaceFunctionContract {
+                module: "math",
+                function: "prod",
+                receiver: MethodReceiverContract::ImportedNamespace("math"),
+                semantic: ImportedNamespaceFunctionSemantic::ProductReduction {
+                    op: Op::Mul,
+                    identity: 1,
+                },
+            })
+        );
+        assert_eq!(
+            imported_namespace_function_contract(Lang::Python, "prod", 2)
+                .map(|contract| contract.semantic),
+            Some(ImportedNamespaceFunctionSemantic::ProductReduction {
+                op: Op::Mul,
+                identity: 1,
+            })
+        );
+        assert_eq!(
+            imported_namespace_function_contract(Lang::JavaScript, "prod", 1),
+            None
+        );
+        assert_eq!(
+            imported_namespace_function_contract(Lang::Python, "prod", 3),
+            None
+        );
+        assert_eq!(
+            imported_namespace_function_contract(Lang::Python, "sum", 1),
+            None
+        );
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -1016,6 +1016,20 @@ pub fn rust_option_some_constructor_contract(
     Some(ShadowedPathContract { shadow_root })
 }
 
+pub fn rust_option_none_sentinel_contract(lang: Lang, name: &str) -> Option<ShadowedPathContract> {
+    if lang != Lang::Rust {
+        return None;
+    }
+    let shadow_root = match name {
+        "None" => "None",
+        "Option::None" => "Option",
+        "std::option::Option::None" => "std",
+        "core::option::Option::None" => "core",
+        _ => return None,
+    };
+    Some(ShadowedPathContract { shadow_root })
+}
+
 pub fn rust_vec_new_factory_contract(lang: Lang, name: &str) -> Option<ShadowedPathContract> {
     if lang != Lang::Rust {
         return None;
@@ -2272,6 +2286,22 @@ mod tests {
         );
         assert_eq!(
             rust_option_some_constructor_contract(Lang::Python, "Some"),
+            None
+        );
+        assert_eq!(
+            rust_option_none_sentinel_contract(Lang::Rust, "None"),
+            Some(ShadowedPathContract {
+                shadow_root: "None",
+            })
+        );
+        assert_eq!(
+            rust_option_none_sentinel_contract(Lang::Rust, "core::option::Option::None"),
+            Some(ShadowedPathContract {
+                shadow_root: "core",
+            })
+        );
+        assert_eq!(
+            rust_option_none_sentinel_contract(Lang::JavaScript, "None"),
             None
         );
         assert_eq!(

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -7,8 +7,8 @@
 //! approve exact clone matches directly.
 
 use nose_il::{
-    stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, NodeId, NodeKind, ParamSemantic,
-    Payload,
+    stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LitClass, NodeId, NodeKind,
+    ParamSemantic, Payload,
 };
 
 /// Stable pack id for the first-party language/stdlib contracts compiled into nose.
@@ -1288,6 +1288,44 @@ pub fn map_key_view_wrapper_contract_by_hash(
         .flatten()
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct GoZeroMapLookupContract {
+    pub map_literal_tag: &'static str,
+    pub entry_tag: &'static str,
+    pub canonical_value_tag: &'static str,
+}
+
+pub fn go_zero_map_lookup_contract(lang: Lang) -> Option<GoZeroMapLookupContract> {
+    (lang == Lang::Go).then_some(GoZeroMapLookupContract {
+        map_literal_tag: "composite_literal",
+        entry_tag: "keyed_element",
+        canonical_value_tag: "go_literal_zero_map",
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum GoZeroMapDefaultKind {
+    Int,
+    String,
+    Bool,
+    Float,
+    Null,
+}
+
+pub fn go_zero_map_default_kind(lang: Lang, payload: Payload) -> Option<GoZeroMapDefaultKind> {
+    if lang != Lang::Go {
+        return None;
+    }
+    Some(match payload {
+        Payload::LitInt(_) => GoZeroMapDefaultKind::Int,
+        Payload::LitStr(_) => GoZeroMapDefaultKind::String,
+        Payload::LitBool(_) => GoZeroMapDefaultKind::Bool,
+        Payload::LitFloat(_) => GoZeroMapDefaultKind::Float,
+        Payload::Lit(LitClass::Null) => GoZeroMapDefaultKind::Null,
+        _ => return None,
+    })
+}
+
 pub fn builder_append_method_contract(lang: Lang, method: &str, arg_count: usize) -> bool {
     matches!(
         (lang, method, arg_count),
@@ -2227,6 +2265,36 @@ mod tests {
             1,
         )
         .is_some());
+    }
+
+    #[test]
+    fn go_zero_map_contracts_are_go_surface_and_default_constrained() {
+        assert_eq!(
+            go_zero_map_lookup_contract(Lang::Go),
+            Some(GoZeroMapLookupContract {
+                map_literal_tag: "composite_literal",
+                entry_tag: "keyed_element",
+                canonical_value_tag: "go_literal_zero_map",
+            })
+        );
+        assert_eq!(go_zero_map_lookup_contract(Lang::Python), None);
+        assert_eq!(
+            go_zero_map_default_kind(Lang::Go, Payload::LitInt(1)),
+            Some(GoZeroMapDefaultKind::Int)
+        );
+        assert_eq!(
+            go_zero_map_default_kind(Lang::Go, Payload::LitStr(stable_symbol_hash("x"))),
+            Some(GoZeroMapDefaultKind::String)
+        );
+        assert_eq!(
+            go_zero_map_default_kind(Lang::Go, Payload::Lit(LitClass::Null)),
+            Some(GoZeroMapDefaultKind::Null)
+        );
+        assert_eq!(
+            go_zero_map_default_kind(Lang::JavaScript, Payload::LitInt(1)),
+            None
+        );
+        assert_eq!(go_zero_map_default_kind(Lang::Go, Payload::None), None);
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -21,7 +21,14 @@ pub enum ChannelEligibility {
     NearOnly,
     ExactEmpirical,
     ExactProven,
-    FirstParty,
+}
+
+/// Trust/provenance policy for a pack, separate from which analysis channel a fact may enter.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PackTrust {
+    DefaultFirstParty,
+    FirstPartyOptional,
+    ExternalOptIn,
 }
 
 /// Kernel-facing domain evidence recovered from source facts, type inference, or future packs.
@@ -129,8 +136,8 @@ impl LanguageProfile {
         FIRST_PARTY_PACK_ID
     }
 
-    pub fn eligibility(self) -> ChannelEligibility {
-        ChannelEligibility::FirstParty
+    pub fn trust(self) -> PackTrust {
+        PackTrust::DefaultFirstParty
     }
 
     pub fn operators(self) -> OperatorSemantics {
@@ -1329,6 +1336,7 @@ pub fn go_zero_map_default_kind(lang: Lang, payload: Payload) -> Option<GoZeroMa
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct MapGetContract {
     pub method: &'static str,
+    pub receiver: MethodReceiverContract,
 }
 
 pub fn map_get_contract(lang: Lang, method: &str, arg_count: usize) -> Option<MapGetContract> {
@@ -1344,7 +1352,10 @@ pub fn map_get_contract(lang: Lang, method: &str, arg_count: usize) -> Option<Ma
     )
     .then_some(())
     .filter(|_| method == "get" && arg_count == 1)
-    .map(|_| MapGetContract { method: "get" })
+    .map(|_| MapGetContract {
+        method: "get",
+        receiver: MethodReceiverContract::ExactMap,
+    })
 }
 
 pub fn map_get_contract_by_hash(
@@ -1364,9 +1375,15 @@ pub enum StaticIndexMembershipKind {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum StaticIndexMembershipReceiverContract {
+    StaticNonFloatLiteralCollection,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct StaticIndexMembershipContract {
     pub method: &'static str,
     pub kind: StaticIndexMembershipKind,
+    pub receiver: StaticIndexMembershipReceiverContract,
 }
 
 pub fn static_index_membership_contract(
@@ -1381,10 +1398,12 @@ pub fn static_index_membership_contract(
         "indexOf" => StaticIndexMembershipContract {
             method: "indexOf",
             kind: StaticIndexMembershipKind::IndexOf,
+            receiver: StaticIndexMembershipReceiverContract::StaticNonFloatLiteralCollection,
         },
         "findIndex" => StaticIndexMembershipContract {
             method: "findIndex",
             kind: StaticIndexMembershipKind::FindIndex,
+            receiver: StaticIndexMembershipReceiverContract::StaticNonFloatLiteralCollection,
         },
         _ => return None,
     })
@@ -1772,7 +1791,7 @@ mod tests {
             let profile = semantics(lang);
             assert_eq!(profile.lang(), lang);
             assert_eq!(profile.pack_id(), FIRST_PARTY_PACK_ID);
-            assert_eq!(profile.eligibility(), ChannelEligibility::FirstParty);
+            assert_eq!(profile.trust(), PackTrust::DefaultFirstParty);
         }
     }
 
@@ -2388,15 +2407,24 @@ mod tests {
     fn map_get_contracts_are_language_and_arity_constrained() {
         assert_eq!(
             map_get_contract(Lang::Rust, "get", 1),
-            Some(MapGetContract { method: "get" })
+            Some(MapGetContract {
+                method: "get",
+                receiver: MethodReceiverContract::ExactMap,
+            })
         );
         assert_eq!(
             map_get_contract_by_hash(Lang::Java, stable_symbol_hash("get"), 1),
-            Some(MapGetContract { method: "get" })
+            Some(MapGetContract {
+                method: "get",
+                receiver: MethodReceiverContract::ExactMap,
+            })
         );
         assert_eq!(
             map_get_contract(Lang::TypeScript, "get", 1),
-            Some(MapGetContract { method: "get" })
+            Some(MapGetContract {
+                method: "get",
+                receiver: MethodReceiverContract::ExactMap,
+            })
         );
         assert_eq!(map_get_contract(Lang::Python, "get", 1), None);
         assert_eq!(map_get_contract(Lang::Rust, "get", 2), None);
@@ -2410,6 +2438,7 @@ mod tests {
             Some(StaticIndexMembershipContract {
                 method: "indexOf",
                 kind: StaticIndexMembershipKind::IndexOf,
+                receiver: StaticIndexMembershipReceiverContract::StaticNonFloatLiteralCollection,
             })
         );
         assert_eq!(
@@ -2417,6 +2446,7 @@ mod tests {
             Some(StaticIndexMembershipContract {
                 method: "findIndex",
                 kind: StaticIndexMembershipKind::FindIndex,
+                receiver: StaticIndexMembershipReceiverContract::StaticNonFloatLiteralCollection,
             })
         );
         assert_eq!(

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -85,6 +85,9 @@ and pack ecosystem.
   Frontend `ParamSemantic` facts still provide the current evidence source, but
   normalize and detect exact gates now consume the kernel-facing domain
   vocabulary so pack-provided evidence can replace the source fact later.
+- Rust stdlib path contracts for `Some`/`Option::Some`, `Option::and_then`, and
+  `Vec::new` moved into the kernel facade with explicit shadow-root obligations.
+  The caller still proves local shadow safety.
 
 ## Phase 0: documentation and vocabulary
 

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -81,6 +81,10 @@ and pack ecosystem.
   non-overloadable C/Go/Java index assignment, and single-item builder append
   calls moved into `nose-semantics`, so predicate and contract paths no longer
   duplicate those language/API gates.
+- The first receiver-domain evidence facade landed as `DomainEvidence`.
+  Frontend `ParamSemantic` facts still provide the current evidence source, but
+  normalize and detect exact gates now consume the kernel-facing domain
+  vocabulary so pack-provided evidence can replace the source fact later.
 
 ## Phase 0: documentation and vocabulary
 
@@ -110,8 +114,8 @@ and pack ecosystem.
   versioned pack-facing effect/place evidence records.
 - Move collection/map factory recognition into `LibraryApiContract` records.
 - Make value-graph and strict exact gates consume the same contract source.
-- Replace `ParamSemantic` with kernel evidence records for receiver/domain
-  proofs while preserving the current precision gates.
+- Replace the current `DomainEvidence` facade with versioned, pack-facing
+  receiver/domain evidence records while preserving the current precision gates.
 - Turn named value-graph rule modules into LawPack-facing law ids/contracts while
   retaining formal-obligation metadata as the first-party proof boundary.
 - Add construct/call distinction facts so constructor-only contracts such as

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -117,6 +117,8 @@ and pack ecosystem.
 - Python `math.prod` product-reduction recognition moved behind an imported
   namespace function contract with missing-import and overwritten-binding hard
   negatives.
+- Java `Math.abs`/`Math.min`/`Math.max` moved out of frontend text-only lowering
+  and into method contracts that require an unshadowed `Math` receiver.
 
 ## Phase 0: documentation and vocabulary
 

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -85,9 +85,11 @@ and pack ecosystem.
   Frontend `ParamSemantic` facts still provide the current evidence source, but
   normalize and detect exact gates now consume the kernel-facing domain
   vocabulary so pack-provided evidence can replace the source fact later.
-- Rust stdlib path contracts for `Some`/`Option::Some`, `Option::and_then`, and
-  `Vec::new` moved into the kernel facade with explicit shadow-root obligations.
-  The caller still proves local shadow safety.
+- Rust stdlib path contracts for `Some`/`Option::Some`,
+  `None`/`Option::None`, `Option::and_then`, and `Vec::new` moved into the
+  kernel facade with explicit shadow-root obligations. The caller still proves
+  local shadow safety, and the Rust frontend no longer lowers bare `None`
+  directly to null before that proof.
 - Java collection/map factory selectors, Python free-name/imported collection
   factories, Rust std collection/map factory paths, and Ruby `Set.new` moved
   behind shared `nose-semantics` contracts. Normalize, strict exact gates, and

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -119,6 +119,8 @@ and pack ecosystem.
   negatives.
 - Java `Math.abs`/`Math.min`/`Math.max` moved out of frontend text-only lowering
   and into method contracts that require an unshadowed `Math` receiver.
+- JS-like `undefined` moved from unconditional frontend null lowering to an
+  unshadowed-global nullish contract, preserving shadowed binding hard negatives.
 
 ## Phase 0: documentation and vocabulary
 

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -100,6 +100,9 @@ and pack ecosystem.
 - JS-like `Map`/`Set` constructors are now represented as explicit closed
   contracts requiring construct-syntax proof; they remain exact-closed until the
   frontend/kernel can distinguish `new Map(...)` from plain `Map(...)`.
+- Map key-view recognition moved behind contracts that distinguish collection
+  views from iterator views. JS-like `Map.keys()` now requires an
+  `Array.from(...)` wrapper before exact membership can consume it.
 
 ## Phase 0: documentation and vocabulary
 
@@ -129,8 +132,6 @@ and pack ecosystem.
   versioned pack-facing effect/place evidence records.
 - Move collection/map factory recognition into `LibraryApiContract` records.
 - Make value-graph and strict exact gates consume the same contract source.
-- Move map key-view contracts (`keys`, Java `keySet`, JS-like
-  `Array.from(map.keys())`) into shared kernel contracts.
 - Move Go composite map literal/default-zero lookup contracts into shared kernel
   contracts.
 - Replace the current `DomainEvidence` facade with versioned, pack-facing

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -88,6 +88,18 @@ and pack ecosystem.
 - Rust stdlib path contracts for `Some`/`Option::Some`, `Option::and_then`, and
   `Vec::new` moved into the kernel facade with explicit shadow-root obligations.
   The caller still proves local shadow safety.
+- Java collection/map factory selectors, Python free-name/imported collection
+  factories, Rust std collection/map factory paths, and Ruby `Set.new` moved
+  behind shared `nose-semantics` contracts. Normalize, strict exact gates, and
+  corpus import proof now consume the same selector source while keeping local
+  import, require, shadow, mutation, and entry-shape proof at the caller.
+- Membership and map-key membership recognition now uses language-scoped method
+  contracts before normalization or strict exact matching assigns containment
+  semantics. This intentionally closes old name-only paths such as JavaScript
+  `.contains(...)`, which had no first-party JS membership contract.
+- JS-like `Map`/`Set` constructors are now represented as explicit closed
+  contracts requiring construct-syntax proof; they remain exact-closed until the
+  frontend/kernel can distinguish `new Map(...)` from plain `Map(...)`.
 
 ## Phase 0: documentation and vocabulary
 
@@ -117,6 +129,10 @@ and pack ecosystem.
   versioned pack-facing effect/place evidence records.
 - Move collection/map factory recognition into `LibraryApiContract` records.
 - Make value-graph and strict exact gates consume the same contract source.
+- Move map key-view contracts (`keys`, Java `keySet`, JS-like
+  `Array.from(map.keys())`) into shared kernel contracts.
+- Move Go composite map literal/default-zero lookup contracts into shared kernel
+  contracts.
 - Replace the current `DomainEvidence` facade with versioned, pack-facing
   receiver/domain evidence records while preserving the current precision gates.
 - Turn named value-graph rule modules into LawPack-facing law ids/contracts while

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -108,6 +108,8 @@ and pack ecosystem.
 - Map `get(key)` lookup surfaces for Java, Rust, and JS-like typed/proven maps
   moved behind an explicit map-get contract. Defaulting surfaces continue through
   the existing `GetOrDefault` method contract.
+- JS-like static array `indexOf`/`findIndex` membership and their accepted
+  threshold comparisons moved behind shared semantic contracts.
 
 ## Phase 0: documentation and vocabulary
 

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -105,6 +105,9 @@ and pack ecosystem.
   `Array.from(...)` wrapper before exact membership can consume it.
 - Go composite map literal/default-zero lookup recognition moved behind a shared
   contract for literal/entry tags and supported zero-default payload classes.
+- Map `get(key)` lookup surfaces for Java, Rust, and JS-like typed/proven maps
+  moved behind an explicit map-get contract. Defaulting surfaces continue through
+  the existing `GetOrDefault` method contract.
 
 ## Phase 0: documentation and vocabulary
 

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -114,6 +114,9 @@ and pack ecosystem.
   provenance and enablement policy, not a semantic channel.
 - Newly migrated selector contracts started carrying explicit receiver/proof
   requirements so extension APIs do not look like name-only semantic guesses.
+- Python `math.prod` product-reduction recognition moved behind an imported
+  namespace function contract with missing-import and overwritten-binding hard
+  negatives.
 
 ## Phase 0: documentation and vocabulary
 

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -65,8 +65,8 @@ and pack ecosystem.
 - Additional call surfaces moved behind proof-gated contracts: JS/TS
   `filter(...).length`, Rust `get(key).is_some()`, Java `keySet().contains`,
   and Java `Stream.count()` require receiver/protocol or map proof. Ruby untyped
-  `Enumerable` and scalar/array numeric helpers remain closed until comparable
-  proof facts exist.
+  `Enumerable` surfaces, including `.each`/`.each_with_index` block loops, and
+  scalar/array numeric helpers remain closed until comparable proof facts exist.
 - New value-graph rewrites began moving into named `rules/*` modules with
   mechanical formal-obligation pairing; `clamp` is the current proof-backed
   example.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -103,6 +103,8 @@ and pack ecosystem.
 - Map key-view recognition moved behind contracts that distinguish collection
   views from iterator views. JS-like `Map.keys()` now requires an
   `Array.from(...)` wrapper before exact membership can consume it.
+- Go composite map literal/default-zero lookup recognition moved behind a shared
+  contract for literal/entry tags and supported zero-default payload classes.
 
 ## Phase 0: documentation and vocabulary
 
@@ -132,8 +134,6 @@ and pack ecosystem.
   versioned pack-facing effect/place evidence records.
 - Move collection/map factory recognition into `LibraryApiContract` records.
 - Make value-graph and strict exact gates consume the same contract source.
-- Move Go composite map literal/default-zero lookup contracts into shared kernel
-  contracts.
 - Replace the current `DomainEvidence` facade with versioned, pack-facing
   receiver/domain evidence records while preserving the current precision gates.
 - Turn named value-graph rule modules into LawPack-facing law ids/contracts while

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -77,6 +77,10 @@ and pack ecosystem.
   language-, signature-, and integer-domain-constrained first-party contract
   instead of a bare method-name recognizer. Float/NaN-sensitive methods remain a
   separate future contract.
+- Exact fragment IL-surface proofs for Java `this.field`, Java `return this`,
+  non-overloadable C/Go/Java index assignment, and single-item builder append
+  calls moved into `nose-semantics`, so predicate and contract paths no longer
+  duplicate those language/API gates.
 
 ## Phase 0: documentation and vocabulary
 
@@ -102,9 +106,12 @@ and pack ecosystem.
 ## Phase 2: shared contracts for duplicated gates
 
 - Move primitive comparison gates behind `OperatorSemantics`.
-- Move index assignment and Java self-field exact gates behind `EffectSemantics`.
+- Expand the exact fragment facade from first-party helper functions into
+  versioned pack-facing effect/place evidence records.
 - Move collection/map factory recognition into `LibraryApiContract` records.
 - Make value-graph and strict exact gates consume the same contract source.
+- Replace `ParamSemantic` with kernel evidence records for receiver/domain
+  proofs while preserving the current precision gates.
 - Turn named value-graph rule modules into LawPack-facing law ids/contracts while
   retaining formal-obligation metadata as the first-party proof boundary.
 - Add construct/call distinction facts so constructor-only contracts such as

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -110,6 +110,10 @@ and pack ecosystem.
   the existing `GetOrDefault` method contract.
 - JS-like static array `indexOf`/`findIndex` membership and their accepted
   threshold comparisons moved behind shared semantic contracts.
+- Channel eligibility and pack trust were split: first-party/default status is
+  provenance and enablement policy, not a semantic channel.
+- Newly migrated selector contracts started carrying explicit receiver/proof
+  requirements so extension APIs do not look like name-only semantic guesses.
 
 ## Phase 0: documentation and vocabulary
 
@@ -190,8 +194,10 @@ different APIs.
 
 ## Phase 6: ecosystem packs
 
-- Add high-value first-party or community packs only when their contracts are
-  narrow and testable.
+- Add high-value first-party packs only when their contracts are narrow and
+  testable.
+- Keep community packs external and opt-in unless nose explicitly adopts them as
+  first-party/default packs with project-owned gates.
 - Candidate areas: Lodash, RxJS, NumPy, pandas, Java Streams/Guava, Rust Iterator
   ecosystem helpers, Tokio futures, Rails ActiveSupport collection helpers.
 - Keep exact eligibility narrow. Many APIs should stay `near-only` because

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -99,6 +99,12 @@ and pack ecosystem.
   contracts before normalization or strict exact matching assigns containment
   semantics. This intentionally closes old name-only paths such as JavaScript
   `.contains(...)`, which had no first-party JS membership contract.
+- Java stream source adapters are now proof-gated: receiver `.stream()` requires
+  exact iterable evidence, and static `Arrays.stream(xs)` requires the
+  `java.util.Arrays` import binding with no local `Arrays` type shadow.
+- Cross-file immutable import replacement now copies import-binding dependencies
+  required by the exported literal expression, preserving provider-side stdlib
+  proofs such as `java.util.Map` for Java static imports.
 - JS-like `Map`/`Set` constructors are now represented as explicit closed
   contracts requiring construct-syntax proof; they remain exact-closed until the
   frontend/kernel can distinguish `new Map(...)` from plain `Map(...)`.

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -56,6 +56,9 @@ migrated.
   closed until a pack/frontend can prove a Promise-like receiver.
 - Rust iterator identity adapters (`iter`, `into_iter`, `collect`, `to_vec`,
   `copied`, `cloned`) are language-, arity-, and receiver-proof constrained.
+- Rust stdlib path contracts for `Some`/`Option::Some`, `Option::and_then`,
+  and `Vec::new` carry the exact selector and shadow-root requirement through
+  `nose-semantics`; normalize/detect still perform the local scope shadow check.
 - Builder append contracts are separate from arbitrary method calls: Java `add`
   and Rust `push` are admitted only for active builder proofs.
 - Exact fragment surface proofs for Java `this.field`, Java `return this`,

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -84,6 +84,10 @@ migrated.
   `get(key).is_some()`, Ruby `key?`/`has_key?`, Python `__contains__`, and
   TypeScript `Array.from(map.keys()).includes(key)` when the receiver is a
   typed/proven map.
+- Map key-view contracts distinguish collection views from iterator views:
+  Python/Ruby `keys` and Java `keySet` are collection views, while JS-like
+  `Map.keys()` is an iterator view and needs the `Array.from(...)` wrapper
+  contract before it can feed exact membership.
 - JS/TS `new Map(...)` and `new Set(...)` remain closed because lowering does not
   yet retain a constructor proof distinct from ordinary `Map(...)`/`Set(...)`.
 
@@ -93,9 +97,9 @@ Semantic knowledge still appears in several forms outside the facade:
 
 - direct `Lang` checks and local recognizers in strict exact gates and value-graph
   rules that have not yet been expressed as shared contracts;
-- library/API recognizers that still lack shared contracts, especially map key
-  views, Go zero-map lookup surfaces, and remaining language-specific import or
-  module proof mechanics;
+- library/API recognizers that still lack shared contracts, especially Go
+  zero-map lookup surfaces and remaining language-specific import or module proof
+  mechanics;
 - module/import proof logic for immutable sibling-module literal bindings;
 - type facts and coarse type inference used to gate numeric and collection laws;
 - named value-graph rule modules that still consume internal `Builder` facts
@@ -172,8 +176,6 @@ The first high-value targets for semantic-kernel extraction are:
   closed contracts waiting on construct-vs-call proof;
 - resolved symbol facts for Java/Rust stdlib factories instead of the current
   path/name plus shadow-proof contracts;
-- shared contracts for map key-view surfaces such as `keys`, Java `keySet`, and
-  JS-like `Array.from(map.keys())`;
 - shared contracts for Go composite map literal/default-zero lookup rules;
 - nested collection element proofs for iterator chains and builder convergence;
 - Promise/future/thenable receiver facts;

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -38,6 +38,9 @@ The current facade is compiled Rust, not an external manifest schema. It is
 intended to make the future pack extension boundary explicit while behavior is
 migrated.
 
+- The first-party profile exposes pack id and trust policy separately from
+  channel eligibility. `ChannelEligibility` describes where a fact may be used;
+  first-party/default status is pack provenance, not an analysis channel.
 - Free-function builtin contracts are language- and arity-constrained and require
   unshadowed builtin/global proof before exact lowering.
 - Method contracts carry receiver obligations such as exact collection, exact
@@ -89,12 +92,13 @@ migrated.
   `Map.keys()` is an iterator view and needs the `Array.from(...)` wrapper
   contract before it can feed exact membership.
 - Map lookup surfaces that return a value/option are now explicit contracts for
-  proven Java/Rust/JS-like map receivers. Python `dict.get(key, default)`,
-  Ruby `fetch(key, default)`, and Java `getOrDefault` still use the
-  `GetOrDefault` method contract.
+  Java/Rust/JS-like `get(key)` plus an exact-map receiver requirement. Python
+  `dict.get(key, default)`, Ruby `fetch(key, default)`, and Java `getOrDefault`
+  still use the `GetOrDefault` method contract.
 - JS-like static array `indexOf`/`findIndex` membership surfaces are explicit
-  contracts, including the accepted `-1`/`0` threshold comparisons. Callers still
-  prove the static non-float literal collection and lambda equality shape.
+  contracts, including the static non-float literal collection requirement and
+  accepted `-1`/`0` threshold comparisons. Callers still prove the receiver and
+  lambda equality shape before exact normalization/detection accepts them.
 - Go literal map default lookup is represented by a shared contract for the
   `composite_literal`/`keyed_element` surface and the supported zero-default
   payload classes. The value graph still constructs the canonical default value,

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -105,6 +105,9 @@ migrated.
 - Java `Math.abs`/`Math.min`/`Math.max` now lower through method contracts with an
   unshadowed `Math` receiver requirement instead of frontend text-only builtin
   lowering.
+- JS-like `undefined` is no longer frontend-collapsed to null unconditionally.
+  It is preserved as a name and only treated as the nullish sentinel through an
+  unshadowed-global contract.
 - Go literal map default lookup is represented by a shared contract for the
   `composite_literal`/`keyed_element` surface and the supported zero-default
   payload classes. The value graph still constructs the canonical default value,

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -189,9 +189,10 @@ this worktree because the required evidence is not yet modeled:
   stay closed unless the nested element collection proof is available. Explicit
   nested builder loops can still converge with identity flat-map when their loop
   structure proves the emitted elements.
-- Ruby untyped `Enumerable` methods, Ruby scalar/array `abs`/`min`/`max`, and C
-  `fmin`/`fmax` remain closed until the relevant receiver, stdlib, and overload
-  facts are modeled as contracts.
+- Ruby untyped `Enumerable` methods, including block loop surfaces such as
+  `.each` and `.each_with_index`, plus Ruby scalar/array `abs`/`min`/`max` and
+  C `fmin`/`fmax`, remain closed until the relevant receiver, stdlib, and
+  overload facts are modeled as contracts.
 - Rust scalar `.abs`, `.min`, `.max`, and `.clamp` are admitted only for the
   current first-party primitive-integer domain. Rust float methods need a separate
   float/NaN contract and proof before they can enter exact matching.

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -88,6 +88,10 @@ migrated.
   Python/Ruby `keys` and Java `keySet` are collection views, while JS-like
   `Map.keys()` is an iterator view and needs the `Array.from(...)` wrapper
   contract before it can feed exact membership.
+- Go literal map default lookup is represented by a shared contract for the
+  `composite_literal`/`keyed_element` surface and the supported zero-default
+  payload classes. The value graph still constructs the canonical default value,
+  and detect still checks exact-safe keys and entries.
 - JS/TS `new Map(...)` and `new Set(...)` remain closed because lowering does not
   yet retain a constructor proof distinct from ordinary `Map(...)`/`Set(...)`.
 
@@ -97,9 +101,8 @@ Semantic knowledge still appears in several forms outside the facade:
 
 - direct `Lang` checks and local recognizers in strict exact gates and value-graph
   rules that have not yet been expressed as shared contracts;
-- library/API recognizers that still lack shared contracts, especially Go
-  zero-map lookup surfaces and remaining language-specific import or module proof
-  mechanics;
+- language-specific import or module proof mechanics that are still local to
+  frontend, normalize, or detect callers;
 - module/import proof logic for immutable sibling-module literal bindings;
 - type facts and coarse type inference used to gate numeric and collection laws;
 - named value-graph rule modules that still consume internal `Builder` facts
@@ -176,7 +179,6 @@ The first high-value targets for semantic-kernel extraction are:
   closed contracts waiting on construct-vs-call proof;
 - resolved symbol facts for Java/Rust stdlib factories instead of the current
   path/name plus shadow-proof contracts;
-- shared contracts for Go composite map literal/default-zero lookup rules;
 - nested collection element proofs for iterator chains and builder convergence;
 - Promise/future/thenable receiver facts;
 - versioned receiver/domain evidence records to replace the current

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -4,7 +4,7 @@ Back to [semantic-kernel](semantic-kernel.md). This page records the current
 implementation shape; planned work and decision history live in
 [semantic-kernel-roadmap](semantic-kernel-roadmap.md).
 
-Snapshot date: 2026-06-07, `feature/semantic-kernel-packs` worktree against
+Snapshot date: 2026-06-07, `feature/semantic-kernel-migration` worktree against
 `origin/main`.
 
 ## What exists today
@@ -53,6 +53,10 @@ migrated.
   `copied`, `cloned`) are language-, arity-, and receiver-proof constrained.
 - Builder append contracts are separate from arbitrary method calls: Java `add`
   and Rust `push` are admitted only for active builder proofs.
+- Exact fragment surface proofs for Java `this.field`, Java `return this`,
+  non-overloadable C/Go/Java index assignment, and single-item builder append
+  calls are now shared through `nose-semantics`; predicate and contract paths
+  consume the same IL-level proof helpers.
 - Collection reductions such as Rust `Iterator::count()` and Java
   `Stream.count()` are admitted through exact protocol receiver contracts, not
   through a bare method-name check.
@@ -77,7 +81,8 @@ Semantic knowledge still appears in several forms outside the facade:
   instead of versioned `LawPack` records;
 - hard-coded oracle evaluation rules for eager calls, short-circuit operators,
   HOFs, nullish defaulting, recursion, and effect traces;
-- duplicated strict exact gates in value-graph and unit/fragment extraction paths.
+- duplicated receiver/domain and library/API proof gates in desugaring,
+  idiom lowering, value-graph, and strict exact paths.
 
 These are valuable, but they do not yet share one complete semantic contract
 language.
@@ -147,6 +152,11 @@ The first high-value targets for semantic-kernel extraction are:
   heuristics;
 - nested collection element proofs for iterator chains and builder convergence;
 - Promise/future/thenable receiver facts;
+- receiver/domain evidence records to replace `ParamSemantic` as the internal
+  proof vocabulary for collection, map, option, string, integer, and byte-array
+  domains;
+- demand/protocol contracts that distinguish eager arrays, lazy iterators,
+  streams, callbacks, futures/promises, and call-by-need thunks;
 - demand/error contracts for language-core oracle behavior such as non-iterable
   `for`/`foreach` evaluation;
 - LawPack-facing ids for named value-graph rules, with the existing formal

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -88,6 +88,10 @@ migrated.
   Python/Ruby `keys` and Java `keySet` are collection views, while JS-like
   `Map.keys()` is an iterator view and needs the `Array.from(...)` wrapper
   contract before it can feed exact membership.
+- Map lookup surfaces that return a value/option are now explicit contracts for
+  proven Java/Rust/JS-like map receivers. Python `dict.get(key, default)`,
+  Ruby `fetch(key, default)`, and Java `getOrDefault` still use the
+  `GetOrDefault` method contract.
 - Go literal map default lookup is represented by a shared contract for the
   `composite_literal`/`keyed_element` surface and the supported zero-default
   payload classes. The value graph still constructs the canonical default value,

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -92,6 +92,9 @@ migrated.
   proven Java/Rust/JS-like map receivers. Python `dict.get(key, default)`,
   Ruby `fetch(key, default)`, and Java `getOrDefault` still use the
   `GetOrDefault` method contract.
+- JS-like static array `indexOf`/`findIndex` membership surfaces are explicit
+  contracts, including the accepted `-1`/`0` threshold comparisons. Callers still
+  prove the static non-float literal collection and lambda equality shape.
 - Go literal map default lookup is represented by a shared contract for the
   `composite_literal`/`keyed_element` surface and the supported zero-default
   payload classes. The value graph still constructs the canonical default value,

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -102,6 +102,9 @@ migrated.
 - Imported namespace function contracts now cover Python `math.prod` as a product
   reduction only when the receiver is proven to be the imported `math` namespace.
   Bare globals named `math` and overwritten module bindings stay exact-closed.
+- Java `Math.abs`/`Math.min`/`Math.max` now lower through method contracts with an
+  unshadowed `Math` receiver requirement instead of frontend text-only builtin
+  lowering.
 - Go literal map default lookup is represented by a shared contract for the
   `composite_literal`/`keyed_element` surface and the supported zero-default
   payload classes. The value graph still constructs the canonical default value,

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -99,6 +99,9 @@ migrated.
   contracts, including the static non-float literal collection requirement and
   accepted `-1`/`0` threshold comparisons. Callers still prove the receiver and
   lambda equality shape before exact normalization/detection accepts them.
+- Imported namespace function contracts now cover Python `math.prod` as a product
+  reduction only when the receiver is proven to be the imported `math` namespace.
+  Bare globals named `math` and overwritten module bindings stay exact-closed.
 - Go literal map default lookup is represented by a shared contract for the
   `composite_literal`/`keyed_element` surface and the supported zero-default
   payload classes. The value graph still constructs the canonical default value,

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -59,6 +59,14 @@ migrated.
 - Rust stdlib path contracts for `Some`/`Option::Some`, `Option::and_then`,
   and `Vec::new` carry the exact selector and shadow-root requirement through
   `nose-semantics`; normalize/detect still perform the local scope shadow check.
+- Collection and map factory contracts have started moving into the facade.
+  Shared rows now cover Python free-name factories (`list`, `set`,
+  `frozenset`, `tuple`), Python imported `collections.deque`, Rust
+  `std::collections::{HashSet,BTreeSet,VecDeque,HashMap,BTreeMap}::from`,
+  Java `List.of`/`Set.of`/`Arrays.asList`, Java `Map.of`/`Map.ofEntries`/
+  `Map.entry`, and Ruby `require "set"; Set.new(...)`. Callers still prove the
+  local import, require, shadowing, entry-shape, mutation, and exact-safety
+  obligations.
 - Builder append contracts are separate from arbitrary method calls: Java `add`
   and Rust `push` are admitted only for active builder proofs.
 - Exact fragment surface proofs for Java `this.field`, Java `return this`,
@@ -68,10 +76,14 @@ migrated.
 - Collection reductions such as Rust `Iterator::count()` and Java
   `Stream.count()` are admitted through exact protocol receiver contracts, not
   through a bare method-name check.
-- Map-key membership contracts now require map receiver proof. Examples include
+- Membership and map-key membership selectors now consume language-scoped method
+  contracts before normalize/detect treat them as semantic containment. A method
+  named `contains` is Java/Rust collection membership only; JavaScript
+  `.contains(...)` is not accepted as array membership. Map-key examples include
   Java `Map.containsKey`, Java `keySet().contains`, Rust `contains_key`, Rust
-  `get(key).is_some()`, and TypeScript `Array.from(map.keys()).includes(key)`
-  when the receiver is a typed/proven map.
+  `get(key).is_some()`, Ruby `key?`/`has_key?`, Python `__contains__`, and
+  TypeScript `Array.from(map.keys()).includes(key)` when the receiver is a
+  typed/proven map.
 - JS/TS `new Map(...)` and `new Set(...)` remain closed because lowering does not
   yet retain a constructor proof distinct from ordinary `Map(...)`/`Set(...)`.
 
@@ -81,8 +93,9 @@ Semantic knowledge still appears in several forms outside the facade:
 
 - direct `Lang` checks and local recognizers in strict exact gates and value-graph
   rules that have not yet been expressed as shared contracts;
-- factory recognizers such as Python collection factories, Ruby `Set.new`, Rust
-  `Vec::new`, Java `List.of`, and Java/Rust map factories;
+- library/API recognizers that still lack shared contracts, especially map key
+  views, Go zero-map lookup surfaces, and remaining language-specific import or
+  module proof mechanics;
 - module/import proof logic for immutable sibling-module literal bindings;
 - type facts and coarse type inference used to gate numeric and collection laws;
 - named value-graph rule modules that still consume internal `Builder` facts
@@ -155,9 +168,13 @@ The first high-value targets for semantic-kernel extraction are:
 
 - field/place identity for field reads and writes, replacing field-name-only
   state with receiver-aware proof;
-- constructor facts for JS/TS `new Map` and `new Set`;
-- resolved symbol facts for Java/Rust stdlib factories instead of path/name
-  heuristics;
+- constructor facts for JS/TS `new Map` and `new Set`, which are now explicit
+  closed contracts waiting on construct-vs-call proof;
+- resolved symbol facts for Java/Rust stdlib factories instead of the current
+  path/name plus shadow-proof contracts;
+- shared contracts for map key-view surfaces such as `keys`, Java `keySet`, and
+  JS-like `Array.from(map.keys())`;
+- shared contracts for Go composite map literal/default-zero lookup rules;
 - nested collection element proofs for iterator chains and builder convergence;
 - Promise/future/thenable receiver facts;
 - versioned receiver/domain evidence records to replace the current

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -43,6 +43,11 @@ migrated.
 - Method contracts carry receiver obligations such as exact collection, exact
   protocol, exact option, exact string, exact primitive integer, exact map literal,
   imported namespace, or unshadowed global.
+- Source-level `ParamSemantic` facts are translated into `nose-semantics`
+  `DomainEvidence` before normalize/detect receiver-domain gates consume them.
+  This preserves the current Array/Collection/Set/Map/Option/String/Integer/
+  Number/ByteArray distinctions while moving the proof vocabulary into the
+  kernel facade.
 - Property builtin contracts are language-constrained; a selector such as
   `length` is not enough without receiver proof. JS/TS `filter(...).length`
   is admitted only after the receiver has already entered a proven collection/HOF
@@ -152,9 +157,9 @@ The first high-value targets for semantic-kernel extraction are:
   heuristics;
 - nested collection element proofs for iterator chains and builder convergence;
 - Promise/future/thenable receiver facts;
-- receiver/domain evidence records to replace `ParamSemantic` as the internal
-  proof vocabulary for collection, map, option, string, integer, and byte-array
-  domains;
+- versioned receiver/domain evidence records to replace the current
+  `DomainEvidence` facade as the pack-facing proof vocabulary for collection,
+  map, option, string, integer, and byte-array domains;
 - demand/protocol contracts that distinguish eager arrays, lazy iterators,
   streams, callbacks, futures/promises, and call-by-need thunks;
 - demand/error contracts for language-core oracle behavior such as non-iterable

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -59,9 +59,12 @@ migrated.
   closed until a pack/frontend can prove a Promise-like receiver.
 - Rust iterator identity adapters (`iter`, `into_iter`, `collect`, `to_vec`,
   `copied`, `cloned`) are language-, arity-, and receiver-proof constrained.
-- Rust stdlib path contracts for `Some`/`Option::Some`, `Option::and_then`,
-  and `Vec::new` carry the exact selector and shadow-root requirement through
-  `nose-semantics`; normalize/detect still perform the local scope shadow check.
+- Rust stdlib path contracts for `Some`/`Option::Some`,
+  `None`/`Option::None`, `Option::and_then`, and `Vec::new` carry the exact
+  selector and shadow-root requirement through `nose-semantics`;
+  normalize/detect still perform the local scope shadow check. The Rust
+  frontend preserves bare `None` as a name rather than lowering it directly to
+  null, so Option absence is admitted only through the contract.
 - Collection and map factory contracts have started moving into the facade.
   Shared rows now cover Python free-name factories (`list`, `set`,
   `frozenset`, `tuple`), Python imported `collections.deque`, Rust

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -82,6 +82,13 @@ migrated.
 - Collection reductions such as Rust `Iterator::count()` and Java
   `Stream.count()` are admitted through exact protocol receiver contracts, not
   through a bare method-name check.
+- Java stream source adapters are split by proof: `receiver.stream()` requires
+  an exact iterable receiver, while `Arrays.stream(xs)` requires the
+  `java.util.Arrays` import binding and no local `Arrays` type shadow.
+- Cross-file immutable import replacement now preserves import-binding
+  dependencies used by the exported literal expression, so a Java static import
+  of `LOOKUP = Map.of(...)` carries the provider's `java.util.Map` proof into
+  the importing file.
 - Membership and map-key membership selectors now consume language-scoped method
   contracts before normalize/detect treat them as semantic containment. A method
   named `contains` is Java/Rust collection membership only; JavaScript

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -221,12 +221,20 @@ The same semantic knowledge can be safe for one channel and unsafe for another.
 | `near-only` | candidate generation and review-oriented scoring |
 | `exact-empirical` | exact channel when required tests, hard negatives, and oracle coverage are present |
 | `exact-proven` | exact channel with proof obligations for the core law |
-| `first-party` | maintained and gated by the nose project |
+
+Eligibility is not a trust class. Pack provenance and enablement are tracked
+separately.
+
+| trust policy | use |
+|---|---|
+| `default-first-party` | maintained, gated, and enabled by the nose project |
+| `first-party-optional` | maintained and gated by nose, but not enabled by default |
+| `external-opt-in` | provider/user responsibility; enabled only by explicit user choice |
 
 External packs may declare their intended eligibility, but users choose whether
 to trust that declaration. The default nose distribution should enable exact
-matching only for first-party packs and any external packs the user explicitly
-opts into.
+matching only for default first-party packs and any external packs the user
+explicitly opts into.
 
 ## Pack conformance
 


### PR DESCRIPTION
## Summary
- centralize semantic surface contracts in `nose-semantics` and migrate call/receiver proofs out of scattered name checks
- require explicit proof for Python `math.prod`, Java `Math`/stream adapters, JS-like `undefined`, Rust `None`/`Some`, map/key/index membership, and Ruby untyped `.each`/`.each_with_index` loop surfaces
- separate pack trust/provenance from channel eligibility in the docs and keep third-party pack validation the provider/user responsibility

## Latest main audit
- audited `origin/main` at `a8ae65c` (`Build semantic kernel pack foundation (#98)`) instead of only rebasing
- found and fixed the remaining frontend-level Ruby `.each` name-based loop inference so it stays closed until receiver/protocol evidence exists

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p nose-cli --test equivalence`
- `cargo test -p nose-cli --test detection cross_language_family_groups_proven_foreach_languages -- --exact`
- `cargo test -p nose-semantics -p nose-frontend -p nose-normalize -p nose-detect`
- `awiki lint --root docs`
- `git diff --check`

## Note
- Full `cargo test -p nose-cli --test detection` still has the pre-existing local failure in `sub_dag_family_annotates_each_site_with_shared_computation_lines`, which also reproduces on clean `origin/main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 다양한 언어에서 코드 패턴 인식 정확도 개선 (Java, Ruby, Python, JavaScript, Rust 등)
  * 변수 명명 충돌 및 import 바인딩으로 인한 잘못된 분석 수정
  * 컬렉션, 맵, 옵션 타입 관련 경계 조건 처리 강화

* **개선 사항**
  * 복합 언어 환경에서 의미론적 분석 신뢰도 향상
  * 엣지 케이스(섀도잉, 타입 정의, import 위치)에 대한 보수적 안전성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->