### PR TITLE
semantics: emit JS static global evidence

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -25,8 +25,9 @@ use nose_semantics::{
     nullish_global_contract, regex_test_contract, ruby_set_factory_contract,
     rust_vec_new_factory_contract, semantics, seq_surface_contract_for_node, source_fact_at_node,
     source_operator_at_node, static_index_membership_contract, typeof_operator_contract,
-    DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind, MapKeyViewKind,
-    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
+    unshadowed_global_symbol, DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind,
+    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
+    StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1206,7 +1207,7 @@ fn strict_exact_nullish_global_safe(il: &Il, interner: &Interner, node: NodeId) 
     let Some(contract) = nullish_global_contract(il.meta.lang, name) else {
         return false;
     };
-    !contract.requires_unshadowed || !file_defines_name(il, interner, contract.name)
+    !contract.requires_unshadowed || unshadowed_global_symbol(il, interner, node, contract.name)
 }
 
 fn strict_exact_safe_seq(il: &Il, interner: &Interner, node: NodeId) -> bool {
@@ -1366,7 +1367,9 @@ fn strict_exact_js_array_is_array_safe(
     ) else {
         return false;
     };
-    if contract.requires_unshadowed_receiver && file_defines_name(il, interner, contract.receiver) {
+    if contract.requires_unshadowed_receiver
+        && !unshadowed_global_symbol(il, interner, receiver, contract.receiver)
+    {
         return false;
     }
     strict_exact_call_args_safe(il, interner, facts, node)
@@ -1815,7 +1818,7 @@ fn strict_exact_membership_collection_safe(
             .all(|&c| strict_exact_safe_tree(il, interner, facts, c))
 }
 
-fn strict_exact_two_arg_var_call(il: &Il, node: NodeId) -> Option<(Symbol, NodeId)> {
+fn strict_exact_two_arg_var_call(il: &Il, node: NodeId) -> Option<(NodeId, Symbol, NodeId)> {
     if il.kind(node) != NodeKind::Call {
         return None;
     }
@@ -1826,7 +1829,7 @@ fn strict_exact_two_arg_var_call(il: &Il, node: NodeId) -> Option<(Symbol, NodeI
         return None;
     }
     match il.node(*callee).payload {
-        Payload::Name(name) => Some((name, *argument)),
+        Payload::Name(name) => Some((*callee, name, *argument)),
         _ => None,
     }
 }
@@ -1840,7 +1843,7 @@ fn strict_exact_set_constructor_collection_safe(
     if !construct_syntax_proof(il, node) {
         return false;
     };
-    let Some((name, collection)) = strict_exact_two_arg_var_call(il, node) else {
+    let Some((callee, name, collection)) = strict_exact_two_arg_var_call(il, node) else {
         return false;
     };
     let Some(contract) = js_like_set_constructor_contract(il.meta.lang, interner.resolve(name))
@@ -1849,7 +1852,7 @@ fn strict_exact_set_constructor_collection_safe(
     };
     contract.receiver == "Set"
         && (!contract.requires_unshadowed_global
-            || !file_defines_name(il, interner, contract.receiver))
+            || unshadowed_global_symbol(il, interner, callee, contract.receiver))
         && strict_exact_static_non_float_collection(il, interner, collection)
 }
 
@@ -2041,7 +2044,7 @@ fn strict_exact_rust_std_collection_factory_safe(
     {
         return false;
     }
-    let Some((name, collection)) = strict_exact_two_arg_var_call(il, node) else {
+    let Some((_, name, collection)) = strict_exact_two_arg_var_call(il, node) else {
         return false;
     };
     let name = interner.resolve(name);
@@ -2214,7 +2217,7 @@ fn strict_exact_map_constructor_entries_safe(
     if !construct_syntax_proof(il, node) {
         return false;
     }
-    let Some((name, entries)) = strict_exact_two_arg_var_call(il, node) else {
+    let Some((callee, name, entries)) = strict_exact_two_arg_var_call(il, node) else {
         return false;
     };
     let Some(contract) = js_like_map_constructor_contract(il.meta.lang, interner.resolve(name))
@@ -2223,7 +2226,7 @@ fn strict_exact_map_constructor_entries_safe(
     };
     contract.receiver == "Map"
         && (!contract.requires_unshadowed_global
-            || !file_defines_name(il, interner, contract.receiver))
+            || unshadowed_global_symbol(il, interner, callee, contract.receiver))
         && strict_exact_map_entries_safe(il, interner, facts, entries)
 }
 
@@ -2236,7 +2239,7 @@ fn strict_exact_rust_std_map_factory_safe(
     if !semantics(il.meta.lang).stdlib().rust_std_map_factories() {
         return false;
     }
-    let Some((name, entries)) = strict_exact_two_arg_var_call(il, node) else {
+    let Some((_, name, entries)) = strict_exact_two_arg_var_call(il, node) else {
         return false;
     };
     let name = interner.resolve(name);

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -13,8 +13,7 @@ use nose_il::{
     SourceLiteralKind, SourceOperatorKind, Span, UnitKind,
 };
 use nose_semantics::{
-    js_array_is_array_contract, js_boolean_coercion_contract, method_call_contract,
-    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
+    js_array_is_array_contract, js_boolean_coercion_contract, static_global_symbol_contract,
 };
 use tree_sitter::Node as TsNode;
 
@@ -840,7 +839,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         "true" => lo.add(NodeKind::Lit, Payload::LitBool(true), span, &[]),
         "false" => lo.add(NodeKind::Lit, Payload::LitBool(false), span, &[]),
         "null" => lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[]),
-        "undefined" => lo.var("undefined", span),
+        "undefined" => lower_js_static_global_or_var(lo, node),
         "regex" => {
             let lit = lo.str_lit(lo.text(node), span);
             lo.record_source_fact(span, SourceFactKind::Literal(SourceLiteralKind::Regex));
@@ -858,7 +857,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         "member_expression" => {
             let obj = node
                 .child_by_field_name("object")
-                .map(|o| lower_expr(lo, o))
+                .map(|o| lower_member_object(lo, o))
                 .unwrap_or_else(|| lo.empty_block(span));
             let prop = node
                 .child_by_field_name("property")
@@ -1067,13 +1066,10 @@ fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {
     if let Some(guard) = lower_own_property_guard_call(lo, node) {
         return guard;
     }
-    if let Some(math_builtin) = lower_math_call(lo, node) {
-        return math_builtin;
-    }
     let span = lo.span(node);
     let mut kids = Vec::new();
     match node.child_by_field_name("function") {
-        Some(f) => kids.push(lower_expr(lo, f)),
+        Some(f) => kids.push(lower_callee_expr(lo, f)),
         None => {
             let e = lo.empty_block(span);
             kids.push(e);
@@ -1090,43 +1086,6 @@ fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {
         }
     }
     lo.add(NodeKind::Call, Payload::None, span, &kids)
-}
-
-fn lower_math_call(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
-    let callee = node.child_by_field_name("function")?;
-    let callee = compact_js_expr(lo.text(callee));
-    let (receiver, method) = callee.split_once('.')?;
-    let args = node.child_by_field_name("arguments")?;
-    let args: Vec<TsNode> = Lowering::named_children(args);
-    let contract = method_call_contract(lo.lang, method, args.len())?;
-    let MethodSemanticContract::Builtin(builtin) = contract.semantic else {
-        return None;
-    };
-    let MethodReceiverContract::UnshadowedGlobal(global) = contract.receiver else {
-        return None;
-    };
-    if global != receiver {
-        return None;
-    }
-    if file_prefix_has_binding_ident(lo, node, global)
-        || enclosing_function_prefix_has_binding_ident(lo, node, global)
-    {
-        return None;
-    }
-    if !matches!(
-        contract.args,
-        MethodBuiltinArgs::First | MethodBuiltinArgs::All
-    ) || args.iter().any(|arg| arg.kind() == "spread_element")
-    {
-        return None;
-    }
-    let lowered: Vec<NodeId> = args.into_iter().map(|arg| lower_expr(lo, arg)).collect();
-    Some(lo.add(
-        NodeKind::Call,
-        Payload::Builtin(builtin),
-        lo.span(node),
-        &lowered,
-    ))
 }
 
 fn lower_own_property_guard_call(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
@@ -1215,8 +1174,16 @@ fn contains_keyword_binding(text: &str, keyword: &str, ident: &str) -> bool {
             return false;
         }
         rest = rest.trim_start();
-        starts_with_js_ident(rest, ident)
+        starts_with_js_ident(rest, ident) || destructuring_pattern_binds_ident(rest, ident)
     })
+}
+
+fn destructuring_pattern_binds_ident(text: &str, ident: &str) -> bool {
+    if !matches!(text.chars().next(), Some('{') | Some('[')) {
+        return false;
+    }
+    let pattern = text.split_once('=').map(|(lhs, _)| lhs).unwrap_or(text);
+    contains_js_identifier(pattern, ident)
 }
 
 fn contains_import_binding(text: &str, ident: &str) -> bool {
@@ -1242,11 +1209,53 @@ fn starts_with_js_ident(text: &str, ident: &str) -> bool {
             .is_some_and(is_js_identifier_continue)
 }
 
+fn lower_callee_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
+    match node.kind() {
+        "identifier" | "undefined" => lower_js_static_global_or_var(lo, node),
+        _ => lower_expr(lo, node),
+    }
+}
+
+fn lower_member_object(lo: &mut Lowering, node: TsNode) -> NodeId {
+    match node.kind() {
+        "identifier" | "undefined" => lower_js_static_global_or_var(lo, node),
+        _ => lower_expr(lo, node),
+    }
+}
+
+fn lower_constructor_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
+    match node.kind() {
+        "identifier" | "undefined" => lower_js_static_global_or_var(lo, node),
+        _ => lower_expr(lo, node),
+    }
+}
+
+fn lower_js_static_global_or_var(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let name = lo.text(node);
+    let span = lo.span(node);
+    if js_static_global_unshadowed_at(lo, node, name) {
+        lo.unshadowed_global_var(name, span)
+    } else {
+        lo.var(name, span)
+    }
+}
+
+fn js_static_global_unshadowed_at(lo: &Lowering, node: TsNode, name: &str) -> bool {
+    let Some(contract) = static_global_symbol_contract(lo.lang, name) else {
+        return false;
+    };
+    if !contract.requires_unshadowed {
+        return true;
+    }
+    !file_prefix_has_binding_ident(lo, node, contract.name)
+        && !enclosing_function_prefix_has_binding_ident(lo, node, contract.name)
+}
+
 fn lower_new(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
     let mut kids = Vec::new();
     match node.child_by_field_name("constructor") {
-        Some(c) => kids.push(lower_expr(lo, c)),
+        Some(c) => kids.push(lower_constructor_expr(lo, c)),
         None => {
             let e = lo.empty_block(span);
             kids.push(e);
@@ -1813,7 +1822,33 @@ fn js_source_operator(text: &str) -> Option<SourceOperatorKind> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_il::{FileId, Interner};
+    use nose_il::{stable_symbol_hash, EvidenceKind, FileId, Interner, SymbolEvidenceKind};
+
+    fn lower_js(src: &str) -> Il {
+        let interner = Interner::new();
+        crate::lower_source(
+            FileId(0),
+            "t.js",
+            src.as_bytes(),
+            Lang::JavaScript,
+            &interner,
+        )
+        .expect("lower js")
+    }
+
+    fn unshadowed_global_evidence_count(il: &Il, name: &str) -> usize {
+        let expected = stable_symbol_hash(name);
+        il.evidence
+            .iter()
+            .filter(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal { name_hash })
+                        if name_hash == expected
+                )
+            })
+            .count()
+    }
 
     fn switch_labels_for_return(src: &str, expected_return: i64) -> Vec<i64> {
         let interner = Interner::new();
@@ -1875,5 +1910,47 @@ mod tests {
     fn stacked_switch_cases_share_the_following_body() {
         let src = "function f(x) { switch (x) { case 1: case 2: return 7; default: return 0; } }";
         assert_eq!(switch_labels_for_return(src, 7), vec![1, 2]);
+    }
+
+    #[test]
+    fn js_static_global_value_occurrences_emit_symbol_evidence() {
+        let il = lower_js(
+            "function f(value) {
+                console.log(Math.abs(value));
+                const picked = new Map([[\"x\", 1]]).get(\"x\") ?? undefined;
+                return Array.isArray(value) || new Set([value]).has(value) || picked;
+            }",
+        );
+
+        for name in ["console", "Math", "Map", "undefined", "Array", "Set"] {
+            assert!(
+                unshadowed_global_evidence_count(&il, name) >= 1,
+                "missing global evidence for {name}"
+            );
+        }
+        assert!(
+            !il.nodes
+                .iter()
+                .any(|node| matches!(node.payload, Payload::Builtin(Builtin::Abs))),
+            "Math.abs should stay as Field(Var(Math), abs) for semantic consumers"
+        );
+    }
+
+    #[test]
+    fn js_static_global_evidence_respects_local_and_destructured_shadows() {
+        let il = lower_js(
+            "function f(Math, value) { return Math.abs(value); }
+             function g(scope) { const { Map } = scope; return new Map([]); }
+             function h(value, undefined) { return value === undefined; }
+             function i(value) { const Array = { isArray() { return false; } }; return Array.isArray(value); }",
+        );
+
+        for name in ["Math", "Map", "undefined", "Array"] {
+            assert_eq!(
+                unshadowed_global_evidence_count(&il, name),
+                0,
+                "shadowed {name} should not get global evidence"
+            );
+        }
     }
 }

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -193,6 +193,20 @@ impl<'a> Lowering<'a> {
         self.b.add(NodeKind::Var, Payload::Name(sym), span, &[])
     }
 
+    /// A `Var` proven by the frontend to denote a language-defined unshadowed
+    /// global symbol at this source occurrence.
+    pub(crate) fn unshadowed_global_var(&mut self, name: &str, span: Span) -> NodeId {
+        let var = self.var(name, span);
+        self.record_evidence(
+            EvidenceAnchor::node(span, NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash(name),
+            }),
+            "symbol_unshadowed_global",
+        );
+        var
+    }
+
     /// Lower an integer literal, retaining its **value** as [`Payload::LitInt`] so the
     /// value-graph (the behavioral fingerprint) keeps behavior-defining constants
     /// distinct — `x % 7` ≢ `x % 11`, `return 100` ≢ `return 200` — rather than

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -62,8 +62,8 @@ use nose_semantics::{
     rust_option_and_then_contract, rust_option_none_sentinel_contract,
     rust_option_some_constructor_contract, rust_vec_new_factory_contract,
     scalar_integer_method_contract, semantics, seq_surface_contract_for_node,
-    source_operator_at_node, static_index_membership_contract, BuiltinArgContract,
-    CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
+    source_operator_at_node, static_index_membership_contract, unshadowed_global_symbol,
+    BuiltinArgContract, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
     GoZeroMapDefaultKind, ImportFactKind, ImportedNamespaceFunctionSemantic,
     IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind, MapKeyViewKind,
     MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract,
@@ -1381,7 +1381,9 @@ impl<'a> Builder<'a> {
         };
         let constructor = self.interner.resolve(name);
         if let Some(contract) = js_like_set_constructor_contract(self.il.meta.lang, constructor) {
-            if contract.requires_unshadowed_global && self.file_defines_name(contract.receiver) {
+            if contract.requires_unshadowed_global
+                && !unshadowed_global_symbol(self.il, self.interner, kids[0], contract.receiver)
+            {
                 return None;
             }
             if !self.is_static_non_float_collection_expr(kids[1]) {
@@ -1390,7 +1392,9 @@ impl<'a> Builder<'a> {
             return Some(self.eval_membership_collection(kids[1], env));
         }
         let contract = js_like_map_constructor_contract(self.il.meta.lang, constructor)?;
-        if contract.requires_unshadowed_global && self.file_defines_name(contract.receiver) {
+        if contract.requires_unshadowed_global
+            && !unshadowed_global_symbol(self.il, self.interner, kids[0], contract.receiver)
+        {
             return None;
         }
         let entry_seq_tag = contract.entry_seq_tag?;
@@ -7319,7 +7323,9 @@ impl<'a> Builder<'a> {
                         return self.null_const();
                     }
                     if let Some(contract) = nullish_global_contract(self.il.meta.lang, name) {
-                        if !contract.requires_unshadowed || !self.file_defines_name(contract.name) {
+                        if !contract.requires_unshadowed
+                            || unshadowed_global_symbol(self.il, self.interner, expr, contract.name)
+                        {
                             return self.null_const();
                         }
                     }

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -2469,6 +2469,33 @@ pub struct StaticGlobalFunctionContract {
     pub requires_unshadowed_function: bool,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct StaticGlobalSymbolContract {
+    pub name: &'static str,
+    pub requires_unshadowed: bool,
+}
+
+pub fn static_global_symbol_contract(lang: Lang, name: &str) -> Option<StaticGlobalSymbolContract> {
+    if !js_like_lang(lang) {
+        return None;
+    }
+    let name = match name {
+        "Array" => "Array",
+        "Boolean" => "Boolean",
+        "Map" => "Map",
+        "Math" => "Math",
+        "Object" => "Object",
+        "Set" => "Set",
+        "console" => "console",
+        "undefined" => "undefined",
+        _ => return None,
+    };
+    Some(StaticGlobalSymbolContract {
+        name,
+        requires_unshadowed: true,
+    })
+}
+
 pub fn js_boolean_coercion_contract(
     lang: Lang,
     function: &str,
@@ -4140,6 +4167,25 @@ mod tests {
 
     #[test]
     fn js_static_builtin_contracts_are_language_and_arity_constrained() {
+        assert_eq!(
+            static_global_symbol_contract(Lang::JavaScript, "Math"),
+            Some(StaticGlobalSymbolContract {
+                name: "Math",
+                requires_unshadowed: true,
+            })
+        );
+        assert_eq!(
+            static_global_symbol_contract(Lang::TypeScript, "undefined"),
+            Some(StaticGlobalSymbolContract {
+                name: "undefined",
+                requires_unshadowed: true,
+            })
+        );
+        assert_eq!(static_global_symbol_contract(Lang::Python, "Math"), None);
+        assert_eq!(
+            static_global_symbol_contract(Lang::JavaScript, "WeakMap"),
+            None
+        );
         assert_eq!(
             typeof_operator_contract(Lang::TypeScript, "typeof", 1),
             Some(TypeofOperatorContract { name: "typeof" })

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -95,14 +95,15 @@ First-party frontends now mirror these facts into `EvidenceRecord`:
 - source-origin facts become `Source` evidence;
 - import binding and namespace lowering emits `Import` evidence for the proof RHS
   and `Symbol` evidence for the local alias identity;
+- JS/TS static-global value occurrences that remain as `Var` nodes, such as
+  member receivers, call callees, constructors, and `undefined`, emit
+  `UnshadowedGlobal` symbol evidence when the frontend proves no local shadow;
 - lowered `Seq` surfaces emit `SequenceSurface` evidence.
 
 The older `ParamTypeFact`, `SourceFact`, and raw import `Seq` shapes remain as
-compatibility mirrors. Unshadowed-global `Symbol` records are defined and
-consumed through the same helper surface, but first-party frontend producers for
-global identity are still a next migration slice; current global proof can still
-come from the compatibility shadow-scan path. These mirrors are not the desired
-pack boundary.
+compatibility mirrors. Some direct JS/TS guard lowerings still use compatibility
+shadow scans until qualified-member and guard evidence lands. These mirrors are
+not the desired pack boundary.
 
 ## Current Consumers
 
@@ -114,9 +115,11 @@ callers:
 - import proof parsing for normalize, value graph, imported literal replacement,
   and strict exact gates;
 - imported namespace/binding symbol proof for normalize idiom admission,
-  value-graph namespace fallbacks, and strict exact gates, plus a shared
-  unshadowed-global helper that still depends on compatibility shadow proof until
-  global `Symbol` producers land;
+  value-graph namespace fallbacks, and strict exact gates;
+- unshadowed-global symbol proof for JS/TS `Math.*` method contracts,
+  `new Map(...)`/`new Set(...)` constructor contracts, static `Array.isArray`
+  exact gates, and `undefined` nullish-default handling, with compatibility
+  fallback only when no relevant evidence record exists;
 - sequence-surface admission for normalize/value-graph/detect exact paths.
 
 Field/place/effect facts, receiver/protocol evidence beyond parameter domains,

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -229,12 +229,15 @@ and pack ecosystem.
   `nose-semantics` lookups fail closed on ambiguous/conflicting evidence before
   falling back to compatibility storage.
 - Symbol-identity evidence now represents static imported binding/namespace
-  aliases, and defines the unshadowed-global record kind that the next producer
-  slice should emit. Normalize idiom admission, value-graph namespace fallbacks,
-  and strict exact gates have started consuming this helper layer instead of each
-  re-scanning raw import assignment shapes. Provider/imported immutable literal
-  replacement also now rejects direct module-binding mutations such as
-  `LOOKUP.push(...)`.
+  aliases. Normalize idiom admission, value-graph namespace fallbacks, and strict
+  exact gates have started consuming this helper layer instead of each re-scanning
+  raw import assignment shapes. Provider/imported immutable literal replacement
+  also now rejects direct module-binding mutations such as `LOOKUP.push(...)`.
+- JS/TS static-global value occurrences now emit `UnshadowedGlobal` evidence for
+  first-party globals such as `Math`, `console`, `Array`, `Map`, `Set`, and
+  `undefined` when no local shadow is proven. JS/TS `Math.*` no longer lowers
+  directly to builtins in the frontend; normalize consumes the preserved
+  `Field(Var(global), method)` shape through symbol-proof contracts instead.
 
 ## Phase 0: documentation and vocabulary (landed)
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -220,23 +220,24 @@ migrated.
   semantics, but computed property names are exact-closed until a future
   contract can prove key evaluation, coercion, order, and side-effect behavior.
 - JS/TS `new Map(...)` and `new Set(...)` now require construct-syntax source
-  facts distinct from ordinary calls plus an unshadowed `Map`/`Set` global. With
-  exact-safe static collection or entry arguments they can enter exact matching,
-  including supported immutable module-level Set/Map bindings. Plain
-  `Set(...)`/`Map(...)` calls and locally shadowed constructor names remain
-  exact-closed.
+  facts distinct from ordinary calls plus `UnshadowedGlobal` symbol proof for
+  the `Map`/`Set` constructor. With exact-safe static collection or entry
+  arguments they can enter exact matching, including supported immutable
+  module-level Set/Map bindings. Plain `Set(...)`/`Map(...)` calls and locally
+  shadowed constructor names remain exact-closed.
 - Static import proof facts now have a typed `ImportFactKind`/`ImportFact`
   facade in `nose-semantics`. First-party frontends emit import binding and
   namespace facts through that contract, and imported literal replacement,
   normalize idiom admission, value-graph import proof, and strict exact gates
   parse import proof RHS nodes through the shared helper instead of local raw
   tag checks.
-- Symbol identity evidence now covers static imported binding/namespace aliases,
-  and the same helper surface defines the next unshadowed-global record path.
-  Normalize idiom admission, value-graph Go namespace fallbacks, and strict exact
+- Symbol identity evidence now covers static imported binding/namespace aliases
+  and JS/TS static-global value occurrences such as `Math`, `console`, `Array`,
+  `Map`, `Set`, and `undefined` when the frontend proves no local shadow.
+  Normalize idiom admission, value-graph namespace fallbacks, and strict exact
   gates consume `nose-semantics` symbol-proof helpers instead of each re-scanning
-  raw import assignment shapes. First-party global producers have not landed yet,
-  so global proof still uses compatibility shadow scans behind the helper.
+  raw import assignment or global shadow shapes. Direct JS/TS guard lowerings for
+  some qualified members still need a dedicated evidence slice.
   A spelling such as `Math`, `fmt`, or `deque` is still only a selector; exact
   consumers need symbol identity proof plus the language/API contract. Binding
   evidence does not prove later uses if the alias is rebound or ambiguous.

--- a/docs/source-facts.md
+++ b/docs/source-facts.md
@@ -93,9 +93,9 @@ compatibility mirror while consumers migrate to evidence records.
 - Python lowering emits source facts for value equality/inequality and identity
   equality/inequality.
 - JS-like `new Set(...)` and `new Map(...)` can enter exact matching only when
-  construct syntax is proven, the `Set`/`Map` global is not shadowed, and the
-  collection/map argument remains exact-safe. Plain `Set(...)` and `Map(...)`
-  stay closed.
+  construct syntax is proven, the `Set`/`Map` callee has unshadowed-global
+  symbol proof, and the collection/map argument remains exact-safe. Plain
+  `Set(...)` and `Map(...)` stay closed.
 - JS/TS regex literal `.test(value)` can enter exact matching only when the
   receiver is proven to be a regex literal. Ordinary string `.test(...)` stays
   closed.


### PR DESCRIPTION
## Summary
- add a first-party static-global symbol contract for JS/TS globals and a lowering helper that emits `UnshadowedGlobal` evidence on proven value occurrences
- stop lowering JS/TS `Math.*` directly to builtin calls in the frontend; preserve `Field(Var(Math), method)` so normalize consumes it through symbol-proof contracts
- move JS/TS `new Map(...)`/`new Set(...)`, `Array.isArray(...)`, and `undefined` exact gates onto `unshadowed_global_symbol`
- update semantic-kernel docs to reflect the landed static-global producer slice and remaining guard/qualified-member work

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo build --release && ./scripts/check-duplication.sh`
- `awiki lint --root docs`
- `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py`

Updates #109.
