### PR TITLE
Migrate map default and Java list constructor contracts

### DIFF
--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -580,17 +580,35 @@ fn java_arraylist_add_builder_loop_converges_with_comprehension() {
     let i = Interner::new();
     let py_comp = "def f(xs):\n    return [x * x for x in xs]\n";
     let java_build = "import java.util.*;\nclass C { static List<Integer> f(int[] xs) { List<Integer> out = new ArrayList<>(); for (int x : xs) { out.add(x * x); } return out; } }\n";
+    let java_qualified_build = "class C { static java.util.List<Integer> f(int[] xs) { java.util.List<Integer> out = new java.util.ArrayList<>(); for (int x : xs) { out.add(x * x); } return out; } }\n";
     let java_build_diff = "import java.util.*;\nclass C { static List<Integer> f(int[] xs) { List<Integer> out = new ArrayList<>(); for (int x : xs) { out.add(x + 1); } return out; } }\n";
+    let java_unimported_arraylist = "class C { static Object f(int[] xs) { var out = new ArrayList<Integer>(); for (int x : xs) { out.add(x * x); } return out; } }\n";
+    let java_shadowed_arraylist = "import java.util.*;\nclass ArrayList<T> { void add(T value) {} }\nclass C { static ArrayList<Integer> f(int[] xs) { ArrayList<Integer> out = new ArrayList<>(); for (int x : xs) { out.add(x * x); } return out; } }\n";
     let comp_fp = value_fp(&i, py_comp, Lang::Python);
     assert_eq!(
         comp_fp,
         value_fp(&i, java_build, Lang::Java),
         "java ArrayList+add builder loop must converge with the python comprehension"
     );
+    assert_eq!(
+        comp_fp,
+        value_fp(&i, java_qualified_build, Lang::Java),
+        "fully-qualified java.util.ArrayList must not require a separate import proof"
+    );
     assert_ne!(
         comp_fp,
         value_fp(&i, java_build_diff, Lang::Java),
         "a different per-element contribution must stay distinct"
+    );
+    assert_ne!(
+        comp_fp,
+        value_fp(&i, java_unimported_arraylist, Lang::Java),
+        "simple ArrayList constructors need a java.util import proof before exact builder seeding"
+    );
+    assert_ne!(
+        comp_fp,
+        value_fp(&i, java_shadowed_arraylist, Lang::Java),
+        "a local ArrayList type must not mint the java.util empty-list builder seed"
     );
 }
 
@@ -4318,13 +4336,28 @@ fn literal_map_default_lookup_converges_with_imported_python_literal_binding() {
     )
     .unwrap();
     std::fs::write(
+        dir.join("mutated_index_tables.py"),
+        "LOOKUP = {\"red\": 1, \"blue\": 2}\nLOOKUP[\"red\"] = 9\n",
+    )
+    .unwrap();
+    std::fs::write(
         dir.join("imported_mutated_provider.py"),
         "from mutated_tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
     )
     .unwrap();
     std::fs::write(
+        dir.join("imported_mutated_index_provider.py"),
+        "from mutated_index_tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
+    )
+    .unwrap();
+    std::fs::write(
         dir.join("imported_mutated_receiver.py"),
         "from tables import LOOKUP\nLOOKUP.clear()\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("imported_mutated_index_receiver.py"),
+        "from tables import LOOKUP\nLOOKUP[\"red\"] = 9\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
     )
     .unwrap();
 
@@ -4347,8 +4380,18 @@ fn literal_map_default_lookup_converges_with_imported_python_literal_binding() {
     );
     assert_ne!(
         local,
+        corpus_value_fp(&corpus, "imported_mutated_index_provider.py", "lookup"),
+        "provider index write must block imported literal provenance"
+    );
+    assert_ne!(
+        local,
         corpus_value_fp(&corpus, "imported_mutated_receiver.py", "lookup"),
         "importer mutation must block imported literal provenance"
+    );
+    assert_ne!(
+        local,
+        corpus_value_fp(&corpus, "imported_mutated_index_receiver.py", "lookup"),
+        "importer index write must block imported literal provenance"
     );
 
     let _ = std::fs::remove_dir_all(&dir);

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -1469,7 +1469,10 @@ fn strict_exact_map_get_default_call_safe(
     };
     if contract.semantic != MethodSemanticContract::Builtin(Builtin::GetOrDefault)
         || contract.receiver != MethodReceiverContract::ExactMap
