### PR TITLE
semantics: add symbol identity evidence

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -17,11 +17,11 @@ use nose_semantics::{
     domain_evidence_for_param as semantic_domain_evidence_for_param, exact_java_return_this,
     exact_java_this_field, exact_non_overloadable_index_assignment,
     exact_non_overloadable_index_assignment_parts, exact_static_membership_predicate_operator,
-    go_zero_map_default_kind, go_zero_map_lookup_contract, import_binding_rhs_matches,
-    import_namespace_rhs_matches, iterator_identity_adapter_contract,
-    java_collection_factory_contract, java_map_entry_contract, java_map_factory_contract,
-    js_array_is_array_contract, js_like_map_constructor_contract, js_like_set_constructor_contract,
-    map_get_contract, map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
+    go_zero_map_default_kind, go_zero_map_lookup_contract, imported_binding_symbol,
+    imported_member_symbol, iterator_identity_adapter_contract, java_collection_factory_contract,
+    java_map_entry_contract, java_map_factory_contract, js_array_is_array_contract,
+    js_like_map_constructor_contract, js_like_set_constructor_contract, map_get_contract,
+    map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
     nullish_global_contract, regex_test_contract, ruby_set_factory_contract,
     rust_vec_new_factory_contract, semantics, seq_surface_contract_for_node, source_fact_at_node,
     source_operator_at_node, static_index_membership_contract, typeof_operator_contract,
@@ -1913,79 +1913,7 @@ fn strict_exact_python_imported_factory_name(
     module: &str,
     exported: &str,
 ) -> bool {
-    match il.kind(callee) {
-        NodeKind::Var => {
-            let Payload::Name(local) = il.node(callee).payload else {
-                return false;
-            };
-            !unit_defines_symbol(il, local)
-                && top_level_assignment_count(il, local) == 1
-                && top_level_assignment_rhs(il, local).is_some_and(|rhs| {
-                    import_binding_rhs_matches(il, interner, rhs, module, exported)
-                })
-        }
-        NodeKind::Field => {
-            let Payload::Name(method) = il.node(callee).payload else {
-                return false;
-            };
-            if interner.resolve(method) != exported {
-                return false;
-            }
-            let Some(&receiver) = il.children(callee).first() else {
-                return false;
-            };
-            if il.kind(receiver) != NodeKind::Var {
-                return false;
-            }
-            let Payload::Name(namespace) = il.node(receiver).payload else {
-                return false;
-            };
-            !unit_defines_symbol(il, namespace)
-                && top_level_assignment_count(il, namespace) == 1
-                && top_level_assignment_rhs(il, namespace)
-                    .is_some_and(|rhs| import_namespace_rhs_matches(il, interner, rhs, module))
-        }
-        _ => false,
-    }
-}
-
-fn unit_defines_symbol(il: &Il, symbol: Symbol) -> bool {
-    il.units
-        .iter()
-        .any(|unit| unit.name.is_some_and(|name| name == symbol))
-}
-
-fn top_level_assignment_count(il: &Il, symbol: Symbol) -> usize {
-    top_level_statements(il)
-        .iter()
-        .filter(|&&stmt| assignment_name(il, stmt).is_some_and(|name| name == symbol))
-        .count()
-}
-
-fn top_level_assignment_rhs(il: &Il, symbol: Symbol) -> Option<NodeId> {
-    top_level_statements(il).into_iter().find_map(|stmt| {
-        if assignment_name(il, stmt).is_none_or(|name| name != symbol) {
-            return None;
-        }
-        let kids = il.children(stmt);
-        (kids.len() == 2).then_some(kids[1])
-    })
-}
-
-fn top_level_assignment_cid(il: &Il, symbol: Symbol) -> Option<u32> {
-    top_level_statements(il).into_iter().find_map(|stmt| {
-        if assignment_name(il, stmt).is_none_or(|name| name != symbol) {
-            return None;
-        }
-        let kids = il.children(stmt);
-        if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Var {
-            return None;
-        }
-        match il.node(kids[0]).payload {
-            Payload::Cid(cid) => Some(cid),
-            _ => None,
-        }
-    })
+    imported_member_symbol(il, interner, callee, module, exported)
 }
 
 fn strict_exact_ruby_set_factory_safe(
@@ -2205,23 +2133,7 @@ fn strict_exact_java_std_var_name(
     if java_file_defines_type_name(il, interner, expected) {
         return false;
     }
-    let symbol = match il.node(node).payload {
-        Payload::Name(name) => name,
-        Payload::Cid(cid) => {
-            let Some(&name) = il.cid_names.get(cid as usize) else {
-                return false;
-            };
-            if top_level_assignment_cid(il, name) != Some(cid) {
-                return false;
-            }
-            name
-        }
-        _ => return false,
-    };
-    interner.resolve(symbol) == expected
-        && top_level_assignment_count(il, symbol) == 1
-        && top_level_assignment_rhs(il, symbol)
-            .is_some_and(|rhs| import_binding_rhs_matches(il, interner, rhs, "java.util", expected))
+    imported_binding_symbol(il, interner, node, "java.util", expected)
 }
 
 fn strict_exact_java_map_factory_safe(

--- a/crates/nose-frontend/src/c.rs
+++ b/crates/nose-frontend/src/c.rs
@@ -7,8 +7,8 @@
 
 use crate::lower::{common_bin_op, Lowering};
 use nose_il::{
-    Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, ParamSemantic,
-    Payload, UnitKind,
+    contains_c_identifier, Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId,
+    NodeKind, Op, ParamSemantic, Payload, UnitKind,
 };
 use std::{fs, path::Path};
 use tree_sitter::Node as TsNode;
@@ -92,18 +92,6 @@ fn c_direct_quote_include_name(line: &str) -> Option<&str> {
     let rest = rest.strip_prefix('"')?;
     let end = rest.find('"')?;
     Some(&rest[..end])
-}
-
-fn contains_c_identifier(text: &str, ident: &str) -> bool {
-    text.match_indices(ident).any(|(start, _)| {
-        let before = text[..start].chars().next_back();
-        let after = text[start + ident.len()..].chars().next();
-        !before.is_some_and(is_c_identifier_char) && !after.is_some_and(is_c_identifier_char)
-    })
-}
-
-fn is_c_identifier_char(ch: char) -> bool {
-    ch == '_' || ch.is_ascii_alphanumeric()
 }
 
 fn c_source_may_contain_u16_byte_pack(source: &str) -> bool {

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -8,8 +8,9 @@
 
 use crate::lower::Lowering;
 use nose_il::{
-    Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload,
-    SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind, Span, UnitKind,
+    contains_js_identifier, is_js_identifier_continue, Builtin, FileId, Il, Interner, Lang,
+    LitClass, LoopKind, NodeId, NodeKind, Op, Payload, SourceCallKind, SourceFactKind,
+    SourceLiteralKind, SourceOperatorKind, Span, UnitKind,
 };
 use nose_semantics::{
     js_array_is_array_contract, js_boolean_coercion_contract, method_call_contract,
@@ -1182,7 +1183,8 @@ fn enclosing_function_prefix_has_binding_ident(lo: &Lowering, node: TsNode, iden
             if end <= lo.src.len() && start <= end {
                 let prefix = std::str::from_utf8(&lo.src[start..end]).unwrap_or("");
                 let header = prefix.find('{').map(|idx| &prefix[..idx]).unwrap_or(prefix);
-                if contains_js_ident(header, ident) || contains_js_binding_ident(prefix, ident) {
+                if contains_js_identifier(header, ident) || contains_js_binding_ident(prefix, ident)
+                {
                     return true;
                 }
             }
@@ -1202,7 +1204,7 @@ fn contains_js_binding_ident(text: &str, ident: &str) -> bool {
 fn contains_keyword_binding(text: &str, keyword: &str, ident: &str) -> bool {
     text.match_indices(keyword).any(|(idx, _)| {
         let before = text[..idx].chars().next_back();
-        if before.is_some_and(is_js_ident_continue) {
+        if before.is_some_and(is_js_identifier_continue) {
             return false;
         }
         let mut rest = &text[idx + keyword.len()..];
@@ -1220,7 +1222,7 @@ fn contains_keyword_binding(text: &str, keyword: &str, ident: &str) -> bool {
 fn contains_import_binding(text: &str, ident: &str) -> bool {
     text.match_indices("import").any(|(idx, _)| {
         let before = text[..idx].chars().next_back();
-        if before.is_some_and(is_js_ident_continue) {
+        if before.is_some_and(is_js_identifier_continue) {
             return false;
         }
         let rest = text[idx + "import".len()..].trim_start();
@@ -1232,24 +1234,12 @@ fn contains_import_binding(text: &str, ident: &str) -> bool {
     })
 }
 
-fn contains_js_ident(text: &str, ident: &str) -> bool {
-    text.match_indices(ident).any(|(idx, _)| {
-        let before = text[..idx].chars().next_back();
-        let after = text[idx + ident.len()..].chars().next();
-        !before.is_some_and(is_js_ident_continue) && !after.is_some_and(is_js_ident_continue)
-    })
-}
-
 fn starts_with_js_ident(text: &str, ident: &str) -> bool {
     text.starts_with(ident)
         && !text[ident.len()..]
             .chars()
             .next()
-            .is_some_and(is_js_ident_continue)
-}
-
-fn is_js_ident_continue(c: char) -> bool {
-    c == '_' || c == '$' || c.is_ascii_alphanumeric()
+            .is_some_and(is_js_identifier_continue)
 }
 
 fn lower_new(lo: &mut Lowering, node: TsNode) -> NodeId {

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -6,7 +6,8 @@ use nose_il::{
     stable_symbol_hash, DomainEvidence, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
     EvidenceProvenance, EvidenceRecord, EvidenceStatus, FileId, FileMeta, Il, IlBuilder,
     ImportEvidenceKind, Interner, Lang, LoopKind, NodeId, NodeKind, Op, ParamSemantic,
-    ParamTypeFact, Payload, SourceFact, SourceFactKind, Span, Symbol, Unit, UnitKind,
+    ParamTypeFact, Payload, SourceFact, SourceFactKind, Span, Symbol, SymbolEvidenceKind, Unit,
+    UnitKind,
 };
 use nose_semantics::{import_fact_tag, sequence_surface_kind_for_tag, ImportFactKind};
 use tree_sitter::Node as TsNode;
@@ -347,11 +348,32 @@ fn import_fact(
             return lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs]);
         }
     };
+    let symbol_kind = match kind {
+        ImportFactKind::Binding if coords.len() == 2 => {
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+                module_hash: stable_symbol_hash(coords[0]),
+                exported_hash: stable_symbol_hash(coords[1]),
+            })
+        }
+        ImportFactKind::Namespace if coords.len() == 1 => {
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace {
+                module_hash: stable_symbol_hash(coords[0]),
+            })
+        }
+        _ => {
+            return lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs]);
+        }
+    };
     lo.record_evidence(EvidenceAnchor::sequence(span), evidence_kind, "import_fact");
     lo.record_evidence(
         EvidenceAnchor::binding(span, stable_symbol_hash(local)),
         evidence_kind,
         "import_binding_subject",
+    );
+    lo.record_evidence(
+        EvidenceAnchor::binding(span, stable_symbol_hash(local)),
+        symbol_kind,
+        "symbol_import_identity",
     );
     lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs])
 }
@@ -998,4 +1020,36 @@ pub(crate) fn common_bin_op(text: &str) -> Option<Op> {
         ">>" => Op::Shr,
         _ => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sp() -> Span {
+        Span::new(FileId(0), 0, 1, 1, 1)
+    }
+
+    #[test]
+    fn import_lowering_emits_symbol_identity_evidence_for_aliases() {
+        let interner = Interner::new();
+        let mut lo = Lowering::new(FileId(0), b"", Lang::Python, &interner);
+
+        import_binding(&mut lo, sp(), "deque", "collections", "deque");
+        import_namespace(&mut lo, sp(), "math", "math");
+
+        assert!(lo.evidence.iter().any(|record| matches!(
+            record.kind,
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+                module_hash,
+                exported_hash,
+            }) if module_hash == stable_symbol_hash("collections")
+                && exported_hash == stable_symbol_hash("deque")
+        )));
+        assert!(lo.evidence.iter().any(|record| matches!(
+            record.kind,
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace { module_hash })
+                if module_hash == stable_symbol_hash("math")
+        )));
+    }
 }

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -485,7 +485,7 @@ fn field_mutates_binding(il: &Il, interner: &Interner, field: NodeId, name: Symb
     let Payload::Name(method) = il.node(field).payload else {
         return false;
     };
-    if !nose_semantics::mutating_method_name(interner.resolve(method)) {
+    if !nose_semantics::module_binding_mutating_method_name(interner.resolve(method)) {
         return false;
     }
     il.children(field)
@@ -703,4 +703,64 @@ fn prepend_root_statement(il: &mut Il, stmt: NodeId) {
         child_len: children.len() as u32,
     });
     il.root = new_root;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nose_il::{FileId, FileMeta, IlBuilder, Lang};
+
+    fn module_with_binding_method(method: &str) -> (Il, Interner, Symbol, NodeId) {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let span = Span::new(FileId(0), 0, 1, 1, 1);
+        let lookup = interner.intern("LOOKUP");
+        let lhs = b.add(NodeKind::Var, Payload::Name(lookup), span, &[]);
+        let rhs = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            span,
+            &[],
+        );
+        let assign = b.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs]);
+        let receiver = b.add(NodeKind::Var, Payload::Name(lookup), span, &[]);
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern(method)),
+            span,
+            &[receiver],
+        );
+        let arg = b.add(NodeKind::Lit, Payload::LitInt(2), span, &[]);
+        let call = b.add(NodeKind::Call, Payload::None, span, &[field, arg]);
+        let stmt = b.add(NodeKind::ExprStmt, Payload::None, span, &[call]);
+        let root = b.add(NodeKind::Module, Payload::None, span, &[assign, stmt]);
+        let il = b.finish(
+            root,
+            FileMeta {
+                path: "tables.js".into(),
+                lang: Lang::JavaScript,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        (il, interner, lookup, assign)
+    }
+
+    #[test]
+    fn module_binding_push_marks_export_unsafe() {
+        let (il, interner, lookup, assign) = module_with_binding_method("push");
+        assert!(
+            exported_binding_unsafe(&il, &interner, lookup, assign),
+            "exported literal bindings mutated through push must not be imported as immutable"
+        );
+    }
+
+    #[test]
+    fn module_binding_get_is_not_a_mutation() {
+        let (il, interner, lookup, assign) = module_with_binding_method("get");
+        assert!(
+            !binding_mutated(&il, &interner, lookup, assign),
+            "read-only lookup methods should not block immutable import replacement"
+        );
+    }
 }

