### PR TITLE
Fix proof-gated exact scan regressions

### DIFF
--- a/crates/nose-cli/tests/detection.rs
+++ b/crates/nose-cli/tests/detection.rs
@@ -97,8 +97,8 @@ fn sub_dag_family_annotates_each_site_with_shared_computation_lines() {
     // Two functions that share a heavy computation but differ elsewhere — a partial / sub-DAG
     // clone caught by the anchor (near) channel. Each site must report ITS OWN source range for
     // the shared computation, so the report can point at where the shared logic lives in each copy.
-    let a = "function reportA(items) {\n  const totals = items.map(i => i.price * i.qty).reduce((s, x) => s + x, 0);\n  const tax = totals * 0.1;\n  const grand = totals + tax;\n  logA(grand);\n  return grand;\n}\n";
-    let b = "function reportB(items) {\n  warmup();\n  warmup2();\n  const totals = items.map(i => i.price * i.qty).reduce((s, x) => s + x, 0);\n  const tax = totals * 0.1;\n  const grand = totals + tax;\n  saveB(grand);\n  notifyB(grand);\n}\n";
+    let a = "function reportA(items) {\n  const subtotal = items.map(x => x.price * x.qty).reduce((s, x) => s + x, 0);\n  const tax = subtotal * rate;\n  const ship = subtotal > 100 ? 0 : 15;\n  const grand = subtotal + tax + ship;\n  renderInvoice(grand);\n  return grand;\n}\n";
+    let b = "function reportB(items) {\n  warmup();\n  warmup2();\n  const subtotal = items.map(x => x.price * x.qty).reduce((s, x) => s + x, 0);\n  const tax = subtotal * rate;\n  const ship = subtotal > 100 ? 0 : 15;\n  const grand = subtotal + tax + ship;\n  saveOrder(grand);\n  notify(grand);\n}\n";
     let corpus = build(&[("a.ts", a, Lang::TypeScript), ("b.ts", b, Lang::TypeScript)]);
     let opts = DetectOptions {
         threshold: 0.70,

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -595,6 +595,18 @@ fn java_arraylist_add_builder_loop_converges_with_comprehension() {
 }
 
 #[test]
+fn java_static_final_map_field_converges_with_inline_factory_lookup() {
+    let i = Interner::new();
+    let inline = "import java.util.Map;\n\nclass JavaMapOf {\n  static int lookup(String key, String other) {\n    return Map.of(\"red\", 1, \"blue\", 2).getOrDefault(key, 0);\n  }\n}\n";
+    let field = "import java.util.Map;\n\nclass JavaModuleMap {\n  static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2);\n\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n";
+    assert_eq!(
+        value_fp(&i, inline, Lang::Java),
+        value_fp(&i, field, Lang::Java),
+        "Java static final literal map fields must seed method-level map proof"
+    );
+}
+
+#[test]
 fn go_functional_append_builder_loop_converges_with_comprehension() {
     // Go builds a list with `out := []T{}; for … { out = append(out, e) }` — a FUNCTIONAL
     // append (reassignment), not the effect-form `out.append(e)` of Python/JS. Recognizing the
@@ -4546,6 +4558,7 @@ fn map_default_lookup_converges_cross_language_with_boundaries() {
     let ts_wrong_default = "function f(lookup: Map<string, number>, other_lookup: Map<string, number>, key: string, other_key: string, fallback: number, other_default: number): number { return lookup.get(key) ?? other_default; }\n";
     let ts_wrong_map = "function f(lookup: Map<string, number>, other_lookup: Map<string, number>, key: string, other_key: string, fallback: number, other_default: number): number { return other_lookup.get(key) ?? fallback; }\n";
     let ts_untyped = "function f(lookup, other_lookup, key, other_key, fallback, other_default) { return lookup.get(key) ?? fallback; }\n";
+    let ts_temp_shadowed_undefined = "function f(lookup: Map<string, number>, other_lookup: Map<string, number>, key: string, other_key: string, fallback: number, other_default: number, undefined: number): number { const selected = lookup.get(key); return selected === undefined ? fallback : selected; }\n";
     let py_wrong_key = "def f(lookup: dict[str, int], other_lookup: dict[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(other_key, fallback)\n";
     let py_wrong_default = "def f(lookup: dict[str, int], other_lookup: dict[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(key, other_default)\n";
     let py_wrong_map = "def f(lookup: dict[str, int], other_lookup: dict[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return other_lookup.get(key, fallback)\n";
@@ -4583,6 +4596,10 @@ fn map_default_lookup_converges_cross_language_with_boundaries() {
     assert_ne!(fp, value_fp(&i, ts_wrong_default, Lang::TypeScript));
     assert_ne!(fp, value_fp(&i, ts_wrong_map, Lang::TypeScript));
     assert_ne!(fp, value_fp(&i, ts_untyped, Lang::TypeScript));
+    assert_ne!(
+        fp,
+        value_fp(&i, ts_temp_shadowed_undefined, Lang::TypeScript)
+    );
     assert_ne!(fp, value_fp(&i, py_wrong_key, Lang::Python));
     assert_ne!(fp, value_fp(&i, py_wrong_default, Lang::Python));
     assert_ne!(fp, value_fp(&i, py_wrong_map, Lang::Python));

--- a/crates/nose-detect/src/fragment/loop_effect.rs
+++ b/crates/nose-detect/src/fragment/loop_effect.rs
@@ -302,45 +302,41 @@ fn temp_chain_consumed_by_effect(
     all_temps.insert(second_cid);
     let mut final_temp = FxHashSet::default();
     final_temp.insert(second_cid);
-    effect_consumes_chained_temp(
-        il,
-        interner,
-        effect,
+    let evidence = TempChainEvidence {
         iter_cids,
-        &all_temps,
-        &final_temp,
-        &first_temp,
-        effects,
-    )
+        all_temps: &all_temps,
+        final_temp: &final_temp,
+        prior_temp: &first_temp,
+    };
+    effect_consumes_chained_temp(il, interner, effect, evidence, effects)
+}
+
+#[derive(Clone, Copy)]
+struct TempChainEvidence<'a> {
+    iter_cids: &'a FxHashSet<u32>,
+    all_temps: &'a FxHashSet<u32>,
+    final_temp: &'a FxHashSet<u32>,
+    prior_temp: &'a FxHashSet<u32>,
 }
 
 fn effect_consumes_chained_temp(
     il: &Il,
     interner: &Interner,
     node: NodeId,
-    iter_cids: &FxHashSet<u32>,
-    all_temps: &FxHashSet<u32>,
-    final_temp: &FxHashSet<u32>,
-    prior_temp: &FxHashSet<u32>,
+    evidence: TempChainEvidence<'_>,
     effects: &mut Vec<EffectSite>,
 ) -> bool {
     match il.kind(node) {
         NodeKind::ExprStmt => {
             let kids = il.children(node);
-            if kids.len() == 1
-                && append_consumes_chained_temp(
-                    il, interner, kids[0], iter_cids, all_temps, final_temp, prior_temp,
-                )
-            {
+            if kids.len() == 1 && append_consumes_chained_temp(il, interner, kids[0], evidence) {
                 effects.push(EffectSite::observable(Effect::Append));
                 return true;
             }
             false
         }
         NodeKind::Assign => {
-            if index_assignment_consumes_chained_temp(
-                il, node, iter_cids, all_temps, final_temp, prior_temp,
-            ) {
+            if index_assignment_consumes_chained_temp(il, node, evidence) {
                 effects.push(EffectSite::observable(Effect::IndexWrite));
                 return true;
             }
@@ -354,38 +350,34 @@ fn append_consumes_chained_temp(
     il: &Il,
     interner: &Interner,
     node: NodeId,
-    iter_cids: &FxHashSet<u32>,
-    all_temps: &FxHashSet<u32>,
-    final_temp: &FxHashSet<u32>,
-    prior_temp: &FxHashSet<u32>,
+    evidence: TempChainEvidence<'_>,
 ) -> bool {
     let Some((recv, value)) = append_call_args(il, interner, node) else {
         return false;
     };
-    !mentions_any(il, recv, iter_cids)
-        && !mentions_any(il, recv, all_temps)
-        && mentions_any(il, value, final_temp)
-        && !mentions_any(il, value, prior_temp)
+    !mentions_any(il, recv, evidence.iter_cids)
+        && !mentions_any(il, recv, evidence.all_temps)
+        && mentions_any(il, value, evidence.final_temp)
+        && !mentions_any(il, value, evidence.prior_temp)
 }
 
 fn index_assignment_consumes_chained_temp(
     il: &Il,
     node: NodeId,
-    iter_cids: &FxHashSet<u32>,
-    all_temps: &FxHashSet<u32>,
-    final_temp: &FxHashSet<u32>,
-    prior_temp: &FxHashSet<u32>,
+    evidence: TempChainEvidence<'_>,
 ) -> bool {
     let Some((receiver, key, value)) = index_assignment_parts(il, node) else {
         return false;
     };
-    if mentions_any(il, receiver, iter_cids) || mentions_any(il, receiver, all_temps) {
+    if mentions_any(il, receiver, evidence.iter_cids)
+        || mentions_any(il, receiver, evidence.all_temps)
+    {
         return false;
     }
-    let key_final = key.is_some_and(|k| mentions_any(il, k, final_temp));
-    let key_prior = key.is_some_and(|k| mentions_any(il, k, prior_temp));
-    let value_final = mentions_any(il, value, final_temp);
-    let value_prior = mentions_any(il, value, prior_temp);
+    let key_final = key.is_some_and(|k| mentions_any(il, k, evidence.final_temp));
+    let key_prior = key.is_some_and(|k| mentions_any(il, k, evidence.prior_temp));
+    let value_final = mentions_any(il, value, evidence.final_temp);
+    let value_prior = mentions_any(il, value, evidence.prior_temp);
     (key_final || value_final) && !key_prior && !value_prior
 }
 

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -20,7 +20,7 @@ use nose_semantics::{
     iterator_identity_adapter_contract, java_collection_factory_contract, java_map_entry_contract,
     java_map_factory_contract, js_like_map_constructor_contract, js_like_set_constructor_contract,
     map_get_contract, map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
-    ruby_set_factory_contract, rust_vec_new_factory_contract, semantics,
+    nullish_global_contract, ruby_set_factory_contract, rust_vec_new_factory_contract, semantics,
     static_index_membership_contract, IndexMembershipThreshold, JavaMapFactoryKind, MapKeyViewKind,
     MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
 };
@@ -876,7 +876,10 @@ fn function_binding_safe(
         NodeKind::Call => matches!(il.node(node).payload, Payload::Builtin(_)),
         NodeKind::Seq => strict_exact_safe_seq(il, interner, node),
         NodeKind::Lit => exact_literal_safe(il, node),
-        NodeKind::Var => strict_exact_safe_var(il, facts, node),
+        NodeKind::Var => {
+            strict_exact_safe_var(il, facts, node)
+                || strict_exact_nullish_global_safe(il, interner, node)
+        }
         _ => il
             .children(node)
             .iter()
@@ -905,7 +908,10 @@ fn strict_exact_safe_tree(il: &Il, interner: &Interner, facts: &StrictFacts, nod
         }
         NodeKind::BinOp if strict_exact_in_membership_safe(il, interner, facts, node) => true,
         NodeKind::Lit => exact_literal_safe(il, node),
-        NodeKind::Var => strict_exact_safe_var(il, facts, node),
+        NodeKind::Var => {
+            strict_exact_safe_var(il, facts, node)
+                || strict_exact_nullish_global_safe(il, interner, node)
+        }
         _ => il
             .children(node)
             .iter()
@@ -1143,6 +1149,17 @@ fn strict_exact_safe_var(il: &Il, facts: &StrictFacts, node: NodeId) -> bool {
         Payload::Name(name) => facts.proven_name(name),
         _ => false,
     }
+}
+
+fn strict_exact_nullish_global_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    let (NodeKind::Var, Payload::Name(name)) = (il.kind(node), il.node(node).payload) else {
+        return false;
+    };
+    let name = interner.resolve(name);
+    let Some(contract) = nullish_global_contract(il.meta.lang, name) else {
+        return false;
+    };
+    !contract.requires_unshadowed || !file_defines_name(il, interner, contract.name)
 }
 
 fn strict_exact_safe_seq(il: &Il, interner: &Interner, node: NodeId) -> bool {
@@ -1996,23 +2013,19 @@ fn strict_exact_java_collection_factory_safe(
     let Some(&receiver) = il.children(kids[0]).first() else {
         return false;
     };
-    if il.kind(receiver) != NodeKind::Var {
-        return false;
-    }
-    let Payload::Name(receiver_name) = il.node(receiver).payload else {
-        return false;
-    };
     let method = interner.resolve(method);
-    let receiver_name = interner.resolve(receiver_name);
-    let Some(contract) = java_collection_factory_contract(il.meta.lang, receiver_name, method)
+    let Some(()) = ["List", "Set", "Arrays"]
+        .into_iter()
+        .find_map(|receiver_name| {
+            let contract = java_collection_factory_contract(il.meta.lang, receiver_name, method)?;
+            strict_exact_java_std_var_name(il, interner, receiver, contract.receiver).then_some(())
+        })
     else {
         return false;
     };
-    !java_file_defines_type_name(il, interner, contract.receiver)
-        && kids
-            .iter()
-            .skip(1)
-            .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
+    kids.iter()
+        .skip(1)
+        .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
 }
 
 fn java_file_defines_type_name(il: &Il, interner: &Interner, name: &str) -> bool {
@@ -2051,11 +2064,23 @@ fn strict_exact_java_std_var_name(
     if il.kind(node) != NodeKind::Var {
         return false;
     }
-    let Payload::Name(name) = il.node(node).payload else {
+    if java_file_defines_type_name(il, interner, expected) {
         return false;
+    }
+    let symbol = match il.node(node).payload {
+        Payload::Name(name) => name,
+        Payload::Cid(cid) => {
+            let Some(&name) = il.cid_names.get(cid as usize) else {
+                return false;
+            };
+            name
+        }
+        _ => return false,
     };
-    let name = interner.resolve(name);
-    name == expected && !java_file_defines_type_name(il, interner, name)
+    interner.resolve(symbol) == expected
+        && top_level_assignment_count(il, symbol) == 1
+        && top_level_assignment_rhs(il, symbol)
+            .is_some_and(|rhs| import_binding_rhs_matches(il, interner, rhs, "java.util", expected))
 }
 
 fn strict_exact_java_map_factory_safe(

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -707,7 +707,7 @@ fn rust_std_map_factory_call(old: &Il, interner: &Interner, node: NodeId) -> boo
     nose_semantics::semantics(old.meta.lang)
         .collections()
         .free_name_map_factories()
-        .any(|factory| factory.names.iter().any(|name| *name == callee))
+        .any(|factory| factory.names.contains(&callee))
 }
 
 /// Canonical sync name for a known async counterpart, so behaviorally-equivalent

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -129,6 +129,9 @@ and pack ecosystem.
   and into method contracts that require an unshadowed `Math` receiver.
 - JS-like `undefined` moved from unconditional frontend null lowering to an
   unshadowed-global nullish contract, preserving shadowed binding hard negatives.
+- Strict exact gates now consume the same nullish-global proof, so temp-bound
+  JS/TS `Map.get(...)` defaulting remains exact-eligible only when `undefined`
+  is the unshadowed JS-like sentinel.
 
 ## Phase 0: documentation and vocabulary
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -117,7 +117,9 @@ migrated.
   lowering.
 - JS-like `undefined` is no longer frontend-collapsed to null unconditionally.
   It is preserved as a name and only treated as the nullish sentinel through an
-  unshadowed-global contract.
+  unshadowed-global contract. Value-graph defaulting and strict exact-safe gates
+  consume that same proof, so temp-bound `Map.get(...)` defaulting can stay open
+  without admitting shadowed `undefined` bindings.
 - Go literal map default lookup is represented by a shared contract for the
   `composite_literal`/`keyed_element` surface and the supported zero-default
   payload classes. The value graph still constructs the canonical default value,


### PR DESCRIPTION
## Summary

- fixes clippy regressions from the semantic-kernel merge
- makes Java collection factory exact-safe checks require the same `java.util` import-binding proof as map factories, including module/class-field Cid receivers
- lets strict exact gates consume the JS-like unshadowed `undefined` nullish contract, so typed `Map.get(...)` temp defaulting is exact-eligible without opening shadowed bindings
- documents the nullish proof-sharing snapshot and adds focused regression coverage

## Main audit notes

This is not a rebase-only follow-up. I rechecked the latest `main` merge and found proof-gate mismatches exposed by CI after PR #100: Java static final `Map.of` / `List.of` fields were normalized with module-scoped Cid receivers, and TS temp-bound `Map.get` defaulting had the right value fingerprint but was excluded by strict exact safety.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo doc --no-deps --workspace`
- `cargo build --release`
- `cargo test -p nose-cli --test cli scan_mode_semantic_proves_typed_typescript_map_default_lookup -- --exact`
- `cargo test -p nose-cli --test cli scan_mode_semantic_proves_literal_map_default_lookup -- --exact`
- `cargo test -p nose-cli --test cli scan_mode_semantic_proves_literal_collection_membership -- --exact`
- `cargo test -p nose-cli --test equivalence map_default_lookup_converges_cross_language_with_boundaries -- --exact`
- `cargo test -p nose-cli --test equivalence java_static_final_map_field_converges_with_inline_factory_lookup -- --exact`
- `cargo test -p nose-semantics -p nose-frontend -p nose-normalize -p nose-detect`
- `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `awiki lint --root docs`
- `git diff --check`
- `./scripts/check-duplication.sh`

`cargo test --release` passes through the semantic-kernel regressions and fails only at the pre-existing `sub_dag_family_annotates_each_site_with_shared_computation_lines` test, which was already reproducible on clean `origin/main` before this follow-up.