### PR TITLE
Close raw-name exact call bypasses

### DIFF
--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -140,6 +140,21 @@ fn scan_families(json: &serde_json::Value) -> &[serde_json::Value] {
         .expect("scan JSON should contain families array")
 }
 
+fn family_contains_all(json: &serde_json::Value, suffixes: &[&str]) -> bool {
+    scan_families(json).iter().any(|family| {
+        let Some(locations) = family["locations"].as_array() else {
+            return false;
+        };
+        suffixes.iter().all(|suffix| {
+            locations.iter().any(|loc| {
+                loc["file"]
+                    .as_str()
+                    .is_some_and(|file| file.ends_with(suffix))
+            })
+        })
+    })
+}
+
 fn json_array_strings<'a>(value: &'a serde_json::Value, key: &str) -> Vec<&'a str> {
     value[key]
         .as_array()
@@ -5304,15 +5319,8 @@ fn scan_mode_semantic_rejects_unproved_regex_predicate_matches() {
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
         semantic_families.len(),
-        1,
-        "semantic mode should report only the same-regex exact family: {semantic}"
-    );
-    let semantic_text = semantic_json.to_string();
-    assert!(
-        semantic_text.contains("dot-only.ts")
-            && semantic_text.contains("dot-only-copy.ts")
-            && !semantic_text.contains("markdown-link.ts"),
-        "semantic mode must distinguish regex pattern semantics: {semantic}"
+        0,
+        "semantic mode must keep literal .test exact-closed until regex literal provenance exists: {semantic}"
     );
 
     let near = run(&[
@@ -5385,6 +5393,146 @@ fn scan_mode_semantic_allows_proved_js_static_builtins() {
             && semantic_text.contains("array_b.ts")
             && !semantic_text.contains("typeof_negative.ts"),
         "semantic mode must keep static builtin calls exact: {semantic}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn scan_mode_semantic_rejects_unproved_typeof_function_name() {
+    let dir = std::env::temp_dir().join(format!(
+        "nose_unproved_typeof_function_{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("provider_a.py"),
+        "def typeof(value):\n    return 1\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("provider_b.py"),
+        "def typeof(value):\n    return 2\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("raw_typeof_a.py"),
+        "from provider_a import *\n\ndef classify(value):\n    return typeof(value)\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("raw_typeof_b.py"),
+        "from provider_b import *\n\ndef classify(value):\n    return typeof(value)\n",
+    )
+    .unwrap();
+
+    let semantic = run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--min-lines",
+        "1",
+        "--min-size",
+        "1",
+        "--format",
+        "json",
+        "--top",
+        "0",
+    ]);
+    let semantic_json = scan_json(&semantic);
+    assert!(
+        !family_contains_all(
+            &semantic_json,
+            &["raw_typeof_a.py", "raw_typeof_b.py"]
+        ),
+        "semantic mode must not treat an arbitrary typeof function as the JS typeof operator: {semantic}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn scan_mode_semantic_rejects_unproved_array_isarray_name() {
+    let dir = std::env::temp_dir().join(format!(
+        "nose_unproved_array_isarray_{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("array_a.py"),
+        "class Array:\n    @staticmethod\n    def isArray(value):\n        return True\n\ndef check(value):\n    return Array.isArray(value)\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("array_b.py"),
+        "class Array:\n    @staticmethod\n    def isArray(value):\n        return False\n\ndef check(value):\n    return Array.isArray(value)\n",
+    )
+    .unwrap();
+
+    let semantic = run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--min-lines",
+        "1",
+        "--min-size",
+        "1",
+        "--format",
+        "json",
+        "--top",
+        "0",
+    ]);
+    let semantic_json = scan_json(&semantic);
+    assert!(
+        !family_contains_all(&semantic_json, &["array_a.py", "array_b.py"]),
+        "semantic mode must not treat an arbitrary Array.isArray method as the JS static builtin: {semantic}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn scan_mode_semantic_rejects_unproved_literal_test_method_name() {
+    let dir =
+        std::env::temp_dir().join(format!("nose_unproved_literal_test_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("literal_test_a.rb"),
+        "class String\n  def test(value)\n    true\n  end\nend\n\ndef accepts(value)\n  \"rule\".test(value)\nend\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("literal_test_b.rb"),
+        "class String\n  def test(value)\n    false\n  end\nend\n\ndef accepts(value)\n  \"rule\".test(value)\nend\n",
+    )
+    .unwrap();
+
+    let semantic = run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--min-lines",
+        "1",
+        "--min-size",
+        "1",
+        "--format",
+        "json",
+        "--top",
+        "0",
+    ]);
+    let semantic_json = scan_json(&semantic);
+    assert!(
+        !family_contains_all(
+            &semantic_json,
+            &["literal_test_a.rb", "literal_test_b.rb"]
+        ),
+        "semantic mode must not treat an arbitrary literal .test method as JS regex semantics: {semantic}"
     );
 
     let _ = fs::remove_dir_all(&dir);

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -18,11 +18,13 @@ use nose_semantics::{
     exact_non_overloadable_index_assignment_parts, go_zero_map_default_kind,
     go_zero_map_lookup_contract, index_membership_threshold_contract,
     iterator_identity_adapter_contract, java_collection_factory_contract, java_map_entry_contract,
-    java_map_factory_contract, js_like_map_constructor_contract, js_like_set_constructor_contract,
-    map_get_contract, map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
-    nullish_global_contract, ruby_set_factory_contract, rust_vec_new_factory_contract, semantics,
-    static_index_membership_contract, IndexMembershipThreshold, JavaMapFactoryKind, MapKeyViewKind,
-    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
+    java_map_factory_contract, js_array_is_array_contract, js_like_map_constructor_contract,
+    js_like_set_constructor_contract, map_get_contract, map_key_view_contract,
+    map_key_view_wrapper_contract, method_call_contract, nullish_global_contract,
+    regex_test_contract, ruby_set_factory_contract, rust_vec_new_factory_contract, semantics,
+    static_index_membership_contract, typeof_operator_contract, IndexMembershipThreshold,
+    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
+    MethodSemanticContract, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1231,8 +1233,8 @@ fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, nod
     let Some(&callee) = il.children(node).first() else {
         return false;
     };
-    if strict_exact_callee_name(il, interner, callee, "typeof") {
-        return strict_exact_call_args_safe(il, interner, facts, node);
+    if strict_exact_typeof_operator_safe(il, interner, facts, node, callee) {
+        return true;
     }
     if il.kind(callee) != NodeKind::Field {
         return strict_exact_callee_identity(il, facts, callee)
@@ -1242,16 +1244,11 @@ fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, nod
         return false;
     };
     let method = interner.resolve(name);
-    if method == "test" {
-        let Some(&receiver) = il.children(callee).first() else {
-            return false;
-        };
-        return matches!(il.node(receiver).payload, Payload::LitStr(_))
-            && strict_exact_call_args_safe(il, interner, facts, node);
+    if strict_exact_requires_regex_literal_proof(il, node, callee, method) {
+        return false;
     }
-    if method == "isArray" {
-        return strict_exact_field_receiver_name(il, interner, callee, "Array")
-            && strict_exact_call_args_safe(il, interner, facts, node);
+    if strict_exact_js_array_is_array_safe(il, interner, facts, node, callee, method) {
+        return true;
     }
     if strict_exact_collection_contains_call_safe(il, interner, facts, node, callee, method) {
         return true;
@@ -1273,6 +1270,77 @@ fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, nod
     // convergence still has to pass the proof-backed contracts above or in normalization.
     strict_exact_callee_identity(il, facts, callee)
         && strict_exact_call_args_safe(il, interner, facts, node)
+}
+
+fn strict_exact_typeof_operator_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+    callee: NodeId,
+) -> bool {
+    let (NodeKind::Var, Payload::Name(name)) = (il.kind(callee), il.node(callee).payload) else {
+        return false;
+    };
+    typeof_operator_contract(
+        il.meta.lang,
+        interner.resolve(name),
+        il.children(node).len().saturating_sub(1),
+    )
+    .is_some()
+        && strict_exact_call_args_safe(il, interner, facts, node)
+}
+
+fn strict_exact_requires_regex_literal_proof(
+    il: &Il,
+    node: NodeId,
+    callee: NodeId,
+    method: &str,
+) -> bool {
+    let Some(contract) = regex_test_contract(
+        il.meta.lang,
+        method,
+        il.children(node).len().saturating_sub(1),
+    ) else {
+        return false;
+    };
+    if !contract.requires_regex_literal_proof {
+        return false;
+    }
+    let Some(&receiver) = il.children(callee).first() else {
+        return false;
+    };
+    matches!(il.node(receiver).payload, Payload::LitStr(_))
+}
+
+fn strict_exact_js_array_is_array_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+    callee: NodeId,
+    method: &str,
+) -> bool {
+    let Some(&receiver) = il.children(callee).first() else {
+        return false;
+    };
+    let (NodeKind::Var, Payload::Name(receiver_name)) =
+        (il.kind(receiver), il.node(receiver).payload)
+    else {
+        return false;
+    };
+    let Some(contract) = js_array_is_array_contract(
+        il.meta.lang,
+        interner.resolve(receiver_name),
+        method,
+        il.children(node).len().saturating_sub(1),
+    ) else {
+        return false;
+    };
+    if contract.requires_unshadowed_receiver && file_defines_name(il, interner, contract.receiver) {
+        return false;
+    }
+    strict_exact_call_args_safe(il, interner, facts, node)
 }
 
 fn strict_exact_collection_contains_call_safe(
@@ -2310,24 +2378,6 @@ fn strict_exact_call_args_safe(
         .iter()
         .skip(1)
         .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
-}
-
-fn strict_exact_field_receiver_name(
-    il: &Il,
-    interner: &Interner,
-    field: NodeId,
-    expected: &str,
-) -> bool {
-    let Some(&receiver) = il.children(field).first() else {
-        return false;
-    };
-    if il.kind(receiver) != NodeKind::Var {
-        return false;
-    }
-    let Payload::Name(name) = il.node(receiver).payload else {
-        return false;
-    };
-    interner.resolve(name) == expected
 }
 
 fn strict_exact_callee_name(il: &Il, interner: &Interner, callee: NodeId, expected: &str) -> bool {

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -1411,6 +1411,59 @@ pub fn map_get_contract_by_hash(
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct TypeofOperatorContract {
+    pub name: &'static str,
+}
+
+pub fn typeof_operator_contract(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<TypeofOperatorContract> {
+    (js_like_lang(lang) && name == "typeof" && arg_count == 1)
+        .then_some(TypeofOperatorContract { name: "typeof" })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct StaticGlobalMethodContract {
+    pub receiver: &'static str,
+    pub method: &'static str,
+    pub requires_unshadowed_receiver: bool,
+}
+
+pub fn js_array_is_array_contract(
+    lang: Lang,
+    receiver: &str,
+    method: &str,
+    arg_count: usize,
+) -> Option<StaticGlobalMethodContract> {
+    (js_like_lang(lang) && receiver == "Array" && method == "isArray" && arg_count == 1).then_some(
+        StaticGlobalMethodContract {
+            receiver: "Array",
+            method: "isArray",
+            requires_unshadowed_receiver: true,
+        },
+    )
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct RegexTestContract {
+    pub method: &'static str,
+    pub requires_regex_literal_proof: bool,
+}
+
+pub fn regex_test_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<RegexTestContract> {
+    (js_like_lang(lang) && method == "test" && arg_count == 1).then_some(RegexTestContract {
+        method: "test",
+        requires_regex_literal_proof: true,
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum StaticIndexMembershipKind {
     IndexOf,
     FindIndex,
@@ -2573,6 +2626,43 @@ mod tests {
         assert_eq!(map_get_contract(Lang::Python, "get", 1), None);
         assert_eq!(map_get_contract(Lang::Rust, "get", 2), None);
         assert_eq!(map_get_contract(Lang::Java, "getOrDefault", 1), None);
+    }
+
+    #[test]
+    fn js_static_builtin_contracts_are_language_and_arity_constrained() {
+        assert_eq!(
+            typeof_operator_contract(Lang::TypeScript, "typeof", 1),
+            Some(TypeofOperatorContract { name: "typeof" })
+        );
+        assert_eq!(typeof_operator_contract(Lang::Python, "typeof", 1), None);
+        assert_eq!(
+            typeof_operator_contract(Lang::JavaScript, "typeof", 2),
+            None
+        );
+        assert_eq!(
+            js_array_is_array_contract(Lang::JavaScript, "Array", "isArray", 1),
+            Some(StaticGlobalMethodContract {
+                receiver: "Array",
+                method: "isArray",
+                requires_unshadowed_receiver: true,
+            })
+        );
+        assert_eq!(
+            js_array_is_array_contract(Lang::Python, "Array", "isArray", 1),
+            None
+        );
+        assert_eq!(
+            js_array_is_array_contract(Lang::TypeScript, "Array", "isArray", 2),
+            None
+        );
+        assert_eq!(
+            regex_test_contract(Lang::JavaScript, "test", 1),
+            Some(RegexTestContract {
+                method: "test",
+                requires_regex_literal_proof: true,
+            })
+        );
+        assert_eq!(regex_test_contract(Lang::Ruby, "test", 1), None);
     }
 
     #[test]

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -132,6 +132,10 @@ and pack ecosystem.
 - Strict exact gates now consume the same nullish-global proof, so temp-bound
   JS/TS `Map.get(...)` defaulting remains exact-eligible only when `undefined`
   is the unshadowed JS-like sentinel.
+- Strict exact call gates for JS-like `typeof` and `Array.isArray(...)` moved
+  behind language/arity/global-shadow contracts, and literal `.test(...)` remains
+  exact-closed until regex-literal provenance exists. This closes raw-name
+  bypasses found after PR #101.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -182,6 +186,8 @@ Remaining in this phase:
   retaining formal-obligation metadata as the first-party proof boundary.
 - Add construct/call distinction facts so constructor-only contracts such as
   JS/TS `new Map` and `new Set` can be reopened safely.
+- Add regex literal provenance so JS/TS `.test(...)` can be reopened safely
+  without treating ordinary string literals or monkey-patched methods as regexes.
 - Add receiver/place facts so field read/write and property contracts are not
   field-name-only.
 - Add provenance fields internally before exposing them in scan JSON.

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -115,6 +115,11 @@ migrated.
 - Java `Math.abs`/`Math.min`/`Math.max` now lower through method contracts with an
   unshadowed `Math` receiver requirement instead of frontend text-only builtin
   lowering.
+- JS-like `typeof` exact-safety now consumes a language- and arity-constrained
+  operator contract. A same-named function from another language or unresolved
+  provider is not treated as the JS operator.
+- JS-like `Array.isArray(...)` exact-safety now consumes a static-global method
+  contract and requires the `Array` global to be unshadowed.
 - JS-like `undefined` is no longer frontend-collapsed to null unconditionally.
   It is preserved as a name and only treated as the nullish sentinel through an
   unshadowed-global contract. Value-graph defaulting and strict exact-safe gates
@@ -186,6 +191,8 @@ this worktree because the required evidence is not yet modeled:
   receiver proof exists.
 - Plain JS/TS `Map` and `Set` constructor semantics do not enter exact matching
   until constructor-vs-call proof exists.
+- JS/TS regex literal `.test(...)` does not enter exact matching until lowering
+  preserves regex-literal provenance distinct from ordinary string literals.
 - Untyped JS/TS array method chains do not enter exact higher-order contracts
   unless the receiver is a literal/proven collection surface.
 - Nested element method chains such as `xs.map(...)` inside a flat-map callback
@@ -211,6 +218,7 @@ The first high-value targets for semantic-kernel extraction are:
   state with receiver-aware proof;
 - constructor facts for JS/TS `new Map` and `new Set`, which are now explicit
   closed contracts waiting on construct-vs-call proof;
+- regex literal provenance for JS/TS `.test(...)`;
 - resolved symbol facts for Java/Rust stdlib factories instead of the current
   path/name plus shadow-proof contracts;
 - nested collection element proofs for iterator chains and builder convergence;


### PR DESCRIPTION
## Summary
- gate JS-like typeof and Array.isArray exact-safety through explicit semantic contracts instead of raw selector exceptions
- keep literal .test exact-closed until regex-literal provenance is available
- add hard negatives for Python star-import typeof, arbitrary Array.isArray, and Ruby literal .test monkey patches
- update semantic-kernel docs with the tightened gates and remaining regex provenance work

## Verification
- cargo fmt --all -- --check
- awiki lint --root docs
- cargo test -p nose-semantics --lib
- cargo test -p nose-cli --test cli
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p nose-detect -p nose-normalize -p nose-semantics
- cargo test --release -p nose-cli --test cli unproved -- --nocapture
- cargo build --release
- ./scripts/check-duplication.sh