-        || contract.args != MethodBuiltinArgs::MapGetDefault
+        || !matches!(
+            contract.args,
+            MethodBuiltinArgs::MapGetDefault | MethodBuiltinArgs::MapGetDefaultOrZeroArgLambda
+        )
     {
         return false;
     }
@@ -1479,7 +1482,60 @@ fn strict_exact_map_get_default_call_safe(
     (strict_exact_proven_map_receiver_safe(il, facts, receiver)
         || strict_exact_java_map_factory_safe(il, interner, facts, receiver)
         || strict_exact_map_constructor_entries_safe(il, interner, facts, receiver))
-        && strict_exact_call_args_safe(il, interner, facts, node)
+        && strict_exact_map_get_default_args_safe(il, interner, facts, node, contract.args)
+}
+
+fn strict_exact_map_get_default_args_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+    contract: MethodBuiltinArgs,
+) -> bool {
+    let kids = il.children(node);
+    let [_, key, default] = kids else {
+        return false;
+    };
+    strict_exact_safe_tree(il, interner, facts, *key)
+        && match contract {
+            MethodBuiltinArgs::MapGetDefault => {
+                strict_exact_safe_tree(il, interner, facts, *default)
+            }
+            MethodBuiltinArgs::MapGetDefaultOrZeroArgLambda => {
+                strict_exact_map_default_value_arg_safe(il, interner, facts, *default)
+            }
+            _ => false,
+        }
+}
+
+fn strict_exact_map_default_value_arg_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    default: NodeId,
+) -> bool {
+    if il.kind(default) != NodeKind::Lambda {
+        return strict_exact_safe_tree(il, interner, facts, default);
+    }
+    let kids = il.children(default);
+    let [body] = kids else {
+        return false;
+    };
+    let value = implicit_single_value_body(il, *body).unwrap_or(*body);
+    strict_exact_safe_tree(il, interner, facts, value)
+}
+
+fn implicit_single_value_body(il: &Il, body: NodeId) -> Option<NodeId> {
+    if il.kind(body) != NodeKind::Block {
+        return None;
+    }
+    let [stmt] = il.children(body) else {
+        return None;
+    };
+    match il.kind(*stmt) {
+        NodeKind::ExprStmt | NodeKind::Return => il.children(*stmt).first().copied(),
+        _ => None,
+    }
 }
 
 fn strict_exact_iterator_identity_adapter_call_safe(

--- a/crates/nose-frontend/src/java.rs
+++ b/crates/nose-frontend/src/java.rs
@@ -11,6 +11,7 @@ use nose_il::{
     FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, ParamSemantic, Payload,
     Span, UnitKind,
 };
+use nose_semantics::{java_collection_constructor_contract, JavaCollectionConstructorKind};
 use tree_sitter::Node as TsNode;
 
 pub(crate) fn lower(
@@ -537,20 +538,9 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                     kids.push(lower_expr(lo, a));
                 }
             }
-            // `new ArrayList<>()` / `new LinkedList<>()` with no args is an empty ordered list —
-            // model it as the empty `array` Seq (like `[]`) so a List builder loop
-            // (`out = new ArrayList<>(); for … out.add(e)`) converges with the comprehension /
-            // `.map` form. Scoped to List types (NOT Set/Map) so the builder's empty-Seq-seed
-            // requirement keeps `set.add` / `map.put` out of the Map-build recognition.
-            if kids.is_empty() {
-                if let Some(ty) = node.child_by_field_name("type") {
-                    let tn = lo.text(ty);
-                    let base = tn.split('<').next().unwrap_or(tn).trim();
-                    if matches!(base, "ArrayList" | "LinkedList") {
-                        let tag = lo.sym("array");
-                        return lo.add(NodeKind::Seq, Payload::Name(tag), span, &[]);
-                    }
-                }
+            if let Some(list) = lower_empty_java_collection_constructor(lo, node, kids.len(), span)
+            {
+                return list;
             }
             lo.add(NodeKind::Call, Payload::None, span, &kids)
         }
