### PR TITLE
[codex] Preserve source facts for exact contracts

### DIFF
--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -5322,7 +5322,7 @@ fn semantic_scan_reports_exact_safe_throw_fragments_under_opaque_functions() {
 }
 
 #[test]
-fn scan_mode_semantic_rejects_unproved_regex_predicate_matches() {
+fn scan_mode_semantic_proves_regex_literal_predicate_matches() {
     let dir = std::env::temp_dir().join(format!("nose_regex_semantic_{}", std::process::id()));
     let _ = fs::remove_dir_all(&dir);
     fs::create_dir_all(&dir).unwrap();
@@ -5339,6 +5339,16 @@ fn scan_mode_semantic_rejects_unproved_regex_predicate_matches() {
     fs::write(
         dir.join("dot-only-copy.ts"),
         "export function matchesDotOnly(segment: string) {\n    return /^\\.+$/u.test(segment);\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("string-test-a.ts"),
+        "export function stringTestA(value: string) {\n    return \"^\\\\.+$\".test(value);\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("string-test-b.ts"),
+        "export function stringTestB(value: string) {\n    return \"^\\\\.+$\".test(value);\n}\n",
     )
     .unwrap();
 
@@ -5360,8 +5370,17 @@ fn scan_mode_semantic_rejects_unproved_regex_predicate_matches() {
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
         semantic_families.len(),
-        0,
-        "semantic mode must keep literal .test exact-closed until regex literal provenance exists: {semantic}"
+        1,
+        "semantic mode should report only the matching regex-literal predicate: {semantic}"
+    );
+    let semantic_text = semantic_json.to_string();
+    assert!(
+        semantic_text.contains("dot-only.ts")
+            && semantic_text.contains("dot-only-copy.ts")
+            && !semantic_text.contains("markdown-link.ts")
+            && !semantic_text.contains("string-test-a.ts")
+            && !semantic_text.contains("string-test-b.ts"),
+        "semantic mode must consume regex literal provenance without merging different patterns: {semantic}"
     );
 
     let near = run(&[
@@ -6100,6 +6119,16 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
     )
     .unwrap();
     fs::write(
+        dir.join("array_some_loose.js"),
+        "function arraySomeLoose(value, other) {\n  return [\"red\", \"blue\"].some((item) => item == value);\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("array_findindex_loose.js"),
+        "function arrayFindIndexLoose(value, other) {\n  return [\"red\", \"blue\"].findIndex((item) => item == value) !== -1;\n}\n",
+    )
+    .unwrap();
+    fs::write(
         dir.join("array_filter_length.js"),
         "function arrayFilterLength(value, other) {\n  return [\"red\", \"blue\"].filter((item) => item === value).length !== 0;\n}\n",
     )
@@ -6130,8 +6159,18 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
     )
     .unwrap();
     fs::write(
+        dir.join("array_every_loose.js"),
+        "function arrayEveryLoose(value, other) {\n  return [\"red\", \"blue\"].every((item) => item != value);\n}\n",
+    )
+    .unwrap();
+    fs::write(
         dir.join("array_filter_length_absence.js"),
         "function arrayFilterLengthAbsence(value, other) {\n  return [\"red\", \"blue\"].filter((item) => item === value).length === 0;\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("array_filter_length_loose.js"),
+        "function arrayFilterLengthLoose(value, other) {\n  return [\"red\", \"blue\"].filter((item) => item == value).length !== 0;\n}\n",
     )
     .unwrap();
     fs::write(
@@ -6510,6 +6549,8 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
         "go_slices_alias.go",
         "go_slices_const.go",
         "go_slices_local.go",
+        "module_set.js",
+        "module_set.ts",
         "module_list.java",
         "java_local_list.java",
         "rust_local_array.rs",
@@ -6532,6 +6573,7 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
         "js_in_array_b.js",
         "array_some_wrong_element.js",
         "array_some_wrong_collection.ts",
+        "array_some_loose.js",
         "array_indexof_wrong_element.js",
         "array_indexof_wrong_collection.ts",
         "array_indexof_value.js",
@@ -6539,18 +6581,19 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
         "array_indexof_reversed_gt_zero.js",
         "array_findindex_wrong_element.js",
         "array_findindex_wrong_collection.ts",
+        "array_findindex_loose.js",
         "array_findindex_value.js",
         "array_findindex_ne_zero.js",
         "array_filter_length_wrong_element.js",
         "array_filter_length_wrong_collection.ts",
+        "array_filter_length_loose.js",
         "array_filter_length_value.js",
         "array_filter_length_absence_wrong_element.js",
         "array_filter_length_absence_wrong_collection.ts",
         "array_every_wrong_element.js",
         "array_every_wrong_collection.ts",
+        "array_every_loose.js",
         "substring.rs",
-        "module_set.js",
-        "module_set.ts",
         "module_set_mutated.js",
         "python_module_mutated.py",
         "module_set_shadowed.ts",
@@ -6844,6 +6887,16 @@ fn scan_mode_semantic_proves_set_membership_when_receiver_is_proven() {
     )
     .unwrap();
     fs::write(
+        dir.join("set_call.js"),
+        "function f(value, other) {\n  return Set([\"red\", \"blue\"]).has(value);\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("shadowed_set_global.js"),
+        "function Set(values) {\n  return { has: function() { return false; } };\n}\nfunction f(value, other) {\n  return new Set([\"red\", \"blue\"]).has(value);\n}\n",
+    )
+    .unwrap();
+    fs::write(
         dir.join("typed_array.ts"),
         "function f(values: string[], value: string, other: string): boolean {\n  return values.includes(value);\n}\n",
     )
@@ -6922,6 +6975,8 @@ fn scan_mode_semantic_proves_set_membership_when_receiver_is_proven() {
     let semantic_families = scan_families(&semantic_json);
     let expected_positive = [
         "literal.py",
+        "set_inline.js",
+        "set_local.js",
         "java_list_of.java",
         "java_set_of.java",
         "java_arrays_aslist.java",
@@ -6949,8 +7004,8 @@ fn scan_mode_semantic_proves_set_membership_when_receiver_is_proven() {
         });
     let typed_text = typed_family.to_string();
     for unexpected in [
-        "set_inline.js",
-        "set_local.js",
+        "set_call.js",
+        "shadowed_set_global.js",
         "wrong_element.js",
         "wrong_collection.js",
         "untyped_receiver.ts",
@@ -7457,6 +7512,16 @@ fn scan_mode_semantic_proves_literal_map_default_lookup() {
     )
     .unwrap();
     fs::write(
+        dir.join("map_default_call.js"),
+        "function lookup(key, other) {\n  return Map([[\"red\", 1], [\"blue\", 2]]).get(key) ?? 0;\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("shadowed_map_global.js"),
+        "function Map(entries) {\n  return { get: function() { return 99; }, has: function() { return true; } };\n}\nfunction lookup(key, other) {\n  return new Map([[\"red\", 1], [\"blue\", 2]]).get(key) ?? 0;\n}\n",
+    )
+    .unwrap();
+    fs::write(
         dir.join("map_default_local.js"),
         "function lookup(key, other) {\n  const values = new Map([[\"red\", 1], [\"blue\", 2]]);\n  return values.get(key) ?? 0;\n}\n",
     )
@@ -7851,6 +7916,12 @@ fn scan_mode_semantic_proves_literal_map_default_lookup() {
         "map_default_java_entries.java",
         "map_default_java_local.java",
         "map_default_module.java",
+        "map_default_inline.js",
+        "map_default_local.js",
+        "map_default_has_get.js",
+        "map_default_inline.ts",
+        "map_default_module.js",
+        "map_default_module.ts",
         "map_default_rust_hashmap.rs",
         "map_default_rust_btreemap.rs",
         "map_default_go_inline.go",
@@ -7986,12 +8057,8 @@ fn scan_mode_semantic_proves_literal_map_default_lookup() {
         "wrong_map.py",
         "ruby_fetch_block_param.rb",
         "ruby_fetch_raise_block.rb",
-        "map_default_inline.js",
-        "map_default_local.js",
-        "map_default_has_get.js",
-        "map_default_inline.ts",
-        "map_default_module.js",
-        "map_default_module.ts",
+        "map_default_call.js",
+        "shadowed_map_global.js",
         "map_default_rust_local.rs",
         "wrong_js_key.js",
         "wrong_js_default.js",

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -3693,6 +3693,7 @@ fn collection_membership_set_construction_converges_with_boundaries() {
     let js_set_inline =
         "function f(value, other) { return new Set([\"red\", \"blue\"]).has(value); }";
     let js_set_local = "function f(value, other) { const values = new Set([\"red\", \"blue\"]); return values.has(value); }";
+    let js_set_call = "function f(value, other) { return Set([\"red\", \"blue\"]).has(value); }";
     let js_module_set =
         "const VALUES = new Set([\"red\", \"blue\"]);\nfunction f(value, other) { return VALUES.has(value); }";
     let ts_module_set = "const VALUES = new Set<string>([\"red\", \"blue\"]);\nfunction f(value: string, other: string): boolean { return VALUES.has(value); }";
@@ -3778,6 +3779,7 @@ fn collection_membership_set_construction_converges_with_boundaries() {
     let js_nan_every = "function f(value, other) { return [NaN].every((item) => item !== value); }";
     let js_shadowed_set =
         "function f(Set, value, other) { return new Set([\"red\", \"blue\"]).has(value); }";
+    let js_global_shadowed_set = "function Set(values) { return { has: function() { return false; } }; }\nfunction f(value, other) { return new Set([\"red\", \"blue\"]).has(value); }";
     let js_module_set_mutated = "const VALUES = new Set([\"red\", \"blue\"]);\nVALUES.add(\"green\");\nfunction f(value, other) { return VALUES.has(value); }";
     let ts_module_set_shadowed = "const Set: any = function(_values: any) { return { has: function() { return false; } }; };\nconst VALUES = new Set([\"red\", \"blue\"]);\nfunction f(value: string, other: string): boolean { return VALUES.has(value); }";
     let java_list_of = "import java.util.List;\n\nclass C { static boolean f(String value, String other) { return List.of(\"red\", \"blue\").contains(value); } }";
@@ -3844,10 +3846,11 @@ fn collection_membership_set_construction_converges_with_boundaries() {
     assert_eq!(literal_fp, value_fp(&i, py_deque_namespace, Lang::Python));
     assert_eq!(literal_fp, value_fp(&i, py_module_tuple, Lang::Python));
     assert_eq!(literal_fp, value_fp(&i, py_module_set, Lang::Python));
-    assert_ne!(literal_fp, value_fp(&i, js_set_inline, Lang::JavaScript));
-    assert_ne!(literal_fp, value_fp(&i, js_set_local, Lang::JavaScript));
-    assert_ne!(literal_fp, value_fp(&i, js_module_set, Lang::JavaScript));
-    assert_ne!(literal_fp, value_fp(&i, ts_module_set, Lang::TypeScript));
+    assert_eq!(literal_fp, value_fp(&i, js_set_inline, Lang::JavaScript));
+    assert_eq!(literal_fp, value_fp(&i, js_set_local, Lang::JavaScript));
+    assert_eq!(literal_fp, value_fp(&i, js_module_set, Lang::JavaScript));
+    assert_eq!(literal_fp, value_fp(&i, ts_module_set, Lang::TypeScript));
+    assert_ne!(literal_fp, value_fp(&i, js_set_call, Lang::JavaScript));
     assert_ne!(
         literal_fp,
         value_fp(&i, js_array_contains, Lang::JavaScript),
@@ -3937,6 +3940,11 @@ fn collection_membership_set_construction_converges_with_boundaries() {
     assert_ne!(
         literal_fp,
         value_fp(&i, js_wrong_collection, Lang::JavaScript)
+    );
+    assert_ne!(
+        literal_fp,
+        value_fp(&i, js_global_shadowed_set, Lang::JavaScript),
+        "construct syntax alone must not prove a shadowed JS Set global"
     );
     assert_ne!(
         literal_fp,
@@ -4239,6 +4247,8 @@ fn literal_map_default_lookup_converges_with_js_map_construction_boundaries() {
     let ruby_literal = "def f(key, other)\n  {\"red\" => 1, \"blue\" => 2}.fetch(key, 0)\nend\n";
     let js_inline =
         "function f(key, other) { return new Map([[\"red\", 1], [\"blue\", 2]]).get(key) ?? 0; }";
+    let js_call =
+        "function f(key, other) { return Map([[\"red\", 1], [\"blue\", 2]]).get(key) ?? 0; }";
     let js_local = "function f(key, other) { const lookup = new Map([[\"red\", 1], [\"blue\", 2]]); return lookup.get(key) ?? 0; }";
     let js_has_get = "function f(key, other) { const lookup = new Map([[\"red\", 1], [\"blue\", 2]]); return lookup.has(key) ? lookup.get(key) : 0; }";
     let ts_inline = "function f(key: string, other: string): number { return new Map<string, number>([[\"red\", 1], [\"blue\", 2]]).get(key) ?? 0; }";
@@ -4250,18 +4260,25 @@ fn literal_map_default_lookup_converges_with_js_map_construction_boundaries() {
         "function f(key, other) { return new Map([[\"red\", 9], [\"blue\", 2]]).get(key) ?? 0; }";
     let js_untyped = "function f(lookup, key, other) { return lookup.get(key) ?? 0; }";
     let js_shadowed_map = "function f(key, other, Map) { return new Map([[\"red\", 1], [\"blue\", 2]]).get(key) ?? 0; }";
+    let js_global_shadowed_map = "function Map(entries) { return { get: function() { return 99; } }; }\nfunction f(key, other) { return new Map([[\"red\", 1], [\"blue\", 2]]).get(key) ?? 0; }";
 
     let fp = value_fp(&i, py_literal, Lang::Python);
     assert_eq!(fp, value_fp(&i, ruby_literal, Lang::Ruby));
-    assert_ne!(fp, value_fp(&i, js_inline, Lang::JavaScript));
-    assert_ne!(fp, value_fp(&i, js_local, Lang::JavaScript));
-    assert_ne!(fp, value_fp(&i, js_has_get, Lang::JavaScript));
-    assert_ne!(fp, value_fp(&i, ts_inline, Lang::TypeScript));
+    assert_eq!(fp, value_fp(&i, js_inline, Lang::JavaScript));
+    assert_eq!(fp, value_fp(&i, js_local, Lang::JavaScript));
+    assert_eq!(fp, value_fp(&i, js_has_get, Lang::JavaScript));
+    assert_eq!(fp, value_fp(&i, ts_inline, Lang::TypeScript));
+    assert_ne!(fp, value_fp(&i, js_call, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, js_wrong_key, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, js_wrong_default, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, js_wrong_map, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, js_untyped, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, js_shadowed_map, Lang::JavaScript));
+    assert_ne!(
+        fp,
+        value_fp(&i, js_global_shadowed_map, Lang::JavaScript),
+        "construct syntax alone must not prove a shadowed JS Map global"
+    );
 }
 
 #[test]
@@ -4426,8 +4443,8 @@ fn literal_map_default_lookup_converges_with_module_map_bindings() {
     let java_shadowed = "class C { static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2); static int f(String key, String other) { return LOOKUP.getOrDefault(key, 0); } }\nclass Map { static java.util.Map<String, Integer> of(Object... values) { return java.util.Map.of(); } }\n";
 
     let fp = value_fp(&i, py_literal, Lang::Python);
-    assert_ne!(fp, value_fp(&i, js_module, Lang::JavaScript));
-    assert_ne!(fp, value_fp(&i, ts_module, Lang::TypeScript));
+    assert_eq!(fp, value_fp(&i, js_module, Lang::JavaScript));
+    assert_eq!(fp, value_fp(&i, ts_module, Lang::TypeScript));
     assert_eq!(fp, value_fp(&i, java_static, Lang::Java));
     assert_ne!(fp, value_fp(&i, js_wrong_key, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, ts_wrong_default, Lang::TypeScript));

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -13,16 +13,17 @@ use nose_normalize::{
     node_tag,
 };
 use nose_semantics::{
-    builder_append_call_args, domain_evidence_from_param_semantic, exact_java_return_this,
-    exact_java_this_field, exact_non_overloadable_index_assignment,
-    exact_non_overloadable_index_assignment_parts, go_zero_map_default_kind,
-    go_zero_map_lookup_contract, import_binding_rhs_matches, import_namespace_rhs_matches,
-    iterator_identity_adapter_contract, java_collection_factory_contract, java_map_entry_contract,
-    java_map_factory_contract, js_array_is_array_contract, js_like_map_constructor_contract,
-    js_like_set_constructor_contract, map_get_contract, map_key_view_contract,
-    map_key_view_wrapper_contract, method_call_contract, nullish_global_contract,
-    regex_test_contract, ruby_set_factory_contract, rust_vec_new_factory_contract, semantics,
-    seq_surface_contract, static_index_membership_contract, typeof_operator_contract,
+    builder_append_call_args, construct_syntax_proof, domain_evidence_from_param_semantic,
+    exact_java_return_this, exact_java_this_field, exact_non_overloadable_index_assignment,
+    exact_non_overloadable_index_assignment_parts, exact_static_membership_predicate_operator,
+    go_zero_map_default_kind, go_zero_map_lookup_contract, import_binding_rhs_matches,
+    import_namespace_rhs_matches, iterator_identity_adapter_contract,
+    java_collection_factory_contract, java_map_entry_contract, java_map_factory_contract,
+    js_array_is_array_contract, js_like_map_constructor_contract, js_like_set_constructor_contract,
+    map_get_contract, map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
+    nullish_global_contract, regex_test_contract, ruby_set_factory_contract,
+    rust_vec_new_factory_contract, semantics, seq_surface_contract, source_fact_at_node,
+    source_operator_at_node, static_index_membership_contract, typeof_operator_contract,
     IndexMembershipThreshold, JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs,
     MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
 };
@@ -1120,6 +1121,10 @@ fn strict_exact_lambda_eq_param_element(
     if il.kind(ret) != NodeKind::BinOp || !matches!(il.node(ret).payload, Payload::Op(Op::Eq)) {
         return None;
     }
+    let source_operator = source_operator_at_node(il, ret)?;
+    if !exact_static_membership_predicate_operator(il.meta.lang, Op::Eq, source_operator) {
+        return None;
+    }
     let ret_kids = il.children(ret);
     if ret_kids.len() != 2 {
         return None;
@@ -1274,8 +1279,10 @@ fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, nod
         return false;
     };
     let method = interner.resolve(name);
-    if strict_exact_requires_regex_literal_proof(il, node, callee, method) {
-        return false;
+    if let Some(regex_safe) =
+        strict_exact_regex_test_safe(il, interner, facts, node, callee, method)
+    {
+        return regex_safe;
     }
     if strict_exact_js_array_is_array_safe(il, interner, facts, node, callee, method) {
         return true;
@@ -1321,26 +1328,26 @@ fn strict_exact_typeof_operator_safe(
         && strict_exact_call_args_safe(il, interner, facts, node)
 }
 
-fn strict_exact_requires_regex_literal_proof(
+fn strict_exact_regex_test_safe(
     il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
     node: NodeId,
     callee: NodeId,
     method: &str,
-) -> bool {
-    let Some(contract) = regex_test_contract(
+) -> Option<bool> {
+    let contract = regex_test_contract(
         il.meta.lang,
         method,
         il.children(node).len().saturating_sub(1),
-    ) else {
-        return false;
-    };
-    if !contract.requires_regex_literal_proof {
-        return false;
-    }
+    )?;
     let Some(&receiver) = il.children(callee).first() else {
-        return false;
+        return Some(false);
     };
-    matches!(il.node(receiver).payload, Payload::LitStr(_))
+    Some(
+        source_fact_at_node(il, receiver, contract.required_receiver_fact)
+            && strict_exact_call_args_safe(il, interner, facts, node),
+    )
 }
 
 fn strict_exact_js_array_is_array_safe(
@@ -1414,6 +1421,7 @@ fn strict_exact_collection_contains_call_safe(
                 return false;
             };
             strict_exact_typed_set_param_receiver_safe(il, receiver)
+                || strict_exact_set_constructor_collection_safe(il, interner, facts, receiver)
         }
         _ => false,
     };
@@ -1842,18 +1850,42 @@ fn strict_exact_membership_collection_safe(
             .all(|&c| strict_exact_safe_tree(il, interner, facts, c))
 }
 
+fn strict_exact_two_arg_var_call(il: &Il, node: NodeId) -> Option<(Symbol, NodeId)> {
+    if il.kind(node) != NodeKind::Call {
+        return None;
+    }
+    let [callee, argument] = il.children(node) else {
+        return None;
+    };
+    if il.kind(*callee) != NodeKind::Var {
+        return None;
+    }
+    match il.node(*callee).payload {
+        Payload::Name(name) => Some((name, *argument)),
+        _ => None,
+    }
+}
+
 fn strict_exact_set_constructor_collection_safe(
     il: &Il,
-    _interner: &Interner,
+    interner: &Interner,
     _facts: &StrictFacts,
-    _node: NodeId,
+    node: NodeId,
 ) -> bool {
-    // JS `new Set(xs)` and plain `Set(xs)` currently lower to the same call
-    // shape, so exact constructor semantics must wait for a construct proof.
-    if js_like_set_constructor_contract(il.meta.lang, "Set").is_none() {
+    if !construct_syntax_proof(il, node) {
         return false;
-    }
-    false
+    };
+    let Some((name, collection)) = strict_exact_two_arg_var_call(il, node) else {
+        return false;
+    };
+    let Some(contract) = js_like_set_constructor_contract(il.meta.lang, interner.resolve(name))
+    else {
+        return false;
+    };
+    contract.receiver == "Set"
+        && (!contract.requires_unshadowed_global
+            || !file_defines_name(il, interner, contract.receiver))
+        && strict_exact_static_non_float_collection(il, interner, collection)
 }
 
 fn strict_exact_python_collection_factory_safe(
@@ -2113,15 +2145,10 @@ fn strict_exact_rust_std_collection_factory_safe(
     if !semantics(il.meta.lang)
         .stdlib()
         .rust_std_collection_factories()
-        || il.kind(node) != NodeKind::Call
     {
         return false;
     }
-    let kids = il.children(node);
-    if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Var {
-        return false;
-    }
-    let Payload::Name(name) = il.node(kids[0]).payload else {
+    let Some((name, collection)) = strict_exact_two_arg_var_call(il, node) else {
         return false;
     };
     let name = interner.resolve(name);
@@ -2135,7 +2162,7 @@ fn strict_exact_rust_std_collection_factory_safe(
     if !strict_exact_free_name_factory_shadow_safe(il, interner, name, factory.shadow_guard) {
         return false;
     }
-    strict_exact_membership_collection_safe(il, interner, facts, kids[1])
+    strict_exact_membership_collection_safe(il, interner, facts, collection)
 }
 
 fn strict_exact_java_collection_factory_safe(
@@ -2303,16 +2330,24 @@ fn strict_exact_java_map_entry_safe(
 
 fn strict_exact_map_constructor_entries_safe(
     il: &Il,
-    _interner: &Interner,
-    _facts: &StrictFacts,
-    _node: NodeId,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
 ) -> bool {
-    // JS `new Map(entries)` and plain `Map(entries)` currently lower to the same
-    // call shape, so exact constructor semantics must wait for a construct proof.
-    if js_like_map_constructor_contract(il.meta.lang, "Map").is_none() {
+    if !construct_syntax_proof(il, node) {
         return false;
     }
-    false
+    let Some((name, entries)) = strict_exact_two_arg_var_call(il, node) else {
+        return false;
+    };
+    let Some(contract) = js_like_map_constructor_contract(il.meta.lang, interner.resolve(name))
+    else {
+        return false;
+    };
+    contract.receiver == "Map"
+        && (!contract.requires_unshadowed_global
+            || !file_defines_name(il, interner, contract.receiver))
+        && strict_exact_map_entries_safe(il, interner, facts, entries)
 }
 
 fn strict_exact_rust_std_map_factory_safe(
@@ -2321,15 +2356,10 @@ fn strict_exact_rust_std_map_factory_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    if !semantics(il.meta.lang).stdlib().rust_std_map_factories() || il.kind(node) != NodeKind::Call
-    {
+    if !semantics(il.meta.lang).stdlib().rust_std_map_factories() {
         return false;
     }
-    let kids = il.children(node);
-    if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Var {
-        return false;
-    }
-    let Payload::Name(name) = il.node(kids[0]).payload else {
+    let Some((name, entries)) = strict_exact_two_arg_var_call(il, node) else {
         return false;
     };
     let name = interner.resolve(name);
@@ -2343,7 +2373,7 @@ fn strict_exact_rust_std_map_factory_safe(
     if !strict_exact_free_name_factory_shadow_safe(il, interner, name, false) {
         return false;
     }
-    strict_exact_map_entries_safe(il, interner, facts, kids[1])
+    strict_exact_map_entries_safe(il, interner, facts, entries)
 }
 
 fn strict_exact_free_name_factory_shadow_safe(

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -8,8 +8,8 @@
 
 use crate::lower::Lowering;
 use nose_il::{
-    Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload, Span,
-    UnitKind,
+    Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload,
+    SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind, Span, UnitKind,
 };
 use nose_semantics::{
     js_array_is_array_contract, js_boolean_coercion_contract, method_call_contract,
@@ -840,7 +840,11 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         "false" => lo.add(NodeKind::Lit, Payload::LitBool(false), span, &[]),
         "null" => lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[]),
         "undefined" => lo.var("undefined", span),
-        "regex" => lo.str_lit(lo.text(node), span),
+        "regex" => {
+            let lit = lo.str_lit(lo.text(node), span);
+            lo.record_source_fact(span, SourceFactKind::Literal(SourceLiteralKind::Regex));
+            lit
+        }
         "call_expression" => lower_call(lo, node),
         "new_expression" => lower_new(lo, node),
         "binary_expression" => {
@@ -1263,7 +1267,9 @@ fn lower_new(lo: &mut Lowering, node: TsNode) -> NodeId {
             kids.push(lower_expr(lo, a));
         }
     }
-    lo.add(NodeKind::Call, Payload::None, span, &kids)
+    let call = lo.add(NodeKind::Call, Payload::None, span, &kids);
+    lo.record_source_fact(span, SourceFactKind::Call(SourceCallKind::Construct));
+    call
 }
 
 fn lower_binary(lo: &mut Lowering, node: TsNode) -> NodeId {
@@ -1292,7 +1298,15 @@ fn lower_binary(lo: &mut Lowering, node: TsNode) -> NodeId {
             .unwrap_or_else(|| lo.empty_block(span));
         return lo.add(NodeKind::If, Payload::None, span, &[cond, fallback, value]);
     }
-    crate::lower::binary(lo, node, js_bin_op, lower_expr)
+    let source_operator = node
+        .child_by_field_name("operator")
+        .map(|op| lo.text(op))
+        .and_then(js_source_operator);
+    let lowered = crate::lower::binary(lo, node, js_bin_op, lower_expr);
+    if let Some(source_operator) = source_operator {
+        lo.record_source_fact(lo.span(node), SourceFactKind::Operator(source_operator));
+    }
+    lowered
 }
 
 fn lower_record_shape_guard(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
@@ -1793,6 +1807,17 @@ fn js_bin_op(text: &str) -> Option<Op> {
         "instanceof" => Some(Op::Eq),
         _ => None,
     })
+}
+
+fn js_source_operator(text: &str) -> Option<SourceOperatorKind> {
+    match text {
+        "===" => Some(SourceOperatorKind::StrictEquality),
+        "!==" => Some(SourceOperatorKind::StrictInequality),
+        "==" => Some(SourceOperatorKind::LooseEquality),
+        "!=" => Some(SourceOperatorKind::LooseInequality),
+        "instanceof" => Some(SourceOperatorKind::TypeMembership),
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -4,7 +4,7 @@
 
 use nose_il::{
     FileId, FileMeta, Il, IlBuilder, Interner, Lang, LoopKind, NodeId, NodeKind, Op, ParamSemantic,
-    ParamTypeFact, Payload, Span, Symbol, Unit, UnitKind,
+    ParamTypeFact, Payload, SourceFact, SourceFactKind, Span, Symbol, Unit, UnitKind,
 };
 use nose_semantics::{import_fact_tag, ImportFactKind};
 use tree_sitter::Node as TsNode;
@@ -17,6 +17,7 @@ pub(crate) struct Lowering<'a> {
     pub interner: &'a Interner,
     pub units: Vec<Unit>,
     pub param_type_facts: Vec<ParamTypeFact>,
+    pub source_facts: Vec<SourceFact>,
     pub param_semantic_aliases: Vec<(String, ParamSemantic)>,
     pub unsigned_32_aliases: Vec<String>,
 }
@@ -30,6 +31,7 @@ impl<'a> Lowering<'a> {
             interner,
             units: Vec::new(),
             param_type_facts: Vec::new(),
+            source_facts: Vec::new(),
             param_semantic_aliases: Vec::new(),
             unsigned_32_aliases: Vec::new(),
         }
@@ -67,6 +69,10 @@ impl<'a> Lowering<'a> {
 
     pub(crate) fn record_param_semantic(&mut self, span: Span, semantic: ParamSemantic) {
         self.param_type_facts.push(ParamTypeFact { span, semantic });
+    }
+
+    pub(crate) fn record_source_fact(&mut self, span: Span, kind: SourceFactKind) {
+        self.source_facts.push(SourceFact { span, kind });
     }
 
     pub(crate) fn record_param_semantic_alias(&mut self, local: &str, semantic: ParamSemantic) {
@@ -352,8 +358,10 @@ pub(crate) fn lower_file_with_setup(
     };
     let units = std::mem::take(&mut lo.units);
     let param_type_facts = std::mem::take(&mut lo.param_type_facts);
+    let source_facts = std::mem::take(&mut lo.source_facts);
     let mut il = lo.b.finish(module, meta, units, Vec::new());
     il.param_type_facts = param_type_facts;
+    il.source_facts = source_facts;
     drop_suppressed_units(&mut il, src);
     Ok(il)
 }

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -10,7 +10,7 @@
 use crate::lower::Lowering;
 use nose_il::{
     Builtin, FileId, HoFKind, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op,
-    Payload, Span, UnitKind,
+    Payload, SourceFactKind, SourceOperatorKind, Span, UnitKind,
 };
 use tree_sitter::Node as TsNode;
 
@@ -900,7 +900,7 @@ fn lower_comparison(lo: &mut Lowering, node: TsNode) -> NodeId {
         )
     }
     let mut operand_nodes: Vec<TsNode> = Vec::new();
-    let mut ops: Vec<(Op, bool)> = Vec::new(); // (op, negated)
+    let mut ops: Vec<(Op, bool, Option<SourceOperatorKind>)> = Vec::new();
     let mut pending: Vec<String> = Vec::new();
     let mut cur = node.walk();
     for c in node.children(&mut cur) {
@@ -911,7 +911,7 @@ fn lower_comparison(lo: &mut Lowering, node: TsNode) -> NodeId {
             operand_nodes.push(c);
             if operand_nodes.len() >= 2 {
                 let key = pending.join(" ");
-                ops.push(py_cmp_op(&key).unwrap_or((Op::Eq, false)));
+                ops.push(py_cmp_op(&key).unwrap_or((Op::Eq, false, None)));
                 pending.clear();
             }
         }
@@ -928,10 +928,16 @@ fn lower_comparison(lo: &mut Lowering, node: TsNode) -> NodeId {
         // independent subtrees (a tree, not a shared-child DAG).
         let l = lower_expr(lo, operand_nodes[i]);
         let r = lower_expr(lo, operand_nodes[i + 1]);
-        let (op, neg) = ops.get(i).copied().unwrap_or((Op::Eq, false));
-        let cmp = lo.add(NodeKind::BinOp, Payload::Op(op), span, &[l, r]);
+        let pair_span = lo
+            .span(operand_nodes[i])
+            .merge(lo.span(operand_nodes[i + 1]));
+        let (op, neg, source_operator) = ops.get(i).copied().unwrap_or((Op::Eq, false, None));
+        let cmp = lo.add(NodeKind::BinOp, Payload::Op(op), pair_span, &[l, r]);
+        if let Some(source_operator) = source_operator {
+            lo.record_source_fact(pair_span, SourceFactKind::Operator(source_operator));
+        }
         let cmp = if neg {
-            lo.add(NodeKind::UnOp, Payload::Op(Op::Not), span, &[cmp])
+            lo.add(NodeKind::UnOp, Payload::Op(Op::Not), pair_span, &[cmp])
         } else {
             cmp
         };
@@ -1143,23 +1149,24 @@ fn py_aug_op(text: &str) -> Option<Op> {
     py_bin_op(text.trim_end_matches('='))
 }
 
-/// Map a comparison operator string to `(op, negated)`. `not in` / `is not` carry the
-/// negation (the caller wraps the comparison in `Not`).
-fn py_cmp_op(text: &str) -> Option<(Op, bool)> {
+/// Map a comparison operator string to `(op, negated, source fact)`. `not in` / `is not`
+/// carry the negation (the caller wraps the comparison in `Not`), while the source fact
+/// preserves whether equality-shaped IL came from value equality or identity syntax.
+fn py_cmp_op(text: &str) -> Option<(Op, bool, Option<SourceOperatorKind>)> {
     Some(match text {
-        "==" => (Op::Eq, false),
-        "!=" | "<>" => (Op::Ne, false),
-        "<" => (Op::Lt, false),
-        "<=" => (Op::Le, false),
-        ">" => (Op::Gt, false),
-        ">=" => (Op::Ge, false),
+        "==" => (Op::Eq, false, Some(SourceOperatorKind::ValueEquality)),
+        "!=" | "<>" => (Op::Ne, false, Some(SourceOperatorKind::ValueInequality)),
+        "<" => (Op::Lt, false, None),
+        "<=" => (Op::Le, false, None),
+        ">" => (Op::Gt, false, None),
+        ">=" => (Op::Ge, false, None),
         // Membership is directional and non-commutative — its own op, so `a in b` ≠
         // `b in a` ≠ `a == b`. Identity (`is`) stays equality-shaped (identity ≈ equality
         // in a value model). `not in` / `is not` negate.
-        "in" => (Op::In, false),
-        "not in" => (Op::In, true),
-        "is" => (Op::Eq, false),
-        "is not" => (Op::Eq, true),
+        "in" => (Op::In, false, None),
+        "not in" => (Op::In, true, None),
+        "is" => (Op::Eq, false, Some(SourceOperatorKind::IdentityEquality)),
+        "is not" => (Op::Eq, true, Some(SourceOperatorKind::IdentityInequality)),
         _ => return None,
     })
 }

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -17,7 +17,7 @@ mod sexpr;
 pub use intern::{stable_symbol_hash, symbol_index, Interner, Symbol, FNV_OFFSET_BASIS, FNV_PRIME};
 pub use node::{
     Builtin, HoFKind, LitClass, LoopKind, Node, NodeId, NodeKind, Op, ParamSemantic, ParamTypeFact,
-    Payload,
+    Payload, SourceCallKind, SourceFact, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
 };
 pub use span::{FileId, FileMeta, Lang, Span};
 
@@ -67,6 +67,11 @@ pub struct Il {
     /// connect these facts to canonical parameter ids for strict proof-gated rewrites.
     #[serde(default)]
     pub param_type_facts: Vec<ParamTypeFact>,
+    /// Source-origin evidence facts keyed by source span. These preserve facts that the
+    /// shared IL shape intentionally abstracts away, such as construct syntax, regex
+    /// literal syntax, and the original equality/operator family.
+    #[serde(default)]
+    pub source_facts: Vec<SourceFact>,
 }
 
 impl Il {
@@ -202,6 +207,7 @@ impl IlBuilder {
             cid_names,
             suppressed: Vec::new(),
             param_type_facts: Vec::new(),
+            source_facts: Vec::new(),
         }
     }
 }

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -145,6 +145,45 @@ pub struct ParamTypeFact {
     pub semantic: ParamSemantic,
 }
 
+/// Source-origin facts that must survive lowering before a semantic contract can
+/// consume them. These are evidence records, not semantic approval: contracts in
+/// `nose-semantics` decide whether a fact is sufficient for an exact rule.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub struct SourceFact {
+    pub span: Span,
+    pub kind: SourceFactKind,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum SourceFactKind {
+    Operator(SourceOperatorKind),
+    Call(SourceCallKind),
+    Literal(SourceLiteralKind),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum SourceOperatorKind {
+    StrictEquality,
+    StrictInequality,
+    LooseEquality,
+    LooseInequality,
+    ValueEquality,
+    ValueInequality,
+    IdentityEquality,
+    IdentityInequality,
+    TypeMembership,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum SourceCallKind {
+    Construct,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum SourceLiteralKind {
+    Regex,
+}
+
 /// Loop flavor; see [`NodeKind::Loop`] for the child layout each implies.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub enum LoopKind {

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -17,6 +17,8 @@ use nose_semantics::{
     MethodBuiltinArgs, MethodCallContract, MethodReceiverContract, MethodSemanticContract,
 };
 
+use crate::contains_js_ident;
+
 /// The result of inspecting a `Call`: it canonicalizes to a builtin, to a
 /// higher-order op (`HoF`), or stays an ordinary call. The carried `NodeId`s are
 /// *old* ids to be rebuilt as the new node's children.
@@ -775,18 +777,6 @@ fn symbol_defines_name(old: &Il, interner: &Interner, symbol: nose_il::Symbol, n
             .modules()
             .js_like_shadowed_module_bindings()
             && contains_js_ident(text, name))
-}
-
-fn contains_js_ident(text: &str, ident: &str) -> bool {
-    text.match_indices(ident).any(|(idx, _)| {
-        let before = text[..idx].chars().next_back();
-        let after = text[idx + ident.len()..].chars().next();
-        !before.is_some_and(is_js_ident_continue) && !after.is_some_and(is_js_ident_continue)
-    })
-}
-
-fn is_js_ident_continue(c: char) -> bool {
-    c == '_' || c == '$' || c.is_ascii_alphanumeric()
 }
 
 fn file_defines_type_name(old: &Il, interner: &Interner, name: &str) -> bool {

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -127,8 +127,8 @@ pub(crate) fn is_pure(il: &Il, node: NodeId) -> bool {
 
 /// Assemble the rewritten `Il` shared by every rebuild pass: carry each old unit forward to
 /// its remapped root (dropping units the pass deleted), copy the file metadata and parameter
-/// type facts, and finish the builder with the given canonical-id names. Passes differ only
-/// in the `cid_names` they preserve (most clone `old.cid_names`; desugar resets to empty
+/// type/source facts, and finish the builder with the given canonical-id names. Passes differ
+/// only in the `cid_names` they preserve (most clone `old.cid_names`; desugar resets to empty
 /// because it rewrites canonical ids), so that stays a caller-supplied argument.
 pub(crate) fn finalize_rebuild(
     old: &Il,
@@ -154,7 +154,20 @@ pub(crate) fn finalize_rebuild(
     };
     let mut out = builder.finish(new_root, meta, units, cid_names);
     out.param_type_facts = old.param_type_facts.clone();
+    out.source_facts = old.source_facts.clone();
     out
+}
+
+pub(crate) fn contains_js_ident(text: &str, ident: &str) -> bool {
+    text.match_indices(ident).any(|(idx, _)| {
+        let before = text[..idx].chars().next_back();
+        let after = text[idx + ident.len()..].chars().next();
+        !before.is_some_and(is_js_ident_continue) && !after.is_some_and(is_js_ident_continue)
+    })
+}
+
+fn is_js_ident_continue(c: char) -> bool {
+    c == '_' || c == '$' || c.is_ascii_alphanumeric()
 }
 
 /// A control-flow terminator: a statement that unconditionally diverts control out of the

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -37,28 +37,30 @@
 
 mod rules;
 
-use crate::combine;
 use crate::module_facts::{
     assignment_name_in_scope, collect_all_node_symbols_in_scope, collect_module_mutations_in_scope,
     local_scope_nodes, mutating_method_name, node_symbol_in_scope,
     shadowed_js_like_module_binding_nodes_for_symbol_in_scope, top_level_statements_for,
 };
 use crate::types::Ty;
+use crate::{combine, contains_js_ident};
 use nose_il::{
     stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LoopKind, NodeId, NodeKind, Op,
     Payload, Span, Symbol, UnitKind,
 };
 use nose_semantics::{
-    builder_append_method_contract, builtin_tag, domain_evidence_from_param_semantic,
+    builder_append_method_contract, builtin_tag, construct_syntax_proof,
+    domain_evidence_from_param_semantic, exact_static_membership_predicate_operator,
     free_function_builtin_contract, go_zero_map_default_kind, go_zero_map_lookup_contract,
     import_fact_contract, import_namespace_rhs_matches, imported_namespace_function_contract,
     iterator_identity_adapter_contract, java_collection_factory_contract_by_hash,
-    java_map_entry_contract_by_hash, java_map_factory_contract_by_hash, map_get_contract_by_hash,
+    java_map_entry_contract_by_hash, java_map_factory_contract_by_hash,
+    js_like_map_constructor_contract, js_like_set_constructor_contract, map_get_contract_by_hash,
     map_key_view_contract_by_hash, map_key_view_wrapper_contract_by_hash, method_call_contract,
     nullish_global_contract, reduction_builtin_contract, ruby_set_factory_contract_by_hash,
     rust_option_and_then_contract, rust_option_none_sentinel_contract,
     rust_option_some_constructor_contract, rust_vec_new_factory_contract,
-    scalar_integer_method_contract, semantics, seq_surface_contract,
+    scalar_integer_method_contract, semantics, seq_surface_contract, source_operator_at_node,
     static_index_membership_contract, BuiltinArgContract, CardinalityPredicate,
     CardinalityThreshold, ComparisonLaw, DomainEvidence, GoZeroMapDefaultKind, ImportFactKind,
     ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
@@ -1377,6 +1379,40 @@ impl<'a> Builder<'a> {
         Some(args[1..].to_vec())
     }
 
+    fn eval_js_like_constructed_collection_or_map(
+        &mut self,
+        expr: NodeId,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if !construct_syntax_proof(self.il, expr)
+            || kids.len() != 2
+            || self.il.kind(kids[0]) != NodeKind::Var
+        {
+            return None;
+        }
+        let Payload::Name(name) = self.il.node(kids[0]).payload else {
+            return None;
+        };
+        let constructor = self.interner.resolve(name);
+        if let Some(contract) = js_like_set_constructor_contract(self.il.meta.lang, constructor) {
+            if contract.requires_unshadowed_global && self.file_defines_name(contract.receiver) {
+                return None;
+            }
+            if !self.is_static_non_float_collection_expr(kids[1]) {
+                return None;
+            }
+            return Some(self.eval_membership_collection(kids[1], env));
+        }
+        let contract = js_like_map_constructor_contract(self.il.meta.lang, constructor)?;
+        if contract.requires_unshadowed_global && self.file_defines_name(contract.receiver) {
+            return None;
+        }
+        let entry_seq_tag = contract.entry_seq_tag?;
+        let entries = self.eval(kids[1], env);
+        self.map_factory_from_seq(entries, entry_seq_tag)
+    }
+
     fn proven_go_literal_zero_map_value(&self, value: ValueId) -> Option<(ValueId, ValueId)> {
         let contract = go_zero_map_lookup_contract(self.il.meta.lang)?;
         let node = &self.nodes[value as usize];
@@ -1609,14 +1645,12 @@ impl<'a> Builder<'a> {
                 return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
             }
             let receiver_value = self.eval(receiver, env);
-            if contract.receiver != MethodReceiverContract::ExactSetOrMap {
-                if let Some(collection) = self
-                    .proven_collection_value(receiver_value)
-                    .or_else(|| self.proven_local_collection_binding_value(receiver, env))
-                {
-                    let collection = self.canonical_membership_collection_value(collection);
-                    return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
-                }
+            if let Some(collection) = self
+                .proven_collection_value(receiver_value)
+                .or_else(|| self.proven_local_collection_binding_value(receiver, env))
+            {
+                let collection = self.canonical_membership_collection_value(collection);
+                return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
             }
             None
         } else if contract.args == MethodBuiltinArgs::GoSliceContains && kids.len() == 3 {
@@ -5947,6 +5981,7 @@ impl<'a> Builder<'a> {
                     if carried_guard.is_none()
                         && code == REDUCE_ANY
                         && self.is_static_non_float_collection_expr(kids[0])
+                        && self.lambda_return_source_operator_allowed(kids[1], Op::Eq)
                     {
                         if let Some((element, collection)) =
                             self.static_literal_membership_predicate(pred)
@@ -5959,6 +5994,7 @@ impl<'a> Builder<'a> {
                     if carried_guard.is_none()
                         && code == REDUCE_ALL
                         && self.is_static_non_float_collection_expr(kids[0])
+                        && self.lambda_return_source_operator_allowed(kids[1], Op::Ne)
                     {
                         if let Some((element, collection)) =
                             self.static_literal_absence_predicate(pred)
@@ -6095,6 +6131,9 @@ impl<'a> Builder<'a> {
         if !self.is_static_non_float_collection_expr(source) {
             return None;
         }
+        if !self.lambda_return_source_operator_allowed(predicate, Op::Eq) {
+            return None;
+        }
         let collection = self.eval(source, env);
         let elem = self.elem(collection);
         let pred = self.eval_lambda_body(predicate, &[elem], env)?;
@@ -6214,6 +6253,9 @@ impl<'a> Builder<'a> {
                 Some((element, collection))
             }
             StaticIndexMembershipKind::FindIndex if self.il.kind(kids[1]) == NodeKind::Lambda => {
+                if !self.lambda_return_source_operator_allowed(kids[1], Op::Eq) {
+                    return None;
+                }
                 let collection = self.eval(receiver, env);
                 let elem = self.elem(collection);
                 let pred = self.eval_lambda_body(kids[1], &[elem], env)?;
@@ -6880,6 +6922,34 @@ impl<'a> Builder<'a> {
     /// returning the value of its first `return` (intermediate assignments update the
     /// local env). Used to unfold a `map`/`reduce` lambda over a canonical `Elem`, and the
     /// `.then` continuation callback (see `rules::promise_then`).
+    fn lambda_return_source_operator_allowed(&self, lambda: NodeId, op: Op) -> bool {
+        let Some(ret) = self.lambda_first_return_expr(lambda) else {
+            return false;
+        };
+        if self.il.kind(ret) != NodeKind::BinOp
+            || !matches!(self.il.node(ret).payload, Payload::Op(actual) if actual == op)
+        {
+            return false;
+        }
+        source_operator_at_node(self.il, ret).is_some_and(|source| {
+            exact_static_membership_predicate_operator(self.il.meta.lang, op, source)
+        })
+    }
+
+    fn lambda_first_return_expr(&self, node: NodeId) -> Option<NodeId> {
+        if self.il.kind(node) == NodeKind::Return {
+            return self.il.children(node).first().copied();
+        }
+        if self.il.kind(node) == NodeKind::Block || self.il.kind(node) == NodeKind::Lambda {
+            return self
+                .il
+                .children(node)
+                .iter()
+                .find_map(|&child| self.lambda_first_return_expr(child));
+        }
+        None
+    }
+
     fn eval_lambda_body(
         &mut self,
         lambda: NodeId,
@@ -7557,6 +7627,9 @@ impl<'a> Builder<'a> {
                 if kids.len() == 1 && self.is_rust_vec_new_call(kids[0]) {
                     return self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), vec![]);
                 }
+                if let Some(v) = self.eval_js_like_constructed_collection_or_map(expr, &kids, env) {
+                    return v;
+                }
                 if let Some(v) = self.eval_iterator_identity_adapter(&kids, env) {
                     return v;
                 }
@@ -8113,18 +8186,6 @@ fn is_assoc_comm_code(opc: u32) -> bool {
         || opc == Op::BitAnd as u32
         || opc == Op::BitOr as u32
         || opc == Op::BitXor as u32
-}
-
-fn contains_js_ident(text: &str, ident: &str) -> bool {
-    text.match_indices(ident).any(|(idx, _)| {
-        let before = text[..idx].chars().next_back();
-        let after = text[idx + ident.len()..].chars().next();
-        !before.is_some_and(is_js_ident_continue) && !after.is_some_and(is_js_ident_continue)
-    })
-}
-
-fn is_js_ident_continue(c: char) -> bool {
-    c == '_' || c == '$' || c.is_ascii_alphanumeric()
 }
 
 /// `Reduce` op codes for the selection reductions (min/max). Kept clear of the small

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -8,7 +8,7 @@
 
 use nose_il::{
     stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LitClass, NodeId, NodeKind, Op,
-    ParamSemantic, Payload,
+    ParamSemantic, Payload, SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
 };
 
 /// Stable pack id for the first-party language/stdlib contracts compiled into nose.
@@ -29,6 +29,86 @@ pub enum PackTrust {
     DefaultFirstParty,
     FirstPartyOptional,
     ExternalOptIn,
+}
+
+/// Source facts are evidence records emitted by a language frontend or future
+/// pack. They preserve source distinctions that the shared IL intentionally
+/// abstracts away; a fact only matters when a semantic contract consumes it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct SourceFactContract {
+    pub kind: SourceFactKind,
+    pub channel: ChannelEligibility,
+}
+
+pub fn source_fact_contract(kind: SourceFactKind) -> SourceFactContract {
+    SourceFactContract {
+        kind,
+        channel: ChannelEligibility::ExactProven,
+    }
+}
+
+pub fn source_fact_at_node(il: &Il, node: NodeId, kind: SourceFactKind) -> bool {
+    let span = il.node(node).span;
+    il.source_facts
+        .iter()
+        .any(|fact| fact.span == span && fact.kind == kind)
+}
+
+pub fn source_operator_at_node(il: &Il, node: NodeId) -> Option<SourceOperatorKind> {
+    let span = il.node(node).span;
+    il.source_facts.iter().find_map(|fact| {
+        (fact.span == span)
+            .then_some(fact.kind)
+            .and_then(|kind| match kind {
+                SourceFactKind::Operator(operator) => Some(operator),
+                SourceFactKind::Call(_) | SourceFactKind::Literal(_) => None,
+            })
+    })
+}
+
+pub fn source_call_at_node(il: &Il, node: NodeId) -> Option<SourceCallKind> {
+    let span = il.node(node).span;
+    il.source_facts.iter().find_map(|fact| {
+        (fact.span == span)
+            .then_some(fact.kind)
+            .and_then(|kind| match kind {
+                SourceFactKind::Call(call) => Some(call),
+                SourceFactKind::Operator(_) | SourceFactKind::Literal(_) => None,
+            })
+    })
+}
+
+pub fn source_literal_at_node(il: &Il, node: NodeId) -> Option<SourceLiteralKind> {
+    let span = il.node(node).span;
+    il.source_facts.iter().find_map(|fact| {
+        (fact.span == span)
+            .then_some(fact.kind)
+            .and_then(|kind| match kind {
+                SourceFactKind::Literal(literal) => Some(literal),
+                SourceFactKind::Operator(_) | SourceFactKind::Call(_) => None,
+            })
+    })
+}
+
+pub fn construct_syntax_proof(il: &Il, node: NodeId) -> bool {
+    source_call_at_node(il, node) == Some(SourceCallKind::Construct)
+}
+
+pub fn regex_literal_proof(il: &Il, node: NodeId) -> bool {
+    source_literal_at_node(il, node) == Some(SourceLiteralKind::Regex)
+}
+
+pub fn exact_static_membership_predicate_operator(
+    lang: Lang,
+    op: Op,
+    source: SourceOperatorKind,
+) -> bool {
+    js_like_lang(lang)
+        && matches!(
+            (op, source),
+            (Op::Eq, SourceOperatorKind::StrictEquality)
+                | (Op::Ne, SourceOperatorKind::StrictInequality)
+        )
 }
 
 /// Kernel-facing domain evidence recovered from source facts, type inference, or future packs.
@@ -1794,6 +1874,8 @@ pub enum ConstructorProofRequirement {
 pub struct ClosedConstructorContract {
     pub receiver: &'static str,
     pub required_proof: ConstructorProofRequirement,
+    pub requires_unshadowed_global: bool,
+    pub entry_seq_tag: Option<u64>,
 }
 
 pub fn js_like_set_constructor_contract(
@@ -1803,6 +1885,8 @@ pub fn js_like_set_constructor_contract(
     (js_like_lang(lang) && receiver == "Set").then_some(ClosedConstructorContract {
         receiver: "Set",
         required_proof: ConstructorProofRequirement::ConstructSyntax,
+        requires_unshadowed_global: true,
+        entry_seq_tag: None,
     })
 }
 
@@ -1813,6 +1897,8 @@ pub fn js_like_map_constructor_contract(
     (js_like_lang(lang) && receiver == "Map").then_some(ClosedConstructorContract {
         receiver: "Map",
         required_proof: ConstructorProofRequirement::ConstructSyntax,
+        requires_unshadowed_global: true,
+        entry_seq_tag: Some(SEQ_VALUE_COLLECTION),
     })
 }
 
@@ -2036,7 +2122,7 @@ pub fn js_array_is_array_contract(
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct RegexTestContract {
     pub method: &'static str,
-    pub requires_regex_literal_proof: bool,
+    pub required_receiver_fact: SourceFactKind,
 }
 
 pub fn regex_test_contract(
@@ -2046,7 +2132,7 @@ pub fn regex_test_contract(
 ) -> Option<RegexTestContract> {
     (js_like_lang(lang) && method == "test" && arg_count == 1).then_some(RegexTestContract {
         method: "test",
-        requires_regex_literal_proof: true,
+        required_receiver_fact: SourceFactKind::Literal(SourceLiteralKind::Regex),
     })
 }
 
@@ -2441,7 +2527,7 @@ pub fn async_to_sync_name(lang: Lang, name: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_il::{FileId, FileMeta, IlBuilder, ParamSemantic, Span, Unit, UnitKind};
+    use nose_il::{FileId, FileMeta, IlBuilder, ParamSemantic, SourceFact, Span, Unit, UnitKind};
 
     const ALL_LANGS: &[Lang] = &[
         Lang::Python,
@@ -3250,6 +3336,8 @@ mod tests {
             Some(ClosedConstructorContract {
                 receiver: "Set",
                 required_proof: ConstructorProofRequirement::ConstructSyntax,
+                requires_unshadowed_global: true,
+                entry_seq_tag: None,
             })
         );
         assert_eq!(
@@ -3257,6 +3345,8 @@ mod tests {
             Some(ClosedConstructorContract {
                 receiver: "Map",
                 required_proof: ConstructorProofRequirement::ConstructSyntax,
+                requires_unshadowed_global: true,
+                entry_seq_tag: Some(SEQ_VALUE_COLLECTION),
             })
         );
         assert_eq!(js_like_map_constructor_contract(Lang::Java, "Map"), None);
@@ -3427,7 +3517,7 @@ mod tests {
             regex_test_contract(Lang::JavaScript, "test", 1),
             Some(RegexTestContract {
                 method: "test",
-                requires_regex_literal_proof: true,
+                required_receiver_fact: SourceFactKind::Literal(SourceLiteralKind::Regex),
             })
         );
         assert_eq!(regex_test_contract(Lang::Ruby, "test", 1), None);
@@ -3758,5 +3848,59 @@ mod tests {
             builder_append_call_args(&rust_il, &interner, push_call),
             None
         );
+    }
+
+    #[test]
+    fn source_fact_contracts_are_span_keyed_evidence() {
+        let mut b = IlBuilder::new(FileId(0));
+        let call = b.add(NodeKind::Call, Payload::None, sp(7), &[]);
+        let regex = b.add(NodeKind::Lit, Payload::LitStr(42), sp(8), &[]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(7), &[call, regex]);
+        let mut il = finish_il(b, root, Lang::JavaScript);
+        il.source_facts.push(SourceFact {
+            span: sp(7),
+            kind: SourceFactKind::Call(SourceCallKind::Construct),
+        });
+        il.source_facts.push(SourceFact {
+            span: sp(8),
+            kind: SourceFactKind::Literal(SourceLiteralKind::Regex),
+        });
+
+        assert!(construct_syntax_proof(&il, call));
+        assert!(regex_literal_proof(&il, regex));
+        assert!(!construct_syntax_proof(&il, regex));
+        assert_eq!(
+            source_fact_contract(SourceFactKind::Call(SourceCallKind::Construct)).channel,
+            ChannelEligibility::ExactProven
+        );
+    }
+
+    #[test]
+    fn static_membership_predicate_operator_requires_js_strict_equality() {
+        assert!(exact_static_membership_predicate_operator(
+            Lang::JavaScript,
+            Op::Eq,
+            SourceOperatorKind::StrictEquality
+        ));
+        assert!(exact_static_membership_predicate_operator(
+            Lang::TypeScript,
+            Op::Ne,
+            SourceOperatorKind::StrictInequality
+        ));
+        assert!(!exact_static_membership_predicate_operator(
+            Lang::JavaScript,
+            Op::Eq,
+            SourceOperatorKind::LooseEquality
+        ));
+        assert!(!exact_static_membership_predicate_operator(
+            Lang::Python,
+            Op::Eq,
+            SourceOperatorKind::ValueEquality
+        ));
+        assert!(!exact_static_membership_predicate_operator(
+            Lang::JavaScript,
+            Op::Eq,
+            SourceOperatorKind::TypeMembership
+        ));
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,8 +39,10 @@ source ──tree-sitter──▶ raw IL ──normalize──▶ canonical IL �
 1. **Lower** ([languages](languages.md)): tree-sitter parses each file; a per-language pass
    walks the CST and emits raw IL using a small, desugared core node set. Every
    node copies its source span, so every match traces back to exact lines.
-   Frontends also tag syntactic unit boundaries (function/method/class/block),
-   which gives detection accurate boundaries for free.
+   Frontends also emit source-origin facts when that core IL would otherwise erase
+   exact source distinctions needed by semantic contracts, then tag syntactic unit
+   boundaries (function/method/class/block), which gives detection accurate
+   boundaries for free.
 2. **Normalize** ([normalization](normalization.md)): a fixed sequence of passes canonicalizes
    the IL — desugaring (with idiom canonicalization), alpha-renaming, an oracle cutoff,
    recursion-to-iteration normalization, dataflow propagation, control-flow normalization,
@@ -74,9 +76,9 @@ A Cargo workspace; data flows left-to-right through them.
 
 | crate | role |
 |---|---|
-| `nose-il` | arena IL model (`Vec<Node>`, `NodeId(u32)`, out-of-line edges), provenance spans, interner, serialization, IR verifier |
-| `nose-semantics` | first-party semantic facade: language profiles, effect/operator/module/stdlib predicates, API contracts, and exact-channel proof obligations |
-| `nose-frontend` | tree-sitter parse + per-language CST→IL lowering (one module per language; embedded `<script>` extraction) |
+| `nose-il` | arena IL model (`Vec<Node>`, `NodeId(u32)`, out-of-line edges), provenance spans, source facts, interner, serialization, IR verifier |
+| `nose-semantics` | first-party semantic facade: language profiles, source-fact helpers, effect/operator/module/stdlib predicates, API contracts, and exact-channel proof obligations |
+| `nose-frontend` | tree-sitter parse + per-language CST→IL lowering and source-fact emission (one module per language; embedded `<script>` extraction) |
 | `nose-normalize` | the normalization passes + the value graph (GVN) |
 | `nose-detect` | unit/feature extraction, MinHash/LSH, scoring, clustering, refactor ranking |
 | `nose-eval` | benchmark scoring (precision/recall, pooled, stratified) — see [benchmark](benchmark.md) |

--- a/docs/home.md
+++ b/docs/home.md
@@ -52,6 +52,7 @@ You want to *change* nose or understand how it works inside.
 - [architecture](architecture.md) — the crates and the lower → normalize → detect → rank pipeline.
 - [normalization](normalization.md) — the passes that make behaviorally-equivalent code converge (the hard part).
 - [semantic-kernel](semantic-kernel.md) — semantic-kernel and pack architecture: language/library semantics, extension boundaries, responsibility model, and exact-channel eligibility.
+- [source-facts](source-facts.md) — source-origin evidence for semantic contracts: construct syntax, literal/operator provenance, pack boundaries, and fail-closed exact admission.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.
 - [fragment-contracts](fragment-contracts.md) — how exact sub-function fragments are modeled: classification, contract, the wrapper-synthesis behavior oracle, the effect algebra, and fail-closed receiver identity.

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -35,7 +35,9 @@ experiments that validated these passes are in [experiments](experiments.md).
 > outer/inner predicates), full **AC flatten+sort in the value graph itself** (not
 > only the `algebra` IL pass), **operator-law contracts** from the semantic kernel
 > gate comparison transforms, comparison-lattice rewrites, static cardinality
-> thresholds, and source membership operators, **distribution/factoring**
+> thresholds, and source membership operators, while source-fact gates protect
+> JS-like constructor factories, regex literal `.test(...)`, and static
+> membership callback equality, **distribution/factoring**
 > `a*c+b*c→(a+b)*c` (Num-gated),
 > min/max and any/all reductions (cross-language), simple **flag+break existence/universal
 > loops** (`found=false; if p { found=true; break }` / the dual `all` form),

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -39,6 +39,12 @@ and pack ecosystem.
    arity, receiver/protocol, shadowing, import, version, overload, demand, and
    effect obligations that make that selector mean the claimed operation.
 
+8. **Source facts are evidence, not semantics.** Source-origin facts preserve
+   distinctions that the shared IL erases, such as construct syntax, literal
+   surface, and equality/operator family. They can feed exact contracts only
+   through kernel-defined fact kinds and contract preconditions; they do not mint
+   fingerprints or approve equivalence directly.
+
 ## History
 
 - The original architecture lowered every supported language into one shared IL,
@@ -109,9 +115,10 @@ and pack ecosystem.
 - Cross-file immutable import replacement now copies import-binding dependencies
   required by the exported literal expression, preserving provider-side stdlib
   proofs such as `java.util.Map` for Java static imports.
-- JS-like `Map`/`Set` constructors are now represented as explicit closed
-  contracts requiring construct-syntax proof; they remain exact-closed until the
-  frontend/kernel can distinguish `new Map(...)` from plain `Map(...)`.
+- JS-like `Map`/`Set` constructor contracts now require construct-syntax proof.
+  They were initially closed while construct-vs-call evidence was missing; the
+  source-fact slice reopened proof-backed `new Map(...)`/`new Set(...)` while
+  plain `Map(...)`/`Set(...)` calls stayed closed.
 - Map key-view recognition moved behind contracts that distinguish collection
   views from iterator views. JS-like `Map.keys()` now requires an
   `Array.from(...)` wrapper before exact membership can consume it.
@@ -137,9 +144,10 @@ and pack ecosystem.
   JS/TS `Map.get(...)` defaulting remains exact-eligible only when `undefined`
   is the unshadowed JS-like sentinel.
 - Strict exact call gates for JS-like `typeof` and `Array.isArray(...)` moved
-  behind language/arity/global-shadow contracts, and literal `.test(...)` remains
-  exact-closed until regex-literal provenance exists. This closes raw-name
-  bypasses found after PR #101.
+  behind language/arity/global-shadow contracts. Regex literal `.test(...)` now
+  consumes regex-literal source provenance, while ordinary string `.test(...)`
+  and same-named method calls remain closed. This closes raw-name bypasses found
+  after PR #101.
 - Normalize idiom receiver admission for iterator identity adapters and Rust
   `zip` now consumes the same semantic contracts as value-graph/detect paths,
   closing language-blind `iter`/`zip` selector bypasses.
@@ -209,6 +217,11 @@ and pack ecosystem.
   longer inherits collection-membership exact safety from the shared `Op::In`
   token; only Python `in` currently has a first-party membership-operator
   contract.
+- Source facts landed for construct syntax, regex literals, and selected
+  equality/operator provenance. Exact consumers now reopen proof-backed JS-like
+  `new Map(...)`/`new Set(...)`, regex literal `.test(...)`, and strict JS-like
+  static membership callbacks while closing plain constructor calls, string
+  `.test(...)`, loose equality, and `instanceof` for those exact contracts.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -251,9 +264,12 @@ Remaining in this phase:
 - Continue moving primitive operator gates behind `OperatorSemantics`. The first
   larger slice covers comparison transforms/laws, cardinality thresholds, static
   index-membership thresholds, and Python source `in` membership exact-safety.
-  Remaining work includes source equality provenance such as JS loose equality,
-  JS `instanceof`, and Python identity before exact callbacks can distinguish
-  all equality-shaped IL safely.
+  A later source-fact slice preserves selected JS/TS and Python equality-like
+  source operators, but broader operator dispatch, overload semantics, and
+  pack-facing consumers remain open.
+- Replace the current internal span-keyed `SourceFact` storage with pack-facing
+  source-fact records that carry stable fact ids, emitter/pack provenance, scope,
+  dependencies, ambiguity status, and contract provenance.
 - Expand the exact fragment facade from first-party helper functions into
   versioned pack-facing effect/place evidence records.
 - Continue replacing any remaining local exact-fragment proof helpers with
@@ -270,10 +286,6 @@ Remaining in this phase:
   receiver/domain evidence records while preserving the current precision gates.
 - Turn named value-graph rule modules into LawPack-facing law ids/contracts while
   retaining formal-obligation metadata as the first-party proof boundary.
-- Add construct/call distinction facts so constructor-only contracts such as
-  JS/TS `new Map` and `new Set` can be reopened safely.
-- Add regex literal provenance so JS/TS `.test(...)` can be reopened safely
-  without treating ordinary string literals or monkey-patched methods as regexes.
 - Add receiver/place facts so field read/write and property contracts are not
   field-name-only.
 - Add provenance fields internally before exposing them in scan JSON.

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -7,7 +7,8 @@ implementation shape; planned work and decision history live in
 Snapshot date: 2026-06-07, current implementation after the semantic-kernel
 foundation and follow-up facade migrations through receiver-aware field state
 sequence-surface contracts, proof-backed append fragment evidence, and the first
-operator-law contracts.
+operator-law contracts, typed import facts, and source-fact gates for construct,
+literal, and equality/operator provenance.
 
 ## What exists today
 
@@ -15,12 +16,14 @@ nose now has a first internal semantic-kernel facade, but most of the engine is
 still being migrated toward it.
 
 - `nose-il` defines a compact shared IL, `Lang`, `Builtin`, `HoFKind`, operators,
-  literals, source spans, units, and parameter semantic facts.
+  literals, source spans, units, parameter semantic facts, and source-origin
+  facts.
 - `nose-semantics` defines the first-party semantic profile facade: language,
-  operator, effect, fragment, module, stdlib, builtin, method-call, property,
-  async, iterator-adapter, builder-append, and factory contracts.
+  source-fact, operator, effect, fragment, module, stdlib, builtin, method-call,
+  property, async, iterator-adapter, builder-append, and factory contracts.
 - `nose-frontend` owns tree-sitter parsing, per-language lowering, embedded
-  `<script>` extraction, import facts, and Raw-node coverage.
+  `<script>` extraction, import facts, source-origin fact emission, and Raw-node
+  coverage.
 - `nose-normalize` owns desugaring, alpha-renaming, recursion normalization,
   dataflow, CFG/algebra normalization, type-gated value-graph rules, and the
   interpreter oracle.
@@ -52,6 +55,14 @@ migrated.
   static-index gates consume these contracts instead of local operator tables.
   The old `primitive_order_comparisons()` helper remains as a compatibility
   wrapper around the stricter lattice law contract.
+- Source facts are now first-class internal evidence for source distinctions that
+  the shared IL erases. The current `SourceFact` storage is span-keyed and covers
+  operator, call-shape, and literal-surface facts. JS/TS frontends emit construct
+  syntax, regex literal, strict/loose equality, strict/loose inequality, and
+  `instanceof` facts. Python emits value equality/inequality and identity
+  equality/inequality facts. `nose-semantics` exposes source-fact contract and
+  lookup helpers; normalize and detect consume them only where a semantic
+  contract requires that exact source surface.
 - Free-function builtin contracts are language- and arity-constrained and require
   unshadowed builtin/global proof before exact lowering.
 - Method contracts carry receiver obligations such as exact collection, exact
@@ -154,8 +165,11 @@ migrated.
   is not inferred from the selector name in normalize/detect.
 - JS-like static array `indexOf`/`findIndex` membership surfaces are explicit
   contracts, including the static non-float literal collection requirement and
-  accepted `-1`/`0` threshold comparisons through `OperatorSemantics`. Callers
-  still prove the receiver and lambda equality shape before exact
+  accepted `-1`/`0` threshold comparisons through `OperatorSemantics`. Callback
+  membership variants also require source operator facts: JS-like strict
+  equality/inequality can enter exact matching, while loose equality,
+  `instanceof`, and non-JS equality surfaces stay closed for these contracts.
+  Callers still prove the receiver and lambda equality shape before exact
   normalization/detection accepts them.
 - Source `Op::In` is not proof by itself. Strict exact collection/map
   membership currently admits Python `in` only through a language-scoped
@@ -197,8 +211,12 @@ migrated.
 - JS/TS object literals preserve static property keys in exact map/object
   semantics, but computed property names are exact-closed until a future
   contract can prove key evaluation, coercion, order, and side-effect behavior.
-- JS/TS `new Map(...)` and `new Set(...)` remain closed because lowering does not
-  yet retain a constructor proof distinct from ordinary `Map(...)`/`Set(...)`.
+- JS/TS `new Map(...)` and `new Set(...)` now require construct-syntax source
+  facts distinct from ordinary calls plus an unshadowed `Map`/`Set` global. With
+  exact-safe static collection or entry arguments they can enter exact matching,
+  including supported immutable module-level Set/Map bindings. Plain
+  `Set(...)`/`Map(...)` calls and locally shadowed constructor names remain
+  exact-closed.
 - Static import proof facts now have a typed `ImportFactKind`/`ImportFact`
   facade in `nose-semantics`. First-party frontends emit import binding and
   namespace facts through that contract, and imported literal replacement,
@@ -219,10 +237,11 @@ Semantic knowledge still appears in several forms outside the facade:
 
 - direct `Lang` checks and local recognizers in strict exact gates and value-graph
   rules that have not yet been expressed as shared contracts;
-- source operator provenance is still lossy for some equality-shaped IL. For
-  example, JS loose equality and `instanceof`, and Python identity, can lower to
-  the same coarse equality operator until future frontend/kernel facts preserve
-  the source equality kind;
+- source operator provenance now exists for selected JS/TS and Python
+  equality-shaped surfaces, but the storage is still internal and span-keyed, and
+  consumption is limited to narrow contracts such as JS-like static membership
+  callbacks. General equality dispatch, report provenance, and pack-facing
+  source-fact records remain open;
 - language-specific import or module proof mechanics that are still local to
   frontend, normalize, or detect callers;
 - IL still stores import facts as `Seq("import_binding")` /
@@ -279,10 +298,10 @@ this worktree because the required evidence is not yet modeled:
 
 - JS-like `.then(lambda)` does not converge with `await` code until Promise-like
   receiver proof exists.
-- Plain JS/TS `Map` and `Set` constructor semantics do not enter exact matching
-  until constructor-vs-call proof exists.
-- JS/TS regex literal `.test(...)` does not enter exact matching until lowering
-  preserves regex-literal provenance distinct from ordinary string literals.
+- Plain JS/TS `Map(...)` and `Set(...)` calls do not enter exact matching because
+  constructor-only contracts require construct-syntax proof.
+- Ordinary JS/TS string `.test(...)` calls do not enter regex-test exact matching
+  because the receiver must have regex-literal provenance.
 - Untyped JS/TS array method chains do not enter exact higher-order contracts
   unless the receiver is a literal/proven collection surface.
 - Nested element method chains such as `xs.map(...)` inside a flat-map callback
@@ -311,9 +330,10 @@ The first high-value targets for semantic-kernel extraction are:
   consumers already parse these through the typed internal `ImportFact` facade;
 - pack-facing sequence/aggregate surface records to replace the current compiled
   `SeqSurfaceContract` facade and private value-graph `Seq` tag registry;
-- constructor facts for JS/TS `new Map` and `new Set`, which are now explicit
-  closed contracts waiting on construct-vs-call proof;
-- regex literal provenance for JS/TS `.test(...)`;
+- pack-facing source-fact records to replace the current internal span-keyed
+  `SourceFact` storage for construct, literal, and operator provenance;
+- source-fact dependency, scope, and ambiguity validation before facts become a
+  stable external extension surface;
 - resolved symbol facts for Java/Rust stdlib factories instead of the current
   path/name plus shadow-proof contracts;
 - nested collection element proofs for iterator chains and builder convergence;

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -2,7 +2,8 @@
 
 Back to [home](home.md). Current implementation status is in
 [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and remaining
-work are tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md).
+work are tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). Source
+origin evidence is detailed in [source-facts](source-facts.md).
 
 ## Context
 
@@ -21,6 +22,11 @@ makes soundness depend on scattered `Lang` checks.
 The semantic kernel is the boundary that all exact semantic reasoning must cross.
 The first internal facade now lives in `nose-semantics`; it is still a compiled
 first-party implementation, not a loadable external pack runtime.
+
+Source facts are one kernel input at that boundary. They preserve source
+distinctions that the IL deliberately abstracts away, but they do not approve
+semantic equivalence by themselves. See [source-facts](source-facts.md) for the
+fact vocabulary, pack boundary, and current implementation slice.
 
 ## Goal
 
@@ -111,9 +117,10 @@ law registry or emit private canonical value-graph nodes.
 Packs may:
 
 - lower source constructs to kernel-defined surface IR;
-- emit semantic facts such as proven type domains, non-shadowed builtins, unique
-  immutable imports, primitive array places, pure callbacks, pull iterators, or
-  memoized thunks;
+- emit source and semantic facts such as construct syntax, literal/operator
+  provenance, proven type domains, non-shadowed builtins, unique immutable
+  imports, primitive array places, pure callbacks, pull iterators, or memoized
+  thunks;
 - declare API contracts that map resolved symbols to protocol operations;
 - declare evaluation and demand behavior for constructs and APIs;
 - declare effect summaries and exact/near eligibility;
@@ -132,6 +139,13 @@ Packs may not:
 
 An API contract is not a name match. A contract must identify the surface it
 claims and the evidence required to admit it.
+
+For source-origin distinctions, that evidence should be represented as
+kernel-defined source facts rather than recovered later from selectors or raw CST
+text. For example, a constructor-only contract should require construct syntax
+evidence; a regex-specific contract should require regex-literal or resolved
+regex-receiver evidence; an equality-sensitive contract should require the
+language-specific source operator kind.
 
 At minimum, exact-capable contracts need:
 

--- a/docs/source-facts.md
+++ b/docs/source-facts.md
@@ -1,0 +1,126 @@
+# Source facts and semantic evidence
+
+Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
+recorded in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and
+remaining work are tracked in
+[semantic-kernel-roadmap](semantic-kernel-roadmap.md).
+
+Source facts are the bridge between source syntax and semantic contracts. They
+preserve source-origin distinctions that the shared IL intentionally abstracts
+away, such as `new Set(...)` versus `Set(...)`, a JavaScript regex literal versus
+an ordinary string, or JavaScript `===` versus `==`.
+
+They are evidence, not semantics. A source fact never approves an exact clone,
+mints a value fingerprint, or bypasses a law. It is admissible only when a
+kernel contract explicitly consumes it together with the contract's language,
+symbol, receiver, arity, shadowing, version, demand, effect, and proof
+preconditions.
+
+## Goal
+
+- Make source-origin facts first-class inputs to semantic contracts.
+- Let language and library packs state which source facts they emit and require.
+- Preserve or improve precision by keeping exact matching fail-closed when a
+  required source fact is absent.
+- Improve recall only where the source fact supplies evidence that the previous
+  IL shape had lost.
+- Build a path to report provenance: source surface, pack id, contract id, law
+  id, evidence status, and proof status.
+
+## Non-goals
+
+- Do not treat source facts as approval for exact equivalence.
+- Do not use broad heuristics such as "a function named `map` means Map
+  semantics" or "a method named `test` means regex semantics".
+- Do not expose raw CST nodes as the pack interface.
+- Do not promise that the current span-keyed storage is the final scan JSON
+  contract.
+- Do not make nose responsible for certifying external pack correctness. nose
+  validates the extension shape and fails closed; external providers own their
+  claims, and users own the decision to enable them.
+
+## Terminology
+
+| term | meaning |
+|---|---|
+| `SourceFact` | Current internal IL record keyed by source span and fact kind. |
+| Evidence record | Future pack-facing form of a source or semantic fact, with stable ids, scope, dependencies, and provenance. |
+| Contract | Kernel rule that maps a proven source/API surface to a semantic operation or law under explicit preconditions. |
+| Pack provenance | The pack id, provider, trust policy, version range, contract id, and evidence status behind an admitted fact or contract. |
+
+## Evidence flow
+
+1. A frontend or language pack parses source, lowers to IL, and emits
+   kernel-defined source facts for source distinctions that would otherwise be
+   lost.
+2. The semantic kernel validates the fact shape and the surrounding obligations:
+   language, arity, receiver, symbol/import proof, shadowing, scope, version,
+   mutation, demand, and effects.
+3. Contracts consume validated evidence. If a required fact is missing or
+   ambiguous, the exact channel stays closed.
+4. Normalize and detect use only admitted contracts and kernel proof helpers for
+   exact semantic fingerprinting.
+5. Reports should eventually expose the pack and contract provenance that
+   influenced each exact match. The current public scan JSON does not yet expose
+   those fields.
+
+## Fact classes
+
+The pack-facing vocabulary should cover at least these classes.
+
+| class | examples |
+|---|---|
+| Symbol and import | resolved import binding, namespace import, unshadowed language global, version range |
+| Receiver and domain | array, collection, map, option, string, primitive integer, byte array, promise-like receiver |
+| Operator | strict equality, loose equality, identity equality, value equality, type membership, language membership |
+| Literal and surface | regex literal, string literal, map/object literal, tuple/list/array surface, computed property key |
+| Call shape | constructor call, ordinary function call, method call, property access, macro-like call |
+| Sequence and aggregate | collection surface, map-entry surface, iterator surface, exported literal surface |
+| Place and mutation | receiver field, index assignment, builder append, immutable binding, direct write, opaque escape |
+| Module export | exported binding, import dependency, provider mutation proof, importer mutation proof |
+
+## Current internal slice
+
+The current implementation has the first internal `SourceFact` storage in
+`nose-il` and source-fact helpers in `nose-semantics`.
+
+- JS/TS lowering emits source facts for construct syntax, regex literals, strict
+  equality, strict inequality, loose equality, loose inequality, and
+  `instanceof`.
+- Python lowering emits source facts for value equality/inequality and identity
+  equality/inequality.
+- JS-like `new Set(...)` and `new Map(...)` can enter exact matching only when
+  construct syntax is proven, the `Set`/`Map` global is not shadowed, and the
+  collection/map argument remains exact-safe. Plain `Set(...)` and `Map(...)`
+  stay closed.
+- JS/TS regex literal `.test(value)` can enter exact matching only when the
+  receiver is proven to be a regex literal. Ordinary string `.test(...)` stays
+  closed.
+- JS-like static membership callbacks such as `x => x === value` consume source
+  operator facts and require strict equality/inequality. Loose equality and
+  `instanceof` stay closed for those exact contracts.
+
+The slice deliberately does not claim that all equality semantics are modeled.
+The IL still has coarse equality operators; source facts are the evidence that
+lets a small set of contracts recover the original source surface safely.
+Construct syntax likewise proves only that the surface used `new`; constructor
+contracts still need callee identity evidence such as an unshadowed global or a
+future resolved-symbol fact.
+
+## Pack boundary
+
+Packs should use only kernel-defined fact kinds and contract fields. A pack that
+claims exact eligibility for a source/API surface must declare:
+
+- the source surface and language/runtime/package/version range;
+- the required symbol, receiver, import, shadowing, overload, and arity proof;
+- the evaluation, demand, effect, mutation, and exception behavior relevant to
+  the contract;
+- the exact/near eligibility and proof status;
+- positive conformance fixtures and hard negatives;
+- known unsupported or unsound boundaries;
+- provenance labels suitable for reports.
+
+Meeting this shape is not nose certification. First-party default packs are
+validated by the nose project. External packs are provider/user responsibility
+and must be explicitly enabled by the user.


### PR DESCRIPTION
## Summary

- add internal `SourceFact` evidence for source surfaces that IL currently erases: construct syntax, regex literals, and selected equality/operator provenance
- make exact consumers use kernel source-fact helpers for regex literal `.test`, JS-like `new Set` / `new Map`, and JS static membership callbacks
- keep precision boundaries explicit: plain `Set(...)`/`Map(...)`, shadowed globals, string `.test(...)`, loose equality, and `instanceof` remain exact-closed for these contracts
- document the source-facts direction and connect it from the semantic-kernel snapshot/roadmap/home/architecture/normalization docs

Closes part of #109.

## Notes

A subagent audit found that construct syntax alone did not prove the `Set`/`Map` callee was the JS global. This PR adds an unshadowed-global obligation to the constructor contract and hard negatives for shadowed constructor names.

## Validation

- `cargo check --all-targets --all-features`
- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `awiki lint --root docs`
- `git diff --check`
- `python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `cargo build --release`
- `./scripts/check-duplication.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 시맨틱 스캔의 정규식 리터럴 및 컬렉션 멤버십 검증 정확도 개선
  * JavaScript/TypeScript `Map`과 `Set` 생성자 처리 강화
  * 동등성 연산자 기반 검증의 정밀도 향상

* **Documentation**
  * 아키텍처 및 시맨틱 커널 문서 업데이트
  * 소스 기원 추적 메커니즘 설명 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->