### PR TITLE
semantics: require evidence-backed import identity

### DIFF
--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -7,11 +7,13 @@
 //! module-binding seed can reuse its mutation and canonicalization logic.
 
 use nose_il::{
-    stable_symbol_hash, Il, Interner, Node, NodeId, NodeKind, Payload, Span, Symbol, UnitKind,
+    stable_symbol_hash, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
+    EvidenceProvenance, EvidenceRecord, EvidenceStatus, Il, ImportEvidenceKind, Interner, Node,
+    NodeId, NodeKind, Payload, Span, Symbol, SymbolEvidenceKind, UnitKind,
 };
 use nose_semantics::{
     import_fact_rhs, java_map_entry_contract, java_map_factory_contract, semantics, ImportFactKind,
-    ImportedMapFactoryContract, JavaMapFactoryKind,
+    ImportedMapFactoryContract, JavaMapFactoryKind, FIRST_PARTY_PACK_ID,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::Path;
@@ -73,6 +75,11 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
         for (stmt, deps, snapshot) in file_replacements {
             for dep in deps {
                 let dep_stmt = append_snapshot(&mut files[file_idx], &dep);
+                mirror_import_fact_evidence_for_assignment(
+                    &mut files[file_idx],
+                    interner,
+                    dep_stmt,
+                );
                 prepend_root_statement(&mut files[file_idx], dep_stmt);
             }
             let rhs = append_snapshot(&mut files[file_idx], &snapshot);
@@ -686,6 +693,91 @@ fn replace_assignment_rhs(il: &mut Il, stmt: NodeId, rhs: NodeId) {
     }
 }
 
+fn mirror_import_fact_evidence_for_assignment(il: &mut Il, interner: &Interner, stmt: NodeId) {
+    if il.kind(stmt) != NodeKind::Assign {
+        return;
+    }
+    let kids = il.children(stmt);
+    let [lhs, rhs] = kids else {
+        return;
+    };
+    let local = match il.node(*lhs).payload {
+        Payload::Name(symbol) => Some(stable_symbol_hash(interner.resolve(symbol))),
+        Payload::Cid(cid) => il
+            .cid_names
+            .get(cid as usize)
+            .map(|&symbol| stable_symbol_hash(interner.resolve(symbol))),
+        _ => None,
+    };
+    let Some(local_hash) = local else {
+        return;
+    };
+    let Some(fact) = import_fact_rhs(il, interner, *rhs) else {
+        return;
+    };
+    let import_kind = match fact.kind {
+        ImportFactKind::Binding => {
+            let Some(exported_hash) = fact.exported_hash else {
+                return;
+            };
+            EvidenceKind::Import(ImportEvidenceKind::Binding {
+                module_hash: fact.module_hash,
+                exported_hash,
+            })
+        }
+        ImportFactKind::Namespace => EvidenceKind::Import(ImportEvidenceKind::Namespace {
+            module_hash: fact.module_hash,
+        }),
+    };
+    let symbol_kind = match fact.kind {
+        ImportFactKind::Binding => {
+            let Some(exported_hash) = fact.exported_hash else {
+                return;
+            };
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+                module_hash: fact.module_hash,
+                exported_hash,
+            })
+        }
+        ImportFactKind::Namespace => EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace {
+            module_hash: fact.module_hash,
+        }),
+    };
+    push_first_party_evidence(
+        il,
+        EvidenceAnchor::sequence(il.node(*rhs).span),
+        import_kind,
+        "module_import_snapshot_import",
+    );
+    push_first_party_evidence(
+        il,
+        EvidenceAnchor::binding(il.node(stmt).span, local_hash),
+        import_kind,
+        "module_import_snapshot_binding_import",
+    );
+    push_first_party_evidence(
+        il,
+        EvidenceAnchor::binding(il.node(stmt).span, local_hash),
+        symbol_kind,
+        "module_import_snapshot_symbol",
+    );
+}
+
+fn push_first_party_evidence(il: &mut Il, anchor: EvidenceAnchor, kind: EvidenceKind, rule: &str) {
+    il.evidence.push(EvidenceRecord {
+        id: EvidenceId(il.evidence.len() as u32),
+        anchor,
+        kind,
+        provenance: EvidenceProvenance {
+            emitter: EvidenceEmitter::FirstParty,
+            pack_hash: Some(stable_symbol_hash(FIRST_PARTY_PACK_ID)),
+            rule_hash: Some(stable_symbol_hash(rule)),
+        },
+        dependencies: Vec::new(),
+        status: EvidenceStatus::Asserted,
+    });
+}
+
 fn prepend_root_statement(il: &mut Il, stmt: NodeId) {
     let old_root = il.root;
     let old_root_node = *il.node(old_root);
@@ -762,5 +854,60 @@ mod tests {
             !binding_mutated(&il, &interner, lookup, assign),
             "read-only lookup methods should not block immutable import replacement"
         );
+    }
+
+    #[test]
+    fn import_snapshot_assignment_regenerates_import_and_symbol_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let span = Span::new(FileId(0), 0, 1, 1, 1);
+        let map = interner.intern("Map");
+        let lhs = b.add(NodeKind::Var, Payload::Name(map), span, &[]);
+        let module = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("java.util")),
+            span,
+            &[],
+        );
+        let exported = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("Map")),
+            span,
+            &[],
+        );
+        let tag = interner.intern(nose_semantics::import_fact_tag(ImportFactKind::Binding));
+        let rhs = b.add(NodeKind::Seq, Payload::Name(tag), span, &[module, exported]);
+        let assign = b.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs]);
+        let root = b.add(NodeKind::Module, Payload::None, span, &[assign]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "imported.java".into(),
+                lang: Lang::Java,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+
+        mirror_import_fact_evidence_for_assignment(&mut il, &interner, assign);
+
+        assert!(il.evidence.iter().any(|record| matches!(
+            record.kind,
+            EvidenceKind::Import(ImportEvidenceKind::Binding {
+                module_hash,
+                exported_hash,
+            }) if record.anchor == EvidenceAnchor::sequence(span)
+                && module_hash == stable_symbol_hash("java.util")
+                && exported_hash == stable_symbol_hash("Map")
+        )));
+        assert!(il.evidence.iter().any(|record| matches!(
+            record.kind,
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+                module_hash,
+                exported_hash,
+            }) if record.anchor == EvidenceAnchor::binding(span, stable_symbol_hash("Map"))
+                && module_hash == stable_symbol_hash("java.util")
+                && exported_hash == stable_symbol_hash("Map")
+        )));
     }
 }

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -926,8 +926,9 @@ mod tests {
     use nose_il::stable_symbol_hash;
     use nose_il::{
         EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
-        EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, Lang, ParamSemantic,
-        ParamTypeFact, SequenceSurfaceKind, Span, Unit, UnitKind,
+        EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, ImportEvidenceKind, Lang,
+        ParamSemantic, ParamTypeFact, SequenceSurfaceKind, Span, SymbolEvidenceKind, Unit,
+        UnitKind,
     };
     use nose_semantics::{import_fact_tag, ImportFactKind};
 
@@ -1335,7 +1336,7 @@ mod tests {
         let call = b.add(NodeKind::Call, Payload::None, sp(), &[field, arg]);
         module_kids.push(call);
         let root = b.add(NodeKind::Module, Payload::None, sp(), &module_kids);
-        let il = b.finish(
+        let mut il = b.finish(
             root,
             FileMeta {
                 path: "t".to_string(),
@@ -1344,6 +1345,24 @@ mod tests {
             Vec::new(),
             Vec::new(),
         );
+        if with_import {
+            il.evidence.push(evidence(
+                0,
+                EvidenceAnchor::sequence(sp()),
+                EvidenceKind::Import(ImportEvidenceKind::Namespace {
+                    module_hash: stable_symbol_hash("math"),
+                }),
+                EvidenceStatus::Asserted,
+            ));
+            il.evidence.push(evidence(
+                1,
+                EvidenceAnchor::binding(sp(), stable_symbol_hash("math")),
+                EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace {
+                    module_hash: stable_symbol_hash("math"),
+                }),
+                EvidenceStatus::Asserted,
+            ));
+        }
         (il, interner, call)
     }
 

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -52,7 +52,7 @@ use nose_semantics::{
     builder_append_method_contract, builtin_tag, construct_syntax_proof,
     domain_evidence_for_param as semantic_domain_evidence_for_param,
     exact_static_membership_predicate_operator, free_function_builtin_contract,
-    go_zero_map_default_kind, go_zero_map_lookup_contract, import_fact_contract,
+    go_zero_map_default_kind, go_zero_map_lookup_contract, import_fact_evidence_rhs,
     imported_namespace_function_contract, imported_namespace_symbol,
     iterator_identity_adapter_contract, java_collection_factory_contract_by_hash,
     java_map_entry_contract_by_hash, java_map_factory_contract_by_hash,
@@ -315,16 +315,23 @@ struct FieldStateKey {
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 enum ValOp {
-    Input(u32),      // a parameter or free variable, keyed by canonical id
-    Const(u32),      // literal class
-    Bin(u32),        // binary operator
-    Un(u32),         // unary operator
-    Field(u64),      // field access, keyed by content hash of the name
-    Index,           // base[index]
-    Call(u32),       // 0 = opaque callee; otherwise builtin discriminant + 1
-    Hof(u32),        // higher-order op kind
-    Clamp,           // numeric clamp over proven integer bounds: args = [x, lo, hi]
-    Seq(u64),        // aggregate literal, keyed by lowered sequence kind
+    Input(u32), // a parameter or free variable, keyed by canonical id
+    Const(u32), // literal class
+    Bin(u32),   // binary operator
+    Un(u32),    // unary operator
+    Field(u64), // field access, keyed by content hash of the name
+    Index,      // base[index]
+    Call(u32),  // 0 = opaque callee; otherwise builtin discriminant + 1
+    Hof(u32),   // higher-order op kind
+    Clamp,      // numeric clamp over proven integer bounds: args = [x, lo, hi]
+    Seq(u64),   // aggregate literal, keyed by lowered sequence kind
+    ImportNamespace {
+        module_hash: u64,
+    },
+    ImportBinding {
+        module_hash: u64,
+        exported_hash: u64,
+    },
     CollectionParam, // proven collection parameter, distinct from map-like key membership
     ArrayParam,      // proven array parameter, distinct from receiver-provided collections
     StringParam,     // proven string parameter, distinct from collection emptiness
@@ -1016,33 +1023,42 @@ impl<'a> Builder<'a> {
 
     fn is_import_namespace_value(&self, value: ValueId, module: &str) -> bool {
         let node = &self.nodes[value as usize];
-        let contract = import_fact_contract(ImportFactKind::Namespace);
-        if !matches!(node.op, ValOp::Seq(tag) if tag == contract.value_tag)
-            || node.args.len() != contract.coordinate_count
-        {
-            return false;
-        }
         matches!(
-            self.nodes[node.args[0] as usize].op,
-            ValOp::Const(k) if k == stable_string_const_key(module)
+            node.op,
+            ValOp::ImportNamespace { module_hash }
+                if module_hash == stable_symbol_hash(module)
         )
     }
 
     fn is_import_binding_value(&self, value: ValueId, module: &str, exported: &str) -> bool {
         let node = &self.nodes[value as usize];
-        let contract = import_fact_contract(ImportFactKind::Binding);
-        if !matches!(node.op, ValOp::Seq(tag) if tag == contract.value_tag)
-            || node.args.len() != contract.coordinate_count
-        {
-            return false;
-        }
         matches!(
-            self.nodes[node.args[0] as usize].op,
-            ValOp::Const(k) if k == stable_string_const_key(module)
-        ) && matches!(
-            self.nodes[node.args[1] as usize].op,
-            ValOp::Const(k) if k == stable_string_const_key(exported)
+            node.op,
+            ValOp::ImportBinding {
+                module_hash,
+                exported_hash,
+            } if module_hash == stable_symbol_hash(module)
+                && exported_hash == stable_symbol_hash(exported)
         )
+    }
+
+    fn import_fact_value(&mut self, expr: NodeId) -> Option<ValueId> {
+        let fact = import_fact_evidence_rhs(self.il, expr)?;
+        match fact.kind {
+            ImportFactKind::Namespace => Some(self.mk(
+                ValOp::ImportNamespace {
+                    module_hash: fact.module_hash,
+                },
+                vec![],
+            )),
+            ImportFactKind::Binding => Some(self.mk(
+                ValOp::ImportBinding {
+                    module_hash: fact.module_hash,
+                    exported_hash: fact.exported_hash?,
+                },
+                vec![],
+            )),
+        }
     }
 
     fn file_imports_namespace(&self, expr: NodeId, module: &str) -> bool {
@@ -7508,17 +7524,14 @@ impl<'a> Builder<'a> {
                             }
                         }
                         let receiver = &self.nodes[a[0] as usize];
-                        let namespace = import_fact_contract(ImportFactKind::Namespace);
-                        if matches!(receiver.op, ValOp::Seq(tag) if tag == namespace.value_tag)
-                            && receiver.args.len() == 1
-                        {
-                            let module = receiver.args[0];
-                            let exported = self.mk(
-                                ValOp::Const(stable_string_const_key(self.interner.resolve(s))),
+                        if let ValOp::ImportNamespace { module_hash } = receiver.op {
+                            return self.mk(
+                                ValOp::ImportBinding {
+                                    module_hash,
+                                    exported_hash: stable_symbol_hash(self.interner.resolve(s)),
+                                },
                                 vec![],
                             );
-                            let binding = import_fact_contract(ImportFactKind::Binding);
-                            return self.mk(ValOp::Seq(binding.value_tag), vec![module, exported]);
                         }
                     }
                 }
@@ -7775,6 +7788,9 @@ impl<'a> Builder<'a> {
                 }
             }
             NodeKind::Seq => {
+                if let Some(value) = self.import_fact_value(expr) {
+                    return value;
+                }
                 let kids = self.il.children(expr).to_vec();
                 let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
                 if matches!(node.payload, Payload::Builtin(Builtin::DictEntry)) {
@@ -7866,7 +7882,11 @@ impl<'a> Builder<'a> {
                 && weight[i] >= min_weight
                 && !matches!(
                     self.nodes[i].op,
-                    ValOp::Const(_) | ValOp::Input(_) | ValOp::Elem(_)
+                    ValOp::Const(_)
+                        | ValOp::Input(_)
+                        | ValOp::Elem(_)
+                        | ValOp::ImportNamespace { .. }
+                        | ValOp::ImportBinding { .. }
                 )
             {
                 let (line_start, line_end) = self
@@ -8243,6 +8263,11 @@ fn op_tag(op: &ValOp) -> u64 {
         ValOp::Hof(h) => (8, *h as u64),
         ValOp::Clamp => (20, 0),
         ValOp::Seq(t) => (9, *t),
+        ValOp::ImportNamespace { module_hash } => (21, *module_hash),
+        ValOp::ImportBinding {
+            module_hash,
+            exported_hash,
+        } => (22, combine(*module_hash, *exported_hash)),
         ValOp::CollectionParam => (17, 0),
         ValOp::ArrayParam => (18, 0),
         ValOp::StringParam => (19, 0),
@@ -8272,11 +8297,41 @@ fn stable_float_const_key(value: &str) -> u32 {
 mod tests {
     use super::*;
     use nose_il::{
-        FileId, FileMeta, IlBuilder, Lang, ParamSemantic, ParamTypeFact, Span, Unit, UnitKind,
+        EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
+        EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, ImportEvidenceKind, Lang,
+        ParamSemantic, ParamTypeFact, Span, Unit, UnitKind,
     };
+    use nose_semantics::{import_fact_tag, FIRST_PARTY_PACK_ID};
 
     fn sp(line: u32) -> Span {
         Span::new(FileId(0), line, line, line, line)
+    }
+
+    fn finish_test_il(builder: IlBuilder, root: NodeId, lang: Lang) -> Il {
+        builder.finish(
+            root,
+            FileMeta {
+                path: "t".into(),
+                lang,
+            },
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    fn evidence(id: u32, anchor: EvidenceAnchor, kind: EvidenceKind) -> EvidenceRecord {
+        EvidenceRecord {
+            id: EvidenceId(id),
+            anchor,
+            kind,
+            provenance: EvidenceProvenance {
+                emitter: EvidenceEmitter::FirstParty,
+                pack_hash: Some(stable_symbol_hash(FIRST_PARTY_PACK_ID)),
+                rule_hash: Some(stable_symbol_hash("test")),
+            },
+            dependencies: Vec::new(),
+            status: EvidenceStatus::Asserted,
+        }
     }
 
     #[derive(Clone, Copy)]
@@ -8439,6 +8494,93 @@ mod tests {
             builder.clamp_candidate_count,
             builder.clamp_proof_backed_candidate_count,
         )
+    }
+
+    #[test]
+    fn import_binding_value_requires_sequence_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let tag = interner.intern(import_fact_tag(ImportFactKind::Binding));
+        let module = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("collections")),
+            sp(40),
+            &[],
+        );
+        let exported = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("deque")),
+            sp(40),
+            &[],
+        );
+        let binding = b.add(
+            NodeKind::Seq,
+            Payload::Name(tag),
+            sp(40),
+            &[module, exported],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(40), &[binding]);
+        let mut il = finish_test_il(b, root, Lang::Python);
+
+        let mut builder = Builder::new(&il, &interner);
+        let raw = builder.eval(binding, &FxHashMap::default());
+        assert!(matches!(builder.nodes[raw as usize].op, ValOp::Seq(_)));
+        assert!(!builder.is_import_binding_value(raw, "collections", "deque"));
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(40)),
+            EvidenceKind::Import(ImportEvidenceKind::Binding {
+                module_hash: stable_symbol_hash("collections"),
+                exported_hash: stable_symbol_hash("deque"),
+            }),
+        ));
+        let mut builder = Builder::new(&il, &interner);
+        let proven = builder.eval(binding, &FxHashMap::default());
+        assert!(matches!(
+            builder.nodes[proven as usize].op,
+            ValOp::ImportBinding { .. }
+        ));
+        assert!(builder.is_import_binding_value(proven, "collections", "deque"));
+    }
+
+    #[test]
+    fn namespace_member_import_binding_requires_proven_namespace_value() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let namespace_tag = interner.intern(import_fact_tag(ImportFactKind::Namespace));
+        let prod = interner.intern("prod");
+        let module = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("math")),
+            sp(50),
+            &[],
+        );
+        let namespace = b.add(
+            NodeKind::Seq,
+            Payload::Name(namespace_tag),
+            sp(50),
+            &[module],
+        );
+        let field = b.add(NodeKind::Field, Payload::Name(prod), sp(51), &[namespace]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(50), &[field]);
+        let mut il = finish_test_il(b, root, Lang::Python);
+
+        let mut builder = Builder::new(&il, &interner);
+        let raw = builder.eval(field, &FxHashMap::default());
+        assert!(matches!(builder.nodes[raw as usize].op, ValOp::Field(_)));
+        assert!(!builder.is_import_binding_value(raw, "math", "prod"));
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(50)),
+            EvidenceKind::Import(ImportEvidenceKind::Namespace {
+                module_hash: stable_symbol_hash("math"),
+            }),
+        ));
+        let mut builder = Builder::new(&il, &interner);
+        let proven = builder.eval(field, &FxHashMap::default());
+        assert!(builder.is_import_binding_value(proven, "math", "prod"));
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -441,12 +441,8 @@ pub struct ImportFact {
     pub exported_hash: Option<u64>,
 }
 
-pub fn import_fact_rhs(il: &Il, interner: &Interner, rhs: NodeId) -> Option<ImportFact> {
-    if il.kind(rhs) != NodeKind::Seq {
-        return None;
-    }
-    let span = il.node(rhs).span;
-    match unique_evidence_at(
+fn import_fact_evidence_at_sequence_span(il: &Il, span: Span) -> EvidenceResolution<ImportFact> {
+    unique_evidence_at(
         il,
         |anchor| matches!(anchor, EvidenceAnchor::Sequence { span: anchor_span } if anchor_span == span),
         |evidence| match evidence {
@@ -467,7 +463,27 @@ pub fn import_fact_rhs(il: &Il, interner: &Interner, rhs: NodeId) -> Option<Impo
             }
             _ => None,
         },
-    ) {
+    )
+}
+
+/// Evidence-only import fact resolution for semantic consumers. This intentionally
+/// does not parse the legacy raw `Seq("import_*")` payload: callers that use this
+/// helper are relying on a provider-owned evidence record, not on tag spelling.
+pub fn import_fact_evidence_rhs(il: &Il, rhs: NodeId) -> Option<ImportFact> {
+    if il.kind(rhs) != NodeKind::Seq {
+        return None;
+    }
+    match import_fact_evidence_at_sequence_span(il, il.node(rhs).span) {
+        EvidenceResolution::Found(fact) => Some(fact),
+        EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
+    }
+}
+
+pub fn import_fact_rhs(il: &Il, interner: &Interner, rhs: NodeId) -> Option<ImportFact> {
+    if il.kind(rhs) != NodeKind::Seq {
+        return None;
+    }
+    match import_fact_evidence_at_sequence_span(il, il.node(rhs).span) {
         EvidenceResolution::Found(fact) => return Some(fact),
         EvidenceResolution::Ambiguous => return None,
         EvidenceResolution::Missing => {}
@@ -620,9 +636,7 @@ pub fn imported_namespace_symbol(il: &Il, interner: &Interner, node: NodeId, mod
     let expected = SymbolEvidenceKind::ImportedNamespace {
         module_hash: stable_symbol_hash(module),
     };
-    imported_symbol(il, interner, node, expected, |rhs| {
-        import_namespace_rhs_matches(il, interner, rhs, module)
-    })
+    imported_symbol(il, interner, node, expected)
 }
 
 /// Prove that `node` denotes a static imported binding for `module.exported`.
@@ -637,9 +651,7 @@ pub fn imported_binding_symbol(
         module_hash: stable_symbol_hash(module),
         exported_hash: stable_symbol_hash(exported),
     };
-    imported_symbol(il, interner, node, expected, |rhs| {
-        import_binding_rhs_matches(il, interner, rhs, module, exported)
-    })
+    imported_symbol(il, interner, node, expected)
 }
 
 /// Prove either `from module import exported as local; local(...)` or
@@ -710,7 +722,6 @@ fn imported_symbol(
     interner: &Interner,
     node: NodeId,
     expected: SymbolEvidenceKind,
-    legacy_rhs_matches: impl Fn(NodeId) -> bool,
 ) -> bool {
     if il.kind(node) != NodeKind::Var {
         return false;
@@ -740,7 +751,7 @@ fn imported_symbol(
         EvidenceResolution::Ambiguous => return false,
         EvidenceResolution::Missing => {}
     }
-    assignment_rhs(il, *assignment).is_some_and(&legacy_rhs_matches)
+    false
 }
 
 fn top_level_statements(il: &Il) -> Vec<NodeId> {
@@ -755,10 +766,6 @@ fn top_level_statements(il: &Il) -> Vec<NodeId> {
             }
             statements
         })
-}
-
-fn assignment_rhs(il: &Il, stmt: NodeId) -> Option<NodeId> {
-    assignment_parts(il, stmt).map(|(_, rhs)| rhs)
 }
 
 fn assignment_alias_hash(il: &Il, interner: &Interner, stmt: NodeId) -> Option<u64> {
@@ -3288,6 +3295,7 @@ mod tests {
             "collections",
             "deque"
         ));
+        assert_eq!(import_fact_evidence_rhs(&il, binding), None);
         assert!(!import_binding_rhs_matches(
             &il,
             &interner,
@@ -3368,6 +3376,75 @@ mod tests {
             EvidenceStatus::Asserted,
         ));
         assert_eq!(import_fact_rhs(&il, &interner, binding), None);
+        assert_eq!(import_fact_evidence_rhs(&il, binding), None);
+    }
+
+    #[test]
+    fn imported_symbol_identity_does_not_fall_back_to_raw_import_seq() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let local = interner.intern("deque");
+        let binding_tag = interner.intern(import_fact_tag(ImportFactKind::Binding));
+        let module = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("collections")),
+            sp(30),
+            &[],
+        );
+        let exported = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("deque")),
+            sp(30),
+            &[],
+        );
+        let lhs = b.add(NodeKind::Var, Payload::Name(local), sp(30), &[]);
+        let rhs = b.add(
+            NodeKind::Seq,
+            Payload::Name(binding_tag),
+            sp(30),
+            &[module, exported],
+        );
+        let assignment = b.add(NodeKind::Assign, Payload::None, sp(30), &[lhs, rhs]);
+        let use_site = b.add(NodeKind::Var, Payload::Name(local), sp(31), &[]);
+        let root = b.add(
+            NodeKind::Module,
+            Payload::None,
+            sp(30),
+            &[assignment, use_site],
+        );
+        let mut il = finish_il(b, root, Lang::Python);
+
+        assert!(import_binding_rhs_matches(
+            &il,
+            &interner,
+            rhs,
+            "collections",
+            "deque"
+        ));
+        assert!(!imported_binding_symbol(
+            &il,
+            &interner,
+            use_site,
+            "collections",
+            "deque"
+        ));
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(sp(30), stable_symbol_hash("deque")),
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+                module_hash: stable_symbol_hash("collections"),
+                exported_hash: stable_symbol_hash("deque"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        assert!(imported_binding_symbol(
+            &il,
+            &interner,
+            use_site,
+            "collections",
+            "deque"
+        ));
     }
 
     #[test]

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -31,7 +31,8 @@ can satisfy an exact-channel precondition.
   scan JSON schema.
 - Do not remove compatibility mirrors in the first slice. `SourceFact`,
   `ParamTypeFact`, and raw import `Seq` payloads still exist while consumers are
