### PR TITLE
semantics: type import facts through kernel facade

### DIFF
--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -967,12 +967,18 @@ fn python_math_prod_converges_with_product_loop() {
         "import math\n\ndef f(xs):\n    return math.prod((x for x in xs if x > 0), start=2)\n";
     let missing_import = "def f(xs):\n    return math.prod((x for x in xs if x > 0), start=1)\n";
     let shadowed_math = "import math\nmath = object()\n\ndef f(xs):\n    return math.prod((x for x in xs if x > 0), start=1)\n";
+    let parameter_shadowed_math =
+        "import math\n\ndef f(xs, math):\n    return math.prod((x for x in xs if x > 0), start=1)\n";
+    let local_shadowed_math =
+        "import math\n\ndef f(xs):\n    math = object()\n    return math.prod((x for x in xs if x > 0), start=1)\n";
     let loop_fp = value_fp(&i, loop_py, Lang::Python);
     assert_eq!(loop_fp, value_fp(&i, prod_py, Lang::Python));
     assert_eq!(loop_fp, value_fp(&i, aliased_prod_py, Lang::Python));
     assert_ne!(loop_fp, value_fp(&i, bad_seed, Lang::Python));
     assert_ne!(loop_fp, value_fp(&i, missing_import, Lang::Python));
     assert_ne!(loop_fp, value_fp(&i, shadowed_math, Lang::Python));
+    assert_ne!(loop_fp, value_fp(&i, parameter_shadowed_math, Lang::Python));
+    assert_ne!(loop_fp, value_fp(&i, local_shadowed_math, Lang::Python));
 }
 
 #[test]