--- a/crates/nose-il/src/ident.rs
+++ b/crates/nose-il/src/ident.rs
@@ -1,0 +1,56 @@
+//! Identifier-boundary helpers shared by frontends and semantic consumers.
+//!
+//! These helpers only answer whether source text contains a bounded identifier
+//! token under a language family spelling rule. They are not semantic proof that
+//! the identifier denotes a particular binding.
+
+/// Return true when `text` contains `ident` bounded by C identifier characters.
+pub fn contains_c_identifier(text: &str, ident: &str) -> bool {
+    contains_identifier(text, ident, is_c_identifier_continue)
+}
+
+/// Return true when `text` contains `ident` bounded by JavaScript identifier
+/// characters supported by nose's current lightweight source scans.
+pub fn contains_js_identifier(text: &str, ident: &str) -> bool {
+    contains_identifier(text, ident, is_js_identifier_continue)
+}
+
+/// Current C identifier-continuation approximation used by source scans.
+pub fn is_c_identifier_continue(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphanumeric()
+}
+
+/// Current JavaScript identifier-continuation approximation used by source scans.
+pub fn is_js_identifier_continue(ch: char) -> bool {
+    ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()
+}
+
+fn contains_identifier(text: &str, ident: &str, is_continue: fn(char) -> bool) -> bool {
+    if ident.is_empty() {
+        return false;
+    }
+    text.match_indices(ident).any(|(idx, _)| {
+        let before = text[..idx].chars().next_back();
+        let after = text[idx + ident.len()..].chars().next();
+        !before.is_some_and(is_continue) && !after.is_some_and(is_continue)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{contains_c_identifier, contains_js_identifier};
+
+    #[test]
+    fn c_identifier_matches_only_token_boundaries() {
+        assert!(contains_c_identifier("typedef unsigned char u8;", "u8"));
+        assert!(!contains_c_identifier("u8_buf", "u8"));
+        assert!(!contains_c_identifier("xu8", "u8"));
+    }
+
+    #[test]
+    fn js_identifier_treats_dollar_as_identifier_character() {
+        assert!(contains_js_identifier("const map = require('x');", "map"));
+        assert!(!contains_js_identifier("map$impl", "map"));
+        assert!(!contains_js_identifier("remap", "map"));
+    }
+}

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -8,19 +8,24 @@
 //!
 //! proof-obligation: il.arena.validity
 
+pub mod ident;
 pub mod intern;
 pub mod node;
 pub mod span;
 
 mod sexpr;
 
+pub use ident::{
+    contains_c_identifier, contains_js_identifier, is_c_identifier_continue,
+    is_js_identifier_continue,
+};
 pub use intern::{stable_symbol_hash, symbol_index, Interner, Symbol, FNV_OFFSET_BASIS, FNV_PRIME};
 pub use node::{
     Builtin, DomainEvidence, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
     EvidenceProvenance, EvidenceRecord, EvidenceStatus, HoFKind, ImportEvidenceKind, LitClass,
     LoopKind, Node, NodeId, NodeKind, Op, ParamSemantic, ParamTypeFact, Payload,
     SequenceSurfaceKind, SourceCallKind, SourceFact, SourceFactKind, SourceLiteralKind,
-    SourceOperatorKind,
+    SourceOperatorKind, SymbolEvidenceKind,
 };
 pub use span::{FileId, FileMeta, Lang, Span};
 

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -304,6 +304,24 @@ pub enum ImportEvidenceKind {
     },
 }
 
+/// Kernel-facing proof that a source-level symbol denotes a specific global or
+/// imported API coordinate. The spelling is only a selector; exact consumers
+/// must require one of these identities, or derive it through a compatibility
+/// fallback that proves shadowing/import preconditions.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum SymbolEvidenceKind {
+    UnshadowedGlobal {
+        name_hash: u64,
+    },
+    ImportedBinding {
+        module_hash: u64,
+        exported_hash: u64,
+    },
+    ImportedNamespace {
+        module_hash: u64,
+    },
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub enum SequenceSurfaceKind {
     Untagged,
@@ -323,6 +341,7 @@ pub enum EvidenceKind {
     Source(SourceFactKind),
     Domain(DomainEvidence),
     Import(ImportEvidenceKind),
+    Symbol(SymbolEvidenceKind),
     SequenceSurface(SequenceSurfaceKind),
 }
 

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -7,17 +7,16 @@
 //! proof-obligation: normalize.value_graph.functor
 //! proof-obligation: normalize.value_graph.min_max
 
-use nose_il::{Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
+use nose_il::{contains_js_identifier, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
 use nose_semantics::{
-    domain_evidence_for_param, free_function_builtin_contract, import_binding_rhs_matches,
-    import_namespace_rhs_matches, iterator_identity_adapter_contract, map_get_contract,
+    domain_evidence_for_param, free_function_builtin_contract, imported_binding_symbol,
+    imported_namespace_symbol, iterator_identity_adapter_contract, map_get_contract,
     map_key_view_contract, method_call_contract, method_hof_contract,
     rust_option_some_constructor_contract, seq_surface_contract_for_node,
-    static_collection_adapter_contract, BuiltinArgContract, DomainEvidence, MapKeyViewKind,
-    MethodBuiltinArgs, MethodCallContract, MethodReceiverContract, MethodSemanticContract,
+    static_collection_adapter_contract, unshadowed_global_symbol, BuiltinArgContract,
+    DomainEvidence, MapKeyViewKind, MethodBuiltinArgs, MethodCallContract, MethodReceiverContract,
+    MethodSemanticContract, SEQ_VALUE_MAP,
 };
-
-use crate::contains_js_ident;
 
 /// The result of inspecting a `Call`: it canonicalizes to a builtin, to a
 /// higher-order op (`HoF`), or stays an ordinary call. The carried `NodeId`s are
@@ -170,12 +169,12 @@ fn prove_method_receiver(
         MethodReceiverContract::LiteralString => {
             literal_string_receiver(old, base).then_some(ProvenReceiver::Direct(base))
         }
-        MethodReceiverContract::UnshadowedGlobal(global) => (name_of(old, interner, base)
-            == Some(global)
-            && !file_defines_name(old, interner, global))
-        .then_some(ProvenReceiver::Direct(base)),
+        MethodReceiverContract::UnshadowedGlobal(global) => {
+            unshadowed_global_symbol(old, interner, base, global)
+                .then_some(ProvenReceiver::Direct(base))
+        }
         MethodReceiverContract::ImportedNamespace(module) => {
-            import_namespace_expr(old, interner, base, module)
+            imported_namespace_symbol(old, interner, base, module)
                 .then_some(ProvenReceiver::Direct(base))
         }
         MethodReceiverContract::RustMapGetOrExactOption => {
@@ -502,7 +501,7 @@ fn static_collection_adapter_arg(
         call_kids.len().saturating_sub(1),
     )?;
     if file_defines_type_name(old, interner, receiver_name)
-        || !import_binding_expr(old, interner, receiver, contract.module, contract.exported)
+        || !imported_binding_symbol(old, interner, receiver, contract.module, contract.exported)
     {
         return None;
     }
@@ -715,7 +714,39 @@ fn rust_std_map_factory_call(old: &Il, interner: &Interner, node: NodeId) -> boo
     nose_semantics::semantics(old.meta.lang)
         .collections()
         .free_name_map_factories()
-        .any(|factory| factory.names.contains(&callee))
+        .any(|factory| {
+            factory.names.contains(&callee)
+                && free_name_factory_shadow_safe(old, interner, callee, false)
+                && map_factory_entries_match_surface(old, interner, kids[1], factory.entry_seq_tag)
+        })
+}
+
+fn free_name_factory_shadow_safe(
+    old: &Il,
+    interner: &Interner,
+    name: &str,
+    shadow_guard: bool,
+) -> bool {
+    if shadow_guard {
+        return !file_defines_name(old, interner, name);
+    }
+    if old.meta.lang == nose_il::Lang::Rust && name.starts_with("std::") {
+        return !file_defines_name(old, interner, "std");
+    }
+    true
+}
+
+fn map_factory_entries_match_surface(
+    old: &Il,
+    interner: &Interner,
+    entries: NodeId,
+    entry_seq_tag: u64,
+) -> bool {
+    old.children(entries).iter().all(|&entry| {
+        old.kind(entry) == NodeKind::Seq
+            && seq_surface_contract_for_node(old, interner, entry)
+                .is_some_and(|contract| contract.value_tag == entry_seq_tag)
+    })
 }
 
 /// Canonical sync name for a known async counterpart, so behaviorally-equivalent
@@ -773,7 +804,7 @@ fn symbol_defines_name(old: &Il, interner: &Interner, symbol: nose_il::Symbol, n
         || (nose_semantics::semantics(old.meta.lang)
             .modules()
             .js_like_shadowed_module_bindings()
-            && contains_js_ident(text, name))
+            && contains_js_identifier(text, name))
 }
 
 fn file_defines_type_name(old: &Il, interner: &Interner, name: &str) -> bool {
@@ -794,96 +825,12 @@ fn name_of<'a>(old: &Il, interner: &'a Interner, id: NodeId) -> Option<&'a str> 
     None
 }
 
-fn import_namespace_expr(old: &Il, interner: &Interner, id: NodeId, module: &str) -> bool {
-    let Some(alias) = name_of(old, interner, id) else {
-        return false;
-    };
-    old.children(old.root).iter().any(|&stmt| {
-        import_namespace_assignment(old, interner, stmt, alias, module)
-            || (old.kind(stmt) == NodeKind::Block
-                && old
-                    .children(stmt)
-                    .iter()
-                    .any(|&child| import_namespace_assignment(old, interner, child, alias, module)))
-    })
-}
-
-fn import_binding_expr(
-    old: &Il,
-    interner: &Interner,
-    id: NodeId,
-    module: &str,
-    exported: &str,
-) -> bool {
-    let Some(alias) = name_of(old, interner, id) else {
-        return false;
-    };
-    old.children(old.root).iter().any(|&stmt| {
-        import_binding_assignment(old, interner, stmt, alias, module, exported)
-            || (old.kind(stmt) == NodeKind::Block
-                && old.children(stmt).iter().any(|&child| {
-                    import_binding_assignment(old, interner, child, alias, module, exported)
-                }))
-    })
-}
-
-fn import_binding_assignment(
-    old: &Il,
-    interner: &Interner,
-    stmt: NodeId,
-    alias: &str,
-    module: &str,
-    exported: &str,
-) -> bool {
-    if old.kind(stmt) != NodeKind::Assign {
-        return false;
-    }
-    let kids = old.children(stmt);
-    if kids.len() != 2 || assignment_alias_name(old, interner, kids[0]) != Some(alias) {
-        return false;
-    }
-    import_binding_rhs_matches(old, interner, kids[1], module, exported)
-}
-
-fn import_namespace_assignment(
-    old: &Il,
-    interner: &Interner,
-    stmt: NodeId,
-    alias: &str,
-    module: &str,
-) -> bool {
-    if old.kind(stmt) != NodeKind::Assign {
-        return false;
-    }
-    let kids = old.children(stmt);
-    if kids.len() != 2 || assignment_alias_name(old, interner, kids[0]) != Some(alias) {
-        return false;
-    }
-    import_namespace_rhs_matches(old, interner, kids[1], module)
-}
-
-fn assignment_alias_name<'a>(old: &Il, interner: &'a Interner, id: NodeId) -> Option<&'a str> {
-    if old.kind(id) != NodeKind::Var {
-        return None;
-    }
-    match old.node(id).payload {
-        Payload::Name(symbol) => Some(interner.resolve(symbol)),
-        Payload::Cid(cid) => old
-            .cid_names
-            .get(cid as usize)
-            .map(|&symbol| interner.resolve(symbol)),
-        _ => None,
-    }
-}
-
 fn map_like_literal(old: &Il, interner: &Interner, id: NodeId) -> bool {
     if old.kind(id) != NodeKind::Seq {
         return false;
     }
-    match old.node(id).payload {
-        Payload::Name(s) => matches!(interner.resolve(s), "dictionary" | "hash" | "object"),
-        _ => false,
-    }
+    seq_surface_contract_for_node(old, interner, id)
+        .is_some_and(|contract| contract.value_tag == SEQ_VALUE_MAP)
 }
 
 fn map_get_call_parts(old: &Il, interner: &Interner, id: NodeId) -> Option<(NodeId, NodeId)> {
@@ -977,11 +924,35 @@ fn identity_lambda(old: &Il, lambda: NodeId) -> bool {
 mod tests {
     use super::*;
     use nose_il::stable_symbol_hash;
-    use nose_il::{FileId, FileMeta, IlBuilder, Lang, ParamSemantic, ParamTypeFact, Span};
+    use nose_il::{
+        EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
+        EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, Lang, ParamSemantic,
+        ParamTypeFact, SequenceSurfaceKind, Span, Unit, UnitKind,
+    };
     use nose_semantics::{import_fact_tag, ImportFactKind};
 
     fn sp() -> Span {
         Span::new(FileId(0), 1, 1, 1, 1)
+    }
+
+    fn evidence(
+        id: u32,
+        anchor: EvidenceAnchor,
+        kind: EvidenceKind,
+        status: EvidenceStatus,
+    ) -> EvidenceRecord {
+        EvidenceRecord {
+            id: EvidenceId(id),
+            anchor,
+            kind,
+            provenance: EvidenceProvenance {
+                emitter: EvidenceEmitter::FirstParty,
+                pack_hash: Some(stable_symbol_hash(nose_semantics::FIRST_PARTY_PACK_ID)),
+                rule_hash: Some(stable_symbol_hash("test")),
+            },
+            dependencies: Vec::new(),
+            status,
+        }
     }
 
     fn free_call_il(lang: Lang, name: &str, shadow_name: bool) -> (Il, Interner, NodeId) {
@@ -1500,6 +1471,105 @@ mod tests {
                 arg_olds
             } if arg_olds.len() == 2
         ));
+    }
+
+    #[test]
+    fn map_like_literal_respects_sequence_surface_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let map = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("dictionary")),
+            sp(),
+            &[],
+        );
+        let root = b.add(NodeKind::Module, Payload::None, sp(), &[map]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t".to_string(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+
+        assert!(map_like_literal(&il, &interner, map));
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp()),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+            EvidenceStatus::Asserted,
+        ));
+        assert!(
+            !map_like_literal(&il, &interner, map),
+            "conflicting sequence-surface evidence must block raw map tag fallback"
+        );
+    }
+
+    fn rust_hash_map_from_call(entry_surface: &str, shadow_std: bool) -> (Il, Interner, NodeId) {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let key = b.add(NodeKind::Lit, Payload::LitStr(1), sp(), &[]);
+        let value = b.add(NodeKind::Lit, Payload::LitInt(1), sp(), &[]);
+        let entry = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern(entry_surface)),
+            sp(),
+            &[key, value],
+        );
+        let entries = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(),
+            &[entry],
+        );
+        let callee = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("std::collections::HashMap::from")),
+            sp(),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(), &[callee, entries]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(), &[call]);
+        let units = if shadow_std {
+            vec![Unit {
+                root,
+                kind: UnitKind::Class,
+                name: Some(interner.intern("std")),
+            }]
+        } else {
+            Vec::new()
+        };
+        let il = b.finish(
+            root,
+            FileMeta {
+                path: "t".to_string(),
+                lang: Lang::Rust,
+            },
+            units,
+            Vec::new(),
+        );
+        (il, interner, call)
+    }
+
+    #[test]
+    fn rust_std_map_factory_requires_entry_surface_and_shadow_proof() {
+        let (il, interner, call) = rust_hash_map_from_call("tuple", false);
+        assert!(rust_std_map_factory_call(&il, &interner, call));
+
+        let (il, interner, call) = rust_hash_map_from_call("array", false);
+        assert!(
+            !rust_std_map_factory_call(&il, &interner, call),
+            "HashMap::from exact map proof requires tuple-shaped entries"
+        );
+
+        let (il, interner, call) = rust_hash_map_from_call("tuple", true);
+        assert!(
+            !rust_std_map_factory_call(&il, &interner, call),
+            "a local std binding must close the Rust stdlib factory path"
+        );
     }
 
     #[test]

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -159,18 +159,6 @@ pub(crate) fn finalize_rebuild(
     out
 }
 
