### PR TITLE
semantics: add qualified global evidence

### DIFF
--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -8858,6 +8858,11 @@ fn scan_mode_semantic_proves_js_own_property_guards() {
         "const Object = { hasOwn() { return false; } };\nfunction shadowedGlobal(value) {\n  return Object.hasOwn(value, \"ready\");\n}\n",
     )
     .unwrap();
+    fs::write(
+        dir.join("shadowed_object_call_negative.js"),
+        "function shadowedObjectCall(Object, value) {\n  return Object.prototype.hasOwnProperty.call(value, \"ready\");\n}\n",
+    )
+    .unwrap();
 
     let semantic = run(&[
         "scan",
@@ -8892,6 +8897,7 @@ fn scan_mode_semantic_proves_js_own_property_guards() {
         "direct_method_negative.js",
         "different_key_negative.js",
         "shadowed_object_negative.js",
+        "shadowed_object_call_negative.js",
         "shadowed_global_object_negative.js",
     ] {
         assert!(

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -3511,6 +3511,7 @@ fn map_key_membership_converges_cross_language_with_boundaries() {
     let ts_array_from_keys_wrong_key = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return Array.from(lookup.keys()).includes(other); }";
     let ts_array_from_keys_wrong_map = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return Array.from(other_lookup.keys()).includes(key); }";
     let ts_array_from_values = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return Array.from(lookup.values()).includes(key); }";
+    let ts_array_from_shadowed_array = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string, Array: any): boolean { return Array.from(lookup.keys()).includes(key); }";
 
     let fp = value_fp(&i, py, Lang::Python);
     assert_ne!(fp, value_fp(&i, py_method, Lang::Python));
@@ -3545,6 +3546,10 @@ fn map_key_membership_converges_cross_language_with_boundaries() {
         value_fp(&i, ts_array_from_keys_wrong_map, Lang::TypeScript)
     );
     assert_ne!(fp, value_fp(&i, ts_array_from_values, Lang::TypeScript));
+    assert_ne!(
+        fp,
+        value_fp(&i, ts_array_from_shadowed_array, Lang::TypeScript)
+    );
 }
 
 #[test]

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -22,12 +22,12 @@ use nose_semantics::{
     java_map_entry_contract, java_map_factory_contract, js_array_is_array_contract,
     js_like_map_constructor_contract, js_like_set_constructor_contract, map_get_contract,
     map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
-    nullish_global_contract, regex_test_contract, ruby_set_factory_contract,
-    rust_vec_new_factory_contract, semantics, seq_surface_contract_for_node, source_fact_at_node,
-    source_operator_at_node, static_index_membership_contract, typeof_operator_contract,
-    unshadowed_global_symbol, DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind,
-    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
-    StaticIndexMembershipKind,
+    nullish_global_contract, qualified_global_symbol, regex_test_contract,
+    ruby_set_factory_contract, rust_vec_new_factory_contract, semantics,
+    seq_surface_contract_for_node, source_fact_at_node, source_operator_at_node,
+    static_index_membership_contract, typeof_operator_contract, unshadowed_global_symbol,
+    DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind, MapKeyViewKind,
+    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1211,8 +1211,19 @@ fn strict_exact_nullish_global_safe(il: &Il, interner: &Interner, node: NodeId) 
 }
 
 fn strict_exact_safe_seq(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    if let Payload::Name(tag) = il.node(node).payload {
+        if interner.resolve(tag) == "own_property_guard" {
+            return strict_exact_own_property_guard_seq_safe(il, node);
+        }
+    }
     seq_surface_contract_for_node(il, interner, node)
         .is_some_and(|contract| contract.exact_tree_safe)
+}
+
+fn strict_exact_own_property_guard_seq_safe(il: &Il, node: NodeId) -> bool {
+    ["Object.hasOwn", "Object.prototype.hasOwnProperty.call"]
+        .into_iter()
+        .any(|path| qualified_global_symbol(il, node, path))
 }
 
 fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, node: NodeId) -> bool {
@@ -1370,6 +1381,9 @@ fn strict_exact_js_array_is_array_safe(
     if contract.requires_unshadowed_receiver
         && !unshadowed_global_symbol(il, interner, receiver, contract.receiver)
     {
+        return false;
+    }
+    if !qualified_global_symbol(il, callee, contract.qualified_path) {
         return false;
     }
     strict_exact_call_args_safe(il, interner, facts, node)
@@ -1766,11 +1780,7 @@ fn strict_exact_map_key_view_collection_safe(
     else {
         return false;
     };
-    let Some(&receiver) = il.children(kids[0]).first() else {
-        return false;
-    };
-    strict_exact_callee_name(il, interner, receiver, contract.receiver)
-        && !file_defines_name(il, interner, contract.receiver)
+    qualified_global_symbol(il, kids[0], contract.qualified_path)
         && strict_exact_map_key_view_safe_matching(il, interner, facts, kids[1], |kind| {
             kind == MapKeyViewKind::Iterator
         })

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -13,7 +13,8 @@ use nose_il::{
     SourceLiteralKind, SourceOperatorKind, Span, UnitKind,
 };
 use nose_semantics::{
-    js_array_is_array_contract, js_boolean_coercion_contract, static_global_symbol_contract,
+    js_array_is_array_contract, js_boolean_coercion_contract, qualified_global_symbol_contract,
+    static_global_symbol_contract,
 };
 use tree_sitter::Node as TsNode;
 
@@ -854,18 +855,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         "update_expression" => lower_update(lo, node),
         "assignment_expression" => crate::lower::assignment(lo, node, lower_expr),
         "augmented_assignment_expression" => lower_aug_assignment(lo, node),
-        "member_expression" => {
-            let obj = node
-                .child_by_field_name("object")
-                .map(|o| lower_member_object(lo, o))
-                .unwrap_or_else(|| lo.empty_block(span));
-            let prop = node
-                .child_by_field_name("property")
-                .map(|p| lo.text(p))
-                .unwrap_or("");
-            let sym = lo.sym(prop);
-            lo.add(NodeKind::Field, Payload::Name(sym), span, &[obj])
-        }
+        "member_expression" => lower_member_expr(lo, node),
         "subscript_expression" => {
             let base = node
                 .child_by_field_name("object")
@@ -1091,14 +1081,16 @@ fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {
 fn lower_own_property_guard_call(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     let callee = node.child_by_field_name("function")?;
     let callee_text = compact_js_expr(lo.text(callee));
+    let contract = qualified_global_symbol_contract(lo.lang, &callee_text)?;
     if !matches!(
-        callee_text.as_str(),
+        contract.path,
         "Object.hasOwn" | "Object.prototype.hasOwnProperty.call"
     ) {
         return None;
     }
-    if file_prefix_has_binding_ident(lo, node, "Object")
-        || enclosing_function_prefix_has_binding_ident(lo, node, "Object")
+    if contract.requires_unshadowed_root
+        && (file_prefix_has_binding_ident(lo, node, contract.root)
+            || enclosing_function_prefix_has_binding_ident(lo, node, contract.root))
     {
         return None;
     }
@@ -1113,12 +1105,14 @@ fn lower_own_property_guard_call(lo: &mut Lowering, node: TsNode) -> Option<Node
     let own = lo.str_lit("own", span);
     let present = lo.str_lit("present", span);
     let tag = lo.sym("own_property_guard");
-    Some(lo.add(
+    let guard = lo.add(
         NodeKind::Seq,
         Payload::Name(tag),
         span,
         &[receiver, key, own, present],
-    ))
+    );
+    lo.record_qualified_global_symbol(span, NodeKind::Seq, contract.path);
+    Some(guard)
 }
 
 fn file_prefix_has_binding_ident(lo: &Lowering, node: TsNode, ident: &str) -> bool {
@@ -1221,6 +1215,30 @@ fn lower_member_object(lo: &mut Lowering, node: TsNode) -> NodeId {
         "identifier" | "undefined" => lower_js_static_global_or_var(lo, node),
         _ => lower_expr(lo, node),
     }
+}
+
+fn lower_member_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let obj = node
+        .child_by_field_name("object")
+        .map(|o| lower_member_object(lo, o))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let prop = node
+        .child_by_field_name("property")
+        .map(|p| lo.text(p))
+        .unwrap_or("");
+    let sym = lo.sym(prop);
+    let field = lo.add(NodeKind::Field, Payload::Name(sym), span, &[obj]);
+    let path = compact_js_expr(lo.text(node));
+    if let Some(contract) = qualified_global_symbol_contract(lo.lang, &path) {
+        let root_unshadowed = !contract.requires_unshadowed_root
+            || (!file_prefix_has_binding_ident(lo, node, contract.root)
+                && !enclosing_function_prefix_has_binding_ident(lo, node, contract.root));
+        if root_unshadowed {
+            lo.record_qualified_global_symbol(span, NodeKind::Field, contract.path);
+        }
+    }
+    field
 }
 
 fn lower_constructor_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
@@ -1822,7 +1840,9 @@ fn js_source_operator(text: &str) -> Option<SourceOperatorKind> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_il::{stable_symbol_hash, EvidenceKind, FileId, Interner, SymbolEvidenceKind};
+    use nose_il::{
+        stable_symbol_hash, EvidenceAnchor, EvidenceKind, FileId, Interner, SymbolEvidenceKind,
+    };
 
     fn lower_js(src: &str) -> Il {
         let interner = Interner::new();
@@ -1845,6 +1865,26 @@ mod tests {
                     record.kind,
                     EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal { name_hash })
                         if name_hash == expected
+                )
+            })
+            .count()
+    }
+
+    fn qualified_global_evidence_count(il: &Il, path: &str, kind: NodeKind) -> usize {
+        let expected = stable_symbol_hash(path);
+        il.evidence
+            .iter()
+            .filter(|record| {
+                matches!(
+                    record.anchor,
+                    EvidenceAnchor::Node {
+                        kind: anchor_kind,
+                        ..
+                    } if anchor_kind == kind
+                ) && matches!(
+                    record.kind,
+                    EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal { path_hash })
+                        if path_hash == expected
                 )
             })
             .count()
@@ -1952,5 +1992,64 @@ mod tests {
                 "shadowed {name} should not get global evidence"
             );
         }
