### PR TITLE
semantics: introduce evidence records

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -13,8 +13,9 @@ use nose_normalize::{
     node_tag,
 };
 use nose_semantics::{
-    builder_append_call_args, construct_syntax_proof, domain_evidence_from_param_semantic,
-    exact_java_return_this, exact_java_this_field, exact_non_overloadable_index_assignment,
+    builder_append_call_args, construct_syntax_proof,
+    domain_evidence_for_param as semantic_domain_evidence_for_param, exact_java_return_this,
+    exact_java_this_field, exact_non_overloadable_index_assignment,
     exact_non_overloadable_index_assignment_parts, exact_static_membership_predicate_operator,
     go_zero_map_default_kind, go_zero_map_lookup_contract, import_binding_rhs_matches,
     import_namespace_rhs_matches, iterator_identity_adapter_contract,
@@ -22,10 +23,10 @@ use nose_semantics::{
     js_array_is_array_contract, js_like_map_constructor_contract, js_like_set_constructor_contract,
     map_get_contract, map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
     nullish_global_contract, regex_test_contract, ruby_set_factory_contract,
-    rust_vec_new_factory_contract, semantics, seq_surface_contract, source_fact_at_node,
+    rust_vec_new_factory_contract, semantics, seq_surface_contract_for_node, source_fact_at_node,
     source_operator_at_node, static_index_membership_contract, typeof_operator_contract,
-    IndexMembershipThreshold, JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs,
-    MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
+    DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind, MapKeyViewKind,
+    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1171,12 +1172,7 @@ fn strict_exact_static_non_float_collection(il: &Il, interner: &Interner, node: 
     if il.kind(node) != NodeKind::Seq {
         return false;
     }
-    let tag = match il.node(node).payload {
-        Payload::None => None,
-        Payload::Name(name) => Some(interner.resolve(name)),
-        _ => return false,
-    };
-    if !seq_surface_contract(il.meta.lang, tag)
+    if !seq_surface_contract_for_node(il, interner, node)
         .is_some_and(|contract| contract.membership_collection)
     {
         return false;
@@ -1214,12 +1210,8 @@ fn strict_exact_nullish_global_safe(il: &Il, interner: &Interner, node: NodeId) 
 }
 
 fn strict_exact_safe_seq(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    let tag = match il.node(node).payload {
-        Payload::None => None,
-        Payload::Name(name) => Some(interner.resolve(name)),
-        _ => return false,
-    };
-    seq_surface_contract(il.meta.lang, tag).is_some_and(|contract| contract.exact_tree_safe)
+    seq_surface_contract_for_node(il, interner, node)
+        .is_some_and(|contract| contract.exact_tree_safe)
 }
 
 fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, node: NodeId) -> bool {
@@ -1645,37 +1637,28 @@ fn strict_exact_iterator_identity_adapter_node_safe(
 }
 
 fn strict_exact_typed_set_param_receiver_safe(il: &Il, receiver: NodeId) -> bool {
-    if il.kind(receiver) != NodeKind::Var {
-        return false;
-    }
-    let Payload::Cid(receiver_cid) = il.node(receiver).payload else {
-        return false;
-    };
-    il.nodes.iter().any(|node| {
-        node.kind == NodeKind::Param
-            && matches!(node.payload, Payload::Cid(param_cid) if param_cid == receiver_cid)
-            && il.param_type_facts.iter().any(|fact| {
-                fact.span == node.span
-                    && domain_evidence_from_param_semantic(fact.semantic).is_set()
-            })
-    })
+    strict_exact_typed_param_receiver_safe(il, receiver, DomainEvidence::is_set)
 }
 
 fn strict_exact_typed_collection_param_receiver_safe(il: &Il, receiver: NodeId) -> bool {
+    strict_exact_typed_param_receiver_safe(il, receiver, DomainEvidence::is_array_collection_or_set)
+}
+
+fn strict_exact_typed_param_receiver_safe(
+    il: &Il,
+    receiver: NodeId,
+    accepts: impl Fn(DomainEvidence) -> bool,
+) -> bool {
     if il.kind(receiver) != NodeKind::Var {
         return false;
     }
     let Payload::Cid(receiver_cid) = il.node(receiver).payload else {
         return false;
     };
-    il.nodes.iter().any(|node| {
+    il.nodes.iter().enumerate().any(|(idx, node)| {
         node.kind == NodeKind::Param
             && matches!(node.payload, Payload::Cid(param_cid) if param_cid == receiver_cid)
-            && il.param_type_facts.iter().any(|fact| {
-                fact.span == node.span
-                    && domain_evidence_from_param_semantic(fact.semantic)
-                        .is_array_collection_or_set()
-            })
+            && semantic_domain_evidence_for_param(il, NodeId(idx as u32)).is_some_and(&accepts)
     })
 }
 
@@ -1697,20 +1680,7 @@ fn strict_exact_proven_collection_receiver_safe(
 }
 
 fn strict_exact_typed_map_param_receiver_safe(il: &Il, receiver: NodeId) -> bool {
-    if il.kind(receiver) != NodeKind::Var {
-        return false;
-    }
-    let Payload::Cid(receiver_cid) = il.node(receiver).payload else {
-        return false;
-    };
-    il.nodes.iter().any(|node| {
-        node.kind == NodeKind::Param
-            && matches!(node.payload, Payload::Cid(param_cid) if param_cid == receiver_cid)
-            && il.param_type_facts.iter().any(|fact| {
-                fact.span == node.span
-                    && domain_evidence_from_param_semantic(fact.semantic).is_map()
-            })
-    })
+    strict_exact_typed_param_receiver_safe(il, receiver, DomainEvidence::is_map)
 }
 
 fn strict_exact_proven_map_receiver_safe(il: &Il, facts: &StrictFacts, receiver: NodeId) -> bool {
@@ -1836,12 +1806,7 @@ fn strict_exact_membership_collection_safe(
         }
         return false;
     }
-    let tag = match il.node(node).payload {
-        Payload::None => None,
-        Payload::Name(name) => Some(interner.resolve(name)),
-        _ => return false,
-    };
-    let tag_safe = seq_surface_contract(il.meta.lang, tag)
+    let tag_safe = seq_surface_contract_for_node(il, interner, node)
         .is_some_and(|contract| contract.membership_collection);
     tag_safe
         && il
@@ -2400,10 +2365,7 @@ fn strict_exact_map_entries_safe(
     if il.kind(node) != NodeKind::Seq {
         return false;
     }
-    let Payload::Name(name) = il.node(node).payload else {
-        return false;
-    };
-    if !seq_surface_contract(il.meta.lang, Some(interner.resolve(name)))
+    if !seq_surface_contract_for_node(il, interner, node)
         .is_some_and(|contract| contract.map_entry_list)
     {
         return false;

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -3,10 +3,12 @@
 //! mechanics live in one place.
 
 use nose_il::{
-    FileId, FileMeta, Il, IlBuilder, Interner, Lang, LoopKind, NodeId, NodeKind, Op, ParamSemantic,
+    stable_symbol_hash, DomainEvidence, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
+    EvidenceProvenance, EvidenceRecord, EvidenceStatus, FileId, FileMeta, Il, IlBuilder,
+    ImportEvidenceKind, Interner, Lang, LoopKind, NodeId, NodeKind, Op, ParamSemantic,
     ParamTypeFact, Payload, SourceFact, SourceFactKind, Span, Symbol, Unit, UnitKind,
 };
-use nose_semantics::{import_fact_tag, ImportFactKind};
+use nose_semantics::{import_fact_tag, sequence_surface_kind_for_tag, ImportFactKind};
 use tree_sitter::Node as TsNode;
 
 /// Mutable state threaded through a single file's lowering.
@@ -17,6 +19,7 @@ pub(crate) struct Lowering<'a> {
     pub interner: &'a Interner,
     pub units: Vec<Unit>,
     pub param_type_facts: Vec<ParamTypeFact>,
+    pub evidence: Vec<EvidenceRecord>,
     pub source_facts: Vec<SourceFact>,
     pub param_semantic_aliases: Vec<(String, ParamSemantic)>,
     pub unsigned_32_aliases: Vec<String>,
@@ -31,6 +34,7 @@ impl<'a> Lowering<'a> {
             interner,
             units: Vec::new(),
             param_type_facts: Vec::new(),
+            evidence: Vec::new(),
             source_facts: Vec::new(),
             param_semantic_aliases: Vec::new(),
             unsigned_32_aliases: Vec::new(),
@@ -64,15 +68,61 @@ impl<'a> Lowering<'a> {
         span: Span,
         children: &[NodeId],
     ) -> NodeId {
-        self.b.add(kind, payload, span, children)
+        let id = self.b.add(kind, payload, span, children);
+        if kind == NodeKind::Seq {
+            let tag = match payload {
+                Payload::None => None,
+                Payload::Name(symbol) => Some(self.interner.resolve(symbol)),
+                _ => return id,
+            };
+            if let Some(surface) = sequence_surface_kind_for_tag(self.lang, tag) {
+                self.record_evidence(
+                    EvidenceAnchor::sequence(span),
+                    EvidenceKind::SequenceSurface(surface),
+                    "sequence_surface",
+                );
+            }
+        }
+        id
     }
 
     pub(crate) fn record_param_semantic(&mut self, span: Span, semantic: ParamSemantic) {
         self.param_type_facts.push(ParamTypeFact { span, semantic });
+        self.record_evidence(
+            EvidenceAnchor::param(span),
+            EvidenceKind::Domain(DomainEvidence::from_param_semantic(semantic)),
+            "param_semantic",
+        );
     }
 
     pub(crate) fn record_source_fact(&mut self, span: Span, kind: SourceFactKind) {
         self.source_facts.push(SourceFact { span, kind });
+        self.record_evidence(
+            EvidenceAnchor::source_span(span),
+            EvidenceKind::Source(kind),
+            "source_fact",
+        );
+    }
+
+    pub(crate) fn record_evidence(
+        &mut self,
+        anchor: EvidenceAnchor,
+        kind: EvidenceKind,
+        rule: &str,
+    ) {
+        let id = EvidenceId(self.evidence.len() as u32);
+        self.evidence.push(EvidenceRecord {
+            id,
+            anchor,
+            kind,
+            provenance: EvidenceProvenance {
+                emitter: EvidenceEmitter::FirstParty,
+                pack_hash: Some(stable_symbol_hash(nose_semantics::FIRST_PARTY_PACK_ID)),
+                rule_hash: Some(stable_symbol_hash(rule)),
+            },
+            dependencies: Vec::new(),
+            status: EvidenceStatus::Asserted,
+        });
     }
 
     pub(crate) fn record_param_semantic_alias(&mut self, local: &str, semantic: ParamSemantic) {
@@ -175,7 +225,7 @@ impl<'a> Lowering<'a> {
     /// behavior-DISTINCT in the value graph (`3.14` ≠ `2.71`). The structural tag stays the
     /// abstract `Float` class (see `node_tag`), so shape similarity is unaffected.
     pub(crate) fn float_lit(&mut self, text: &str, span: Span) -> NodeId {
-        let h = nose_il::stable_symbol_hash(text.trim().trim_end_matches(['f', 'F', 'd', 'D']));
+        let h = stable_symbol_hash(text.trim().trim_end_matches(['f', 'F', 'd', 'D']));
         self.b.add(NodeKind::Lit, Payload::LitFloat(h), span, &[])
     }
 
@@ -185,7 +235,7 @@ impl<'a> Lowering<'a> {
     /// class (see `node_tag`), so shape similarity is unaffected.
     pub(crate) fn str_lit(&mut self, text: &str, span: Span) -> NodeId {
         let content = text.trim_matches(|c| c == '"' || c == '\'' || c == '`');
-        let h = nose_il::stable_symbol_hash(content);
+        let h = stable_symbol_hash(content);
         self.b.add(NodeKind::Lit, Payload::LitStr(h), span, &[])
     }
 
@@ -281,6 +331,28 @@ fn import_fact(
     let strs: Vec<NodeId> = coords.iter().map(|c| lo.str_lit(c, span)).collect();
     let tag = lo.sym(import_fact_tag(kind));
     let rhs = lo.add(NodeKind::Seq, Payload::Name(tag), span, &strs);
+    let evidence_kind = match kind {
+        ImportFactKind::Binding if coords.len() == 2 => {
+            EvidenceKind::Import(ImportEvidenceKind::Binding {
+                module_hash: stable_symbol_hash(coords[0]),
+                exported_hash: stable_symbol_hash(coords[1]),
+            })
+        }
+        ImportFactKind::Namespace if coords.len() == 1 => {
+            EvidenceKind::Import(ImportEvidenceKind::Namespace {
+                module_hash: stable_symbol_hash(coords[0]),
+            })
+        }
+        _ => {
+            return lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs]);
+        }
+    };
+    lo.record_evidence(EvidenceAnchor::sequence(span), evidence_kind, "import_fact");
+    lo.record_evidence(
+        EvidenceAnchor::binding(span, stable_symbol_hash(local)),
+        evidence_kind,
+        "import_binding_subject",
+    );
     lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs])
 }
 
@@ -358,9 +430,11 @@ pub(crate) fn lower_file_with_setup(
     };
     let units = std::mem::take(&mut lo.units);
     let param_type_facts = std::mem::take(&mut lo.param_type_facts);
+    let evidence = std::mem::take(&mut lo.evidence);
     let source_facts = std::mem::take(&mut lo.source_facts);
     let mut il = lo.b.finish(module, meta, units, Vec::new());
     il.param_type_facts = param_type_facts;
+    il.evidence = evidence;
     il.source_facts = source_facts;
     drop_suppressed_units(&mut il, src);
     Ok(il)

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -16,8 +16,11 @@ mod sexpr;
 
 pub use intern::{stable_symbol_hash, symbol_index, Interner, Symbol, FNV_OFFSET_BASIS, FNV_PRIME};
 pub use node::{
-    Builtin, HoFKind, LitClass, LoopKind, Node, NodeId, NodeKind, Op, ParamSemantic, ParamTypeFact,
-    Payload, SourceCallKind, SourceFact, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
+    Builtin, DomainEvidence, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
+    EvidenceProvenance, EvidenceRecord, EvidenceStatus, HoFKind, ImportEvidenceKind, LitClass,
+    LoopKind, Node, NodeId, NodeKind, Op, ParamSemantic, ParamTypeFact, Payload,
+    SequenceSurfaceKind, SourceCallKind, SourceFact, SourceFactKind, SourceLiteralKind,
+    SourceOperatorKind,
 };
 pub use span::{FileId, FileMeta, Lang, Span};
 
@@ -67,6 +70,11 @@ pub struct Il {
     /// connect these facts to canonical parameter ids for strict proof-gated rewrites.
     #[serde(default)]
     pub param_type_facts: Vec<ParamTypeFact>,
+    /// Pack-facing semantic evidence records keyed by stable source anchors.
+    /// Existing source/param/import side tables are mirrored here for compatibility
+    /// today; future language/library packs should emit this record shape directly.
+    #[serde(default)]
+    pub evidence: Vec<EvidenceRecord>,
     /// Source-origin evidence facts keyed by source span. These preserve facts that the
     /// shared IL shape intentionally abstracts away, such as construct syntax, regex
     /// literal syntax, and the original equality/operator family.
@@ -207,6 +215,7 @@ impl IlBuilder {
             cid_names,
             suppressed: Vec::new(),
             param_type_facts: Vec::new(),
+            evidence: Vec::new(),
             source_facts: Vec::new(),
         }
     }

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -139,10 +139,203 @@ pub enum ParamSemantic {
     String,
 }
 
+/// Kernel-facing receiver/domain evidence recovered from source annotations,
+/// inference, or semantic packs. Unknown is represented by absence, and
+/// consumers must fail closed when evidence is missing or conflicting.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum DomainEvidence {
+    Array,
+    ByteArray,
+    Collection,
+    Integer,
+    Map,
+    Number,
+    Option,
+    Set,
+    String,
+}
+
+impl DomainEvidence {
+    pub fn from_param_semantic(semantic: ParamSemantic) -> Self {
+        match semantic {
+            ParamSemantic::Array => DomainEvidence::Array,
+            ParamSemantic::ByteArray => DomainEvidence::ByteArray,
+            ParamSemantic::Collection => DomainEvidence::Collection,
+            ParamSemantic::Integer => DomainEvidence::Integer,
+            ParamSemantic::Map => DomainEvidence::Map,
+            ParamSemantic::Number => DomainEvidence::Number,
+            ParamSemantic::Option => DomainEvidence::Option,
+            ParamSemantic::Set => DomainEvidence::Set,
+            ParamSemantic::String => DomainEvidence::String,
+        }
+    }
+
+    pub fn is_array(self) -> bool {
+        self == DomainEvidence::Array
+    }
+
+    pub fn is_byte_array(self) -> bool {
+        self == DomainEvidence::ByteArray
+    }
+
+    pub fn is_collection_or_set(self) -> bool {
+        matches!(self, DomainEvidence::Collection | DomainEvidence::Set)
+    }
+
+    pub fn is_array_or_collection(self) -> bool {
+        matches!(self, DomainEvidence::Array | DomainEvidence::Collection)
+    }
+
+    pub fn is_array_collection_or_set(self) -> bool {
+        matches!(
+            self,
+            DomainEvidence::Array | DomainEvidence::Collection | DomainEvidence::Set
+        )
+    }
+
+    pub fn is_set(self) -> bool {
+        self == DomainEvidence::Set
+    }
+
+    pub fn is_map(self) -> bool {
+        self == DomainEvidence::Map
+    }
+
+    pub fn is_option(self) -> bool {
+        self == DomainEvidence::Option
+    }
+
+    pub fn is_string(self) -> bool {
+        self == DomainEvidence::String
+    }
+
+    pub fn is_integer(self) -> bool {
+        self == DomainEvidence::Integer
+    }
+
+    pub fn is_integer_or_number(self) -> bool {
+        matches!(self, DomainEvidence::Integer | DomainEvidence::Number)
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub struct ParamTypeFact {
     pub span: Span,
     pub semantic: ParamSemantic,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub struct EvidenceId(pub u32);
+
+/// Stable subject addressed by a semantic evidence record. Node ids are not used
+/// because normalization rebuilds arenas; consumers match by source span plus the
+/// expected subject kind and fail closed when that is ambiguous.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum EvidenceAnchor {
+    SourceSpan(Span),
+    Node { span: Span, kind: NodeKind },
+    Param { span: Span },
+    Binding { span: Span, local_hash: u64 },
+    Sequence { span: Span },
+}
+
+impl EvidenceAnchor {
+    pub fn source_span(span: Span) -> Self {
+        EvidenceAnchor::SourceSpan(span)
+    }
+
+    pub fn node(span: Span, kind: NodeKind) -> Self {
+        EvidenceAnchor::Node { span, kind }
+    }
+
+    pub fn param(span: Span) -> Self {
+        EvidenceAnchor::Param { span }
+    }
+
+    pub fn binding(span: Span, local_hash: u64) -> Self {
+        EvidenceAnchor::Binding { span, local_hash }
+    }
+
+    pub fn sequence(span: Span) -> Self {
+        EvidenceAnchor::Sequence { span }
+    }
+
+    pub fn matches_span(self, span: Span) -> bool {
+        match self {
+            EvidenceAnchor::SourceSpan(subject)
+            | EvidenceAnchor::Node { span: subject, .. }
+            | EvidenceAnchor::Param { span: subject }
+            | EvidenceAnchor::Binding { span: subject, .. }
+            | EvidenceAnchor::Sequence { span: subject } => subject == span,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum EvidenceEmitter {
+    FirstParty,
+    External,
+    Legacy,
+}
+
+/// Provenance attached to semantic evidence. Hashes are stable symbol hashes so
+/// serialized IL does not depend on an interner instance.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub struct EvidenceProvenance {
+    pub emitter: EvidenceEmitter,
+    pub pack_hash: Option<u64>,
+    pub rule_hash: Option<u64>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum EvidenceStatus {
+    Asserted,
+    Ambiguous,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum ImportEvidenceKind {
+    Binding {
+        module_hash: u64,
+        exported_hash: u64,
+    },
+    Namespace {
+        module_hash: u64,
+    },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum SequenceSurfaceKind {
+    Untagged,
+    Collection,
+    Tuple,
+    Map,
+    Pair,
+    ImportBinding,
+    ImportNamespace,
+    RecordGuard,
+    OwnPropertyGuard,
+    GoCompositeMapLiteral,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum EvidenceKind {
+    Source(SourceFactKind),
+    Domain(DomainEvidence),
+    Import(ImportEvidenceKind),
+    SequenceSurface(SequenceSurfaceKind),
+}
+
+/// Pack-facing semantic evidence record. It is evidence, not a verdict: exact
+/// consumers must check contracts, provenance, dependencies, and ambiguity.
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub struct EvidenceRecord {
+    pub id: EvidenceId,
+    pub anchor: EvidenceAnchor,
+    pub kind: EvidenceKind,
+    pub provenance: EvidenceProvenance,
+    pub dependencies: Vec<EvidenceId>,
+    pub status: EvidenceStatus,
 }
 
 /// Source-origin facts that must survive lowering before a semantic contract can

--- a/crates/nose-normalize/src/desugar.rs
+++ b/crates/nose-normalize/src/desugar.rs
@@ -14,7 +14,7 @@
 use crate::idioms::{canon_call, CallCanon};
 use crate::NormalizeOptions;
 use nose_il::{Il, IlBuilder, Interner, LoopKind, NodeId, NodeKind, Payload};
-use nose_semantics::{domain_evidence_from_param_semantic, seq_surface_contract, DomainEvidence};
+use nose_semantics::{domain_evidence_for_param, seq_surface_contract_for_node, DomainEvidence};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 pub(crate) fn run(old: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il {
@@ -276,12 +276,8 @@ fn seq_receiver_exact_collection_safe(il: &Il, interner: &Interner, node: NodeId
     if il.kind(node) != NodeKind::Seq {
         return false;
     }
-    let tag = match il.node(node).payload {
-        Payload::None => None,
-        Payload::Name(name) => Some(interner.resolve(name)),
-        _ => return false,
-    };
-    seq_surface_contract(il.meta.lang, tag).is_some_and(|contract| contract.membership_collection)
+    seq_surface_contract_for_node(il, interner, node)
+        .is_some_and(|contract| contract.membership_collection)
 }
 
 fn domain_evidence_for_var(il: &Il, node: NodeId) -> Option<DomainEvidence> {
@@ -291,14 +287,11 @@ fn domain_evidence_for_var(il: &Il, node: NodeId) -> Option<DomainEvidence> {
     let Payload::Cid(cid) = il.node(node).payload else {
         return None;
     };
-    let span = il.nodes.iter().find_map(|candidate| {
+    il.nodes.iter().enumerate().find_map(|(idx, candidate)| {
         (candidate.kind == NodeKind::Param && candidate.payload == Payload::Cid(cid))
-            .then_some(candidate.span)
-    })?;
-    il.param_type_facts
-        .iter()
-        .find(|fact| fact.span == span)
-        .map(|fact| domain_evidence_from_param_semantic(fact.semantic))
+            .then(|| domain_evidence_for_param(il, NodeId(idx as u32)))
+            .flatten()
+    })
 }
 
 fn property_receiver_exact_hof_call(il: &Il, interner: &Interner, node: NodeId) -> bool {

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -9,10 +9,10 @@
 
 use nose_il::{Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
 use nose_semantics::{
-    domain_evidence_from_param_semantic, free_function_builtin_contract,
-    import_binding_rhs_matches, import_namespace_rhs_matches, iterator_identity_adapter_contract,
-    map_get_contract, map_key_view_contract, method_call_contract, method_hof_contract,
-    rust_option_some_constructor_contract, seq_surface_contract,
+    domain_evidence_for_param, free_function_builtin_contract, import_binding_rhs_matches,
+    import_namespace_rhs_matches, iterator_identity_adapter_contract, map_get_contract,
+    map_key_view_contract, method_call_contract, method_hof_contract,
+    rust_option_some_constructor_contract, seq_surface_contract_for_node,
     static_collection_adapter_contract, BuiltinArgContract, DomainEvidence, MapKeyViewKind,
     MethodBuiltinArgs, MethodCallContract, MethodReceiverContract, MethodSemanticContract,
 };
@@ -544,10 +544,11 @@ fn domain_evidence_for_var(old: &Il, node: NodeId) -> Option<DomainEvidence> {
         _ => None,
     };
     param_span.and_then(|span| {
-        old.param_type_facts
-            .iter()
-            .find(|fact| fact.span == span)
-            .map(|fact| domain_evidence_from_param_semantic(fact.semantic))
+        old.nodes.iter().enumerate().find_map(|(idx, candidate)| {
+            (candidate.kind == NodeKind::Param && candidate.span == span)
+                .then(|| domain_evidence_for_param(old, NodeId(idx as u32)))
+                .flatten()
+        })
     })
 }
 
@@ -630,12 +631,8 @@ fn exact_collection_literal(old: &Il, interner: &Interner, node: NodeId) -> bool
     if old.kind(node) != NodeKind::Seq {
         return false;
     }
-    let tag = match old.node(node).payload {
-        Payload::None => None,
-        Payload::Name(name) => Some(interner.resolve(name)),
-        _ => return false,
-    };
-    seq_surface_contract(old.meta.lang, tag).is_some_and(|contract| contract.membership_collection)
+    seq_surface_contract_for_node(old, interner, node)
+        .is_some_and(|contract| contract.membership_collection)
 }
 
 fn exact_option_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -154,6 +154,7 @@ pub(crate) fn finalize_rebuild(
     };
     let mut out = builder.finish(new_root, meta, units, cid_names);
     out.param_type_facts = old.param_type_facts.clone();
+    out.evidence = old.evidence.clone();
     out.source_facts = old.source_facts.clone();
     out
 }

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -50,9 +50,10 @@ use nose_il::{
 };
 use nose_semantics::{
     builder_append_method_contract, builtin_tag, construct_syntax_proof,
-    domain_evidence_from_param_semantic, exact_static_membership_predicate_operator,
-    free_function_builtin_contract, go_zero_map_default_kind, go_zero_map_lookup_contract,
-    import_fact_contract, import_namespace_rhs_matches, imported_namespace_function_contract,
+    domain_evidence_for_param as semantic_domain_evidence_for_param,
+    exact_static_membership_predicate_operator, free_function_builtin_contract,
+    go_zero_map_default_kind, go_zero_map_lookup_contract, import_fact_contract,
+    import_namespace_rhs_matches, imported_namespace_function_contract,
     iterator_identity_adapter_contract, java_collection_factory_contract_by_hash,
     java_map_entry_contract_by_hash, java_map_factory_contract_by_hash,
     js_like_map_constructor_contract, js_like_set_constructor_contract, map_get_contract_by_hash,
@@ -60,14 +61,15 @@ use nose_semantics::{
     nullish_global_contract, reduction_builtin_contract, ruby_set_factory_contract_by_hash,
     rust_option_and_then_contract, rust_option_none_sentinel_contract,
     rust_option_some_constructor_contract, rust_vec_new_factory_contract,
-    scalar_integer_method_contract, semantics, seq_surface_contract, source_operator_at_node,
-    static_index_membership_contract, BuiltinArgContract, CardinalityPredicate,
-    CardinalityThreshold, ComparisonLaw, DomainEvidence, GoZeroMapDefaultKind, ImportFactKind,
-    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
-    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
-    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract,
-    StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD,
-    SEQ_VALUE_PAIR, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
+    scalar_integer_method_contract, semantics, seq_surface_contract_for_node,
+    source_operator_at_node, static_index_membership_contract, BuiltinArgContract,
+    CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
+    GoZeroMapDefaultKind, ImportFactKind, ImportedNamespaceFunctionSemantic,
+    IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind, MapKeyViewKind,
+    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract,
+    ScalarIntegerMethod, SeqSurfaceContract, StaticIndexMembershipKind, SEQ_VALUE_COLLECTION,
+    SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR, SEQ_VALUE_TUPLE,
+    SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -729,12 +731,7 @@ impl<'a> Builder<'a> {
     }
 
     fn domain_evidence_for_param(&self, param: NodeId) -> Option<DomainEvidence> {
-        let span = self.il.node(param).span;
-        self.il
-            .param_type_facts
-            .iter()
-            .find(|fact| fact.span == span)
-            .map(|fact| domain_evidence_from_param_semantic(fact.semantic))
+        semantic_domain_evidence_for_param(self.il, param)
     }
 
     fn seed_param_domains(&mut self, root: NodeId) {
@@ -7940,13 +7937,7 @@ impl<'a> Builder<'a> {
     }
 
     fn seq_surface(&self, node: NodeId) -> Option<SeqSurfaceContract> {
-        match self.il.node(node).payload {
-            Payload::None => seq_surface_contract(self.il.meta.lang, None),
-            Payload::Name(s) => {
-                seq_surface_contract(self.il.meta.lang, Some(self.interner.resolve(s)))
-            }
-            _ => None,
-        }
+        seq_surface_contract_for_node(self.il, self.interner, node)
     }
 }
 

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -7,9 +7,13 @@
 //! approve exact clone matches directly.
 
 use nose_il::{
-    stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LitClass, NodeId, NodeKind, Op,
-    ParamSemantic, Payload, SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
+    stable_symbol_hash, Builtin, EvidenceAnchor, EvidenceKind, EvidenceStatus, HoFKind, Il,
+    ImportEvidenceKind, Interner, Lang, LitClass, NodeId, NodeKind, Op, ParamSemantic, Payload,
+    SequenceSurfaceKind, SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
+    Span,
 };
+
+pub use nose_il::DomainEvidence;
 
 /// Stable pack id for the first-party language/stdlib contracts compiled into nose.
 pub const FIRST_PARTY_PACK_ID: &str = "nose.first_party";
@@ -47,47 +51,126 @@ pub fn source_fact_contract(kind: SourceFactKind) -> SourceFactContract {
     }
 }
 
+enum EvidenceResolution<T> {
+    Missing,
+    Found(T),
+    Ambiguous,
+}
+
+fn unique_evidence_at<T: Copy + Eq>(
+    il: &Il,
+    anchor_matches: impl Fn(EvidenceAnchor) -> bool,
+    project: impl Fn(EvidenceKind) -> Option<T>,
+) -> EvidenceResolution<T> {
+    let mut found = None;
+    for record in &il.evidence {
+        if !anchor_matches(record.anchor) {
+            continue;
+        }
+        let Some(value) = project(record.kind) else {
+            continue;
+        };
+        if record.status != EvidenceStatus::Asserted {
+            return EvidenceResolution::Ambiguous;
+        }
+        match found {
+            None => found = Some(value),
+            Some(existing) if existing == value => {}
+            Some(_) => return EvidenceResolution::Ambiguous,
+        }
+    }
+    found.map_or(EvidenceResolution::Missing, EvidenceResolution::Found)
+}
+
+fn evidence_at_span<T: Copy + Eq>(
+    il: &Il,
+    span: Span,
+    project: impl Fn(EvidenceKind) -> Option<T>,
+) -> EvidenceResolution<T> {
+    unique_evidence_at(il, |anchor| anchor.matches_span(span), project)
+}
+
 pub fn source_fact_at_node(il: &Il, node: NodeId, kind: SourceFactKind) -> bool {
-    let span = il.node(node).span;
-    il.source_facts
-        .iter()
-        .any(|fact| fact.span == span && fact.kind == kind)
+    match kind {
+        SourceFactKind::Operator(operator) => source_operator_at_node(il, node) == Some(operator),
+        SourceFactKind::Call(call) => source_call_at_node(il, node) == Some(call),
+        SourceFactKind::Literal(literal) => source_literal_at_node(il, node) == Some(literal),
+    }
 }
 
 pub fn source_operator_at_node(il: &Il, node: NodeId) -> Option<SourceOperatorKind> {
     let span = il.node(node).span;
-    il.source_facts.iter().find_map(|fact| {
-        (fact.span == span)
-            .then_some(fact.kind)
-            .and_then(|kind| match kind {
-                SourceFactKind::Operator(operator) => Some(operator),
-                SourceFactKind::Call(_) | SourceFactKind::Literal(_) => None,
-            })
-    })
+    match evidence_at_span(il, span, |evidence| match evidence {
+        EvidenceKind::Source(SourceFactKind::Operator(operator)) => Some(operator),
+        _ => None,
+    }) {
+        EvidenceResolution::Found(operator) => Some(operator),
+        EvidenceResolution::Ambiguous => None,
+        EvidenceResolution::Missing => {
+            unique_legacy_source_fact(il.source_facts.iter().filter_map(|fact| {
+                (fact.span == span)
+                    .then_some(fact.kind)
+                    .and_then(|kind| match kind {
+                        SourceFactKind::Operator(operator) => Some(operator),
+                        SourceFactKind::Call(_) | SourceFactKind::Literal(_) => None,
+                    })
+            }))
+        }
+    }
 }
 
 pub fn source_call_at_node(il: &Il, node: NodeId) -> Option<SourceCallKind> {
     let span = il.node(node).span;
-    il.source_facts.iter().find_map(|fact| {
-        (fact.span == span)
-            .then_some(fact.kind)
-            .and_then(|kind| match kind {
-                SourceFactKind::Call(call) => Some(call),
-                SourceFactKind::Operator(_) | SourceFactKind::Literal(_) => None,
-            })
-    })
+    match evidence_at_span(il, span, |evidence| match evidence {
+        EvidenceKind::Source(SourceFactKind::Call(call)) => Some(call),
+        _ => None,
+    }) {
+        EvidenceResolution::Found(call) => Some(call),
+        EvidenceResolution::Ambiguous => None,
+        EvidenceResolution::Missing => {
+            unique_legacy_source_fact(il.source_facts.iter().filter_map(|fact| {
+                (fact.span == span)
+                    .then_some(fact.kind)
+                    .and_then(|kind| match kind {
+                        SourceFactKind::Call(call) => Some(call),
+                        SourceFactKind::Operator(_) | SourceFactKind::Literal(_) => None,
+                    })
+            }))
+        }
+    }
 }
 
 pub fn source_literal_at_node(il: &Il, node: NodeId) -> Option<SourceLiteralKind> {
     let span = il.node(node).span;
-    il.source_facts.iter().find_map(|fact| {
-        (fact.span == span)
-            .then_some(fact.kind)
-            .and_then(|kind| match kind {
-                SourceFactKind::Literal(literal) => Some(literal),
-                SourceFactKind::Operator(_) | SourceFactKind::Call(_) => None,
-            })
-    })
+    match evidence_at_span(il, span, |evidence| match evidence {
+        EvidenceKind::Source(SourceFactKind::Literal(literal)) => Some(literal),
+        _ => None,
+    }) {
+        EvidenceResolution::Found(literal) => Some(literal),
+        EvidenceResolution::Ambiguous => None,
+        EvidenceResolution::Missing => {
+            unique_legacy_source_fact(il.source_facts.iter().filter_map(|fact| {
+                (fact.span == span)
+                    .then_some(fact.kind)
+                    .and_then(|kind| match kind {
+                        SourceFactKind::Literal(literal) => Some(literal),
+                        SourceFactKind::Operator(_) | SourceFactKind::Call(_) => None,
+                    })
+            }))
+        }
+    }
+}
+
+fn unique_legacy_source_fact<T: Copy + Eq>(facts: impl Iterator<Item = T>) -> Option<T> {
+    let mut found = None;
+    for fact in facts {
+        match found {
+            None => found = Some(fact),
+            Some(existing) if existing == fact => {}
+            Some(_) => return None,
+        }
+    }
+    found
 }
 
 pub fn construct_syntax_proof(il: &Il, node: NodeId) -> bool {
@@ -111,89 +194,36 @@ pub fn exact_static_membership_predicate_operator(
         )
 }
 
-/// Kernel-facing domain evidence recovered from source facts, type inference, or future packs.
-///
-/// `nose-il::ParamSemantic` is the current frontend storage format for source-level parameter
-/// annotations. Exact gates should consume this semantic-kernel vocabulary instead, so future
-/// packs can provide equivalent evidence without becoming coupled to frontend syntax facts.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub enum DomainEvidence {
-    Array,
-    ByteArray,
-    Collection,
-    Integer,
-    Map,
-    Number,
-    Option,
-    Set,
-    String,
-}
-
-impl DomainEvidence {
-    pub fn from_param_semantic(semantic: ParamSemantic) -> Self {
-        match semantic {
-            ParamSemantic::Array => DomainEvidence::Array,
-            ParamSemantic::ByteArray => DomainEvidence::ByteArray,
-            ParamSemantic::Collection => DomainEvidence::Collection,
-            ParamSemantic::Integer => DomainEvidence::Integer,
-            ParamSemantic::Map => DomainEvidence::Map,
-            ParamSemantic::Number => DomainEvidence::Number,
-            ParamSemantic::Option => DomainEvidence::Option,
-            ParamSemantic::Set => DomainEvidence::Set,
-            ParamSemantic::String => DomainEvidence::String,
-        }
-    }
-
-    pub fn is_array(self) -> bool {
-        self == DomainEvidence::Array
-    }
-
-    pub fn is_byte_array(self) -> bool {
-        self == DomainEvidence::ByteArray
-    }
-
-    pub fn is_collection_or_set(self) -> bool {
-        matches!(self, DomainEvidence::Collection | DomainEvidence::Set)
-    }
-
-    pub fn is_array_or_collection(self) -> bool {
-        matches!(self, DomainEvidence::Array | DomainEvidence::Collection)
-    }
-
-    pub fn is_array_collection_or_set(self) -> bool {
-        matches!(
-            self,
-            DomainEvidence::Array | DomainEvidence::Collection | DomainEvidence::Set
-        )
-    }
-
-    pub fn is_set(self) -> bool {
-        self == DomainEvidence::Set
-    }
-
-    pub fn is_map(self) -> bool {
-        self == DomainEvidence::Map
-    }
-
-    pub fn is_option(self) -> bool {
-        self == DomainEvidence::Option
-    }
-
-    pub fn is_string(self) -> bool {
-        self == DomainEvidence::String
-    }
-
-    pub fn is_integer(self) -> bool {
-        self == DomainEvidence::Integer
-    }
-
-    pub fn is_integer_or_number(self) -> bool {
-        matches!(self, DomainEvidence::Integer | DomainEvidence::Number)
-    }
-}
-
 pub fn domain_evidence_from_param_semantic(semantic: ParamSemantic) -> DomainEvidence {
     DomainEvidence::from_param_semantic(semantic)
+}
+
+pub fn domain_evidence_at_span(il: &Il, span: Span) -> Option<DomainEvidence> {
+    match evidence_at_span(il, span, |evidence| match evidence {
+        EvidenceKind::Domain(domain) => Some(domain),
+        _ => None,
+    }) {
+        EvidenceResolution::Found(domain) => Some(domain),
+        EvidenceResolution::Ambiguous => None,
+        EvidenceResolution::Missing => {
+            let mut found = None;
+            for fact in il.param_type_facts.iter().filter(|fact| fact.span == span) {
+                let domain = domain_evidence_from_param_semantic(fact.semantic);
+                match found {
+                    None => found = Some(domain),
+                    Some(existing) if existing == domain => {}
+                    Some(_) => return None,
+                }
+            }
+            found
+        }
+    }
+}
+
+pub fn domain_evidence_for_param(il: &Il, param: NodeId) -> Option<DomainEvidence> {
+    (il.kind(param) == NodeKind::Param)
+        .then_some(il.node(param).span)
+        .and_then(|span| domain_evidence_at_span(il, span))
 }
 
 pub const SEQ_VALUE_UNTAGGED: u64 = 0;
@@ -225,102 +255,137 @@ pub struct SeqSurfaceContract {
     pub imported_literal: bool,
 }
 
-pub fn seq_surface_contract(lang: Lang, tag: Option<&str>) -> Option<SeqSurfaceContract> {
-    let contract = match tag {
-        None => SeqSurfaceContract {
+pub fn sequence_surface_kind_for_tag(lang: Lang, tag: Option<&str>) -> Option<SequenceSurfaceKind> {
+    match tag {
+        None => Some(SequenceSurfaceKind::Untagged),
+        Some("array" | "array_expression" | "list") => Some(SequenceSurfaceKind::Collection),
+        Some("tuple" | "tuple_expression") => Some(SequenceSurfaceKind::Tuple),
+        Some("dictionary" | "object" | "hash") => Some(SequenceSurfaceKind::Map),
+        Some("pair") => Some(SequenceSurfaceKind::Pair),
+        Some(IMPORT_BINDING_TAG) => Some(SequenceSurfaceKind::ImportBinding),
+        Some(IMPORT_NAMESPACE_TAG) => Some(SequenceSurfaceKind::ImportNamespace),
+        Some("record_guard") => Some(SequenceSurfaceKind::RecordGuard),
+        Some("own_property_guard") => Some(SequenceSurfaceKind::OwnPropertyGuard),
+        Some("composite_literal") if lang == Lang::Go => {
+            Some(SequenceSurfaceKind::GoCompositeMapLiteral)
+        }
+        _ => None,
+    }
+}
+
+fn seq_surface_contract_for_tag(
+    lang: Lang,
+    tag: Option<&str>,
+) -> Option<(SequenceSurfaceKind, SeqSurfaceContract)> {
+    let kind = sequence_surface_kind_for_tag(lang, tag)?;
+    let contract = match kind {
+        SequenceSurfaceKind::Untagged => SeqSurfaceContract {
             value_tag: SEQ_VALUE_UNTAGGED,
             exact_tree_safe: false,
             membership_collection: false,
             map_entry_list: false,
             imported_literal: false,
         },
-        Some("array" | "array_expression") => SeqSurfaceContract {
+        SequenceSurfaceKind::Collection => SeqSurfaceContract {
             value_tag: SEQ_VALUE_COLLECTION,
             exact_tree_safe: true,
             membership_collection: true,
             map_entry_list: true,
-            imported_literal: true,
+            imported_literal: matches!(tag, Some("array" | "array_expression")),
         },
-        Some("list") => SeqSurfaceContract {
-            value_tag: SEQ_VALUE_COLLECTION,
-            exact_tree_safe: true,
-            membership_collection: true,
-            map_entry_list: true,
-            imported_literal: false,
-        },
-        Some("tuple") => SeqSurfaceContract {
+        SequenceSurfaceKind::Tuple => SeqSurfaceContract {
             value_tag: SEQ_VALUE_TUPLE,
             exact_tree_safe: true,
             membership_collection: false,
             map_entry_list: false,
-            imported_literal: false,
+            imported_literal: matches!(tag, Some("tuple_expression")),
         },
-        Some("tuple_expression") => SeqSurfaceContract {
-            value_tag: SEQ_VALUE_TUPLE,
-            exact_tree_safe: true,
-            membership_collection: false,
-            map_entry_list: false,
-            imported_literal: true,
-        },
-        Some("dictionary" | "object") => SeqSurfaceContract {
+        SequenceSurfaceKind::Map => SeqSurfaceContract {
             value_tag: SEQ_VALUE_MAP,
             exact_tree_safe: true,
             membership_collection: false,
             map_entry_list: false,
-            imported_literal: true,
+            imported_literal: matches!(tag, Some("dictionary" | "object")),
         },
-        Some("hash") => SeqSurfaceContract {
-            value_tag: SEQ_VALUE_MAP,
-            exact_tree_safe: true,
-            membership_collection: false,
-            map_entry_list: false,
-            imported_literal: false,
-        },
-        Some("pair") => SeqSurfaceContract {
+        SequenceSurfaceKind::Pair => SeqSurfaceContract {
             value_tag: SEQ_VALUE_PAIR,
             exact_tree_safe: true,
             membership_collection: false,
             map_entry_list: false,
             imported_literal: false,
         },
-        Some(IMPORT_BINDING_TAG) => SeqSurfaceContract {
+        SequenceSurfaceKind::ImportBinding => SeqSurfaceContract {
             value_tag: SEQ_VALUE_IMPORT_BINDING,
             exact_tree_safe: true,
             membership_collection: false,
             map_entry_list: false,
             imported_literal: false,
         },
-        Some(IMPORT_NAMESPACE_TAG) => SeqSurfaceContract {
+        SequenceSurfaceKind::ImportNamespace => SeqSurfaceContract {
             value_tag: SEQ_VALUE_IMPORT_NAMESPACE,
             exact_tree_safe: true,
             membership_collection: false,
             map_entry_list: false,
             imported_literal: false,
         },
-        Some("record_guard") => SeqSurfaceContract {
+        SequenceSurfaceKind::RecordGuard => SeqSurfaceContract {
             value_tag: SEQ_VALUE_RECORD_GUARD,
             exact_tree_safe: true,
             membership_collection: false,
             map_entry_list: false,
             imported_literal: false,
         },
-        Some("own_property_guard") => SeqSurfaceContract {
+        SequenceSurfaceKind::OwnPropertyGuard => SeqSurfaceContract {
             value_tag: SEQ_VALUE_OWN_PROPERTY_GUARD,
             exact_tree_safe: true,
             membership_collection: false,
             map_entry_list: false,
             imported_literal: false,
         },
-        Some("composite_literal") if lang == Lang::Go => SeqSurfaceContract {
+        SequenceSurfaceKind::GoCompositeMapLiteral => SeqSurfaceContract {
             value_tag: stable_symbol_hash("go_composite_map_literal"),
             exact_tree_safe: false,
             membership_collection: false,
             map_entry_list: false,
             imported_literal: false,
         },
+    };
+    Some((kind, contract))
+}
+
+pub fn seq_surface_contract(lang: Lang, tag: Option<&str>) -> Option<SeqSurfaceContract> {
+    seq_surface_contract_for_tag(lang, tag).map(|(_, contract)| contract)
+}
+
+pub fn seq_surface_contract_for_node(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<SeqSurfaceContract> {
+    if il.kind(node) != NodeKind::Seq {
+        return None;
+    }
+    let raw_tag = match il.node(node).payload {
+        Payload::None => None,
+        Payload::Name(name) => Some(interner.resolve(name)),
         _ => return None,
     };
-    Some(contract)
+    let span = il.node(node).span;
+    match unique_evidence_at(
+        il,
+        |anchor| matches!(anchor, EvidenceAnchor::Sequence { span: anchor_span } if anchor_span == span),
+        |evidence| match evidence {
+            EvidenceKind::SequenceSurface(kind) => Some(kind),
+            _ => None,
+        },
+    ) {
+        EvidenceResolution::Found(kind) => {
+            let (raw_kind, raw_contract) = seq_surface_contract_for_tag(il.meta.lang, raw_tag)?;
+            (kind == raw_kind).then_some(raw_contract)
+        }
+        EvidenceResolution::Ambiguous => None,
+        EvidenceResolution::Missing => seq_surface_contract(il.meta.lang, raw_tag),
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -379,6 +444,33 @@ pub struct ImportFact {
 pub fn import_fact_rhs(il: &Il, interner: &Interner, rhs: NodeId) -> Option<ImportFact> {
     if il.kind(rhs) != NodeKind::Seq {
         return None;
+    }
+    let span = il.node(rhs).span;
+    match unique_evidence_at(
+        il,
+        |anchor| matches!(anchor, EvidenceAnchor::Sequence { span: anchor_span } if anchor_span == span),
+        |evidence| match evidence {
+            EvidenceKind::Import(ImportEvidenceKind::Binding {
+                module_hash,
+                exported_hash,
+            }) => Some(ImportFact {
+                kind: ImportFactKind::Binding,
+                module_hash,
+                exported_hash: Some(exported_hash),
+            }),
+            EvidenceKind::Import(ImportEvidenceKind::Namespace { module_hash }) => {
+                Some(ImportFact {
+                    kind: ImportFactKind::Namespace,
+                    module_hash,
+                    exported_hash: None,
+                })
+            }
+            _ => None,
+        },
+    ) {
+        EvidenceResolution::Found(fact) => return Some(fact),
+        EvidenceResolution::Ambiguous => return None,
+        EvidenceResolution::Missing => {}
     }
     let Payload::Name(tag) = il.node(rhs).payload else {
         return None;
@@ -2527,7 +2619,11 @@ pub fn async_to_sync_name(lang: Lang, name: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_il::{FileId, FileMeta, IlBuilder, ParamSemantic, SourceFact, Span, Unit, UnitKind};
+    use nose_il::{
+        EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
+        EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, ImportEvidenceKind,
+        ParamSemantic, ParamTypeFact, SequenceSurfaceKind, SourceFact, Span, Unit, UnitKind,
+    };
 
     const ALL_LANGS: &[Lang] = &[
         Lang::Python,
@@ -2591,6 +2687,26 @@ mod tests {
         )
     }
 
+    fn evidence(
+        id: u32,
+        anchor: EvidenceAnchor,
+        kind: EvidenceKind,
+        status: EvidenceStatus,
+    ) -> EvidenceRecord {
+        EvidenceRecord {
+            id: EvidenceId(id),
+            anchor,
+            kind,
+            provenance: EvidenceProvenance {
+                emitter: EvidenceEmitter::FirstParty,
+                pack_hash: Some(stable_symbol_hash(FIRST_PARTY_PACK_ID)),
+                rule_hash: Some(stable_symbol_hash("test")),
+            },
+            dependencies: Vec::new(),
+            status,
+        }
+    }
+
     #[test]
     fn first_party_profile_wraps_each_language() {
         for &lang in ALL_LANGS {
@@ -2623,6 +2739,55 @@ mod tests {
     }
 
     #[test]
+    fn domain_evidence_records_are_preferred_over_legacy_param_facts() {
+        let mut b = IlBuilder::new(FileId(0));
+        let param = b.add(NodeKind::Param, Payload::None, sp(3), &[]);
+        let root = b.add(NodeKind::Func, Payload::None, sp(3), &[param]);
+        let mut il = finish_il(b, root, Lang::TypeScript);
+        il.param_type_facts.push(ParamTypeFact {
+            span: sp(3),
+            semantic: ParamSemantic::Set,
+        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::param(sp(3)),
+            EvidenceKind::Domain(DomainEvidence::Map),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert_eq!(
+            domain_evidence_for_param(&il, param),
+            Some(DomainEvidence::Map)
+        );
+    }
+
+    #[test]
+    fn ambiguous_domain_evidence_blocks_legacy_fallback() {
+        let mut b = IlBuilder::new(FileId(0));
+        let param = b.add(NodeKind::Param, Payload::None, sp(4), &[]);
+        let root = b.add(NodeKind::Func, Payload::None, sp(4), &[param]);
+        let mut il = finish_il(b, root, Lang::TypeScript);
+        il.param_type_facts.push(ParamTypeFact {
+            span: sp(4),
+            semantic: ParamSemantic::Set,
+        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::param(sp(4)),
+            EvidenceKind::Domain(DomainEvidence::Set),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::param(sp(4)),
+            EvidenceKind::Domain(DomainEvidence::Map),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert_eq!(domain_evidence_for_param(&il, param), None);
+    }
+
+    #[test]
     fn sequence_surface_contracts_keep_value_and_exact_axes_separate() {
         let array = seq_surface_contract(Lang::JavaScript, Some("array")).unwrap();
         assert_eq!(array.value_tag, SEQ_VALUE_COLLECTION);
@@ -2652,6 +2817,32 @@ mod tests {
         assert!(seq_surface_contract(Lang::Python, Some("composite_literal")).is_none());
         assert!(imported_literal_seq_tag_safe(Lang::Python, "dictionary"));
         assert!(!imported_literal_seq_tag_safe(Lang::Ruby, "hash"));
+    }
+
+    #[test]
+    fn sequence_surface_evidence_must_match_the_lowered_surface() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let array = interner.intern("array");
+        let seq = b.add(NodeKind::Seq, Payload::Name(array), sp(5), &[]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(5), &[seq]);
+        let mut il = finish_il(b, root, Lang::JavaScript);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(5)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+            EvidenceStatus::Asserted,
+        ));
+        assert!(seq_surface_contract_for_node(&il, &interner, seq)
+            .is_some_and(|contract| contract.membership_collection));
+
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::sequence(sp(5)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Map),
+            EvidenceStatus::Asserted,
+        ));
+        assert_eq!(seq_surface_contract_for_node(&il, &interner, seq), None);
     }
 
     #[test]
@@ -2728,6 +2919,63 @@ mod tests {
             binding,
             "collections"
         ));
+    }
+
+    #[test]
+    fn import_evidence_records_are_fail_closed_before_raw_seq_fallback() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let binding_tag = interner.intern(import_fact_tag(ImportFactKind::Binding));
+        let module = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("collections")),
+            sp(10),
+            &[],
+        );
+        let exported = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("deque")),
+            sp(10),
+            &[],
+        );
+        let binding = b.add(
+            NodeKind::Seq,
+            Payload::Name(binding_tag),
+            sp(10),
+            &[module, exported],
+        );
+        let root = b.add(NodeKind::Module, Payload::None, sp(10), &[binding]);
+        let mut il = finish_il(b, root, Lang::Python);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(10)),
+            EvidenceKind::Import(ImportEvidenceKind::Namespace {
+                module_hash: stable_symbol_hash("math"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert!(!import_binding_rhs_matches(
+            &il,
+            &interner,
+            binding,
+            "collections",
+            "deque"
+        ));
+        assert!(import_namespace_rhs_matches(
+            &il, &interner, binding, "math"
+        ));
+
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::sequence(sp(10)),
+            EvidenceKind::Import(ImportEvidenceKind::Binding {
+                module_hash: stable_symbol_hash("collections"),
+                exported_hash: stable_symbol_hash("deque"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        assert_eq!(import_fact_rhs(&il, &interner, binding), None);
     }
 
     #[test]
@@ -3873,6 +4121,36 @@ mod tests {
             source_fact_contract(SourceFactKind::Call(SourceCallKind::Construct)).channel,
             ChannelEligibility::ExactProven
         );
+    }
+
+    #[test]
+    fn source_fact_evidence_conflicts_fail_closed() {
+        let mut b = IlBuilder::new(FileId(0));
+        let op = b.add(NodeKind::BinOp, Payload::Op(Op::Eq), sp(9), &[]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(9), &[op]);
+        let mut il = finish_il(b, root, Lang::JavaScript);
+        il.source_facts.push(SourceFact {
+            span: sp(9),
+            kind: SourceFactKind::Operator(SourceOperatorKind::StrictEquality),
+        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::source_span(sp(9)),
+            EvidenceKind::Source(SourceFactKind::Operator(SourceOperatorKind::StrictEquality)),
+            EvidenceStatus::Asserted,
+        ));
+        assert_eq!(
+            source_operator_at_node(&il, op),
+            Some(SourceOperatorKind::StrictEquality)
+        );
+
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::source_span(sp(9)),
+            EvidenceKind::Source(SourceFactKind::Operator(SourceOperatorKind::LooseEquality)),
+            EvidenceStatus::Asserted,
+        ));
+        assert_eq!(source_operator_at_node(&il, op), None);
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,8 +76,8 @@ A Cargo workspace; data flows left-to-right through them.
 
 | crate | role |
 |---|---|
-| `nose-il` | arena IL model (`Vec<Node>`, `NodeId(u32)`, out-of-line edges), provenance spans, source facts, interner, serialization, IR verifier |
-| `nose-semantics` | first-party semantic facade: language profiles, source-fact helpers, effect/operator/module/stdlib predicates, API contracts, and exact-channel proof obligations |
+| `nose-il` | arena IL model (`Vec<Node>`, `NodeId(u32)`, out-of-line edges), provenance spans, semantic evidence records, compatibility source facts, interner, serialization, IR verifier |
+| `nose-semantics` | first-party semantic facade: language profiles, evidence/source-fact helpers, effect/operator/module/stdlib predicates, API contracts, and exact-channel proof obligations |
 | `nose-frontend` | tree-sitter parse + per-language CST→IL lowering and source-fact emission (one module per language; embedded `<script>` extraction) |
 | `nose-normalize` | the normalization passes + the value graph (GVN) |
 | `nose-detect` | unit/feature extraction, MinHash/LSH, scoring, clustering, refactor ranking |

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -1,0 +1,105 @@
+# Semantic evidence records
+
+Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
+recorded in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and
+remaining work are tracked in
+[semantic-kernel-roadmap](semantic-kernel-roadmap.md). Source-origin facts are
+covered in [source-facts](source-facts.md).
+
+Evidence records are the internal substrate that lets language and library packs
+emit proof facts without giving those packs authority to approve exact clones.
+They are facts, not verdicts. Contracts in `nose-semantics` decide whether a fact
+can satisfy an exact-channel precondition.
+
+## Goal
+
+- Give source, domain, import, and sequence-surface proof facts one shared shape.
+- Make facts carry stable ids, anchors, provenance, dependencies, and status.
+- Keep exact matching fail-closed when evidence is missing, ambiguous, or
+  conflicting.
+- Preserve existing behavior while first-party frontends mirror their older
+  side-table facts into the new record shape.
+- Make the future external pack schema a narrowing of an implemented internal
+  boundary, not a speculative document-only API.
+
+## Non-goals
+
+- Do not let evidence records mint value fingerprints, bypass laws, or mark clone
+  pairs exact.
+- Do not expose this internal Rust record as the final external pack manifest or
+  scan JSON schema.
+- Do not remove compatibility mirrors in the first slice. `SourceFact`,
+  `ParamTypeFact`, and raw import `Seq` payloads still exist while consumers are
+  migrated.
+- Do not certify external pack claims. nose validates record shape and fails
+  closed; providers own their claims, and users own opt-in decisions.
+- Do not model place/effect/demand evidence completely in this slice. Those are
+  next consumers of the same record substrate.
+
+## Record Shape
+
+`nose-il` now carries `Il::evidence: Vec<EvidenceRecord>`.
+
+An evidence record has:
+
+- `id`: stable within the IL file, used by dependencies;
+- `anchor`: the source subject the fact is about, such as a source span,
+  parameter span, binding span plus local-name hash, or sequence span;
+- `kind`: the kernel-defined fact kind;
+- `provenance`: emitter class, pack hash, and rule hash;
+- `dependencies`: other evidence ids this fact depends on;
+- `status`: currently `Asserted` or `Ambiguous`.
+
+The current implemented kinds are:
+
+| kind | purpose |
+|---|---|
+| `Source` | construct syntax, regex literal provenance, and source operator family |
+| `Domain` | receiver/value domain such as collection, map, option, string, integer, or byte array |
+| `Import` | static import binding and namespace proof |
+| `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, record guard, or Go composite map literal |
+
+## Consumption Rules
+
+Consumers should go through `nose-semantics` helpers rather than scanning raw IL
+side tables.
+
+- A lookup succeeds only when asserted evidence resolves to exactly one relevant
+  fact.
+- Conflicting asserted evidence is treated as missing evidence.
+- `Ambiguous` evidence is treated as missing evidence.
+- If any relevant ambiguous/conflicting evidence exists, compatibility fallback
+  must not reopen the exact path.
+- Compatibility fallback is allowed only when no relevant evidence record exists.
+
+This is stricter than a name or tag check. For example, a raw
+`Seq("import_binding")` is still serialized for compatibility, but import
+contracts first consult `Import` evidence. If that evidence is ambiguous, exact
+import proof stays closed instead of falling back to the raw sequence payload.
+
+## Current Producers
+
+First-party frontends now mirror these facts into `EvidenceRecord`:
+
+- parameter semantic annotations become `Domain` evidence;
+- source-origin facts become `Source` evidence;
+- import binding and namespace lowering emits `Import` evidence;
+- lowered `Seq` surfaces emit `SequenceSurface` evidence.
+
+The older `ParamTypeFact`, `SourceFact`, and raw import `Seq` shapes remain as
+compatibility mirrors. They are not the desired pack boundary.
+
+## Current Consumers
+
+The first migrated consumers are the shared semantic helpers and their direct
+callers:
+
+- source-fact lookup for construct syntax, regex literal, and operator provenance;
+- parameter domain lookup used by normalize and strict exact receiver gates;
+- import proof parsing for normalize, value graph, imported literal replacement,
+  and strict exact gates;
+- sequence-surface admission for normalize/value-graph/detect exact paths.
+
+Field/place/effect facts, receiver/protocol evidence beyond parameter domains,
+resolved symbol facts, report-level provenance, and external manifest loading are
+still open work.

--- a/docs/home.md
+++ b/docs/home.md
@@ -52,6 +52,7 @@ You want to *change* nose or understand how it works inside.
 - [architecture](architecture.md) — the crates and the lower → normalize → detect → rank pipeline.
 - [normalization](normalization.md) — the passes that make behaviorally-equivalent code converge (the hard part).
 - [semantic-kernel](semantic-kernel.md) — semantic-kernel and pack architecture: language/library semantics, extension boundaries, responsibility model, and exact-channel eligibility.
+- [evidence-records](evidence-records.md) — the internal pack-facing evidence substrate for source, domain, import, and sequence-surface facts.
 - [source-facts](source-facts.md) — source-origin evidence for semantic contracts: construct syntax, literal/operator provenance, pack boundaries, and fail-closed exact admission.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -222,6 +222,12 @@ and pack ecosystem.
   `new Map(...)`/`new Set(...)`, regex literal `.test(...)`, and strict JS-like
   static membership callbacks while closing plain constructor calls, string
   `.test(...)`, loose equality, and `instanceof` for those exact contracts.
+- The first shared `EvidenceRecord` substrate landed for source, domain, import,
+  and sequence-surface facts. First-party frontends now mirror compatibility
+  `SourceFact`, `ParamTypeFact`, raw import `Seq`, and lowered `Seq` surface
+  facts into records with ids, anchors, provenance, dependencies, and status.
+  `nose-semantics` lookups fail closed on ambiguous/conflicting evidence before
+  falling back to compatibility storage.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -267,23 +273,25 @@ Remaining in this phase:
   A later source-fact slice preserves selected JS/TS and Python equality-like
   source operators, but broader operator dispatch, overload semantics, and
   pack-facing consumers remain open.
-- Replace the current internal span-keyed `SourceFact` storage with pack-facing
-  source-fact records that carry stable fact ids, emitter/pack provenance, scope,
-  dependencies, ambiguity status, and contract provenance.
+- Continue migrating compatibility source/domain/import/sequence storage onto
+  `EvidenceRecord` consumers, then remove the old mirrors once no exact gate
+  depends on them.
+- Add scope, dependency, and ambiguity validation for evidence records before
+  they become a stable external extension surface.
 - Expand the exact fragment facade from first-party helper functions into
   versioned pack-facing effect/place evidence records.
 - Continue replacing any remaining local exact-fragment proof helpers with
   versioned pack-facing evidence records.
 - Move collection/map factory recognition into `LibraryApiContract` records.
 - Make value-graph and strict exact gates consume the same contract source.
-- Replace the remaining raw import/module proof IL payload storage with
-  pack-facing `ImportFact` records. The current compiled facade already provides
-  shared typed parsing for frontend, normalize, detect, and imported-literal
-  consumers.
-- Replace the compiled `SeqSurfaceContract` facade with pack-facing
-  sequence/aggregate surface records and named kernel constructors.
-- Replace the current `DomainEvidence` facade with versioned, pack-facing
-  receiver/domain evidence records while preserving the current precision gates.
+- Remove the remaining raw import/module proof IL payload storage after import
+  evidence records can carry every consumer obligation, including module export
+  dependencies and mutation proof.
+- Expand the first `SequenceSurface` evidence into sequence/aggregate records for
+  factories, nested entries, iterator views, and exported-literal eligibility.
+- Expand domain evidence from parameter annotations into receiver/protocol
+  evidence records for exact collection/map/set/option/string/integer proofs,
+  immutable local/module bindings, and mutation exclusion.
 - Turn named value-graph rule modules into LawPack-facing law ids/contracts while
   retaining formal-obligation metadata as the first-party proof boundary.
 - Add receiver/place facts so field read/write and property contracts are not

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -2,13 +2,15 @@
 
 Back to [semantic-kernel](semantic-kernel.md). This page records the current
 implementation shape; planned work and decision history live in
-[semantic-kernel-roadmap](semantic-kernel-roadmap.md).
+[semantic-kernel-roadmap](semantic-kernel-roadmap.md). The internal evidence
+record substrate is described in [evidence-records](evidence-records.md).
 
 Snapshot date: 2026-06-07, current implementation after the semantic-kernel
 foundation and follow-up facade migrations through receiver-aware field state
 sequence-surface contracts, proof-backed append fragment evidence, and the first
 operator-law contracts, typed import facts, and source-fact gates for construct,
-literal, and equality/operator provenance.
+literal, equality/operator provenance, and the first shared evidence-record
+substrate for source, domain, import, and sequence-surface facts.
 
 ## What exists today
 
@@ -16,8 +18,8 @@ nose now has a first internal semantic-kernel facade, but most of the engine is
 still being migrated toward it.
 
 - `nose-il` defines a compact shared IL, `Lang`, `Builtin`, `HoFKind`, operators,
-  literals, source spans, units, parameter semantic facts, and source-origin
-  facts.
+  literals, source spans, units, compatibility parameter/source facts, and
+  pack-facing internal `EvidenceRecord` facts.
 - `nose-semantics` defines the first-party semantic profile facade: language,
   source-fact, operator, effect, fragment, module, stdlib, builtin, method-call,
   property, async, iterator-adapter, builder-append, and factory contracts.
@@ -46,6 +48,12 @@ migrated.
 - The first-party profile exposes pack id and trust policy separately from
   channel eligibility. `ChannelEligibility` describes where a fact may be used;
   first-party/default status is pack provenance, not an analysis channel.
+- `Il::evidence` is now the shared internal substrate for source, domain, import,
+  and sequence-surface proof facts. Records carry ids, stable source anchors,
+  kind, provenance, dependencies, and asserted/ambiguous status. Lookups in
+  `nose-semantics` fail closed on ambiguous or conflicting evidence and use older
+  side tables only as compatibility fallback when no relevant evidence record is
+  present.
 - `OperatorSemantics` now owns the first shared operator contracts:
   comparison-direction transforms, comparison negation, equality operand
   commutativity, comparison-lattice laws, abs/min/max/selection guard laws,
@@ -56,23 +64,22 @@ migrated.
   The old `primitive_order_comparisons()` helper remains as a compatibility
   wrapper around the stricter lattice law contract.
 - Source facts are now first-class internal evidence for source distinctions that
-  the shared IL erases. The current `SourceFact` storage is span-keyed and covers
-  operator, call-shape, and literal-surface facts. JS/TS frontends emit construct
-  syntax, regex literal, strict/loose equality, strict/loose inequality, and
-  `instanceof` facts. Python emits value equality/inequality and identity
-  equality/inequality facts. `nose-semantics` exposes source-fact contract and
-  lookup helpers; normalize and detect consume them only where a semantic
-  contract requires that exact source surface.
+  the shared IL erases. JS/TS frontends emit construct syntax, regex literal,
+  strict/loose equality, strict/loose inequality, and `instanceof` facts. Python
+  emits value equality/inequality and identity equality/inequality facts. These
+  are mirrored into `EvidenceRecord::Source`; the older `SourceFact` vector
+  remains a compatibility fallback. Normalize and detect consume source facts
+  only where a semantic contract requires that exact source surface.
 - Free-function builtin contracts are language- and arity-constrained and require
   unshadowed builtin/global proof before exact lowering.
 - Method contracts carry receiver obligations such as exact collection, exact
   protocol, exact option, exact string, exact primitive integer, exact map literal,
   imported namespace, or unshadowed global.
-- Source-level `ParamSemantic` facts are translated into `nose-semantics`
-  `DomainEvidence` before normalize/detect receiver-domain gates consume them.
-  This preserves the current Array/Collection/Set/Map/Option/String/Integer/
-  Number/ByteArray distinctions while moving the proof vocabulary into the
-  kernel facade.
+- Source-level `ParamSemantic` facts are mirrored into
+  `EvidenceRecord::Domain`, and normalize/detect receiver-domain gates consume
+  domain evidence through `nose-semantics` helpers. This preserves the current
+  Array/Collection/Set/Map/Option/String/Integer/Number/ByteArray distinctions
+  while moving the proof storage toward the pack-facing evidence substrate.
 - Property builtin contracts are language-constrained; a selector such as
   `length` is not enough without receiver proof. JS/TS `filter(...).length`
   is admitted only after the receiver has already entered a proven collection/HOF
@@ -238,17 +245,16 @@ Semantic knowledge still appears in several forms outside the facade:
 - direct `Lang` checks and local recognizers in strict exact gates and value-graph
   rules that have not yet been expressed as shared contracts;
 - source operator provenance now exists for selected JS/TS and Python
-  equality-shaped surfaces, but the storage is still internal and span-keyed, and
-  consumption is limited to narrow contracts such as JS-like static membership
-  callbacks. General equality dispatch, report provenance, and pack-facing
-  source-fact records remain open;
+  equality-shaped surfaces, but consumption is limited to narrow contracts such
+  as JS-like static membership callbacks. General equality dispatch, report
+  provenance, and external pack manifests remain open;
 - language-specific import or module proof mechanics that are still local to
   frontend, normalize, or detect callers;
 - IL still stores import facts as `Seq("import_binding")` /
-  `Seq("import_namespace")` payloads for compatibility, but the semantic
-  interpretation now flows through typed `ImportFact` helpers in
-  `nose-semantics`. A future pack-facing representation should replace the raw IL
-  storage shape as well;
+  `Seq("import_namespace")` payloads for compatibility. Frontends also emit
+  `EvidenceRecord::Import`, and semantic interpretation flows through typed
+  `ImportFact` helpers in `nose-semantics`, but the raw IL storage shape has not
+  been removed;
 - module/import proof logic for immutable sibling-module literal bindings;
 - type facts and coarse type inference used to gate numeric and collection laws;
 - named value-graph rule modules that still consume internal `Builder` facts
@@ -325,22 +331,20 @@ The first high-value targets for semantic-kernel extraction are:
 
 - pack-facing field/place evidence for all field reads and writes, building on
   the receiver-aware value-graph field state now used for same-unit caching;
-- pack-facing import/module fact records to replace the remaining raw
-  `Seq("import_binding")` and `Seq("import_namespace")` IL storage shape; current
-  consumers already parse these through the typed internal `ImportFact` facade;
-- pack-facing sequence/aggregate surface records to replace the current compiled
-  `SeqSurfaceContract` facade and private value-graph `Seq` tag registry;
-- pack-facing source-fact records to replace the current internal span-keyed
-  `SourceFact` storage for construct, literal, and operator provenance;
-- source-fact dependency, scope, and ambiguity validation before facts become a
+- full import/module fact migration to remove the remaining raw
+  `Seq("import_binding")` and `Seq("import_namespace")` compatibility payloads;
+- richer sequence/aggregate evidence for factories, nested entries, iterator
+  views, and exported-literal eligibility beyond the current first
+  `SequenceSurface` substrate;
+- dependency, scope, and ambiguity validation before evidence records become a
   stable external extension surface;
 - resolved symbol facts for Java/Rust stdlib factories instead of the current
   path/name plus shadow-proof contracts;
 - nested collection element proofs for iterator chains and builder convergence;
 - Promise/future/thenable receiver facts;
-- versioned receiver/domain evidence records to replace the current
-  `DomainEvidence` facade as the pack-facing proof vocabulary for collection,
-  map, option, string, integer, and byte-array domains;
+- receiver/protocol evidence records beyond parameter-domain facts, including
+  exact collection/map/set/option/string/integer receiver proofs, immutable
+  local/module bindings, and mutation exclusion;
 - demand/protocol contracts that distinguish eager arrays, lazy iterators,
   streams, callbacks, futures/promises, and call-by-need thunks;
 - demand/error contracts for language-core oracle behavior such as non-iterable

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -3,7 +3,9 @@
 Back to [home](home.md). Current implementation status is in
 [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and remaining
 work are tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). Source
-origin evidence is detailed in [source-facts](source-facts.md).
+origin evidence is detailed in [source-facts](source-facts.md); the shared
+internal evidence substrate is described in
+[evidence-records](evidence-records.md).
 
 ## Context
 
@@ -23,10 +25,12 @@ The semantic kernel is the boundary that all exact semantic reasoning must cross
 The first internal facade now lives in `nose-semantics`; it is still a compiled
 first-party implementation, not a loadable external pack runtime.
 
-Source facts are one kernel input at that boundary. They preserve source
-distinctions that the IL deliberately abstracts away, but they do not approve
-semantic equivalence by themselves. See [source-facts](source-facts.md) for the
-fact vocabulary, pack boundary, and current implementation slice.
+Evidence records are one kernel input at that boundary. They preserve facts that
+the IL deliberately abstracts away, but they do not approve semantic equivalence
+by themselves. Source facts are one evidence class; domain, import, and sequence
+surface facts now use the same internal substrate. See
+[evidence-records](evidence-records.md) for the record shape and
+[source-facts](source-facts.md) for the source-origin vocabulary.
 
 ## Goal
 

--- a/docs/source-facts.md
+++ b/docs/source-facts.md
@@ -3,7 +3,9 @@
 Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
 recorded in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and
 remaining work are tracked in
-[semantic-kernel-roadmap](semantic-kernel-roadmap.md).
+[semantic-kernel-roadmap](semantic-kernel-roadmap.md). The shared internal record
+shape for all semantic evidence is described in
+[evidence-records](evidence-records.md).
 
 Source facts are the bridge between source syntax and semantic contracts. They
 preserve source-origin distinctions that the shared IL intentionally abstracts
@@ -33,8 +35,8 @@ preconditions.
 - Do not use broad heuristics such as "a function named `map` means Map
   semantics" or "a method named `test` means regex semantics".
 - Do not expose raw CST nodes as the pack interface.
-- Do not promise that the current span-keyed storage is the final scan JSON
-  contract.
+- Do not promise that the current internal evidence records are the final scan
+  JSON or external pack manifest contract.
 - Do not make nose responsible for certifying external pack correctness. nose
   validates the extension shape and fails closed; external providers own their
   claims, and users own the decision to enable them.
@@ -43,16 +45,16 @@ preconditions.
 
 | term | meaning |
 |---|---|
-| `SourceFact` | Current internal IL record keyed by source span and fact kind. |
-| Evidence record | Future pack-facing form of a source or semantic fact, with stable ids, scope, dependencies, and provenance. |
+| `SourceFact` | Compatibility mirror keyed by source span and fact kind. |
+| Evidence record | Current internal form of a source or semantic fact, with stable ids, anchors, dependencies, status, and provenance. The external pack manifest is not defined yet. |
 | Contract | Kernel rule that maps a proven source/API surface to a semantic operation or law under explicit preconditions. |
 | Pack provenance | The pack id, provider, trust policy, version range, contract id, and evidence status behind an admitted fact or contract. |
 
 ## Evidence flow
 
 1. A frontend or language pack parses source, lowers to IL, and emits
-   kernel-defined source facts for source distinctions that would otherwise be
-   lost.
+   kernel-defined evidence records for source distinctions that would otherwise
+   be lost.
 2. The semantic kernel validates the fact shape and the surrounding obligations:
    language, arity, receiver, symbol/import proof, shadowing, scope, version,
    mutation, demand, and effects.
@@ -81,8 +83,9 @@ The pack-facing vocabulary should cover at least these classes.
 
 ## Current internal slice
 
-The current implementation has the first internal `SourceFact` storage in
-`nose-il` and source-fact helpers in `nose-semantics`.
+The current implementation has `Il::evidence` records in `nose-il` and
+source-fact helpers in `nose-semantics`. `SourceFact` still exists as a
+compatibility mirror while consumers migrate to evidence records.
 
 - JS/TS lowering emits source facts for construct syntax, regex literals, strict
   equality, strict inequality, loose equality, loose inequality, and


### PR DESCRIPTION
## Summary
- add Il evidence storage and shared EvidenceRecord kinds for source, domain, import, and sequence-surface proof facts
- mirror first-party SourceFact, ParamTypeFact, import proof, and lowered Seq surface facts into evidence records while keeping compatibility storage
- route source, domain, import, and sequence helpers through nose-semantics with fail-closed ambiguity/conflict handling before compatibility fallback
- update normalize, value-graph, detect consumers and semantic-kernel docs for the new substrate

## Non-goals
- raw import Seq payloads, SourceFact, and ParamTypeFact remain compatibility mirrors for now
- place, effect, demand evidence, richer receiver/protocol evidence, resolved symbol facts, external manifests, and scan JSON provenance stay as follow-up slices

## Verification
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --workspace
- cargo test --release
- awiki lint --root docs
- python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py

Tracking: #109