@@ -3548,6 +3554,9 @@ fn import_named_and_namespace_member_coordinates_converge() {
     let js_namespace = "import * as mathOps from \"./shared-math\";\nfunction f(value) { return mathOps.helper(value + 1); }\n";
     let js_wrong_member = "import * as mathOps from \"./shared-math\";\nfunction f(value) { return mathOps.otherHelper(value + 1); }\n";
     let ts_namespace = "import * as mathOps from \"./shared-math\";\nfunction f(value: number): number { return mathOps.helper(value + 1); }\n";
+    let ts_type_only =
+        "import type { helper } from \"./shared-math\";\nfunction f(value: number): number { return helper(value + 1); }\n";
+    let ts_mixed_type_only = "import { helper, type otherHelper } from \"./shared-math\";\nfunction f(value: number): number { return otherHelper(value + 1); }\n";
     let py_named =
         "from shared_math import helper\n\ndef f(value):\n    return helper(value + 1)\n";
     let py_namespace =
@@ -3559,6 +3568,8 @@ fn import_named_and_namespace_member_coordinates_converge() {
     assert_eq!(fp, value_fp(&i, js_namespace, Lang::JavaScript));
     assert_eq!(fp, value_fp(&i, ts_namespace, Lang::TypeScript));
     assert_ne!(fp, value_fp(&i, js_wrong_member, Lang::JavaScript));
+    assert_ne!(fp, value_fp(&i, ts_type_only, Lang::TypeScript));
+    assert_ne!(fp, value_fp(&i, ts_mixed_type_only, Lang::TypeScript));
 
     let py_fp = value_fp(&i, py_named, Lang::Python);
     assert_eq!(py_fp, value_fp(&i, py_namespace, Lang::Python));
@@ -4183,12 +4194,17 @@ fn java_arrays_aslist_single_argument_respects_array_provenance() {
     let array_membership = "import java.util.Arrays;\n\nclass C { static boolean f(String[] values, String value) { return Arrays.asList(values).contains(value); } }\n";
     let list_membership = "import java.util.Arrays;\nimport java.util.List;\n\nclass C { static boolean f(List<String> values, String value) { return Arrays.asList(values).contains(value); } }\n";
     let singleton_list_membership = "import java.util.List;\n\nclass C { static boolean f(String[] values, String value) { return List.of(values).contains(value); } }\n";
+    let parameter_shadowed_arrays = "import java.util.Arrays;\n\nclass FakeArrays { java.util.List<String> asList(String[] values) { return java.util.List.of(\"green\"); } }\nclass C { static boolean f(FakeArrays Arrays, String[] values, String value) { return Arrays.asList(values).contains(value); } }\n";
 
     let array_fp = value_fp(&i, array_membership, Lang::Java);
     assert_ne!(array_fp, value_fp(&i, list_membership, Lang::Java));
     assert_ne!(
         array_fp,
         value_fp(&i, singleton_list_membership, Lang::Java)
+    );
+    assert_ne!(
+        array_fp,
+        value_fp(&i, parameter_shadowed_arrays, Lang::Java)
     );
 }
 
@@ -4458,6 +4474,11 @@ fn literal_map_default_lookup_converges_with_imported_python_literal_binding() {
     )
     .unwrap();
     std::fs::write(
+        dir.join("escaped_tables.py"),
+        "LOOKUP = {\"red\": 1, \"blue\": 2}\nmutate(LOOKUP)\n",
+    )
+    .unwrap();
+    std::fs::write(
         dir.join("imported_mutated_provider.py"),
         "from mutated_tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
     )
@@ -4465,6 +4486,11 @@ fn literal_map_default_lookup_converges_with_imported_python_literal_binding() {
     std::fs::write(
         dir.join("imported_mutated_index_provider.py"),
         "from mutated_index_tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("imported_escaped_provider.py"),
+        "from escaped_tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
     )
     .unwrap();
     std::fs::write(
@@ -4499,6 +4525,11 @@ fn literal_map_default_lookup_converges_with_imported_python_literal_binding() {
         local,
         corpus_value_fp(&corpus, "imported_mutated_index_provider.py", "lookup"),
         "provider index write must block imported literal provenance"
+    );
+    assert_ne!(
+        local,
+        corpus_value_fp(&corpus, "imported_escaped_provider.py", "lookup"),
+        "provider opaque argument escape must block imported literal provenance"
     );
     assert_ne!(
         local,

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -16,15 +16,16 @@ use nose_semantics::{
     builder_append_call_args, domain_evidence_from_param_semantic, exact_java_return_this,
     exact_java_this_field, exact_non_overloadable_index_assignment,
     exact_non_overloadable_index_assignment_parts, go_zero_map_default_kind,
-    go_zero_map_lookup_contract, index_membership_threshold_contract,
-    iterator_identity_adapter_contract, java_collection_factory_contract, java_map_entry_contract,
-    java_map_factory_contract, js_array_is_array_contract, js_like_map_constructor_contract,
-    js_like_set_constructor_contract, map_get_contract, map_key_view_contract,
-    map_key_view_wrapper_contract, method_call_contract, nullish_global_contract,
-    regex_test_contract, ruby_set_factory_contract, rust_vec_new_factory_contract, semantics,
-    seq_surface_contract, static_index_membership_contract, typeof_operator_contract,
-    IndexMembershipThreshold, JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs,
-    MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
+    go_zero_map_lookup_contract, import_binding_rhs_matches, import_namespace_rhs_matches,
+    index_membership_threshold_contract, iterator_identity_adapter_contract,
+    java_collection_factory_contract, java_map_entry_contract, java_map_factory_contract,
+    js_array_is_array_contract, js_like_map_constructor_contract, js_like_set_constructor_contract,
+    map_get_contract, map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
+    nullish_global_contract, regex_test_contract, ruby_set_factory_contract,
+    rust_vec_new_factory_contract, semantics, seq_surface_contract,
+    static_index_membership_contract, typeof_operator_contract, IndexMembershipThreshold,
+    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
+    MethodSemanticContract, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -604,6 +605,8 @@ pub(crate) fn extract(
 struct StrictFacts {
     immutable_names: FxHashSet<Symbol>,
     function_names: FxHashSet<Symbol>,
+    collection_names: FxHashSet<Symbol>,
+    map_names: FxHashSet<Symbol>,
     collection_cids: FxHashSet<u32>,
     map_cids: FxHashSet<u32>,
 }
@@ -660,10 +663,18 @@ impl StrictFacts {
                 continue;
             }
             let safe_literal = immutable_binding_safe(il, &env, &self.immutable_names, kids[1]);
-            let safe_proven_container =
-                strict_exact_module_container_binding_safe(il, interner, self, kids[1]);
-            if safe_literal || safe_proven_container {
+            let safe_collection_container =
+                strict_exact_module_collection_binding_safe(il, interner, self, kids[1]);
+            let safe_map_container =
+                strict_exact_module_map_binding_safe(il, interner, self, kids[1]);
+            if safe_literal || safe_collection_container || safe_map_container {
                 self.immutable_names.insert(name);
+                if safe_collection_container {
+                    self.collection_names.insert(name);
+                }
+                if safe_map_container {
+                    self.map_names.insert(name);
+                }
                 if let Payload::Cid(cid) = il.node(kids[0]).payload {
                     env.insert(cid);
                 }
@@ -788,7 +799,22 @@ fn assignment_name(il: &Il, stmt: NodeId) -> Option<Symbol> {
     il.cid_names.get(cid as usize).copied()
 }
 
-fn strict_exact_module_container_binding_safe(
+fn strict_exact_module_collection_binding_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+) -> bool {
+    strict_exact_literal_collection_receiver_safe(il, interner, facts, node)
+        || strict_exact_python_collection_factory_safe(il, interner, facts, node)
+        || strict_exact_ruby_set_factory_safe(il, interner, facts, node)
+        || strict_exact_rust_vec_macro_collection_safe(il, interner, facts, node)
+        || strict_exact_rust_std_collection_factory_safe(il, interner, facts, node)
+        || strict_exact_set_constructor_collection_safe(il, interner, facts, node)
+        || strict_exact_java_collection_factory_safe(il, interner, facts, node)
+}
+
+fn strict_exact_module_map_binding_safe(
     il: &Il,
     interner: &Interner,
     facts: &StrictFacts,
@@ -797,12 +823,6 @@ fn strict_exact_module_container_binding_safe(
     strict_exact_map_constructor_entries_safe(il, interner, facts, node)
         || strict_exact_java_map_factory_safe(il, interner, facts, node)
         || strict_exact_rust_std_map_factory_safe(il, interner, facts, node)
-        || strict_exact_python_collection_factory_safe(il, interner, facts, node)
-        || strict_exact_ruby_set_factory_safe(il, interner, facts, node)
-        || strict_exact_rust_vec_macro_collection_safe(il, interner, facts, node)
-        || strict_exact_rust_std_collection_factory_safe(il, interner, facts, node)
-        || strict_exact_set_constructor_collection_safe(il, interner, facts, node)
-        || strict_exact_java_collection_factory_safe(il, interner, facts, node)
 }
 
 fn strict_exact_local_collection_binding_safe(
@@ -1648,6 +1668,9 @@ fn strict_exact_proven_collection_receiver_safe(
     matches!(
         (il.kind(receiver), il.node(receiver).payload),
         (NodeKind::Var, Payload::Cid(cid)) if facts.collection_cids.contains(&cid)
+    ) || matches!(
+        (il.kind(receiver), il.node(receiver).payload),
+        (NodeKind::Var, Payload::Name(name)) if facts.collection_names.contains(&name)
     )
 }
 
@@ -1675,6 +1698,9 @@ fn strict_exact_proven_map_receiver_safe(il: &Il, facts: &StrictFacts, receiver:
     matches!(
         (il.kind(receiver), il.node(receiver).payload),
         (NodeKind::Var, Payload::Cid(cid)) if facts.map_cids.contains(&cid)
+    ) || matches!(
+        (il.kind(receiver), il.node(receiver).payload),
+        (NodeKind::Var, Payload::Name(name)) if facts.map_names.contains(&name)
     )
 }
 
@@ -1786,7 +1812,7 @@ fn strict_exact_membership_collection_safe(
         {
             return true;
         }
-        return strict_exact_safe_tree(il, interner, facts, node);
+        return false;
     }
     let tag = match il.node(node).payload {
         Payload::None => None,
@@ -1935,33 +1961,20 @@ fn top_level_assignment_rhs(il: &Il, symbol: Symbol) -> Option<NodeId> {
     })
 }
 
-fn import_binding_rhs_matches(
-    il: &Il,
-    interner: &Interner,
-    rhs: NodeId,
-    module: &str,
-    exported: &str,
-) -> bool {
-    let kids = il.children(rhs);
-    il.kind(rhs) == NodeKind::Seq
-        && matches!(
-            il.node(rhs).payload,
-            Payload::Name(seq_name) if interner.resolve(seq_name) == "import_binding"
-        )
-        && kids.len() == 2
-        && matches!(il.node(kids[0]).payload, Payload::LitStr(hash) if hash == stable_symbol_hash(module))
-        && matches!(il.node(kids[1]).payload, Payload::LitStr(hash) if hash == stable_symbol_hash(exported))
-}
-
-fn import_namespace_rhs_matches(il: &Il, interner: &Interner, rhs: NodeId, module: &str) -> bool {
-    let kids = il.children(rhs);
-    il.kind(rhs) == NodeKind::Seq
-        && matches!(
-            il.node(rhs).payload,
-            Payload::Name(seq_name) if interner.resolve(seq_name) == "import_namespace"
-        )
-        && kids.len() == 1
-        && matches!(il.node(kids[0]).payload, Payload::LitStr(hash) if hash == stable_symbol_hash(module))
+fn top_level_assignment_cid(il: &Il, symbol: Symbol) -> Option<u32> {
+    top_level_statements(il).into_iter().find_map(|stmt| {
+        if assignment_name(il, stmt).is_none_or(|name| name != symbol) {
+            return None;
+        }
+        let kids = il.children(stmt);
+        if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Var {
+            return None;
+        }
+        match il.node(kids[0]).payload {
+            Payload::Cid(cid) => Some(cid),
+            _ => None,
+        }
+    })
 }
 
 fn strict_exact_ruby_set_factory_safe(
@@ -2192,6 +2205,9 @@ fn strict_exact_java_std_var_name(
             let Some(&name) = il.cid_names.get(cid as usize) else {
                 return false;
             };
+            if top_level_assignment_cid(il, name) != Some(cid) {
+                return false;
+            }
             name
         }
         _ => return false,

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -154,6 +154,9 @@ fn lower_stmt(lo: &mut Lowering, node: TsNode, in_class: bool) -> Option<NodeId>
 fn lower_static_import(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     let span = lo.span(node);
     let text = lo.text(node).trim().trim_end_matches(';').trim();
+    if text.starts_with("import type ") {
+        return None;
+    }
     let module = quoted_after_from(text)?;
     let mut assigns = Vec::new();
 
@@ -167,6 +170,9 @@ fn lower_static_import(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     } else if let Some((start, end)) = brace_range(text) {
         let inner = &text[start + 1..end];
         for part in inner.split(',').map(str::trim).filter(|p| !p.is_empty()) {
+            if part.starts_with("type ") {
+                continue;
+            }
             let (exported, local) = js_import_specifier(part)?;
             assigns.push(crate::lower::import_binding(
                 lo, span, local, module, exported,

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -6,6 +6,7 @@ use nose_il::{
     FileId, FileMeta, Il, IlBuilder, Interner, Lang, LoopKind, NodeId, NodeKind, Op, ParamSemantic,
     ParamTypeFact, Payload, Span, Symbol, Unit, UnitKind,
 };
+use nose_semantics::{import_fact_tag, ImportFactKind};
 use tree_sitter::Node as TsNode;
 
 /// Mutable state threaded through a single file's lowering.
@@ -243,13 +244,19 @@ pub(crate) fn import_binding(
     module: &str,
     exported: &str,
 ) -> NodeId {
-    import_fact(lo, span, local, "import_binding", &[module, exported])
+    import_fact(
+        lo,
+        span,
+        local,
+        ImportFactKind::Binding,
+        &[module, exported],
+    )
 }
 
 /// A strict semantic proof fact for a static namespace import:
 /// local namespace → module coordinate.
 pub(crate) fn import_namespace(lo: &mut Lowering, span: Span, local: &str, module: &str) -> NodeId {
-    import_fact(lo, span, local, "import_namespace", &[module])
+    import_fact(lo, span, local, ImportFactKind::Namespace, &[module])
 }
 
 /// Shared shape of the static-import proof facts: `local = Seq[tag](str_lit(c) for c in
@@ -257,10 +264,16 @@ pub(crate) fn import_namespace(lo: &mut Lowering, span: Span, local: &str, modul
 /// only in the Seq tag and the coordinate count. The node-allocation order — lhs var, then
 /// each coordinate string, then the Seq, then the Assign — is preserved identically to the
 /// original two functions.
-fn import_fact(lo: &mut Lowering, span: Span, local: &str, tag: &str, coords: &[&str]) -> NodeId {
+fn import_fact(
+    lo: &mut Lowering,
+    span: Span,
+    local: &str,
+    kind: ImportFactKind,
+    coords: &[&str],
+) -> NodeId {
     let lhs = lo.var(local, span);
     let strs: Vec<NodeId> = coords.iter().map(|c| lo.str_lit(c, span)).collect();
-    let tag = lo.sym(tag);
+    let tag = lo.sym(import_fact_tag(kind));
     let rhs = lo.add(NodeKind::Seq, Payload::Name(tag), span, &strs);
     lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs])
 }

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -10,8 +10,8 @@ use nose_il::{
     stable_symbol_hash, Il, Interner, Node, NodeId, NodeKind, Payload, Span, Symbol, UnitKind,
 };
 use nose_semantics::{
-    java_map_entry_contract, java_map_factory_contract, semantics, ImportedMapFactoryContract,
-    JavaMapFactoryKind,
+    import_fact_rhs, java_map_entry_contract, java_map_factory_contract, semantics, ImportFactKind,
+    ImportedMapFactoryContract, JavaMapFactoryKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::Path;
@@ -159,7 +159,7 @@ fn collect_statement_exports(
         if counts.get(&name).copied().unwrap_or(0) != 1 {
             continue;
         }
-        if binding_mutated(il, interner, name, stmt) {
+        if exported_binding_unsafe(il, interner, name, stmt) {
             continue;
         }
         let Some(rhs) = assignment_rhs(il, stmt) else {
@@ -258,30 +258,8 @@ fn assignment_rhs(il: &Il, stmt: NodeId) -> Option<NodeId> {
 
 fn import_binding_key(il: &Il, interner: &Interner, stmt: NodeId) -> Option<(u64, u64)> {
     let rhs = assignment_rhs(il, stmt)?;
-    if il.kind(rhs) != NodeKind::Seq {
-        return None;
-    }
-    let Payload::Name(tag) = il.node(rhs).payload else {
-        return None;
-    };
-    if interner.resolve(tag) != "import_binding" {
-        return None;
-    }
-    let kids = il.children(rhs);
-    if kids.len() != 2 {
-        return None;
-    }
-    Some((
-        literal_string_hash(il, kids[0])?,
-        literal_string_hash(il, kids[1])?,
-    ))
-}
-
-fn literal_string_hash(il: &Il, node: NodeId) -> Option<u64> {
-    match il.node(node).payload {
-        Payload::LitStr(hash) => Some(hash),
-        _ => None,
-    }
+    let fact = import_fact_rhs(il, interner, rhs)?;
+    (fact.kind == ImportFactKind::Binding).then_some((fact.module_hash, fact.exported_hash?))
 }
 
 fn imported_literal_export_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
@@ -306,10 +284,8 @@ fn literal_export_value_safe(il: &Il, interner: &Interner, node: NodeId) -> bool
     match il.kind(node) {
         NodeKind::Lit => true,
         NodeKind::Seq => {
-            if let Payload::Name(tag) = il.node(node).payload {
-                if matches!(interner.resolve(tag), "import_binding" | "import_namespace") {
-                    return false;
-                }
+            if import_fact_rhs(il, interner, node).is_some() {
+                return false;
             }
             il.children(node)
                 .iter()
@@ -481,6 +457,28 @@ fn binding_mutated(il: &Il, interner: &Interner, name: Symbol, defining_stmt: No
             _ => false,
         }
     })
+}
+
+fn exported_binding_unsafe(
+    il: &Il,
+    interner: &Interner,
+    name: Symbol,
+    defining_stmt: NodeId,
+) -> bool {
+    binding_mutated(il, interner, name, defining_stmt)
+        || il.nodes.iter().enumerate().any(|(idx, node)| {
+            let node_id = NodeId(idx as u32);
+            node_id != defining_stmt
+                && node.kind == NodeKind::Call
+                && call_argument_escapes_binding(il, node_id, name)
+        })
+}
+
+fn call_argument_escapes_binding(il: &Il, call: NodeId, name: Symbol) -> bool {
+    il.children(call)
+        .iter()
+        .skip(1)
+        .any(|&arg| node_contains_symbol(il, arg, name))
 }
 
 fn field_mutates_binding(il: &Il, interner: &Interner, field: NodeId, name: Symbol) -> bool {

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -7,14 +7,14 @@
 //! proof-obligation: normalize.value_graph.functor
 //! proof-obligation: normalize.value_graph.min_max
 
-use nose_il::{stable_symbol_hash, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
+use nose_il::{Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
 use nose_semantics::{
     domain_evidence_from_param_semantic, free_function_builtin_contract,
-    iterator_identity_adapter_contract, map_get_contract, map_key_view_contract,
-    method_call_contract, method_hof_contract, rust_option_some_constructor_contract,
-    seq_surface_contract, static_collection_adapter_contract, BuiltinArgContract, DomainEvidence,
-    MapKeyViewKind, MethodBuiltinArgs, MethodCallContract, MethodReceiverContract,
-    MethodSemanticContract,
+    import_binding_rhs_matches, import_namespace_rhs_matches, iterator_identity_adapter_contract,
+    map_get_contract, map_key_view_contract, method_call_contract, method_hof_contract,
+    rust_option_some_constructor_contract, seq_surface_contract,
+    static_collection_adapter_contract, BuiltinArgContract, DomainEvidence, MapKeyViewKind,
+    MethodBuiltinArgs, MethodCallContract, MethodReceiverContract, MethodSemanticContract,
 };
 
 /// The result of inspecting a `Call`: it canonicalizes to a builtin, to a
@@ -855,26 +855,7 @@ fn import_binding_assignment(
     if kids.len() != 2 || assignment_alias_name(old, interner, kids[0]) != Some(alias) {
         return false;
     }
-    if old.kind(kids[1]) != NodeKind::Seq {
-        return false;
-    }
-    let Payload::Name(seq_name) = old.node(kids[1]).payload else {
-        return false;
-    };
-    if interner.resolve(seq_name) != "import_binding" {
-        return false;
-    }
-    let coords = old.children(kids[1]);
-    if coords.len() != 2 {
-        return false;
-    }
-    matches!(
-        old.node(coords[0]).payload,
-        Payload::LitStr(hash) if hash == stable_symbol_hash(module)
-    ) && matches!(
-        old.node(coords[1]).payload,
-        Payload::LitStr(hash) if hash == stable_symbol_hash(exported)
-    )
+    import_binding_rhs_matches(old, interner, kids[1], module, exported)
 }
 
 fn import_namespace_assignment(
@@ -891,22 +872,7 @@ fn import_namespace_assignment(
     if kids.len() != 2 || assignment_alias_name(old, interner, kids[0]) != Some(alias) {
         return false;
     }
-    if old.kind(kids[1]) != NodeKind::Seq {
-        return false;
-    }
-    let Payload::Name(seq_name) = old.node(kids[1]).payload else {
-        return false;
-    };
-    if interner.resolve(seq_name) != "import_namespace" {
-        return false;
-    }
-    let Some(&module_node) = old.children(kids[1]).first() else {
-        return false;
-    };
-    matches!(
-        old.node(module_node).payload,
-        Payload::LitStr(hash) if hash == stable_symbol_hash(module)
-    )
+    import_namespace_rhs_matches(old, interner, kids[1], module)
 }
 
 fn assignment_alias_name<'a>(old: &Il, interner: &'a Interner, id: NodeId) -> Option<&'a str> {
@@ -1023,7 +989,9 @@ fn identity_lambda(old: &Il, lambda: NodeId) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nose_il::stable_symbol_hash;
     use nose_il::{FileId, FileMeta, IlBuilder, Lang, ParamSemantic, ParamTypeFact, Span};
+    use nose_semantics::{import_fact_tag, ImportFactKind};
 
     fn sp() -> Span {
         Span::new(FileId(0), 1, 1, 1, 1)
@@ -1384,7 +1352,7 @@ mod tests {
                 sp(),
                 &[],
             );
-            let tag = interner.intern("import_namespace");
+            let tag = interner.intern(import_fact_tag(ImportFactKind::Namespace));
             let rhs = b.add(NodeKind::Seq, Payload::Name(tag), sp(), &[module]);
             module_kids.push(b.add(NodeKind::Assign, Payload::None, sp(), &[lhs, rhs]));
         }

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -51,21 +51,20 @@ use nose_il::{
 use nose_semantics::{
     builder_append_method_contract, builtin_tag, domain_evidence_from_param_semantic,
     free_function_builtin_contract, go_zero_map_default_kind, go_zero_map_lookup_contract,
-    imported_namespace_function_contract, index_membership_threshold_contract,
-    iterator_identity_adapter_contract, java_collection_factory_contract_by_hash,
-    java_map_entry_contract_by_hash, java_map_factory_contract_by_hash, map_get_contract_by_hash,
-    map_key_view_contract_by_hash, map_key_view_wrapper_contract_by_hash, method_call_contract,
-    nullish_global_contract, reduction_builtin_contract, ruby_set_factory_contract_by_hash,
-    rust_option_and_then_contract, rust_option_none_sentinel_contract,
-    rust_option_some_constructor_contract, rust_vec_new_factory_contract,
-    scalar_integer_method_contract, semantics, seq_surface_contract,
+    import_fact_contract, import_namespace_rhs_matches, imported_namespace_function_contract,
+    index_membership_threshold_contract, iterator_identity_adapter_contract,
+    java_collection_factory_contract_by_hash, java_map_entry_contract_by_hash,
+    java_map_factory_contract_by_hash, map_get_contract_by_hash, map_key_view_contract_by_hash,
+    map_key_view_wrapper_contract_by_hash, method_call_contract, nullish_global_contract,
+    reduction_builtin_contract, ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
+    rust_option_none_sentinel_contract, rust_option_some_constructor_contract,
+    rust_vec_new_factory_contract, scalar_integer_method_contract, semantics, seq_surface_contract,
     static_index_membership_contract, BuiltinArgContract, DomainEvidence, GoZeroMapDefaultKind,
-    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
-    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
-    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract,
-    StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_IMPORT_BINDING,
-    SEQ_VALUE_IMPORT_NAMESPACE, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR,
-    SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
+    ImportFactKind, ImportedNamespaceFunctionSemantic, IndexMembershipThreshold,
+    IteratorAdapterReceiverContract, JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs,
+    MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
+    SeqSurfaceContract, StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP,
+    SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -1017,7 +1016,10 @@ impl<'a> Builder<'a> {
 
     fn is_import_namespace_value(&self, value: ValueId, module: &str) -> bool {
         let node = &self.nodes[value as usize];
-        if !matches!(node.op, ValOp::Seq(SEQ_VALUE_IMPORT_NAMESPACE)) || node.args.len() != 1 {
+        let contract = import_fact_contract(ImportFactKind::Namespace);
+        if !matches!(node.op, ValOp::Seq(tag) if tag == contract.value_tag)
+            || node.args.len() != contract.coordinate_count
+        {
             return false;
         }
         matches!(
@@ -1028,7 +1030,10 @@ impl<'a> Builder<'a> {
 
     fn is_import_binding_value(&self, value: ValueId, module: &str, exported: &str) -> bool {
         let node = &self.nodes[value as usize];
-        if !matches!(node.op, ValOp::Seq(SEQ_VALUE_IMPORT_BINDING)) || node.args.len() != 2 {
+        let contract = import_fact_contract(ImportFactKind::Binding);
+        if !matches!(node.op, ValOp::Seq(tag) if tag == contract.value_tag)
+            || node.args.len() != contract.coordinate_count
+        {
             return false;
         }
         matches!(
@@ -1055,22 +1060,7 @@ impl<'a> Builder<'a> {
                 return false;
             }
             let kids = self.il.children(stmt);
-            if kids.len() != 2 || self.il.kind(kids[1]) != NodeKind::Seq {
-                return false;
-            }
-            let Payload::Name(seq_name) = self.il.node(kids[1]).payload else {
-                return false;
-            };
-            if self.interner.resolve(seq_name) != "import_namespace" {
-                return false;
-            }
-            let Some(&module_node) = self.il.children(kids[1]).first() else {
-                return false;
-            };
-            matches!(
-                self.il.node(module_node).payload,
-                Payload::LitStr(hash) if hash == stable_symbol_hash(module)
-            )
+            kids.len() == 2 && import_namespace_rhs_matches(self.il, self.interner, kids[1], module)
         })
     }
 
@@ -7381,7 +7371,8 @@ impl<'a> Builder<'a> {
                             }
                         }
                         let receiver = &self.nodes[a[0] as usize];
-                        if matches!(receiver.op, ValOp::Seq(SEQ_VALUE_IMPORT_NAMESPACE))
+                        let namespace = import_fact_contract(ImportFactKind::Namespace);
+                        if matches!(receiver.op, ValOp::Seq(tag) if tag == namespace.value_tag)
                             && receiver.args.len() == 1
                         {
                             let module = receiver.args[0];
@@ -7389,8 +7380,8 @@ impl<'a> Builder<'a> {
                                 ValOp::Const(stable_string_const_key(self.interner.resolve(s))),
                                 vec![],
                             );
-                            return self
-                                .mk(ValOp::Seq(SEQ_VALUE_IMPORT_BINDING), vec![module, exported]);
+                            let binding = import_fact_contract(ImportFactKind::Binding);
+                            return self.mk(ValOp::Seq(binding.value_tag), vec![module, exported]);
                         }
                     }
                 }

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -126,6 +126,9 @@ pub const SEQ_VALUE_IMPORT_NAMESPACE: u64 = 6;
 pub const SEQ_VALUE_RECORD_GUARD: u64 = 7;
 pub const SEQ_VALUE_OWN_PROPERTY_GUARD: u64 = 8;
 
+pub const IMPORT_BINDING_TAG: &str = "import_binding";
+pub const IMPORT_NAMESPACE_TAG: &str = "import_namespace";
+
 /// Kernel contract for a lowered `Seq` surface tag.
 ///
 /// This is deliberately not just a value-graph tag table. The same surface may be
@@ -200,14 +203,14 @@ pub fn seq_surface_contract(lang: Lang, tag: Option<&str>) -> Option<SeqSurfaceC
             map_entry_list: false,
             imported_literal: false,
         },
-        Some("import_binding") => SeqSurfaceContract {
+        Some(IMPORT_BINDING_TAG) => SeqSurfaceContract {
             value_tag: SEQ_VALUE_IMPORT_BINDING,
             exact_tree_safe: true,
             membership_collection: false,
             map_entry_list: false,
             imported_literal: false,
         },
-        Some("import_namespace") => SeqSurfaceContract {
+        Some(IMPORT_NAMESPACE_TAG) => SeqSurfaceContract {
             value_tag: SEQ_VALUE_IMPORT_NAMESPACE,
             exact_tree_safe: true,
             membership_collection: false,
@@ -238,6 +241,117 @@ pub fn seq_surface_contract(lang: Lang, tag: Option<&str>) -> Option<SeqSurfaceC
         _ => return None,
     };
     Some(contract)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ImportFactKind {
+    Binding,
+    Namespace,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ImportFactContract {
+    pub kind: ImportFactKind,
+    pub tag: &'static str,
+    pub coordinate_count: usize,
+    pub value_tag: u64,
+    pub channel: ChannelEligibility,
+}
+
+pub fn import_fact_contract(kind: ImportFactKind) -> ImportFactContract {
+    match kind {
+        ImportFactKind::Binding => ImportFactContract {
+            kind,
+            tag: IMPORT_BINDING_TAG,
+            coordinate_count: 2,
+            value_tag: SEQ_VALUE_IMPORT_BINDING,
+            channel: ChannelEligibility::ExactProven,
+        },
+        ImportFactKind::Namespace => ImportFactContract {
+            kind,
+            tag: IMPORT_NAMESPACE_TAG,
+            coordinate_count: 1,
+            value_tag: SEQ_VALUE_IMPORT_NAMESPACE,
+            channel: ChannelEligibility::ExactProven,
+        },
+    }
+}
+
+pub fn import_fact_contract_for_tag(tag: &str) -> Option<ImportFactContract> {
+    match tag {
+        IMPORT_BINDING_TAG => Some(import_fact_contract(ImportFactKind::Binding)),
+        IMPORT_NAMESPACE_TAG => Some(import_fact_contract(ImportFactKind::Namespace)),
+        _ => None,
+    }
+}
+
+pub fn import_fact_tag(kind: ImportFactKind) -> &'static str {
+    import_fact_contract(kind).tag
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ImportFact {
+    pub kind: ImportFactKind,
+    pub module_hash: u64,
+    pub exported_hash: Option<u64>,
+}
+
+pub fn import_fact_rhs(il: &Il, interner: &Interner, rhs: NodeId) -> Option<ImportFact> {
+    if il.kind(rhs) != NodeKind::Seq {
+        return None;
+    }
+    let Payload::Name(tag) = il.node(rhs).payload else {
+        return None;
+    };
+    let contract = import_fact_contract_for_tag(interner.resolve(tag))?;
+    let coords = il.children(rhs);
+    if coords.len() != contract.coordinate_count {
+        return None;
+    }
+    let module_hash = literal_string_hash(il, coords[0])?;
+    let exported_hash = match contract.kind {
+        ImportFactKind::Binding => Some(literal_string_hash(il, coords[1])?),
+        ImportFactKind::Namespace => None,
+    };
+    Some(ImportFact {
+        kind: contract.kind,
+        module_hash,
+        exported_hash,
+    })
+}
+
+pub fn import_binding_rhs_matches(
+    il: &Il,
+    interner: &Interner,
+    rhs: NodeId,
+    module: &str,
+    exported: &str,
+) -> bool {
+    import_fact_rhs(il, interner, rhs).is_some_and(|fact| {
+        fact.kind == ImportFactKind::Binding
+            && fact.module_hash == stable_symbol_hash(module)
+            && fact.exported_hash == Some(stable_symbol_hash(exported))
+    })
+}
+
+pub fn import_namespace_rhs_matches(
+    il: &Il,
+    interner: &Interner,
+    rhs: NodeId,
+    module: &str,
+) -> bool {
+    import_fact_rhs(il, interner, rhs).is_some_and(|fact| {
+        fact.kind == ImportFactKind::Namespace
+            && fact.module_hash == stable_symbol_hash(module)
+            && fact.exported_hash.is_none()
+    })
+}
+
+fn literal_string_hash(il: &Il, node: NodeId) -> Option<u64> {
+    match il.node(node).payload {
+        Payload::LitStr(hash) => Some(hash),
+        _ => None,
+    }
 }
 
 /// A first-party language profile. Keep this cheap and copyable; callers use it as a
@@ -2187,6 +2301,82 @@ mod tests {
         assert!(seq_surface_contract(Lang::Python, Some("composite_literal")).is_none());
         assert!(imported_literal_seq_tag_safe(Lang::Python, "dictionary"));
         assert!(!imported_literal_seq_tag_safe(Lang::Ruby, "hash"));
+    }
+
+    #[test]
+    fn import_fact_contracts_parse_typed_binding_and_namespace_proofs() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let binding_tag = interner.intern(import_fact_tag(ImportFactKind::Binding));
+        let namespace_tag = interner.intern(import_fact_tag(ImportFactKind::Namespace));
+        let collections = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("collections")),
+            sp(1),
+            &[],
+        );
+        let deque = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("deque")),
+            sp(1),
+            &[],
+        );
+        let binding = b.add(
+            NodeKind::Seq,
+            Payload::Name(binding_tag),
+            sp(1),
+            &[collections, deque],
+        );
+        let math = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("math")),
+            sp(2),
+            &[],
+        );
+        let namespace = b.add(NodeKind::Seq, Payload::Name(namespace_tag), sp(2), &[math]);
+        let malformed_binding = b.add(NodeKind::Seq, Payload::Name(binding_tag), sp(3), &[math]);
+        let root = b.add(
+            NodeKind::Module,
+            Payload::None,
+            sp(1),
+            &[binding, namespace, malformed_binding],
+        );
+        let il = finish_il(b, root, Lang::Python);
+
+        assert_eq!(
+            import_fact_contract(ImportFactKind::Binding).channel,
+            ChannelEligibility::ExactProven
+        );
+        assert!(import_binding_rhs_matches(
+            &il,
+            &interner,
+            binding,
+            "collections",
+            "deque"
+        ));
+        assert!(!import_binding_rhs_matches(
+            &il,
+            &interner,
+            namespace,
+            "collections",
+            "deque"
+        ));
+        assert!(!import_binding_rhs_matches(
+            &il,
+            &interner,
+            malformed_binding,
+            "math",
+            "prod"
+        ));
+        assert!(import_namespace_rhs_matches(
+            &il, &interner, namespace, "math"
+        ));
+        assert!(!import_namespace_rhs_matches(
+            &il,
+            &interner,
+            binding,
+            "collections"
+        ));
     }
 
     #[test]

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -180,6 +180,22 @@ and pack ecosystem.
   rather than an arbitrary evaluated receiver value, so aliases and computed
   call-result receivers stay exact-closed until pack-facing place evidence
   exists.
+- Import binding and namespace proof interpretation now goes through a typed
+  `ImportFactKind`/`ImportFact` facade in `nose-semantics`. Frontend emitters,
+  imported immutable literal replacement, normalize idiom gates, value-graph
+  import proof, and strict exact gates now share the same tag, coordinate-count,
+  and module/export hash checks instead of parsing raw import `Seq` tags locally.
+- TypeScript type-only imports no longer emit runtime import facts: whole
+  `import type ...` declarations and type-only named specifiers stay outside
+  exact library/API proof.
+- Imported literal provenance now treats provider-side opaque argument escapes
+  such as `mutate(LOOKUP)` as mutation risk, so exported bindings must be direct,
+  unescaped immutable values before cross-file replacement can copy them.
+- Strict exact collection-membership receiver proof no longer falls back from
+  "not a known collection surface" to "any strict-safe tree." Top-level immutable
+  collection and map bindings are tracked separately from generic immutable names,
+  preserving supported module-level collection cases while closing unproven
+  receiver expressions.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -222,10 +238,15 @@ Remaining in this phase:
 - Move primitive comparison gates behind `OperatorSemantics`.
 - Expand the exact fragment facade from first-party helper functions into
   versioned pack-facing effect/place evidence records.
+- Move exact fragment append-effect classification off selector-only
+  `push`/`add` recognition and onto receiver/builder evidence shared with the
+  normal semantic contracts.
 - Move collection/map factory recognition into `LibraryApiContract` records.
 - Make value-graph and strict exact gates consume the same contract source.
-- Replace raw import/module proof payloads with typed `ImportFact` records shared
-  by frontend, normalize, detect, and idiom lowering.
+- Replace the remaining raw import/module proof IL payload storage with
+  pack-facing `ImportFact` records. The current compiled facade already provides
+  shared typed parsing for frontend, normalize, detect, and imported-literal
+  consumers.
 - Replace the compiled `SeqSurfaceContract` facade with pack-facing
   sequence/aggregate surface records and named kernel constructors.
 - Replace the current `DomainEvidence` facade with versioned, pack-facing

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -115,8 +115,9 @@ migrated.
   of `LOOKUP = Map.of(...)` carries the provider's `java.util.Map` proof into
   the importing file. Provider and importer module-binding mutation proof now
   rejects direct binding mutations and direct place writes such as
-  `LOOKUP.clear()` and `LOOKUP[key] = value` before imported literal provenance
-  can enter exact matching.
+  `LOOKUP.clear()` and `LOOKUP[key] = value`, and provider-side opaque argument
+  escapes such as `mutate(LOOKUP)`, before imported literal provenance can enter
+  exact matching.
 - Membership and map-key membership selectors now consume language-scoped method
   contracts before normalize/detect treat them as semantic containment. A method
   named `contains` is Java/Rust collection membership only; JavaScript
@@ -176,6 +177,19 @@ migrated.
   contract can prove key evaluation, coercion, order, and side-effect behavior.
 - JS/TS `new Map(...)` and `new Set(...)` remain closed because lowering does not
   yet retain a constructor proof distinct from ordinary `Map(...)`/`Set(...)`.
+- Static import proof facts now have a typed `ImportFactKind`/`ImportFact`
+  facade in `nose-semantics`. First-party frontends emit import binding and
+  namespace facts through that contract, and imported literal replacement,
+  normalize idiom admission, value-graph import proof, and strict exact gates
+  parse import proof RHS nodes through the shared helper instead of local raw
+  tag checks.
+- TypeScript `import type ...` and type-only named import specifiers are erased
+  for runtime import proof; they remain unavailable to exact semantic library
+  contracts.
+- Strict exact collection-membership gates no longer treat any strict-safe
+  expression as collection evidence. Non-literal receivers must now be proven by
+  typed parameter facts, local collection/map binding facts, or module-level
+  immutable collection/map binding facts.
 
 ## Scattered semantic knowledge
 
@@ -185,9 +199,11 @@ Semantic knowledge still appears in several forms outside the facade:
   rules that have not yet been expressed as shared contracts;
 - language-specific import or module proof mechanics that are still local to
   frontend, normalize, or detect callers;
-- raw IL `Seq("import_binding")` / `Seq("import_namespace")` payloads still carry
-  import facts. They pass through the surface contract now, but they are not yet
-  typed `ImportFact` records shared by frontend, normalize, detect, and idioms;
+- IL still stores import facts as `Seq("import_binding")` /
+  `Seq("import_namespace")` payloads for compatibility, but the semantic
+  interpretation now flows through typed `ImportFact` helpers in
+  `nose-semantics`. A future pack-facing representation should replace the raw IL
+  storage shape as well;
 - module/import proof logic for immutable sibling-module literal bindings;
 - type facts and coarse type inference used to gate numeric and collection laws;
 - named value-graph rule modules that still consume internal `Builder` facts
@@ -264,9 +280,9 @@ The first high-value targets for semantic-kernel extraction are:
 
 - pack-facing field/place evidence for all field reads and writes, building on
   the receiver-aware value-graph field state now used for same-unit caching;
-- typed import/module facts to replace raw `Seq("import_binding")` and
-  `Seq("import_namespace")` payload parsing across frontend, normalize, detect,
-  and idiom lowering;
+- pack-facing import/module fact records to replace the remaining raw
+  `Seq("import_binding")` and `Seq("import_namespace")` IL storage shape; current
+  consumers already parse these through the typed internal `ImportFact` facade;
 - pack-facing sequence/aggregate surface records to replace the current compiled
   `SeqSurfaceContract` facade and private value-graph `Seq` tag registry;
 - constructor facts for JS/TS `new Map` and `new Set`, which are now explicit


### PR DESCRIPTION
## Summary
- add a typed `ImportFactKind`/`ImportFact` facade in `nose-semantics` and route frontend, normalize, value-graph, imported-literal, and strict exact consumers through it
- erase TypeScript type-only imports from runtime import proof
- tighten imported literal provenance against provider-side opaque argument escapes
- remove the broad strict membership fallback from arbitrary strict-safe trees, preserving explicit collection/map evidence
- document the landed slice and the remaining append-fragment receiver-evidence migration target

## Verification
- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `git diff --check`
- `cargo fmt --all -- --check`
- `awiki lint --root docs`

## Notes
This intentionally does not migrate exact fragment append-effect recognition off selector-only `push`/`add` classification. The roadmap now tracks that as the next kernel-evidence slice because it spans fragment recognition/oracle behavior and existing append-fragment tests.