-  migrated.
+  migrated, though new proof-bearing consumers should prefer evidence-only
+  helpers.
 - Do not certify external pack claims. nose validates record shape and fails
   closed; providers own their claims, and users own opt-in decisions.
 - Do not model place/effect/demand evidence completely in this slice. Those are
@@ -72,20 +73,24 @@ side tables.
 - `Ambiguous` evidence is treated as missing evidence.
 - If any relevant ambiguous/conflicting evidence exists, compatibility fallback
   must not reopen the exact path.
-- Compatibility fallback is allowed only when no relevant evidence record exists.
+- Compatibility fallback is allowed only when no relevant evidence record exists,
+  and only for explicitly legacy compatibility helpers.
 
 This is stricter than a name or tag check. For example, a raw
 `Seq("import_binding")` is still serialized for compatibility, but import
 contracts first consult `Import` evidence. If that evidence is ambiguous, exact
 import proof stays closed instead of falling back to the raw sequence payload.
+Value-graph import identity goes further: it consumes only sequence `Import`
+evidence and materializes dedicated internal import values, never raw
+`ValOp::Seq("import_*")` proof objects.
 
 Symbol identity follows the same rule. A method selector such as `abs` or a
 receiver spelling such as `Math` is not proof. Exact consumers must require a
-language-scoped contract plus symbol evidence, or a compatibility fallback that
-proves the same import/global/shadowing obligations. Binding-level import
-evidence does not by itself prove every use of the same local name; if the alias
-is rebound or ambiguous, the exact path stays closed until a node-level symbol
-fact or stronger scope-resolution evidence exists.
+language-scoped contract plus symbol evidence. Imported binding/namespace symbol
+helpers no longer accept a raw import assignment RHS as proof. Binding-level
+import evidence does not by itself prove every use of the same local name; if the
+alias is rebound or ambiguous, the exact path stays closed until a node-level
+symbol fact or stronger scope-resolution evidence exists.
 
 Qualified global identity is also evidence, not a selector guess. The current
 first-party JS/TS producer emits `QualifiedGlobal` only for selected static paths
