### PR TITLE
semantics: gate operators through kernel contracts

### DIFF
--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -6015,6 +6015,16 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
     )
     .unwrap();
     fs::write(
+        dir.join("js_in_array_a.js"),
+        "function jsInArrayA(value, other) {\n  return value in [\"red\", \"blue\"];\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("js_in_array_b.js"),
+        "function jsInArrayB(value, other) {\n  return value in [\"red\", \"blue\"];\n}\n",
+    )
+    .unwrap();
+    fs::write(
         dir.join("membership.go"),
         "package p\n\nimport \"slices\"\n\nfunc Membership(value string, other string) bool {\n    return slices.Contains([]string{\"red\", \"blue\"}, value)\n}\n",
     )
@@ -6230,6 +6240,16 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
     )
     .unwrap();
     fs::write(
+        dir.join("array_indexof_ne_zero.js"),
+        "function arrayIndexOfNeZero(value, other) {\n  return [\"red\", \"blue\"].indexOf(value) !== 0;\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("array_indexof_reversed_gt_zero.js"),
+        "function arrayIndexOfReversedGtZero(value, other) {\n  return 0 < [\"red\", \"blue\"].indexOf(value);\n}\n",
+    )
+    .unwrap();
+    fs::write(
         dir.join("array_findindex_wrong_element.js"),
         "function arrayFindIndexWrongElement(value, other, third) {\n  return [\"red\", \"blue\"].findIndex((item) => item === value + third + other) !== -1;\n}\n",
     )
@@ -6242,6 +6262,11 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
     fs::write(
         dir.join("array_findindex_value.js"),
         "function arrayFindIndexValue(value, other) {\n  return [\"red\", \"blue\"].findIndex((item) => item === value);\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("array_findindex_ne_zero.js"),
+        "function arrayFindIndexNeZero(value, other) {\n  return [\"red\", \"blue\"].findIndex((item) => item === value) !== 0;\n}\n",
     )
     .unwrap();
     fs::write(
@@ -6503,14 +6528,19 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
     for unexpected in [
         "wrong_element.py",
         "wrong_collection.js",
+        "js_in_array_a.js",
+        "js_in_array_b.js",
         "array_some_wrong_element.js",
         "array_some_wrong_collection.ts",
         "array_indexof_wrong_element.js",
         "array_indexof_wrong_collection.ts",
         "array_indexof_value.js",
+        "array_indexof_ne_zero.js",
+        "array_indexof_reversed_gt_zero.js",
         "array_findindex_wrong_element.js",
         "array_findindex_wrong_collection.ts",
         "array_findindex_value.js",
+        "array_findindex_ne_zero.js",
         "array_filter_length_wrong_element.js",
         "array_filter_length_wrong_collection.ts",
         "array_filter_length_value.js",
@@ -6551,6 +6581,10 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
             "semantic mode must preserve literal membership boundaries: {semantic}"
         );
     }
