### PR TITLE
semantics: gate seq surfaces through contracts

### DIFF
--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -8876,6 +8876,16 @@ fn scan_mode_semantic_preserves_js_object_keys() {
         "export function makeParam(name: string, description: string) {\n    return { name, description };\n}\n",
     )
     .unwrap();
+    fs::write(
+        dir.join("object_computed_a.ts"),
+        "const KEY = \"command\";\nexport function computed(command: string, description: string) {\n    return { [KEY]: command, description };\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("object_computed_b.ts"),
+        "const FIELD = \"command\";\nexport function computedOther(cmd: string, desc: string) {\n    return { [FIELD]: cmd, description: desc };\n}\n",
+    )
+    .unwrap();
 
     let semantic = run(&[
         "scan",
@@ -8902,8 +8912,10 @@ fn scan_mode_semantic_preserves_js_object_keys() {
     assert!(
         semantic_text.contains("object_a.ts")
             && semantic_text.contains("object_b.ts")
-            && !semantic_text.contains("object_key_negative.ts"),
-        "semantic mode must preserve object keys: {semantic}"
+            && !semantic_text.contains("object_key_negative.ts")
+            && !semantic_text.contains("object_computed_a.ts")
+            && !semantic_text.contains("object_computed_b.ts"),
+        "semantic mode must preserve static object keys and reject computed-key object contracts: {semantic}"
     );
 
     let _ = fs::remove_dir_all(&dir);

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -584,6 +584,8 @@ fn java_arraylist_add_builder_loop_converges_with_comprehension() {
     let java_build_diff = "import java.util.*;\nclass C { static List<Integer> f(int[] xs) { List<Integer> out = new ArrayList<>(); for (int x : xs) { out.add(x + 1); } return out; } }\n";
     let java_unimported_arraylist = "class C { static Object f(int[] xs) { var out = new ArrayList<Integer>(); for (int x : xs) { out.add(x * x); } return out; } }\n";
     let java_shadowed_arraylist = "import java.util.*;\nclass ArrayList<T> { void add(T value) {} }\nclass C { static ArrayList<Integer> f(int[] xs) { ArrayList<Integer> out = new ArrayList<>(); for (int x : xs) { out.add(x * x); } return out; } }\n";
+    let java_conflicting_arraylist_import = "import other.ArrayList;\nimport java.util.*;\nclass C { static Object f(int[] xs) { var out = new ArrayList<Integer>(); for (int x : xs) { out.add(x * x); } return out; } }\n";
+    let java_conflicting_exact_arraylist_import = "import other.ArrayList;\nimport java.util.ArrayList;\nclass C { static Object f(int[] xs) { var out = new ArrayList<Integer>(); for (int x : xs) { out.add(x * x); } return out; } }\n";
     let comp_fp = value_fp(&i, py_comp, Lang::Python);
     assert_eq!(
         comp_fp,
@@ -609,6 +611,16 @@ fn java_arraylist_add_builder_loop_converges_with_comprehension() {
         comp_fp,
         value_fp(&i, java_shadowed_arraylist, Lang::Java),
         "a local ArrayList type must not mint the java.util empty-list builder seed"
+    );
+    assert_ne!(
+        comp_fp,
+        value_fp(&i, java_conflicting_arraylist_import, Lang::Java),
+        "a conflicting explicit ArrayList import must override java.util wildcard proof"
+    );
+    assert_ne!(
+        comp_fp,
+        value_fp(&i, java_conflicting_exact_arraylist_import, Lang::Java),
+        "a conflicting explicit ArrayList import must close even an exact java.util import proof"
     );
 }
 
@@ -763,6 +775,66 @@ fn go_slice_literal_converges_with_array_but_struct_stays_distinct() {
         list_fp,
         value_fp(&i, go_struct, Lang::Go),
         "a go struct literal must stay distinct from a list (it is a record, not a collection)"
+    );
+}
+
+#[test]
+fn seq_surface_contracts_keep_maps_out_of_collection_membership() {
+    let i = Interner::new();
+    let py_membership = "def f(x):\n    return x in [\"red\", \"blue\"]\n";
+    let go_slice_membership = "package p\nimport \"slices\"\nfunc f(x string) bool { return slices.Contains([]string{\"red\", \"blue\"}, x) }\n";
+    let go_map_as_slice_membership = "package p\nimport \"slices\"\nfunc f(x string) bool { return slices.Contains(map[string]int{\"red\": 0, \"blue\": 0}, x) }\n";
+    let go_zero_map_lookup =
+        "package p\nfunc f(x string) int { return map[string]int{\"red\": 0, \"blue\": 0}[x] }\n";
+    let go_empty_map = "package p\nfunc f() map[string]int { return map[string]int{} }\n";
+    let go_empty_slice = "package p\nfunc f() []int { return []int{} }\n";
+
+    let membership = value_fp(&i, py_membership, Lang::Python);
+    assert_eq!(
+        membership,
+        value_fp(&i, go_slice_membership, Lang::Go),
+        "Go slices.Contains over a slice literal is a proven collection membership"
+    );
+    assert_ne!(
+        membership,
+        value_fp(&i, go_map_as_slice_membership, Lang::Go),
+        "Go map composite literals must not leak into collection membership semantics"
+    );
+    assert_ne!(
+        value_fp(&i, go_zero_map_lookup, Lang::Go),
+        value_fp(&i, go_map_as_slice_membership, Lang::Go),
+        "the supported Go zero-map lookup contract is separate from collection membership"
+    );
+    assert_ne!(
+        value_fp(&i, go_empty_map, Lang::Go),
+        value_fp(&i, go_empty_slice, Lang::Go),
+        "empty Go map literals must not fall back to the empty collection value tag"
+    );
+}
+
+#[test]
+fn js_object_length_and_computed_keys_stay_outside_exact_collection_contracts() {
+    let i = Interner::new();
+    let py_dict_len = "def f():\n    return len({\"length\": 99, \"a\": 0})\n";
+    let js_object_length = "function f() { return ({ length: 99, a: 0 }).length; }";
+    let py_object = "def f():\n    return {\"red\": 1, \"blue\": 2}\n";
+    let js_static_object = "function f() { return { red: 1, blue: 2 }; }";
+    let js_computed_object = "function f(k) { return { [k]: 1, blue: 2 }; }";
+
+    assert_ne!(
+        value_fp(&i, py_dict_len, Lang::Python),
+        value_fp(&i, js_object_length, Lang::JavaScript),
+        "JS object `.length` is a property read, not map/dict cardinality"
+    );
+    assert_eq!(
+        value_fp(&i, py_object, Lang::Python),
+        value_fp(&i, js_static_object, Lang::JavaScript),
+        "static JS object keys remain an exact map/object literal surface"
+    );
+    assert_ne!(
+        value_fp(&i, js_static_object, Lang::JavaScript),
+        value_fp(&i, js_computed_object, Lang::JavaScript),
+        "computed object keys need a future key-evaluation contract before exact map semantics"
     );
 }
 
@@ -2930,6 +3002,8 @@ fn value_graph_reads_field_written_in_unit() {
     let return_value = "def f(self):\n    self.x = 7\n    return 7\n";
     let read_other_receiver = "def f(a, b):\n    a.x = 7\n    return b.x\n";
     let read_written_receiver = "def f(a, b):\n    a.x = 7\n    return a.x\n";
+    let unknown_alias_receiver = "def f(a):\n    r = receiver(a)\n    r.x = 7\n    return a.x\n";
+    let computed_receiver = "def f(a):\n    receiver(a).x = 7\n    return receiver(a).x\n";
     assert_eq!(
         value_fp(&i, read_field, Lang::Python),
         value_fp(&i, return_value, Lang::Python),
@@ -2939,6 +3013,16 @@ fn value_graph_reads_field_written_in_unit() {
         value_fp(&i, read_other_receiver, Lang::Python),
         value_fp(&i, read_written_receiver, Lang::Python),
         "a same-named field write on one receiver must not satisfy a read on another receiver"
+    );
+    assert_ne!(
+        value_fp(&i, unknown_alias_receiver, Lang::Python),
+        value_fp(&i, return_value, Lang::Python),
+        "field-state readback must not assume call-result aliasing without receiver-place proof"
+    );
+    assert_ne!(
+        value_fp(&i, computed_receiver, Lang::Python),
+        value_fp(&i, return_value, Lang::Python),
+        "computed field receivers must not enter same-unit field-state caching"
     );
 }
 
@@ -3608,6 +3692,8 @@ fn collection_membership_set_construction_converges_with_boundaries() {
     let ts_array_some = "function f(value: string, other: string): boolean { return [\"red\", \"blue\"].some((item: string) => item === value); }";
     let js_array_indexof_ne =
         "function f(value, other) { return [\"red\", \"blue\"].indexOf(value) !== -1; }";
+    let js_sequence_indexof_ne =
+        "function f(value, other) { return (\"red\", \"blue\").indexOf(value) !== -1; }";
     let ts_array_indexof_ge = "function f(value: string, other: string): boolean { return [\"red\", \"blue\"].indexOf(value) >= 0; }";
     let js_array_indexof_gt =
         "function f(value, other) { return [\"red\", \"blue\"].indexOf(value) > -1; }";
@@ -3761,6 +3847,11 @@ fn collection_membership_set_construction_converges_with_boundaries() {
     assert_eq!(
         literal_fp,
         value_fp(&i, js_array_indexof_ne, Lang::JavaScript)
+    );
+    assert_ne!(
+        literal_fp,
+        value_fp(&i, js_sequence_indexof_ne, Lang::JavaScript),
+        "JS sequence expressions must not prove static array membership"
     );
     assert_eq!(
         literal_fp,

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -22,9 +22,9 @@ use nose_semantics::{
     js_like_set_constructor_contract, map_get_contract, map_key_view_contract,
     map_key_view_wrapper_contract, method_call_contract, nullish_global_contract,
     regex_test_contract, ruby_set_factory_contract, rust_vec_new_factory_contract, semantics,
-    static_index_membership_contract, typeof_operator_contract, IndexMembershipThreshold,
-    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
-    MethodSemanticContract, StaticIndexMembershipKind,
+    seq_surface_contract, static_index_membership_contract, typeof_operator_contract,
+    IndexMembershipThreshold, JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs,
+    MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -994,7 +994,7 @@ fn strict_exact_static_index_membership_safe(
             strict_exact_static_index_membership_parts(il, interner, facts, kids[0])
         {
             return strict_exact_safe_tree(il, interner, facts, element)
-                && strict_exact_static_non_float_collection(il, collection);
+                && strict_exact_static_non_float_collection(il, interner, collection);
         }
     }
     if strict_exact_index_membership_threshold(il, op, true, kids[0]) {
@@ -1002,7 +1002,7 @@ fn strict_exact_static_index_membership_safe(
             strict_exact_static_index_membership_parts(il, interner, facts, kids[1])
         {
             return strict_exact_safe_tree(il, interner, facts, element)
-                && strict_exact_static_non_float_collection(il, collection);
+                && strict_exact_static_non_float_collection(il, interner, collection);
         }
     }
     false
@@ -1026,7 +1026,7 @@ fn strict_exact_static_index_membership_parts(
     };
     let method = interner.resolve(method);
     let receiver = *il.children(kids[0]).first()?;
-    if !strict_exact_static_non_float_collection(il, receiver) {
+    if !strict_exact_static_non_float_collection(il, interner, receiver) {
         return None;
     }
     let contract = static_index_membership_contract(il.meta.lang, method, kids.len() - 1)?;
@@ -1128,8 +1128,18 @@ fn strict_exact_minus_one_literal(il: &Il, node: NodeId) -> bool {
     kids.len() == 1 && matches!(il.node(kids[0]).payload, Payload::LitInt(1))
 }
 
-fn strict_exact_static_non_float_collection(il: &Il, node: NodeId) -> bool {
+fn strict_exact_static_non_float_collection(il: &Il, interner: &Interner, node: NodeId) -> bool {
     if il.kind(node) != NodeKind::Seq {
+        return false;
+    }
+    let tag = match il.node(node).payload {
+        Payload::None => None,
+        Payload::Name(name) => Some(interner.resolve(name)),
+        _ => return false,
+    };
+    if !seq_surface_contract(il.meta.lang, tag)
+        .is_some_and(|contract| contract.membership_collection)
+    {
         return false;
     }
     let kids = il.children(node);
@@ -1165,26 +1175,12 @@ fn strict_exact_nullish_global_safe(il: &Il, interner: &Interner, node: NodeId) 
 }
 
 fn strict_exact_safe_seq(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    match il.node(node).payload {
-        Payload::None => true,
-        Payload::Name(name) => matches!(
-            interner.resolve(name),
-            "array"
-                | "list"
-                | "tuple"
-                | "dictionary"
-                | "hash"
-                | "array_expression"
-                | "tuple_expression"
-                | "object"
-                | "pair"
-                | "import_binding"
-                | "import_namespace"
-                | "own_property_guard"
-                | "record_guard"
-        ),
-        _ => false,
-    }
+    let tag = match il.node(node).payload {
+        Payload::None => None,
+        Payload::Name(name) => Some(interner.resolve(name)),
+        _ => return false,
+    };
+    seq_surface_contract(il.meta.lang, tag).is_some_and(|contract| contract.exact_tree_safe)
 }
 
 fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, node: NodeId) -> bool {
@@ -1792,14 +1788,13 @@ fn strict_exact_membership_collection_safe(
         }
         return strict_exact_safe_tree(il, interner, facts, node);
     }
-    let tag_safe = match il.node(node).payload {
-        Payload::None => true,
-        Payload::Name(name) => matches!(
-            interner.resolve(name),
-            "array" | "list" | "array_expression" | "composite_literal"
-        ),
-        _ => false,
+    let tag = match il.node(node).payload {
+        Payload::None => None,
+        Payload::Name(name) => Some(interner.resolve(name)),
+        _ => return false,
     };
+    let tag_safe = seq_surface_contract(il.meta.lang, tag)
+        .is_some_and(|contract| contract.membership_collection);
     tag_safe
         && il
             .children(node)
@@ -2348,10 +2343,9 @@ fn strict_exact_map_entries_safe(
     let Payload::Name(name) = il.node(node).payload else {
         return false;
     };
-    if !matches!(
-        interner.resolve(name),
-        "array" | "list" | "array_expression"
-    ) {
+    if !seq_surface_contract(il.meta.lang, Some(interner.resolve(name)))
+        .is_some_and(|contract| contract.map_entry_list)
+    {
         return false;
     }
     il.children(node).iter().all(|&entry| {
@@ -3270,9 +3264,9 @@ fn exact_index_assignment_fragment_root(il: &Il, node: NodeId) -> bool {
     exact_non_overloadable_index_assignment(il, node)
 }
 
-// Field-write fingerprints intentionally model final self-field state without a receiver
-// coordinate. Expose only Java's fixed `this.field = ...`; arbitrary receivers such as
-// `other.field = ...` need a receiver-aware proof fact before they can be exact fragments.
+// Field-write fingerprints model final receiver+field state. Expose only Java's fixed
+// `this.field = ...`; arbitrary receivers such as `other.field = ...` need a
+// receiver-place proof fact before they can be exact fragments.
 fn exact_self_field_assignment_fragment_root(il: &Il, interner: &Interner, node: NodeId) -> bool {
     if !semantics(il.meta.lang)
         .exact_fragments()

--- a/crates/nose-frontend/src/go.rs
+++ b/crates/nose-frontend/src/go.rs
@@ -425,7 +425,8 @@ fn lower_for(lo: &mut Lowering, node: TsNode) -> NodeId {
                         span,
                         &[iter],
                     );
-                    lo.add(NodeKind::Seq, Payload::None, span, &vars)
+                    let tag = lo.sym("tuple");
+                    lo.add(NodeKind::Seq, Payload::Name(tag), span, &vars)
                 }
                 Some(l) => lower_expr(lo, range_value_var(l)),
                 None => lo.empty_block(span),

--- a/crates/nose-frontend/src/java.rs
+++ b/crates/nose-frontend/src/java.rs
@@ -736,7 +736,7 @@ fn lower_empty_java_collection_constructor(
     if uses_simple_type {
         let root = java_root(node);
         if contract.requires_import_for_simple_type
-            && !java_tree_imports_type(lo, root, contract.module, contract.simple_type)
+            && !java_tree_resolves_simple_type(lo, root, contract.module, contract.simple_type)
         {
             return None;
         }
@@ -770,19 +770,64 @@ fn java_root(mut node: TsNode) -> TsNode {
     node
 }
 
-fn java_tree_imports_type(lo: &Lowering, node: TsNode, module: &str, simple_type: &str) -> bool {
+fn java_tree_resolves_simple_type(
+    lo: &Lowering,
+    node: TsNode,
+    module: &str,
+    simple_type: &str,
+) -> bool {
+    let mut saw_wildcard = false;
+    let mut saw_exact = false;
+    let mut saw_conflict = false;
+    java_tree_import_resolution(
+        lo,
+        node,
+        module,
+        simple_type,
+        &mut saw_wildcard,
+        &mut saw_exact,
+        &mut saw_conflict,
+    );
+    (saw_exact || saw_wildcard) && !saw_conflict
+}
+
+fn java_tree_import_resolution(
+    lo: &Lowering,
+    node: TsNode,
+    module: &str,
+    simple_type: &str,
+    saw_wildcard: &mut bool,
+    saw_exact: &mut bool,
+    saw_conflict: &mut bool,
+) {
     if node.kind() == "import_declaration" {
         let compact: String = lo
             .text(node)
             .chars()
             .filter(|c| !c.is_whitespace())
             .collect();
-        return compact == format!("import{module}.{simple_type};")
-            || compact == format!("import{module}.*;");
+        let exact = format!("import{module}.{simple_type};");
+        let wildcard = format!("import{module}.*;");
+        if compact == exact {
+            *saw_exact = true;
+        } else if compact == wildcard {
+            *saw_wildcard = true;
+        } else if compact.starts_with("import") && compact.ends_with(&format!(".{simple_type};")) {
+            *saw_conflict = true;
+        }
+        return;
     }
-    Lowering::named_children(node)
-        .into_iter()
-        .any(|child| java_tree_imports_type(lo, child, module, simple_type))
+    for child in Lowering::named_children(node) {
+        java_tree_import_resolution(
+            lo,
+            child,
+            module,
+            simple_type,
+            saw_wildcard,
+            saw_exact,
+            saw_conflict,
+        );
+    }
 }
 
 fn java_tree_declares_type(lo: &Lowering, node: TsNode, simple_type: &str) -> bool {

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -1589,7 +1589,7 @@ fn lower_object_pair(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
     let key = node
         .child_by_field_name("key")
-        .map(|x| lo.str_lit(lo.text(x), lo.span(x)))
+        .map(|x| lower_object_pair_key(lo, x))
         .unwrap_or_else(|| lo.empty_block(span));
     let value = node
         .child_by_field_name("value")
@@ -1597,6 +1597,27 @@ fn lower_object_pair(lo: &mut Lowering, node: TsNode) -> NodeId {
         .unwrap_or_else(|| lo.empty_block(span));
     let tag = lo.sym("pair");
     lo.add(NodeKind::Seq, Payload::Name(tag), span, &[key, value])
+}
+
+fn lower_object_pair_key(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    if let Some(key) = static_object_property_key(lo, node) {
+        return lo.str_lit(&key, span);
+    }
+    let inner: Vec<NodeId> = Lowering::named_children(node)
+        .into_iter()
+        .map(|c| lower_expr(lo, c))
+        .collect();
+    lo.raw(node.kind(), span, &inner)
+}
+
+fn static_object_property_key(lo: &Lowering, node: TsNode) -> Option<String> {
+    match node.kind() {
+        "property_identifier" | "identifier" => Some(lo.text(node).to_string()),
+        "string" => static_string_key(lo, node),
+        "number" => Some(lo.text(node).to_string()),
+        _ => None,
+    }
 }
 
 fn lower_object_shorthand(lo: &mut Lowering, node: TsNode) -> NodeId {

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -290,7 +290,7 @@ fn imported_literal_export_safe(il: &Il, interner: &Interner, node: NodeId) -> b
             let Payload::Name(tag) = il.node(node).payload else {
                 return false;
             };
-            if !nose_semantics::imported_literal_seq_tag_safe(interner.resolve(tag)) {
+            if !nose_semantics::imported_literal_seq_tag_safe(il.meta.lang, interner.resolve(tag)) {
                 return false;
             }
             il.children(node)

--- a/crates/nose-normalize/src/desugar.rs
+++ b/crates/nose-normalize/src/desugar.rs
@@ -14,7 +14,7 @@
 use crate::idioms::{canon_call, CallCanon};
 use crate::NormalizeOptions;
 use nose_il::{Il, IlBuilder, Interner, LoopKind, NodeId, NodeKind, Payload};
-use nose_semantics::{domain_evidence_from_param_semantic, DomainEvidence};
+use nose_semantics::{domain_evidence_from_param_semantic, seq_surface_contract, DomainEvidence};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 pub(crate) fn run(old: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il {
@@ -266,10 +266,22 @@ impl Rebuilder<'_> {
 }
 
 fn property_receiver_exact_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    il.kind(node) == NodeKind::Seq
+    seq_receiver_exact_collection_safe(il, interner, node)
         || domain_evidence_for_var(il, node).is_some_and(DomainEvidence::is_array_or_collection)
         || property_receiver_exact_hof_node(il, interner, node)
         || property_receiver_exact_hof_call(il, interner, node)
+}
+
+fn seq_receiver_exact_collection_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    if il.kind(node) != NodeKind::Seq {
+        return false;
+    }
+    let tag = match il.node(node).payload {
+        Payload::None => None,
+        Payload::Name(name) => Some(interner.resolve(name)),
+        _ => return false,
+    };
+    seq_surface_contract(il.meta.lang, tag).is_some_and(|contract| contract.membership_collection)
 }
 
 fn domain_evidence_for_var(il: &Il, node: NodeId) -> Option<DomainEvidence> {

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -12,8 +12,9 @@ use nose_semantics::{
     domain_evidence_from_param_semantic, free_function_builtin_contract,
     iterator_identity_adapter_contract, map_get_contract, map_key_view_contract,
     method_call_contract, method_hof_contract, rust_option_some_constructor_contract,
-    static_collection_adapter_contract, BuiltinArgContract, DomainEvidence, MapKeyViewKind,
-    MethodBuiltinArgs, MethodCallContract, MethodReceiverContract, MethodSemanticContract,
+    seq_surface_contract, static_collection_adapter_contract, BuiltinArgContract, DomainEvidence,
+    MapKeyViewKind, MethodBuiltinArgs, MethodCallContract, MethodReceiverContract,
+    MethodSemanticContract,
 };
 
 /// The result of inspecting a `Call`: it canonicalizes to a builtin, to a
@@ -627,14 +628,12 @@ fn exact_collection_literal(old: &Il, interner: &Interner, node: NodeId) -> bool
     if old.kind(node) != NodeKind::Seq {
         return false;
     }
-    match old.node(node).payload {
-        Payload::None => true,
-        Payload::Name(name) => matches!(
-            interner.resolve(name),
-            "array" | "array_expression" | "list" | "tuple" | "tuple_expression"
-        ),
-        _ => false,
-    }
+    let tag = match old.node(node).payload {
+        Payload::None => None,
+        Payload::Name(name) => Some(interner.resolve(name)),
+        _ => return false,
+    };
+    seq_surface_contract(old.meta.lang, tag).is_some_and(|contract| contract.membership_collection)
 }
 
 fn exact_option_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
@@ -1071,7 +1070,12 @@ mod tests {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
         let receiver = if literal_receiver {
-            b.add(NodeKind::Seq, Payload::None, sp(), &[])
+            b.add(
+                NodeKind::Seq,
+                Payload::Name(interner.intern("array")),
+                sp(),
+                &[],
+            )
         } else {
             b.add(
                 NodeKind::Var,
@@ -1114,7 +1118,12 @@ mod tests {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
         let receiver = if literal_receiver {
-            b.add(NodeKind::Seq, Payload::None, sp(), &[])
+            b.add(
+                NodeKind::Seq,
+                Payload::Name(interner.intern("array")),
+                sp(),
+                &[],
+            )
         } else {
             b.add(
                 NodeKind::Var,
@@ -1152,7 +1161,12 @@ mod tests {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
         let receiver = if literal_receiver {
-            b.add(NodeKind::Seq, Payload::None, sp(), &[])
+            b.add(
+                NodeKind::Seq,
+                Payload::Name(interner.intern("array")),
+                sp(),
+                &[],
+            )
         } else {
             b.add(
                 NodeKind::Var,
@@ -1168,7 +1182,12 @@ mod tests {
             &[receiver],
         );
         let arg = if literal_arg {
-            b.add(NodeKind::Seq, Payload::None, sp(), &[])
+            b.add(
+                NodeKind::Seq,
+                Payload::Name(interner.intern("array")),
+                sp(),
+                &[],
+            )
         } else {
             b.add(
                 NodeKind::Var,

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -58,11 +58,14 @@ use nose_semantics::{
     nullish_global_contract, reduction_builtin_contract, ruby_set_factory_contract_by_hash,
     rust_option_and_then_contract, rust_option_none_sentinel_contract,
     rust_option_some_constructor_contract, rust_vec_new_factory_contract,
-    scalar_integer_method_contract, semantics, static_index_membership_contract,
-    BuiltinArgContract, DomainEvidence, GoZeroMapDefaultKind, ImportedNamespaceFunctionSemantic,
-    IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind, MapKeyViewKind,
-    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract,
-    ScalarIntegerMethod, StaticIndexMembershipKind,
+    scalar_integer_method_contract, semantics, seq_surface_contract,
+    static_index_membership_contract, BuiltinArgContract, DomainEvidence, GoZeroMapDefaultKind,
+    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
+    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
+    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract,
+    StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_IMPORT_BINDING,
+    SEQ_VALUE_IMPORT_NAMESPACE, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR,
+    SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -832,6 +835,10 @@ impl<'a> Builder<'a> {
 
     fn free_name_input_key(&self, name: &str) -> u32 {
         let sym = self.interner.intern(name);
+        self.free_name_key(sym)
+    }
+
+    fn free_name_key(&self, sym: Symbol) -> u32 {
         0x8000_0000u32 | (self.interner.symbol_hash(sym) as u32)
     }
 
@@ -842,7 +849,8 @@ impl<'a> Builder<'a> {
         )
     }
 
-    /// Shared skeleton of the collection-factory recognizers: a `Call(0, [callee, Seq(1)])`
+    /// Shared skeleton of the collection-factory recognizers: a collection sequence literal
+    /// call `Call(0, [callee, Seq(collection)])`
     /// whose `callee` passes `is_factory` wraps the sequence literal `args[1]`; return it. The
     /// per-language recognizers differ ONLY in their callee predicate, so this collapses the
     /// identical skeletons that nose's own duplication gate flagged across them.
@@ -856,7 +864,10 @@ impl<'a> Builder<'a> {
             return None;
         }
         let (callee, seq) = (node.args[0], node.args[1]);
-        if !matches!(self.nodes[seq as usize].op, ValOp::Seq(1)) {
+        if !matches!(
+            self.nodes[seq as usize].op,
+            ValOp::Seq(SEQ_VALUE_COLLECTION)
+        ) {
             return None;
         }
         is_factory(self, callee).then_some(seq)
@@ -950,7 +961,7 @@ impl<'a> Builder<'a> {
             }
             return None;
         }
-        Some(self.mk(ValOp::Seq(1), args[1..].to_vec()))
+        Some(self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), args[1..].to_vec()))
     }
 
     fn proven_ruby_set_factory_value(&self, value: ValueId) -> Option<ValueId> {
@@ -986,7 +997,7 @@ impl<'a> Builder<'a> {
         if !self.is_free_name_value(args[0], "vec") || self.file_defines_name("vec") {
             return None;
         }
-        Some(self.mk(ValOp::Seq(1), args[1..].to_vec()))
+        Some(self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), args[1..].to_vec()))
     }
 
     fn is_imported_java_util_name(&self, value: ValueId, name: &str) -> bool {
@@ -1006,7 +1017,7 @@ impl<'a> Builder<'a> {
 
     fn is_import_namespace_value(&self, value: ValueId, module: &str) -> bool {
         let node = &self.nodes[value as usize];
-        if !matches!(node.op, ValOp::Seq(6)) || node.args.len() != 1 {
+        if !matches!(node.op, ValOp::Seq(SEQ_VALUE_IMPORT_NAMESPACE)) || node.args.len() != 1 {
             return false;
         }
         matches!(
@@ -1017,7 +1028,7 @@ impl<'a> Builder<'a> {
 
     fn is_import_binding_value(&self, value: ValueId, module: &str, exported: &str) -> bool {
         let node = &self.nodes[value as usize];
-        if !matches!(node.op, ValOp::Seq(5)) || node.args.len() != 2 {
+        if !matches!(node.op, ValOp::Seq(SEQ_VALUE_IMPORT_BINDING)) || node.args.len() != 2 {
             return false;
         }
         matches!(
@@ -1150,17 +1161,23 @@ impl<'a> Builder<'a> {
     }
 
     fn proven_collection_value(&mut self, value: ValueId) -> Option<ValueId> {
-        if matches!(self.nodes[value as usize].op, ValOp::Seq(1)) {
+        if matches!(
+            self.nodes[value as usize].op,
+            ValOp::Seq(SEQ_VALUE_COLLECTION)
+        ) {
             return Some(value);
         }
-        if matches!(self.nodes[value as usize].op, ValOp::Seq(2))
+        if matches!(self.nodes[value as usize].op, ValOp::Seq(SEQ_VALUE_TUPLE))
             || (semantics(self.il.meta.lang)
                 .collections()
                 .empty_sequence_is_collection()
-                && matches!(self.nodes[value as usize].op, ValOp::Seq(0)))
+                && matches!(
+                    self.nodes[value as usize].op,
+                    ValOp::Seq(SEQ_VALUE_UNTAGGED)
+                ))
         {
             let items = self.nodes[value as usize].args.clone();
-            return Some(self.mk(ValOp::Seq(1), items));
+            return Some(self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), items));
         }
         self.proven_free_name_collection_factory(value)
             .or_else(|| self.proven_java_collection_factory_value(value))
@@ -1271,7 +1288,10 @@ impl<'a> Builder<'a> {
             return None;
         }
         let (callee, seq) = (node.args[0], node.args[1]);
-        if !matches!(self.nodes[seq as usize].op, ValOp::Seq(1)) {
+        if !matches!(
+            self.nodes[seq as usize].op,
+            ValOp::Seq(SEQ_VALUE_COLLECTION)
+        ) {
             return None;
         }
         let entry_tag = semantics(self.il.meta.lang)
@@ -1287,9 +1307,8 @@ impl<'a> Builder<'a> {
         self.map_factory_from_seq(seq, entry_tag)
     }
 
-    /// Canonicalize a `Seq(1)` of 2-element entries (each a `Seq(entry_tag)` of `[key, value]`) to
-    /// the canonical map shape `Seq(3)` of `Seq(4)` pairs. Shared by the free-name and (entry-wise)
-    /// other map factories.
+    /// Canonicalize a collection sequence of 2-element entries to the canonical map shape.
+    /// Shared by the free-name and (entry-wise) other map factories.
     fn map_factory_from_seq(&mut self, seq: ValueId, entry_tag: u64) -> Option<ValueId> {
         let entries = self.nodes[seq as usize].args.clone();
         let mut canonical_entries = Vec::with_capacity(entries.len());
@@ -1301,9 +1320,9 @@ impl<'a> Builder<'a> {
                 return None;
             }
             let kv = entry_node.args.clone();
-            canonical_entries.push(self.mk(ValOp::Seq(4), kv));
+            canonical_entries.push(self.mk(ValOp::Seq(SEQ_VALUE_PAIR), kv));
         }
-        Some(self.mk(ValOp::Seq(3), canonical_entries))
+        Some(self.mk(ValOp::Seq(SEQ_VALUE_MAP), canonical_entries))
     }
 
     fn proven_java_map_factory_entries(&mut self, value: ValueId) -> Option<ValueId> {
@@ -1333,17 +1352,17 @@ impl<'a> Builder<'a> {
             }
             let mut canonical_entries = Vec::with_capacity(entries.len() / 2);
             for kv in entries.chunks(2) {
-                canonical_entries.push(self.mk(ValOp::Seq(4), kv.to_vec()));
+                canonical_entries.push(self.mk(ValOp::Seq(SEQ_VALUE_PAIR), kv.to_vec()));
             }
-            return Some(self.mk(ValOp::Seq(3), canonical_entries));
+            return Some(self.mk(ValOp::Seq(SEQ_VALUE_MAP), canonical_entries));
         }
         if contract.kind == JavaMapFactoryKind::OfEntries {
             let mut canonical_entries = Vec::with_capacity(args.len().saturating_sub(1));
             for entry in args.iter().skip(1).copied() {
                 let kv = self.proven_java_map_entry_pair(entry)?;
-                canonical_entries.push(self.mk(ValOp::Seq(4), kv));
+                canonical_entries.push(self.mk(ValOp::Seq(SEQ_VALUE_PAIR), kv));
             }
-            return Some(self.mk(ValOp::Seq(3), canonical_entries));
+            return Some(self.mk(ValOp::Seq(SEQ_VALUE_MAP), canonical_entries));
         }
         None
     }
@@ -1430,9 +1449,10 @@ impl<'a> Builder<'a> {
             {
                 return None;
             }
-            canonical_entries.push(self.mk(ValOp::Seq(4), entry_value_node.args.clone()));
+            canonical_entries
+                .push(self.mk(ValOp::Seq(SEQ_VALUE_PAIR), entry_value_node.args.clone()));
         }
-        let map = self.mk(ValOp::Seq(3), canonical_entries);
+        let map = self.mk(ValOp::Seq(SEQ_VALUE_MAP), canonical_entries);
         Some(self.mk(
             ValOp::Seq(stable_symbol_hash(contract.canonical_value_tag)),
             vec![default?, map],
@@ -1454,7 +1474,7 @@ impl<'a> Builder<'a> {
     }
 
     fn proven_map_value(&mut self, value: ValueId) -> Option<ValueId> {
-        if matches!(self.nodes[value as usize].op, ValOp::Seq(3)) {
+        if matches!(self.nodes[value as usize].op, ValOp::Seq(SEQ_VALUE_MAP)) {
             return Some(value);
         }
         self.proven_free_name_map_factory(value)
@@ -1894,11 +1914,7 @@ impl<'a> Builder<'a> {
         self.sinks.push(Sink::new(SinkKind::Throw, g));
     }
 
-    fn field_state_key(
-        &mut self,
-        target: NodeId,
-        env: &FxHashMap<u32, ValueId>,
-    ) -> Option<FieldStateKey> {
+    fn field_state_key(&mut self, target: NodeId) -> Option<FieldStateKey> {
         if self.il.kind(target) != NodeKind::Field {
             return None;
         }
@@ -1906,10 +1922,64 @@ impl<'a> Builder<'a> {
             return None;
         };
         let receiver = self.il.children(target).first().copied()?;
+        let receiver = self.field_place_value(receiver)?;
         Some(FieldStateKey {
-            receiver: self.eval(receiver, env),
+            receiver,
             field: self.interner.symbol_hash(field),
         })
+    }
+
+    fn field_place_value(&mut self, node: NodeId) -> Option<ValueId> {
+        match self.il.kind(node) {
+            NodeKind::Var => self.var_place_value(node),
+            NodeKind::Field => {
+                let receiver = self.il.children(node).first().copied()?;
+                let receiver = self.field_place_value(receiver)?;
+                let Payload::Name(field) = self.il.node(node).payload else {
+                    return None;
+                };
+                Some(self.mk(
+                    ValOp::Field(self.interner.symbol_hash(field)),
+                    vec![receiver],
+                ))
+            }
+            NodeKind::Index => {
+                let kids = self.il.children(node);
+                let receiver = kids.first().copied()?;
+                let receiver = self.field_place_value(receiver)?;
+                let key = kids
+                    .get(1)
+                    .and_then(|&key| self.field_place_key_value(key))?;
+                Some(self.mk(ValOp::Index, vec![receiver, key]))
+            }
+            _ => None,
+        }
+    }
+
+    fn var_place_value(&mut self, node: NodeId) -> Option<ValueId> {
+        match self.il.node(node).payload {
+            Payload::Cid(cid) => Some(self.mk(ValOp::Input(cid), vec![])),
+            Payload::Name(name) => Some(self.mk(ValOp::Input(self.free_name_key(name)), vec![])),
+            _ => None,
+        }
+    }
+
+    fn field_place_key_value(&mut self, node: NodeId) -> Option<ValueId> {
+        match self.il.node(node).payload {
+            Payload::LitInt(value) => Some(self.mk(
+                ValOp::Const(0x1000_0000u32.wrapping_add(value as u32)),
+                vec![],
+            )),
+            Payload::LitStr(hash) => Some(self.mk(
+                ValOp::Const(0x2000_0000u32.wrapping_add(hash as u32)),
+                vec![],
+            )),
+            Payload::Name(name) => Some(self.mk(ValOp::Input(self.free_name_key(name)), vec![])),
+            Payload::Cid(cid) if self.il.kind(node) == NodeKind::Var => {
+                Some(self.mk(ValOp::Input(cid), vec![]))
+            }
+            _ => None,
+        }
     }
 
     /// Tag a value with the current path condition: under branch conditions, the
@@ -4055,7 +4125,7 @@ impl<'a> Builder<'a> {
                     // (last-write-wins), flushed as a (receiver, field, final-value) sink
                     // later — order-insensitive across distinct places, correct for
                     // same-place overwrites.
-                    if let Some(key) = self.field_state_key(kids[0], env) {
+                    if let Some(key) = self.field_state_key(kids[0]) {
                         let g = self.guarded(rhs);
                         self.field_env.insert(key, g);
                         return;
@@ -5529,7 +5599,7 @@ impl<'a> Builder<'a> {
         }
         items.sort_by_key(|&v| (self.vhash[v as usize], v));
         items.dedup();
-        let collection = self.mk(ValOp::Seq(1), items);
+        let collection = self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), items);
         Some(self.mk(ValOp::Bin(Op::In as u32), vec![element?, collection]))
     }
 
@@ -5560,7 +5630,7 @@ impl<'a> Builder<'a> {
             ValOp::Bin(op) if op == Op::In as u32 && node.args.len() == 2 => {
                 let candidate = node.args[0];
                 let collection = &self.nodes[node.args[1] as usize];
-                if !matches!(collection.op, ValOp::Seq(1))
+                if !matches!(collection.op, ValOp::Seq(SEQ_VALUE_COLLECTION))
                     || !collection
                         .args
                         .iter()
@@ -6330,14 +6400,14 @@ impl<'a> Builder<'a> {
 
     fn is_static_membership_collection(&self, value: ValueId) -> bool {
         let node = &self.nodes[value as usize];
-        matches!(node.op, ValOp::Seq(1)) && !node.args.is_empty()
+        matches!(node.op, ValOp::Seq(SEQ_VALUE_COLLECTION)) && !node.args.is_empty()
     }
 
     fn own_property_condition(&self, cond: ValueId) -> Option<(ValueId, ValueId, bool)> {
         let parse = |node: &ValNode| {
-            if matches!(node.op, ValOp::Seq(OWN_PROPERTY_GUARD_SEQ_TAG)) && node.args.len() == 4 {
+            if matches!(node.op, ValOp::Seq(SEQ_VALUE_OWN_PROPERTY_GUARD)) && node.args.len() == 4 {
                 let map = node.args[0];
-                if !matches!(self.nodes[map as usize].op, ValOp::Seq(3)) {
+                if !matches!(self.nodes[map as usize].op, ValOp::Seq(SEQ_VALUE_MAP)) {
                     return None;
                 }
                 return Some((node.args[1], map, false));
@@ -6394,34 +6464,47 @@ impl<'a> Builder<'a> {
             let value = self.eval(collection, env);
             return self.mk(ValOp::CollectionParam, vec![value]);
         }
-        if self.il.kind(collection) != NodeKind::Seq {
+        if self.il.kind(collection) == NodeKind::Seq {
+            if self
+                .seq_surface(collection)
+                .is_some_and(|contract| contract.membership_collection)
+            {
+                let kids = self.il.children(collection).to_vec();
+                let mut items: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+                items.sort_by_key(|&v| (self.vhash[v as usize], v));
+                items.dedup();
+                return self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), items);
+            }
             let value = self.eval(collection, env);
-            let collection = self
-                .proven_collection_value(value)
-                .or_else(|| self.proven_local_collection_binding_value(collection, env))
-                .unwrap_or(value);
-            return self.canonical_membership_collection_value(collection);
+            return self.canonical_membership_collection_value(value);
         }
-        let kids = self.il.children(collection).to_vec();
-        let mut items: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
-        items.sort_by_key(|&v| (self.vhash[v as usize], v));
-        items.dedup();
-        self.mk(ValOp::Seq(1), items)
+        let value = self.eval(collection, env);
+        let collection = self
+            .proven_collection_value(value)
+            .or_else(|| self.proven_local_collection_binding_value(collection, env))
+            .unwrap_or(value);
+        self.canonical_membership_collection_value(collection)
     }
 
     fn canonical_membership_collection_value(&mut self, value: ValueId) -> ValueId {
         let node = &self.nodes[value as usize];
-        if !matches!(node.op, ValOp::Seq(1)) {
+        if !matches!(node.op, ValOp::Seq(SEQ_VALUE_COLLECTION)) {
             return value;
         }
         let mut items = node.args.clone();
         items.sort_by_key(|&v| (self.vhash[v as usize], v));
         items.dedup();
-        self.mk(ValOp::Seq(1), items)
+        self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), items)
     }
 
     fn is_static_non_float_collection_expr(&self, collection: NodeId) -> bool {
         if self.il.kind(collection) != NodeKind::Seq {
+            return false;
+        }
+        if !self
+            .seq_surface(collection)
+            .is_some_and(|contract| contract.membership_collection)
+        {
             return false;
         }
         let kids = self.il.children(collection);
@@ -6443,13 +6526,7 @@ impl<'a> Builder<'a> {
         collection: NodeId,
         env: &FxHashMap<u32, ValueId>,
     ) -> ValueId {
-        let value = if self.il.kind(collection) == NodeKind::Seq {
-            let kids = self.il.children(collection).to_vec();
-            let entries: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
-            self.mk(ValOp::Seq(3), entries)
-        } else {
-            self.eval(collection, env)
-        };
+        let value = self.eval(collection, env);
         self.proven_map_value(value).unwrap_or(value)
     }
 
@@ -7139,8 +7216,7 @@ impl<'a> Builder<'a> {
                             return self.null_const();
                         }
                     }
-                    let key = 0x8000_0000u32 | (self.interner.symbol_hash(s) as u32);
-                    self.mk(ValOp::Input(key), vec![])
+                    self.mk(ValOp::Input(self.free_name_key(s)), vec![])
                 }
                 _ => self.fresh_opaque(),
             },
@@ -7305,20 +7381,22 @@ impl<'a> Builder<'a> {
                             }
                         }
                         let receiver = &self.nodes[a[0] as usize];
-                        if matches!(receiver.op, ValOp::Seq(6)) && receiver.args.len() == 1 {
+                        if matches!(receiver.op, ValOp::Seq(SEQ_VALUE_IMPORT_NAMESPACE))
+                            && receiver.args.len() == 1
+                        {
                             let module = receiver.args[0];
                             let exported = self.mk(
                                 ValOp::Const(stable_string_const_key(self.interner.resolve(s))),
                                 vec![],
                             );
-                            return self.mk(ValOp::Seq(5), vec![module, exported]);
+                            return self
+                                .mk(ValOp::Seq(SEQ_VALUE_IMPORT_BINDING), vec![module, exported]);
                         }
                     }
                 }
                 if a.len() == 1 {
-                    let key = FieldStateKey {
-                        receiver: a[0],
-                        field: name,
+                    let Some(key) = self.field_state_key(expr) else {
+                        return self.mk(ValOp::Field(name), a);
                     };
                     if let Some(&written) = self.field_env.get(&key) {
                         return written;
@@ -7424,7 +7502,7 @@ impl<'a> Builder<'a> {
                     return r;
                 }
                 if kids.len() == 1 && self.is_rust_vec_new_call(kids[0]) {
-                    return self.mk(ValOp::Seq(1), vec![]);
+                    return self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), vec![]);
                 }
                 if let Some(v) = self.eval_iterator_identity_adapter(&kids, env) {
                     return v;
@@ -7728,19 +7806,20 @@ impl<'a> Builder<'a> {
     }
 
     fn seq_tag(&self, node: NodeId) -> u64 {
+        match (self.seq_surface(node), self.il.node(node).payload) {
+            (Some(contract), _) => contract.value_tag,
+            (None, Payload::Name(s)) => self.interner.symbol_hash(s),
+            _ => SEQ_VALUE_UNTAGGED,
+        }
+    }
+
+    fn seq_surface(&self, node: NodeId) -> Option<SeqSurfaceContract> {
         match self.il.node(node).payload {
-            Payload::Name(s) => match self.interner.resolve(s) {
-                "array" | "list" | "array_expression" | "composite_literal" => 1,
-                "tuple" | "tuple_expression" => 2,
-                "object" | "dictionary" | "hash" => 3,
-                "pair" => 4,
-                "import_binding" => 5,
-                "import_namespace" => 6,
-                "record_guard" => 7,
-                "own_property_guard" => OWN_PROPERTY_GUARD_SEQ_TAG,
-                _ => self.interner.symbol_hash(s),
-            },
-            _ => 0,
+            Payload::None => seq_surface_contract(self.il.meta.lang, None),
+            Payload::Name(s) => {
+                seq_surface_contract(self.il.meta.lang, Some(self.interner.resolve(s)))
+            }
+            _ => None,
         }
     }
 }
@@ -8008,7 +8087,6 @@ const MAX_CODE: u32 = 0x32A;
 const JS_PROTOTYPE_IN_CODE: u32 = 0x4A53_494E;
 const C_U16_BE_BYTE_PACK_CODE: u32 = 0x4331_3642;
 const C_U32_BE_BYTE_PACK_CODE: u32 = 0x4333_3242;
-const OWN_PROPERTY_GUARD_SEQ_TAG: u64 = 8;
 const EFFECT_ORDINAL_SINK_TAG: u64 = 0xEFFE_C701;
 
 /// A selection reduction (min/max) keeps no additive/multiplicative identity, so its

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -116,6 +116,130 @@ pub fn domain_evidence_from_param_semantic(semantic: ParamSemantic) -> DomainEvi
     DomainEvidence::from_param_semantic(semantic)
 }
 
+pub const SEQ_VALUE_UNTAGGED: u64 = 0;
+pub const SEQ_VALUE_COLLECTION: u64 = 1;
+pub const SEQ_VALUE_TUPLE: u64 = 2;
+pub const SEQ_VALUE_MAP: u64 = 3;
+pub const SEQ_VALUE_PAIR: u64 = 4;
+pub const SEQ_VALUE_IMPORT_BINDING: u64 = 5;
+pub const SEQ_VALUE_IMPORT_NAMESPACE: u64 = 6;
+pub const SEQ_VALUE_RECORD_GUARD: u64 = 7;
+pub const SEQ_VALUE_OWN_PROPERTY_GUARD: u64 = 8;
+
+/// Kernel contract for a lowered `Seq` surface tag.
+///
+/// This is deliberately not just a value-graph tag table. The same surface may be
+/// exact-safe as a literal, admissible as a membership collection, exportable as an
+/// immutable module literal, or none of those. Keeping the axes separate prevents a
+/// frontend tag such as Go's `composite_literal` from silently becoming a collection
+/// merely because it is represented as `Seq` in IL.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct SeqSurfaceContract {
+    pub value_tag: u64,
+    pub exact_tree_safe: bool,
+    pub membership_collection: bool,
+    pub map_entry_list: bool,
+    pub imported_literal: bool,
+}
+
+pub fn seq_surface_contract(lang: Lang, tag: Option<&str>) -> Option<SeqSurfaceContract> {
+    let contract = match tag {
+        None => SeqSurfaceContract {
+            value_tag: SEQ_VALUE_UNTAGGED,
+            exact_tree_safe: false,
+            membership_collection: false,
+            map_entry_list: false,
+            imported_literal: false,
+        },
+        Some("array" | "array_expression") => SeqSurfaceContract {
+            value_tag: SEQ_VALUE_COLLECTION,
+            exact_tree_safe: true,
+            membership_collection: true,
+            map_entry_list: true,
+            imported_literal: true,
+        },
+        Some("list") => SeqSurfaceContract {
+            value_tag: SEQ_VALUE_COLLECTION,
+            exact_tree_safe: true,
+            membership_collection: true,
+            map_entry_list: true,
+            imported_literal: false,
+        },
+        Some("tuple") => SeqSurfaceContract {
+            value_tag: SEQ_VALUE_TUPLE,
+            exact_tree_safe: true,
+            membership_collection: false,
+            map_entry_list: false,
+            imported_literal: false,
+        },
+        Some("tuple_expression") => SeqSurfaceContract {
+            value_tag: SEQ_VALUE_TUPLE,
+            exact_tree_safe: true,
+            membership_collection: false,
+            map_entry_list: false,
+            imported_literal: true,
+        },
+        Some("dictionary" | "object") => SeqSurfaceContract {
+            value_tag: SEQ_VALUE_MAP,
+            exact_tree_safe: true,
+            membership_collection: false,
+            map_entry_list: false,
+            imported_literal: true,
+        },
+        Some("hash") => SeqSurfaceContract {
+            value_tag: SEQ_VALUE_MAP,
+            exact_tree_safe: true,
+            membership_collection: false,
+            map_entry_list: false,
+            imported_literal: false,
+        },
+        Some("pair") => SeqSurfaceContract {
+            value_tag: SEQ_VALUE_PAIR,
+            exact_tree_safe: true,
+            membership_collection: false,
+            map_entry_list: false,
+            imported_literal: false,
+        },
+        Some("import_binding") => SeqSurfaceContract {
+            value_tag: SEQ_VALUE_IMPORT_BINDING,
+            exact_tree_safe: true,
+            membership_collection: false,
+            map_entry_list: false,
+            imported_literal: false,
+        },
+        Some("import_namespace") => SeqSurfaceContract {
+            value_tag: SEQ_VALUE_IMPORT_NAMESPACE,
+            exact_tree_safe: true,
+            membership_collection: false,
+            map_entry_list: false,
+            imported_literal: false,
+        },
+        Some("record_guard") => SeqSurfaceContract {
+            value_tag: SEQ_VALUE_RECORD_GUARD,
+            exact_tree_safe: true,
+            membership_collection: false,
+            map_entry_list: false,
+            imported_literal: false,
+        },
+        Some("own_property_guard") => SeqSurfaceContract {
+            value_tag: SEQ_VALUE_OWN_PROPERTY_GUARD,
+            exact_tree_safe: true,
+            membership_collection: false,
+            map_entry_list: false,
+            imported_literal: false,
+        },
+        Some("composite_literal") if lang == Lang::Go => SeqSurfaceContract {
+            value_tag: stable_symbol_hash("go_composite_map_literal"),
+            exact_tree_safe: false,
+            membership_collection: false,
+            map_entry_list: false,
+            imported_literal: false,
+        },
+        _ => return None,
+    };
+    Some(contract)
+}
+
 /// A first-party language profile. Keep this cheap and copyable; callers use it as a
 /// named semantic boundary around currently-supported language behavior.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -229,7 +353,7 @@ pub fn exact_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
         && matches!(il.node(node).payload, Payload::Name(name) if interner.resolve(name) == "this")
 }
 
-/// Exact Java `this.field` place proof for receiver-free field-write fingerprints.
+/// Exact Java `this.field` place proof for receiver-aware field-write fingerprints.
 pub fn exact_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
     if !semantics(il.meta.lang)
         .exact_fragments()
@@ -1841,7 +1965,7 @@ const FREE_NAME_MAP_FACTORIES: &[FreeNameMapFactory] = &[FreeNameMapFactory {
         "std::collections::HashMap::from",
         "std::collections::BTreeMap::from",
     ],
-    entry_seq_tag: 2,
+    entry_seq_tag: SEQ_VALUE_TUPLE,
 }];
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -1857,11 +1981,8 @@ const IMPORTED_COLLECTION_FACTORIES: &[ImportedCollectionFactory] = &[ImportedCo
     exported: "deque",
 }];
 
-pub fn imported_literal_seq_tag_safe(tag: &str) -> bool {
-    matches!(
-        tag,
-        "dictionary" | "object" | "array" | "array_expression" | "tuple_expression"
-    )
+pub fn imported_literal_seq_tag_safe(lang: Lang, tag: &str) -> bool {
+    seq_surface_contract(lang, Some(tag)).is_some_and(|contract| contract.imported_literal)
 }
 
 pub fn mutating_method_name(method: &str) -> bool {
@@ -2034,6 +2155,38 @@ mod tests {
         assert!(!DomainEvidence::Number.is_integer());
         assert!(!DomainEvidence::Array.is_collection_or_set());
         assert!(!DomainEvidence::Set.is_array_or_collection());
+    }
+
+    #[test]
+    fn sequence_surface_contracts_keep_value_and_exact_axes_separate() {
+        let array = seq_surface_contract(Lang::JavaScript, Some("array")).unwrap();
+        assert_eq!(array.value_tag, SEQ_VALUE_COLLECTION);
+        assert!(array.exact_tree_safe);
+        assert!(array.membership_collection);
+
+        let untagged = seq_surface_contract(Lang::JavaScript, None).unwrap();
+        assert_eq!(untagged.value_tag, SEQ_VALUE_UNTAGGED);
+        assert!(!untagged.exact_tree_safe);
+        assert!(!untagged.membership_collection);
+
+        let object = seq_surface_contract(Lang::JavaScript, Some("object")).unwrap();
+        assert_eq!(object.value_tag, SEQ_VALUE_MAP);
+        assert!(object.exact_tree_safe);
+        assert!(!object.membership_collection);
+        assert!(object.imported_literal);
+
+        let go_map = seq_surface_contract(Lang::Go, Some("composite_literal")).unwrap();
+        assert_eq!(
+            go_map.value_tag,
+            stable_symbol_hash("go_composite_map_literal")
+        );
+        assert!(!go_map.exact_tree_safe);
+        assert!(!go_map.membership_collection);
+        assert!(!go_map.imported_literal);
+
+        assert!(seq_surface_contract(Lang::Python, Some("composite_literal")).is_none());
+        assert!(imported_literal_seq_tag_safe(Lang::Python, "dictionary"));
+        assert!(!imported_literal_seq_tag_safe(Lang::Ruby, "hash"));
     }
 
     #[test]

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -138,6 +138,12 @@ Guiding constraints for every pass:
   pure `Some(x).and_then(...)` helper chains, and guarded builders today. Wrapped
   `Some(None)`-style callbacks are emitted `Null` payloads, not dropped items, while
   effectful callbacks and unmodeled option helper chains remain fail-closed.
+  Lowered aggregate surfaces now pass through a `SeqSurfaceContract`: arrays/slices can
+  enter collection membership, maps/objects enter map/object value semantics, Go
+  `composite_literal` map surfaces are consumed only by the Go zero-map contract, JS object
+  `.length` is not collection cardinality, untagged `Seq` groupings do not prove
+  collection membership, and computed JS object keys stay exact-closed until key
+  evaluation semantics are explicit.
   The remaining documented *exceptions* are large-constant/float abstraction (genuinely
   missing type information). The **fuzziness** a clone detector needs — abstracting magic
   numbers, tolerating structural difference — lives in the **candidate axis** and its

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -161,6 +161,25 @@ and pack ecosystem.
   of caching by field name alone. Same-place readback and distinct-field
   commutation remain open, while cross-receiver reads/writes with the same field
   name stay exact-distinct.
+- Lowered `Seq` surface admission now goes through `SeqSurfaceContract` instead
+  of local raw-string allowlists. The contract separates exact-tree safety,
+  membership collection admission, map-entry-list admission, imported-literal
+  eligibility, and value-graph tags, so Go `composite_literal` map surfaces no
+  longer leak into generic collection semantics. Untagged `Seq` is now
+  non-semantic by default; static membership and idiom receiver gates consume
+  explicit membership-collection surface proof.
+- JS/TS object surfaces were narrowed: static property keys remain exact
+  map/object entries, computed property names are exact-closed until key
+  evaluation semantics are contracted, and object `.length` no longer lowers to
+  collection `Len` merely because the receiver is a `Seq`.
+- Java `java.util.*` wildcard proof for empty `ArrayList`/`LinkedList`
+  constructors now closes when another package explicitly imports the same
+  simple type, matching Java import resolution before the constructor surface can
+  enter the collection builder contract.
+- Same-unit value-graph field readback now uses the receiver/place proof shape
+  rather than an arbitrary evaluated receiver value, so aliases and computed
+  call-result receivers stay exact-closed until pack-facing place evidence
+  exists.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -205,6 +224,10 @@ Remaining in this phase:
   versioned pack-facing effect/place evidence records.
 - Move collection/map factory recognition into `LibraryApiContract` records.
 - Make value-graph and strict exact gates consume the same contract source.
+- Replace raw import/module proof payloads with typed `ImportFact` records shared
+  by frontend, normalize, detect, and idiom lowering.
+- Replace the compiled `SeqSurfaceContract` facade with pack-facing
+  sequence/aggregate surface records and named kernel constructors.
 - Replace the current `DomainEvidence` facade with versioned, pack-facing
   receiver/domain evidence records while preserving the current precision gates.
 - Turn named value-graph rule modules into LawPack-facing law ids/contracts while

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -4,8 +4,9 @@ Back to [semantic-kernel](semantic-kernel.md). This page records the current
 implementation shape; planned work and decision history live in
 [semantic-kernel-roadmap](semantic-kernel-roadmap.md).
 
-Snapshot date: 2026-06-07, current `main` after the semantic-kernel foundation
-and proof-gated exact-scan follow-up landed in PR #100 and PR #101.
+Snapshot date: 2026-06-07, current implementation after the semantic-kernel
+foundation and follow-up facade migrations through receiver-aware field state
+and sequence-surface contracts.
 
 ## What exists today
 
@@ -54,7 +55,7 @@ migrated.
 - Property builtin contracts are language-constrained; a selector such as
   `length` is not enough without receiver proof. JS/TS `filter(...).length`
   is admitted only after the receiver has already entered a proven collection/HOF
-  value.
+  value. JS object `.length` remains a property read, not collection cardinality.
 - Promise `.then` has a JS-like surface contract, but exact beta-reduction is
   closed until a pack/frontend can prove a Promise-like receiver.
 - Rust iterator identity adapters (`iter`, `into_iter`, `collect`, `to_vec`,
@@ -80,8 +81,9 @@ migrated.
 - Java empty collection constructor contracts cover `new ArrayList<>()` and
   `new LinkedList<>()` only for the Java `java.util` list types. Simple names
   require `java.util` import proof and no local type declaration with the same
-  simple name; fully-qualified `java.util.*List` names carry the namespace proof
-  in the selector itself.
+  simple name. A `java.util.*` wildcard import is not enough when another
+  package explicitly imports the same simple type; fully-qualified
+  `java.util.*List` names carry the namespace proof in the selector itself.
 - Builder append contracts are separate from arbitrary method calls: Java `add`
   and Rust `push` are admitted only for active builder proofs.
 - Exact fragment surface proofs for Java `this.field`, Java `return this`,
@@ -91,6 +93,17 @@ migrated.
 - Value-graph and oracle same-unit field state are receiver-aware: a cached write
   is keyed by receiver/place plus field name, so `a.x = v` can satisfy `a.x`
   but not `b.x`, and final field-write sinks preserve the receiver identity.
+  Same-unit value-graph readback uses syntactic receiver/place evidence only; it
+  does not assume aliasing or computed call-result receivers.
+- `SeqSurfaceContract` now centralizes first-party lowered sequence tags and
+  keeps separate axes for exact-tree safety, membership-collection admission,
+  map-entry-list admission, imported-literal eligibility, and value-graph
+  canonical tags. Strict exact gates, value-graph sequence lowering, and
+  sibling-module literal export checks consume this contract instead of local
+  string allowlists. Untagged `Seq` remains an internal grouping surface and
+  does not itself prove exact collection semantics; the older Python empty
+  sequence collection case is handled only by the explicit collection profile
+  path.
 - Collection reductions such as Rust `Iterator::count()` and Java
   `Stream.count()` are admitted through exact protocol receiver contracts, not
   through a bare method-name check.
@@ -151,8 +164,16 @@ migrated.
   without admitting shadowed `undefined` bindings.
 - Go literal map default lookup is represented by a shared contract for the
   `composite_literal`/`keyed_element` surface and the supported zero-default
-  payload classes. The value graph still constructs the canonical default value,
-  and detect still checks exact-safe keys and entries.
+  payload classes. Go `composite_literal` no longer falls back to a generic
+  collection sequence tag; it is consumed only by the Go map contract or left as
+  a distinct surface.
+- Static JS-like `indexOf`/`findIndex` membership requires a receiver whose
+  sequence surface has membership-collection admission. Untagged sequence
+  expressions, destructuring surfaces, and other positional groupings do not
+  become static array membership merely because their children are literals.
+- JS/TS object literals preserve static property keys in exact map/object
+  semantics, but computed property names are exact-closed until a future
+  contract can prove key evaluation, coercion, order, and side-effect behavior.
 - JS/TS `new Map(...)` and `new Set(...)` remain closed because lowering does not
   yet retain a constructor proof distinct from ordinary `Map(...)`/`Set(...)`.
 
@@ -164,6 +185,9 @@ Semantic knowledge still appears in several forms outside the facade:
   rules that have not yet been expressed as shared contracts;
 - language-specific import or module proof mechanics that are still local to
   frontend, normalize, or detect callers;
+- raw IL `Seq("import_binding")` / `Seq("import_namespace")` payloads still carry
+  import facts. They pass through the surface contract now, but they are not yet
+  typed `ImportFact` records shared by frontend, normalize, detect, and idioms;
 - module/import proof logic for immutable sibling-module literal bindings;
 - type facts and coarse type inference used to gate numeric and collection laws;
 - named value-graph rule modules that still consume internal `Builder` facts
@@ -240,6 +264,11 @@ The first high-value targets for semantic-kernel extraction are:
 
 - pack-facing field/place evidence for all field reads and writes, building on
   the receiver-aware value-graph field state now used for same-unit caching;
+- typed import/module facts to replace raw `Seq("import_binding")` and
+  `Seq("import_namespace")` payload parsing across frontend, normalize, detect,
+  and idiom lowering;
+- pack-facing sequence/aggregate surface records to replace the current compiled
+  `SeqSurfaceContract` facade and private value-graph `Seq` tag registry;
 - constructor facts for JS/TS `new Map` and `new Set`, which are now explicit
   closed contracts waiting on construct-vs-call proof;
 - regex literal provenance for JS/TS `.test(...)`;


### PR DESCRIPTION
## Summary
- add a first-party `SeqSurfaceContract` facade for lowered aggregate/proof `Seq` tags, with separate axes for exact-tree safety, membership collection admission, map-entry-list admission, imported literal eligibility, and value-graph tags
- route strict exact gates, value-graph sequence lowering, JS `.length` receiver checks, and sibling-module literal export checks through that contract
- close concrete boundary leaks: Go `composite_literal` map literals no longer fall back to collection membership, JS computed object keys stay exact-closed, and JS object `.length` is not treated as collection cardinality
- update semantic-kernel docs with current status and remaining typed `ImportFact` migration work

## Verification
- `cargo test -p nose-semantics sequence_surface`
- `cargo test -p nose-cli --test equivalence seq_surface_contracts_keep_maps_out_of_collection_membership -- --exact`
- `cargo test -p nose-cli --test equivalence js_object_length_and_computed_keys_stay_outside_exact_collection_contracts -- --exact`
- `cargo test -p nose-cli --test cli scan_mode_semantic_preserves_js_object_keys -- --exact`
- `cargo test -p nose-cli --test equivalence literal_map_default`
- `cargo test -p nose-cli --test equivalence filtered_count_aggregates_converge_with_count_loop -- --exact`
- `cargo test -p nose-cli --test cli scan_mode_semantic_converges_cross_language_list_literals -- --exact`
- `cargo test -p nose-cli --test cli scan_mode_semantic_converges_cross_language_map_literals -- --exact`
- `cargo test -p nose-detect --lib fragment`
- `awiki lint --root docs`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `python3 scripts/check-formal-obligations.py && ./scripts/check-lean-proofs.sh`
- `cargo test --all-targets --all-features`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  - JavaScript/TypeScript 객체 속성 처리 강화로 정적 키와 동적 키를 더 정확히 구분
  - 다양한 프로그래밍 언어에서 컬렉션 및 맵 관련 의미 분석 개선
  - 복합 자료구조에 대한 타입 안전성 검증 로직 정밀화

* **문서**
  - 시맨틱 정규화 및 설계 로드맵 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->