@@ -122,10 +127,14 @@ callers:
 
 - source-fact lookup for construct syntax, regex literal, and operator provenance;
 - parameter domain lookup used by normalize and strict exact receiver gates;
-- import proof parsing for normalize, value graph, imported literal replacement,
-  and strict exact gates;
+- import proof parsing for compatibility helpers and imported literal
+  replacement, with value-graph import identity consuming evidence-only facts;
 - imported namespace/binding symbol proof for normalize idiom admission,
-  value-graph namespace fallbacks, and strict exact gates;
+  value-graph namespace fallbacks, and strict exact gates, without raw assignment
+  fallback;
+- value-graph internal import identity now uses dedicated
+  `ImportNamespace`/`ImportBinding` value ops derived from `Import` evidence, so
+  raw import `Seq` payloads cannot hash-cons with proof-bearing import values;
 - unshadowed-global symbol proof for JS/TS `Math.*` method contracts,
   `new Map(...)`/`new Set(...)` constructor contracts, static `Array.isArray`
   exact gates, and `undefined` nullish-default handling, with compatibility

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -191,8 +191,8 @@ and pack ecosystem.
 - Import binding and namespace proof interpretation now goes through a typed
   `ImportFactKind`/`ImportFact` facade in `nose-semantics`. Frontend emitters,
   imported immutable literal replacement, normalize idiom gates, value-graph