+    }
+
+    #[test]
+    fn js_qualified_global_paths_emit_symbol_evidence() {
+        let il = lower_js(
+            "function hasOwn(value) { return Object.hasOwn(value, \"ready\"); }
+             function hasOwnCall(value) { return Object.prototype.hasOwnProperty.call(value, \"ready\"); }
+             function fromKeys(lookup) { return Array.from(lookup.keys()).includes(\"ready\"); }
+             function isArray(value) { return Array.isArray(value); }",
+        );
+
+        assert_eq!(
+            qualified_global_evidence_count(&il, "Object.hasOwn", NodeKind::Seq),
+            1
+        );
+        assert_eq!(
+            qualified_global_evidence_count(
+                &il,
+                "Object.prototype.hasOwnProperty.call",
+                NodeKind::Seq
+            ),
+            1
+        );
+        assert_eq!(
+            qualified_global_evidence_count(&il, "Array.from", NodeKind::Field),
+            1
+        );
+        assert_eq!(
+            qualified_global_evidence_count(&il, "Array.isArray", NodeKind::Field),
+            1
+        );
+    }
+
+    #[test]
+    fn js_qualified_global_evidence_respects_shadowed_roots() {
+        let il = lower_js(
+            "function a(Object, value) { return Object.hasOwn(value, \"ready\"); }
+             const Object = { prototype: { hasOwnProperty: { call() { return true; } } } };
+             function b(value) { return Object.prototype.hasOwnProperty.call(value, \"ready\"); }
+             function c(Array, lookup) { return Array.from(lookup.keys()).includes(\"ready\"); }
+             function d(scope, lookup) { const { Array } = scope; return Array.from(lookup.keys()).includes(\"ready\"); }",
+        );
+
+        assert_eq!(
+            qualified_global_evidence_count(&il, "Object.hasOwn", NodeKind::Seq),
+            0
+        );
+        assert_eq!(
+            qualified_global_evidence_count(
+                &il,
+                "Object.prototype.hasOwnProperty.call",
+                NodeKind::Seq
+            ),
+            0
+        );
+        assert_eq!(
+            qualified_global_evidence_count(&il, "Array.from", NodeKind::Field),
+            0
+        );
     }
 }

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -207,6 +207,23 @@ impl<'a> Lowering<'a> {
         var
     }
 
+    /// Record that a source node denotes an exact language-defined qualified
+    /// global path, such as `Array.from` or `Object.hasOwn`.
+    pub(crate) fn record_qualified_global_symbol(
+        &mut self,
+        span: Span,
+        kind: NodeKind,
+        path: &str,
+    ) {
+        self.record_evidence(
+            EvidenceAnchor::node(span, kind),
+            EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+                path_hash: stable_symbol_hash(path),
+            }),
+            "symbol_qualified_global",
+        );
+    }
+
     /// Lower an integer literal, retaining its **value** as [`Payload::LitInt`] so the
     /// value-graph (the behavioral fingerprint) keeps behavior-defining constants
     /// distinct — `x % 7` ≢ `x % 11`, `return 100` ≢ `return 200` — rather than

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -320,6 +320,9 @@ pub enum SymbolEvidenceKind {
     ImportedNamespace {
         module_hash: u64,
     },
+    QualifiedGlobal {
+        path_hash: u64,
+    },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -58,18 +58,18 @@ use nose_semantics::{
     java_map_entry_contract_by_hash, java_map_factory_contract_by_hash,
     js_like_map_constructor_contract, js_like_set_constructor_contract, map_get_contract_by_hash,
     map_key_view_contract_by_hash, map_key_view_wrapper_contract_by_hash, method_call_contract,
-    nullish_global_contract, reduction_builtin_contract, ruby_set_factory_contract_by_hash,
-    rust_option_and_then_contract, rust_option_none_sentinel_contract,
-    rust_option_some_constructor_contract, rust_vec_new_factory_contract,
-    scalar_integer_method_contract, semantics, seq_surface_contract_for_node,
-    source_operator_at_node, static_index_membership_contract, unshadowed_global_symbol,
-    BuiltinArgContract, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
-    GoZeroMapDefaultKind, ImportFactKind, ImportedNamespaceFunctionSemantic,
-    IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind, MapKeyViewKind,
-    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract,
-    ScalarIntegerMethod, SeqSurfaceContract, StaticIndexMembershipKind, SEQ_VALUE_COLLECTION,
-    SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR, SEQ_VALUE_TUPLE,
-    SEQ_VALUE_UNTAGGED,
+    nullish_global_contract, qualified_global_symbol_at_span, reduction_builtin_contract,
+    ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
+    rust_option_none_sentinel_contract, rust_option_some_constructor_contract,
+    rust_vec_new_factory_contract, scalar_integer_method_contract, semantics,
+    seq_surface_contract_for_node, source_operator_at_node, static_index_membership_contract,
+    unshadowed_global_symbol, BuiltinArgContract, CardinalityPredicate, CardinalityThreshold,
+    ComparisonLaw, DomainEvidence, GoZeroMapDefaultKind, ImportFactKind,
+    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
+    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
+    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract,
+    StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD,
+    SEQ_VALUE_PAIR, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -1563,8 +1563,12 @@ impl<'a> Builder<'a> {
                 map_key_view_wrapper_contract_by_hash(self.il.meta.lang, "Array", method, 1)?;
             if accepted != MapKeyViewKind::Collection
                 || callee.args.len() != 1
-                || !self.is_free_name_value(callee.args[0], contract.receiver)
-                || self.file_defines_name(contract.receiver)
+                || !qualified_global_symbol_at_span(
+                    self.il,
+                    self.node_span[args[0] as usize],
+                    NodeKind::Field,
+                    contract.qualified_path,
+                )
             {
                 return None;
             }
@@ -6487,8 +6491,12 @@ impl<'a> Builder<'a> {
     }
 
     fn own_property_condition(&self, cond: ValueId) -> Option<(ValueId, ValueId, bool)> {
-        let parse = |node: &ValNode| {
+        let parse = |value: ValueId| {
+            let node = &self.nodes[value as usize];
             if matches!(node.op, ValOp::Seq(SEQ_VALUE_OWN_PROPERTY_GUARD)) && node.args.len() == 4 {
+                if !self.proven_own_property_guard_value(value) {
+                    return None;
+                }
                 let map = node.args[0];
                 if !matches!(self.nodes[map as usize].op, ValOp::Seq(SEQ_VALUE_MAP)) {
                     return None;
@@ -6498,16 +6506,22 @@ impl<'a> Builder<'a> {
             None
         };
         let node = &self.nodes[cond as usize];
-        if let Some(parts) = parse(node) {
+        if let Some(parts) = parse(cond) {
             return Some(parts);
         }
         if matches!(node.op, ValOp::Un(o) if o == Op::Not as u32) && node.args.len() == 1 {
-            let inner = &self.nodes[node.args[0] as usize];
-            if let Some((key, map, _)) = parse(inner) {
+            if let Some((key, map, _)) = parse(node.args[0]) {
                 return Some((key, map, true));
             }
         }
         None
+    }
+
+    fn proven_own_property_guard_value(&self, value: ValueId) -> bool {
+        let span = self.node_span[value as usize];
+        ["Object.hasOwn", "Object.prototype.hasOwnProperty.call"]
+            .into_iter()
+            .any(|path| qualified_global_symbol_at_span(self.il, span, NodeKind::Seq, path))
     }
 
     fn map_lookup_value_matches(&mut self, value: ValueId, map: ValueId, key: ValueId) -> bool {

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -522,6 +522,14 @@ pub fn import_namespace_rhs_matches(
 fn symbol_evidence_at_node(il: &Il, node: NodeId) -> EvidenceResolution<SymbolEvidenceKind> {
     let span = il.node(node).span;
     let kind = il.kind(node);
+    symbol_evidence_at_node_anchor(il, span, kind)
+}
+
+fn symbol_evidence_at_node_anchor(
+    il: &Il,
+    span: Span,
+    kind: NodeKind,
+) -> EvidenceResolution<SymbolEvidenceKind> {
     unique_evidence_at(
         il,
         |anchor| {
@@ -658,6 +666,42 @@ pub fn imported_member_symbol(
                 .is_some_and(|receiver| imported_namespace_symbol(il, interner, receiver, module))
         }
         _ => false,
+    }
+}
+
+/// Prove that `node` denotes an exact language-defined qualified global path,
+/// such as `Array.from` or `Object.hasOwn`. This is intentionally evidence-only:
+/// unlike legacy import/global helpers, a matching selector spelling cannot prove
+/// a qualified API identity by itself.
+pub fn qualified_global_symbol(il: &Il, node: NodeId, path: &str) -> bool {
+    qualified_global_symbol_at_anchor(il, il.node(node).span, il.kind(node), path)
+}
+
+/// Prove a qualified global identity at a preserved span/kind anchor. This is
+/// used by value-graph consumers after IL node ids have been erased but source
+/// spans remain attached to value nodes.
+pub fn qualified_global_symbol_at_span(
+    il: &Il,
+    span: Option<Span>,
+    kind: NodeKind,
+    path: &str,
+) -> bool {
+    let Some(span) = span else {
+        return false;
+    };
+    qualified_global_symbol_at_anchor(il, span, kind, path)
+}
+
+fn qualified_global_symbol_at_anchor(il: &Il, span: Span, kind: NodeKind, path: &str) -> bool {
+    if qualified_global_symbol_contract(il.meta.lang, path).is_none() {
+        return false;
+    }
+    let expected = SymbolEvidenceKind::QualifiedGlobal {
+        path_hash: stable_symbol_hash(path),
+    };
+    match symbol_evidence_at_node_anchor(il, span, kind) {
+        EvidenceResolution::Found(actual) => actual == expected,
+        EvidenceResolution::Ambiguous | EvidenceResolution::Missing => false,
     }
 }
 
@@ -2342,6 +2386,7 @@ pub fn map_key_view_contract_by_hash(
 pub struct MapKeyViewWrapperContract {
     pub receiver: &'static str,
     pub method: &'static str,
+    pub qualified_path: &'static str,
 }
 
 pub fn map_key_view_wrapper_contract(
@@ -2354,6 +2399,7 @@ pub fn map_key_view_wrapper_contract(
         MapKeyViewWrapperContract {
             receiver: "Array",
             method: "from",
+            qualified_path: "Array.from",
         },
     )
 }
@@ -2460,6 +2506,7 @@ pub fn typeof_operator_contract(
 pub struct StaticGlobalMethodContract {
     pub receiver: &'static str,
     pub method: &'static str,
+    pub qualified_path: &'static str,
     pub requires_unshadowed_receiver: bool,
 }
 
@@ -2473,6 +2520,13 @@ pub struct StaticGlobalFunctionContract {
 pub struct StaticGlobalSymbolContract {
     pub name: &'static str,
     pub requires_unshadowed: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct QualifiedGlobalSymbolContract {
+    pub path: &'static str,
+    pub root: &'static str,
+    pub requires_unshadowed_root: bool,
 }
 
 pub fn static_global_symbol_contract(lang: Lang, name: &str) -> Option<StaticGlobalSymbolContract> {
@@ -2493,6 +2547,29 @@ pub fn static_global_symbol_contract(lang: Lang, name: &str) -> Option<StaticGlo
     Some(StaticGlobalSymbolContract {
         name,
         requires_unshadowed: true,
+    })
+}
+
+pub fn qualified_global_symbol_contract(
+    lang: Lang,
+    path: &str,
+) -> Option<QualifiedGlobalSymbolContract> {
+    if !js_like_lang(lang) {
+        return None;
+    }
+    let (path, root) = match path {
+        "Array.from" => ("Array.from", "Array"),
+        "Array.isArray" => ("Array.isArray", "Array"),
+        "Object.hasOwn" => ("Object.hasOwn", "Object"),
+        "Object.prototype.hasOwnProperty.call" => {
+            ("Object.prototype.hasOwnProperty.call", "Object")
+        }
+        _ => return None,
+    };
+    Some(QualifiedGlobalSymbolContract {
+        path,
+        root,
+        requires_unshadowed_root: true,
     })
 }
 
@@ -2519,6 +2596,7 @@ pub fn js_array_is_array_contract(
         StaticGlobalMethodContract {
             receiver: "Array",
             method: "isArray",
+            qualified_path: "Array.isArray",
             requires_unshadowed_receiver: true,
         },
     )
@@ -3432,6 +3510,85 @@ mod tests {
     }
 
     #[test]
+    fn qualified_global_symbol_contracts_are_language_and_path_scoped() {
+        assert_eq!(
+            qualified_global_symbol_contract(Lang::JavaScript, "Object.hasOwn"),
+            Some(QualifiedGlobalSymbolContract {
+                path: "Object.hasOwn",
+                root: "Object",
+                requires_unshadowed_root: true,
+            })
+        );
+        assert_eq!(
+            qualified_global_symbol_contract(Lang::TypeScript, "Array.from"),
+            Some(QualifiedGlobalSymbolContract {
+                path: "Array.from",
+                root: "Array",
+                requires_unshadowed_root: true,
+            })
+        );
+        assert!(qualified_global_symbol_contract(
+            Lang::JavaScript,
+            "Object.prototype.hasOwnProperty.call"
+        )
+        .is_some());
+        assert!(qualified_global_symbol_contract(Lang::Python, "Array.from").is_none());
+        assert!(
+            qualified_global_symbol_contract(Lang::JavaScript, "value.hasOwnProperty").is_none()
+        );
+        assert!(qualified_global_symbol_contract(Lang::JavaScript, "Array.fromAsync").is_none());
+    }
+
+    #[test]
+    fn qualified_global_symbol_requires_matching_node_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let array = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("Array")),
+            sp(27),
+            &[],
+        );
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("from")),
+            sp(27),
+            &[array],
+        );
+        let root = b.add(NodeKind::Module, Payload::None, sp(27), &[field]);
+        let mut il = finish_il(b, root, Lang::JavaScript);
+
+        assert!(!qualified_global_symbol(&il, field, "Array.from"));
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(27), NodeKind::Field),
+            EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+                path_hash: stable_symbol_hash("Array.from"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        assert!(qualified_global_symbol(&il, field, "Array.from"));
+        assert!(qualified_global_symbol_at_span(
+            &il,
+            Some(sp(27)),
+            NodeKind::Field,
+            "Array.from"
+        ));
+        assert!(!qualified_global_symbol(&il, field, "Array.fromAsync"));
+
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(sp(27), NodeKind::Field),
+            EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+                path_hash: stable_symbol_hash("Array.isArray"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        assert!(!qualified_global_symbol(&il, field, "Array.from"));
+    }
+
+    #[test]
     fn language_predicates_preserve_existing_gates() {
         for &lang in ALL_LANGS {
             let profile = semantics(lang);
@@ -4087,6 +4244,7 @@ mod tests {
             Some(MapKeyViewWrapperContract {
                 receiver: "Array",
                 method: "from",
+                qualified_path: "Array.from",
             })
         );
         assert_eq!(
@@ -4200,6 +4358,7 @@ mod tests {
             Some(StaticGlobalMethodContract {
                 receiver: "Array",
                 method: "isArray",
+                qualified_path: "Array.isArray",
                 requires_unshadowed_receiver: true,
             })
         );

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -58,7 +58,7 @@ The current implemented kinds are:
 | `Source` | construct syntax, regex literal provenance, and source operator family |
 | `Domain` | receiver/value domain such as collection, map, option, string, integer, or byte array |
 | `Import` | static import binding and namespace proof |
-| `Symbol` | resolved or proven symbol identity, with record kinds for unshadowed globals and static imported binding/namespace aliases |
+| `Symbol` | resolved or proven symbol identity, with record kinds for unshadowed globals, static imported binding/namespace aliases, and selected qualified global API paths |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, record guard, or Go composite map literal |
 
 ## Consumption Rules
@@ -87,6 +87,11 @@ evidence does not by itself prove every use of the same local name; if the alias
 is rebound or ambiguous, the exact path stays closed until a node-level symbol
 fact or stronger scope-resolution evidence exists.
 
+Qualified global identity is also evidence, not a selector guess. The current
+first-party JS/TS producer emits `QualifiedGlobal` only for selected static paths
+whose root is proven unshadowed, such as `Object.hasOwn`,
+`Object.prototype.hasOwnProperty.call`, `Array.from`, and `Array.isArray`.
+
 ## Current Producers
 
 First-party frontends now mirror these facts into `EvidenceRecord`:
@@ -98,12 +103,17 @@ First-party frontends now mirror these facts into `EvidenceRecord`:
 - JS/TS static-global value occurrences that remain as `Var` nodes, such as
   member receivers, call callees, constructors, and `undefined`, emit
   `UnshadowedGlobal` symbol evidence when the frontend proves no local shadow;
+- selected JS/TS qualified static global paths emit `QualifiedGlobal` symbol
+  evidence at the lowered node anchor: own-property guards at their
+  `Seq("own_property_guard")` node, and static member expressions such as
+  `Array.from` and `Array.isArray` at their `Field` node;
 - lowered `Seq` surfaces emit `SequenceSurface` evidence.
 
 The older `ParamTypeFact`, `SourceFact`, and raw import `Seq` shapes remain as
-compatibility mirrors. Some direct JS/TS guard lowerings still use compatibility
-shadow scans until qualified-member and guard evidence lands. These mirrors are
-not the desired pack boundary.
+compatibility mirrors. JS/TS record-shape guard lowering still needs dedicated
+multi-obligation guard evidence for surfaces such as `Array.isArray(...)` plus
+optional `Boolean(...)`; that is separate from the selected qualified-path
+evidence already landed. These mirrors are not the desired pack boundary.
 
 ## Current Consumers
 
@@ -120,8 +130,13 @@ callers:
   `new Map(...)`/`new Set(...)` constructor contracts, static `Array.isArray`
   exact gates, and `undefined` nullish-default handling, with compatibility
   fallback only when no relevant evidence record exists;
+- qualified-global symbol proof for selected JS/TS API paths: own-property
+  guard normalization and strict exact safety require evidence for
+  `Object.hasOwn` or `Object.prototype.hasOwnProperty.call`, and map-key view
+  wrappers require evidence for `Array.from`;
 - sequence-surface admission for normalize/value-graph/detect exact paths.
 
 Field/place/effect facts, receiver/protocol evidence beyond parameter domains,
-full scope-resolution and namespace-member evidence, report-level provenance,
-and external manifest loading are still open work.
+full scope-resolution and namespace-member evidence, record-shape
+multi-obligation guard evidence, report-level provenance, and external manifest
+loading are still open work.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -238,6 +238,13 @@ and pack ecosystem.
   `undefined` when no local shadow is proven. JS/TS `Math.*` no longer lowers
   directly to builtins in the frontend; normalize consumes the preserved
   `Field(Var(global), method)` shape through symbol-proof contracts instead.
+- Selected JS/TS qualified static global paths now emit `QualifiedGlobal`
+  evidence. `Object.hasOwn` and
+  `Object.prototype.hasOwnProperty.call` gate own-property guard normalization
+  and strict exact safety, while `Array.from` gates JS-like map-key iterator
+  wrappers. `Array.isArray` emits the same path evidence for strict exact call
+  gates. Full namespace-member resolution and record-shape multi-obligation
+  guard evidence remain open.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -297,7 +304,12 @@ Remaining in this phase:
 - Remove the remaining raw import/module proof IL payload storage after import
   and symbol evidence records can carry every consumer obligation, including
   namespace-member resolution, module export dependencies, scope, rebinding, and
-  mutation proof.
+  mutation proof. Selected JS/TS `QualifiedGlobal` paths are now covered, but
+  general qualified-member and namespace export identity is not.
+- Add dedicated guard evidence for multi-obligation guards such as JS/TS
+  record-shape checks, where one lowered guard depends on source operator facts,
+  several qualified/static API facts, subject identity, and truthiness/null
+  semantics.
 - Expand the first `SequenceSurface` evidence into sequence/aggregate records for
   factories, nested entries, iterator views, and exported-literal eligibility.
 - Expand domain evidence from parameter annotations into receiver/protocol

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -164,7 +164,8 @@ migrated.
 - Map key-view contracts distinguish collection views from iterator views:
   Python/Ruby `keys` and Java `keySet` are collection views, while JS-like
   `Map.keys()` is an iterator view and needs the `Array.from(...)` wrapper
-  contract before it can feed exact membership.
+  contract plus `QualifiedGlobal("Array.from")` symbol evidence before it can
+  feed exact membership.
 - Map lookup surfaces that return a value/option are now explicit contracts for
   Java/Rust/JS-like `get(key)` plus an exact-map receiver requirement. Python
   `dict.get(key, default)`, Java `getOrDefault`, and Ruby `fetch` still use the
@@ -236,8 +237,11 @@ migrated.
   `Map`, `Set`, and `undefined` when the frontend proves no local shadow.
   Normalize idiom admission, value-graph namespace fallbacks, and strict exact
   gates consume `nose-semantics` symbol-proof helpers instead of each re-scanning
-  raw import assignment or global shadow shapes. Direct JS/TS guard lowerings for
-  some qualified members still need a dedicated evidence slice.
+  raw import assignment or global shadow shapes. Selected JS/TS qualified static
+  global paths now emit `QualifiedGlobal` evidence as well: `Object.hasOwn` and
+  `Object.prototype.hasOwnProperty.call` gate own-property guards, while
+  `Array.from` gates JS-like map-key iterator wrappers. This does not cover all
+  qualified members or namespace exports.
   A spelling such as `Math`, `fmt`, or `deque` is still only a selector; exact
   consumers need symbol identity proof plus the language/API contract. Binding
   evidence does not prove later uses if the alias is rebound or ambiguous.
@@ -261,6 +265,10 @@ Semantic knowledge still appears in several forms outside the facade:
   provenance, and external pack manifests remain open;
 - language-specific import, symbol, or module proof mechanics that are still
   local to frontend, normalize, detect, or value-graph callers;
+- JS/TS record-shape guards still need dedicated multi-obligation guard
+  evidence, because their proof depends on several source/API facts such as
+  `typeof`, `Array.isArray`, optional `Boolean`, null/truthiness, and matching
+  subject identity;
 - IL still stores import facts as `Seq("import_binding")` /
   `Seq("import_namespace")` payloads for compatibility. Frontends also emit
   `EvidenceRecord::Import`, and semantic interpretation flows through typed

--- a/docs/source-facts.md
+++ b/docs/source-facts.md
@@ -55,9 +55,10 @@ preconditions.
 1. A frontend or language pack parses source, lowers to IL, and emits
    kernel-defined evidence records for source distinctions that would otherwise
    be lost.
-2. The semantic kernel validates the fact shape and the surrounding obligations:
+2. The semantic kernel checks the fact shape and contract admission obligations:
    language, arity, receiver, symbol/import proof, shadowing, scope, version,
-   mutation, demand, and effects.
+   mutation, demand, and effects. External semantic correctness remains the
+   provider's claim and the user's opt-in decision.
 3. Contracts consume validated evidence. If a required fact is missing or
    ambiguous, the exact channel stays closed.
 4. Normalize and detect use only admitted contracts and kernel proof helpers for
@@ -72,7 +73,7 @@ The pack-facing vocabulary should cover at least these classes.
 
 | class | examples |
 |---|---|
-| Symbol and import | resolved import binding, namespace import, unshadowed language global, version range |
+| Symbol and import | resolved import binding, namespace import, unshadowed language global, qualified global/member API path, version range |
 | Receiver and domain | array, collection, map, option, string, primitive integer, byte array, promise-like receiver |
 | Operator | strict equality, loose equality, identity equality, value equality, type membership, language membership |
 | Literal and surface | regex literal, string literal, map/object literal, tuple/list/array surface, computed property key |
@@ -102,6 +103,10 @@ compatibility mirror while consumers migrate to evidence records.
 - JS-like static membership callbacks such as `x => x === value` consume source
   operator facts and require strict equality/inequality. Loose equality and
   `instanceof` stay closed for those exact contracts.
+- Qualified API path evidence is symbol evidence, not a source fact by itself.
+  The current JS/TS producer emits selected `QualifiedGlobal` facts such as
+  `Object.hasOwn`, `Object.prototype.hasOwnProperty.call`, and `Array.from`
+  only when their root global is proven unshadowed.
 
 The slice deliberately does not claim that all equality semantics are modeled.
 The IL still has coarse equality operators; source facts are the evidence that


### PR DESCRIPTION
## Summary

Adds a first-party qualified-global symbol evidence slice for selected JS/TS static API paths.

- Adds `SymbolEvidenceKind::QualifiedGlobal` and `nose-semantics` helpers for node and span/kind anchored proof.
- Adds JS/TS qualified path contracts for `Object.hasOwn`, `Object.prototype.hasOwnProperty.call`, `Array.from`, and `Array.isArray`.
- Emits `QualifiedGlobal` evidence from JS/TS lowering only when the root global is proven unshadowed.
- Makes own-property guard normalization and strict exact safety require qualified evidence for `Object.hasOwn*`.
- Makes JS-like `Array.from(map.keys())` map-key iterator wrapper recognition require `QualifiedGlobal("Array.from")` instead of raw receiver spelling plus file shadow scans.
- Makes `Array.isArray(...)` strict exact admission require the qualified coordinate as well as existing static-global proof.
- Documents the landed selected-path scope and leaves record-shape multi-obligation guard evidence as future work.

## Precision / recall judgment

This is a precision-oriented migration. Previously, some consumers trusted source text or receiver spelling after local shadow scans. The new path requires an explicit language-scoped qualified-path contract plus symbol evidence. Existing positive JS/TS own-property and `Array.from(map.keys())` cases remain open because the first-party frontend now emits the required evidence. Shadowed `Object` and shadowed `Array` cases stay closed.

Record-shape guards are deliberately not fully migrated in this PR. They need dedicated multi-obligation guard evidence because one lowered guard can depend on `typeof`, `Array.isArray`, optional `Boolean`, null/truthiness semantics, and subject identity.

## Validation

- `cargo fmt --all --check`
- `cargo test -p nose-semantics --lib qualified_global -- --nocapture`
- `cargo test -p nose-frontend --lib js_qualified_global -- --nocapture`
- `cargo test -p nose-cli --test cli scan_mode_semantic_proves_js_own_property_guards -- --exact --nocapture`
- `cargo test -p nose-cli --test equivalence map_key_membership_converges_cross_language_with_boundaries -- --exact --nocapture`
- `cargo test -p nose-cli --test equivalence literal_map_default_lookup_converges_with_js_object_own_property_boundaries -- --exact --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo build --release && ./scripts/check-duplication.sh`
- `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `git diff --cached --check`
- `awiki lint --root docs`

Refs #109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 전역 심볼 섀도우 처리 및 한정된 전역 경로에 대한 테스트 커버리지 강화

* **Refactor**
  * 정규화된 전역 심볼 경로 인식 및 안전성 판정 로직 정밀화
  * 소유 속성 가드와 맵 키 뷰 검증 메커니즘 개선

* **Documentation**
  * 심볼 증거 기록 스키마 및 의미 커널 문서 업데이트
  * 한정된 전역 API 경로 검증 프로세스 설명 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->