### PR TITLE
[codex] scan: add abstraction witness mode

### DIFF
--- a/crates/nose-cli/src/cache.rs
+++ b/crates/nose-cli/src/cache.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 /// cache entries then live under a different directory and are ignored. (v5: exact
 /// Type-4 features include the newly modeled record, membership, flag-loop, and ordered
 /// string-builder idioms.)
-const SCHEMA: u32 = 5;
+const SCHEMA: u32 = 6;
 
 pub(crate) struct CachedUnits {
     pub units: Vec<UnitFeat>,

--- a/crates/nose-cli/src/cache.rs
+++ b/crates/nose-cli/src/cache.rs
@@ -141,6 +141,7 @@ fn options_signature(opts: &DetectOptions) -> u64 {
         opts.dce as u64,
         opts.minhash_k as u64,
         opts.shape_features as u64,
+        opts.abstraction_witnesses as u64,
     ] {
         h = crate::fnv::mix(h, v);
     }

--- a/crates/nose-cli/src/config.rs
+++ b/crates/nose-cli/src/config.rs
@@ -5,7 +5,7 @@
 //! ```toml
 //! [scan]
 //! exclude = ["tests/**", "**/*.generated.ts", "vendor/**"]
-//! mode = ["syntax", "semantic", "near:0.8"] # near's threshold rides on the mode
+//! mode = ["syntax", "semantic", "near:0.8"] # fuzzy thresholds ride on the mode
 //! min-value = 200
 //! sort = "extractability"
 //! min-members = 3

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -133,8 +133,8 @@ enum Cmd {
         config: Option<PathBuf>,
         /// Detection channels to run. Omit for `syntax,semantic`. If present, this
         /// replaces the default; pass a comma-list or repeat it, e.g.
-        /// `--mode syntax,near` or `--mode syntax --mode semantic`. The `near` channel
-        /// takes an optional acceptance threshold inline: `--mode near:0.8` (default 0.70).
+        /// `--mode syntax,near` or `--mode syntax --mode semantic`. Fuzzy channels
+        /// take an optional acceptance threshold inline: `--mode near:0.8`.
         #[arg(
             long,
             value_delimiter = ',',
@@ -373,8 +373,9 @@ pub(crate) enum ReportFormat {
     Sarif,
 }
 
-/// One `--mode` channel. `near` carries its own acceptance threshold (`near:0.8`),
-/// so there is no separate `--threshold` flag to mis-combine.
+/// One `--mode` channel. Fuzzy modes carry their acceptance threshold inline
+/// (`near:0.8` / `abstraction:0.5`), so there is no separate `--threshold` flag
+/// to mis-combine.
 #[derive(Clone, Copy, PartialEq, serde::Deserialize)]
 #[serde(try_from = "String")]
 enum ScanMode {
@@ -416,7 +417,7 @@ impl std::str::FromStr for ScanMode {
                     Ok(ScanMode::Abstraction(Some(v)))
                 } else {
                     Err(format!(
-                        "unknown mode `{s}` (expected syntax, semantic, near, or near:T)"
+                        "unknown mode `{s}` (expected syntax, semantic, near, near:T, abstraction, or abstraction:T)"
                     ))
                 }
             }
@@ -448,7 +449,7 @@ struct ScanChannels {
     semantic: bool,
     near: bool,
     abstraction: bool,
-    /// The `near:T` threshold, if one was given in the mode spec.
+    /// The shared fuzzy acceptance threshold, if one was given in the mode spec.
     threshold: Option<f64>,
 }
 
@@ -474,22 +475,35 @@ impl ScanChannels {
                 ScanMode::Semantic => channels.semantic = true,
                 ScanMode::Near(t) => {
                     channels.near = true;
-                    if t.is_some() {
-                        channels.threshold = t;
-                    }
+                    channels.set_threshold("near", t)?;
                 }
                 ScanMode::Abstraction(t) => {
                     channels.abstraction = true;
-                    if t.is_some() {
-                        channels.threshold = t;
-                    }
+                    channels.set_threshold("abstraction", t)?;
                 }
             }
         }
         if !channels.syntax && !channels.semantic && !channels.near && !channels.abstraction {
-            anyhow::bail!("--mode must include at least one of syntax, semantic, or near");
+            anyhow::bail!(
+                "--mode must include at least one of syntax, semantic, near, or abstraction"
+            );
         }
         Ok(channels)
+    }
+
+    fn set_threshold(&mut self, mode: &'static str, threshold: Option<f64>) -> Result<()> {
+        let Some(next) = threshold else {
+            return Ok(());
+        };
+        if let Some(prev) = self.threshold {
+            if (prev - next).abs() > f64::EPSILON {
+                anyhow::bail!(
+                    "conflicting --mode thresholds: near and abstraction share one acceptance threshold; got {prev} and {mode}:{next}"
+                );
+            }
+        }
+        self.threshold = Some(next);
+        Ok(())
     }
 
     fn structural(self) -> bool {

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -384,6 +384,8 @@ enum ScanMode {
     Semantic,
     /// Fuzzy Type-3 near-duplicate candidates, with an optional acceptance threshold.
     Near(Option<f64>),
+    /// Experimental weak refactoring-template witnesses over near candidates.
+    Abstraction(Option<f64>),
 }
 
 impl std::str::FromStr for ScanMode {
@@ -394,6 +396,7 @@ impl std::str::FromStr for ScanMode {
             "syntax" => Ok(ScanMode::Syntax),
             "semantic" => Ok(ScanMode::Semantic),
             "near" => Ok(ScanMode::Near(None)),
+            "abstraction" => Ok(ScanMode::Abstraction(None)),
             _ => {
                 if let Some(t) = s.strip_prefix("near:") {
                     let v: f64 = t
@@ -403,6 +406,14 @@ impl std::str::FromStr for ScanMode {
                         return Err(format!("near threshold must be in [0,1], got {v}"));
                     }
                     Ok(ScanMode::Near(Some(v)))
+                } else if let Some(t) = s.strip_prefix("abstraction:") {
+                    let v: f64 = t
+                        .parse()
+                        .map_err(|_| format!("invalid abstraction threshold in `{s}`"))?;
+                    if !(0.0..=1.0).contains(&v) {
+                        return Err(format!("abstraction threshold must be in [0,1], got {v}"));
+                    }
+                    Ok(ScanMode::Abstraction(Some(v)))
                 } else {
                     Err(format!(
                         "unknown mode `{s}` (expected syntax, semantic, near, or near:T)"
@@ -436,6 +447,7 @@ struct ScanChannels {
     syntax: bool,
     semantic: bool,
     near: bool,
+    abstraction: bool,
     /// The `near:T` threshold, if one was given in the mode spec.
     threshold: Option<f64>,
 }
@@ -453,6 +465,7 @@ impl ScanChannels {
             syntax: false,
             semantic: false,
             near: false,
+            abstraction: false,
             threshold: None,
         };
         for mode in selected {
@@ -465,39 +478,70 @@ impl ScanChannels {
                         channels.threshold = t;
                     }
                 }
+                ScanMode::Abstraction(t) => {
+                    channels.abstraction = true;
+                    if t.is_some() {
+                        channels.threshold = t;
+                    }
+                }
             }
         }
-        if !channels.syntax && !channels.semantic && !channels.near {
+        if !channels.syntax && !channels.semantic && !channels.near && !channels.abstraction {
             anyhow::bail!("--mode must include at least one of syntax, semantic, or near");
         }
         Ok(channels)
     }
 
     fn structural(self) -> bool {
-        self.semantic || self.near
+        self.semantic || self.near || self.abstraction
     }
 
     fn report_label(self, count: usize) -> &'static str {
         let singular = count == 1;
-        match (self.syntax, self.semantic, self.near, singular) {
-            (true, false, false, true) => "syntax clone family",
-            (true, false, false, false) => "syntax clone families",
-            (false, true, false, true) => "semantic clone family",
-            (false, true, false, false) => "semantic clone families",
-            (false, false, true, true) => "near-duplicate family",
-            (false, false, true, false) => "near-duplicate families",
-            (_, _, _, true) => "clone family",
-            (_, _, _, false) => "clone families",
+        match (
+            self.syntax,
+            self.semantic,
+            self.near,
+            self.abstraction,
+            singular,
+        ) {
+            (true, false, false, false, true) => "syntax clone family",
+            (true, false, false, false, false) => "syntax clone families",
+            (false, true, false, false, true) => "semantic clone family",
+            (false, true, false, false, false) => "semantic clone families",
+            (false, false, true, false, true) => "near-duplicate family",
+            (false, false, true, false, false) => "near-duplicate families",
+            (false, false, false, true, true) => "abstraction candidate family",
+            (false, false, false, true, false) => "abstraction candidate families",
+            (_, _, _, _, true) => "clone family",
+            (_, _, _, _, false) => "clone families",
         }
     }
 
     fn markdown_title(self) -> &'static str {
-        match (self.syntax, self.semantic, self.near) {
-            (true, false, false) => "Syntax Clone Families",
-            (false, true, false) => "Semantic Clone Families",
-            (false, false, true) => "Near-Duplicate Families",
+        match (self.syntax, self.semantic, self.near, self.abstraction) {
+            (true, false, false, false) => "Syntax Clone Families",
+            (false, true, false, false) => "Semantic Clone Families",
+            (false, false, true, false) => "Near-Duplicate Families",
+            (false, false, false, true) => "Abstraction Candidate Families",
             _ => "Clone Families",
         }
+    }
+
+    fn threshold(self) -> f64 {
+        if self.near || self.abstraction {
+            self.threshold.unwrap_or(if self.abstraction && !self.near {
+                0.50
+            } else {
+                0.70
+            })
+        } else {
+            1.0
+        }
+    }
+
+    fn abstraction_only(self) -> bool {
+        self.abstraction && !self.syntax && !self.semantic && !self.near
     }
 }
 
@@ -1055,6 +1099,21 @@ fn family_summary(f: &nose_detect::RefactorFamily) -> String {
         f.members,
         removable_lines(f)
     )
+}
+
+fn abstraction_witness_summary(witness: &nose_detect::AbstractionWitness) -> String {
+    let caveats = if witness.caveats.is_empty() {
+        "no caveats".to_string()
+    } else {
+        format!("caveats: {}", witness.caveats.join(", "))
+    };
+    let holes = witness
+        .holes
+        .iter()
+        .map(|hole| format!("{} {}->{}", hole.kind, hole.left, hole.right))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{} · {} · {}", witness.reason_code, holes, caveats)
 }
 
 /// Lines you'd actually delete by extracting one shared copy. For same-language
@@ -2361,11 +2420,7 @@ pub(crate) fn detect_families(
 ) -> Result<Vec<nose_detect::RefactorFamily>> {
     let refs = paths_as_refs(paths);
     let channels = ScanChannels::resolve(mode, cfg_mode)?;
-    let threshold = if channels.near {
-        channels.threshold.unwrap_or(0.70)
-    } else {
-        1.0
-    };
+    let threshold = channels.threshold();
     let opts = nose_detect::DetectOptions {
         threshold,
         min_lines,
@@ -2377,15 +2432,20 @@ pub(crate) fn detect_families(
         // Near also generates VALUE candidates so behaviorally-convergent but shape-divergent
         // pairs (async `.then` ≡ await, impure loop ≡ comprehension) reach the candidate scorer —
         // they share no shape band, so shape-LSH alone would never propose them.
-        value_candidates: channels.semantic || channels.near,
-        shape_candidates: channels.near,
-        shape_features: channels.near,
+        value_candidates: channels.semantic || channels.near || channels.abstraction,
+        shape_candidates: channels.near || channels.abstraction,
+        shape_features: channels.near || channels.abstraction,
+        abstraction_witnesses: channels.abstraction,
         ..Default::default()
     };
     let detector = scan_detector(channels, &opts);
     let corpus = nose_frontend::lower_corpus_filtered(&refs, exclude);
     let report = nose_detect::detect(&corpus, &opts, detector.as_ref());
-    Ok(nose_detect::rank_families(&report))
+    let mut families = nose_detect::rank_families(&report);
+    if channels.abstraction_only() {
+        families.retain(|f| f.abstraction_witness.is_some());
+    }
+    Ok(families)
 }
 
 fn scan_detector(
@@ -2396,7 +2456,7 @@ fn scan_detector(
     if channels.semantic {
         detectors.push(Box::new(nose_detect::ExactBehaviorDetector));
     }
-    if channels.near {
+    if channels.near || channels.abstraction {
         detectors.push(Box::new(
             nose_detect::StructuralDetector::candidates(opts.jaccard_weight)
                 .without_exact_behavior()
@@ -2408,7 +2468,13 @@ fn scan_detector(
         0 => Box::new(nose_detect::CopyPasteDetector),
         1 => detectors.pop().expect("one detector"),
         _ => Box::new(ChannelDetector {
-            name: "semantic+near",
+            name: if channels.abstraction && !channels.near {
+                "semantic+abstraction"
+            } else if channels.abstraction {
+                "semantic+near+abstraction"
+            } else {
+                "semantic+near"
+            },
             detectors,
         }),
     }
@@ -2477,11 +2543,7 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
     let min_value = args.min_value.or(cfg.min_value).unwrap_or(0.0);
     let sort = args.sort.or(cfg.sort).unwrap_or(SortKey::Extractability);
     let channels = ScanChannels::resolve(args.mode, cfg.mode)?;
-    let threshold = if channels.near {
-        channels.threshold.unwrap_or(0.70)
-    } else {
-        1.0
-    };
+    let threshold = channels.threshold();
     let min_lines = args.min_lines.or(cfg.min_lines).unwrap_or(5);
     let min_tokens = args.min_size.or(cfg.min_size).unwrap_or(24);
     let ignore_file = args.ignore_file.or(cfg.ignore_file);
@@ -2504,9 +2566,10 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
         // Near also generates VALUE candidates so behaviorally-convergent but shape-divergent
         // pairs (async `.then` ≡ await, impure loop ≡ comprehension) reach the candidate scorer —
         // they share no shape band, so shape-LSH alone would never propose them.
-        value_candidates: channels.semantic || channels.near,
-        shape_candidates: channels.near,
-        shape_features: channels.near,
+        value_candidates: channels.semantic || channels.near || channels.abstraction,
+        shape_candidates: channels.near || channels.abstraction,
+        shape_features: channels.near || channels.abstraction,
+        abstraction_witnesses: channels.abstraction,
         ..Default::default()
     };
     let detector = scan_detector(channels, &opts);
@@ -2539,6 +2602,9 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
     };
 
     let mut families = nose_detect::rank_families(&report);
+    if channels.abstraction_only() {
+        families.retain(|f| f.abstraction_witness.is_some());
+    }
     families.retain(|f| f.members >= min_members && f.value >= min_value);
     // Show paths relative to the working directory — absolute paths are unreadable
     // in CI logs and reviews, and relative ones are clickable and portable.
@@ -3064,6 +3130,9 @@ fn print_refactor_human(
             family_summary(f)
         );
         println!("    → {}", family_hint(f));
+        if let Some(witness) = &f.abstraction_witness {
+            println!("    witness {}", abstraction_witness_summary(witness));
+        }
         for l in f.locations.iter().take(SITE_CAP) {
             let name = l
                 .name
@@ -3461,6 +3530,9 @@ fn print_refactor_markdown(
             xlang
         );
         println!("\n*{}*\n", family_hint(f));
+        if let Some(witness) = &f.abstraction_witness {
+            println!("_witness: {}_\n", abstraction_witness_summary(witness));
+        }
         for l in &f.locations {
             let name = l
                 .name
@@ -3756,6 +3828,7 @@ mod tests {
             mean_sem: 50.0,
             scope: "prod",
             discount: 1.0,
+            abstraction_witness: None,
         }
     }
 

--- a/crates/nose-cli/src/review.rs
+++ b/crates/nose-cli/src/review.rs
@@ -709,6 +709,7 @@ index 1111111..2222222 100644
             mean_sem: 4.0,
             scope: "prod",
             discount: 1.0,
+            abstraction_witness: None,
         }
     }
 

--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -9366,6 +9366,10 @@ fn non_near_scan_modes_reject_similarity_thresholds() {
             stderr.contains("unknown mode"),
             "specific error explains the invalid threshold for {mode}: {stderr}"
         );
+        assert!(
+            stderr.contains("abstraction:T"),
+            "unknown-mode help should include the hidden abstraction threshold spelling: {stderr}"
+        );
     }
     let _ = fs::remove_dir_all(&dir);
 }
@@ -9414,6 +9418,55 @@ fn abstraction_scan_mode_accepts_similarity_threshold() {
         out.status.success(),
         "abstraction mode should accept inline abstraction:T thresholds: {}",
         String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn combined_fuzzy_modes_accept_one_shared_threshold() {
+    let dir = make_mode_project("shared_threshold");
+    let out = Command::new(bin())
+        .args([
+            "scan",
+            dir.to_str().unwrap(),
+            "--mode",
+            "near:0.5,abstraction:0.5",
+            "--min-size",
+            "12",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("run nose");
+    assert!(
+        out.status.success(),
+        "near and abstraction should accept the same shared threshold: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn combined_fuzzy_modes_reject_conflicting_thresholds() {
+    let dir = make_mode_project("conflicting_thresholds");
+    let out = Command::new(bin())
+        .args([
+            "scan",
+            dir.to_str().unwrap(),
+            "--mode",
+            "near:0.8,abstraction:0.5",
+        ])
+        .output()
+        .expect("run nose");
+    assert!(
+        !out.status.success(),
+        "conflicting near/abstraction thresholds should not silently overwrite each other"
+    );
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("conflicting --mode thresholds")
+            && stderr.contains("share one acceptance threshold"),
+        "error should explain the shared fuzzy threshold: {stderr}"
     );
     let _ = fs::remove_dir_all(&dir);
 }

--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -141,7 +141,14 @@ fn scan_families(json: &serde_json::Value) -> &[serde_json::Value] {
 }
 
 fn family_contains_all(json: &serde_json::Value, suffixes: &[&str]) -> bool {
-    scan_families(json).iter().any(|family| {
+    family_with_all(json, suffixes).is_some()
+}
+
+fn family_with_all<'a>(
+    json: &'a serde_json::Value,
+    suffixes: &[&str],
+) -> Option<&'a serde_json::Value> {
+    scan_families(json).iter().find(|family| {
         let Some(locations) = family["locations"].as_array() else {
             return false;
         };
@@ -9344,7 +9351,7 @@ fn default_mode_runs_syntax_and_semantic() {
 #[test]
 fn non_near_scan_modes_reject_similarity_thresholds() {
     let dir = make_mode_project("exact_threshold");
-    // Only `near` carries an inline threshold; `syntax:0.5` / `semantic:0.5` are invalid.
+    // Exact channels carry no inline threshold; `syntax:0.5` / `semantic:0.5` are invalid.
     for mode in ["syntax:0.5", "semantic:0.5"] {
         let out = Command::new(bin())
             .args(["scan", dir.to_str().unwrap(), "--mode", mode])
@@ -9383,6 +9390,173 @@ fn near_scan_mode_accepts_similarity_threshold() {
         out.status.success(),
         "near mode should accept inline near:T thresholds: {}",
         String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn abstraction_scan_mode_accepts_similarity_threshold() {
+    let dir = make_mode_project("abstraction_threshold");
+    let out = Command::new(bin())
+        .args([
+            "scan",
+            dir.to_str().unwrap(),
+            "--mode",
+            "abstraction:0.5",
+            "--min-size",
+            "12",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("run nose");
+    assert!(
+        out.status.success(),
+        "abstraction mode should accept inline abstraction:T thresholds: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn abstraction_mode_reports_numeric_literal_witness() {
+    let dir = std::env::temp_dir().join(format!("nose_abstraction_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("a")).unwrap();
+    fs::create_dir_all(dir.join("b")).unwrap();
+    fs::write(
+        dir.join("a/sum.py"),
+        "def sum_int(xs):\n    total = 0\n    for x in xs:\n        total = total + x\n    return total\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("b/sum.py"),
+        "def sum_float(xs):\n    total = 0.0\n    for x in xs:\n        total = total + x\n    return total\n",
+    )
+    .unwrap();
+
+    let semantic = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--min-size",
+        "8",
+        "--format",
+        "json",
+        "--top",
+        "0",
+    ]));
+    assert!(
+        !family_contains_all(&semantic, &["a/sum.py", "b/sum.py"]),
+        "int/float literal seeds must not become exact semantic clones: {semantic}"
+    );
+
+    let abstraction = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "abstraction",
+        "--min-size",
+        "8",
+        "--format",
+        "json",
+        "--top",
+        "0",
+    ]));
+    let family = family_with_all(&abstraction, &["a/sum.py", "b/sum.py"])
+        .unwrap_or_else(|| panic!("abstraction mode should report the pair: {abstraction}"));
+    let witness = &family["abstraction_witness"];
+    assert_eq!(witness["reason_code"], "type-parametric");
+    assert_eq!(witness["holes"][0]["kind"], "literal");
+    assert_eq!(witness["holes"][0]["left"], "int-literal");
+    assert_eq!(witness["holes"][0]["right"], "float-literal");
+    assert!(
+        witness["caveats"]
+            .as_array()
+            .is_some_and(|caveats| caveats.iter().any(|c| c == "numeric-domain-sensitive")),
+        "numeric caveat should be explicit: {witness}"
+    );
+    assert!(
+        witness["template"]
+            .as_array()
+            .is_some_and(|template| template.iter().any(|t| t == "<hole 1: literal>")),
+        "template should mark the typed hole: {witness}"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn abstraction_mode_reports_same_class_literal_without_numeric_caveat() {
+    let dir = std::env::temp_dir().join(format!("nose_abstraction_lit_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("a")).unwrap();
+    fs::create_dir_all(dir.join("b")).unwrap();
+    fs::write(
+        dir.join("a/scale.py"),
+        "def scale(xs):\n    total = 0\n    for x in xs:\n        total = total + x * 2\n    return total\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("b/scale.py"),
+        "def scale_more(xs):\n    total = 0\n    for x in xs:\n        total = total + x * 3\n    return total\n",
+    )
+    .unwrap();
+
+    let abstraction = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "abstraction",
+        "--min-size",
+        "8",
+        "--format",
+        "json",
+        "--top",
+        "0",
+    ]));
+    let family =
+        family_with_all(&abstraction, &["a/scale.py", "b/scale.py"]).unwrap_or_else(|| {
+            panic!("abstraction mode should report the literal pair: {abstraction}")
+        });
+    let witness = &family["abstraction_witness"];
+    assert_eq!(witness["reason_code"], "literal-abstracted");
+    assert_eq!(witness["holes"][0]["left"], "int-literal");
+    assert_eq!(witness["holes"][0]["right"], "int-literal");
+    assert!(
+        witness["caveats"].as_array().is_some_and(|c| c.is_empty()),
+        "same-class literal abstraction should not invent a numeric-domain caveat: {witness}"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn abstraction_mode_rejects_operator_swap_witnesses() {
+    let dir = std::env::temp_dir().join(format!("nose_abstraction_op_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("a")).unwrap();
+    fs::create_dir_all(dir.join("b")).unwrap();
+    let mk = |op: &str| {
+        format!("def fold(xs):\n    total = 1\n    for x in xs:\n        total = total {op} x\n    return total\n")
+    };
+    fs::write(dir.join("a/fold.py"), mk("+")).unwrap();
+    fs::write(dir.join("b/fold.py"), mk("*")).unwrap();
+
+    let abstraction = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "abstraction",
+        "--min-size",
+        "8",
+        "--format",
+        "json",
+        "--top",
+        "0",
+    ]));
+    assert!(
+        !family_contains_all(&abstraction, &["a/fold.py", "b/fold.py"]),
+        "operator swaps are behavioral diffs, not abstraction witnesses: {abstraction}"
     );
     let _ = fs::remove_dir_all(&dir);
 }

--- a/crates/nose-detect/src/contiguous.rs
+++ b/crates/nose-detect/src/contiguous.rs
@@ -234,6 +234,7 @@ pub(crate) fn detect(streams: &[Stream], min_tokens: usize, min_lines: u32) -> V
         groups.push(crate::Group {
             score: 1.0,
             members: members.iter().map(|&m| locs[m].clone()).collect(),
+            abstraction_witness: None,
         });
     }
     groups

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -793,7 +793,10 @@ pub fn units_of_file(il: &Il, interner: &Interner, opts: &DetectOptions) -> Vec<
         opts.min_lines,
         opts.min_tokens,
         opts.block_units,
-        opts.shape_features,
+        units::ExtractFeatures {
+            shape_features: opts.shape_features,
+            abstraction_witnesses: opts.abstraction_witnesses,
+        },
     )
 }
 
@@ -828,7 +831,10 @@ pub fn detect_with_dump(
                     opts.min_lines,
                     opts.min_tokens,
                     opts.block_units,
-                    opts.shape_features,
+                    units::ExtractFeatures {
+                        shape_features: opts.shape_features,
+                        abstraction_witnesses: opts.abstraction_witnesses,
+                    },
                 )
             } else {
                 Vec::new()

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -83,6 +83,10 @@ pub struct DetectOptions {
     /// structural scoring. Exact semantic scans do not need them: candidate generation
     /// and scoring both use the value graph only.
     pub shape_features: bool,
+    /// Attach experimental abstraction witnesses to near-derived families whose normalized
+    /// structure differs by exactly one supported literal leaf. This is a weak refactoring
+    /// claim and never participates in exact semantic acceptance.
+    pub abstraction_witnesses: bool,
 }
 
 impl Default for DetectOptions {
@@ -110,6 +114,7 @@ impl Default for DetectOptions {
             value_candidates: true,
             shape_candidates: false,
             shape_features: true,
+            abstraction_witnesses: false,
         }
     }
 }
@@ -552,10 +557,30 @@ pub struct DupPair {
     pub cross_language: bool,
 }
 
+#[derive(Serialize, Clone, PartialEq, Eq, Debug)]
+pub struct AbstractionWitness {
+    pub reason_code: &'static str,
+    pub template: Vec<String>,
+    pub holes: Vec<AbstractionHole>,
+    pub caveats: Vec<&'static str>,
+}
+
+#[derive(Serialize, Clone, PartialEq, Eq, Debug)]
+pub struct AbstractionHole {
+    pub index: u32,
+    pub kind: &'static str,
+    pub left: &'static str,
+    pub right: &'static str,
+    pub left_line: u32,
+    pub right_line: u32,
+}
+
 #[derive(Serialize)]
 pub struct Group {
     pub score: f64,
     pub members: Vec<Loc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub abstraction_witness: Option<AbstractionWitness>,
 }
 
 #[derive(Serialize)]
@@ -933,13 +958,32 @@ pub fn detect_from_units(
         e.0 += s;
         e.1 += 1;
     }
+    let mut abstraction_by_root: rustc_hash::FxHashMap<
+        usize,
+        (f64, usize, usize, AbstractionWitness),
+    > = rustc_hash::FxHashMap::default();
+    if opts.abstraction_witnesses {
+        for &(i, j, s) in &accepted {
+            if let Some(witness) = units::abstraction_witness(&units[i], &units[j]) {
+                let root = uf.find(i);
+                let replace =
+                    abstraction_by_root
+                        .get(&root)
+                        .is_none_or(|(best_score, best_i, best_j, _)| {
+                            s.total_cmp(best_score).is_gt()
+                                || (s == *best_score && (i, j) < (*best_i, *best_j))
+                        });
+                if replace {
+                    abstraction_by_root.insert(root, (s, i, j, witness));
+                }
+            }
+        }
+    }
     let groups: Vec<Group> = raw_groups
         .iter()
         .map(|members| {
-            let (sum, n) = by_root
-                .get(&uf.find(members[0]))
-                .copied()
-                .unwrap_or((0.0, 0));
+            let root = uf.find(members[0]);
+            let (sum, n) = by_root.get(&root).copied().unwrap_or((0.0, 0));
             let score = if n == 0 { 0.0 } else { sum / n as f64 };
             let mut locs: Vec<Loc> = members
                 .iter()
@@ -960,6 +1004,9 @@ pub fn detect_from_units(
             Group {
                 score: round3(score),
                 members: locs,
+                abstraction_witness: abstraction_by_root
+                    .get(&root)
+                    .map(|(_, _, _, witness)| witness.clone()),
             }
         })
         .collect();

--- a/crates/nose-detect/src/report.rs
+++ b/crates/nose-detect/src/report.rs
@@ -9,7 +9,7 @@
 //!   - **design-level spread** — a family spanning many files / modules signals a
 //!     missing abstraction, weighted above a local copy-paste.
 
-use crate::{Group, Loc, Report};
+use crate::{AbstractionWitness, Group, Loc, Report};
 use serde::Serialize;
 use std::path::Path;
 
@@ -61,6 +61,11 @@ pub struct RefactorFamily {
     /// all-type-definition and all-generated families. Applied to *both* `value` and
     /// `extractability` so the default ranking honors it too.
     pub discount: f64,
+    /// Experimental weak-claim witness for `abstraction` mode. This records a typed
+    /// template and caveats for near candidates that share structure but differ by one
+    /// supported literal leaf. It is not a semantic-equivalence proof.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub abstraction_witness: Option<AbstractionWitness>,
 }
 
 impl RefactorFamily {
@@ -481,6 +486,7 @@ fn family_of(group: &Group) -> RefactorFamily {
         mean_sem,
         scope,
         discount,
+        abstraction_witness: group.abstraction_witness.clone(),
     }
 }
 
@@ -660,6 +666,7 @@ mod tests {
             mean_sem: 50.0,
             scope: "prod",
             discount: 1.0,
+            abstraction_witness: None,
         }
     }
 
@@ -878,6 +885,7 @@ mod tests {
                 loc("a.rs", 1, 20, "rust"),
                 loc("b.rs", 1, 20, "rust"),
             ],
+            abstraction_witness: None,
         };
         let f = &rank_families(&report(vec![g]))[0];
         assert_eq!(
@@ -894,10 +902,12 @@ mod tests {
         let outer = Group {
             score: 0.9,
             members: vec![loc("a.rs", 10, 40, "rust"), loc("b.rs", 10, 40, "rust")],
+            abstraction_witness: None,
         };
         let inner = Group {
             score: 1.0,
             members: vec![loc("a.rs", 15, 25, "rust"), loc("b.rs", 15, 25, "rust")],
+            abstraction_witness: None,
         };
         let fams = rank_families(&report(vec![inner, outer]));
         assert_eq!(fams.len(), 1, "the contained family should be dropped");
@@ -916,6 +926,7 @@ mod tests {
         let mk = |f1: &'static str, f2: &'static str| Group {
             score: 1.0,
             members: vec![loc(f1, 1, 20, "rust"), loc(f2, 1, 20, "rust")],
+            abstraction_witness: None,
         };
         let keys = |groups| {
             rank_families(&report(groups))
@@ -950,6 +961,7 @@ mod tests {
                 loc("con.py", 143, 167, "python"),
                 loc("con.py", 144, 167, "python"), // off-by-one near-duplicate
             ],
+            abstraction_witness: None,
         };
         let f = &rank_families(&report(vec![g]))[0];
         assert_eq!(
@@ -969,6 +981,7 @@ mod tests {
                 loc("p.py", 763, 794, "python"),
                 loc("p.py", 795, 818, "python"),
             ],
+            abstraction_witness: None,
         };
         let f = &rank_families(&report(vec![g]))[0];
         assert_eq!(
@@ -987,6 +1000,7 @@ mod tests {
                 loc("y/b.rs", 1, 10, "rust"),
                 loc("z/c.rs", 1, 10, "rust"),
             ],
+            abstraction_witness: None,
         };
         let f = &rank_families(&report(vec![g]))[0];
         assert_eq!(f.members, 3);
@@ -1003,10 +1017,12 @@ mod tests {
             members: (0..10)
                 .map(|i| loc(&format!("m{i}/f.rs"), 1, 30, "rust"))
                 .collect(),
+            abstraction_witness: None,
         };
         let small = Group {
             score: 1.0,
             members: vec![loc("p/a.rs", 1, 6, "rust"), loc("p/b.rs", 1, 6, "rust")],
+            abstraction_witness: None,
         };
         let fams = rank_families(&report(vec![small, big]));
         assert!(
@@ -1021,6 +1037,7 @@ mod tests {
         let mono = Group {
             score: 0.9,
             members: vec![loc("a.py", 1, 10, "python"), loc("b.py", 1, 10, "python")],
+            abstraction_witness: None,
         };
         let cross = Group {
             score: 0.9,
@@ -1028,6 +1045,7 @@ mod tests {
                 loc("a.py", 1, 10, "python"),
                 loc("b.ts", 1, 10, "typescript"),
             ],
+            abstraction_witness: None,
         };
         let fm = family_of(&mono);
         let fc = family_of(&cross);
@@ -1048,6 +1066,7 @@ mod tests {
                 loc("src/a.rs", 1, 30, "rust"),
                 loc("src/b.rs", 1, 30, "rust"),
             ],
+            abstraction_witness: None,
         };
         let test = Group {
             score: 1.0,
@@ -1055,6 +1074,7 @@ mod tests {
                 loc("tests/a.rs", 1, 30, "rust"),
                 loc("tests/b.rs", 1, 30, "rust"),
             ],
+            abstraction_witness: None,
         };
         let fp = family_of(&prod);
         let ft = family_of(&test);
@@ -1078,6 +1098,7 @@ mod tests {
         let mixed = Group {
             score: 1.0,
             members: vec![loc("src/a.rs", 1, 30, "rust"), test_named],
+            abstraction_witness: None,
         };
         let pure = Group {
             score: 1.0,
@@ -1085,6 +1106,7 @@ mod tests {
                 loc("src/a.rs", 1, 30, "rust"),
                 loc("src/b.rs", 1, 30, "rust"),
             ],
+            abstraction_witness: None,
         };
         let fmixed = family_of(&mixed);
         let fpure = family_of(&pure);
@@ -1204,6 +1226,7 @@ mod tests {
                 loc_k("src/a.rs", 1, 30, Class, 5),
                 loc_k("src/b.rs", 1, 30, Class, 5),
             ],
+            abstraction_witness: None,
         };
         // A behavior-rich class of the same size is a genuine candidate.
         let rich = Group {
@@ -1212,6 +1235,7 @@ mod tests {
                 loc_k("src/c.rs", 1, 30, Class, 80),
                 loc_k("src/d.rs", 1, 30, Class, 80),
             ],
+            abstraction_witness: None,
         };
         let ftd = family_of(&typedef);
         let frich = family_of(&rich);
@@ -1226,6 +1250,7 @@ mod tests {
                 loc_k("src/e.rs", 1, 30, Function, 5),
                 loc_k("src/f.rs", 1, 30, Function, 5),
             ],
+            abstraction_witness: None,
         };
         assert!(
             family_of(&func).value > ftd.value,
@@ -1242,10 +1267,12 @@ mod tests {
                 loc("a/vendor/x.go", 1, 30, "go"),
                 loc("b/vendor/y.go", 1, 30, "go"),
             ],
+            abstraction_witness: None,
         };
         let owned = Group {
             score: 1.0,
             members: vec![loc("src/x.go", 1, 30, "go"), loc("src/y.go", 1, 30, "go")],
+            abstraction_witness: None,
         };
         assert!(
             family_of(&owned).value > family_of(&vendored).value,

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -10,7 +10,7 @@ use nose_il::{
 };
 use nose_normalize::{
     module_facts::{collect_module_mutations, mutating_method_name},
-    node_tag,
+    node_tag, node_tag_valued,
 };
 use nose_semantics::{
     builder_append_call_args, construct_syntax_proof,
@@ -66,6 +66,13 @@ pub struct UnitFeat {
     pub minhash: Vec<u64>,
     /// Pre-order node-tag sequence, for alignment scoring.
     pub linear: Vec<u64>,
+    /// Pre-order typed tokens used only by the experimental abstraction witness layer.
+    ///
+    /// Unlike `linear`, this keeps a value-sensitive literal tag so a pair that differs
+    /// only by `0` vs `1` can be explained as one literal hole without weakening the
+    /// exact semantic fingerprint.
+    #[serde(default)]
+    pub(crate) abstraction_tokens: Vec<AbstractionToken>,
     /// Sorted multiset of literal (`Const`) value hashes. A high `lits/value`
     /// ratio marks a "data-table" unit (constant-dominated, e.g. a locale map),
     /// where the constants must match for a clone.
@@ -100,6 +107,172 @@ pub struct UnitFeat {
     /// [`fragment_kind`](Self::fragment_kind) is `Some`.
     #[serde(default)]
     pub proof_facts: Option<ProofFacts>,
+}
+
+#[derive(Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub(crate) struct AbstractionToken {
+    kind: NodeKind,
+    arity: u16,
+    shape_tag: u64,
+    exact_tag: u64,
+    literal: Option<AbstractionLiteral>,
+    line: u32,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+enum AbstractionLiteral {
+    Int,
+    Float,
+    Str,
+}
+
+impl AbstractionLiteral {
+    fn label(self) -> &'static str {
+        match self {
+            AbstractionLiteral::Int => "int-literal",
+            AbstractionLiteral::Float => "float-literal",
+            AbstractionLiteral::Str => "string-literal",
+        }
+    }
+}
+
+fn abstraction_literal(payload: Payload) -> Option<AbstractionLiteral> {
+    match payload {
+        Payload::LitInt(_) | Payload::Lit(LitClass::Int) => Some(AbstractionLiteral::Int),
+        Payload::LitFloat(_) | Payload::Lit(LitClass::Float) => Some(AbstractionLiteral::Float),
+        Payload::LitStr(_) | Payload::Lit(LitClass::Str) => Some(AbstractionLiteral::Str),
+        _ => None,
+    }
+}
+
+pub(crate) fn abstraction_witness(a: &UnitFeat, b: &UnitFeat) -> Option<crate::AbstractionWitness> {
+    if a.lang != b.lang || a.kind != b.kind {
+        return None;
+    }
+    if a.abstraction_tokens.len() != b.abstraction_tokens.len() || a.abstraction_tokens.is_empty() {
+        return None;
+    }
+
+    let mut hole_index = None;
+    let mut reason_code = None;
+    let mut caveats: Vec<&'static str> = Vec::new();
+    for (idx, (left, right)) in a
+        .abstraction_tokens
+        .iter()
+        .zip(&b.abstraction_tokens)
+        .enumerate()
+    {
+        if same_abstraction_token(left, right) {
+            continue;
+        }
+        if hole_index.is_some() {
+            return None;
+        }
+        let (reason, hole_caveats) = literal_hole_reason(left, right)?;
+        hole_index = Some(idx);
+        reason_code = Some(reason);
+        caveats = hole_caveats;
+    }
+
+    let hole_index = hole_index?;
+    let left = a.abstraction_tokens[hole_index];
+    let right = b.abstraction_tokens[hole_index];
+    let template = a
+        .abstraction_tokens
+        .iter()
+        .enumerate()
+        .map(|(idx, token)| {
+            if idx == hole_index {
+                "<hole 1: literal>".to_string()
+            } else {
+                abstraction_token_label(token).to_string()
+            }
+        })
+        .collect();
+
+    Some(crate::AbstractionWitness {
+        reason_code: reason_code?,
+        template,
+        holes: vec![crate::AbstractionHole {
+            index: 1,
+            kind: "literal",
+            left: left.literal?.label(),
+            right: right.literal?.label(),
+            left_line: left.line,
+            right_line: right.line,
+        }],
+        caveats,
+    })
+}
+
+fn same_abstraction_token(a: &AbstractionToken, b: &AbstractionToken) -> bool {
+    a.kind == b.kind && a.arity == b.arity && a.exact_tag == b.exact_tag
+}
+
+fn literal_hole_reason(
+    a: &AbstractionToken,
+    b: &AbstractionToken,
+) -> Option<(&'static str, Vec<&'static str>)> {
+    if a.kind != NodeKind::Lit || b.kind != NodeKind::Lit || a.arity != 0 || b.arity != 0 {
+        return None;
+    }
+    let left = a.literal?;
+    let right = b.literal?;
+    let shape_compatible = a.shape_tag == b.shape_tag
+        || matches!(
+            (left, right),
+            (AbstractionLiteral::Int, AbstractionLiteral::Float)
+                | (AbstractionLiteral::Float, AbstractionLiteral::Int)
+        );
+    if !shape_compatible {
+        return None;
+    }
+    match (left, right) {
+        (AbstractionLiteral::Int, AbstractionLiteral::Float)
+        | (AbstractionLiteral::Float, AbstractionLiteral::Int) => {
+            Some(("type-parametric", vec!["numeric-domain-sensitive"]))
+        }
+        (AbstractionLiteral::Int, AbstractionLiteral::Int)
+        | (AbstractionLiteral::Float, AbstractionLiteral::Float)
+        | (AbstractionLiteral::Str, AbstractionLiteral::Str) => {
+            Some(("literal-abstracted", Vec::new()))
+        }
+        _ => None,
+    }
+}
+
+fn abstraction_token_label(token: &AbstractionToken) -> &'static str {
+    match token.literal {
+        Some(AbstractionLiteral::Int) => "Lit<Int>",
+        Some(AbstractionLiteral::Float) => "Lit<Float>",
+        Some(AbstractionLiteral::Str) => "Lit<String>",
+        None => match token.kind {
+            NodeKind::Module => "Module",
+            NodeKind::Func => "Func",
+            NodeKind::Param => "Param",
+            NodeKind::Block => "Block",
+            NodeKind::Assign => "Assign",
+            NodeKind::ExprStmt => "ExprStmt",
+            NodeKind::Return => "Return",
+            NodeKind::If => "If",
+            NodeKind::Loop => "Loop",
+            NodeKind::Break => "Break",
+            NodeKind::Continue => "Continue",
+            NodeKind::Throw => "Throw",
+            NodeKind::Try => "Try",
+            NodeKind::Var => "Var",
+            NodeKind::Lit => "Lit",
+            NodeKind::Call => "Call",
+            NodeKind::BinOp => "BinOp",
+            NodeKind::UnOp => "UnOp",
+            NodeKind::Index => "Index",
+            NodeKind::Field => "Field",
+            NodeKind::Lambda => "Lambda",
+            NodeKind::Seq => "Seq",
+            NodeKind::HoF => "HoF",
+            NodeKind::Raw => "Raw",
+        },
+    }
 }
 
 const SEED: u64 = 0x9E37_79B9_7F4A_7C15;
@@ -524,13 +697,22 @@ pub(crate) fn extract(
             continue;
         }
         let feature_start = unit_timer.start();
-        let (shapes, shape_minhash, linear) = if shape_features {
+        let (shapes, shape_minhash, linear, abstraction_tokens) = if shape_features {
             let mut shapes = Vec::with_capacity(pre.len());
             let mut linear = Vec::with_capacity(pre.len());
+            let mut abstraction_tokens = Vec::with_capacity(pre.len());
             for &nid in &pre {
                 let n = il.node(nid);
                 let tag = node_tag(n.kind, n.payload, interner);
                 linear.push(tag);
+                abstraction_tokens.push(AbstractionToken {
+                    kind: n.kind,
+                    arity: il.children(nid).len().min(u16::MAX as usize) as u16,
+                    shape_tag: tag,
+                    exact_tag: node_tag_valued(n.kind, n.payload, interner),
+                    literal: abstraction_literal(n.payload),
+                    line: n.span.start_line,
+                });
                 let mut shape = tag;
                 for &c in il.children(nid) {
                     let cn = il.node(c);
@@ -545,9 +727,10 @@ pub(crate) fn extract(
                 shapes,
                 crate::minhash::sign(&distinct_shapes, seeds),
                 linear,
+                abstraction_tokens,
             )
         } else {
-            (Vec::new(), Vec::new(), Vec::new())
+            (Vec::new(), Vec::new(), Vec::new(), Vec::new())
         };
 
         // Candidate generation keys on the value graph when present (so clones
@@ -599,6 +782,7 @@ pub(crate) fn extract(
             value,
             minhash,
             linear,
+            abstraction_tokens,
             lits,
             returns,
             anchors,

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -145,6 +145,23 @@ fn abstraction_literal(payload: Payload) -> Option<AbstractionLiteral> {
     }
 }
 
+fn abstraction_token(
+    il: &Il,
+    interner: &Interner,
+    nid: NodeId,
+    shape_tag: u64,
+) -> AbstractionToken {
+    let n = il.node(nid);
+    AbstractionToken {
+        kind: n.kind,
+        arity: il.children(nid).len().min(u16::MAX as usize) as u16,
+        shape_tag,
+        exact_tag: node_tag_valued(n.kind, n.payload, interner),
+        literal: abstraction_literal(n.payload),
+        line: n.span.start_line,
+    }
+}
+
 pub(crate) fn abstraction_witness(a: &UnitFeat, b: &UnitFeat) -> Option<crate::AbstractionWitness> {
     if a.lang != b.lang || a.kind != b.kind {
         return None;
@@ -549,6 +566,12 @@ struct UnitRoot {
     fragment_kind: Option<FragmentKind>,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct ExtractFeatures {
+    pub(crate) shape_features: bool,
+    pub(crate) abstraction_witnesses: bool,
+}
+
 /// Extract all units of `il` passing the size gates, with features computed.
 pub(crate) fn extract(
     il: &Il,
@@ -557,7 +580,7 @@ pub(crate) fn extract(
     min_lines: u32,
     min_tokens: usize,
     block_units: bool,
-    shape_features: bool,
+    features: ExtractFeatures,
 ) -> Vec<UnitFeat> {
     // Frontend-tagged functions/methods/classes, and (when enabled) substantial
     // sub-function blocks (loops / ifs / try) plus exact-safe statement fragments.
@@ -697,22 +720,21 @@ pub(crate) fn extract(
             continue;
         }
         let feature_start = unit_timer.start();
-        let (shapes, shape_minhash, linear, abstraction_tokens) = if shape_features {
+        let (shapes, shape_minhash, linear, abstraction_tokens) = if features.shape_features {
             let mut shapes = Vec::with_capacity(pre.len());
             let mut linear = Vec::with_capacity(pre.len());
-            let mut abstraction_tokens = Vec::with_capacity(pre.len());
+            let mut abstraction_tokens = if features.abstraction_witnesses {
+                Vec::with_capacity(pre.len())
+            } else {
+                Vec::new()
+            };
             for &nid in &pre {
                 let n = il.node(nid);
                 let tag = node_tag(n.kind, n.payload, interner);
                 linear.push(tag);
-                abstraction_tokens.push(AbstractionToken {
-                    kind: n.kind,
-                    arity: il.children(nid).len().min(u16::MAX as usize) as u16,
-                    shape_tag: tag,
-                    exact_tag: node_tag_valued(n.kind, n.payload, interner),
-                    literal: abstraction_literal(n.payload),
-                    line: n.span.start_line,
-                });
+                if features.abstraction_witnesses {
+                    abstraction_tokens.push(abstraction_token(il, interner, nid, tag));
+                }
                 let mut shape = tag;
                 for &c in il.children(nid) {
                     let cn = il.node(c);
@@ -729,13 +751,23 @@ pub(crate) fn extract(
                 linear,
                 abstraction_tokens,
             )
+        } else if features.abstraction_witnesses {
+            let abstraction_tokens = pre
+                .iter()
+                .map(|&nid| {
+                    let n = il.node(nid);
+                    let tag = node_tag(n.kind, n.payload, interner);
+                    abstraction_token(il, interner, nid, tag)
+                })
+                .collect();
+            (Vec::new(), Vec::new(), Vec::new(), abstraction_tokens)
         } else {
             (Vec::new(), Vec::new(), Vec::new(), Vec::new())
         };
 
         // Candidate generation keys on the value graph when present (so clones
         // that converge only semantically still become candidates).
-        let minhash = if value.is_empty() && !shape_features {
+        let minhash = if value.is_empty() && !features.shape_features {
             Vec::new()
         } else {
             let mut distinct = if value.is_empty() {
@@ -4642,22 +4674,83 @@ mod tests {
         ));
     }
 
-    fn lowered_java_unit(src: &str, interner: &Interner, kind: UnitKind, name: &str) -> UnitFeat {
+    fn lowered_java_unit_with_features(
+        src: &str,
+        interner: &Interner,
+        kind: UnitKind,
+        name: &str,
+        shape_features: bool,
+        abstraction_witnesses: bool,
+    ) -> UnitFeat {
         let raw =
             nose_frontend::lower_source(FileId(0), "T.java", src.as_bytes(), Lang::Java, interner)
                 .expect("lower Java source");
         let il =
             nose_normalize::normalize(&raw, interner, &nose_normalize::NormalizeOptions::default());
         let seeds = crate::minhash::seeds(64);
-        let units = extract(&il, interner, &seeds, 1, 1, true, false);
+        let units = extract(
+            &il,
+            interner,
+            &seeds,
+            1,
+            1,
+            true,
+            ExtractFeatures {
+                shape_features,
+                abstraction_witnesses,
+            },
+        );
         units
             .into_iter()
             .find(|unit| unit.kind == kind && unit.name.as_deref() == Some(name))
             .expect("requested Java unit")
     }
 
+    fn lowered_java_unit(src: &str, interner: &Interner, kind: UnitKind, name: &str) -> UnitFeat {
+        lowered_java_unit_with_features(src, interner, kind, name, false, false)
+    }
+
     fn lowered_java_method_unit(src: &str, interner: &Interner) -> UnitFeat {
         lowered_java_unit(src, interner, UnitKind::Method, "f")
+    }
+
+    #[test]
+    fn abstraction_tokens_do_not_depend_on_shape_features() {
+        let interner = Interner::new();
+        let left = lowered_java_unit_with_features(
+            "class Left { static int f() { return 1; } }\n",
+            &interner,
+            UnitKind::Method,
+            "f",
+            false,
+            true,
+        );
+        let right = lowered_java_unit_with_features(
+            "class Right { static int f() { return 2; } }\n",
+            &interner,
+            UnitKind::Method,
+            "f",
+            false,
+            true,
+        );
+
+        assert!(
+            left.shapes.is_empty(),
+            "shape features should stay disabled"
+        );
+        assert!(
+            left.linear.is_empty(),
+            "linear shape features should stay disabled"
+        );
+        assert!(
+            !left.abstraction_tokens.is_empty() && !right.abstraction_tokens.is_empty(),
+            "abstraction witnesses need their own tokens even when shape features are off"
+        );
+        let witness = abstraction_witness(&left, &right)
+            .expect("one changed integer literal should produce an abstraction witness");
+        assert_eq!(witness.reason_code, "literal-abstracted");
+        assert_eq!(witness.holes[0].left, "int-literal");
+        assert_eq!(witness.holes[0].right, "int-literal");
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,12 +59,14 @@ source ──tree-sitter──▶ raw IL ──normalize──▶ canonical IL �
    the strict precision gates.
 4. **Candidate generation**: the selected scan channels decide which candidates exist.
    `semantic` uses value-fingerprint MinHash signatures plus exact-value buckets, `near`
-   uses shape MinHash signatures, and `syntax` bypasses unit LSH with a Rabin-Karp
-   token-stream pass.
+   uses shape MinHash signatures, experimental `abstraction` reuses the near candidate
+   stream, and `syntax` bypasses unit LSH with a Rabin-Karp token-stream pass.
 5. **Accept / score**: `semantic` accepts only exact-safe value-fingerprint equality, `near`
    scores candidates with structural alignment (RANSAC) plus weighted shape/value
    Jaccard and accepts above the inline `near:T` threshold (default `near:0.70`), and
-   `syntax` emits duplicated runs above the line/token floors.
+   `syntax` emits duplicated runs above the line/token floors. Experimental
+   `abstraction` then filters accepted near-style pairs to same-language, single
+   supported literal-leaf holes and attaches a weak witness instead of an exact claim.
 6. **Cluster & rank**: union-find over accepted pairs/runs forms clone groups, which
    are grouped into **families** and sorted by refactoring value (removable lines
    × similarity × cross-module/-file/-language spread). See [usage](usage.md) for how the

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -87,6 +87,10 @@ nose capabilities
 }
 ```
 
+`scan.modes` lists stable scan modes only. Hidden experimental modes such as
+`abstraction` may be accepted by a development binary without appearing here; wrappers
+should treat absence from `scan.modes` as "not stable for automation."
+
 `tool.version` is shown as the `<version>` placeholder because the field always reports the
 installed binary's own version (`nose --version`); the example deliberately does not pin a
 release so it can't drift.

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -40,6 +40,11 @@ runs that a token detector should catch, including runs that cross function boun
 it is not the renamed/literal-varied Type-2 story by itself. Use the default or add `near`
 when renamed or literal-varied copies matter.
 
+The hidden experimental `abstraction` mode narrows one slice of this space for tools:
+it starts from low-threshold `near` candidates, then reports only same-language pairs
+whose normalized IL differs by exactly one supported literal leaf. The output is a typed
+template witness, not a claim that the copies are behavior-equivalent.
+
 ## Type-3 — near-duplicate via similarity (the primary use)
 
 Unit pairs are scored by value-graph + shape similarity and structural alignment, and
@@ -143,7 +148,9 @@ separately with `recommended_surface`: default, review, or hidden. See
 Each type maps to a detection channel by evidence surface: **Type-1 and token-level
 copy floors → `syntax`**, identifier/type-normalized **Type-2 → `semantic` or `near`**,
 literal-varied Type-2 and **Type-3 → `near`** (fuzzy; the threshold rides on the mode,
-`near:0.8`), and exact **Type-4 → `semantic`**. The default is `syntax,semantic`; see
+`near:0.8`), and exact **Type-4 → `semantic`**. The experimental
+`abstraction[:T]` mode is a weak witness layer over a narrow `near` subset; it does not
+feed `semantic` or `verify`. The default is `syntax,semantic`; see
 [usage → Scan modes](usage.md#scan-modes) for the full table and how to compose channels.
 
 The taxonomy is usually stated within a single language; because every language lowers to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,11 @@ The `near` channel's acceptance threshold rides on the `mode` value itself —
 There is no separate threshold setting, so it can never be mis-applied to the exact
 `syntax`/`semantic` channels.
 
+The hidden experimental `abstraction[:T]` mode is also accepted in `mode`, but it is
+not a stable project-policy surface and is intentionally absent from
+[capabilities](capabilities.md)' stable mode list. Prefer it for local research or
+tooling experiments, not CI gates.
+
 ```sh
 nose scan src --mode syntax,semantic,near:0.70
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,9 @@ There is no separate threshold setting, so it can never be mis-applied to the ex
 The hidden experimental `abstraction[:T]` mode is also accepted in `mode`, but it is
 not a stable project-policy surface and is intentionally absent from
 [capabilities](capabilities.md)' stable mode list. Prefer it for local research or
-tooling experiments, not CI gates.
+tooling experiments, not CI gates. If `near:T` and `abstraction:T` appear together,
+they must name the same threshold because both modes share one fuzzy acceptance
+cutoff.
 
 ```sh
 nose scan src --mode syntax,semantic,near:0.70

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -150,6 +150,7 @@ schema version 1:
 | `discount` | number | Refactor-worthiness discount for generated or type-heavy families. |
 | `recommended_surface` | string | Product placement hint. Current detector output uses `default`, `review`, or `hidden`; `debug` is reserved for diagnostics/regression tooling. This is ranking/presentation policy, not detector exactness. |
 | `baseline_status` | string, optional | `new` or `changed` when this family is shown because of `--baseline`. |
+| `abstraction_witness` | object, optional | Experimental weak-claim witness emitted only for `--mode abstraction` families that share a normalized template with one supported literal leaf hole. |
 
 Each `locations[]` item has:
 
@@ -189,11 +190,40 @@ The optional `enclosing_unit` object has:
 | `name` | string, optional | Enclosing symbol name when recoverable. |
 | `unit_key` | string | Stable key built from file, kind, span, and name for grouping/review context. |
 
-Do not confuse fragment `reason_code` with future family/actionability reason codes from
-[#11](https://github.com/corca-ai/nose/issues/11). Fragment `reason_code` answers why this
-sub-function fragment was accepted as exact-safe. Future family/actionability reason codes
-answer why a clone family is worth refactoring or reviewing. They intentionally do not
-share one field.
+Do not confuse fragment `reason_code` with family-level witness reason codes. Fragment
+`reason_code` answers why this sub-function fragment was accepted as exact-safe. Future
+family/actionability reason codes answer why a clone family is worth refactoring or
+reviewing. The experimental `abstraction_witness.reason_code` below is a weak-template
+reason, not exact-fragment proof.
+
+### Abstraction witnesses
+
+`abstraction_witness` is present only for the hidden experimental
+`scan --mode abstraction[:T]` surface. It is a sibling claim to `semantic`, not a
+relaxed semantic clone verdict: the family is a refactoring-template candidate whose
+representative pair has identical normalized structure except for one supported literal
+leaf. Operator swaps, call-shape differences, and multi-hole diffs do not receive a
+witness.
+
+The object has:
+
+| field | type | meaning |
+|---|---|---|
+| `reason_code` | string | Stable weak-template reason. Current values are `type-parametric` for int/float literal holes and `literal-abstracted` for same-class int, float, or string literal holes. |
+| `template` | array of strings | Pre-order normalized IL template tokens with `<hole 1: literal>` at the abstracted leaf. This is intentionally internal and machine-oriented, not source text. |
+| `holes` | array | Typed hole metadata for the representative pair. v1 emits exactly one hole. |
+| `caveats` | array of strings | Caveats attached to the weak claim. `numeric-domain-sensitive` is emitted for int/float literal holes. |
+
+Each `holes[]` item has:
+
+| field | type | meaning |
+|---|---|---|
+| `index` | integer | 1-based hole index in the template. |
+| `kind` | string | Hole kind; currently `literal`. |
+| `left` | string | Left representative leaf class, such as `int-literal`, `float-literal`, or `string-literal`. |
+| `right` | string | Right representative leaf class. |
+| `left_line` | integer | Source line for the left representative leaf when known. |
+| `right_line` | integer | Source line for the right representative leaf when known. |
 
 `proof_facts` are not part of the stable scan JSON contract. They remain internal
 diagnostic facts unless a future schema explicitly adds an unstable diagnostics namespace.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -304,6 +304,10 @@ and pack ecosystem.
   dependencies when spans survive normalization, and Java map provider proofs no
   longer replace current receiver identity except for imported literal snapshots
   already validated in the provider module.
+- An experimental `abstraction` scan mode landed as a weak sibling claim over a
+  narrow `near` subset. It emits typed literal-hole witnesses and caveats for
+  refactoring-template candidates, but does not feed `semantic`, `verify`, or exact
+  kernel admission.
 
 ## Phase 0: documentation and vocabulary (landed)
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -43,6 +43,12 @@ still being migrated toward it.
 The current model already enforces the main product principle: exact semantic
 matches must be fail-closed and false merges are bugs.
 
+An experimental `abstraction` scan mode now exists as a weak sibling surface over
+`near`, not as an exact semantic relaxation. It keeps only same-language candidates
+whose normalized IL differs by exactly one supported literal leaf and emits an
+`abstraction_witness` with a typed hole, a reason code, and caveats such as
+`numeric-domain-sensitive`.
+
 ## Implemented facade contracts
 
 The current facade is compiled Rust, not an external manifest schema. It is

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -238,6 +238,7 @@ The same semantic knowledge can be safe for one channel and unsafe for another.
 |---|---|
 | `syntax-only` | parsing/lowering/reporting only |
 | `near-only` | candidate generation and review-oriented scoring |
+| `abstraction-witness` | weak refactoring-template witnesses over `near` candidates; never exact equivalence |
 | `exact-empirical` | exact channel when required tests, hard negatives, and oracle coverage are present |
 | `exact-proven` | exact channel with proof obligations for the core law |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,7 +67,7 @@ Grouped by what they do. Config-backed scan defaults are listed in
 | `--min-members N` | only families with at least N duplicated sites (default 2) |
 | `--min-value V` | hide families below this refactoring value (noise floor on large repos) |
 | `--min-size N` | ignore units or syntax copy-paste runs smaller than this size, in IL tokens (default 24) |
-| `--mode MODE` | one or more of `syntax`, `semantic`, `near[:T]`; comma-list or repeatable; when present, replaces the default |
+| `--mode MODE` | one or more of `syntax`, `semantic`, `near[:T]`; comma-list or repeatable; when present, replaces the default. Experimental `abstraction[:T]` is accepted but not a stable capabilities mode. |
 | `--exclude <glob>` | skip paths matching a gitignore-syntax glob (repeatable) |
 | `--ignore-file <file>` | suppress reviewed families using a structured ignore file with reason/owner/expiry metadata |
 
@@ -115,10 +115,10 @@ Structured suppressions are covered in [structured-ignores](structured-ignores.m
 
 ### Scan modes
 
-`nose scan` has three orthogonal channels. Omitting `--mode` runs `syntax,semantic`.
-When `--mode` is present, nose runs exactly the channels you list; it does not add
-them to the default. See [clone-types](clone-types.md) for what each finds against
-the standard Type-1–4 taxonomy.
+`nose scan` has three stable orthogonal channels. Omitting `--mode` runs
+`syntax,semantic`. When `--mode` is present, nose runs exactly the channels you
+list; it does not add them to the default. See [clone-types](clone-types.md) for
+what each finds against the standard Type-1–4 taxonomy.
 
 | mode | clone type | detector channel | use when |
 |---|---|---|---|
@@ -139,6 +139,14 @@ nose scan src --mode syntax --mode semantic    # same as --mode syntax,semantic
 
 The `near` channel takes its acceptance threshold inline — `--mode near:0.8` (default
 `0.70`). `syntax` and `semantic` are exact channels and take no threshold.
+
+There is also a hidden experimental `abstraction[:T]` mode. It reuses the `near`
+candidate stream, defaults to threshold `0.50`, and then keeps only same-language
+families whose normalized IL differs by exactly one supported literal leaf. Its
+claim is weaker than `semantic`: it reports a refactoring-template witness with a
+typed hole and caveats such as `numeric-domain-sensitive`; it does not say the two
+copies are behavior-equivalent. Use `--format json --top 0` to consume the
+`abstraction_witness` field documented in [scan-json](scan-json.md#abstraction-witnesses).
 
 The `syntax` channel is the CPD floor: it finds same-language duplicated token runs even
 when they start or end in the middle of a function. The normalized unit channels

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -147,6 +147,9 @@ claim is weaker than `semantic`: it reports a refactoring-template witness with 
 typed hole and caveats such as `numeric-domain-sensitive`; it does not say the two
 copies are behavior-equivalent. Use `--format json --top 0` to consume the
 `abstraction_witness` field documented in [scan-json](scan-json.md#abstraction-witnesses).
+When `near:T` and `abstraction:T` are combined in one scan, they share one fuzzy
+acceptance threshold; giving different inline values is rejected instead of silently
+choosing the last one.
 
 The `syntax` channel is the CPD floor: it finds same-language duplicated token runs even
 when they start or end in the middle of a function. The normalized unit channels


### PR DESCRIPTION
Closes #99.

## What changed

- Added hidden experimental `scan --mode abstraction[:T]`, backed by the near candidate stream with a default threshold of 0.50.
- Filters abstraction-only scans to same-language families with a single supported literal leaf hole, preserving strict `semantic` behavior.
- Emits JSON-visible `abstraction_witness` data with a normalized template, typed hole metadata, stable reason codes, and caveats such as `numeric-domain-sensitive`.
- Added CLI coverage for int/float literal caveats, same-class literal abstraction without numeric caveats, threshold parsing, and operator-swap rejection.
- Updated scan usage, JSON schema docs, clone taxonomy docs, capabilities/config notes, architecture, and semantic-kernel docs.

## Validation

- `cargo test -p nose-cli --test cli abstraction -- --nocapture`
- `cargo test -p nose-cli --test cli -- --nocapture`
- `cargo test -p nose-detect --lib -- --nocapture`
- `cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `awiki lint --root docs`
- `git diff --check`
- `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `cargo build --release && ./scripts/check-duplication.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * `abstraction[:T]` 스캔 모드 추가 (실험적 기능)
  * 코드 패턴 감지 시 리팩터링 템플릿 증거 정보 포함

* **Improvements**
  * 캐시 스키마 업데이트로 성능 최적화

* **Documentation**
  * 새로운 스캔 모드 사용법 및 제약 사항 명시
  * JSON 출력 스키마 확대 및 설명 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->