@@ -731,6 +721,87 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             lo.raw(node.kind(), span, &kids)
         }
     }
+}
+
+fn lower_empty_java_collection_constructor(
+    lo: &mut Lowering,
+    node: TsNode,
+    arg_count: usize,
+    span: Span,
+) -> Option<NodeId> {
+    let ty = node.child_by_field_name("type")?;
+    let type_name = java_constructor_type_name(lo.text(ty));
+    let contract = java_collection_constructor_contract(lo.lang, &type_name, arg_count)?;
+    let uses_simple_type = type_name == contract.simple_type;
+    if uses_simple_type {
+        let root = java_root(node);
+        if contract.requires_import_for_simple_type
+            && !java_tree_imports_type(lo, root, contract.module, contract.simple_type)
+        {
+            return None;
+        }
+        if contract.requires_no_local_type_shadow
+            && java_tree_declares_type(lo, root, contract.simple_type)
+        {
+            return None;
+        }
+    }
+    match contract.kind {
+        JavaCollectionConstructorKind::EmptyList => {
+            let tag = lo.sym("array");
+            Some(lo.add(NodeKind::Seq, Payload::Name(tag), span, &[]))
+        }
+    }
+}
+
+fn java_constructor_type_name(text: &str) -> String {
+    text.split('<')
+        .next()
+        .unwrap_or(text)
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect()
+}
+
+fn java_root(mut node: TsNode) -> TsNode {
+    while let Some(parent) = node.parent() {
+        node = parent;
+    }
+    node
+}
+
+fn java_tree_imports_type(lo: &Lowering, node: TsNode, module: &str, simple_type: &str) -> bool {
+    if node.kind() == "import_declaration" {
+        let compact: String = lo
+            .text(node)
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        return compact == format!("import{module}.{simple_type};")
+            || compact == format!("import{module}.*;");
+    }
+    Lowering::named_children(node)
+        .into_iter()
+        .any(|child| java_tree_imports_type(lo, child, module, simple_type))
+}
+
+fn java_tree_declares_type(lo: &Lowering, node: TsNode, simple_type: &str) -> bool {
+    if matches!(
+        node.kind(),
+        "class_declaration"
+            | "interface_declaration"
+            | "enum_declaration"
+            | "record_declaration"
+            | "annotation_type_declaration"
+    ) && node
+        .child_by_field_name("name")
+        .is_some_and(|name| lo.text(name) == simple_type)
+    {
+        return true;
+    }
+    Lowering::named_children(node)
+        .into_iter()
+        .any(|child| java_tree_declares_type(lo, child, simple_type))
 }
 
 fn lambda_single_param_from_text(text: &str) -> Option<&str> {

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -50,9 +50,13 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
             collect_top_level_statements(il)
                 .into_iter()
                 .filter_map(|stmt| {
+                    let local = assignment_name(il, stmt)?;
                     let key = import_binding_key(il, interner, stmt)?;
                     let export = exports.get(&key)?;
                     if export.file_idx == file_idx {
+                        return None;
+                    }
+                    if binding_mutated(il, interner, local, stmt) {
                         return None;
                     }
                     Some((

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -90,7 +90,7 @@ pub(crate) fn canon_call(old: &Il, interner: &Interner, call_id: NodeId) -> Call
                     else {
                         return CallCanon::None;
                     };
-                    return apply_method_contract(old, interner, fname, contract, proven, args);
+                    return apply_method_contract(old, interner, contract, proven, args);
                 }
             }
         }
@@ -188,7 +188,6 @@ fn prove_method_receiver(
 fn apply_method_contract(
     old: &Il,
     interner: &Interner,
-    method: &str,
     contract: MethodCallContract,
     receiver: ProvenReceiver,
     args: &[NodeId],
@@ -271,7 +270,16 @@ fn apply_method_contract(
             let Some(base) = direct else {
                 return CallCanon::None;
             };
-            let fallback = if method == "fetch" && old.kind(args[1]) == NodeKind::Lambda {
+            CallCanon::Builtin {
+                op,
+                arg_olds: vec![base, args[0], args[1]],
+            }
+        }
+        MethodBuiltinArgs::MapGetDefaultOrZeroArgLambda => {
+            let Some(base) = direct else {
+                return CallCanon::None;
+            };
+            let fallback = if old.kind(args[1]) == NodeKind::Lambda {
                 let Some(fallback) = zero_arg_lambda_body_value(old, args[1]) else {
                     return CallCanon::None;
                 };
@@ -1183,6 +1191,57 @@ mod tests {
         (il, interner, call)
     }
 
+    fn map_get_default_call_il(
+        lang: Lang,
+        method: &str,
+        default_lambda: bool,
+        lambda_param: bool,
+    ) -> (Il, Interner, NodeId, NodeId) {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("hash")),
+            sp(),
+            &[],
+        );
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern(method)),
+            sp(),
+            &[receiver],
+        );
+        let key = b.add(NodeKind::Lit, Payload::LitStr(1), sp(), &[]);
+        let fallback_value = b.add(NodeKind::Lit, Payload::LitInt(0), sp(), &[]);
+        let fallback = if default_lambda {
+            if lambda_param {
+                let param = b.add(NodeKind::Param, Payload::Cid(0), sp(), &[]);
+                b.add(
+                    NodeKind::Lambda,
+                    Payload::None,
+                    sp(),
+                    &[param, fallback_value],
+                )
+            } else {
+                b.add(NodeKind::Lambda, Payload::None, sp(), &[fallback_value])
+            }
+        } else {
+            fallback_value
+        };
+        let call = b.add(NodeKind::Call, Payload::None, sp(), &[field, key, fallback]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(), &[call]);
+        let il = b.finish(
+            root,
+            FileMeta {
+                path: "t".to_string(),
+                lang,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        (il, interner, call, fallback_value)
+    }
+
     fn typed_method_call_il(
         lang: Lang,
         method: &str,
@@ -1382,6 +1441,39 @@ mod tests {
                 kind: HoFKind::Map,
                 ..
             }
+        ));
+    }
+
+    #[test]
+    fn map_get_default_lambda_fallback_is_contract_controlled() {
+        let (ruby, ruby_interner, ruby_call, ruby_fallback_value) =
+            map_get_default_call_il(Lang::Ruby, "fetch", true, false);
+        assert!(matches!(
+            canon_call(&ruby, &ruby_interner, ruby_call),
+            CallCanon::Builtin {
+                op: Builtin::GetOrDefault,
+                arg_olds
+            } if arg_olds.len() == 3 && arg_olds[2] == ruby_fallback_value
+        ));
+
+        let (ruby_param, ruby_param_interner, ruby_param_call, _) =
+            map_get_default_call_il(Lang::Ruby, "fetch", true, true);
+        assert!(
+            matches!(
+                canon_call(&ruby_param, &ruby_param_interner, ruby_param_call),
+                CallCanon::None
+            ),
+            "Ruby fetch block fallback must be zero-arg before exact canonicalization"
+        );
+
+        let (python, python_interner, python_call, python_fallback_value) =
+            map_get_default_call_il(Lang::Python, "get", true, false);
+        assert!(matches!(
+            canon_call(&python, &python_interner, python_call),
+            CallCanon::Builtin {
+                op: Builtin::GetOrDefault,
+                arg_olds
+            } if arg_olds.len() == 3 && arg_olds[2] != python_fallback_value
         ));
     }
 

--- a/crates/nose-normalize/src/module_facts.rs
+++ b/crates/nose-normalize/src/module_facts.rs
@@ -115,16 +115,21 @@ pub(crate) fn collect_module_mutations_in_scope(
                     );
                 }
             }
-            NodeKind::Assign if !is_top_level.get(idx).copied().unwrap_or(false) => {
+            NodeKind::Assign => {
                 if let Some(lhs) = il.children(node_id).first().copied() {
-                    collect_unshadowed_node_symbols(
-                        il,
-                        lhs,
-                        candidates,
-                        &shadowed,
-                        local_scope,
-                        &mut mutated,
-                    );
+                    let direct_top_level_definition =
+                        is_top_level.get(idx).copied().unwrap_or(false)
+                            && assignment_name_in_scope(il, node_id, local_scope).is_some();
+                    if !direct_top_level_definition {
+                        collect_unshadowed_node_symbols(
+                            il,
+                            lhs,
+                            candidates,
+                            &shadowed,
+                            local_scope,
+                            &mut mutated,
+                        );
+                    }
                 }
             }
             _ => {}
@@ -377,5 +382,46 @@ mod tests {
         let mutated =
             collect_module_mutations(&fixture.il, &fixture.interner, &candidates, &is_top_level);
         assert!(mutated.contains(&fixture.arr));
+    }
+
+    #[test]
+    fn top_level_place_assignment_marks_module_binding_mutated() {
+        let interner = Interner::new();
+        let arr = interner.intern("arr");
+        let mut b = IlBuilder::new(FileId(0));
+        let arr_def = b.add(NodeKind::Var, Payload::Cid(0), sp(1), &[]);
+        let empty_array = b.add(NodeKind::Seq, Payload::None, sp(1), &[]);
+        let assign_arr = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            sp(1),
+            &[arr_def, empty_array],
+        );
+
+        let arr_ref = b.add(NodeKind::Var, Payload::Name(arr), sp(2), &[]);
+        let index = b.add(NodeKind::Lit, Payload::LitInt(0), sp(2), &[]);
+        let place = b.add(NodeKind::Index, Payload::None, sp(2), &[arr_ref, index]);
+        let value = b.add(NodeKind::Lit, Payload::LitInt(9), sp(2), &[]);
+        let write = b.add(NodeKind::Assign, Payload::None, sp(2), &[place, value]);
+        let module = b.add(NodeKind::Module, Payload::None, sp(1), &[assign_arr, write]);
+        let il = b.finish(
+            module,
+            FileMeta {
+                path: "t.js".to_string(),
+                lang: Lang::JavaScript,
+            },
+            Vec::new(),
+            vec![arr],
+        );
+
+        let mut candidates = FxHashSet::default();
+        candidates.insert(arr);
+        let top_level = top_level_statements_for(&il);
+        let mut is_top_level = vec![false; il.nodes.len()];
+        for stmt in top_level {
+            is_top_level[stmt.0 as usize] = true;
+        }
+        let mutated = collect_module_mutations(&il, &interner, &candidates, &is_top_level);
+        assert!(mutated.contains(&arr));
     }
 }

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -1599,8 +1599,11 @@ impl<'a> Builder<'a> {
             None
         } else if contract.args == MethodBuiltinArgs::GoSliceContains && kids.len() == 3 {
             let receiver = receiver?;
-            if !self.is_import_namespace_expr(receiver, "slices", env)
-                && !self.file_imports_namespace(receiver, "slices")
+            let MethodReceiverContract::ImportedNamespace(module) = contract.receiver else {
+                return None;
+            };
+            if !self.is_import_namespace_expr(receiver, module, env)
+                && !self.file_imports_namespace(receiver, module)
             {
                 return None;
             }
@@ -1678,7 +1681,10 @@ impl<'a> Builder<'a> {
         )?;
         if contract.semantic != MethodSemanticContract::Builtin(Builtin::GetOrDefault)
             || contract.receiver != MethodReceiverContract::ExactMap
-            || contract.args != MethodBuiltinArgs::MapGetDefault
+            || !matches!(
+                contract.args,
+                MethodBuiltinArgs::MapGetDefault | MethodBuiltinArgs::MapGetDefaultOrZeroArgLambda
+            )
         {
             return None;
         }
@@ -1690,11 +1696,44 @@ impl<'a> Builder<'a> {
             self.proven_map_value(receiver_value)?
         };
         let key = self.eval(kids[1], env);
-        let default = self.eval(kids[2], env);
+        let default = self.eval_map_get_default_arg(contract.args, kids[2], env)?;
         Some(self.mk(
             ValOp::Call(builtin_tag(Builtin::GetOrDefault)),
             vec![map, key, default],
         ))
+    }
+
+    fn eval_map_get_default_arg(
+        &mut self,
+        contract: MethodBuiltinArgs,
+        default: NodeId,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        match contract {
+            MethodBuiltinArgs::MapGetDefault => Some(self.eval(default, env)),
+            MethodBuiltinArgs::MapGetDefaultOrZeroArgLambda => {
+                if self.il.kind(default) == NodeKind::Lambda {
+                    return self.eval_zero_arg_lambda_body(default, env);
+                }
+                Some(self.eval(default, env))
+            }
+            _ => None,
+        }
+    }
+
+    fn eval_zero_arg_lambda_body(
+        &mut self,
+        lambda: NodeId,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if self.il.kind(lambda) != NodeKind::Lambda {
+            return None;
+        }
+        let kids = self.il.children(lambda);
+        if kids.len() != 1 {
+            return None;
+        }
+        self.eval_lambda_body(lambda, &[], env)
     }
 
     fn eval_proven_integer_method_call(

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -648,6 +648,7 @@ pub enum MethodBuiltinArgs {
     FirstThenReceiver,
     GoSliceContains,
     MapGetDefault,
+    MapGetDefaultOrZeroArgLambda,
     RustMapGetOrOptionDefault,
     RustOptionDefaultLambda,
     RustOptionMapOrIdentity,
@@ -858,10 +859,15 @@ pub fn method_call_contract(
             Receiver::LiteralString,
             Args::ReceiverAndFirst,
         ),
-        (Lang::Python, "get", 2) | (Lang::Ruby, "fetch", 2) => (
+        (Lang::Python, "get", 2) => (
             Builtin::GetOrDefault,
             Receiver::ExactMap,
             Args::MapGetDefault,
+        ),
+        (Lang::Ruby, "fetch", 2) => (
+            Builtin::GetOrDefault,
+            Receiver::ExactMap,
+            Args::MapGetDefaultOrZeroArgLambda,
         ),
         (Lang::Java, "getOrDefault", 2) => (
             Builtin::GetOrDefault,
@@ -1136,6 +1142,48 @@ pub fn java_collection_factory_contract_by_hash(
         (stable_symbol_hash(method) == method_hash)
             .then(|| java_collection_factory_contract(lang, receiver, method))
             .flatten()
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum JavaCollectionConstructorKind {
+    EmptyList,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct JavaCollectionConstructorContract {
+    pub simple_type: &'static str,
+    pub qualified_type: &'static str,
+    pub module: &'static str,
+    pub kind: JavaCollectionConstructorKind,
+    pub requires_import_for_simple_type: bool,
+    pub requires_no_local_type_shadow: bool,
+}
+
+pub fn java_collection_constructor_contract(
+    lang: Lang,
+    type_name: &str,
+    arg_count: usize,
+) -> Option<JavaCollectionConstructorContract> {
+    if lang != Lang::Java || arg_count != 0 {
+        return None;
+    }
+    let simple_type = match type_name {
+        "ArrayList" | "java.util.ArrayList" => "ArrayList",
+        "LinkedList" | "java.util.LinkedList" => "LinkedList",
+        _ => return None,
+    };
+    Some(JavaCollectionConstructorContract {
+        simple_type,
+        qualified_type: match simple_type {
+            "ArrayList" => "java.util.ArrayList",
+            "LinkedList" => "java.util.LinkedList",
+            _ => return None,
+        },
+        module: "java.util",
+        kind: JavaCollectionConstructorKind::EmptyList,
+        requires_import_for_simple_type: true,
+        requires_no_local_type_shadow: true,
     })
 }
 
@@ -2259,6 +2307,14 @@ mod tests {
             })
         );
         assert_eq!(
+            method_call_contract(Lang::Go, "Contains", 2),
+            Some(MethodCallContract {
+                semantic: MethodSemanticContract::Builtin(Builtin::Contains),
+                receiver: MethodReceiverContract::ImportedNamespace("slices"),
+                args: MethodBuiltinArgs::GoSliceContains,
+            })
+        );
+        assert_eq!(
             method_call_contract(Lang::Java, "abs", 1),
             Some(MethodCallContract {
                 semantic: MethodSemanticContract::Builtin(Builtin::Abs),
@@ -2305,6 +2361,22 @@ mod tests {
                 semantic: MethodSemanticContract::Builtin(Builtin::GetOrDefault),
                 receiver: MethodReceiverContract::ExactMap,
                 args: MethodBuiltinArgs::MapGetDefault,
+            })
+        );
+        assert_eq!(
+            method_call_contract(Lang::Python, "get", 2),
+            Some(MethodCallContract {
+                semantic: MethodSemanticContract::Builtin(Builtin::GetOrDefault),
+                receiver: MethodReceiverContract::ExactMap,
+                args: MethodBuiltinArgs::MapGetDefault,
+            })
+        );
+        assert_eq!(
+            method_call_contract(Lang::Ruby, "fetch", 2),
+            Some(MethodCallContract {
+                semantic: MethodSemanticContract::Builtin(Builtin::GetOrDefault),
+                receiver: MethodReceiverContract::ExactMap,
+                args: MethodBuiltinArgs::MapGetDefaultOrZeroArgLambda,
             })
         );
         assert_eq!(method_call_contract(Lang::JavaScript, "abs", 0), None);
@@ -2490,6 +2562,30 @@ mod tests {
         );
         assert_eq!(
             java_collection_factory_contract(Lang::Java, "Map", "of"),
+            None
+        );
+        assert_eq!(
+            java_collection_constructor_contract(Lang::Java, "ArrayList", 0),
+            Some(JavaCollectionConstructorContract {
+                simple_type: "ArrayList",
+                qualified_type: "java.util.ArrayList",
+                module: "java.util",
+                kind: JavaCollectionConstructorKind::EmptyList,
+                requires_import_for_simple_type: true,
+                requires_no_local_type_shadow: true,
+            })
+        );
+        assert_eq!(
+            java_collection_constructor_contract(Lang::Java, "java.util.LinkedList", 0)
+                .map(|contract| contract.kind),
+            Some(JavaCollectionConstructorKind::EmptyList)
+        );
+        assert_eq!(
+            java_collection_constructor_contract(Lang::Java, "ArrayList", 1),
+            None
+        );
+        assert_eq!(
+            java_collection_constructor_contract(Lang::JavaScript, "ArrayList", 0),
             None
         );
         assert_eq!(

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -95,6 +95,10 @@ and pack ecosystem.
   behind shared `nose-semantics` contracts. Normalize, strict exact gates, and
   corpus import proof now consume the same selector source while keeping local
   import, require, shadow, mutation, and entry-shape proof at the caller.
+- Java empty `ArrayList`/`LinkedList` constructor lowering now consumes a
+  `java.util` constructor contract instead of a raw simple-name check. Simple
+  names need import proof and no local type shadow before they can seed exact
+  builder-loop equivalence.
 - Membership and map-key membership recognition now uses language-scoped method
   contracts before normalization or strict exact matching assigns containment
   semantics. This intentionally closes old name-only paths such as JavaScript
@@ -146,6 +150,13 @@ and pack ecosystem.
 - Value-graph two-argument free `min(...)`/`max(...)` now consumes the Python
   free-function builtin contract instead of the raw callee name, closing
   unqualified JS `min(...)` and local-shadowing false positives.
+- Ruby `fetch(key) { fallback }` map-default handling now consumes an explicit
+  zero-arg-lambda fallback argument contract, and Go `slices.Contains` value-graph
+  membership proof consumes the imported namespace carried by the method contract
+  instead of spelling the namespace locally.
+- Imported immutable literal replacement and exact module-binding gates now share
+  stronger mutation evidence for top-level place writes such as
+  `LOOKUP[key] = value`, closing importer-side direct-write false exact cases.
 
 ## Phase 0: documentation and vocabulary (landed)
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -77,6 +77,11 @@ migrated.
   `Map.entry`, and Ruby `require "set"; Set.new(...)`. Callers still prove the
   local import, require, shadowing, entry-shape, mutation, and exact-safety
   obligations.
+- Java empty collection constructor contracts cover `new ArrayList<>()` and
+  `new LinkedList<>()` only for the Java `java.util` list types. Simple names
+  require `java.util` import proof and no local type declaration with the same
+  simple name; fully-qualified `java.util.*List` names carry the namespace proof
+  in the selector itself.
 - Builder append contracts are separate from arbitrary method calls: Java `add`
   and Rust `push` are admitted only for active builder proofs.
 - Exact fragment surface proofs for Java `this.field`, Java `return this`,
@@ -92,7 +97,10 @@ migrated.
 - Cross-file immutable import replacement now preserves import-binding
   dependencies used by the exported literal expression, so a Java static import
   of `LOOKUP = Map.of(...)` carries the provider's `java.util.Map` proof into
-  the importing file.
+  the importing file. Provider and importer module-binding mutation proof now
+  rejects direct binding mutations and direct place writes such as
+  `LOOKUP.clear()` and `LOOKUP[key] = value` before imported literal provenance
+  can enter exact matching.
 - Membership and map-key membership selectors now consume language-scoped method
   contracts before normalize/detect treat them as semantic containment. A method
   named `contains` is Java/Rust collection membership only; JavaScript
@@ -107,8 +115,10 @@ migrated.
   contract before it can feed exact membership.
 - Map lookup surfaces that return a value/option are now explicit contracts for
   Java/Rust/JS-like `get(key)` plus an exact-map receiver requirement. Python
-  `dict.get(key, default)`, Ruby `fetch(key, default)`, and Java `getOrDefault`
-  still use the `GetOrDefault` method contract.
+  `dict.get(key, default)`, Java `getOrDefault`, and Ruby `fetch` still use the
+  `GetOrDefault` method contract. Ruby `fetch(key) { fallback }` carries a
+  separate zero-arg-lambda fallback argument contract, so block fallback demand
+  is not inferred from the selector name in normalize/detect.
 - JS-like static array `indexOf`/`findIndex` membership surfaces are explicit
   contracts, including the static non-float literal collection requirement and
   accepted `-1`/`0` threshold comparisons. Callers still prove the receiver and


### PR DESCRIPTION
## Summary
- split map-default contracts so Ruby `fetch(key) { fallback }` carries an explicit zero-arg-lambda fallback shape instead of relying on selector text
- route Go `slices.Contains` and Java empty `ArrayList`/`LinkedList` semantics through kernel contracts and proof obligations
- strengthen imported immutable literal replacement and module mutation evidence for direct place writes such as `LOOKUP[key] = value`
- update semantic-kernel snapshot/history docs

## Main review
- fetched and checked `origin/main`; current branch was already based on latest `main` (`66f5e7c`) and `HEAD..origin/main` was empty
- reviewed the latest main semantic-kernel changes for design mismatches; this PR addresses the risky raw-name/raw-selector paths found on top of that baseline

## Verification
- `cargo fmt --all -- --check`
- `awiki lint --root docs`
- `cargo test -p nose-semantics --lib`
- `cargo test -p nose-frontend --lib`
- `cargo test -p nose-normalize --lib`
- `cargo test -p nose-detect --lib`
- `cargo test -p nose-cli --test equivalence java_arraylist_add_builder_loop_converges_with_comprehension -- --exact`
- `cargo test -p nose-cli --test equivalence literal_map_default_lookup_converges_with_imported_python_literal_binding -- --exact`
- `cargo test -p nose-cli --test equivalence map_default_lookup_converges_cross_language_with_boundaries -- --exact`
- `cargo test -p nose-cli --test cli scan_mode_semantic_proves_literal_map_default_lookup -- --exact`
- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`