-pub(crate) fn contains_js_ident(text: &str, ident: &str) -> bool {
-    text.match_indices(ident).any(|(idx, _)| {
-        let before = text[..idx].chars().next_back();
-        let after = text[idx + ident.len()..].chars().next();
-        !before.is_some_and(is_js_ident_continue) && !after.is_some_and(is_js_ident_continue)
-    })
-}
-
-fn is_js_ident_continue(c: char) -> bool {
-    c == '_' || c == '$' || c.is_ascii_alphanumeric()
-}
-
 /// A control-flow terminator: a statement that unconditionally diverts control out of the
 /// straight-line flow, so any code after it in the same block is unreachable. Shared by DCE
 /// (dead-code-after-terminator) and desugar (guard-clause then-block termination).

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -37,23 +37,23 @@
 
 mod rules;
 
+use crate::combine;
 use crate::module_facts::{
     assignment_name_in_scope, collect_all_node_symbols_in_scope, collect_module_mutations_in_scope,
     local_scope_nodes, mutating_method_name, node_symbol_in_scope,
     shadowed_js_like_module_binding_nodes_for_symbol_in_scope, top_level_statements_for,
 };
 use crate::types::Ty;
-use crate::{combine, contains_js_ident};
 use nose_il::{
-    stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LoopKind, NodeId, NodeKind, Op,
-    Payload, Span, Symbol, UnitKind,
+    contains_js_identifier, stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LoopKind,
+    NodeId, NodeKind, Op, Payload, Span, Symbol, UnitKind,
 };
 use nose_semantics::{
     builder_append_method_contract, builtin_tag, construct_syntax_proof,
     domain_evidence_for_param as semantic_domain_evidence_for_param,
     exact_static_membership_predicate_operator, free_function_builtin_contract,
     go_zero_map_default_kind, go_zero_map_lookup_contract, import_fact_contract,
-    import_namespace_rhs_matches, imported_namespace_function_contract,
+    imported_namespace_function_contract, imported_namespace_symbol,
     iterator_identity_adapter_contract, java_collection_factory_contract_by_hash,
     java_map_entry_contract_by_hash, java_map_factory_contract_by_hash,
     js_like_map_constructor_contract, js_like_set_constructor_contract, map_get_contract_by_hash,
@@ -1046,22 +1046,10 @@ impl<'a> Builder<'a> {
     }
 
     fn file_imports_namespace(&self, expr: NodeId, module: &str) -> bool {
-        if !semantics(self.il.meta.lang)
+        semantics(self.il.meta.lang)
             .modules()
             .go_import_namespace_facts()
-        {
-            return false;
-        }
-        let Some(alias) = self.node_symbol(expr) else {
-            return false;
-        };
-        self.top_level_statements().iter().any(|&stmt| {
-            if self.assignment_name(stmt) != Some(alias) {
-                return false;
-            }
-            let kids = self.il.children(stmt);
-            kids.len() == 2 && import_namespace_rhs_matches(self.il, self.interner, kids[1], module)
-        })
+            && imported_namespace_symbol(self.il, self.interner, expr, module)
     }
 
     fn java_file_defines_type_name(&self, name: &str) -> bool {
@@ -1116,7 +1104,7 @@ impl<'a> Builder<'a> {
 
     fn symbol_defines_name(&self, symbol: Symbol, name: &str) -> bool {
         let text = self.interner.resolve(symbol);
-        text == name || (self.is_js_like_lang() && contains_js_ident(text, name))
+        text == name || (self.is_js_like_lang() && contains_js_identifier(text, name))
     }
 
     fn ruby_file_requires_module(&self, module: &str) -> bool {

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -7,10 +7,10 @@
 //! approve exact clone matches directly.
 
 use nose_il::{
-    stable_symbol_hash, Builtin, EvidenceAnchor, EvidenceKind, EvidenceStatus, HoFKind, Il,
-    ImportEvidenceKind, Interner, Lang, LitClass, NodeId, NodeKind, Op, ParamSemantic, Payload,
-    SequenceSurfaceKind, SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
-    Span,
+    contains_js_identifier, stable_symbol_hash, Builtin, EvidenceAnchor, EvidenceKind,
+    EvidenceStatus, HoFKind, Il, ImportEvidenceKind, Interner, Lang, LitClass, NodeId, NodeKind,
+    Op, ParamSemantic, Payload, SequenceSurfaceKind, SourceCallKind, SourceFactKind,
+    SourceLiteralKind, SourceOperatorKind, Span, SymbolEvidenceKind,
 };
 
 pub use nose_il::DomainEvidence;
@@ -517,6 +517,292 @@ pub fn import_namespace_rhs_matches(
             && fact.module_hash == stable_symbol_hash(module)
             && fact.exported_hash.is_none()
     })
+}
+
+fn symbol_evidence_at_node(il: &Il, node: NodeId) -> EvidenceResolution<SymbolEvidenceKind> {
+    let span = il.node(node).span;
+    let kind = il.kind(node);
+    unique_evidence_at(
+        il,
+        |anchor| {
+            matches!(
+                anchor,
+                EvidenceAnchor::Node {
+                    span: anchor_span,
+                    kind: anchor_kind,
+                } if anchor_span == span && anchor_kind == kind
+            )
+        },
+        |evidence| match evidence {
+            EvidenceKind::Symbol(symbol) => Some(symbol),
+            _ => None,
+        },
+    )
+}
+
+fn symbol_evidence_for_binding(
+    il: &Il,
+    local_hash: u64,
+    span: Span,
+) -> EvidenceResolution<SymbolEvidenceKind> {
+    unique_evidence_at(
+        il,
+        |anchor| {
+            matches!(
+                anchor,
+                EvidenceAnchor::Binding {
+                    span: anchor_span,
+                    local_hash: anchor_hash,
+                } if anchor_hash == local_hash && anchor_span == span
+            )
+        },
+        |evidence| match evidence {
+            EvidenceKind::Symbol(symbol) => Some(symbol),
+            _ => None,
+        },
+    )
+}
+
+fn symbol_identity_at_node_matches(
+    il: &Il,
+    node: NodeId,
+    expected: SymbolEvidenceKind,
+) -> EvidenceResolution<bool> {
+    match symbol_evidence_at_node(il, node) {
+        EvidenceResolution::Found(actual) => EvidenceResolution::Found(actual == expected),
+        EvidenceResolution::Ambiguous => EvidenceResolution::Ambiguous,
+        EvidenceResolution::Missing => EvidenceResolution::Missing,
+    }
+}
+
+fn binding_identity_matches(
+    il: &Il,
+    local_hash: u64,
+    span: Span,
+    expected: SymbolEvidenceKind,
+) -> EvidenceResolution<bool> {
+    match symbol_evidence_for_binding(il, local_hash, span) {
+        EvidenceResolution::Found(actual) => EvidenceResolution::Found(actual == expected),
+        EvidenceResolution::Ambiguous => EvidenceResolution::Ambiguous,
+        EvidenceResolution::Missing => EvidenceResolution::Missing,
+    }
+}
+
+/// Prove that `node` denotes a language-defined unshadowed global with the exact
+/// requested name. The raw spelling is not enough: when symbol evidence exists it
+/// is authoritative, and ambiguous/conflicting evidence keeps the exact path
+/// closed instead of falling back to spelling checks.
+pub fn unshadowed_global_symbol(il: &Il, interner: &Interner, node: NodeId, name: &str) -> bool {
+    if il.kind(node) != NodeKind::Var {
+        return false;
+    }
+    let expected = SymbolEvidenceKind::UnshadowedGlobal {
+        name_hash: stable_symbol_hash(name),
+    };
+    match symbol_identity_at_node_matches(il, node, expected) {
+        EvidenceResolution::Found(matches) => return matches,
+        EvidenceResolution::Ambiguous => return false,
+        EvidenceResolution::Missing => {}
+    }
+    node_name(il, interner, node) == Some(name) && !file_defines_name(il, interner, name)
+}
+
+/// Prove that `node` denotes a static imported namespace for `module`.
+pub fn imported_namespace_symbol(il: &Il, interner: &Interner, node: NodeId, module: &str) -> bool {
+    let expected = SymbolEvidenceKind::ImportedNamespace {
+        module_hash: stable_symbol_hash(module),
+    };
+    imported_symbol(il, interner, node, expected, |rhs| {
+        import_namespace_rhs_matches(il, interner, rhs, module)
+    })
+}
+
+/// Prove that `node` denotes a static imported binding for `module.exported`.
+pub fn imported_binding_symbol(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    module: &str,
+    exported: &str,
+) -> bool {
+    let expected = SymbolEvidenceKind::ImportedBinding {
+        module_hash: stable_symbol_hash(module),
+        exported_hash: stable_symbol_hash(exported),
+    };
+    imported_symbol(il, interner, node, expected, |rhs| {
+        import_binding_rhs_matches(il, interner, rhs, module, exported)
+    })
+}
+
+/// Prove either `from module import exported as local; local(...)` or
+/// `import module as ns; ns.exported(...)`.
+pub fn imported_member_symbol(
+    il: &Il,
+    interner: &Interner,
+    callee: NodeId,
+    module: &str,
+    exported: &str,
+) -> bool {
+    match il.kind(callee) {
+        NodeKind::Var => imported_binding_symbol(il, interner, callee, module, exported),
+        NodeKind::Field => {
+            let Payload::Name(method) = il.node(callee).payload else {
+                return false;
+            };
+            if interner.resolve(method) != exported {
+                return false;
+            }
+            il.children(callee)
+                .first()
+                .copied()
+                .is_some_and(|receiver| imported_namespace_symbol(il, interner, receiver, module))
+        }
+        _ => false,
+    }
+}
+
+fn imported_symbol(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    expected: SymbolEvidenceKind,
+    legacy_rhs_matches: impl Fn(NodeId) -> bool,
+) -> bool {
+    if il.kind(node) != NodeKind::Var {
+        return false;
+    }
+    match symbol_identity_at_node_matches(il, node, expected) {
+        EvidenceResolution::Found(matches) => return matches,
+        EvidenceResolution::Ambiguous => return false,
+        EvidenceResolution::Missing => {}
+    }
+    let Some(local_hash) = node_name_hash(il, interner, node) else {
+        return false;
+    };
+    if unit_defines_hash(il, interner, local_hash) {
+        return false;
+    }
+    let statements = top_level_statements(il);
+    let matching_assignments = statements
+        .iter()
+        .copied()
+        .filter(|&stmt| assignment_alias_hash(il, interner, stmt) == Some(local_hash))
+        .collect::<Vec<_>>();
+    let [assignment] = matching_assignments.as_slice() else {
+        return false;
+    };
+    match binding_identity_matches(il, local_hash, il.node(*assignment).span, expected) {
+        EvidenceResolution::Found(matches) => return matches,
+        EvidenceResolution::Ambiguous => return false,
+        EvidenceResolution::Missing => {}
+    }
+    assignment_rhs(il, *assignment).is_some_and(&legacy_rhs_matches)
+}
+
+fn top_level_statements(il: &Il) -> Vec<NodeId> {
+    il.children(il.root)
+        .iter()
+        .copied()
+        .fold(Vec::new(), |mut statements, node| {
+            if il.kind(node) == NodeKind::Block {
+                statements.extend_from_slice(il.children(node));
+            } else {
+                statements.push(node);
+            }
+            statements
+        })
+}
+
+fn assignment_rhs(il: &Il, stmt: NodeId) -> Option<NodeId> {
+    assignment_parts(il, stmt).map(|(_, rhs)| rhs)
+}
+
+fn assignment_alias_hash(il: &Il, interner: &Interner, stmt: NodeId) -> Option<u64> {
+    let (lhs, _) = assignment_parts(il, stmt)?;
+    (il.kind(lhs) == NodeKind::Var)
+        .then(|| node_name_hash(il, interner, lhs))
+        .flatten()
+}
+
+fn assignment_parts(il: &Il, stmt: NodeId) -> Option<(NodeId, NodeId)> {
+    if il.kind(stmt) != NodeKind::Assign {
+        return None;
+    }
+    let [lhs, rhs] = il.children(stmt) else {
+        return None;
+    };
+    Some((*lhs, *rhs))
+}
+
+fn node_name<'a>(il: &Il, interner: &'a Interner, node: NodeId) -> Option<&'a str> {
+    if il.kind(node) != NodeKind::Var {
+        return None;
+    }
+    match il.node(node).payload {
+        Payload::Name(symbol) => Some(interner.resolve(symbol)),
+        Payload::Cid(cid) => il
+            .cid_names
+            .get(cid as usize)
+            .map(|&symbol| interner.resolve(symbol)),
+        _ => None,
+    }
+}
+
+fn node_name_hash(il: &Il, interner: &Interner, node: NodeId) -> Option<u64> {
+    node_name(il, interner, node).map(stable_symbol_hash)
+}
+
+fn unit_defines_hash(il: &Il, interner: &Interner, name_hash: u64) -> bool {
+    il.units.iter().any(|unit| {
+        unit.name
+            .is_some_and(|symbol| stable_symbol_hash(interner.resolve(symbol)) == name_hash)
+    })
+}
+
+fn file_defines_name(il: &Il, interner: &Interner, name: &str) -> bool {
+    let name_hash = stable_symbol_hash(name);
+    il.units.iter().any(|unit| {
+        unit.name.is_some_and(|symbol| {
+            symbol_defines_name(il.meta.lang, interner.resolve(symbol), name, name_hash)
+        })
+    }) || il
+        .nodes
+        .iter()
+        .enumerate()
+        .any(|(idx, node)| match node.kind {
+            NodeKind::Module | NodeKind::Block | NodeKind::Param => {
+                node_defines_name(il, interner, NodeId(idx as u32), name, name_hash)
+            }
+            NodeKind::Assign => il
+                .children(NodeId(idx as u32))
+                .first()
+                .copied()
+                .is_some_and(|lhs| node_defines_name(il, interner, lhs, name, name_hash)),
+            _ => false,
+        })
+}
+
+fn node_defines_name(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    name: &str,
+    name_hash: u64,
+) -> bool {
+    match il.node(node).payload {
+        Payload::Name(symbol) => {
+            symbol_defines_name(il.meta.lang, interner.resolve(symbol), name, name_hash)
+        }
+        Payload::Cid(cid) => il.cid_names.get(cid as usize).is_some_and(|symbol| {
+            symbol_defines_name(il.meta.lang, interner.resolve(*symbol), name, name_hash)
+        }),
+        _ => false,
+    }
+}
+
+fn symbol_defines_name(lang: Lang, text: &str, name: &str, name_hash: u64) -> bool {
+    stable_symbol_hash(text) == name_hash
+        || (js_like_lang(lang) && contains_js_identifier(text, name))
 }
 
 fn literal_string_hash(il: &Il, node: NodeId) -> Option<u64> {
@@ -2622,7 +2908,8 @@ mod tests {
     use nose_il::{
         EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
         EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, ImportEvidenceKind,
-        ParamSemantic, ParamTypeFact, SequenceSurfaceKind, SourceFact, Span, Unit, UnitKind,
+        ParamSemantic, ParamTypeFact, SequenceSurfaceKind, SourceFact, Span, SymbolEvidenceKind,
+        Unit, UnitKind,
     };
 
     const ALL_LANGS: &[Lang] = &[
@@ -2976,6 +3263,145 @@ mod tests {
             EvidenceStatus::Asserted,
         ));
         assert_eq!(import_fact_rhs(&il, &interner, binding), None);
+    }
+
+    #[test]
+    fn direct_symbol_evidence_proves_imported_namespace_without_raw_assignment() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("m")),
+            sp(20),
+            &[],
+        );
+        let root = b.add(NodeKind::Module, Payload::None, sp(20), &[receiver]);
+        let mut il = finish_il(b, root, Lang::Python);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(20), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace {
+                module_hash: stable_symbol_hash("math"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert!(imported_namespace_symbol(&il, &interner, receiver, "math"));
+        assert!(!imported_namespace_symbol(
+            &il,
+            &interner,
+            receiver,
+            "collections"
+        ));
+    }
+
+    #[test]
+    fn symbol_evidence_blocks_import_assignment_fallback() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let local = interner.intern("math");
+        let lhs = b.add(NodeKind::Var, Payload::Name(local), sp(21), &[]);
+        let module = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("math")),
+            sp(21),
+            &[],
+        );
+        let namespace_tag = interner.intern(import_fact_tag(ImportFactKind::Namespace));
+        let rhs = b.add(
+            NodeKind::Seq,
+            Payload::Name(namespace_tag),
+            sp(21),
+            &[module],
+        );
+        let assign = b.add(NodeKind::Assign, Payload::None, sp(21), &[lhs, rhs]);
+        let receiver = b.add(NodeKind::Var, Payload::Name(local), sp(22), &[]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(21), &[assign, receiver]);
+        let mut il = finish_il(b, root, Lang::Python);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(sp(21), stable_symbol_hash("math")),
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace {
+                module_hash: stable_symbol_hash("other"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert!(!imported_namespace_symbol(&il, &interner, receiver, "math"));
+    }
+
+    #[test]
+    fn binding_symbol_evidence_does_not_prove_rebound_alias_uses() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let local = interner.intern("math");
+        let lhs = b.add(NodeKind::Var, Payload::Name(local), sp(24), &[]);
+        let module = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("math")),
+            sp(24),
+            &[],
+        );
+        let namespace_tag = interner.intern(import_fact_tag(ImportFactKind::Namespace));
+        let rhs = b.add(
+            NodeKind::Seq,
+            Payload::Name(namespace_tag),
+            sp(24),
+            &[module],
+        );
+        let import_assign = b.add(NodeKind::Assign, Payload::None, sp(24), &[lhs, rhs]);
+        let rebound_lhs = b.add(NodeKind::Var, Payload::Name(local), sp(25), &[]);
+        let rebound_rhs = b.add(NodeKind::Lit, Payload::LitInt(0), sp(25), &[]);
+        let rebound = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            sp(25),
+            &[rebound_lhs, rebound_rhs],
+        );
+        let receiver = b.add(NodeKind::Var, Payload::Name(local), sp(26), &[]);
+        let root = b.add(
+            NodeKind::Module,
+            Payload::None,
+            sp(24),
+            &[import_assign, rebound, receiver],
+        );
+        let mut il = finish_il(b, root, Lang::Python);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(sp(24), stable_symbol_hash("math")),
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace {
+                module_hash: stable_symbol_hash("math"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert!(!imported_namespace_symbol(&il, &interner, receiver, "math"));
+    }
+
+    #[test]
+    fn ambiguous_global_symbol_evidence_blocks_name_fallback() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let math = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("Math")),
+            sp(23),
+            &[],
+        );
+        let root = b.add(NodeKind::Module, Payload::None, sp(23), &[math]);
+        let mut il = finish_il(b, root, Lang::JavaScript);
+
+        assert!(unshadowed_global_symbol(&il, &interner, math, "Math"));
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(23), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("Math"),
+            }),
+            EvidenceStatus::Ambiguous,
+        ));
+        assert!(!unshadowed_global_symbol(&il, &interner, math, "Math"));
     }
 
     #[test]

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -13,7 +13,8 @@ can satisfy an exact-channel precondition.
 
 ## Goal
 
