### PR TITLE
Migrate exact semantics through kernel contracts

### DIFF
--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -8613,6 +8613,11 @@ fn scan_mode_semantic_proves_js_record_shape_guards() {
     )
     .unwrap();
     fs::write(
+        dir.join("boolean_shadowed_negative.js"),
+        "function shadowed(Boolean, input) {\n  return Boolean(input) && typeof input === \"object\" && !Array.isArray(input);\n}\n",
+    )
+    .unwrap();
+    fs::write(
         dir.join("array_allowed_negative.js"),
         "function arrayAllowed(value) {\n  return typeof value === \"object\" && value !== null;\n}\n",
     )
@@ -8658,6 +8663,7 @@ fn scan_mode_semantic_proves_js_record_shape_guards() {
     }
     for unexpected in [
         "array_allowed_negative.js",
+        "boolean_shadowed_negative.js",
         "null_allowed_negative.js",
         "wrong_typeof_literal_negative.js",
     ] {

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -1145,6 +1145,8 @@ fn scalar_minmax_builtins_converge_cross_language_with_shadow_boundary() {
         "def f(left, right, other):\n    selected = min(left, right)\n    return selected + other\n";
     let js_min = "function f(left, right, other) { const selected = Math.min(left, right); return selected + other; }";
     let ts_min = "function f(left: number, right: number, other: number): number { const selected = Math.min(left, right); return selected + other; }";
+    let js_free_min =
+        "function f(left, right, other) { const selected = min(left, right); return selected + other; }";
     let go_min = "package p\n\nimport \"math\"\n\nfunc F(left float64, right float64, other float64) float64 { selected := math.Min(left, right); return selected + other }\n";
     let java_min = "class C { static int f(int left, int right, int other) { int selected = Math.min(left, right); return selected + other; } }\n";
     let c_min = "#include <math.h>\n\ndouble f(double left, double right, double other) { double selected = fmin(left, right); return selected + other; }\n";
@@ -1159,7 +1161,10 @@ fn scalar_minmax_builtins_converge_cross_language_with_shadow_boundary() {
         "def f(left, right, other):\n    selected = min(left, other)\n    return selected + other\n";
     let py_shadowed_min =
         "def min(_left, _right):\n    return 0\n\ndef f(left, right, other):\n    selected = min(left, right)\n    return selected + other\n";
+    let py_local_shadowed_min =
+        "def f(left, right, other):\n    min = lambda _left, _right: 0\n    selected = min(left, right)\n    return selected + other\n";
     let shadowed_js = "function f(left, right, other) { const Math = { min: function(_left, _right) { return 0; } }; const selected = Math.min(left, right); return selected + other; }";
+    let destructured_shadowed_js = "function f(scope, left, right, other) { const { Math } = scope; const selected = Math.min(left, right); return selected + other; }";
     let java_shadowed_math_type = "class C { static int f(int left, int right, int other) { int selected = Math.min(left, right); return selected + other; } }\nclass Math { static int min(int left, int right) { return 0; } }\n";
     let ts_number_method_min = "function f(left: number, right: number, other: number): number { const selected = left.min(right); return selected + other; }";
     let rust_float_min = "pub fn f(left: f64, right: f64, other: f64) -> f64 { let selected = left.min(right); selected + other }\n";
@@ -1170,6 +1175,7 @@ fn scalar_minmax_builtins_converge_cross_language_with_shadow_boundary() {
     assert_eq!(fp, value_fp(&i, py_min_call, Lang::Python));
     assert_eq!(fp, value_fp(&i, js_min, Lang::JavaScript));
     assert_eq!(fp, value_fp(&i, ts_min, Lang::TypeScript));
+    assert_ne!(fp, value_fp(&i, js_free_min, Lang::JavaScript));
     assert_eq!(fp, value_fp(&i, go_min, Lang::Go));
     assert_eq!(fp, value_fp(&i, java_min, Lang::Java));
     assert_ne!(fp, value_fp(&i, c_min, Lang::C));
@@ -1186,7 +1192,9 @@ fn scalar_minmax_builtins_converge_cross_language_with_shadow_boundary() {
     );
     assert_ne!(fp, value_fp(&i, py_wrong_value, Lang::Python));
     assert_ne!(fp, value_fp(&i, py_shadowed_min, Lang::Python));
+    assert_ne!(fp, value_fp(&i, py_local_shadowed_min, Lang::Python));
     assert_ne!(fp, value_fp(&i, shadowed_js, Lang::JavaScript));
+    assert_ne!(fp, value_fp(&i, destructured_shadowed_js, Lang::JavaScript));
     assert_ne!(
         fp,
         value_fp_named(&i, java_shadowed_math_type, Lang::Java, "f")

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -11,6 +11,10 @@ use nose_il::{
     Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload, Span,
     UnitKind,
 };
+use nose_semantics::{
+    js_array_is_array_contract, js_boolean_coercion_contract, method_call_contract,
+    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
+};
 use tree_sitter::Node as TsNode;
 
 pub(crate) fn lower(
@@ -1079,20 +1083,30 @@ fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {
 
 fn lower_math_call(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     let callee = node.child_by_field_name("function")?;
-    let (builtin, arity) = match compact_js_expr(lo.text(callee)).as_str() {
-        "Math.abs" => (Builtin::Abs, 1),
-        "Math.min" => (Builtin::Min, 2),
-        "Math.max" => (Builtin::Max, 2),
-        _ => return None,
+    let callee = compact_js_expr(lo.text(callee));
+    let (receiver, method) = callee.split_once('.')?;
+    let args = node.child_by_field_name("arguments")?;
+    let args: Vec<TsNode> = Lowering::named_children(args);
+    let contract = method_call_contract(lo.lang, method, args.len())?;
+    let MethodSemanticContract::Builtin(builtin) = contract.semantic else {
+        return None;
     };
-    if file_prefix_has_binding_ident(lo, node, "Math")
-        || enclosing_function_prefix_has_binding_ident(lo, node, "Math")
+    let MethodReceiverContract::UnshadowedGlobal(global) = contract.receiver else {
+        return None;
+    };
+    if global != receiver {
+        return None;
+    }
+    if file_prefix_has_binding_ident(lo, node, global)
+        || enclosing_function_prefix_has_binding_ident(lo, node, global)
     {
         return None;
     }
-    let args = node.child_by_field_name("arguments")?;
-    let args: Vec<TsNode> = Lowering::named_children(args);
-    if args.len() != arity || args.iter().any(|arg| arg.kind() == "spread_element") {
+    if !matches!(
+        contract.args,
+        MethodBuiltinArgs::First | MethodBuiltinArgs::All
+    ) || args.iter().any(|arg| arg.kind() == "spread_element")
+    {
         return None;
     }
     let lowered: Vec<NodeId> = args.into_iter().map(|arg| lower_expr(lo, arg)).collect();
@@ -1290,6 +1304,7 @@ fn lower_record_shape_guard(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     let mut has_typeof_object = false;
     let mut has_non_null_or_truthy = false;
     let mut has_not_array = false;
+    let mut requires_boolean_global = false;
     for clause in clauses {
         let (kind, name) = record_guard_clause(&clause)?;
         if !simple_js_ident(&name) {
@@ -1302,7 +1317,12 @@ fn lower_record_shape_guard(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
         }
         match kind {
             RecordGuardClause::TypeofObject => has_typeof_object = true,
-            RecordGuardClause::NonNullOrTruthy => has_non_null_or_truthy = true,
+            RecordGuardClause::NonNullOrTruthy {
+                requires_boolean_global: requires,
+            } => {
+                has_non_null_or_truthy = true;
+                requires_boolean_global |= requires;
+            }
             RecordGuardClause::NotArray => has_not_array = true,
         }
     }
@@ -1310,9 +1330,24 @@ fn lower_record_shape_guard(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     if !(has_typeof_object && has_non_null_or_truthy && has_not_array) {
         return None;
     }
-    if file_prefix_has_binding_ident(lo, node, "Array")
-        || enclosing_function_prefix_has_binding_ident(lo, node, "Array")
+    let array_contract = js_array_is_array_contract(lo.lang, "Array", "isArray", 1)?;
+    if array_contract.requires_unshadowed_receiver
+        && (file_prefix_has_binding_ident(lo, node, array_contract.receiver)
+            || enclosing_function_prefix_has_binding_ident(lo, node, array_contract.receiver))
     {
+        return None;
+    }
+    let boolean_contract = requires_boolean_global
+        .then(|| js_boolean_coercion_contract(lo.lang, "Boolean", 1))
+        .flatten();
+    if requires_boolean_global && boolean_contract.is_none() {
+        return None;
+    }
+    if boolean_contract.is_some_and(|contract| {
+        contract.requires_unshadowed_function
+            && (file_prefix_has_binding_ident(lo, node, contract.function)
+                || enclosing_function_prefix_has_binding_ident(lo, node, contract.function))
+    }) {
         return None;
     }
     let span = lo.span(node);
@@ -1332,20 +1367,26 @@ fn lower_record_shape_guard(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
 #[derive(Clone, Copy)]
 enum RecordGuardClause {
     TypeofObject,
-    NonNullOrTruthy,
+    NonNullOrTruthy { requires_boolean_global: bool },
     NotArray,
 }
 
 fn record_guard_clause(clause: &str) -> Option<(RecordGuardClause, String)> {
     parse_typeof_object_clause(clause)
         .map(|name| (RecordGuardClause::TypeofObject, name))
+        .or_else(|| parse_non_null_clause(clause).map(|name| (non_null_guard_clause(false), name)))
         .or_else(|| {
-            parse_non_null_clause(clause).map(|name| (RecordGuardClause::NonNullOrTruthy, name))
-        })
-        .or_else(|| {
-            parse_truthy_clause(clause).map(|name| (RecordGuardClause::NonNullOrTruthy, name))
+            parse_truthy_clause(clause).map(|(name, requires_boolean_global)| {
+                (non_null_guard_clause(requires_boolean_global), name)
+            })
         })
         .or_else(|| parse_not_array_clause(clause).map(|name| (RecordGuardClause::NotArray, name)))
+}
+
+fn non_null_guard_clause(requires_boolean_global: bool) -> RecordGuardClause {
+    RecordGuardClause::NonNullOrTruthy {
+        requires_boolean_global,
+    }
 }
 
 fn parse_typeof_object_clause(clause: &str) -> Option<String> {
@@ -1379,14 +1420,14 @@ fn parse_non_null_clause(clause: &str) -> Option<String> {
     None
 }
 
-fn parse_truthy_clause(clause: &str) -> Option<String> {
+fn parse_truthy_clause(clause: &str) -> Option<(String, bool)> {
     if let Some(name) = clause.strip_prefix("!!") {
-        return Some(name.to_string());
+        return Some((name.to_string(), false));
     }
     clause
         .strip_prefix("Boolean(")
         .and_then(|inner| inner.strip_suffix(')'))
-        .map(str::to_string)
+        .map(|name| (name.to_string(), true))
 }
 
 fn parse_not_array_clause(clause: &str) -> Option<String> {

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -12,6 +12,7 @@ use tree_sitter::Node as TsNode;
 pub(crate) struct Lowering<'a> {
     pub b: IlBuilder,
     pub src: &'a [u8],
+    pub lang: Lang,
     pub interner: &'a Interner,
     pub units: Vec<Unit>,
     pub param_type_facts: Vec<ParamTypeFact>,
@@ -20,10 +21,11 @@ pub(crate) struct Lowering<'a> {
 }
 
 impl<'a> Lowering<'a> {
-    pub(crate) fn new(file: FileId, src: &'a [u8], interner: &'a Interner) -> Self {
+    pub(crate) fn new(file: FileId, src: &'a [u8], lang: Lang, interner: &'a Interner) -> Self {
         Lowering {
             b: IlBuilder::new(file),
             src,
+            lang,
             interner,
             units: Vec::new(),
             param_type_facts: Vec::new(),
@@ -328,7 +330,7 @@ pub(crate) fn lower_file_with_setup(
     lower_root: impl FnOnce(&mut Lowering, TsNode) -> NodeId,
 ) -> anyhow::Result<Il> {
     let tree = parse(key, lang_fn, src)?;
-    let mut lo = Lowering::new(file, src, interner);
+    let mut lo = Lowering::new(file, src, lang, interner);
     setup(&mut lo);
     let module = lower_root(&mut lo, tree.root_node());
     let meta = FileMeta {

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -451,15 +451,17 @@ fn exact_protocol_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool 
     let Some(&receiver) = old.children(callee).first() else {
         return false;
     };
-    if matches!(method, "iter" | "into_iter" | "iter_mut") {
-        return exact_collection_receiver(old, interner, receiver);
-    }
     if let Some(arg) = static_collection_adapter_arg(old, interner, receiver, method, kids) {
         return exact_collection_receiver(old, interner, arg);
     }
-    if method == "zip" && kids.len() == 2 {
-        return exact_protocol_receiver(old, interner, receiver)
-            && exact_protocol_receiver(old, interner, kids[1]);
+    if let Some(contract) = method_call_contract(old.meta.lang, method, kids.len() - 1) {
+        if contract.semantic == MethodSemanticContract::Builtin(Builtin::Zip)
+            && contract.receiver == MethodReceiverContract::ExactProtocolPairArgument
+            && contract.args == MethodBuiltinArgs::RustZip
+        {
+            return exact_protocol_receiver(old, interner, receiver)
+                && exact_protocol_receiver(old, interner, kids[1]);
+        }
     }
     if iterator_identity_adapter_contract(old.meta.lang, method, kids.len() - 1).is_some() {
         return exact_protocol_receiver(old, interner, receiver);
@@ -723,16 +725,61 @@ fn file_defines_name(old: &Il, interner: &Interner, name: &str) -> bool {
         .iter()
         .filter_map(|unit| unit.name)
         .any(|symbol| interner.resolve(symbol) == name)
-        || old.nodes.iter().any(|node| match node.payload {
-            Payload::Cid(cid) => old
-                .cid_names
-                .get(cid as usize)
-                .is_some_and(|symbol| interner.resolve(*symbol) == name),
-            Payload::Name(symbol) if matches!(node.kind, NodeKind::Module | NodeKind::Block) => {
-                interner.resolve(symbol) == name
-            }
-            _ => false,
-        })
+        || old
+            .nodes
+            .iter()
+            .enumerate()
+            .any(|(idx, node)| match node.payload {
+                Payload::Cid(cid) => old
+                    .cid_names
+                    .get(cid as usize)
+                    .is_some_and(|symbol| symbol_defines_name(old, interner, *symbol, name)),
+                Payload::Name(symbol)
+                    if matches!(
+                        node.kind,
+                        NodeKind::Module | NodeKind::Block | NodeKind::Param
+                    ) =>
+                {
+                    symbol_defines_name(old, interner, symbol, name)
+                }
+                _ if node.kind == NodeKind::Assign => old
+                    .children(NodeId(idx as u32))
+                    .first()
+                    .is_some_and(|&lhs| node_defines_name(old, interner, lhs, name)),
+                _ => false,
+            })
+}
+
+fn node_defines_name(old: &Il, interner: &Interner, node: NodeId, name: &str) -> bool {
+    match old.node(node).payload {
+        Payload::Name(symbol) => symbol_defines_name(old, interner, symbol, name),
+        Payload::Cid(cid) => old
+            .cid_names
+            .get(cid as usize)
+            .is_some_and(|symbol| symbol_defines_name(old, interner, *symbol, name)),
+        _ => false,
+    }
+}
+
+fn symbol_defines_name(old: &Il, interner: &Interner, symbol: nose_il::Symbol, name: &str) -> bool {
+    let text = interner.resolve(symbol);
+    text == name
+        || (nose_semantics::semantics(old.meta.lang)
+            .modules()
+            .js_like_shadowed_module_bindings()
+            && contains_js_ident(text, name))
+}
+
+fn contains_js_ident(text: &str, ident: &str) -> bool {
+    text.match_indices(ident).any(|(idx, _)| {
+        let before = text[..idx].chars().next_back();
+        let after = text[idx + ident.len()..].chars().next();
+        !before.is_some_and(is_js_ident_continue) && !after.is_some_and(is_js_ident_continue)
+    })
+}
+
+fn is_js_ident_continue(c: char) -> bool {
+    c == '_' || c == '$' || c.is_ascii_alphanumeric()
 }
 
 fn file_defines_type_name(old: &Il, interner: &Interner, name: &str) -> bool {
@@ -1051,6 +1098,91 @@ mod tests {
         (il, interner, call)
     }
 
+    fn method_call_no_arg_il(
+        lang: Lang,
+        method: &str,
+        literal_receiver: bool,
+    ) -> (Il, Interner, NodeId) {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = if literal_receiver {
+            b.add(NodeKind::Seq, Payload::None, sp(), &[])
+        } else {
+            b.add(
+                NodeKind::Var,
+                Payload::Name(interner.intern("xs")),
+                sp(),
+                &[],
+            )
+        };
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern(method)),
+            sp(),
+            &[receiver],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(), &[field]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(), &[call]);
+        let il = b.finish(
+            root,
+            FileMeta {
+                path: "t".to_string(),
+                lang,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        (il, interner, call)
+    }
+
+    fn method_call_with_arg_il(
+        lang: Lang,
+        method: &str,
+        literal_receiver: bool,
+        literal_arg: bool,
+    ) -> (Il, Interner, NodeId) {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = if literal_receiver {
+            b.add(NodeKind::Seq, Payload::None, sp(), &[])
+        } else {
+            b.add(
+                NodeKind::Var,
+                Payload::Name(interner.intern("xs")),
+                sp(),
+                &[],
+            )
+        };
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern(method)),
+            sp(),
+            &[receiver],
+        );
+        let arg = if literal_arg {
+            b.add(NodeKind::Seq, Payload::None, sp(), &[])
+        } else {
+            b.add(
+                NodeKind::Var,
+                Payload::Name(interner.intern("ys")),
+                sp(),
+                &[],
+            )
+        };
+        let call = b.add(NodeKind::Call, Payload::None, sp(), &[field, arg]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(), &[call]);
+        let il = b.finish(
+            root,
+            FileMeta {
+                path: "t".to_string(),
+                lang,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        (il, interner, call)
+    }
+
     fn typed_method_call_il(
         lang: Lang,
         method: &str,
@@ -1251,6 +1383,44 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn iterator_identity_adapter_requires_kernel_contract() {
+        let (js, js_interner, js_iter) = method_call_no_arg_il(Lang::JavaScript, "iter", true);
+        assert!(
+            !exact_protocol_receiver(&js, &js_interner, js_iter),
+            "a JS method named iter is not a Rust iterator adapter"
+        );
+
+        let (rust_bad, rust_bad_interner, rust_bad_iter) = method_call_il(Lang::Rust, "iter", true);
+        assert!(
+            !exact_protocol_receiver(&rust_bad, &rust_bad_interner, rust_bad_iter),
+            "Rust iter with unexpected arguments must not bypass the arity contract"
+        );
+
+        let (rust, rust_interner, rust_iter) = method_call_no_arg_il(Lang::Rust, "iter", true);
+        assert!(
+            exact_protocol_receiver(&rust, &rust_interner, rust_iter),
+            "Rust iter stays admitted through iterator_identity_adapter_contract"
+        );
+    }
+
+    #[test]
+    fn zip_protocol_pair_requires_kernel_contract() {
+        let (js, js_interner, js_zip) =
+            method_call_with_arg_il(Lang::JavaScript, "zip", true, true);
+        assert!(
+            !exact_protocol_receiver(&js, &js_interner, js_zip),
+            "a JS method named zip is not a Rust zip protocol contract"
+        );
+
+        let (rust, rust_interner, rust_zip) =
+            method_call_with_arg_il(Lang::Rust, "zip", true, true);
+        assert!(
+            exact_protocol_receiver(&rust, &rust_interner, rust_zip),
+            "Rust zip stays admitted through method_call_contract"
+        );
     }
 
     #[test]

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -50,19 +50,19 @@ use nose_il::{
 };
 use nose_semantics::{
     builder_append_method_contract, builtin_tag, domain_evidence_from_param_semantic,
-    go_zero_map_default_kind, go_zero_map_lookup_contract, imported_namespace_function_contract,
-    index_membership_threshold_contract, iterator_identity_adapter_contract,
-    java_collection_factory_contract_by_hash, java_map_entry_contract_by_hash,
-    java_map_factory_contract_by_hash, map_get_contract_by_hash, map_key_view_contract_by_hash,
-    map_key_view_wrapper_contract_by_hash, method_call_contract, nullish_global_contract,
-    reduction_builtin_contract, ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
-    rust_option_none_sentinel_contract, rust_option_some_constructor_contract,
-    rust_vec_new_factory_contract, scalar_integer_method_contract, semantics,
-    static_index_membership_contract, DomainEvidence, GoZeroMapDefaultKind,
-    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
-    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
-    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
-    StaticIndexMembershipKind,
+    free_function_builtin_contract, go_zero_map_default_kind, go_zero_map_lookup_contract,
+    imported_namespace_function_contract, index_membership_threshold_contract,
+    iterator_identity_adapter_contract, java_collection_factory_contract_by_hash,
+    java_map_entry_contract_by_hash, java_map_factory_contract_by_hash, map_get_contract_by_hash,
+    map_key_view_contract_by_hash, map_key_view_wrapper_contract_by_hash, method_call_contract,
+    nullish_global_contract, reduction_builtin_contract, ruby_set_factory_contract_by_hash,
+    rust_option_and_then_contract, rust_option_none_sentinel_contract,
+    rust_option_some_constructor_contract, rust_vec_new_factory_contract,
+    scalar_integer_method_contract, semantics, static_index_membership_contract,
+    BuiltinArgContract, DomainEvidence, GoZeroMapDefaultKind, ImportedNamespaceFunctionSemantic,
+    IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind, MapKeyViewKind,
+    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract,
+    ScalarIntegerMethod, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -1074,10 +1074,37 @@ impl<'a> Builder<'a> {
         }) || self.il.units.iter().any(|unit| {
             unit.name
                 .is_some_and(|symbol| self.interner.resolve(symbol) == name)
-        }) || self.il.nodes.iter().any(|node| {
-            matches!(node.kind, NodeKind::Module | NodeKind::Block)
-                && matches!(node.payload, Payload::Name(symbol) if self.interner.resolve(symbol) == name)
+        }) || self.il.nodes.iter().enumerate().any(|(idx, node)| {
+            let id = NodeId(idx as u32);
+            match node.kind {
+                NodeKind::Module | NodeKind::Block | NodeKind::Param => {
+                    self.node_has_name(id, name)
+                }
+                NodeKind::Assign => self
+                    .il
+                    .children(id)
+                    .first()
+                    .is_some_and(|&lhs| self.node_has_name(lhs, name)),
+                _ => false,
+            }
         })
+    }
+
+    fn node_has_name(&self, node: NodeId, name: &str) -> bool {
+        match self.il.node(node).payload {
+            Payload::Name(symbol) => self.symbol_defines_name(symbol, name),
+            Payload::Cid(cid) => self
+                .il
+                .cid_names
+                .get(cid as usize)
+                .is_some_and(|symbol| self.symbol_defines_name(*symbol, name)),
+            _ => false,
+        }
+    }
+
+    fn symbol_defines_name(&self, symbol: Symbol, name: &str) -> bool {
+        let text = self.interner.resolve(symbol);
+        text == name || (self.is_js_like_lang() && contains_js_ident(text, name))
     }
 
     fn ruby_file_requires_module(&self, module: &str) -> bool {
@@ -1721,6 +1748,32 @@ impl<'a> Builder<'a> {
             return None;
         }
         Some(self.mk(ValOp::Bin(op), vec![receiver, rhs]))
+    }
+
+    fn eval_proven_free_minmax_call(
+        &mut self,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if kids.len() != 3 || self.il.kind(kids[0]) != NodeKind::Var {
+            return None;
+        }
+        let Payload::Name(name) = self.il.node(kids[0]).payload else {
+            return None;
+        };
+        let method = self.interner.resolve(name);
+        let contract = free_function_builtin_contract(self.il.meta.lang, method, 2)?;
+        if contract.requires_unshadowed && self.file_defines_name(method) {
+            return None;
+        }
+        let op = match (contract.builtin, contract.args) {
+            (Builtin::Min, BuiltinArgContract::All) => MIN_CODE,
+            (Builtin::Max, BuiltinArgContract::All) => MAX_CODE,
+            _ => return None,
+        };
+        let left = self.eval(kids[1], env);
+        let right = self.eval(kids[2], env);
+        Some(self.mk(ValOp::Bin(op), vec![left, right]))
     }
 
     fn eval_proven_integer_clamp_method_call(
@@ -7304,27 +7357,8 @@ impl<'a> Builder<'a> {
                 if let Some(v) = self.eval_iterator_identity_adapter(&kids, env) {
                     return v;
                 }
-                // 2-way `min(x, y)` / `max(x, y)` → canonical Min/Max, converging with the
-                // ternary idiom `x if x<y else y`. (1-arg `min(iterable)` is a reduction,
-                // handled above.) The callee is a free `Var` keeping its name after alpha.
-                if kids.len() == 3 {
-                    if let (NodeKind::Var, Payload::Name(s)) =
-                        (self.il.kind(kids[0]), self.il.node(kids[0]).payload)
-                    {
-                        let method = self.interner.resolve(s);
-                        let code = match method {
-                            "min" => Some(MIN_CODE),
-                            "max" => Some(MAX_CODE),
-                            _ => None,
-                        };
-                        if let Some(c) = code {
-                            if !self.file_defines_name(method) {
-                                let x = self.eval(kids[1], env);
-                                let y = self.eval(kids[2], env);
-                                return self.mk(ValOp::Bin(c), vec![x, y]);
-                            }
-                        }
-                    }
+                if let Some(v) = self.eval_proven_free_minmax_call(&kids, env) {
+                    return v;
                 }
                 if let Some(r) = self.eval_proven_collection_membership_call(&kids, env) {
                     return r;
@@ -7867,6 +7901,18 @@ fn is_assoc_comm_code(opc: u32) -> bool {
         || opc == Op::BitAnd as u32
         || opc == Op::BitOr as u32
         || opc == Op::BitXor as u32
+}
+
+fn contains_js_ident(text: &str, ident: &str) -> bool {
+    text.match_indices(ident).any(|(idx, _)| {
+        let before = text[..idx].chars().next_back();
+        let after = text[idx + ident.len()..].chars().next();
+        !before.is_some_and(is_js_ident_continue) && !after.is_some_and(is_js_ident_continue)
+    })
+}
+
+fn is_js_ident_continue(c: char) -> bool {
+    c == '_' || c == '$' || c.is_ascii_alphanumeric()
 }
 
 /// `Reduce` op codes for the selection reductions (min/max). Kept clear of the small

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -891,6 +891,19 @@ pub fn method_call_contract(
         ),
         (Lang::Go, "Min", 2) => (Builtin::Min, Receiver::ImportedNamespace("math"), Args::All),
         (Lang::Go, "Max", 2) => (Builtin::Max, Receiver::ImportedNamespace("math"), Args::All),
+        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "abs", 1) => {
+            (
+                Builtin::Abs,
+                Receiver::UnshadowedGlobal("Math"),
+                Args::First,
+            )
+        }
+        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "min", 2) => {
+            (Builtin::Min, Receiver::UnshadowedGlobal("Math"), Args::All)
+        }
+        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "max", 2) => {
+            (Builtin::Max, Receiver::UnshadowedGlobal("Math"), Args::All)
+        }
         (Lang::Java, "abs", 1) => (
             Builtin::Abs,
             Receiver::UnshadowedGlobal("Math"),
@@ -1429,6 +1442,25 @@ pub struct StaticGlobalMethodContract {
     pub receiver: &'static str,
     pub method: &'static str,
     pub requires_unshadowed_receiver: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct StaticGlobalFunctionContract {
+    pub function: &'static str,
+    pub requires_unshadowed_function: bool,
+}
+
+pub fn js_boolean_coercion_contract(
+    lang: Lang,
+    function: &str,
+    arg_count: usize,
+) -> Option<StaticGlobalFunctionContract> {
+    (js_like_lang(lang) && function == "Boolean" && arg_count == 1).then_some(
+        StaticGlobalFunctionContract {
+            function: "Boolean",
+            requires_unshadowed_function: true,
+        },
+    )
 }
 
 pub fn js_array_is_array_contract(
@@ -2209,6 +2241,16 @@ mod tests {
             })
         );
         assert_eq!(
+            method_call_contract(Lang::JavaScript, "min", 2),
+            Some(MethodCallContract {
+                semantic: MethodSemanticContract::Builtin(Builtin::Min),
+                receiver: MethodReceiverContract::UnshadowedGlobal("Math"),
+                args: MethodBuiltinArgs::All,
+            })
+        );
+        assert_eq!(method_call_contract(Lang::JavaScript, "min", 1), None);
+        assert_eq!(method_call_contract(Lang::Python, "min", 2), None);
+        assert_eq!(
             method_call_contract(Lang::Go, "Abs", 1),
             Some(MethodCallContract {
                 semantic: MethodSemanticContract::Builtin(Builtin::Abs),
@@ -2653,6 +2695,28 @@ mod tests {
         );
         assert_eq!(
             js_array_is_array_contract(Lang::TypeScript, "Array", "isArray", 2),
+            None
+        );
+        assert_eq!(
+            js_boolean_coercion_contract(Lang::JavaScript, "Boolean", 1),
+            Some(StaticGlobalFunctionContract {
+                function: "Boolean",
+                requires_unshadowed_function: true,
+            })
+        );
+        assert_eq!(
+            js_boolean_coercion_contract(Lang::TypeScript, "Boolean", 1),
+            Some(StaticGlobalFunctionContract {
+                function: "Boolean",
+                requires_unshadowed_function: true,
+            })
+        );
+        assert_eq!(
+            js_boolean_coercion_contract(Lang::Python, "Boolean", 1),
+            None
+        );
+        assert_eq!(
+            js_boolean_coercion_contract(Lang::JavaScript, "Boolean", 2),
             None
         );
         assert_eq!(

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -136,6 +136,16 @@ and pack ecosystem.
   behind language/arity/global-shadow contracts, and literal `.test(...)` remains
   exact-closed until regex-literal provenance exists. This closes raw-name
   bypasses found after PR #101.
+- Normalize idiom receiver admission for iterator identity adapters and Rust
+  `zip` now consumes the same semantic contracts as value-graph/detect paths,
+  closing language-blind `iter`/`zip` selector bypasses.
+- JS-like `Math.abs`/`Math.min`/`Math.max` now consume method contracts with an
+  unshadowed `Math` receiver, and JS record-shape guards using `Boolean(...)`
+  consume a static-global function contract with an unshadowed `Boolean`
+  requirement.
+- Value-graph two-argument free `min(...)`/`max(...)` now consumes the Python
+  free-function builtin contract instead of the raw callee name, closing
+  unqualified JS `min(...)` and local-shadowing false positives.
 
 ## Phase 0: documentation and vocabulary (landed)
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -59,6 +59,10 @@ migrated.
   closed until a pack/frontend can prove a Promise-like receiver.
 - Rust iterator identity adapters (`iter`, `into_iter`, `collect`, `to_vec`,
   `copied`, `cloned`) are language-, arity-, and receiver-proof constrained.
+  Normalize's exact protocol receiver admission consumes this same contract
+  instead of accepting same-named methods from other languages.
+- Rust method `zip(...)` is admitted as a protocol-pair operation only through
+  the Rust `method_call_contract` and exact protocol proof for both sides.
 - Rust stdlib path contracts for `Some`/`Option::Some`,
   `None`/`Option::None`, `Option::and_then`, and `Vec::new` carry the exact
   selector and shadow-root requirement through `nose-semantics`;
@@ -112,14 +116,21 @@ migrated.
 - Imported namespace function contracts now cover Python `math.prod` as a product
   reduction only when the receiver is proven to be the imported `math` namespace.
   Bare globals named `math` and overwritten module bindings stay exact-closed.
-- Java `Math.abs`/`Math.min`/`Math.max` now lower through method contracts with an
-  unshadowed `Math` receiver requirement instead of frontend text-only builtin
-  lowering.
+- Java and JS-like `Math.abs`/`Math.min`/`Math.max` now lower through method
+  contracts with an unshadowed `Math` receiver requirement instead of frontend
+  text-only builtin lowering.
+- Two-argument free `min(...)`/`max(...)` normalization consumes the Python
+  free-function builtin contract. Same-named functions from other languages,
+  including JS `min(...)`, and locally shadowed Python names stay exact-closed.
 - JS-like `typeof` exact-safety now consumes a language- and arity-constrained
   operator contract. A same-named function from another language or unresolved
   provider is not treated as the JS operator.
 - JS-like `Array.isArray(...)` exact-safety now consumes a static-global method
   contract and requires the `Array` global to be unshadowed.
+- JS-like record-shape guards that use `Boolean(value)` as the non-null/truthy
+  clause consume a static-global function contract and require the `Boolean`
+  global to be unshadowed. `value !== null` and `!!value` remain available when
+  their own clauses prove the same record shape.
 - JS-like `undefined` is no longer frontend-collapsed to null unconditionally.
   It is preserved as a name and only treated as the nullish sentinel through an
   unshadowed-global contract. Value-graph defaulting and strict exact-safe gates


### PR DESCRIPTION
## Summary
- route Rust iterator identity adapters and Rust zip exact-protocol admission through semantic contracts instead of raw selector names
- move JS-like Math.abs/min/max and Boolean(record guard) recognition behind language/arity/global-shadow contracts
- require the Python free-function builtin contract for two-argument free min/max normalization, preserving hard negatives for JS free min and local shadowing
- update semantic-kernel snapshot/history docs for this migration slice

## Verification
- cargo fmt --all -- --check
- awiki lint --root docs
- cargo test --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * JavaScript/TypeScript의 shadowed 식별자 감지 개선으로 거짓 양성 제거
  * 수학 연산(min/max/abs)의 정확한 인식 강화
  * 레코드 가드 조건 검증 개선

* **테스트**
  * Shadowing 시나리오에 대한 테스트 케이스 추가
  * 언어 간 동등성 검증 강화

* **문서**
  * Semantic kernel 로드맵 및 구현 사항 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->