### PR TITLE
semantics: require evidence-backed record guards

### DIFF
--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -8760,6 +8760,16 @@ fn scan_mode_semantic_proves_js_record_shape_guards() {
     )
     .unwrap();
     fs::write(
+        dir.join("array_shadowed_negative.js"),
+        "function shadowed(Array, input) {\n  return typeof input === \"object\" && input !== null && !Array.isArray(input);\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("array_destructured_shadow_negative.js"),
+        "function shadowed(scope, input) {\n  const { Array } = scope;\n  return typeof input === \"object\" && input !== null && !Array.isArray(input);\n}\n",
+    )
+    .unwrap();
+    fs::write(
         dir.join("array_allowed_negative.js"),
         "function arrayAllowed(value) {\n  return typeof value === \"object\" && value !== null;\n}\n",
     )
@@ -8772,6 +8782,11 @@ fn scan_mode_semantic_proves_js_record_shape_guards() {
     fs::write(
         dir.join("wrong_typeof_literal_negative.js"),
         "function wrongLiteral(value) {\n  return typeof value === \"ob ject\" && value !== null && !Array.isArray(value);\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("typeof_identifier_negative.js"),
+        "function wrongIdentifier(value) {\n  return typeofvalue === \"object\" && value !== null && !Array.isArray(value);\n}\n",
     )
     .unwrap();
 
@@ -8805,8 +8820,11 @@ fn scan_mode_semantic_proves_js_record_shape_guards() {
     }
     for unexpected in [
         "array_allowed_negative.js",
+        "array_destructured_shadow_negative.js",
+        "array_shadowed_negative.js",
         "boolean_shadowed_negative.js",
         "null_allowed_negative.js",
+        "typeof_identifier_negative.js",
         "wrong_typeof_literal_negative.js",
     ] {
         assert!(

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -22,8 +22,8 @@ use nose_semantics::{
     java_map_entry_contract, java_map_factory_contract, js_array_is_array_contract,
     js_like_map_constructor_contract, js_like_set_constructor_contract, map_get_contract,
     map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
-    nullish_global_contract, qualified_global_symbol, regex_test_contract,
-    ruby_set_factory_contract, rust_vec_new_factory_contract, semantics,
+    nullish_global_contract, qualified_global_symbol, record_shape_guard_for_node,
+    regex_test_contract, ruby_set_factory_contract, rust_vec_new_factory_contract, semantics,
     seq_surface_contract_for_node, source_fact_at_node, source_operator_at_node,
     static_index_membership_contract, typeof_operator_contract, unshadowed_global_symbol,
     DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind, MapKeyViewKind,
@@ -1212,8 +1212,10 @@ fn strict_exact_nullish_global_safe(il: &Il, interner: &Interner, node: NodeId) 
 
 fn strict_exact_safe_seq(il: &Il, interner: &Interner, node: NodeId) -> bool {
     if let Payload::Name(tag) = il.node(node).payload {
-        if interner.resolve(tag) == "own_property_guard" {
-            return strict_exact_own_property_guard_seq_safe(il, node);
+        match interner.resolve(tag) {
+            "own_property_guard" => return strict_exact_own_property_guard_seq_safe(il, node),
+            "record_guard" => return record_shape_guard_for_node(il, interner, node),
+            _ => {}
         }
     }
     seq_surface_contract_for_node(il, interner, node)

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -8,9 +8,11 @@
 
 use crate::lower::Lowering;
 use nose_il::{
-    contains_js_identifier, is_js_identifier_continue, Builtin, FileId, Il, Interner, Lang,
-    LitClass, LoopKind, NodeId, NodeKind, Op, Payload, SourceCallKind, SourceFactKind,
-    SourceLiteralKind, SourceOperatorKind, Span, UnitKind,
+    contains_js_identifier, is_js_identifier_continue, stable_symbol_hash, Builtin, EvidenceAnchor,
+    EvidenceKind, FileId, GuardEvidenceKind, Il, Interner, JsRecordGuardComparison,
+    JsRecordGuardNullCheck, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload,
+    SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind, Span,
+    SymbolEvidenceKind, UnitKind,
 };
 use nose_semantics::{
     js_array_is_array_contract, js_boolean_coercion_contract, qualified_global_symbol_contract,
@@ -1339,11 +1341,12 @@ fn lower_record_shape_guard(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
 
     let mut ident: Option<String> = None;
     let mut has_typeof_object = false;
-    let mut has_non_null_or_truthy = false;
+    let mut null_check = None;
     let mut has_not_array = false;
-    let mut requires_boolean_global = false;
+    let mut comparison = JsRecordGuardComparison::StrictOnly;
     for clause in clauses {
-        let (kind, name) = record_guard_clause(&clause)?;
+        let parsed = record_guard_clause(&clause)?;
+        let name = parsed.name;
         if !simple_js_ident(&name) {
             return None;
         }
@@ -1352,19 +1355,15 @@ fn lower_record_shape_guard(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
             None => ident = Some(name.clone()),
             _ => {}
         }
-        match kind {
+        comparison = merge_record_guard_comparison(comparison, parsed.comparison);
+        match parsed.kind {
             RecordGuardClause::TypeofObject => has_typeof_object = true,
-            RecordGuardClause::NonNullOrTruthy {
-                requires_boolean_global: requires,
-            } => {
-                has_non_null_or_truthy = true;
-                requires_boolean_global |= requires;
-            }
+            RecordGuardClause::NonNullOrTruthy { kind } => null_check = Some(kind),
             RecordGuardClause::NotArray => has_not_array = true,
         }
     }
 
-    if !(has_typeof_object && has_non_null_or_truthy && has_not_array) {
+    if !(has_typeof_object && null_check.is_some() && has_not_array) {
         return None;
     }
     let array_contract = js_array_is_array_contract(lo.lang, "Array", "isArray", 1)?;
@@ -1374,6 +1373,8 @@ fn lower_record_shape_guard(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     {
         return None;
     }
+    let null_check = null_check?;
+    let requires_boolean_global = null_check == JsRecordGuardNullCheck::BooleanGlobalTruthy;
     let boolean_contract = requires_boolean_global
         .then(|| js_boolean_coercion_contract(lo.lang, "Boolean", 1))
         .flatten();
@@ -1387,100 +1388,165 @@ fn lower_record_shape_guard(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     }) {
         return None;
     }
+    let ident = ident?;
     let span = lo.span(node);
-    let value = lo.var(&ident?, span);
+    let value = lo.var(&ident, span);
     let object = lo.str_lit("object", span);
     let non_null = lo.str_lit("non_null", span);
     let not_array = lo.str_lit("not_array", span);
     let tag = lo.sym("record_guard");
-    Some(lo.add(
+    let guard = lo.add(
         NodeKind::Seq,
         Payload::Name(tag),
         span,
         &[value, object, non_null, not_array],
-    ))
+    );
+    let array_dependency = lo.record_evidence(
+        EvidenceAnchor::source_span(span),
+        EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+            path_hash: stable_symbol_hash(array_contract.qualified_path),
+        }),
+        "record_guard_array_is_array_api",
+    );
+    let mut dependencies = vec![array_dependency];
+    if let Some(contract) = boolean_contract {
+        dependencies.push(lo.record_evidence(
+            EvidenceAnchor::source_span(span),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash(contract.function),
+            }),
+            "record_guard_boolean_api",
+        ));
+    }
+    lo.record_evidence_with_dependencies(
+        EvidenceAnchor::sequence(span),
+        EvidenceKind::Guard(GuardEvidenceKind::JsRecordShape {
+            subject_hash: stable_symbol_hash(&ident),
+            null_check,
+            comparison,
+        }),
+        "record_guard_js_shape",
+        dependencies,
+    );
+    Some(guard)
 }
 
 #[derive(Clone, Copy)]
 enum RecordGuardClause {
     TypeofObject,
-    NonNullOrTruthy { requires_boolean_global: bool },
+    NonNullOrTruthy { kind: JsRecordGuardNullCheck },
     NotArray,
 }
 
-fn record_guard_clause(clause: &str) -> Option<(RecordGuardClause, String)> {
+struct ParsedRecordGuardClause {
+    kind: RecordGuardClause,
+    name: String,
+    comparison: JsRecordGuardComparison,
+}
+
+fn record_guard_clause(clause: &str) -> Option<ParsedRecordGuardClause> {
     parse_typeof_object_clause(clause)
-        .map(|name| (RecordGuardClause::TypeofObject, name))
-        .or_else(|| parse_non_null_clause(clause).map(|name| (non_null_guard_clause(false), name)))
+        .map(|(name, comparison)| ParsedRecordGuardClause {
+            kind: RecordGuardClause::TypeofObject,
+            name,
+            comparison,
+        })
         .or_else(|| {
-            parse_truthy_clause(clause).map(|(name, requires_boolean_global)| {
-                (non_null_guard_clause(requires_boolean_global), name)
+            parse_non_null_clause(clause).map(|(name, kind, comparison)| ParsedRecordGuardClause {
+                kind: RecordGuardClause::NonNullOrTruthy { kind },
+                name,
+                comparison,
             })
         })
-        .or_else(|| parse_not_array_clause(clause).map(|name| (RecordGuardClause::NotArray, name)))
+        .or_else(|| {
+            parse_truthy_clause(clause).map(|(name, kind)| ParsedRecordGuardClause {
+                kind: RecordGuardClause::NonNullOrTruthy { kind },
+                name,
+                comparison: JsRecordGuardComparison::StrictOnly,
+            })
+        })
+        .or_else(|| {
+            parse_not_array_clause(clause).map(|(name, comparison)| ParsedRecordGuardClause {
+                kind: RecordGuardClause::NotArray,
+                name,
+                comparison,
+            })
+        })
 }
 
-fn non_null_guard_clause(requires_boolean_global: bool) -> RecordGuardClause {
-    RecordGuardClause::NonNullOrTruthy {
-        requires_boolean_global,
-    }
-}
-
-fn parse_typeof_object_clause(clause: &str) -> Option<String> {
+fn parse_typeof_object_clause(clause: &str) -> Option<(String, JsRecordGuardComparison)> {
     for op in ["===", "=="] {
-        if let Some(rest) = clause.strip_prefix("typeof") {
+        let comparison = record_guard_comparison_for_op(op);
+        if let Some(rest) = clause.strip_prefix("typeof ") {
             let (name, value) = rest.split_once(op)?;
             if is_object_literal(value) {
-                return Some(name.to_string());
+                return Some((name.to_string(), comparison));
             }
         }
         for object_lit in ["'object'", "\"object\""] {
-            let prefix = format!("{object_lit}{op}typeof");
+            let prefix = format!("{object_lit}{op}typeof ");
             if let Some(name) = clause.strip_prefix(&prefix) {
-                return Some(name.to_string());
+                return Some((name.to_string(), comparison));
             }
         }
     }
     None
 }
 
-fn parse_non_null_clause(clause: &str) -> Option<String> {
+fn parse_non_null_clause(
+    clause: &str,
+) -> Option<(String, JsRecordGuardNullCheck, JsRecordGuardComparison)> {
     for op in ["!==", "!="] {
+        let null_check = match op {
+            "!==" => JsRecordGuardNullCheck::StrictNonNull,
+            "!=" => JsRecordGuardNullCheck::LooseNonNull,
+            _ => unreachable!(),
+        };
+        let comparison = record_guard_comparison_for_op(op);
         if let Some((name, "null")) = clause.split_once(op) {
-            return Some(name.to_string());
+            return Some((name.to_string(), null_check, comparison));
         }
         let prefix = format!("null{op}");
         if let Some(name) = clause.strip_prefix(&prefix) {
-            return Some(name.to_string());
+            return Some((name.to_string(), null_check, comparison));
         }
     }
     None
 }
 
-fn parse_truthy_clause(clause: &str) -> Option<(String, bool)> {
+fn parse_truthy_clause(clause: &str) -> Option<(String, JsRecordGuardNullCheck)> {
     if let Some(name) = clause.strip_prefix("!!") {
-        return Some((name.to_string(), false));
+        return Some((
+            name.to_string(),
+            JsRecordGuardNullCheck::DoubleNegationTruthy,
+        ));
     }
     clause
         .strip_prefix("Boolean(")
         .and_then(|inner| inner.strip_suffix(')'))
-        .map(|name| (name.to_string(), true))
+        .map(|name| {
+            (
+                name.to_string(),
+                JsRecordGuardNullCheck::BooleanGlobalTruthy,
+            )
+        })
 }
 
-fn parse_not_array_clause(clause: &str) -> Option<String> {
+fn parse_not_array_clause(clause: &str) -> Option<(String, JsRecordGuardComparison)> {
     if let Some(name) = clause
         .strip_prefix("!Array.isArray(")
         .and_then(|inner| inner.strip_suffix(')'))
     {
-        return Some(name.to_string());
+        return Some((name.to_string(), JsRecordGuardComparison::StrictOnly));
     }
     for op in ["===", "=="] {
+        let comparison = record_guard_comparison_for_op(op);
         if let Some(call) = clause.strip_suffix(&format!("{op}false")) {
             if let Some(name) = call
                 .strip_prefix("Array.isArray(")
                 .and_then(|inner| inner.strip_suffix(')'))
             {
-                return Some(name.to_string());
+                return Some((name.to_string(), comparison));
             }
         }
         let prefix = format!("false{op}Array.isArray(");
@@ -1488,10 +1554,32 @@ fn parse_not_array_clause(clause: &str) -> Option<String> {
             .strip_prefix(&prefix)
             .and_then(|inner| inner.strip_suffix(')'))
         {
-            return Some(name.to_string());
+            return Some((name.to_string(), comparison));
         }
     }
     None
+}
+
+fn record_guard_comparison_for_op(op: &str) -> JsRecordGuardComparison {
+    match op {
+        "==" | "!=" => JsRecordGuardComparison::LooseEqualityAllowed,
+        _ => JsRecordGuardComparison::StrictOnly,
+    }
+}
+
+fn merge_record_guard_comparison(
+    left: JsRecordGuardComparison,
+    right: JsRecordGuardComparison,
+) -> JsRecordGuardComparison {
+    if matches!(
+        (left, right),
+        (JsRecordGuardComparison::LooseEqualityAllowed, _)
+            | (_, JsRecordGuardComparison::LooseEqualityAllowed)
+    ) {
+        JsRecordGuardComparison::LooseEqualityAllowed
+    } else {
+        JsRecordGuardComparison::StrictOnly
+    }
 }
 
 fn is_object_literal(value: &str) -> bool {
@@ -1502,7 +1590,8 @@ fn compact_js_expr(text: &str) -> String {
     let mut out = String::new();
     let mut quote = None;
     let mut escaped = false;
-    for c in text.chars() {
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
         if let Some(q) = quote {
             out.push(c);
             if escaped {
@@ -1517,7 +1606,17 @@ fn compact_js_expr(text: &str) -> String {
         if c == '\'' || c == '"' {
             quote = Some(c);
             out.push(c);
-        } else if !c.is_whitespace() {
+        } else if c.is_whitespace() {
+            let next = chars.clone().find(|next| !next.is_whitespace());
+            if out
+                .chars()
+                .next_back()
+                .is_some_and(is_js_identifier_continue)
+                && next.is_some_and(is_js_identifier_continue)
+            {
+                out.push(' ');
+            }
+        } else {
             out.push(c);
         }
     }
@@ -1841,7 +1940,8 @@ fn js_source_operator(text: &str) -> Option<SourceOperatorKind> {
 mod tests {
     use super::*;
     use nose_il::{
-        stable_symbol_hash, EvidenceAnchor, EvidenceKind, FileId, Interner, SymbolEvidenceKind,
+        stable_symbol_hash, EvidenceAnchor, EvidenceKind, FileId, GuardEvidenceKind, Interner,
+        JsRecordGuardComparison, JsRecordGuardNullCheck, SymbolEvidenceKind,
     };
 
     fn lower_js(src: &str) -> Il {
@@ -1888,6 +1988,18 @@ mod tests {
                 )
             })
             .count()
+    }
+
+    fn js_record_shape_guard_evidence(il: &Il) -> Vec<&nose_il::EvidenceRecord> {
+        il.evidence
+            .iter()
+            .filter(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::Guard(GuardEvidenceKind::JsRecordShape { .. })
+                )
+            })
+            .collect()
     }
 
     fn switch_labels_for_return(src: &str, expected_return: i64) -> Vec<i64> {
@@ -2023,6 +2135,70 @@ mod tests {
             qualified_global_evidence_count(&il, "Array.isArray", NodeKind::Field),
             1
         );
+    }
+
+    #[test]
+    fn js_record_shape_guards_emit_guard_evidence_with_api_dependencies() {
+        let il = lower_js(
+            "function direct(value) {
+                return typeof value === \"object\" && value !== null && !Array.isArray(value);
+             }
+             function truthy(input) {
+                return Boolean(input) && typeof input === \"object\" && !Array.isArray(input);
+             }",
+        );
+
+        let guards = js_record_shape_guard_evidence(&il);
+        assert_eq!(guards.len(), 2);
+        assert!(guards.iter().any(|record| {
+            matches!(
+                record.kind,
+                EvidenceKind::Guard(GuardEvidenceKind::JsRecordShape {
+                    subject_hash,
+                    null_check: JsRecordGuardNullCheck::StrictNonNull,
+                    comparison: JsRecordGuardComparison::StrictOnly,
+                }) if subject_hash == stable_symbol_hash("value")
+            ) && record.dependencies.len() == 1
+        }));
+        assert!(guards.iter().any(|record| {
+            matches!(
+                record.kind,
+                EvidenceKind::Guard(GuardEvidenceKind::JsRecordShape {
+                    subject_hash,
+                    null_check: JsRecordGuardNullCheck::BooleanGlobalTruthy,
+                    comparison: JsRecordGuardComparison::StrictOnly,
+                }) if subject_hash == stable_symbol_hash("input")
+            ) && record.dependencies.len() == 2
+        }));
+    }
+
+    #[test]
+    fn js_record_shape_guard_evidence_respects_array_shadowing() {
+        let il = lower_js(
+            "function f(Array, value) {
+                return typeof value === \"object\" && value !== null && !Array.isArray(value);
+             }
+             function g(scope, value) {
+                const { Array } = scope;
+                return typeof value === \"object\" && value !== null && !Array.isArray(value);
+             }",
+        );
+
+        assert!(js_record_shape_guard_evidence(&il).is_empty());
+    }
+
+    #[test]
+    fn js_record_shape_guard_evidence_requires_typeof_keyword_boundary() {
+        let il = lower_js(
+            "function f(value) {
+                return typeofvalue === \"object\" && value !== null && !Array.isArray(value);
+             }
+             function g(value) {
+                return \"object\" === typeofvalue && value !== null && !Array.isArray(value);
+             }",
+        );
+
+        assert!(js_record_shape_guard_evidence(&il).is_empty());
     }
 
     #[test]

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -110,7 +110,17 @@ impl<'a> Lowering<'a> {
         anchor: EvidenceAnchor,
         kind: EvidenceKind,
         rule: &str,
-    ) {
+    ) -> EvidenceId {
+        self.record_evidence_with_dependencies(anchor, kind, rule, Vec::new())
+    }
+
+    pub(crate) fn record_evidence_with_dependencies(
+        &mut self,
+        anchor: EvidenceAnchor,
+        kind: EvidenceKind,
+        rule: &str,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceId {
         let id = EvidenceId(self.evidence.len() as u32);
         self.evidence.push(EvidenceRecord {
             id,
@@ -121,9 +131,10 @@ impl<'a> Lowering<'a> {
                 pack_hash: Some(stable_symbol_hash(nose_semantics::FIRST_PARTY_PACK_ID)),
                 rule_hash: Some(stable_symbol_hash(rule)),
             },
-            dependencies: Vec::new(),
+            dependencies,
             status: EvidenceStatus::Asserted,
         });
+        id
     }
 
     pub(crate) fn record_param_semantic_alias(&mut self, local: &str, semantic: ParamSemantic) {
@@ -214,14 +225,14 @@ impl<'a> Lowering<'a> {
         span: Span,
         kind: NodeKind,
         path: &str,
-    ) {
+    ) -> EvidenceId {
         self.record_evidence(
             EvidenceAnchor::node(span, kind),
             EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
                 path_hash: stable_symbol_hash(path),
             }),
             "symbol_qualified_global",
-        );
+        )
     }
 
     /// Lower an integer literal, retaining its **value** as [`Payload::LitInt`] so the

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -22,10 +22,11 @@ pub use ident::{
 pub use intern::{stable_symbol_hash, symbol_index, Interner, Symbol, FNV_OFFSET_BASIS, FNV_PRIME};
 pub use node::{
     Builtin, DomainEvidence, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
-    EvidenceProvenance, EvidenceRecord, EvidenceStatus, HoFKind, ImportEvidenceKind, LitClass,
-    LoopKind, Node, NodeId, NodeKind, Op, ParamSemantic, ParamTypeFact, Payload,
-    SequenceSurfaceKind, SourceCallKind, SourceFact, SourceFactKind, SourceLiteralKind,
-    SourceOperatorKind, SymbolEvidenceKind,
+    EvidenceProvenance, EvidenceRecord, EvidenceStatus, GuardEvidenceKind, HoFKind,
+    ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, LitClass, LoopKind, Node,
+    NodeId, NodeKind, Op, ParamSemantic, ParamTypeFact, Payload, SequenceSurfaceKind,
+    SourceCallKind, SourceFact, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
+    SymbolEvidenceKind,
 };
 pub use span::{FileId, FileMeta, Lang, Span};
 

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -326,6 +326,29 @@ pub enum SymbolEvidenceKind {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum JsRecordGuardNullCheck {
+    StrictNonNull,
+    LooseNonNull,
+    DoubleNegationTruthy,
+    BooleanGlobalTruthy,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum JsRecordGuardComparison {
+    StrictOnly,
+    LooseEqualityAllowed,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum GuardEvidenceKind {
+    JsRecordShape {
+        subject_hash: u64,
+        null_check: JsRecordGuardNullCheck,
+        comparison: JsRecordGuardComparison,
+    },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub enum SequenceSurfaceKind {
     Untagged,
     Collection,
@@ -345,6 +368,7 @@ pub enum EvidenceKind {
     Domain(DomainEvidence),
     Import(ImportEvidenceKind),
     Symbol(SymbolEvidenceKind),
+    Guard(GuardEvidenceKind),
     SequenceSurface(SequenceSurfaceKind),
 }
 

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -58,8 +58,8 @@ use nose_semantics::{
     java_map_entry_contract_by_hash, java_map_factory_contract_by_hash,
     js_like_map_constructor_contract, js_like_set_constructor_contract, map_get_contract_by_hash,
     map_key_view_contract_by_hash, map_key_view_wrapper_contract_by_hash, method_call_contract,
-    nullish_global_contract, qualified_global_symbol_at_span, reduction_builtin_contract,
-    ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
+    nullish_global_contract, qualified_global_symbol_at_span, record_shape_guard_for_node,
+    reduction_builtin_contract, ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
     rust_option_none_sentinel_contract, rust_option_some_constructor_contract,
     rust_vec_new_factory_contract, scalar_integer_method_contract, semantics,
     seq_surface_contract_for_node, source_operator_at_node, static_index_membership_contract,
@@ -69,7 +69,7 @@ use nose_semantics::{
     JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
     MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract,
     StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD,
-    SEQ_VALUE_PAIR, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
+    SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -7957,6 +7957,15 @@ impl<'a> Builder<'a> {
     }
 
     fn seq_tag(&self, node: NodeId) -> u64 {
+        if let Payload::Name(tag) = self.il.node(node).payload {
+            if self.interner.resolve(tag) == "record_guard" {
+                return if record_shape_guard_for_node(self.il, self.interner, node) {
+                    SEQ_VALUE_RECORD_GUARD
+                } else {
+                    self.interner.symbol_hash(tag)
+                };
+            }
+        }
         match (self.seq_surface(node), self.il.node(node).payload) {
             (Some(contract), _) => contract.value_tag,
             (None, Payload::Name(s)) => self.interner.symbol_hash(s),
@@ -8298,8 +8307,9 @@ mod tests {
     use super::*;
     use nose_il::{
         EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
-        EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, ImportEvidenceKind, Lang,
-        ParamSemantic, ParamTypeFact, Span, Unit, UnitKind,
+        EvidenceRecord, EvidenceStatus, FileId, FileMeta, GuardEvidenceKind, IlBuilder,
+        ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, Lang, ParamSemantic,
+        ParamTypeFact, SequenceSurfaceKind, Span, SymbolEvidenceKind, Unit, UnitKind,
     };
     use nose_semantics::{import_fact_tag, FIRST_PARTY_PACK_ID};
 
@@ -8581,6 +8591,88 @@ mod tests {
         let mut builder = Builder::new(&il, &interner);
         let proven = builder.eval(field, &FxHashMap::default());
         assert!(builder.is_import_binding_value(proven, "math", "prod"));
+    }
+
+    #[test]
+    fn record_guard_value_tag_requires_guard_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let tag = interner.intern("record_guard");
+        let subject = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("value")),
+            sp(60),
+            &[],
+        );
+        let object = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("object")),
+            sp(60),
+            &[],
+        );
+        let non_null = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("non_null")),
+            sp(60),
+            &[],
+        );
+        let not_array = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("not_array")),
+            sp(60),
+            &[],
+        );
+        let guard = b.add(
+            NodeKind::Seq,
+            Payload::Name(tag),
+            sp(60),
+            &[subject, object, non_null, not_array],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(60), &[guard]);
+        let mut il = finish_test_il(b, root, Lang::JavaScript);
+
+        let mut builder = Builder::new(&il, &interner);
+        let raw = builder.eval(guard, &FxHashMap::default());
+        assert!(!matches!(
+            builder.nodes[raw as usize].op,
+            ValOp::Seq(SEQ_VALUE_RECORD_GUARD)
+        ));
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(60)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
+        ));
+        let mut builder = Builder::new(&il, &interner);
+        let surface_only = builder.eval(guard, &FxHashMap::default());
+        assert!(!matches!(
+            builder.nodes[surface_only as usize].op,
+            ValOp::Seq(SEQ_VALUE_RECORD_GUARD)
+        ));
+
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::source_span(sp(60)),
+            EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+                path_hash: stable_symbol_hash("Array.isArray"),
+            }),
+        ));
+        il.evidence.push(evidence(
+            2,
+            EvidenceAnchor::sequence(sp(60)),
+            EvidenceKind::Guard(GuardEvidenceKind::JsRecordShape {
+                subject_hash: stable_symbol_hash("value"),
+                null_check: JsRecordGuardNullCheck::StrictNonNull,
+                comparison: JsRecordGuardComparison::StrictOnly,
+            }),
+        ));
+        il.evidence.last_mut().unwrap().dependencies = vec![EvidenceId(1)];
+        let mut builder = Builder::new(&il, &interner);
+        let proven = builder.eval(guard, &FxHashMap::default());
+        assert!(matches!(
+            builder.nodes[proven as usize].op,
+            ValOp::Seq(SEQ_VALUE_RECORD_GUARD)
+        ));
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -8,9 +8,10 @@
 
 use nose_il::{
     contains_js_identifier, stable_symbol_hash, Builtin, EvidenceAnchor, EvidenceKind,
-    EvidenceStatus, HoFKind, Il, ImportEvidenceKind, Interner, Lang, LitClass, NodeId, NodeKind,
-    Op, ParamSemantic, Payload, SequenceSurfaceKind, SourceCallKind, SourceFactKind,
-    SourceLiteralKind, SourceOperatorKind, Span, SymbolEvidenceKind,
+    EvidenceRecord, EvidenceStatus, GuardEvidenceKind, HoFKind, Il, ImportEvidenceKind, Interner,
+    Lang, LitClass, NodeId, NodeKind, Op, ParamSemantic, Payload, SequenceSurfaceKind,
+    SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind, Span,
+    SymbolEvidenceKind,
 };
 
 pub use nose_il::DomainEvidence;
@@ -330,7 +331,7 @@ fn seq_surface_contract_for_tag(
         },
         SequenceSurfaceKind::RecordGuard => SeqSurfaceContract {
             value_tag: SEQ_VALUE_RECORD_GUARD,
-            exact_tree_safe: true,
+            exact_tree_safe: false,
             membership_collection: false,
             map_entry_list: false,
             imported_literal: false,
@@ -371,20 +372,174 @@ pub fn seq_surface_contract_for_node(
         _ => return None,
     };
     let span = il.node(node).span;
-    match unique_evidence_at(
-        il,
-        |anchor| matches!(anchor, EvidenceAnchor::Sequence { span: anchor_span } if anchor_span == span),
-        |evidence| match evidence {
-            EvidenceKind::SequenceSurface(kind) => Some(kind),
-            _ => None,
-        },
-    ) {
+    match sequence_surface_evidence_at_sequence_span(il, span) {
         EvidenceResolution::Found(kind) => {
             let (raw_kind, raw_contract) = seq_surface_contract_for_tag(il.meta.lang, raw_tag)?;
             (kind == raw_kind).then_some(raw_contract)
         }
         EvidenceResolution::Ambiguous => None,
         EvidenceResolution::Missing => seq_surface_contract(il.meta.lang, raw_tag),
+    }
+}
+
+fn sequence_surface_evidence_at_sequence_span(
+    il: &Il,
+    span: Span,
+) -> EvidenceResolution<SequenceSurfaceKind> {
+    unique_evidence_at(
+        il,
+        |anchor| matches!(anchor, EvidenceAnchor::Sequence { span: anchor_span } if anchor_span == span),
+        |evidence| match evidence {
+            EvidenceKind::SequenceSurface(kind) => Some(kind),
+            _ => None,
+        },
+    )
+}
+
+fn guard_evidence_at_sequence_span(il: &Il, span: Span) -> EvidenceResolution<GuardEvidenceKind> {
+    let mut found = None;
+    for record in &il.evidence {
+        if !matches!(record.anchor, EvidenceAnchor::Sequence { span: anchor_span } if anchor_span == span)
+        {
+            continue;
+        }
+        let EvidenceKind::Guard(kind) = record.kind else {
+            continue;
+        };
+        if record.status != EvidenceStatus::Asserted
+            || !guard_evidence_dependencies_valid(il, record, kind, span)
+        {
+            return EvidenceResolution::Ambiguous;
+        }
+        match found {
+            None => found = Some(kind),
+            Some(existing) if existing == kind => {}
+            Some(_) => return EvidenceResolution::Ambiguous,
+        }
+    }
+    found.map_or(EvidenceResolution::Missing, EvidenceResolution::Found)
+}
+
+fn guard_evidence_dependencies_valid(
+    il: &Il,
+    record: &EvidenceRecord,
+    kind: GuardEvidenceKind,
+    span: Span,
+) -> bool {
+    match kind {
+        GuardEvidenceKind::JsRecordShape { null_check, .. } => {
+            js_record_shape_guard_dependencies_valid(il, record, null_check, span)
+        }
+    }
+}
+
+fn js_record_shape_guard_dependencies_valid(
+    il: &Il,
+    record: &EvidenceRecord,
+    null_check: nose_il::JsRecordGuardNullCheck,
+    span: Span,
+) -> bool {
+    let mut has_array_is_array = false;
+    let mut has_boolean = null_check != nose_il::JsRecordGuardNullCheck::BooleanGlobalTruthy;
+    for id in &record.dependencies {
+        let Some(dependency) = il.evidence.get(id.0 as usize) else {
+            return false;
+        };
+        if dependency.id != *id || dependency.status != EvidenceStatus::Asserted {
+            return false;
+        }
+        if !dependency.anchor.matches_span(span) {
+            return false;
+        }
+        match dependency.kind {
+            EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal { path_hash })
+                if path_hash == stable_symbol_hash("Array.isArray") =>
+            {
+                has_array_is_array = true;
+            }
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal { name_hash })
+                if null_check == nose_il::JsRecordGuardNullCheck::BooleanGlobalTruthy
+                    && name_hash == stable_symbol_hash("Boolean") =>
+            {
+                has_boolean = true;
+            }
+            _ => return false,
+        }
+    }
+    has_array_is_array && has_boolean
+}
+
+/// Prove that a lowered `Seq("record_guard")` denotes the first-party JS-like
+/// record-shape guard contract. The surface tag is not enough: the sequence must
+/// carry both matching sequence-surface evidence and a dedicated guard evidence
+/// record whose dependencies are asserted.
+pub fn record_shape_guard_for_node(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    record_shape_guard_evidence_for_node(il, interner, node).is_some()
+}
+
+pub fn record_shape_guard_evidence_for_node(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<GuardEvidenceKind> {
+    if il.kind(node) != NodeKind::Seq || !js_like_lang(il.meta.lang) {
+        return None;
+    }
+    let span = il.node(node).span;
+    if !matches!(
+        sequence_surface_evidence_at_sequence_span(il, span),
+        EvidenceResolution::Found(SequenceSurfaceKind::RecordGuard)
+    ) {
+        return None;
+    }
+    match guard_evidence_at_sequence_span(il, span) {
+        EvidenceResolution::Found(
+            evidence @ GuardEvidenceKind::JsRecordShape { subject_hash, .. },
+        ) if record_shape_guard_sequence_matches(il, interner, node, subject_hash) => {
+            Some(evidence)
+        }
+        EvidenceResolution::Found(_)
+        | EvidenceResolution::Ambiguous
+        | EvidenceResolution::Missing => None,
+    }
+}
+
+fn record_shape_guard_sequence_matches(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    subject_hash: u64,
+) -> bool {
+    let Payload::Name(tag) = il.node(node).payload else {
+        return false;
+    };
+    if sequence_surface_kind_for_tag(il.meta.lang, Some(interner.resolve(tag)))
+        != Some(SequenceSurfaceKind::RecordGuard)
+    {
+        return false;
+    }
+    let [subject, object, non_null, not_array] = il.children(node) else {
+        return false;
+    };
+    record_shape_guard_subject_matches(il, interner, *subject, subject_hash)
+        && literal_string_hash(il, *object) == Some(stable_symbol_hash("object"))
+        && literal_string_hash(il, *non_null) == Some(stable_symbol_hash("non_null"))
+        && literal_string_hash(il, *not_array) == Some(stable_symbol_hash("not_array"))
+}
+
+fn record_shape_guard_subject_matches(
+    il: &Il,
+    interner: &Interner,
+    subject: NodeId,
+    subject_hash: u64,
+) -> bool {
+    if il.kind(subject) != NodeKind::Var {
+        return false;
+    }
+    match il.node(subject).payload {
+        Payload::Name(_) => node_name_hash(il, interner, subject) == Some(subject_hash),
+        Payload::Cid(_) => true,
+        _ => false,
     }
 }
 
@@ -3019,9 +3174,9 @@ mod tests {
     use super::*;
     use nose_il::{
         EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
-        EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, ImportEvidenceKind,
-        ParamSemantic, ParamTypeFact, SequenceSurfaceKind, SourceFact, Span, SymbolEvidenceKind,
-        Unit, UnitKind,
+        EvidenceRecord, EvidenceStatus, FileId, FileMeta, GuardEvidenceKind, IlBuilder,
+        ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, ParamSemantic,
+        ParamTypeFact, SequenceSurfaceKind, SourceFact, Span, SymbolEvidenceKind, Unit, UnitKind,
     };
 
     const ALL_LANGS: &[Lang] = &[
@@ -3092,6 +3247,16 @@ mod tests {
         kind: EvidenceKind,
         status: EvidenceStatus,
     ) -> EvidenceRecord {
+        evidence_with_dependencies(id, anchor, kind, status, Vec::new())
+    }
+
+    fn evidence_with_dependencies(
+        id: u32,
+        anchor: EvidenceAnchor,
+        kind: EvidenceKind,
+        status: EvidenceStatus,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceRecord {
         EvidenceRecord {
             id: EvidenceId(id),
             anchor,
@@ -3101,7 +3266,7 @@ mod tests {
                 pack_hash: Some(stable_symbol_hash(FIRST_PARTY_PACK_ID)),
                 rule_hash: Some(stable_symbol_hash("test")),
             },
-            dependencies: Vec::new(),
+            dependencies,
             status,
         }
     }
@@ -3242,6 +3407,392 @@ mod tests {
             EvidenceStatus::Asserted,
         ));
         assert_eq!(seq_surface_contract_for_node(&il, &interner, seq), None);
+    }
+
+    fn js_record_guard_il(interner: &Interner, subject: &str) -> (Il, NodeId) {
+        let mut b = IlBuilder::new(FileId(0));
+        let tag = interner.intern("record_guard");
+        let subject = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern(subject)),
+            sp(12),
+            &[],
+        );
+        let object = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("object")),
+            sp(12),
+            &[],
+        );
+        let non_null = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("non_null")),
+            sp(12),
+            &[],
+        );
+        let not_array = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("not_array")),
+            sp(12),
+            &[],
+        );
+        let guard = b.add(
+            NodeKind::Seq,
+            Payload::Name(tag),
+            sp(12),
+            &[subject, object, non_null, not_array],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(12), &[guard]);
+        (finish_il(b, root, Lang::JavaScript), guard)
+    }
+
+    fn record_guard_evidence_with_null_check(
+        subject: &str,
+        null_check: JsRecordGuardNullCheck,
+    ) -> EvidenceKind {
+        EvidenceKind::Guard(GuardEvidenceKind::JsRecordShape {
+            subject_hash: stable_symbol_hash(subject),
+            null_check,
+            comparison: JsRecordGuardComparison::StrictOnly,
+        })
+    }
+
+    fn array_is_array_dependency(id: u32, span: Span, status: EvidenceStatus) -> EvidenceRecord {
+        evidence(
+            id,
+            EvidenceAnchor::source_span(span),
+            EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+                path_hash: stable_symbol_hash("Array.isArray"),
+            }),
+            status,
+        )
+    }
+
+    fn boolean_dependency(id: u32, span: Span, status: EvidenceStatus) -> EvidenceRecord {
+        evidence(
+            id,
+            EvidenceAnchor::source_span(span),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("Boolean"),
+            }),
+            status,
+        )
+    }
+
+    fn record_guard_record(
+        id: u32,
+        span: Span,
+        subject: &str,
+        null_check: JsRecordGuardNullCheck,
+        dependencies: &[u32],
+    ) -> EvidenceRecord {
+        evidence_with_dependencies(
+            id,
+            EvidenceAnchor::sequence(span),
+            record_guard_evidence_with_null_check(subject, null_check),
+            EvidenceStatus::Asserted,
+            dependencies.iter().copied().map(EvidenceId).collect(),
+        )
+    }
+
+    #[test]
+    fn record_shape_guard_requires_dedicated_guard_evidence() {
+        let interner = Interner::new();
+        let (mut il, guard) = js_record_guard_il(&interner, "value");
+
+        assert!(!record_shape_guard_for_node(&il, &interner, guard));
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(12)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
+            EvidenceStatus::Asserted,
+        ));
+        assert!(!record_shape_guard_for_node(&il, &interner, guard));
+
+        il.evidence.push(array_is_array_dependency(
+            1,
+            sp(12),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(record_guard_record(
+            2,
+            sp(12),
+            "value",
+            JsRecordGuardNullCheck::StrictNonNull,
+            &[1],
+        ));
+        assert!(record_shape_guard_for_node(&il, &interner, guard));
+    }
+
+    #[test]
+    fn record_shape_guard_validates_required_dependencies() {
+        let interner = Interner::new();
+
+        let (mut il, guard) = js_record_guard_il(&interner, "value");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(12)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(record_guard_record(
+            1,
+            sp(12),
+            "value",
+            JsRecordGuardNullCheck::StrictNonNull,
+            &[],
+        ));
+        assert!(!record_shape_guard_for_node(&il, &interner, guard));
+
+        let (mut il, guard) = js_record_guard_il(&interner, "value");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(12)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::source_span(sp(12)),
+            EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+                path_hash: stable_symbol_hash("Array.from"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(record_guard_record(
+            2,
+            sp(12),
+            "value",
+            JsRecordGuardNullCheck::StrictNonNull,
+            &[1],
+        ));
+        assert!(!record_shape_guard_for_node(&il, &interner, guard));
+
+        let (mut il, guard) = js_record_guard_il(&interner, "value");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(12)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(array_is_array_dependency(
+            1,
+            sp(12),
+            EvidenceStatus::Ambiguous,
+        ));
+        il.evidence.push(record_guard_record(
+            2,
+            sp(12),
+            "value",
+            JsRecordGuardNullCheck::StrictNonNull,
+            &[1],
+        ));
+        assert!(!record_shape_guard_for_node(&il, &interner, guard));
+
+        let (mut il, guard) = js_record_guard_il(&interner, "value");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(12)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(array_is_array_dependency(
+            1,
+            sp(14),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(record_guard_record(
+            2,
+            sp(12),
+            "value",
+            JsRecordGuardNullCheck::StrictNonNull,
+            &[1],
+        ));
+        assert!(!record_shape_guard_for_node(&il, &interner, guard));
+
+        let (mut il, guard) = js_record_guard_il(&interner, "value");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(12)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(array_is_array_dependency(
+            1,
+            sp(12),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(record_guard_record(
+            2,
+            sp(12),
+            "value",
+            JsRecordGuardNullCheck::BooleanGlobalTruthy,
+            &[1],
+        ));
+        assert!(!record_shape_guard_for_node(&il, &interner, guard));
+
+        il.evidence
+            .push(boolean_dependency(3, sp(12), EvidenceStatus::Asserted));
+        il.evidence.push(record_guard_record(
+            4,
+            sp(12),
+            "value",
+            JsRecordGuardNullCheck::BooleanGlobalTruthy,
+            &[1, 3],
+        ));
+        assert!(!record_shape_guard_for_node(&il, &interner, guard));
+
+        let (mut il, guard) = js_record_guard_il(&interner, "value");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(12)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(array_is_array_dependency(
+            1,
+            sp(12),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence
+            .push(boolean_dependency(2, sp(12), EvidenceStatus::Asserted));
+        il.evidence.push(record_guard_record(
+            3,
+            sp(12),
+            "value",
+            JsRecordGuardNullCheck::BooleanGlobalTruthy,
+            &[1, 2],
+        ));
+        assert!(record_shape_guard_for_node(&il, &interner, guard));
+    }
+
+    #[test]
+    fn record_shape_guard_rejects_mismatched_or_ambiguous_evidence() {
+        let interner = Interner::new();
+        let (mut il, guard) = js_record_guard_il(&interner, "value");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(12)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(array_is_array_dependency(
+            1,
+            sp(12),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(record_guard_record(
+            2,
+            sp(12),
+            "other",
+            JsRecordGuardNullCheck::StrictNonNull,
+            &[1],
+        ));
+        assert!(!record_shape_guard_for_node(&il, &interner, guard));
+
+        let (mut il, guard) = js_record_guard_il(&interner, "value");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(12)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(array_is_array_dependency(
+            1,
+            sp(12),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            2,
+            EvidenceAnchor::sequence(sp(12)),
+            record_guard_evidence_with_null_check("value", JsRecordGuardNullCheck::StrictNonNull),
+            EvidenceStatus::Ambiguous,
+            vec![EvidenceId(1)],
+        ));
+        assert!(!record_shape_guard_for_node(&il, &interner, guard));
+
+        let (mut il, guard) = js_record_guard_il(&interner, "value");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(12)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(array_is_array_dependency(
+            1,
+            sp(12),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(record_guard_record(
+            2,
+            sp(12),
+            "value",
+            JsRecordGuardNullCheck::StrictNonNull,
+            &[1],
+        ));
+        il.evidence.push(record_guard_record(
+            3,
+            sp(12),
+            "candidate",
+            JsRecordGuardNullCheck::StrictNonNull,
+            &[1],
+        ));
+        assert!(!record_shape_guard_for_node(&il, &interner, guard));
+    }
+
+    #[test]
+    fn record_shape_guard_keeps_source_subject_proof_after_alpha_rename() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let tag = interner.intern("record_guard");
+        let subject = b.add(NodeKind::Var, Payload::Cid(0), sp(13), &[]);
+        let object = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("object")),
+            sp(13),
+            &[],
+        );
+        let non_null = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("non_null")),
+            sp(13),
+            &[],
+        );
+        let not_array = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("not_array")),
+            sp(13),
+            &[],
+        );
+        let guard = b.add(
+            NodeKind::Seq,
+            Payload::Name(tag),
+            sp(13),
+            &[subject, object, non_null, not_array],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(13), &[guard]);
+        let mut il = finish_il(b, root, Lang::JavaScript);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(13)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(array_is_array_dependency(
+            1,
+            sp(13),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(record_guard_record(
+            2,
+            sp(13),
+            "source_name",
+            JsRecordGuardNullCheck::StrictNonNull,
+            &[1],
+        ));
+
+        assert!(record_shape_guard_for_node(&il, &interner, guard));
     }
 
     #[test]

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -60,6 +60,7 @@ The current implemented kinds are:
 | `Domain` | receiver/value domain such as collection, map, option, string, integer, or byte array |
 | `Import` | static import binding and namespace proof |
 | `Symbol` | resolved or proven symbol identity, with record kinds for unshadowed globals, static imported binding/namespace aliases, and selected qualified global API paths |
+| `Guard` | multi-obligation guard proof facts such as the first JS/TS record-shape guard contract |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, record guard, or Go composite map literal |
 
 ## Consumption Rules
@@ -97,6 +98,15 @@ first-party JS/TS producer emits `QualifiedGlobal` only for selected static path
 whose root is proven unshadowed, such as `Object.hasOwn`,
 `Object.prototype.hasOwnProperty.call`, `Array.from`, and `Array.isArray`.
 
+Guard identity is separate from sequence shape. A raw `Seq("record_guard")` or a
+matching `SequenceSurface(RecordGuard)` fact proves only that the frontend
+lowered a guard-shaped surface. Exact consumers additionally require a
+dedicated `Guard::JsRecordShape` record whose subject, null/truthiness form,
+comparison form, and asserted `Array.isArray`/optional `Boolean` dependencies
+match the lowered sequence. Generic `SequenceSurface(RecordGuard)` is therefore
+not `exact_tree_safe`; missing, ambiguous, conflicting, wrong-kind, wrong-anchor,
+or dependency-broken guard evidence keeps the exact path closed.
+
 ## Current Producers
 
 First-party frontends now mirror these facts into `EvidenceRecord`:
@@ -112,13 +122,18 @@ First-party frontends now mirror these facts into `EvidenceRecord`:
   evidence at the lowered node anchor: own-property guards at their
   `Seq("own_property_guard")` node, and static member expressions such as
   `Array.from` and `Array.isArray` at their `Field` node;
+- JS/TS record-shape guard lowering emits `Guard::JsRecordShape` evidence for
+  the lowered `Seq("record_guard")`, including the shared subject hash, the
+  null/truthiness clause kind, whether JS loose equality was admitted, and
+  asserted dependencies for the required `Array.isArray` API proof plus optional
+  `Boolean` proof;
 - lowered `Seq` surfaces emit `SequenceSurface` evidence.
 
 The older `ParamTypeFact`, `SourceFact`, and raw import `Seq` shapes remain as
-compatibility mirrors. JS/TS record-shape guard lowering still needs dedicated
-multi-obligation guard evidence for surfaces such as `Array.isArray(...)` plus
-optional `Boolean(...)`; that is separate from the selected qualified-path
-evidence already landed. These mirrors are not the desired pack boundary.
+compatibility mirrors. First-party JS/TS record-shape guards now have dedicated
+guard evidence, but broader guard families, richer source-clause dependencies,
+and general evidence validation remain open. These mirrors are not the desired
+pack boundary.
 
 ## Current Consumers
 
@@ -143,9 +158,15 @@ callers:
   guard normalization and strict exact safety require evidence for
   `Object.hasOwn` or `Object.prototype.hasOwnProperty.call`, and map-key view
   wrappers require evidence for `Array.from`;
-- sequence-surface admission for normalize/value-graph/detect exact paths.
+- JS/TS record-shape guard exact admission and value-graph tagging require both
+  `SequenceSurface(RecordGuard)` and `Guard::JsRecordShape`; raw
+  `Seq("record_guard")` cannot enter the proof-bearing exact/value-graph path by
+  tag spelling alone;
+- sequence-surface admission for normalize/value-graph/detect exact paths where
+  the surface contract is independently exact-safe; guard surfaces use their
+  dedicated guard helper instead.
 
 Field/place/effect facts, receiver/protocol evidence beyond parameter domains,
-full scope-resolution and namespace-member evidence, record-shape
-multi-obligation guard evidence, report-level provenance, and external manifest
-loading are still open work.
+full scope-resolution and namespace-member evidence, broader guard evidence and
+dependency validation, report-level provenance, and external manifest loading
+are still open work.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -243,13 +243,17 @@ and pack ecosystem.
   `Object.prototype.hasOwnProperty.call` gate own-property guard normalization
   and strict exact safety, while `Array.from` gates JS-like map-key iterator
   wrappers. `Array.isArray` emits the same path evidence for strict exact call
-  gates. Full namespace-member resolution and record-shape multi-obligation
-  guard evidence remain open.
+  gates. Full namespace-member resolution remains open.
 - Value-graph import identity now consumes sequence `Import` evidence into
   dedicated internal `ImportNamespace`/`ImportBinding` value ops instead of
   treating raw `ValOp::Seq(import_*)` shapes as proof objects. Imported
   binding/namespace symbol helpers also no longer accept raw import assignment
   RHS parsing as an exact proof fallback.
+- JS/TS record-shape guards now emit dedicated `Guard::JsRecordShape` evidence
+  with subject, null/truthiness, equality-form, and API-dependency obligations.
+  Strict exact and value-graph paths require that evidence plus
+  `SequenceSurface(RecordGuard)`, so raw `Seq("record_guard")` no longer acts as
+  a proof object by tag spelling.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -313,10 +317,9 @@ Remaining in this phase:
   selected JS/TS `QualifiedGlobal` paths are covered, but general
   qualified-member, namespace export identity, and cross-module dependency
   evidence are not.
-- Add dedicated guard evidence for multi-obligation guards such as JS/TS
-  record-shape checks, where one lowered guard depends on source operator facts,
-  several qualified/static API facts, subject identity, and truthiness/null
-  semantics.
+- Generalize dedicated guard evidence beyond the first JS/TS record-shape
+  contract, including richer source-clause records, API dependency validation,
+  subject/place identity, and truthiness/null semantics.
 - Expand the first `SequenceSurface` evidence into sequence/aggregate records for
   factories, nested entries, iterator views, and exported-literal eligibility.
 - Expand domain evidence from parameter annotations into receiver/protocol

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -202,7 +202,12 @@ migrated.
 - JS-like record-shape guards that use `Boolean(value)` as the non-null/truthy
   clause consume a static-global function contract and require the `Boolean`
   global to be unshadowed. `value !== null` and `!!value` remain available when
-  their own clauses prove the same record shape.
+  their own clauses prove the same record shape. The collapsed
+  `Seq("record_guard")` is no longer admitted by tag spelling alone: strict
+  exact and value-graph paths require matching `SequenceSurface(RecordGuard)` and
+  `Guard::JsRecordShape` evidence, including subject identity, null/truthiness
+  form, comparison form, and asserted API dependencies for `Array.isArray` plus
+  optional `Boolean`.
 - JS-like `undefined` is no longer frontend-collapsed to null unconditionally.
   It is preserved as a name and only treated as the nullish sentinel through an
   unshadowed-global contract. Value-graph defaulting and strict exact-safe gates
@@ -267,10 +272,11 @@ Semantic knowledge still appears in several forms outside the facade:
   provenance, and external pack manifests remain open;
 - language-specific import, symbol, or module proof mechanics that are still
   local to frontend, normalize, detect, or value-graph callers;
-- JS/TS record-shape guards still need dedicated multi-obligation guard
-  evidence, because their proof depends on several source/API facts such as
-  `typeof`, `Array.isArray`, optional `Boolean`, null/truthiness, and matching
-  subject identity;
+- JS/TS record-shape guards now have a first dedicated `Guard::JsRecordShape`
+  record consumed by strict exact and value-graph paths. The recognizer is still
+  first-party JS/TS lowering code, and broader guard families, richer
+  source-clause dependency records, and pack-facing dependency validation remain
+  open;
 - IL still stores import facts as `Seq("import_binding")` /
   `Seq("import_namespace")` payloads for compatibility. Frontends also emit
   `EvidenceRecord::Import`, and value-graph import identity is now evidence-only,
@@ -357,6 +363,8 @@ The first high-value targets for semantic-kernel extraction are:
 - richer sequence/aggregate evidence for factories, nested entries, iterator
   views, and exported-literal eligibility beyond the current first
   `SequenceSurface` substrate;
+- generalized guard evidence beyond the first JS/TS record-shape contract,
+  including richer source/API dependency records and validation;
 - dependency, scope, and ambiguity validation before evidence records become a
   stable external extension surface;
 - resolved symbol facts for Java/Rust stdlib factories instead of the current


### PR DESCRIPTION
## Summary
- add `Guard::JsRecordShape` evidence for first-party JS/TS record-shape guards
- require guard evidence plus `SequenceSurface(RecordGuard)` before strict exact/value-graph record-guard admission
- validate guard dependencies for `Array.isArray`, optional `Boolean`, status, and span anchors; close raw `Seq(\"record_guard\")` and malformed `typeofvalue` paths
- update semantic-kernel docs to separate landed snapshot from remaining generalized guard/dependency work

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --release`
- `cargo test --release`
- `awiki lint --root docs`
- `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `./scripts/check-duplication.sh` (20 substantial families, budget 21)

Tracks #109.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * JavaScript 타입 가드 검증 로직을 개선하여 더 정확한 패턴 인식 제공
  * 식별자 섀도잉 및 구조 분해 케이스에 대한 검증 강화

* **테스트**
  * 엣지 케이스를 포함한 확장된 테스트 커버리지 추가
  * 의존성 검증 테스트 추가

* **문서**
  * 증거 시스템 설계 및 가드 검증 요구사항 문서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->