-  import proof, and strict exact gates now share the same tag, coordinate-count,
-  and module/export hash checks instead of parsing raw import `Seq` tags locally.
+  import proof, and strict exact gates initially moved behind that shared facade
+  instead of parsing raw import `Seq` tags locally.
 - TypeScript type-only imports no longer emit runtime import facts: whole
   `import type ...` declarations and type-only named specifiers stay outside
   exact library/API proof.
@@ -245,6 +245,11 @@ and pack ecosystem.
   wrappers. `Array.isArray` emits the same path evidence for strict exact call
   gates. Full namespace-member resolution and record-shape multi-obligation
   guard evidence remain open.
+- Value-graph import identity now consumes sequence `Import` evidence into
+  dedicated internal `ImportNamespace`/`ImportBinding` value ops instead of
+  treating raw `ValOp::Seq(import_*)` shapes as proof objects. Imported
+  binding/namespace symbol helpers also no longer accept raw import assignment
+  RHS parsing as an exact proof fallback.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -303,9 +308,11 @@ Remaining in this phase:
 - Make value-graph and strict exact gates consume the same contract source.
 - Remove the remaining raw import/module proof IL payload storage after import
   and symbol evidence records can carry every consumer obligation, including
-  namespace-member resolution, module export dependencies, scope, rebinding, and
-  mutation proof. Selected JS/TS `QualifiedGlobal` paths are now covered, but
-  general qualified-member and namespace export identity is not.
+  module export dependencies, scope, rebinding, and mutation proof. Value-graph
+  import identity and imported-symbol exact proof are now evidence-only, and
+  selected JS/TS `QualifiedGlobal` paths are covered, but general
+  qualified-member, namespace export identity, and cross-module dependency
+  evidence are not.
 - Add dedicated guard evidence for multi-obligation guards such as JS/TS
   record-shape checks, where one lowered guard depends on source operator facts,
   several qualified/static API facts, subject identity, and truthiness/null

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -228,17 +228,19 @@ migrated.
   shadowed constructor names remain exact-closed.
 - Static import proof facts now have a typed `ImportFactKind`/`ImportFact`
   facade in `nose-semantics`. First-party frontends emit import binding and