-- Give source, domain, import, and sequence-surface proof facts one shared shape.
+- Give source, domain, import, symbol-identity, and sequence-surface proof facts
+  one shared shape.
 - Make facts carry stable ids, anchors, provenance, dependencies, and status.
 - Keep exact matching fail-closed when evidence is missing, ambiguous, or
   conflicting.
@@ -57,6 +58,7 @@ The current implemented kinds are:
 | `Source` | construct syntax, regex literal provenance, and source operator family |
 | `Domain` | receiver/value domain such as collection, map, option, string, integer, or byte array |
 | `Import` | static import binding and namespace proof |
+| `Symbol` | resolved or proven symbol identity, with record kinds for unshadowed globals and static imported binding/namespace aliases |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, record guard, or Go composite map literal |
 
 ## Consumption Rules
@@ -77,17 +79,30 @@ This is stricter than a name or tag check. For example, a raw
 contracts first consult `Import` evidence. If that evidence is ambiguous, exact
 import proof stays closed instead of falling back to the raw sequence payload.
 
+Symbol identity follows the same rule. A method selector such as `abs` or a
+receiver spelling such as `Math` is not proof. Exact consumers must require a
+language-scoped contract plus symbol evidence, or a compatibility fallback that
+proves the same import/global/shadowing obligations. Binding-level import
+evidence does not by itself prove every use of the same local name; if the alias
+is rebound or ambiguous, the exact path stays closed until a node-level symbol
+fact or stronger scope-resolution evidence exists.
+
 ## Current Producers
 
 First-party frontends now mirror these facts into `EvidenceRecord`:
 
 - parameter semantic annotations become `Domain` evidence;
 - source-origin facts become `Source` evidence;
