### PR TITLE
Make field state receiver-aware

### DIFF
--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -365,6 +365,42 @@ fn fail_on_any_ignores_hidden_exact_fragments() {
 }
 
 #[test]
+fn scan_mode_semantic_rejects_cross_receiver_field_state() {
+    let dir = std::env::temp_dir().join(format!("nose_field_place_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("read_other.py"),
+        "def f(a, b):\n    a.x = 7\n    return b.x\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("read_written.py"),
+        "def f(a, b):\n    a.x = 7\n    return a.x\n",
+    )
+    .unwrap();
+
+    let json = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--min-size",
+        "1",
+        "--min-lines",
+        "1",
+        "--format",
+        "json",
+    ]));
+    assert!(
+        scan_families(&json).is_empty(),
+        "same-named fields on different receivers must not report as exact semantic clones: {json}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn scan_human_hides_generated_header_families() {
     let dir = make_generated_header_project("human");
 

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -2928,10 +2928,36 @@ fn value_graph_reads_field_written_in_unit() {
     let i = Interner::new();
     let read_field = "def f(self):\n    self.x = 7\n    return self.x\n";
     let return_value = "def f(self):\n    self.x = 7\n    return 7\n";
+    let read_other_receiver = "def f(a, b):\n    a.x = 7\n    return b.x\n";
+    let read_written_receiver = "def f(a, b):\n    a.x = 7\n    return a.x\n";
     assert_eq!(
         value_fp(&i, read_field, Lang::Python),
         value_fp(&i, return_value, Lang::Python),
         "a field read after a same-unit field write should resolve to the written value"
+    );
+    assert_ne!(
+        value_fp(&i, read_other_receiver, Lang::Python),
+        value_fp(&i, read_written_receiver, Lang::Python),
+        "a same-named field write on one receiver must not satisfy a read on another receiver"
+    );
+}
+
+#[test]
+fn value_graph_field_state_is_receiver_aware() {
+    let i = Interner::new();
+    let same_receiver_order_a = "def f(self):\n    self.x = 1\n    self.y = 2\n";
+    let same_receiver_order_b = "def f(self):\n    self.y = 2\n    self.x = 1\n";
+    let crossed_receivers_a = "def f(a, b):\n    a.x = 1\n    b.x = 2\n";
+    let crossed_receivers_b = "def f(a, b):\n    b.x = 1\n    a.x = 2\n";
+    assert_eq!(
+        value_fp(&i, same_receiver_order_a, Lang::Python),
+        value_fp(&i, same_receiver_order_b, Lang::Python),
+        "final writes to distinct fields on the same receiver should still commute"
+    );
+    assert_ne!(
+        value_fp(&i, crossed_receivers_a, Lang::Python),
+        value_fp(&i, crossed_receivers_b, Lang::Python),
+        "same-named field writes on different receivers must preserve receiver identity"
     );
 }
 

--- a/crates/nose-detect/src/fragment/contract.rs
+++ b/crates/nose-detect/src/fragment/contract.rs
@@ -161,10 +161,10 @@ impl FragmentContract {
 ///   *ordered effect trace*: the written key/value is observable, so two fragments that
 ///   write different keys or values diverge in [`Behavior`](nose_normalize::Behavior)
 ///   without needing receiver-identity proof.
-/// - [`Effect::FieldWrite`] is recorded in the interpreter's *field-state map*, keyed by
-///   field name only — the receiver identity is **not** observed. A field write is
-///   therefore exact-safe only when its [`Place`] receiver is proven (fail-closed); this is
-///   why only a fixed `this` receiver is admitted today.
+/// - [`Effect::FieldWrite`] is recorded in the interpreter's final *field-state map*, keyed
+///   by receiver+field place. A field write is therefore exact-safe only when its
+///   [`Place`] receiver is proven (fail-closed); this is why only a fixed `this` receiver
+///   is admitted today.
 /// - [`Effect::Other`] is any other proven single effect (e.g. a generic effectful call
 ///   statement) whose observability the oracle establishes by running it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -173,8 +173,8 @@ pub enum Effect {
     Append,
     /// An index/key assignment `target[key] = value`; key and value are observable.
     IndexWrite,
-    /// A field assignment `receiver.field = value`; final per-field state, receiver
-    /// identity unobserved — requires a proven [`Place`].
+    /// A field assignment `receiver.field = value`; final per-place state, requiring a
+    /// proven [`Place`].
     FieldWrite,
     /// Any other single proven observable effect.
     Other,
@@ -182,8 +182,8 @@ pub enum Effect {
 
 impl Effect {
     /// Whether soundness for this effect requires the write target's [`Place`] to be a
-    /// proven (exact-safe) receiver. Only field writes do: the interpreter does not observe
-    /// the receiver of a field write, so an unproven receiver could falsely merge.
+    /// proven (exact-safe) receiver. Only field writes do: their final state is keyed by
+    /// receiver-bearing place, so an unproven receiver stays fail-closed.
     pub fn requires_proven_place(self) -> bool {
         matches!(self, Effect::FieldWrite)
     }

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -127,9 +127,9 @@ fn recognize_assignment_effect(
         && exact_java_this_field(il, interner, target)
     {
         let place = resolve_place(il, interner, target);
-        // Field writes do not observe their receiver in the oracle (the field-state map is
-        // keyed by name only), so the write is exact-safe only with a proven receiver. The
-        // `this.field` recognizer guarantees this; assert the invariant fail-closed.
+        // Field-write final state is keyed by receiver+field place, so the write is exact-safe
+        // only with a proven receiver. The `this.field` recognizer guarantees this; assert the
+        // invariant fail-closed.
         debug_assert!(
             place.is_exact_safe(),
             "self-field write must resolve to a proven place, got {place:?}"

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -45,17 +45,33 @@ pub enum Value {
     Err,
 }
 
+/// A receiver identity proven by the IL shape during interpretation.
+#[derive(Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
+pub enum FieldPlace {
+    Name(i64),
+    Param(u32),
+    Field(Box<FieldPlace>, i64),
+    Index(Box<FieldPlace>, i64),
+}
+
+/// A concrete final field-state slot: receiver identity plus field name.
+#[derive(Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
+pub struct FieldKey {
+    pub receiver: FieldPlace,
+    pub field: i64,
+}
+
 /// The observable behavior of one run: the returned value, an ordered I/O effect trace
-/// (appended/printed values, in order — order IS observable), and the final per-field
-/// object state (`self.x = …`) as a name→value map in canonical name order. Field state
-/// is order-INSENSITIVE across distinct fields (writing two distinct fields commutes —
-/// the resulting object is identical) but reflects last-write-wins per field. Two units
-/// are behaviorally equal on an input iff all three components match.
+/// (appended/printed values, in order — order IS observable), and the final per-place
+/// object state (`self.x = …`) as a receiver+name→value map in canonical place order.
+/// Field state is order-INSENSITIVE across distinct places but reflects
+/// last-write-wins per receiver+field. Two units are behaviorally equal on an input iff
+/// all three components match.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Behavior {
     pub ret: Value,
     pub effects: Vec<Value>,
-    pub fields: Vec<(i64, Value)>,
+    pub fields: Vec<(FieldKey, Value)>,
 }
 
 /// Marker: the unit hit a construct the interpreter does not model. The whole unit is
@@ -85,7 +101,7 @@ struct Interp<'a> {
     il: &'a Il,
     steps: u64,
     effects: Vec<Value>,
-    fields: FxHashMap<i64, Value>,
+    fields: FxHashMap<FieldKey, Value>,
     /// Parameter cids — appending to one is a caller-visible mutation (an effect); appending
     /// to a LOCAL list var builds that list's value (faithful, converges with a comprehension).
     params: FxHashSet<u32>,
@@ -166,8 +182,8 @@ pub fn run_unit(il: &Il, root: NodeId, args: &[Value]) -> Option<Behavior> {
         Ok(_) => Value::Null,
         Err(_) => return None,
     };
-    let mut fields: Vec<(i64, Value)> = it.fields.into_iter().collect();
-    fields.sort_by_key(|&(k, _)| k);
+    let mut fields: Vec<(FieldKey, Value)> = it.fields.into_iter().collect();
+    fields.sort_by(|(left, _), (right, _)| left.cmp(right));
     Some(Behavior {
         ret,
         effects: it.effects,
@@ -182,6 +198,47 @@ impl<'a> Interp<'a> {
             Err(Unsupported)
         } else {
             Ok(())
+        }
+    }
+
+    fn field_place(&self, node: NodeId) -> Option<FieldPlace> {
+        match self.il.kind(node) {
+            NodeKind::Var => match self.il.node(node).payload {
+                Payload::Cid(cid) => Some(FieldPlace::Param(cid)),
+                Payload::Name(name) => Some(FieldPlace::Name(nose_il::symbol_index(name) as i64)),
+                _ => None,
+            },
+            NodeKind::Field => {
+                let receiver = self.il.children(node).first().copied()?;
+                let receiver = self.field_place(receiver)?;
+                let Payload::Name(field) = self.il.node(node).payload else {
+                    return None;
+                };
+                Some(FieldPlace::Field(
+                    Box::new(receiver),
+                    nose_il::symbol_index(field) as i64,
+                ))
+            }
+            NodeKind::Index => {
+                let kids = self.il.children(node);
+                let receiver = kids.first().copied()?;
+                let receiver = self.field_place(receiver)?;
+                let key = kids
+                    .get(1)
+                    .and_then(|&key| self.field_place_key_hash(key))?;
+                Some(FieldPlace::Index(Box::new(receiver), key))
+            }
+            _ => None,
+        }
+    }
+
+    fn field_place_key_hash(&self, node: NodeId) -> Option<i64> {
+        match self.il.node(node).payload {
+            Payload::LitInt(value) => Some(value),
+            Payload::LitStr(hash) => Some(hash as i64),
+            Payload::Name(symbol) => Some(nose_il::symbol_index(symbol) as i64),
+            Payload::Cid(cid) if self.il.kind(node) == NodeKind::Var => Some(i64::from(cid)),
+            _ => None,
         }
     }
 
@@ -386,25 +443,28 @@ impl<'a> Interp<'a> {
                 }
                 Ok(false)
             }
-            // A store into a field/index is an effect; record *what* is written to as
-            // well as the value, so `self.a = x` and `self.b = x` (or `xs[i]=` vs
-            // `xs[j]=`) are distinguished — otherwise field-blindness conflates
-            // near-twin setters and pollutes the completeness signal with false leads.
-            // A field store updates per-field object state (last-write-wins), keyed by
-            // field name — NOT an ordered effect. Writing distinct fields commutes (same
-            // resulting object), so `self.a=x; self.b=y` and the swap are behaviorally
-            // equal; same-field overwrites keep the last value. (Previously pushed to the
-            // ordered effect trace, which wrongly made commuting field-write order
-            // observable — splitting equivalent constructors the value graph merges.)
+            // A field store updates per-place object state (last-write-wins), keyed by
+            // receiver identity plus field name. Writing distinct receiver+field places
+            // commutes; same-place overwrites keep the last value.
             NodeKind::Field => {
-                if let Some(&receiver) = self.il.children(target).first() {
-                    let receiver = self.eval(receiver, env)?;
-                    if matches!(receiver, Value::Err) {
-                        return Ok(true);
-                    }
+                let Some(&receiver) = self.il.children(target).first() else {
+                    return Err(Unsupported);
+                };
+                let receiver_value = self.eval(receiver, env)?;
+                if matches!(receiver_value, Value::Err) {
+                    return Ok(true);
                 }
                 if let Payload::Name(sym) = self.il.node(target).payload {
-                    self.fields.insert(nose_il::symbol_index(sym) as i64, val);
+                    let Some(receiver) = self.field_place(receiver) else {
+                        return Err(Unsupported);
+                    };
+                    self.fields.insert(
+                        FieldKey {
+                            receiver,
+                            field: nose_il::symbol_index(sym) as i64,
+                        },
+                        val,
+                    );
                     Ok(false)
                 } else {
                     Err(Unsupported)
@@ -527,18 +587,26 @@ impl<'a> Interp<'a> {
                 Ok(Value::List(out))
             }
             NodeKind::Field => {
-                if let Some(&receiver) = self.il.children(node).first() {
-                    let receiver = self.eval(receiver, env)?;
-                    if matches!(receiver, Value::Err) {
-                        return Ok(Value::Err);
-                    }
+                let Some(&receiver) = self.il.children(node).first() else {
+                    return Err(Unsupported);
+                };
+                let receiver_value = self.eval(receiver, env)?;
+                if matches!(receiver_value, Value::Err) {
+                    return Ok(Value::Err);
                 }
                 match n.payload {
-                    Payload::Name(sym) => self
-                        .fields
-                        .get(&(nose_il::symbol_index(sym) as i64))
-                        .cloned()
-                        .ok_or(Unsupported),
+                    Payload::Name(sym) => {
+                        let Some(receiver) = self.field_place(receiver) else {
+                            return Err(Unsupported);
+                        };
+                        self.fields
+                            .get(&FieldKey {
+                                receiver,
+                                field: nose_il::symbol_index(sym) as i64,
+                            })
+                            .cloned()
+                            .ok_or(Unsupported)
+                    }
                     _ => Err(Unsupported),
                 }
             }
@@ -1458,20 +1526,25 @@ mod tests {
         assert_eq!(run_throw_then_return(), Value::Err);
     }
 
-    fn run_field_write_read() -> (Behavior, i64) {
+    fn run_field_write_read() -> (Behavior, FieldKey) {
         let sp = Span::synthetic(FileId(0));
         let mut b = IlBuilder::new(FileId(0));
         let interner = Interner::new();
-        let base = b.add(NodeKind::Lit, Payload::Lit(LitClass::Null), sp, &[]);
+        let param = b.add(NodeKind::Param, Payload::Cid(0), sp, &[]);
+        let base = b.add(NodeKind::Var, Payload::Cid(0), sp, &[]);
         let field_name = interner.intern("x");
-        let field_key = nose_il::symbol_index(field_name) as i64;
+        let field_key = FieldKey {
+            receiver: FieldPlace::Param(0),
+            field: nose_il::symbol_index(field_name) as i64,
+        };
         let write_target = b.add(NodeKind::Field, Payload::Name(field_name), sp, &[base]);
         let seven = b.add(NodeKind::Lit, Payload::LitInt(7), sp, &[]);
         let assign = b.add(NodeKind::Assign, Payload::None, sp, &[write_target, seven]);
-        let read_target = b.add(NodeKind::Field, Payload::Name(field_name), sp, &[base]);
+        let read_base = b.add(NodeKind::Var, Payload::Cid(0), sp, &[]);
+        let read_target = b.add(NodeKind::Field, Payload::Name(field_name), sp, &[read_base]);
         let ret = b.add(NodeKind::Return, Payload::None, sp, &[read_target]);
         let block = b.add(NodeKind::Block, Payload::None, sp, &[assign, ret]);
-        let func = b.add(NodeKind::Func, Payload::None, sp, &[block]);
+        let func = b.add(NodeKind::Func, Payload::None, sp, &[param, block]);
         let il = b.finish(
             func,
             FileMeta {
@@ -1496,7 +1569,8 @@ mod tests {
         let mut b = IlBuilder::new(FileId(0));
         let interner = Interner::new();
         let field_name = interner.intern("x");
-        let base = b.add(NodeKind::Lit, Payload::Lit(LitClass::Null), sp, &[]);
+        let param = b.add(NodeKind::Param, Payload::Cid(0), sp, &[]);
+        let base = b.add(NodeKind::Var, Payload::Cid(0), sp, &[]);
         let write_target = b.add(NodeKind::Field, Payload::Name(field_name), sp, &[base]);
         let seven = b.add(NodeKind::Lit, Payload::LitInt(7), sp, &[]);
         let assign = b.add(NodeKind::Assign, Payload::None, sp, &[write_target, seven]);
@@ -1511,7 +1585,7 @@ mod tests {
         );
         let ret = b.add(NodeKind::Return, Payload::None, sp, &[read_target]);
         let block = b.add(NodeKind::Block, Payload::None, sp, &[assign, ret]);
-        let func = b.add(NodeKind::Func, Payload::None, sp, &[block]);
+        let func = b.add(NodeKind::Func, Payload::None, sp, &[param, block]);
         let il = b.finish(
             func,
             FileMeta {
@@ -1566,6 +1640,63 @@ mod tests {
         let behavior = run_field_write_with_error_receiver();
         assert_eq!(behavior.ret, Value::Err);
         assert!(behavior.fields.is_empty());
+    }
+
+    fn run_receiver_field_writes(swapped: bool) -> Behavior {
+        let sp = Span::synthetic(FileId(0));
+        let mut b = IlBuilder::new(FileId(0));
+        let interner = Interner::new();
+        let field_name = interner.intern("x");
+        let param_a = b.add(NodeKind::Param, Payload::Cid(0), sp, &[]);
+        let param_b = b.add(NodeKind::Param, Payload::Cid(1), sp, &[]);
+        let a = b.add(NodeKind::Var, Payload::Cid(0), sp, &[]);
+        let b_var = b.add(NodeKind::Var, Payload::Cid(1), sp, &[]);
+        let a_x = b.add(NodeKind::Field, Payload::Name(field_name), sp, &[a]);
+        let b_x = b.add(NodeKind::Field, Payload::Name(field_name), sp, &[b_var]);
+        let one = b.add(NodeKind::Lit, Payload::LitInt(1), sp, &[]);
+        let two = b.add(NodeKind::Lit, Payload::LitInt(2), sp, &[]);
+        let (left_target, left_value, right_target, right_value) = if swapped {
+            (b_x, one, a_x, two)
+        } else {
+            (a_x, one, b_x, two)
+        };
+        let left = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            sp,
+            &[left_target, left_value],
+        );
+        let right = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            sp,
+            &[right_target, right_value],
+        );
+        let block = b.add(NodeKind::Block, Payload::None, sp, &[left, right]);
+        let func = b.add(
+            NodeKind::Func,
+            Payload::None,
+            sp,
+            &[param_a, param_b, block],
+        );
+        let il = b.finish(
+            func,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        run_unit(&il, func, &[]).expect("receiver field writes should interpret")
+    }
+
+    #[test]
+    fn field_state_preserves_receiver_identity() {
+        assert_ne!(
+            run_receiver_field_writes(false).fields,
+            run_receiver_field_writes(true).fields
+        );
     }
 
     fn run_try(body_stmt: NodeId, handler_stmt: NodeId, mut b: IlBuilder, sp: Span) -> Value {

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -300,6 +300,12 @@ pub fn value_fingerprint_and_contracts(
 
 type ValueId = u32;
 
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct FieldStateKey {
+    receiver: ValueId,
+    field: u64,
+}
+
 #[derive(Clone, PartialEq, Eq, Hash)]
 enum ValOp {
     Input(u32),      // a parameter or free variable, keyed by canonical id
@@ -381,15 +387,14 @@ struct Builder<'a> {
     intern: FxHashMap<(ValOp, Vec<ValueId>), ValueId>,
     sinks: Vec<Sink>,
     opaque_ctr: u32,
-    /// Object field writes (`self.x = v`), keyed by field name → its CURRENT value
-    /// (last-write-wins). Flushed to sinks at the end as one (field, final-value) sink
-    /// each. This makes the fingerprint depend on the *final per-field state* — order-
-    /// insensitive across DISTINCT fields (so two constructors that assign the same
-    /// fields in swapped order converge, as they must: distinct field writes commute),
-    /// yet correct for same-field overwrites (`x=1;x=2` ≠ `x=2;x=1` — last value wins).
+    /// Object field writes (`self.x = v`), keyed by receiver identity plus field name → its
+    /// CURRENT value (last-write-wins). Flushed to sinks at the end as one
+    /// (receiver, field, final-value) sink each. This makes the fingerprint depend on the
+    /// final per-place state — order-insensitive across DISTINCT places, yet correct for
+    /// same-place overwrites (`x=1;x=2` ≠ `x=2;x=1` — last value wins).
     /// The old order-independent effect multiset got BOTH wrong (it split commuting
     /// swaps — false split vs the oracle — and merged same-field overwrites — unsound).
-    field_env: FxHashMap<u64, ValueId>,
+    field_env: FxHashMap<FieldStateKey, ValueId>,
     /// Lazily-computed subtree hash per IL node (kind + payload + children), used to
     /// key unlowered `Raw` constructs and lambda bodies by content. Computed once per
     /// graph (the whole-IL pass is O(n)); `None` until first needed.
@@ -616,13 +621,19 @@ impl<'a> Builder<'a> {
         }
     }
 
-    /// Flush accumulated object-field writes to sinks: one (field-name, final-value)
-    /// sink per distinct field, in canonical name order. See `field_env`.
+    /// Flush accumulated object-field writes to sinks: one (receiver, field-name,
+    /// final-value) sink per distinct place, in canonical place order. See `field_env`.
     fn flush_fields(&mut self) {
-        let mut entries: Vec<(u64, ValueId)> = self.field_env.drain().collect();
-        entries.sort_unstable_by_key(|(k, _)| *k);
-        for (name, v) in entries {
-            let f = self.mk(ValOp::Field(name), vec![v]);
+        let mut entries: Vec<(FieldStateKey, ValueId)> = self.field_env.drain().collect();
+        entries.sort_unstable_by_key(|(key, _)| {
+            (
+                self.vhash[key.receiver as usize],
+                key.field,
+                key.receiver as u64,
+            )
+        });
+        for (key, v) in entries {
+            let f = self.mk(ValOp::Field(key.field), vec![key.receiver, v]);
             self.sinks.push(Sink::new(SinkKind::Effect, f));
         }
     }
@@ -1881,6 +1892,24 @@ impl<'a> Builder<'a> {
     fn emit_throw(&mut self, v: ValueId) {
         let g = self.guarded(v);
         self.sinks.push(Sink::new(SinkKind::Throw, g));
+    }
+
+    fn field_state_key(
+        &mut self,
+        target: NodeId,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<FieldStateKey> {
+        if self.il.kind(target) != NodeKind::Field {
+            return None;
+        }
+        let Payload::Name(field) = self.il.node(target).payload else {
+            return None;
+        };
+        let receiver = self.il.children(target).first().copied()?;
+        Some(FieldStateKey {
+            receiver: self.eval(receiver, env),
+            field: self.interner.symbol_hash(field),
+        })
     }
 
     /// Tag a value with the current path condition: under branch conditions, the
@@ -4022,16 +4051,14 @@ impl<'a> Builder<'a> {
                             return;
                         }
                     }
-                    // A field write (`self.x = v`) updates per-field state (last-write-
-                    // wins), flushed as a (field, final-value) sink later — order-
-                    // insensitive across distinct fields, correct for overwrites.
-                    if self.il.kind(kids[0]) == NodeKind::Field {
-                        if let Payload::Name(s) = self.il.node(kids[0]).payload {
-                            let name = self.interner.symbol_hash(s);
-                            let g = self.guarded(rhs);
-                            self.field_env.insert(name, g);
-                            return;
-                        }
+                    // A field write (`self.x = v`) updates per-place state
+                    // (last-write-wins), flushed as a (receiver, field, final-value) sink
+                    // later — order-insensitive across distinct places, correct for
+                    // same-place overwrites.
+                    if let Some(key) = self.field_state_key(kids[0], env) {
+                        let g = self.guarded(rhs);
+                        self.field_env.insert(key, g);
+                        return;
                     }
                     // `d[k] = v` to an ACTIVE dict-builder records a `DictEntry` contribution
                     // (so the loop becomes a `Map` of entries, converging with `{k:v for x}`).
@@ -7288,8 +7315,14 @@ impl<'a> Builder<'a> {
                         }
                     }
                 }
-                if let Some(&written) = self.field_env.get(&name) {
-                    return written;
+                if a.len() == 1 {
+                    let key = FieldStateKey {
+                        receiver: a[0],
+                        field: name,
+                    };
+                    if let Some(&written) = self.field_env.get(&key) {
+                        return written;
+                    }
                 }
                 self.mk(ValOp::Field(name), a)
             }

--- a/docs/fragment-contracts.md
+++ b/docs/fragment-contracts.md
@@ -84,13 +84,13 @@ obligation — it does not treat every mutation as append-like:
 |---|---|---|
 | `Append` | ordered effect trace (the appended values, in order) | not required |
 | `IndexWrite` | ordered effect trace (key then value) | not required |
-| `FieldWrite` | field-state map, keyed by **field name only** | **required (proven place)** |
+| `FieldWrite` | final field-state map, keyed by **receiver+field place** | **required (proven place)** |
 | `Other` | established by running the fragment | — |
 
-A field write is the one case where the interpreter does **not** observe the receiver (the
-field-state map is keyed by name), so a field write is exact-safe only when its receiver is a
-proven place. This is exactly why a fixed `this` is the only admitted field receiver — not a
-special case, but a consequence of the algebra. The boundary is registered as
+A field write is the one case whose final-state slot is receiver-bearing, so a field write is
+exact-safe only when its receiver resolves to a proven place. This is exactly why a fixed
+`this` is the only admitted field receiver — not a special case, but a consequence of the
+algebra. The boundary is registered as
 [detect.fragment.effect_place](../formal/obligations/detect/fragment/effect_place/Proof.lean);
 free-input extraction and wrapper synthesis are tracked by
 [detect.fragment.free_inputs](../formal/obligations/detect/fragment/free_inputs/Proof.lean)

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -268,11 +268,12 @@ statically selected branches) with
 its handler. Richer exception control flow remains outside the oracle.
 Field writes and reads evaluate their receiver before consulting or updating same-unit
 field state, so receiver errors propagate instead of falling through to a cached field
-value. After that, reads are interpreted only when the same unit has written the field; an
-unwritten field access remains unsupported rather than invented. The value graph follows
-the same boundary:
-`self.x = v; return self.x` resolves the read to `v`, while an unproven field read stays
-field-shaped.
+value. Same-unit field state is keyed by receiver identity plus field name; a write to
+`a.x` can satisfy a later read from `a.x`, but not a read from `b.x`. After that, reads
+are interpreted only when the same unit has written that receiver+field place; an unwritten
+field access remains unsupported rather than invented. The value graph follows the same
+boundary: `self.x = v; return self.x` resolves the read to `v`, while an unproven field
+read stays field-shaped.
 
 Out of scope (sound but not yet convergent, or genuinely hard): tree & mutual recursion
 (multiple / non-tail self-calls); list-tail catamorphisms `head ⊕ f(xs[1:])`, whose slice is

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -157,6 +157,10 @@ and pack ecosystem.
 - Imported immutable literal replacement and exact module-binding gates now share
   stronger mutation evidence for top-level place writes such as
   `LOOKUP[key] = value`, closing importer-side direct-write false exact cases.
+- Value-graph and oracle field state now preserve receiver+field identity instead
+  of caching by field name alone. Same-place readback and distinct-field
+  commutation remain open, while cross-receiver reads/writes with the same field
+  name stay exact-distinct.
 
 ## Phase 0: documentation and vocabulary (landed)
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -88,6 +88,9 @@ migrated.
   non-overloadable C/Go/Java index assignment, and single-item builder append
   calls are now shared through `nose-semantics`; predicate and contract paths
   consume the same IL-level proof helpers.
+- Value-graph and oracle same-unit field state are receiver-aware: a cached write
+  is keyed by receiver/place plus field name, so `a.x = v` can satisfy `a.x`
+  but not `b.x`, and final field-write sinks preserve the receiver identity.
 - Collection reductions such as Rust `Iterator::count()` and Java
   `Stream.count()` are admitted through exact protocol receiver contracts, not
   through a bare method-name check.
@@ -235,8 +238,8 @@ until packs can emit the missing facts.
 
 The first high-value targets for semantic-kernel extraction are:
 
-- field/place identity for field reads and writes, replacing field-name-only
-  state with receiver-aware proof;
+- pack-facing field/place evidence for all field reads and writes, building on
+  the receiver-aware value-graph field state now used for same-unit caching;
 - constructor facts for JS/TS `new Map` and `new Set`, which are now explicit
   closed contracts waiting on construct-vs-call proof;
 - regex literal provenance for JS/TS `.test(...)`;

--- a/formal/lib/Effects.lean
+++ b/formal/lib/Effects.lean
@@ -3,7 +3,7 @@ Shared model for exact-fragment observable effects.
 
 This is a small Lean mirror of `fragment/contract.rs`: append/index effects are
 observed directly by the behavior trace, while field writes need a proven receiver
-place because the interpreter's field-state map is keyed by field name only.
+place because final field state is keyed by receiver+field place.
 -/
 
 namespace NoseFormal.Effects

--- a/formal/obligations/normalize/value_graph/field_writes/Counterexamples.lean
+++ b/formal/obligations/normalize/value_graph/field_writes/Counterexamples.lean
@@ -1,21 +1,21 @@
 /-
-Counterexample for treating same-field writes as order-insensitive.
+Counterexample for treating same-place field writes as order-insensitive.
 -/
 
 namespace NoseFieldWriteCounterexamples
 
-abbrev Field := Nat
+abbrev Place := Nat
 abbrev Value := Int
-abbrev Store := Field → Value
+abbrev Store := Place → Value
 
-def write (field : Field) (value : Value) (store : Store) : Store :=
-  fun current => if current = field then value else store current
+def write (place : Place) (value : Value) (store : Store) : Store :=
+  fun current => if current = place then value else store current
 
-/-- Same-field writes are not commutative; the last value wins. -/
+/-- Same receiver+field-place writes are not commutative; the last value wins. -/
 theorem same_field_write_order_matters :
-    ∃ store field first second,
-      write field second (write field first store)
-        ≠ write field first (write field second store) :=
+    ∃ store place first second,
+      write place second (write place first store)
+        ≠ write place first (write place second store) :=
   ⟨fun _ => 0, 0, 1, 2, by
     intro h
     have pointwise := congrFun h 0

--- a/formal/obligations/normalize/value_graph/field_writes/Proof.lean
+++ b/formal/obligations/normalize/value_graph/field_writes/Proof.lean
@@ -1,28 +1,29 @@
 /-
 Soundness of field-write normalization boundaries.
 
-The interpreter records final field state with last-write-wins semantics. Writes to
-different fields commute in the final state; writes to the same field do not.
+The value graph records final field state per receiver+field place with last-write-wins
+semantics. Writes to different places commute in the final state; writes to the same
+place do not.
 -/
 
 namespace NoseFieldWrites
 
-abbrev Field := Nat
+abbrev Place := Nat
 abbrev Value := Int
-abbrev Store := Field → Value
+abbrev Store := Place → Value
 
-def write (field : Field) (value : Value) (store : Store) : Store :=
-  fun current => if current = field then value else store current
+def write (place : Place) (value : Value) (store : Store) : Store :=
+  fun current => if current = place then value else store current
 
-/-- Two writes to the same field collapse to the last write. -/
-theorem same_field_last_write_wins (store : Store) (field : Field) (first second : Value) :
-    write field second (write field first store) = write field second store := by
+/-- Two writes to the same receiver+field place collapse to the last write. -/
+theorem same_field_last_write_wins (store : Store) (place : Place) (first second : Value) :
+    write place second (write place first store) = write place second store := by
   funext current
-  by_cases h : current = field <;> simp [write, h]
+  by_cases h : current = place <;> simp [write, h]
 
-/-- Writes to different fields commute when only the final field state is observed. -/
+/-- Writes to different receiver+field places commute when only final state is observed. -/
 theorem different_field_writes_commute
-    (store : Store) (left right : Field) (leftValue rightValue : Value)
+    (store : Store) (left right : Place) (leftValue rightValue : Value)
     (distinct : left ≠ right) :
     write left leftValue (write right rightValue store)
       = write right rightValue (write left leftValue store) := by

--- a/formal/obligations/normalize/value_graph/field_writes/meta.toml
+++ b/formal/obligations/normalize/value_graph/field_writes/meta.toml
@@ -1,11 +1,11 @@
 id = "normalize.value_graph.field_writes"
 status = "proven"
 kind = "soundness-boundary"
-summary = "Field writes are interpreted as final field state with last-write-wins semantics."
+summary = "Value-graph field writes are interpreted as final receiver+field state with last-write-wins semantics."
 
 [rust]
 files = ["crates/nose-normalize/src/value_graph.rs", "crates/nose-normalize/src/interp.rs"]
-symbols = ["flush_fields", "field_env"]
+symbols = ["FieldStateKey", "flush_fields", "field_env"]
 
 [lean]
 proof = "Proof.lean"


### PR DESCRIPTION
## Summary
- make value-graph field-state caching and final field sinks receiver-aware instead of keyed by field name alone
- make the interpreter/oracle final field state use receiver+field `FieldKey`, so verification can distinguish `a.x` from `b.x`
- add semantic-scan and value-fingerprint hard negatives for cross-receiver field reads/writes while preserving same-place readback and distinct-field commutation
- update fragment/normalization/semantic-kernel docs and the field-write Lean obligation model

## Why
The latest `main` still admitted a false exact merge: `a.x = 7; return b.x` could share a semantic fingerprint with `a.x = 7; return a.x` because same-unit field state was keyed only by the raw field name. That is an old behavior bug, not a new-kernel regression.

## Verification
- `cargo test -p nose-normalize --lib field`
- `cargo test -p nose-normalize --lib`
- `cargo test -p nose-detect --lib fragment`
- `cargo test -p nose-cli --test cli scan_mode_semantic_rejects_cross_receiver_field_state -- --exact`
- `cargo test -p nose-cli --test equivalence value_graph_`
- temp `nose scan --mode semantic --min-size 1 --min-lines 1 --format json` repro now reports 0 families
- temp `nose verify --max-violations 0` repro reports 0 false merges
- `awiki lint --root docs`
- `python3 scripts/check-formal-obligations.py --self-test`
- `python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`