+    assert!(
+        !semantic_text.contains("js_in_array_a.js") && !semantic_text.contains("js_in_array_b.js"),
+        "semantic mode must not treat JavaScript `in` as collection membership: {semantic}"
+    );
     let absence_family = semantic_families
         .iter()
         .map(serde_json::Value::to_string)

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -17,15 +17,14 @@ use nose_semantics::{
     exact_java_this_field, exact_non_overloadable_index_assignment,
     exact_non_overloadable_index_assignment_parts, go_zero_map_default_kind,
     go_zero_map_lookup_contract, import_binding_rhs_matches, import_namespace_rhs_matches,
-    index_membership_threshold_contract, iterator_identity_adapter_contract,
-    java_collection_factory_contract, java_map_entry_contract, java_map_factory_contract,
-    js_array_is_array_contract, js_like_map_constructor_contract, js_like_set_constructor_contract,
-    map_get_contract, map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
-    nullish_global_contract, regex_test_contract, ruby_set_factory_contract,
-    rust_vec_new_factory_contract, semantics, seq_surface_contract,
-    static_index_membership_contract, typeof_operator_contract, IndexMembershipThreshold,
-    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
-    MethodSemanticContract, StaticIndexMembershipKind,
+    iterator_identity_adapter_contract, java_collection_factory_contract, java_map_entry_contract,
+    java_map_factory_contract, js_array_is_array_contract, js_like_map_constructor_contract,
+    js_like_set_constructor_contract, map_get_contract, map_key_view_contract,
+    map_key_view_wrapper_contract, method_call_contract, nullish_global_contract,
+    regex_test_contract, ruby_set_factory_contract, rust_vec_new_factory_contract, semantics,
+    seq_surface_contract, static_index_membership_contract, typeof_operator_contract,
+    IndexMembershipThreshold, JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs,
+    MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -928,7 +927,9 @@ fn strict_exact_safe_tree(il: &Il, interner: &Interner, facts: &StrictFacts, nod
         NodeKind::BinOp if strict_exact_static_index_membership_safe(il, interner, facts, node) => {
             true
         }
-        NodeKind::BinOp if strict_exact_in_membership_safe(il, interner, facts, node) => true,
+        NodeKind::BinOp if matches!(il.node(node).payload, Payload::Op(Op::In)) => {
+            strict_exact_in_membership_safe(il, interner, facts, node)
+        }
         NodeKind::Lit => exact_literal_safe(il, node),
         NodeKind::Var => {
             strict_exact_safe_var(il, facts, node)
@@ -950,6 +951,13 @@ fn strict_exact_in_membership_safe(
     let Payload::Op(Op::In) = il.node(node).payload else {
         return false;
     };
+    if semantics(il.meta.lang)
+        .operators()
+        .membership_operator(Op::In)
+        .is_none()
+    {
+        return false;
+    }
     let kids = il.children(node);
     kids.len() == 2
         && strict_exact_safe_tree(il, interner, facts, kids[0])
@@ -1066,18 +1074,24 @@ fn strict_exact_index_membership_threshold(
     threshold: NodeId,
 ) -> bool {
     if strict_exact_minus_one_literal(il, threshold) {
-        return index_membership_threshold_contract(
-            op,
-            index_call_on_right,
-            IndexMembershipThreshold::MinusOne,
-        );
+        return semantics(il.meta.lang)
+            .operators()
+            .static_index_membership_threshold(
+                op,
+                index_call_on_right,
+                IndexMembershipThreshold::MinusOne,
+            )
+            .is_some();
     }
     if matches!(il.node(threshold).payload, Payload::LitInt(0)) {
-        return index_membership_threshold_contract(
-            op,
-            index_call_on_right,
-            IndexMembershipThreshold::Zero,
-        );
+        return semantics(il.meta.lang)
+            .operators()
+            .static_index_membership_threshold(
+                op,
+                index_call_on_right,
+                IndexMembershipThreshold::Zero,
+            )
+            .is_some();
     }
     false
 }

--- a/crates/nose-normalize/src/algebra.rs
+++ b/crates/nose-normalize/src/algebra.rs
@@ -22,6 +22,7 @@
 
 use crate::combine;
 use nose_il::{Il, IlBuilder, Interner, NodeId, NodeKind, Op, Payload, Span};
+use nose_semantics::{semantics, ComparisonLaw};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 pub(crate) fn run(old: &Il, interner: &Interner) -> Il {
@@ -140,25 +141,31 @@ impl Rewriter<'_> {
         if kids.len() != 2 {
             return self.generic(old_id, span);
         }
-        match op {
+        let operators = semantics(self.old.meta.lang).operators();
+        if let Some(contract) = operators.comparison_direction(op) {
             // Canonicalize comparison direction by reflecting the order: `a > b` → `b < a`
             // (`normalize.value_graph.compare`), `a >= b` → `b <= a`.
             // Both arms swap the operands and emit the mirror operator; only the target
             // opcode differs.
-            Op::Gt | Op::Ge => {
-                let flipped = if op == Op::Gt { Op::Lt } else { Op::Le };
-                let (r, rh) = self.rewrite(kids[1]);
-                let (l, lh) = self.rewrite(kids[0]);
-                self.emit(
-                    NodeKind::BinOp,
-                    Payload::Op(flipped),
-                    span,
-                    &[r, l],
-                    &[rh, lh],
-                )
-            }
+            let (r, rh) = self.rewrite(kids[1]);
+            let (l, lh) = self.rewrite(kids[0]);
+            return self.emit(
+                NodeKind::BinOp,
+                Payload::Op(contract.output),
+                span,
+                &[r, l],
+                &[rh, lh],
+            );
+        }
+        match op {
             // commutative but not associative: sort the two operands
-            Op::Eq | Op::Ne => self.emit_commutative_cmp(op, span, kids[0], kids[1]),
+            Op::Eq | Op::Ne
+                if operators
+                    .comparison_law(ComparisonLaw::EqualityCommutativity)
+                    .is_some() =>
+            {
+                self.emit_commutative_cmp(op, span, kids[0], kids[1])
+            }
             _ => {
                 let (l, lh) = self.rewrite(kids[0]);
                 let (r, rh) = self.rewrite(kids[1]);
@@ -282,6 +289,7 @@ impl Rewriter<'_> {
                     _ => return self.negate_wrap(old, span),
                 };
                 let kids = self.old.children(old).to_vec();
+                let operators = semantics(self.old.meta.lang).operators();
                 match op {
                     Op::And | Op::Or => {
                         // De Morgan: negate each (flattened) operand, flip the op.
@@ -292,10 +300,6 @@ impl Rewriter<'_> {
                             olds.into_iter().map(|o| self.rewrite_negated(o)).collect();
                         self.build_assoc(flip, span, negated)
                     }
-                    Op::Eq | Op::Ne => {
-                        let flip = if op == Op::Eq { Op::Ne } else { Op::Eq };
-                        self.emit_commutative_cmp(flip, span, kids[0], kids[1])
-                    }
                     // Negate an order comparison on a total order, canonicalized to `<`/`<=`:
                     //   !(x < y)  = y <= x   !(x <= y) = y < x    (operands reflect)
                     //   !(x > y)  = x <= y   !(x >= y) = x < y     (operands stay)
@@ -303,20 +307,36 @@ impl Rewriter<'_> {
                     // and only the already-reflected `<`/`<=` cases swap operands so the result
                     // points the canonical way. Lean obligation: `normalize.value_graph.compare`,
                     // `not_le_eq_gt`+`gt_eq_lt_swap`, `not_gt_eq_le`, `not_ge_eq_lt`.
-                    Op::Lt | Op::Le | Op::Gt | Op::Ge => {
-                        let flip = if matches!(op, Op::Lt | Op::Gt) {
-                            Op::Le
-                        } else {
-                            Op::Lt
+                    Op::Eq | Op::Ne | Op::Lt | Op::Le | Op::Gt | Op::Ge => {
+                        let Some(contract) = operators.canonical_negated_comparison(op) else {
+                            return self.negate_wrap(old, span);
                         };
-                        let (first, second) = if matches!(op, Op::Lt | Op::Le) {
+                        if matches!(contract.output, Op::Eq | Op::Ne)
+                            && operators
+                                .comparison_law(ComparisonLaw::EqualityCommutativity)
+                                .is_some()
+                        {
+                            return self.emit_commutative_cmp(
+                                contract.output,
+                                span,
+                                kids[0],
+                                kids[1],
+                            );
+                        }
+                        let (first, second) = if contract.swap_operands {
                             (kids[1], kids[0])
                         } else {
                             (kids[0], kids[1])
                         };
                         let (a, ah) = self.rewrite(first);
                         let (b, bh) = self.rewrite(second);
-                        self.emit(NodeKind::BinOp, Payload::Op(flip), span, &[a, b], &[ah, bh])
+                        self.emit(
+                            NodeKind::BinOp,
+                            Payload::Op(contract.output),
+                            span,
+                            &[a, b],
+                            &[ah, bh],
+                        )
                     }
                     _ => self.negate_wrap(old, span),
                 }

--- a/crates/nose-normalize/src/cfg_norm.rs
+++ b/crates/nose-normalize/src/cfg_norm.rs
@@ -13,6 +13,7 @@
 
 use crate::commutative::subtree_hashes;
 use nose_il::{Il, IlBuilder, Interner, NodeId, NodeKind, Op, Payload};
+use nose_semantics::semantics;
 use rustc_hash::FxHashMap;
 
 // ----------------------------------------------------------------------------
@@ -217,13 +218,13 @@ fn invert_comparison(il: &Il, cond: NodeId) -> Option<(Op, bool)> {
         return None;
     }
     match n.payload {
-        Payload::Op(op) => Some(match op {
-            Op::Eq => (Op::Ne, false),
-            Op::Ne => (Op::Eq, false),
-            Op::Lt => (Op::Le, true),
-            Op::Le => (Op::Lt, true),
-            _ => return None,
-        }),
+        Payload::Op(op) if matches!(op, Op::Eq | Op::Ne | Op::Lt | Op::Le) => {
+            semantics(il.meta.lang)
+                .operators()
+                .canonical_negated_comparison(op)
+                .map(|contract| (contract.output, contract.swap_operands))
+        }
+        Payload::Op(_) => None,
         _ => None,
     }
 }

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -52,19 +52,20 @@ use nose_semantics::{
     builder_append_method_contract, builtin_tag, domain_evidence_from_param_semantic,
     free_function_builtin_contract, go_zero_map_default_kind, go_zero_map_lookup_contract,
     import_fact_contract, import_namespace_rhs_matches, imported_namespace_function_contract,
-    index_membership_threshold_contract, iterator_identity_adapter_contract,
-    java_collection_factory_contract_by_hash, java_map_entry_contract_by_hash,
-    java_map_factory_contract_by_hash, map_get_contract_by_hash, map_key_view_contract_by_hash,
-    map_key_view_wrapper_contract_by_hash, method_call_contract, nullish_global_contract,
-    reduction_builtin_contract, ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
-    rust_option_none_sentinel_contract, rust_option_some_constructor_contract,
-    rust_vec_new_factory_contract, scalar_integer_method_contract, semantics, seq_surface_contract,
-    static_index_membership_contract, BuiltinArgContract, DomainEvidence, GoZeroMapDefaultKind,
-    ImportFactKind, ImportedNamespaceFunctionSemantic, IndexMembershipThreshold,
-    IteratorAdapterReceiverContract, JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs,
-    MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
-    SeqSurfaceContract, StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP,
-    SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
+    iterator_identity_adapter_contract, java_collection_factory_contract_by_hash,
+    java_map_entry_contract_by_hash, java_map_factory_contract_by_hash, map_get_contract_by_hash,
+    map_key_view_contract_by_hash, map_key_view_wrapper_contract_by_hash, method_call_contract,
+    nullish_global_contract, reduction_builtin_contract, ruby_set_factory_contract_by_hash,
+    rust_option_and_then_contract, rust_option_none_sentinel_contract,
+    rust_option_some_constructor_contract, rust_vec_new_factory_contract,
+    scalar_integer_method_contract, semantics, seq_surface_contract,
+    static_index_membership_contract, BuiltinArgContract, CardinalityPredicate,
+    CardinalityThreshold, ComparisonLaw, DomainEvidence, GoZeroMapDefaultKind, ImportFactKind,
+    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
+    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
+    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract,
+    StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD,
+    SEQ_VALUE_PAIR, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -2031,7 +2032,7 @@ impl<'a> Builder<'a> {
             // one node). Language-agnostic and sound (total order). This is what lets a
             // `reduce(λa,v: a+v if v>0 else a, …)` fold converge with its loop, whose
             // guard may lower to the mirror comparison.
-            if args.len() == 2 {
+            if args.len() == 2 && self.comparison_law_enabled(ComparisonLaw::DirectionCanon) {
                 if opc == Op::Gt as u32 {
                     op = ValOp::Bin(Op::Lt as u32);
                     args.swap(0, 1);
@@ -2078,9 +2079,12 @@ impl<'a> Builder<'a> {
             // This canonicalizes the residual `Not` the algebra pass leaves on a pushed
             // double-negation (`!!(a<b)` → `!(b<=a)` → `a<b`), converging it with the bare
             // comparison without the unsound untyped `!!x → x`.
-            if o == Op::Not as u32 && !args.is_empty() {
+            if o == Op::Not as u32
+                && !args.is_empty()
+                && self.comparison_law_enabled(ComparisonLaw::Negation)
+            {
                 if let ValOp::Bin(bo) = self.nodes[args[0] as usize].op {
-                    if let Some(neg) = negate_cmp_code(bo) {
+                    if let Some(neg) = negate_cmp_code(self.il.meta.lang, bo) {
                         let cargs = self.nodes[args[0] as usize].args.clone();
                         return self.mk(ValOp::Bin(neg), cargs);
                     }
@@ -2477,13 +2481,17 @@ impl<'a> Builder<'a> {
     /// `(x ≤ y) ∧ (x ≠ y) → x < y`. Sound on a total order
     /// (`normalize.value_graph.compare`); the post-normalize oracle re-checks it.
     fn lattice_le_ne_to_lt(&mut self, a: ValueId, b: ValueId) -> Option<ValueId> {
+        if !self.comparison_law_enabled(ComparisonLaw::LatticeLeNeToLt) {
+            return None;
+        }
         self.lattice_pair_canon(a, b, Op::Le as u32, Op::Ne as u32, Op::Lt as u32)
     }
 
-    fn has_primitive_order_comparisons(&self) -> bool {
+    fn comparison_law_enabled(&self, law: ComparisonLaw) -> bool {
         semantics(self.il.meta.lang)
             .operators()
-            .primitive_order_comparisons()
+            .comparison_law(law)
+            .is_some()
     }
 
     /// `(x < y) ∧ (x ≤ y) → x < y`. Guard-clause lowering accumulates path conditions
@@ -2493,7 +2501,7 @@ impl<'a> Builder<'a> {
     /// can be absorbed only for source languages whose comparison operators are primitive
     /// rather than receiver-overloadable.
     fn lattice_strict_absorbs_nonstrict(&mut self, a: ValueId, b: ValueId) -> Option<ValueId> {
-        if !self.has_primitive_order_comparisons() {
+        if !self.comparison_law_enabled(ComparisonLaw::LatticeStrictAbsorbsNonstrict) {
             return None;
         }
         for (lt_v, le_v) in [(a, b), (b, a)] {
@@ -2509,6 +2517,9 @@ impl<'a> Builder<'a> {
     /// `(x < y) ∨ (x = y) → x ≤ y` — the dual of [`lattice_le_ne_to_lt`] over `∨`
     /// (`normalize.value_graph.compare`).
     fn lattice_lt_eq_to_le(&mut self, a: ValueId, b: ValueId) -> Option<ValueId> {
+        if !self.comparison_law_enabled(ComparisonLaw::LatticeLtEqToLe) {
+            return None;
+        }
         self.lattice_pair_canon(a, b, Op::Lt as u32, Op::Eq as u32, Op::Le as u32)
     }
 
@@ -4871,7 +4882,7 @@ impl<'a> Builder<'a> {
                 (cid, kids[1], cmp)
             }
             (None, Some(cid)) if !mentioned_cids(self.il, kids[0]).contains(&cid) => {
-                (cid, kids[0], reverse_cmp_code(cmp)?)
+                (cid, kids[0], reverse_cmp_code(self.il.meta.lang, cmp)?)
             }
             _ => return None,
         };
@@ -5166,10 +5177,12 @@ impl<'a> Builder<'a> {
     /// converges with the positive guard a loop produces — and anything else is wrapped
     /// in logical `Not`.
     fn negate_guard(&mut self, v: ValueId) -> ValueId {
-        if let ValOp::Bin(opc) = self.nodes[v as usize].op {
-            if let Some(flip) = negate_cmp_code(opc) {
-                let args = self.nodes[v as usize].args.clone();
-                return self.mk(ValOp::Bin(flip), args);
+        if self.comparison_law_enabled(ComparisonLaw::Negation) {
+            if let ValOp::Bin(opc) = self.nodes[v as usize].op {
+                if let Some(flip) = negate_cmp_code(self.il.meta.lang, opc) {
+                    let args = self.nodes[v as usize].args.clone();
+                    return self.mk(ValOp::Bin(flip), args);
+                }
             }
         }
         self.mk(ValOp::Un(Op::Not as u32), vec![v])
@@ -5179,6 +5192,9 @@ impl<'a> Builder<'a> {
     /// classify the selection as max or min. Operand order is meaningful (comparisons
     /// are not commutative-canonicalized), so `cand > acc` and `acc < cand` both → max.
     fn selection_code(&self, cond: ValueId, cand: ValueId, loopv: ValueId) -> Option<u32> {
+        if !self.comparison_law_enabled(ComparisonLaw::SelectionReductionGuard) {
+            return None;
+        }
         let n = &self.nodes[cond as usize];
         let opc = match n.op {
             ValOp::Bin(o) => o,
@@ -5207,6 +5223,9 @@ impl<'a> Builder<'a> {
     /// Recognize the absolute-value idiom `x if x>=0 else -x` (and its mirror
     /// `-x if x<0 else x`) as `Un(ABS_CODE, [x])`, so it converges with `abs(x)`.
     fn abs_pattern(&mut self, cond: ValueId, then: ValueId, els: ValueId) -> Option<ValueId> {
+        if !self.comparison_law_enabled(ComparisonLaw::AbsSignTernary) {
+            return None;
+        }
         let is_neg_of = |s: &Self, neg: ValueId, base: ValueId| {
             matches!(s.nodes[neg as usize].op, ValOp::Un(o) if o == Op::Neg as u32)
                 && s.nodes[neg as usize].args == [base]
@@ -5256,6 +5275,9 @@ impl<'a> Builder<'a> {
     /// `</<= ` family by `mk` (`x>y` → `y<x`). Sound: it is the literal meaning of the
     /// ternary (and `MIN_CODE`/`MAX_CODE` are interpreted as exactly that).
     fn minmax_pattern(&mut self, cond: ValueId, then: ValueId, els: ValueId) -> Option<ValueId> {
+        if !self.comparison_law_enabled(ComparisonLaw::MinMaxTernary) {
+            return None;
+        }
         let cn = &self.nodes[cond as usize];
         let opc = match cn.op {
             ValOp::Bin(o) => o,
@@ -6012,7 +6034,10 @@ impl<'a> Builder<'a> {
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
-        if kids.len() != 2 || !(op == Op::Eq as u32 || op == Op::Ne as u32) {
+        let cardinality = semantics(self.il.meta.lang)
+            .operators()
+            .zero_cardinality_equality(op_from_code(op)?)?;
+        if kids.len() != 2 {
             return None;
         }
         let coll = if self.is_zero_literal(kids[0]) {
@@ -6024,10 +6049,9 @@ impl<'a> Builder<'a> {
         };
         let coll_value = self.eval(coll, env);
         let empty = self.is_empty_value(coll_value);
-        if op == Op::Eq as u32 {
-            Some(empty)
-        } else {
-            Some(self.mk(ValOp::Un(Op::Not as u32), vec![empty]))
+        match cardinality.predicate {
+            CardinalityPredicate::Empty => Some(empty),
+            CardinalityPredicate::NonEmpty => Some(self.mk(ValOp::Un(Op::Not as u32), vec![empty])),
         }
     }
 
@@ -6083,27 +6107,59 @@ impl<'a> Builder<'a> {
         count_on_right: bool,
         threshold: NodeId,
     ) -> bool {
+        let Some(op) = op_from_code(op) else {
+            return false;
+        };
         if self.is_zero_literal(threshold) {
-            return op == Op::Ne as u32
-                || (!count_on_right && op == Op::Gt as u32)
-                || (count_on_right && op == Op::Lt as u32);
+            return semantics(self.il.meta.lang)
+                .operators()
+                .cardinality_threshold(
+                    op,
+                    count_on_right,
+                    CardinalityThreshold::Zero,
+                    CardinalityPredicate::NonEmpty,
+                )
+                .is_some();
         }
         if self.is_one_literal(threshold) {
-            return (!count_on_right && op == Op::Ge as u32)
-                || (count_on_right && op == Op::Le as u32);
+            return semantics(self.il.meta.lang)
+                .operators()
+                .cardinality_threshold(
+                    op,
+                    count_on_right,
+                    CardinalityThreshold::One,
+                    CardinalityPredicate::NonEmpty,
+                )
+                .is_some();
         }
         false
     }
 
     fn is_count_zero_threshold(&self, op: u32, count_on_right: bool, threshold: NodeId) -> bool {
+        let Some(op) = op_from_code(op) else {
+            return false;
+        };
         if self.is_zero_literal(threshold) {
-            return op == Op::Eq as u32
-                || (!count_on_right && op == Op::Le as u32)
-                || (count_on_right && op == Op::Ge as u32);
+            return semantics(self.il.meta.lang)
+                .operators()
+                .cardinality_threshold(
+                    op,
+                    count_on_right,
+                    CardinalityThreshold::Zero,
+                    CardinalityPredicate::Empty,
+                )
+                .is_some();
         }
         if self.is_one_literal(threshold) {
-            return (!count_on_right && op == Op::Lt as u32)
-                || (count_on_right && op == Op::Gt as u32);
+            return semantics(self.il.meta.lang)
+                .operators()
+                .cardinality_threshold(
+                    op,
+                    count_on_right,
+                    CardinalityThreshold::One,
+                    CardinalityPredicate::Empty,
+                )
+                .is_some();
         }
         false
     }
@@ -6174,18 +6230,24 @@ impl<'a> Builder<'a> {
         threshold: NodeId,
     ) -> bool {
         if self.is_minus_one_literal(threshold) {
-            return index_membership_threshold_contract(
-                op,
-                index_call_on_right,
-                IndexMembershipThreshold::MinusOne,
-            );
+            return semantics(self.il.meta.lang)
+                .operators()
+                .static_index_membership_threshold(
+                    op,
+                    index_call_on_right,
+                    IndexMembershipThreshold::MinusOne,
+                )
+                .is_some();
         }
         if self.is_zero_literal(threshold) {
-            return index_membership_threshold_contract(
-                op,
-                index_call_on_right,
-                IndexMembershipThreshold::Zero,
-            );
+            return semantics(self.il.meta.lang)
+                .operators()
+                .static_index_membership_threshold(
+                    op,
+                    index_call_on_right,
+                    IndexMembershipThreshold::Zero,
+                )
+                .is_some();
         }
         false
     }
@@ -7963,43 +8025,51 @@ fn is_increment(il: &Il, expr: NodeId, cid: u32) -> bool {
 }
 
 /// The complementary comparison op code, if `opc` is a comparison; else `None`.
-fn negate_cmp_code(opc: u32) -> Option<u32> {
-    let flip = if opc == Op::Lt as u32 {
-        Op::Ge
-    } else if opc == Op::Le as u32 {
-        Op::Gt
-    } else if opc == Op::Gt as u32 {
-        Op::Le
-    } else if opc == Op::Ge as u32 {
-        Op::Lt
-    } else if opc == Op::Eq as u32 {
-        Op::Ne
-    } else if opc == Op::Ne as u32 {
-        Op::Eq
-    } else {
-        return None;
-    };
-    Some(flip as u32)
+fn negate_cmp_code(lang: Lang, opc: u32) -> Option<u32> {
+    let op = op_from_code(opc)?;
+    semantics(lang)
+        .operators()
+        .comparison_complement(op)
+        .map(|contract| contract.output as u32)
 }
 
 /// The same comparison with operands swapped: `a < b` becomes `b > a`.
-fn reverse_cmp_code(opc: u32) -> Option<u32> {
-    let rev = if opc == Op::Lt as u32 {
-        Op::Gt
-    } else if opc == Op::Le as u32 {
-        Op::Ge
-    } else if opc == Op::Gt as u32 {
-        Op::Lt
-    } else if opc == Op::Ge as u32 {
-        Op::Le
-    } else if opc == Op::Eq as u32 {
-        Op::Eq
-    } else if opc == Op::Ne as u32 {
-        Op::Ne
-    } else {
-        return None;
-    };
-    Some(rev as u32)
+fn reverse_cmp_code(lang: Lang, opc: u32) -> Option<u32> {
+    let op = op_from_code(opc)?;
+    semantics(lang)
+        .operators()
+        .comparison_reverse(op)
+        .map(|contract| contract.output as u32)
+}
+
+fn op_from_code(opc: u32) -> Option<Op> {
+    const OPS: &[Op] = &[
+        Op::Add,
+        Op::Sub,
+        Op::Mul,
+        Op::Div,
+        Op::Mod,
+        Op::Pow,
+        Op::Eq,
+        Op::Ne,
+        Op::Lt,
+        Op::Le,
+        Op::Gt,
+        Op::Ge,
+        Op::In,
+        Op::And,
+        Op::Or,
+        Op::Not,
+        Op::BitAnd,
+        Op::BitOr,
+        Op::BitXor,
+        Op::Shl,
+        Op::Shr,
+        Op::BitNot,
+        Op::Neg,
+        Op::Pos,
+    ];
+    OPS.iter().copied().find(|op| *op as u32 == opc)
 }
 
 fn is_commutative(opc: u32) -> bool {

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -408,12 +408,265 @@ pub struct OperatorSemantics {
     lang: Lang,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ComparisonLaw {
+    DirectionCanon,
+    Negation,
+    EqualityCommutativity,
+    LatticeLeNeToLt,
+    LatticeLtEqToLe,
+    LatticeStrictAbsorbsNonstrict,
+    AbsSignTernary,
+    MinMaxTernary,
+    SelectionReductionGuard,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum OperatorEvidence {
+    ModeledIlOperator,
+    PrimitiveTotalOrder,
+    StaticCardinalityThreshold,
+    JsLikeStaticIndexMembershipThreshold,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct OperatorLawContract {
+    pub law: ComparisonLaw,
+    pub channel: ChannelEligibility,
+    pub evidence: OperatorEvidence,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ComparisonTransformContract {
+    pub law: ComparisonLaw,
+    pub input: Op,
+    pub output: Op,
+    pub swap_operands: bool,
+    pub channel: ChannelEligibility,
+    pub evidence: OperatorEvidence,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CardinalityThreshold {
+    Zero,
+    One,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CardinalityPredicate {
+    Empty,
+    NonEmpty,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct CardinalityThresholdContract {
+    pub threshold: CardinalityThreshold,
+    pub predicate: CardinalityPredicate,
+    pub channel: ChannelEligibility,
+    pub evidence: OperatorEvidence,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct StaticIndexMembershipThresholdContract {
+    pub threshold: IndexMembershipThreshold,
+    pub channel: ChannelEligibility,
+    pub evidence: OperatorEvidence,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MembershipOperatorReceiverContract {
+    ExactCollectionOrMap,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct MembershipOperatorContract {
+    pub operator: Op,
+    pub receiver: MembershipOperatorReceiverContract,
+    pub channel: ChannelEligibility,
+    pub evidence: OperatorEvidence,
+}
+
 impl OperatorSemantics {
+    pub fn comparison_law(self, law: ComparisonLaw) -> Option<OperatorLawContract> {
+        let evidence = match law {
+            ComparisonLaw::LatticeStrictAbsorbsNonstrict => {
+                if !matches!(self.lang, Lang::C | Lang::Go | Lang::Java) {
+                    return None;
+                }
+                OperatorEvidence::PrimitiveTotalOrder
+            }
+            ComparisonLaw::DirectionCanon
+            | ComparisonLaw::Negation
+            | ComparisonLaw::EqualityCommutativity
+            | ComparisonLaw::LatticeLeNeToLt
+            | ComparisonLaw::LatticeLtEqToLe
+            | ComparisonLaw::AbsSignTernary
+            | ComparisonLaw::MinMaxTernary
+            | ComparisonLaw::SelectionReductionGuard => OperatorEvidence::ModeledIlOperator,
+        };
+        Some(OperatorLawContract {
+            law,
+            channel: ChannelEligibility::ExactProven,
+            evidence,
+        })
+    }
+
+    pub fn comparison_direction(self, op: Op) -> Option<ComparisonTransformContract> {
+        let output = match op {
+            Op::Gt => Op::Lt,
+            Op::Ge => Op::Le,
+            _ => return None,
+        };
+        let law = self.comparison_law(ComparisonLaw::DirectionCanon)?;
+        Some(ComparisonTransformContract {
+            law: law.law,
+            input: op,
+            output,
+            swap_operands: true,
+            channel: law.channel,
+            evidence: law.evidence,
+        })
+    }
+
+    pub fn comparison_reverse(self, op: Op) -> Option<ComparisonTransformContract> {
+        let output = match op {
+            Op::Lt => Op::Gt,
+            Op::Le => Op::Ge,
+            Op::Gt => Op::Lt,
+            Op::Ge => Op::Le,
+            Op::Eq => Op::Eq,
+            Op::Ne => Op::Ne,
+            _ => return None,
+        };
+        let law = self.comparison_law(ComparisonLaw::DirectionCanon)?;
+        Some(ComparisonTransformContract {
+            law: law.law,
+            input: op,
+            output,
+            swap_operands: true,
+            channel: law.channel,
+            evidence: law.evidence,
+        })
+    }
+
+    pub fn comparison_complement(self, op: Op) -> Option<ComparisonTransformContract> {
+        let output = match op {
+            Op::Lt => Op::Ge,
+            Op::Le => Op::Gt,
+            Op::Gt => Op::Le,
+            Op::Ge => Op::Lt,
+            Op::Eq => Op::Ne,
+            Op::Ne => Op::Eq,
+            _ => return None,
+        };
+        let law = self.comparison_law(ComparisonLaw::Negation)?;
+        Some(ComparisonTransformContract {
+            law: law.law,
+            input: op,
+            output,
+            swap_operands: false,
+            channel: law.channel,
+            evidence: law.evidence,
+        })
+    }
+
+    pub fn canonical_negated_comparison(self, op: Op) -> Option<ComparisonTransformContract> {
+        let (output, swap_operands) = match op {
+            Op::Eq => (Op::Ne, false),
+            Op::Ne => (Op::Eq, false),
+            Op::Lt => (Op::Le, true),
+            Op::Le => (Op::Lt, true),
+            Op::Gt => (Op::Le, false),
+            Op::Ge => (Op::Lt, false),
+            _ => return None,
+        };
+        let law = self.comparison_law(ComparisonLaw::Negation)?;
+        Some(ComparisonTransformContract {
+            law: law.law,
+            input: op,
+            output,
+            swap_operands,
+            channel: law.channel,
+            evidence: law.evidence,
+        })
+    }
+
     /// Source comparison operators are primitive total-order comparisons rather
     /// than receiver-overloadable/user-dispatched comparisons. This gates lattice
     /// comparison absorption rules.
     pub fn primitive_order_comparisons(self) -> bool {
-        matches!(self.lang, Lang::C | Lang::Go | Lang::Java)
+        self.comparison_law(ComparisonLaw::LatticeStrictAbsorbsNonstrict)
+            .is_some()
+    }
+
+    pub fn zero_cardinality_equality(self, op: Op) -> Option<CardinalityThresholdContract> {
+        let predicate = match op {
+            Op::Eq => CardinalityPredicate::Empty,
+            Op::Ne => CardinalityPredicate::NonEmpty,
+            _ => return None,
+        };
+        Some(CardinalityThresholdContract {
+            threshold: CardinalityThreshold::Zero,
+            predicate,
+            channel: ChannelEligibility::ExactProven,
+            evidence: OperatorEvidence::StaticCardinalityThreshold,
+        })
+    }
+
+    pub fn cardinality_threshold(
+        self,
+        op: Op,
+        count_on_right: bool,
+        threshold: CardinalityThreshold,
+        predicate: CardinalityPredicate,
+    ) -> Option<CardinalityThresholdContract> {
+        let matches = match (predicate, threshold) {
+            (CardinalityPredicate::NonEmpty, CardinalityThreshold::Zero) => {
+                threshold_excludes_floor(op, count_on_right)
+            }
+            (CardinalityPredicate::NonEmpty, CardinalityThreshold::One) => {
+                threshold_reaches_floor(op, count_on_right)
+            }
+            (CardinalityPredicate::Empty, CardinalityThreshold::Zero) => {
+                threshold_at_or_below_floor(op, count_on_right)
+            }
+            (CardinalityPredicate::Empty, CardinalityThreshold::One) => {
+                threshold_below_floor(op, count_on_right)
+            }
+        };
+        matches.then_some(CardinalityThresholdContract {
+            threshold,
+            predicate,
+            channel: ChannelEligibility::ExactProven,
+            evidence: OperatorEvidence::StaticCardinalityThreshold,
+        })
+    }
+
+    pub fn static_index_membership_threshold(
+        self,
+        op: Op,
+        index_call_on_right: bool,
+        threshold: IndexMembershipThreshold,
+    ) -> Option<StaticIndexMembershipThresholdContract> {
+        if !js_like_lang(self.lang) {
+            return None;
+        }
+        index_membership_threshold_matches(op, index_call_on_right, threshold).then_some(
+            StaticIndexMembershipThresholdContract {
+                threshold,
+                channel: ChannelEligibility::ExactProven,
+                evidence: OperatorEvidence::JsLikeStaticIndexMembershipThreshold,
+            },
+        )
+    }
+
+    pub fn membership_operator(self, op: Op) -> Option<MembershipOperatorContract> {
+        (self.lang == Lang::Python && op == Op::In).then_some(MembershipOperatorContract {
+            operator: op,
+            receiver: MembershipOperatorReceiverContract::ExactCollectionOrMap,
+            channel: ChannelEligibility::ExactProven,
+            evidence: OperatorEvidence::ModeledIlOperator,
+        })
     }
 
     /// C unsigned byte/word packing contracts are currently first-party only for
@@ -421,6 +674,22 @@ impl OperatorSemantics {
     pub fn c_integer_byte_pack_contracts(self) -> bool {
         self.lang == Lang::C
     }
+}
+
+fn threshold_excludes_floor(op: Op, value_on_right: bool) -> bool {
+    op == Op::Ne || (!value_on_right && op == Op::Gt) || (value_on_right && op == Op::Lt)
+}
+
+fn threshold_reaches_floor(op: Op, value_on_right: bool) -> bool {
+    (!value_on_right && op == Op::Ge) || (value_on_right && op == Op::Le)
+}
+
+fn threshold_at_or_below_floor(op: Op, value_on_right: bool) -> bool {
+    op == Op::Eq || (!value_on_right && op == Op::Le) || (value_on_right && op == Op::Ge)
+}
+
+fn threshold_below_floor(op: Op, value_on_right: bool) -> bool {
+    (!value_on_right && op == Op::Lt) || (value_on_right && op == Op::Gt)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -1828,21 +2097,23 @@ pub enum IndexMembershipThreshold {
     Zero,
 }
 
-pub fn index_membership_threshold_contract(
+fn index_membership_threshold_matches(
     op: Op,
     index_call_on_right: bool,
     threshold: IndexMembershipThreshold,
 ) -> bool {
     match threshold {
-        IndexMembershipThreshold::MinusOne => {
-            op == Op::Ne
-                || (!index_call_on_right && op == Op::Gt)
-                || (index_call_on_right && op == Op::Lt)
-        }
-        IndexMembershipThreshold::Zero => {
-            (!index_call_on_right && op == Op::Ge) || (index_call_on_right && op == Op::Le)
-        }
+        IndexMembershipThreshold::MinusOne => threshold_excludes_floor(op, index_call_on_right),
+        IndexMembershipThreshold::Zero => threshold_reaches_floor(op, index_call_on_right),
     }
+}
+
+pub fn index_membership_threshold_contract(
+    op: Op,
+    index_call_on_right: bool,
+    threshold: IndexMembershipThreshold,
+) -> bool {
+    index_membership_threshold_matches(op, index_call_on_right, threshold)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -3163,6 +3434,118 @@ mod tests {
     }
 
     #[test]
+    fn operator_law_contracts_preserve_comparison_gates() {
+        for &lang in ALL_LANGS {
+            let profile = semantics(lang);
+            assert_eq!(
+                profile
+                    .operators()
+                    .comparison_law(ComparisonLaw::LatticeStrictAbsorbsNonstrict)
+                    .is_some(),
+                matches!(lang, Lang::C | Lang::Go | Lang::Java)
+            );
+            assert_eq!(
+                profile
+                    .operators()
+                    .comparison_law(ComparisonLaw::LatticeLeNeToLt),
+                Some(OperatorLawContract {
+                    law: ComparisonLaw::LatticeLeNeToLt,
+                    channel: ChannelEligibility::ExactProven,
+                    evidence: OperatorEvidence::ModeledIlOperator,
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn comparison_transform_contracts_carry_outputs_and_operand_swaps() {
+        let ops = semantics(Lang::Python).operators();
+        assert_eq!(
+            ops.comparison_direction(Op::Gt),
+            Some(ComparisonTransformContract {
+                law: ComparisonLaw::DirectionCanon,
+                input: Op::Gt,
+                output: Op::Lt,
+                swap_operands: true,
+                channel: ChannelEligibility::ExactProven,
+                evidence: OperatorEvidence::ModeledIlOperator,
+            })
+        );
+        assert_eq!(
+            ops.comparison_complement(Op::Lt)
+                .map(|contract| (contract.output, contract.swap_operands)),
+            Some((Op::Ge, false))
+        );
+        assert_eq!(
+            ops.canonical_negated_comparison(Op::Lt)
+                .map(|contract| (contract.output, contract.swap_operands)),
+            Some((Op::Le, true))
+        );
+        assert_eq!(ops.comparison_direction(Op::Eq), None);
+    }
+
+    #[test]
+    fn cardinality_threshold_contracts_name_existing_operator_shapes() {
+        let ops = semantics(Lang::JavaScript).operators();
+        assert_eq!(
+            ops.zero_cardinality_equality(Op::Eq),
+            Some(CardinalityThresholdContract {
+                threshold: CardinalityThreshold::Zero,
+                predicate: CardinalityPredicate::Empty,
+                channel: ChannelEligibility::ExactProven,
+                evidence: OperatorEvidence::StaticCardinalityThreshold,
+            })
+        );
+        assert_eq!(ops.zero_cardinality_equality(Op::Gt), None);
+        assert_eq!(
+            ops.cardinality_threshold(
+                Op::Gt,
+                false,
+                CardinalityThreshold::Zero,
+                CardinalityPredicate::NonEmpty,
+            )
+            .map(|contract| contract.predicate),
+            Some(CardinalityPredicate::NonEmpty)
+        );
+        assert_eq!(
+            ops.cardinality_threshold(
+                Op::Eq,
+                false,
+                CardinalityThreshold::One,
+                CardinalityPredicate::NonEmpty,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn membership_operator_contract_is_language_scoped() {
+        assert_eq!(
+            semantics(Lang::Python)
+                .operators()
+                .membership_operator(Op::In),
+            Some(MembershipOperatorContract {
+                operator: Op::In,
+                receiver: MembershipOperatorReceiverContract::ExactCollectionOrMap,
+                channel: ChannelEligibility::ExactProven,
+                evidence: OperatorEvidence::ModeledIlOperator,
+            })
+        );
+        assert_eq!(
+            semantics(Lang::JavaScript)
+                .operators()
+                .membership_operator(Op::In),
+            None
+        );
+        assert_eq!(
+            semantics(Lang::Python)
+                .operators()
+                .membership_operator(Op::Eq),
+            None
+        );
+    }
+
+    #[test]
     fn static_index_membership_contracts_are_js_like_and_threshold_constrained() {
         assert_eq!(
             static_index_membership_contract(Lang::JavaScript, "indexOf", 1),
@@ -3192,21 +3575,29 @@ mod tests {
             static_index_membership_contract(Lang::JavaScript, "includes", 1),
             None
         );
-        assert!(index_membership_threshold_contract(
-            Op::Ne,
-            false,
-            IndexMembershipThreshold::MinusOne
-        ));
-        assert!(index_membership_threshold_contract(
-            Op::Le,
-            true,
-            IndexMembershipThreshold::Zero
-        ));
-        assert!(!index_membership_threshold_contract(
-            Op::Eq,
-            false,
-            IndexMembershipThreshold::MinusOne
-        ));
+        assert_eq!(
+            semantics(Lang::JavaScript)
+                .operators()
+                .static_index_membership_threshold(
+                    Op::Ne,
+                    false,
+                    IndexMembershipThreshold::MinusOne
+                )
+                .map(|contract| contract.evidence),
+            Some(OperatorEvidence::JsLikeStaticIndexMembershipThreshold)
+        );
+        assert!(semantics(Lang::TypeScript)
+            .operators()
+            .static_index_membership_threshold(Op::Le, true, IndexMembershipThreshold::Zero)
+            .is_some());
+        assert!(semantics(Lang::Python)
+            .operators()
+            .static_index_membership_threshold(Op::Ne, false, IndexMembershipThreshold::MinusOne)
+            .is_none());
+        assert!(semantics(Lang::JavaScript)
+            .operators()
+            .static_index_membership_threshold(Op::Eq, false, IndexMembershipThreshold::MinusOne)
+            .is_none());
     }
 
     #[test]

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -33,7 +33,10 @@ experiments that validated these passes are in [experiments](experiments.md).
 > changed flattened predicates; filtered Sum/Reduce FlatMap aggregates, method-terminal
 > Any/All predicates, and filtered nested early-return any/all loops preserve carried
 > outer/inner predicates), full **AC flatten+sort in the value graph itself** (not
-> only the `algebra` IL pass), **distribution/factoring** `a*c+b*c→(a+b)*c` (Num-gated),
+> only the `algebra` IL pass), **operator-law contracts** from the semantic kernel
+> gate comparison transforms, comparison-lattice rewrites, static cardinality
+> thresholds, and source membership operators, **distribution/factoring**
+> `a*c+b*c→(a+b)*c` (Num-gated),
 > min/max and any/all reductions (cross-language), simple **flag+break existence/universal
 > loops** (`found=false; if p { found=true; break }` / the dual `all` form),
 > **reduce-lambda selection** (`reduce(λ. a if a>b else b)≡max`), **count-of-filter**
@@ -117,6 +120,10 @@ Guiding constraints for every pass:
   Java `Arrays.asList(values).contains(x)` also carries the array domain when `values` is
   a proven array parameter, keeping element membership distinct from singleton-list
   membership such as `List.of(values).contains(x)` or `Arrays.asList(listParam).contains(x)`.
+  Source membership operators are language-scoped: Python `in` can enter exact
+  collection/map membership when the receiver is proven, while JavaScript `in`
+  remains exact-closed for collection membership because it is a property/key
+  existence operator.
   Module-binding facts respect alpha's per-function cid spaces: top-level assignment cids may
   resolve back to module symbols, but cids inside functions and lambdas are local and never
   prove or shadow a module binding by table index alone.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -201,6 +201,14 @@ and pack ecosystem.
   prove append fragments by name; first-party language/library paths must first
   prove the receiver or active-builder contract and lower the call to
   `Builtin::Append`.
+- Primitive operator gates now enter through `OperatorSemantics` contracts for
+  comparison transforms, comparison laws, cardinality thresholds, static
+  `indexOf`/`findIndex` thresholds, and source membership operators. Algebra,
+  CFG normalization, value-graph comparison/count rewrites, and strict exact
+  static-membership gates consume the shared contract vocabulary. JS `in` no
+  longer inherits collection-membership exact safety from the shared `Op::In`
+  token; only Python `in` currently has a first-party membership-operator
+  contract.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -240,7 +248,12 @@ Remaining in this phase:
 
 ## Phase 2: shared contracts for duplicated gates
 
-- Move primitive comparison gates behind `OperatorSemantics`.
+- Continue moving primitive operator gates behind `OperatorSemantics`. The first
+  larger slice covers comparison transforms/laws, cardinality thresholds, static
+  index-membership thresholds, and Python source `in` membership exact-safety.
+  Remaining work includes source equality provenance such as JS loose equality,
+  JS `instanceof`, and Python identity before exact callbacks can distinguish
+  all equality-shaped IL safely.
 - Expand the exact fragment facade from first-party helper functions into
   versioned pack-facing effect/place evidence records.
 - Continue replacing any remaining local exact-fragment proof helpers with

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -6,7 +6,8 @@ implementation shape; planned work and decision history live in
 
 Snapshot date: 2026-06-07, current implementation after the semantic-kernel
 foundation and follow-up facade migrations through receiver-aware field state
-sequence-surface contracts, and proof-backed append fragment evidence.
+sequence-surface contracts, proof-backed append fragment evidence, and the first
+operator-law contracts.
 
 ## What exists today
 
@@ -42,6 +43,15 @@ migrated.
 - The first-party profile exposes pack id and trust policy separately from
   channel eligibility. `ChannelEligibility` describes where a fact may be used;
   first-party/default status is pack provenance, not an analysis channel.
+- `OperatorSemantics` now owns the first shared operator contracts:
+  comparison-direction transforms, comparison negation, equality operand
+  commutativity, comparison-lattice laws, abs/min/max/selection guard laws,
+  static cardinality thresholds, JS-like static `indexOf`/`findIndex`
+  thresholds, and source membership operators. Algebra normalization, CFG
+  branch orientation, value-graph comparison/count rewrites, and strict exact
+  static-index gates consume these contracts instead of local operator tables.
+  The old `primitive_order_comparisons()` helper remains as a compatibility
+  wrapper around the stricter lattice law contract.
 - Free-function builtin contracts are language- and arity-constrained and require
   unshadowed builtin/global proof before exact lowering.
 - Method contracts carry receiver obligations such as exact collection, exact
@@ -144,8 +154,14 @@ migrated.
   is not inferred from the selector name in normalize/detect.
 - JS-like static array `indexOf`/`findIndex` membership surfaces are explicit
   contracts, including the static non-float literal collection requirement and
-  accepted `-1`/`0` threshold comparisons. Callers still prove the receiver and
-  lambda equality shape before exact normalization/detection accepts them.
+  accepted `-1`/`0` threshold comparisons through `OperatorSemantics`. Callers
+  still prove the receiver and lambda equality shape before exact
+  normalization/detection accepts them.
+- Source `Op::In` is not proof by itself. Strict exact collection/map
+  membership currently admits Python `in` only through a language-scoped
+  membership-operator contract plus receiver evidence. JS `in` remains
+  exact-closed for collection membership because it means property/key existence,
+  not array element membership.
 - Imported namespace function contracts now cover Python `math.prod` as a product
   reduction only when the receiver is proven to be the imported `math` namespace.
   Bare globals named `math` and overwritten module bindings stay exact-closed.
@@ -203,6 +219,10 @@ Semantic knowledge still appears in several forms outside the facade:
 
 - direct `Lang` checks and local recognizers in strict exact gates and value-graph
   rules that have not yet been expressed as shared contracts;
+- source operator provenance is still lossy for some equality-shaped IL. For
+  example, JS loose equality and `instanceof`, and Python identity, can lower to
+  the same coarse equality operator until future frontend/kernel facts preserve
+  the source equality kind;
 - language-specific import or module proof mechanics that are still local to
   frontend, normalize, or detect callers;
 - IL still stores import facts as `Seq("import_binding")` /


### PR DESCRIPTION
## Summary

- add first-class `OperatorSemantics` contracts for comparison transforms/laws, cardinality thresholds, JS-like static index-membership thresholds, and source membership operators
- route algebra, CFG branch orientation, value-graph comparison/count/index-threshold rewrites, and strict exact gates through the shared operator contract vocabulary
- close raw `Op::In` exact-safety for JavaScript `in`; Python `in` remains exact-eligible only with the language-scoped membership operator contract plus receiver proof
- update semantic-kernel roadmap/snapshot and normalization docs; record remaining source equality provenance work

## Precision/recall notes

This preserves current supported positives for comparison normalization, Rust integer methods, collection emptiness, and JS-like `indexOf`/`findIndex` membership thresholds. It intentionally tightens JS `in`: the shared IL token no longer proves collection membership because JavaScript `in` is property/key existence, not array element membership.

The slice does not change frontend operator provenance. JS loose equality/`instanceof` and Python identity can still lower to coarse equality-shaped IL; the roadmap/snapshot now call that out as a remaining kernel evidence task.

## Verification

- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `awiki lint --root docs`
- `git diff --check`

Refs #109