-  namespace facts through that contract, and imported literal replacement,
-  normalize idiom admission, value-graph import proof, and strict exact gates
-  parse import proof RHS nodes through the shared helper instead of local raw
-  tag checks.
+  namespace facts through that contract. Value-graph import identity consumes
+  sequence `Import` evidence into dedicated `ImportNamespace`/`ImportBinding`
+  value ops, so raw import `Seq` payloads can no longer become proof-bearing
+  value nodes by tag shape. Imported literal replacement still uses the typed
+  compatibility helper while raw IL mirrors remain.
 - Symbol identity evidence now covers static imported binding/namespace aliases
   and JS/TS static-global value occurrences such as `Math`, `console`, `Array`,
   `Map`, `Set`, and `undefined` when the frontend proves no local shadow.
   Normalize idiom admission, value-graph namespace fallbacks, and strict exact
-  gates consume `nose-semantics` symbol-proof helpers instead of each re-scanning
-  raw import assignment or global shadow shapes. Selected JS/TS qualified static
-  global paths now emit `QualifiedGlobal` evidence as well: `Object.hasOwn` and
+  gates consume `nose-semantics` symbol-proof helpers; imported binding/namespace
+  symbol helpers no longer fall back to raw import assignment RHS parsing.
+  Selected JS/TS qualified static global paths now emit `QualifiedGlobal`
+  evidence as well: `Object.hasOwn` and
   `Object.prototype.hasOwnProperty.call` gate own-property guards, while
   `Array.from` gates JS-like map-key iterator wrappers. This does not cover all
   qualified members or namespace exports.