-- import binding and namespace lowering emits `Import` evidence;
+- import binding and namespace lowering emits `Import` evidence for the proof RHS
+  and `Symbol` evidence for the local alias identity;
 - lowered `Seq` surfaces emit `SequenceSurface` evidence.
 
 The older `ParamTypeFact`, `SourceFact`, and raw import `Seq` shapes remain as
-compatibility mirrors. They are not the desired pack boundary.
+compatibility mirrors. Unshadowed-global `Symbol` records are defined and
+consumed through the same helper surface, but first-party frontend producers for
+global identity are still a next migration slice; current global proof can still
+come from the compatibility shadow-scan path. These mirrors are not the desired
+pack boundary.
 
 ## Current Consumers
 
@@ -98,8 +113,12 @@ callers:
 - parameter domain lookup used by normalize and strict exact receiver gates;
 - import proof parsing for normalize, value graph, imported literal replacement,
   and strict exact gates;
+- imported namespace/binding symbol proof for normalize idiom admission,
+  value-graph namespace fallbacks, and strict exact gates, plus a shared
+  unshadowed-global helper that still depends on compatibility shadow proof until
+  global `Symbol` producers land;
 - sequence-surface admission for normalize/value-graph/detect exact paths.
 
 Field/place/effect facts, receiver/protocol evidence beyond parameter domains,
-resolved symbol facts, report-level provenance, and external manifest loading are
-still open work.
+full scope-resolution and namespace-member evidence, report-level provenance,
+and external manifest loading are still open work.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -228,6 +228,13 @@ and pack ecosystem.
   facts into records with ids, anchors, provenance, dependencies, and status.
   `nose-semantics` lookups fail closed on ambiguous/conflicting evidence before
   falling back to compatibility storage.
+- Symbol-identity evidence now represents static imported binding/namespace
+  aliases, and defines the unshadowed-global record kind that the next producer
+  slice should emit. Normalize idiom admission, value-graph namespace fallbacks,
+  and strict exact gates have started consuming this helper layer instead of each
+  re-scanning raw import assignment shapes. Provider/imported immutable literal
+  replacement also now rejects direct module-binding mutations such as
+  `LOOKUP.push(...)`.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -273,8 +280,8 @@ Remaining in this phase:
   A later source-fact slice preserves selected JS/TS and Python equality-like
   source operators, but broader operator dispatch, overload semantics, and
   pack-facing consumers remain open.
-- Continue migrating compatibility source/domain/import/sequence storage onto
-  `EvidenceRecord` consumers, then remove the old mirrors once no exact gate
+- Continue migrating compatibility source/domain/import/symbol/sequence storage
+  onto `EvidenceRecord` consumers, then remove the old mirrors once no exact gate
   depends on them.
 - Add scope, dependency, and ambiguity validation for evidence records before
   they become a stable external extension surface.