@@ -271,9 +273,9 @@ Semantic knowledge still appears in several forms outside the facade:
   subject identity;
 - IL still stores import facts as `Seq("import_binding")` /
   `Seq("import_namespace")` payloads for compatibility. Frontends also emit
-  `EvidenceRecord::Import`, and semantic interpretation flows through typed
-  `ImportFact` helpers in `nose-semantics`, but the raw IL storage shape has not
-  been removed;
+  `EvidenceRecord::Import`, and value-graph import identity is now evidence-only,
+  but the raw IL storage shape and some compatibility consumers have not been
+  removed;
 - module/import proof logic for immutable sibling-module literal bindings;
 - type facts and coarse type inference used to gate numeric and collection laws;
 - named value-graph rule modules that still consume internal `Builder` facts


### PR DESCRIPTION
## Summary
- add an evidence-only import fact resolver and make imported binding/namespace symbol proof stop falling back to raw import assignment RHS parsing
- move value-graph import identity to dedicated `ImportNamespace` / `ImportBinding` ops derived from sequence `Import` evidence, not raw `ValOp::Seq(import_*)` shapes
- regenerate first-party import/symbol evidence when module-import snapshots copy import dependency assignments, preserving Java/Rust imported literal recall
- update semantic-kernel snapshot/roadmap/evidence docs for the new boundary

Fixes part of #109.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --release`
- `cargo test --release`
- `awiki lint --root docs`
- `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `./scripts/check-duplication.sh` (19 substantial families, budget 21)