@@ -285,8 +292,9 @@ Remaining in this phase:
 - Move collection/map factory recognition into `LibraryApiContract` records.
 - Make value-graph and strict exact gates consume the same contract source.
 - Remove the remaining raw import/module proof IL payload storage after import
-  evidence records can carry every consumer obligation, including module export
-  dependencies and mutation proof.
+  and symbol evidence records can carry every consumer obligation, including
+  namespace-member resolution, module export dependencies, scope, rebinding, and
+  mutation proof.
 - Expand the first `SequenceSurface` evidence into sequence/aggregate records for
   factories, nested entries, iterator views, and exported-literal eligibility.
 - Expand domain evidence from parameter annotations into receiver/protocol

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -10,7 +10,8 @@ foundation and follow-up facade migrations through receiver-aware field state
 sequence-surface contracts, proof-backed append fragment evidence, and the first
 operator-law contracts, typed import facts, and source-fact gates for construct,
 literal, equality/operator provenance, and the first shared evidence-record
-substrate for source, domain, import, and sequence-surface facts.
+substrate for source, domain, import, symbol-identity, and sequence-surface
+facts.
 
 ## What exists today
 
@@ -49,11 +50,11 @@ migrated.
   channel eligibility. `ChannelEligibility` describes where a fact may be used;
   first-party/default status is pack provenance, not an analysis channel.
 - `Il::evidence` is now the shared internal substrate for source, domain, import,
-  and sequence-surface proof facts. Records carry ids, stable source anchors,
-  kind, provenance, dependencies, and asserted/ambiguous status. Lookups in
-  `nose-semantics` fail closed on ambiguous or conflicting evidence and use older
-  side tables only as compatibility fallback when no relevant evidence record is
-  present.
+  symbol-identity, and sequence-surface proof facts. Records carry ids, stable
+  source anchors, kind, provenance, dependencies, and asserted/ambiguous status.
+  Lookups in `nose-semantics` fail closed on ambiguous or conflicting evidence
+  and use older side tables only as compatibility fallback when no relevant
+  evidence record is present.
 - `OperatorSemantics` now owns the first shared operator contracts:
   comparison-direction transforms, comparison negation, equality operand
   commutativity, comparison-lattice laws, abs/min/max/selection guard laws,
@@ -149,9 +150,9 @@ migrated.
   of `LOOKUP = Map.of(...)` carries the provider's `java.util.Map` proof into
   the importing file. Provider and importer module-binding mutation proof now
   rejects direct binding mutations and direct place writes such as
-  `LOOKUP.clear()` and `LOOKUP[key] = value`, and provider-side opaque argument
-  escapes such as `mutate(LOOKUP)`, before imported literal provenance can enter
-  exact matching.
+  `LOOKUP.clear()`, `LOOKUP.push(...)`, and `LOOKUP[key] = value`, and
+  provider-side opaque argument escapes such as `mutate(LOOKUP)`, before
+  imported literal provenance can enter exact matching.
 - Membership and map-key membership selectors now consume language-scoped method
   contracts before normalize/detect treat them as semantic containment. A method
   named `contains` is Java/Rust collection membership only; JavaScript
@@ -230,6 +231,15 @@ migrated.
   normalize idiom admission, value-graph import proof, and strict exact gates
   parse import proof RHS nodes through the shared helper instead of local raw
   tag checks.
+- Symbol identity evidence now covers static imported binding/namespace aliases,
+  and the same helper surface defines the next unshadowed-global record path.
+  Normalize idiom admission, value-graph Go namespace fallbacks, and strict exact
+  gates consume `nose-semantics` symbol-proof helpers instead of each re-scanning
+  raw import assignment shapes. First-party global producers have not landed yet,
+  so global proof still uses compatibility shadow scans behind the helper.
+  A spelling such as `Math`, `fmt`, or `deque` is still only a selector; exact
+  consumers need symbol identity proof plus the language/API contract. Binding
+  evidence does not prove later uses if the alias is rebound or ambiguous.
 - TypeScript `import type ...` and type-only named import specifiers are erased
   for runtime import proof; they remain unavailable to exact semantic library
   contracts.
@@ -248,8 +258,8 @@ Semantic knowledge still appears in several forms outside the facade:
   equality-shaped surfaces, but consumption is limited to narrow contracts such
   as JS-like static membership callbacks. General equality dispatch, report
   provenance, and external pack manifests remain open;
-- language-specific import or module proof mechanics that are still local to
-  frontend, normalize, or detect callers;
+- language-specific import, symbol, or module proof mechanics that are still
+  local to frontend, normalize, detect, or value-graph callers;
 - IL still stores import facts as `Seq("import_binding")` /
   `Seq("import_namespace")` payloads for compatibility. Frontends also emit
   `EvidenceRecord::Import`, and semantic interpretation flows through typed


### PR DESCRIPTION
## Summary

- add `EvidenceKind::Symbol` for unshadowed globals and static imported binding/namespace identities
- mirror first-party import aliases into symbol evidence and route normalize/value-graph/detect proof paths through shared `nose-semantics` helpers
- close precision holes around mutated imported literals, raw map sequence proof, and Rust std map factory shadow/entry-shape proof
- update semantic-kernel evidence/snapshot/roadmap docs

## Why

Function, method, and receiver names are selectors, not proof. This moves another layer of exact semantic admission toward provider-scoped evidence records so future language and library packs can declare which symbols they prove without each consumer re-scanning raw import shapes.

The immutable export `.push(...)` case was also a precision bug: a provider-side direct mutation must prevent imported literal replacement from entering exact matching.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --release`
- `awiki lint --root docs`
- `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py`

Refs #109.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 심볼 정체성 증거 시스템 도입으로 전역 변수 및 정적 import 바인딩/네임스페이스 추적 개선

* **Refactor**
  * 내부 검증 로직을 중앙집중식 헬퍼 함수로 통합하여 코드 단순화

* **Tests**
  * 모듈 바인딩 변이 및 심볼 증거 검증 테스트 추가

* **Documentation**
  * 증거 기록 및 의미론적 커널 로드맵 설명서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->