### PR TITLE
semantics: add library API contract layer

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -18,16 +18,21 @@ use nose_semantics::{
     exact_java_this_field, exact_non_overloadable_index_assignment,
     exact_non_overloadable_index_assignment_parts, exact_static_membership_predicate_operator,
     go_zero_map_default_kind, go_zero_map_lookup_contract, imported_binding_symbol,
-    imported_member_symbol, iterator_identity_adapter_contract, java_collection_factory_contract,
-    java_map_entry_contract, java_map_factory_contract, js_array_is_array_contract,
-    js_like_map_constructor_contract, js_like_set_constructor_contract, map_get_contract,
-    map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
+    imported_member_symbol, iterator_identity_adapter_contract, js_array_is_array_contract,
+    library_api_free_name_shadow_safe, library_free_name_collection_factory_contract,
+    library_free_name_map_factory_contract, library_imported_collection_factory_contracts,
+    library_java_collection_factory_contract, library_java_map_entry_contract,
+    library_java_map_factory_contract, library_js_like_map_constructor_contract,
+    library_js_like_set_constructor_contract, library_ruby_set_factory_contract,
+    library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
+    map_get_contract, map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
     nullish_global_contract, qualified_global_symbol, record_shape_guard_for_node,
-    regex_test_contract, ruby_set_factory_contract, rust_vec_new_factory_contract, semantics,
-    seq_surface_contract_for_node, source_fact_at_node, source_operator_at_node,
-    static_index_membership_contract, typeof_operator_contract, unshadowed_global_symbol,
-    DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind, MapKeyViewKind,
-    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
+    regex_test_contract, semantics, seq_surface_contract_for_node, source_fact_at_node,
+    source_operator_at_node, static_index_membership_contract, typeof_operator_contract,
+    unshadowed_global_symbol, DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind,
+    LibraryApiCalleeContract, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
+    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
+    StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1858,13 +1863,20 @@ fn strict_exact_set_constructor_collection_safe(
     let Some((callee, name, collection)) = strict_exact_two_arg_var_call(il, node) else {
         return false;
     };
-    let Some(contract) = js_like_set_constructor_contract(il.meta.lang, interner.resolve(name))
+    let Some(contract) =
+        library_js_like_set_constructor_contract(il.meta.lang, interner.resolve(name))
     else {
         return false;
     };
-    contract.receiver == "Set"
-        && (!contract.requires_unshadowed_global
-            || unshadowed_global_symbol(il, interner, callee, contract.receiver))
+    let LibraryApiCalleeContract::JsGlobalConstructor {
+        receiver,
+        requires_unshadowed_global,
+    } = contract.callee
+    else {
+        return false;
+    };
+    receiver == "Set"
+        && (!requires_unshadowed_global || unshadowed_global_symbol(il, interner, callee, receiver))
         && strict_exact_static_non_float_collection(il, interner, collection)
 }
 
@@ -1886,36 +1898,40 @@ fn strict_exact_python_collection_factory_safe(
         return false;
     }
     let builtin = if il.kind(kids[0]) == NodeKind::Var {
-        let Payload::Name(name) = il.node(kids[0]).payload else {
-            return false;
-        };
-        let name = interner.resolve(name);
-        semantics(il.meta.lang)
-            .collections()
-            .free_name_collection_factories()
-            .any(|factory| {
-                factory.names.contains(&name)
-                    && strict_exact_free_name_factory_shadow_safe(
-                        il,
-                        interner,
-                        name,
-                        factory.shadow_guard,
-                    )
-            })
+        match il.node(kids[0]).payload {
+            Payload::Name(name) => {
+                let name = interner.resolve(name);
+                library_free_name_collection_factory_contract(il.meta.lang, name).is_some_and(
+                    |contract| {
+                        let LibraryApiCalleeContract::FreeName {
+                            name: expected_name,
+                            shadow,
+                        } = contract.callee
+                        else {
+                            return false;
+                        };
+                        expected_name == name
+                            && library_api_free_name_shadow_safe(
+                                il.meta.lang,
+                                name,
+                                shadow,
+                                |candidate| file_defines_name(il, interner, candidate),
+                            )
+                    },
+                )
+            }
+            _ => false,
+        }
     } else {
         false
     };
-    let imported_stdlib_factory = semantics(il.meta.lang)
-        .collections()
-        .imported_collection_factories()
-        .any(|factory| {
-            strict_exact_python_imported_factory_name(
-                il,
-                interner,
-                kids[0],
-                factory.module,
-                factory.exported,
-            )
+    let imported_stdlib_factory =
+        library_imported_collection_factory_contracts(il.meta.lang).any(|contract| {
+            let LibraryApiCalleeContract::ImportedBinding { module, exported } = contract.callee
+            else {
+                return false;
+            };
+            strict_exact_python_imported_factory_name(il, interner, kids[0], module, exported)
         });
     (builtin || imported_stdlib_factory)
         && strict_exact_membership_collection_safe(il, interner, facts, kids[1])
@@ -1958,12 +1974,22 @@ fn strict_exact_ruby_set_factory_safe(
         return false;
     };
     let receiver_name = interner.resolve(receiver_name);
-    let Some(contract) = ruby_set_factory_contract(il.meta.lang, receiver_name, method, 1) else {
+    let Some(contract) = library_ruby_set_factory_contract(il.meta.lang, receiver_name, method, 1)
+    else {
         return false;
     };
-    ruby_file_requires_module(il, interner, contract.required_module)
-        && !file_defines_name(il, interner, contract.shadow_root)
-        && strict_exact_callee_name(il, interner, receiver, contract.receiver)
+    let LibraryApiCalleeContract::RubyRequireStaticMember {
+        receiver: expected_receiver,
+        required_module,
+        shadow_root,
+        ..
+    } = contract.callee
+    else {
+        return false;
+    };
+    ruby_file_requires_module(il, interner, required_module)
+        && !file_defines_name(il, interner, shadow_root)
+        && strict_exact_callee_name(il, interner, receiver, expected_receiver)
         && strict_exact_membership_collection_safe(il, interner, facts, kids[1])
 }
 
@@ -2012,8 +2038,16 @@ fn strict_exact_rust_vec_macro_collection_safe(
     let Some(&callee) = kids.first() else {
         return false;
     };
-    strict_exact_callee_name(il, interner, callee, "vec")
-        && !file_defines_name(il, interner, "vec")
+    let Some(contract) = library_rust_vec_macro_factory_contract(il.meta.lang, "vec") else {
+        return false;
+    };
+    let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+        return false;
+    };
+    strict_exact_callee_name(il, interner, callee, name)
+        && library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+            file_defines_name(il, interner, candidate)
+        })
         && kids
             .iter()
             .skip(1)
@@ -2040,8 +2074,15 @@ fn strict_exact_rust_vec_new_safe(il: &Il, interner: &Interner, node: NodeId) ->
 }
 
 fn strict_exact_rust_vec_new_name(il: &Il, interner: &Interner, text: &str) -> bool {
-    rust_vec_new_factory_contract(il.meta.lang, text)
-        .is_some_and(|contract| !file_defines_name(il, interner, contract.shadow_root))
+    library_rust_vec_new_factory_contract(il.meta.lang, text).is_some_and(|contract| {
+        let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+            return false;
+        };
+        name == text
+            && library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+                file_defines_name(il, interner, candidate)
+            })
+    })
 }
 
 fn strict_exact_rust_std_collection_factory_safe(
@@ -2060,14 +2101,21 @@ fn strict_exact_rust_std_collection_factory_safe(
         return false;
     };
     let name = interner.resolve(name);
-    let factory = semantics(il.meta.lang)
-        .collections()
-        .free_name_collection_factories()
-        .find(|factory| factory.names.contains(&name));
-    let Some(factory) = factory else {
+    let Some(contract) = library_free_name_collection_factory_contract(il.meta.lang, name) else {
         return false;
     };
-    if !strict_exact_free_name_factory_shadow_safe(il, interner, name, factory.shadow_guard) {
+    let LibraryApiCalleeContract::FreeName {
+        name: expected_name,
+        shadow,
+    } = contract.callee
+    else {
+        return false;
+    };
+    if expected_name != name
+        || !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+            file_defines_name(il, interner, candidate)
+        })
+    {
         return false;
     }
     strict_exact_membership_collection_safe(il, interner, facts, collection)
@@ -2095,15 +2143,30 @@ fn strict_exact_java_collection_factory_safe(
         return false;
     };
     let method = interner.resolve(method);
-    let Some(()) = ["List", "Set", "Arrays"]
+    let Some(contract) = ["List", "Set", "Arrays"]
         .into_iter()
         .find_map(|receiver_name| {
-            let contract = java_collection_factory_contract(il.meta.lang, receiver_name, method)?;
-            strict_exact_java_std_var_name(il, interner, receiver, contract.receiver).then_some(())
+            let contract =
+                library_java_collection_factory_contract(il.meta.lang, receiver_name, method)?;
+            let LibraryApiCalleeContract::JavaUtilStaticMember {
+                receiver: expected_receiver,
+                ..
+            } = contract.callee
+            else {
+                return None;
+            };
+            strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
+                .then_some(contract)
         })
     else {
         return false;
     };
+    if !matches!(
+        contract.result,
+        LibraryCollectionFactoryResult::VariadicElements { .. }
+    ) {
+        return false;
+    }
     kids.iter()
         .skip(1)
         .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
@@ -2171,13 +2234,23 @@ fn strict_exact_java_map_factory_safe(
         return false;
     };
     let method = interner.resolve(method);
-    let Some(contract) = java_map_factory_contract(il.meta.lang, "Map", method) else {
+    let Some(contract) = library_java_map_factory_contract(il.meta.lang, "Map", method) else {
         return false;
     };
-    if !strict_exact_java_std_var_name(il, interner, receiver, contract.receiver) {
+    let LibraryApiCalleeContract::JavaUtilStaticMember {
+        receiver: expected_receiver,
+        ..
+    } = contract.callee
+    else {
+        return false;
+    };
+    if !strict_exact_java_std_var_name(il, interner, receiver, expected_receiver) {
         return false;
     }
-    match contract.kind {
+    let LibraryMapFactoryResult::JavaFactory { kind } = contract.result else {
+        return false;
+    };
+    match kind {
         JavaMapFactoryKind::Of => {
             let entries = &kids[1..];
             entries.len() % 2 == 0
@@ -2212,8 +2285,17 @@ fn strict_exact_java_map_entry_safe(
     let Some(&receiver) = il.children(kids[0]).first() else {
         return false;
     };
-    java_map_entry_contract(il.meta.lang, "Map", method)
-        && strict_exact_java_std_var_name(il, interner, receiver, "Map")
+    let Some(contract) = library_java_map_entry_contract(il.meta.lang, "Map", method) else {
+        return false;
+    };
+    let LibraryApiCalleeContract::JavaUtilStaticMember {
+        receiver: expected_receiver,
+        ..
+    } = contract.callee
+    else {
+        return false;
+    };
+    strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
         && kids
             .iter()
             .skip(1)
@@ -2232,13 +2314,24 @@ fn strict_exact_map_constructor_entries_safe(
     let Some((callee, name, entries)) = strict_exact_two_arg_var_call(il, node) else {
         return false;
     };
-    let Some(contract) = js_like_map_constructor_contract(il.meta.lang, interner.resolve(name))
+    let Some(contract) =
+        library_js_like_map_constructor_contract(il.meta.lang, interner.resolve(name))
     else {
         return false;
     };
-    contract.receiver == "Map"
-        && (!contract.requires_unshadowed_global
-            || unshadowed_global_symbol(il, interner, callee, contract.receiver))
+    let LibraryApiCalleeContract::JsGlobalConstructor {
+        receiver,
+        requires_unshadowed_global,
+    } = contract.callee
+    else {
+        return false;
+    };
+    receiver == "Map"
+        && matches!(
+            contract.result,
+            LibraryMapFactoryResult::EntrySequence { .. }
+        )
+        && (!requires_unshadowed_global || unshadowed_global_symbol(il, interner, callee, receiver))
         && strict_exact_map_entries_safe(il, interner, facts, entries)
 }
 
@@ -2255,32 +2348,28 @@ fn strict_exact_rust_std_map_factory_safe(
         return false;
     };
     let name = interner.resolve(name);
-    let factory = semantics(il.meta.lang)
-        .collections()
-        .free_name_map_factories()
-        .find(|factory| factory.names.contains(&name));
-    if factory.is_none() {
+    let Some(contract) = library_free_name_map_factory_contract(il.meta.lang, name) else {
         return false;
-    }
-    if !strict_exact_free_name_factory_shadow_safe(il, interner, name, false) {
+    };
+    let LibraryApiCalleeContract::FreeName {
+        name: expected_name,
+        shadow,
+    } = contract.callee
+    else {
+        return false;
+    };
+    if expected_name != name
+        || !matches!(
+            contract.result,
+            LibraryMapFactoryResult::EntrySequence { .. }
+        )
+        || !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+            file_defines_name(il, interner, candidate)
+        })
+    {
         return false;
     }
     strict_exact_map_entries_safe(il, interner, facts, entries)
-}
-
-fn strict_exact_free_name_factory_shadow_safe(
-    il: &Il,
-    interner: &Interner,
-    name: &str,
-    shadow_guard: bool,
-) -> bool {
-    if shadow_guard {
-        return !file_defines_name(il, interner, name);
-    }
-    if il.meta.lang == Lang::Rust && name.starts_with("std::") {
-        return !file_defines_name(il, interner, "std");
-    }
-    true
 }
 
 fn strict_exact_map_entries_safe(

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -10,12 +10,14 @@
 use nose_il::{contains_js_identifier, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
 use nose_semantics::{
     domain_evidence_for_param, free_function_builtin_contract, imported_binding_symbol,
-    imported_namespace_symbol, iterator_identity_adapter_contract, map_get_contract,
+    imported_namespace_symbol, iterator_identity_adapter_contract,
+    library_api_free_name_shadow_safe, library_free_name_map_factory_contract, map_get_contract,
     map_key_view_contract, method_call_contract, method_hof_contract,
     rust_option_some_constructor_contract, seq_surface_contract_for_node,
     static_collection_adapter_contract, unshadowed_global_symbol, BuiltinArgContract,
-    DomainEvidence, MapKeyViewKind, MethodBuiltinArgs, MethodCallContract, MethodReceiverContract,
-    MethodSemanticContract, SEQ_VALUE_MAP,
+    DomainEvidence, LibraryApiCalleeContract, LibraryMapFactoryResult, MapKeyViewKind,
+    MethodBuiltinArgs, MethodCallContract, MethodReceiverContract, MethodSemanticContract,
+    SEQ_VALUE_MAP,
 };
 
 /// The result of inspecting a `Call`: it canonicalizes to a builtin, to a
@@ -711,29 +713,20 @@ fn rust_std_map_factory_call(old: &Il, interner: &Interner, node: NodeId) -> boo
         return false;
     };
     let callee = interner.resolve(callee);
-    nose_semantics::semantics(old.meta.lang)
-        .collections()
-        .free_name_map_factories()
-        .any(|factory| {
-            factory.names.contains(&callee)
-                && free_name_factory_shadow_safe(old, interner, callee, false)
-                && map_factory_entries_match_surface(old, interner, kids[1], factory.entry_seq_tag)
+    let Some(contract) = library_free_name_map_factory_contract(old.meta.lang, callee) else {
+        return false;
+    };
+    let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+        return false;
+    };
+    let LibraryMapFactoryResult::EntrySequence { entry_seq_tag } = contract.result else {
+        return false;
+    };
+    name == callee
+        && library_api_free_name_shadow_safe(old.meta.lang, name, shadow, |candidate| {
+            file_defines_name(old, interner, candidate)
         })
-}
-
-fn free_name_factory_shadow_safe(
-    old: &Il,
-    interner: &Interner,
-    name: &str,
-    shadow_guard: bool,
-) -> bool {
-    if shadow_guard {
-        return !file_defines_name(old, interner, name);
-    }
-    if old.meta.lang == nose_il::Lang::Rust && name.starts_with("std::") {
-        return !file_defines_name(old, interner, "std");
-    }
-    true
+        && map_factory_entries_match_surface(old, interner, kids[1], entry_seq_tag)
 }
 
 fn map_factory_entries_match_surface(

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -54,22 +54,27 @@ use nose_semantics::{
     exact_static_membership_predicate_operator, free_function_builtin_contract,
     go_zero_map_default_kind, go_zero_map_lookup_contract, import_fact_evidence_rhs,
     imported_namespace_function_contract, imported_namespace_symbol,
-    iterator_identity_adapter_contract, java_collection_factory_contract_by_hash,
-    java_map_entry_contract_by_hash, java_map_factory_contract_by_hash,
-    js_like_map_constructor_contract, js_like_set_constructor_contract, map_get_contract_by_hash,
-    map_key_view_contract_by_hash, map_key_view_wrapper_contract_by_hash, method_call_contract,
-    nullish_global_contract, qualified_global_symbol_at_span, record_shape_guard_for_node,
-    reduction_builtin_contract, ruby_set_factory_contract_by_hash, rust_option_and_then_contract,
+    iterator_identity_adapter_contract, library_api_free_name_shadow_safe,
+    library_free_name_collection_factory_contracts, library_free_name_map_factory_contracts,
+    library_imported_collection_factory_contracts,
+    library_java_collection_factory_contract_by_hash, library_java_map_entry_contract_by_hash,
+    library_java_map_factory_contract_by_hash, library_js_like_map_constructor_contract,
+    library_js_like_set_constructor_contract, library_ruby_set_factory_contract_by_hash,
+    library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
+    map_get_contract_by_hash, map_key_view_contract_by_hash, map_key_view_wrapper_contract_by_hash,
+    method_call_contract, nullish_global_contract, qualified_global_symbol_at_span,
+    record_shape_guard_for_node, reduction_builtin_contract, rust_option_and_then_contract,
     rust_option_none_sentinel_contract, rust_option_some_constructor_contract,
-    rust_vec_new_factory_contract, scalar_integer_method_contract, semantics,
-    seq_surface_contract_for_node, source_operator_at_node, static_index_membership_contract,
-    unshadowed_global_symbol, BuiltinArgContract, CardinalityPredicate, CardinalityThreshold,
-    ComparisonLaw, DomainEvidence, GoZeroMapDefaultKind, ImportFactKind,
-    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
-    JavaMapFactoryKind, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
-    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract,
-    StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD,
-    SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
+    scalar_integer_method_contract, semantics, seq_surface_contract_for_node,
+    source_operator_at_node, static_index_membership_contract, unshadowed_global_symbol,
+    BuiltinArgContract, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
+    GoZeroMapDefaultKind, ImportFactKind, ImportedNamespaceFunctionSemantic,
+    IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind,
+    LibraryApiCalleeContract, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
+    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
+    ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract, StaticIndexMembershipKind,
+    SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR,
+    SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -885,40 +890,42 @@ impl<'a> Builder<'a> {
     /// shadows the builtin.
     fn proven_free_name_collection_factory(&self, value: ValueId) -> Option<ValueId> {
         self.collection_factory_seq(value, |s, callee| {
-            semantics(s.il.meta.lang)
-                .collections()
-                .free_name_collection_factories()
-                .flat_map(|factory| {
-                    factory
-                        .names
-                        .iter()
-                        .map(move |name| (*name, factory.shadow_guard))
+            let node = &s.nodes[callee as usize];
+            let ValOp::Input(key) = node.op else {
+                return false;
+            };
+            let Some(contract) = library_free_name_collection_factory_contracts(s.il.meta.lang)
+                .find(|contract| {
+                    let LibraryApiCalleeContract::FreeName { name, .. } = contract.callee else {
+                        return false;
+                    };
+                    key == s.free_name_input_key(name)
                 })
-                .any(|(name, guard)| {
-                    s.is_free_name_value(callee, name)
-                        && s.free_name_factory_shadow_safe(name, guard)
+            else {
+                return false;
+            };
+            let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+                return false;
+            };
+            s.is_free_name_value(callee, name)
+                && library_api_free_name_shadow_safe(s.il.meta.lang, name, shadow, |candidate| {
+                    s.file_defines_name(candidate)
                 })
         })
-    }
-
-    fn free_name_factory_shadow_safe(&self, name: &str, shadow_guard: bool) -> bool {
-        if shadow_guard {
-            return !self.file_defines_name(name);
-        }
-        if self.il.meta.lang == Lang::Rust && name.starts_with("std::") {
-            return !self.file_defines_name("std");
-        }
-        true
     }
 
     /// Python `from collections import deque; deque(<seq>)` — the imported-stdlib collection
     /// factory (the non-free-name part of the former python recognizer).
     fn proven_python_deque_collection_value(&self, value: ValueId) -> Option<ValueId> {
         self.collection_factory_seq(value, |s, callee| {
-            semantics(s.il.meta.lang)
-                .collections()
-                .imported_collection_factories()
-                .any(|factory| s.is_import_binding_value(callee, factory.module, factory.exported))
+            library_imported_collection_factory_contracts(s.il.meta.lang).any(|contract| {
+                let LibraryApiCalleeContract::ImportedBinding { module, exported } =
+                    contract.callee
+                else {
+                    return false;
+                };
+                s.is_import_binding_value(callee, module, exported)
+            })
         })
     }
 
@@ -945,12 +952,19 @@ impl<'a> Builder<'a> {
         let contract = ["List", "Set", "Arrays"]
             .into_iter()
             .find_map(|receiver_name| {
-                let contract = java_collection_factory_contract_by_hash(
+                let contract = library_java_collection_factory_contract_by_hash(
                     self.il.meta.lang,
                     receiver_name,
                     method,
                 )?;
-                self.is_imported_java_util_name(receiver, contract.receiver)
+                let LibraryApiCalleeContract::JavaUtilStaticMember {
+                    receiver: expected_receiver,
+                    ..
+                } = contract.callee
+                else {
+                    return None;
+                };
+                self.is_imported_java_util_name(receiver, expected_receiver)
                     .then_some(contract)
             })?;
         // A single argument to a varargs collection factory (`Arrays.asList(x)`,
@@ -962,7 +976,13 @@ impl<'a> Builder<'a> {
         // must refuse, or an array-typed field and a list-typed field of the same name
         // would false-merge. Multi-argument factories are always a literal element list.
         if args.len() == 2 {
-            if contract.single_arg_spreads_array && self.is_array_param_value(args[1]) {
+            let single_arg_spreads_array = match contract.result {
+                LibraryCollectionFactoryResult::VariadicElements {
+                    single_arg_spreads_array,
+                } => single_arg_spreads_array,
+                _ => false,
+            };
+            if single_arg_spreads_array && self.is_array_param_value(args[1]) {
                 return Some(self.mk(ValOp::ArrayParam, vec![args[1]]));
             }
             return None;
@@ -977,14 +997,23 @@ impl<'a> Builder<'a> {
                 return false;
             };
             let Some(contract) =
-                ruby_set_factory_contract_by_hash(s.il.meta.lang, "Set", method, 1)
+                library_ruby_set_factory_contract_by_hash(s.il.meta.lang, "Set", method, 1)
+            else {
+                return false;
+            };
+            let LibraryApiCalleeContract::RubyRequireStaticMember {
+                receiver,
+                required_module,
+                shadow_root,
+                ..
+            } = contract.callee
             else {
                 return false;
             };
             callee.args.len() == 1
-                && s.ruby_file_requires_module(contract.required_module)
-                && !s.file_defines_name(contract.shadow_root)
-                && s.is_free_name_value(callee.args[0], contract.receiver)
+                && s.ruby_file_requires_module(required_module)
+                && !s.file_defines_name(shadow_root)
+                && s.is_free_name_value(callee.args[0], receiver)
         })
     }
 
@@ -1000,7 +1029,15 @@ impl<'a> Builder<'a> {
             return None;
         }
         let args = node.args.clone();
-        if !self.is_free_name_value(args[0], "vec") || self.file_defines_name("vec") {
+        let contract = library_rust_vec_macro_factory_contract(self.il.meta.lang, "vec")?;
+        let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+            return None;
+        };
+        if !self.is_free_name_value(args[0], name)
+            || !library_api_free_name_shadow_safe(self.il.meta.lang, name, shadow, |candidate| {
+                self.file_defines_name(candidate)
+            })
+        {
             return None;
         }
         Some(self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), args[1..].to_vec()))
@@ -1288,16 +1325,26 @@ impl<'a> Builder<'a> {
         ) {
             return None;
         }
-        let entry_tag = semantics(self.il.meta.lang)
-            .collections()
-            .free_name_map_factories()
-            .find(|factory| {
-                factory.names.iter().any(|name| {
-                    self.is_free_name_value(callee, name)
-                        && self.free_name_factory_shadow_safe(name, false)
-                })
-            })
-            .map(|factory| factory.entry_seq_tag)?;
+        let entry_tag =
+            library_free_name_map_factory_contracts(self.il.meta.lang).find_map(|contract| {
+                let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+                    return None;
+                };
+                if !self.is_free_name_value(callee, name)
+                    || !library_api_free_name_shadow_safe(
+                        self.il.meta.lang,
+                        name,
+                        shadow,
+                        |candidate| self.file_defines_name(candidate),
+                    )
+                {
+                    return None;
+                }
+                match contract.result {
+                    LibraryMapFactoryResult::EntrySequence { entry_seq_tag } => Some(entry_seq_tag),
+                    _ => None,
+                }
+            })?;
         self.map_factory_from_seq(seq, entry_tag)
     }
 
@@ -1335,11 +1382,21 @@ impl<'a> Builder<'a> {
         if callee.args.len() != 1 {
             return None;
         }
-        let contract = java_map_factory_contract_by_hash(self.il.meta.lang, "Map", method)?;
-        if !self.is_imported_java_util_name(callee.args[0], contract.receiver) {
+        let contract = library_java_map_factory_contract_by_hash(self.il.meta.lang, "Map", method)?;
+        let LibraryApiCalleeContract::JavaUtilStaticMember {
+            receiver: expected_receiver,
+            ..
+        } = contract.callee
+        else {
+            return None;
+        };
+        if !self.is_imported_java_util_name(callee.args[0], expected_receiver) {
             return None;
         }
-        if contract.kind == JavaMapFactoryKind::Of {
+        let LibraryMapFactoryResult::JavaFactory { kind } = contract.result else {
+            return None;
+        };
+        if kind == JavaMapFactoryKind::Of {
             let entries = &args[1..];
             if entries.len() % 2 != 0 {
                 return None;
@@ -1350,7 +1407,7 @@ impl<'a> Builder<'a> {
             }
             return Some(self.mk(ValOp::Seq(SEQ_VALUE_MAP), canonical_entries));
         }
-        if contract.kind == JavaMapFactoryKind::OfEntries {
+        if kind == JavaMapFactoryKind::OfEntries {
             let mut canonical_entries = Vec::with_capacity(args.len().saturating_sub(1));
             for entry in args.iter().skip(1).copied() {
                 let kv = self.proven_java_map_entry_pair(entry)?;
@@ -1371,9 +1428,16 @@ impl<'a> Builder<'a> {
         let ValOp::Field(method) = callee.op else {
             return None;
         };
+        let contract = library_java_map_entry_contract_by_hash(self.il.meta.lang, "Map", method)?;
+        let LibraryApiCalleeContract::JavaUtilStaticMember {
+            receiver: expected_receiver,
+            ..
+        } = contract.callee
+        else {
+            return None;
+        };
         if callee.args.len() != 1
-            || !java_map_entry_contract_by_hash(self.il.meta.lang, "Map", method)
-            || !self.is_imported_java_util_name(callee.args[0], "Map")
+            || !self.is_imported_java_util_name(callee.args[0], expected_receiver)
         {
             return None;
         }
@@ -1396,9 +1460,18 @@ impl<'a> Builder<'a> {
             return None;
         };
         let constructor = self.interner.resolve(name);
-        if let Some(contract) = js_like_set_constructor_contract(self.il.meta.lang, constructor) {
-            if contract.requires_unshadowed_global
-                && !unshadowed_global_symbol(self.il, self.interner, kids[0], contract.receiver)
+        if let Some(contract) =
+            library_js_like_set_constructor_contract(self.il.meta.lang, constructor)
+        {
+            let LibraryApiCalleeContract::JsGlobalConstructor {
+                receiver,
+                requires_unshadowed_global,
+            } = contract.callee
+            else {
+                return None;
+            };
+            if requires_unshadowed_global
+                && !unshadowed_global_symbol(self.il, self.interner, kids[0], receiver)
             {
                 return None;
             }
@@ -1407,13 +1480,22 @@ impl<'a> Builder<'a> {
             }
             return Some(self.eval_membership_collection(kids[1], env));
         }
-        let contract = js_like_map_constructor_contract(self.il.meta.lang, constructor)?;
-        if contract.requires_unshadowed_global
-            && !unshadowed_global_symbol(self.il, self.interner, kids[0], contract.receiver)
+        let contract = library_js_like_map_constructor_contract(self.il.meta.lang, constructor)?;
+        let LibraryApiCalleeContract::JsGlobalConstructor {
+            receiver,
+            requires_unshadowed_global,
+        } = contract.callee
+        else {
+            return None;
+        };
+        if requires_unshadowed_global
+            && !unshadowed_global_symbol(self.il, self.interner, kids[0], receiver)
         {
             return None;
         }
-        let entry_seq_tag = contract.entry_seq_tag?;
+        let LibraryMapFactoryResult::EntrySequence { entry_seq_tag } = contract.result else {
+            return None;
+        };
         let entries = self.eval(kids[1], env);
         self.map_factory_from_seq(entries, entry_seq_tag)
     }
@@ -7230,8 +7312,15 @@ impl<'a> Builder<'a> {
     }
 
     fn rust_vec_new_name(&self, text: &str) -> bool {
-        rust_vec_new_factory_contract(self.il.meta.lang, text)
-            .is_some_and(|contract| !self.file_defines_name(contract.shadow_root))
+        library_rust_vec_new_factory_contract(self.il.meta.lang, text).is_some_and(|contract| {
+            let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+                return false;
+            };
+            name == text
+                && library_api_free_name_shadow_safe(self.il.meta.lang, name, shadow, |candidate| {
+                    self.file_defines_name(candidate)
+                })
+        })
     }
 
     fn is_null_literal(&self, node: NodeId) -> bool {

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -3091,6 +3091,416 @@ const IMPORTED_COLLECTION_FACTORIES: &[ImportedCollectionFactory] = &[ImportedCo
     exported: "deque",
 }];
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LibraryApiContractId {
+    PythonBuiltinCollectionFactory,
+    PythonImportedCollectionFactory,
+    RustStdCollectionFactory,
+    RustStdMapFactory,
+    RustVecMacroFactory,
+    RustVecNewFactory,
+    JavaCollectionFactory(JavaCollectionFactoryKind),
+    JavaMapFactory(JavaMapFactoryKind),
+    JavaMapEntryFactory,
+    RubySetFactory,
+    JsLikeSetConstructor,
+    JsLikeMapConstructor,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LibraryApiShadowPolicy {
+    None,
+    SameName,
+    RustStdRootForStdPath,
+    ExplicitRoot(&'static str),
+}
+
+pub fn library_api_free_name_shadow_safe(
+    lang: Lang,
+    name: &str,
+    policy: LibraryApiShadowPolicy,
+    defines_name: impl Fn(&str) -> bool,
+) -> bool {
+    match policy {
+        LibraryApiShadowPolicy::None => true,
+        LibraryApiShadowPolicy::SameName => !defines_name(name),
+        LibraryApiShadowPolicy::RustStdRootForStdPath => {
+            !(lang == Lang::Rust && name.starts_with("std::") && defines_name("std"))
+        }
+        LibraryApiShadowPolicy::ExplicitRoot(root) => !defines_name(root),
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LibraryApiCalleeContract {
+    FreeName {
+        name: &'static str,
+        shadow: LibraryApiShadowPolicy,
+    },
+    ImportedBinding {
+        module: &'static str,
+        exported: &'static str,
+    },
+    JavaUtilStaticMember {
+        receiver: &'static str,
+        method: &'static str,
+    },
+    RubyRequireStaticMember {
+        receiver: &'static str,
+        method: &'static str,
+        required_module: &'static str,
+        shadow_root: &'static str,
+    },
+    JsGlobalConstructor {
+        receiver: &'static str,
+        requires_unshadowed_global: bool,
+    },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LibraryCollectionFactoryResult {
+    SequenceArgument,
+    VariadicElements { single_arg_spreads_array: bool },
+    StaticNonFloatSequenceArgument,
+    EmptySequence,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryCollectionFactoryContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: LibraryCollectionFactoryResult,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LibraryMapFactoryResult {
+    EntrySequence { entry_seq_tag: u64 },
+    JavaFactory { kind: JavaMapFactoryKind },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryMapFactoryContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: LibraryMapFactoryResult,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryMapEntryFactoryContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+}
+
+pub fn library_free_name_collection_factory_contract(
+    lang: Lang,
+    name: &str,
+) -> Option<LibraryCollectionFactoryContract> {
+    FREE_NAME_COLLECTION_FACTORIES
+        .iter()
+        .find(|row| row.lang.is_none_or(|row_lang| row_lang == lang) && row.names.contains(&name))
+        .and_then(|row| {
+            let matched_name = row
+                .names
+                .iter()
+                .copied()
+                .find(|candidate| *candidate == name)?;
+            let id = match lang {
+                Lang::Python => LibraryApiContractId::PythonBuiltinCollectionFactory,
+                Lang::Rust => LibraryApiContractId::RustStdCollectionFactory,
+                _ => return None,
+            };
+            Some(LibraryCollectionFactoryContract {
+                id,
+                callee: LibraryApiCalleeContract::FreeName {
+                    name: matched_name,
+                    shadow: library_free_name_shadow_policy(lang, row.shadow_guard),
+                },
+                result: LibraryCollectionFactoryResult::SequenceArgument,
+            })
+        })
+}
+
+pub fn library_free_name_collection_factory_contracts(
+    lang: Lang,
+) -> impl Iterator<Item = LibraryCollectionFactoryContract> {
+    FREE_NAME_COLLECTION_FACTORIES
+        .iter()
+        .filter(move |row| row.lang.is_none_or(|row_lang| row_lang == lang))
+        .flat_map(move |row| {
+            row.names
+                .iter()
+                .filter_map(move |name| library_free_name_collection_factory_contract(lang, name))
+        })
+}
+
+pub fn library_imported_collection_factory_contract(
+    lang: Lang,
+    module: &str,
+    exported: &str,
+) -> Option<LibraryCollectionFactoryContract> {
+    IMPORTED_COLLECTION_FACTORIES
+        .iter()
+        .find(|row| {
+            row.lang.is_none_or(|row_lang| row_lang == lang)
+                && row.module == module
+                && row.exported == exported
+        })
+        .map(|row| LibraryCollectionFactoryContract {
+            id: LibraryApiContractId::PythonImportedCollectionFactory,
+            callee: LibraryApiCalleeContract::ImportedBinding {
+                module: row.module,
+                exported: row.exported,
+            },
+            result: LibraryCollectionFactoryResult::SequenceArgument,
+        })
+}
+
+pub fn library_imported_collection_factory_contracts(
+    lang: Lang,
+) -> impl Iterator<Item = LibraryCollectionFactoryContract> {
+    IMPORTED_COLLECTION_FACTORIES
+        .iter()
+        .filter(move |row| row.lang.is_none_or(|row_lang| row_lang == lang))
+        .filter_map(move |row| {
+            library_imported_collection_factory_contract(lang, row.module, row.exported)
+        })
+}
+
+pub fn library_free_name_map_factory_contract(
+    lang: Lang,
+    name: &str,
+) -> Option<LibraryMapFactoryContract> {
+    FREE_NAME_MAP_FACTORIES
+        .iter()
+        .find(|row| row.lang.is_none_or(|row_lang| row_lang == lang) && row.names.contains(&name))
+        .and_then(|row| {
+            let matched_name = row
+                .names
+                .iter()
+                .copied()
+                .find(|candidate| *candidate == name)?;
+            let id = match lang {
+                Lang::Rust => LibraryApiContractId::RustStdMapFactory,
+                _ => return None,
+            };
+            Some(LibraryMapFactoryContract {
+                id,
+                callee: LibraryApiCalleeContract::FreeName {
+                    name: matched_name,
+                    shadow: library_free_name_shadow_policy(lang, false),
+                },
+                result: LibraryMapFactoryResult::EntrySequence {
+                    entry_seq_tag: row.entry_seq_tag,
+                },
+            })
+        })
+}
+
+pub fn library_free_name_map_factory_contracts(
+    lang: Lang,
+) -> impl Iterator<Item = LibraryMapFactoryContract> {
+    FREE_NAME_MAP_FACTORIES
+        .iter()
+        .filter(move |row| row.lang.is_none_or(|row_lang| row_lang == lang))
+        .flat_map(move |row| {
+            row.names
+                .iter()
+                .filter_map(move |name| library_free_name_map_factory_contract(lang, name))
+        })
+}
+
+pub fn library_java_collection_factory_contract(
+    lang: Lang,
+    receiver: &str,
+    method: &str,
+) -> Option<LibraryCollectionFactoryContract> {
+    let contract = java_collection_factory_contract(lang, receiver, method)?;
+    Some(LibraryCollectionFactoryContract {
+        id: LibraryApiContractId::JavaCollectionFactory(contract.kind),
+        callee: LibraryApiCalleeContract::JavaUtilStaticMember {
+            receiver: contract.receiver,
+            method: contract.method,
+        },
+        result: LibraryCollectionFactoryResult::VariadicElements {
+            single_arg_spreads_array: contract.single_arg_spreads_array,
+        },
+    })
+}
+
+pub fn library_java_collection_factory_contract_by_hash(
+    lang: Lang,
+    receiver: &str,
+    method_hash: u64,
+) -> Option<LibraryCollectionFactoryContract> {
+    ["of", "asList"].into_iter().find_map(|method| {
+        (stable_symbol_hash(method) == method_hash)
+            .then(|| library_java_collection_factory_contract(lang, receiver, method))
+            .flatten()
+    })
+}
+
+pub fn library_java_map_factory_contract(
+    lang: Lang,
+    receiver: &str,
+    method: &str,
+) -> Option<LibraryMapFactoryContract> {
+    let contract = java_map_factory_contract(lang, receiver, method)?;
+    Some(LibraryMapFactoryContract {
+        id: LibraryApiContractId::JavaMapFactory(contract.kind),
+        callee: LibraryApiCalleeContract::JavaUtilStaticMember {
+            receiver: contract.receiver,
+            method: contract.method,
+        },
+        result: LibraryMapFactoryResult::JavaFactory {
+            kind: contract.kind,
+        },
+    })
+}
+
+pub fn library_java_map_factory_contract_by_hash(
+    lang: Lang,
+    receiver: &str,
+    method_hash: u64,
+) -> Option<LibraryMapFactoryContract> {
+    ["of", "ofEntries"].into_iter().find_map(|method| {
+        (stable_symbol_hash(method) == method_hash)
+            .then(|| library_java_map_factory_contract(lang, receiver, method))
+            .flatten()
+    })
+}
+
+pub fn library_java_map_entry_contract(
+    lang: Lang,
+    receiver: &str,
+    method: &str,
+) -> Option<LibraryMapEntryFactoryContract> {
+    java_map_entry_contract(lang, receiver, method).then_some(LibraryMapEntryFactoryContract {
+        id: LibraryApiContractId::JavaMapEntryFactory,
+        callee: LibraryApiCalleeContract::JavaUtilStaticMember {
+            receiver: "Map",
+            method: "entry",
+        },
+    })
+}
+
+pub fn library_java_map_entry_contract_by_hash(
+    lang: Lang,
+    receiver: &str,
+    method_hash: u64,
+) -> Option<LibraryMapEntryFactoryContract> {
+    (method_hash == stable_symbol_hash("entry"))
+        .then(|| library_java_map_entry_contract(lang, receiver, "entry"))
+        .flatten()
+}
+
+pub fn library_ruby_set_factory_contract(
+    lang: Lang,
+    receiver: &str,
+    method: &str,
+    arg_count: usize,
+) -> Option<LibraryCollectionFactoryContract> {
+    let contract = ruby_set_factory_contract(lang, receiver, method, arg_count)?;
+    Some(LibraryCollectionFactoryContract {
+        id: LibraryApiContractId::RubySetFactory,
+        callee: LibraryApiCalleeContract::RubyRequireStaticMember {
+            receiver: contract.receiver,
+            method: contract.method,
+            required_module: contract.required_module,
+            shadow_root: contract.shadow_root,
+        },
+        result: LibraryCollectionFactoryResult::SequenceArgument,
+    })
+}
+
+pub fn library_ruby_set_factory_contract_by_hash(
+    lang: Lang,
+    receiver: &str,
+    method_hash: u64,
+    arg_count: usize,
+) -> Option<LibraryCollectionFactoryContract> {
+    (method_hash == stable_symbol_hash("new"))
+        .then(|| library_ruby_set_factory_contract(lang, receiver, "new", arg_count))
+        .flatten()
+}
+
+pub fn library_js_like_set_constructor_contract(
+    lang: Lang,
+    receiver: &str,
+) -> Option<LibraryCollectionFactoryContract> {
+    let contract = js_like_set_constructor_contract(lang, receiver)?;
+    Some(LibraryCollectionFactoryContract {
+        id: LibraryApiContractId::JsLikeSetConstructor,
+        callee: LibraryApiCalleeContract::JsGlobalConstructor {
+            receiver: contract.receiver,
+            requires_unshadowed_global: contract.requires_unshadowed_global,
+        },
+        result: LibraryCollectionFactoryResult::StaticNonFloatSequenceArgument,
+    })
+}
+
+pub fn library_js_like_map_constructor_contract(
+    lang: Lang,
+    receiver: &str,
+) -> Option<LibraryMapFactoryContract> {
+    let contract = js_like_map_constructor_contract(lang, receiver)?;
+    Some(LibraryMapFactoryContract {
+        id: LibraryApiContractId::JsLikeMapConstructor,
+        callee: LibraryApiCalleeContract::JsGlobalConstructor {
+            receiver: contract.receiver,
+            requires_unshadowed_global: contract.requires_unshadowed_global,
+        },
+        result: LibraryMapFactoryResult::EntrySequence {
+            entry_seq_tag: contract.entry_seq_tag?,
+        },
+    })
+}
+
+pub fn library_rust_vec_macro_factory_contract(
+    lang: Lang,
+    name: &str,
+) -> Option<LibraryCollectionFactoryContract> {
+    (lang == Lang::Rust && name == "vec").then_some(LibraryCollectionFactoryContract {
+        id: LibraryApiContractId::RustVecMacroFactory,
+        callee: LibraryApiCalleeContract::FreeName {
+            name: "vec",
+            shadow: LibraryApiShadowPolicy::SameName,
+        },
+        result: LibraryCollectionFactoryResult::VariadicElements {
+            single_arg_spreads_array: false,
+        },
+    })
+}
+
+pub fn library_rust_vec_new_factory_contract(
+    lang: Lang,
+    name: &str,
+) -> Option<LibraryCollectionFactoryContract> {
+    let contract = rust_vec_new_factory_contract(lang, name)?;
+    Some(LibraryCollectionFactoryContract {
+        id: LibraryApiContractId::RustVecNewFactory,
+        callee: LibraryApiCalleeContract::FreeName {
+            name: match name {
+                "Vec::new" => "Vec::new",
+                "std::vec::Vec::new" => "std::vec::Vec::new",
+                "alloc::vec::Vec::new" => "alloc::vec::Vec::new",
+                _ => return None,
+            },
+            shadow: LibraryApiShadowPolicy::ExplicitRoot(contract.shadow_root),
+        },
+        result: LibraryCollectionFactoryResult::EmptySequence,
+    })
+}
+
+fn library_free_name_shadow_policy(lang: Lang, shadow_guard: bool) -> LibraryApiShadowPolicy {
+    if shadow_guard {
+        LibraryApiShadowPolicy::SameName
+    } else if lang == Lang::Rust {
+        LibraryApiShadowPolicy::RustStdRootForStdPath
+    } else {
+        LibraryApiShadowPolicy::None
+    }
+}
+
 pub fn imported_literal_seq_tag_safe(lang: Lang, tag: &str) -> bool {
     seq_surface_contract(lang, Some(tag)).is_some_and(|contract| contract.imported_literal)
 }
@@ -4308,6 +4718,106 @@ mod tests {
             .map(|factory| factory.entry_seq_tag)
             .collect();
         assert!(js_map_tags.is_empty());
+    }
+
+    #[test]
+    fn library_api_contracts_carry_identity_and_result_obligations() {
+        assert_eq!(
+            library_free_name_collection_factory_contract(Lang::Python, "list"),
+            Some(LibraryCollectionFactoryContract {
+                id: LibraryApiContractId::PythonBuiltinCollectionFactory,
+                callee: LibraryApiCalleeContract::FreeName {
+                    name: "list",
+                    shadow: LibraryApiShadowPolicy::SameName,
+                },
+                result: LibraryCollectionFactoryResult::SequenceArgument,
+            })
+        );
+        assert_eq!(
+            library_imported_collection_factory_contract(Lang::Python, "collections", "deque"),
+            Some(LibraryCollectionFactoryContract {
+                id: LibraryApiContractId::PythonImportedCollectionFactory,
+                callee: LibraryApiCalleeContract::ImportedBinding {
+                    module: "collections",
+                    exported: "deque",
+                },
+                result: LibraryCollectionFactoryResult::SequenceArgument,
+            })
+        );
+        assert_eq!(
+            library_free_name_map_factory_contract(Lang::Rust, "std::collections::HashMap::from"),
+            Some(LibraryMapFactoryContract {
+                id: LibraryApiContractId::RustStdMapFactory,
+                callee: LibraryApiCalleeContract::FreeName {
+                    name: "std::collections::HashMap::from",
+                    shadow: LibraryApiShadowPolicy::RustStdRootForStdPath,
+                },
+                result: LibraryMapFactoryResult::EntrySequence {
+                    entry_seq_tag: SEQ_VALUE_TUPLE,
+                },
+            })
+        );
+        assert!(!library_api_free_name_shadow_safe(
+            Lang::Rust,
+            "std::collections::HashMap::from",
+            LibraryApiShadowPolicy::RustStdRootForStdPath,
+            |name| name == "std"
+        ));
+        assert!(library_api_free_name_shadow_safe(
+            Lang::Rust,
+            "std::collections::HashMap::from",
+            LibraryApiShadowPolicy::RustStdRootForStdPath,
+            |_| false
+        ));
+        assert_eq!(
+            library_java_collection_factory_contract(Lang::Java, "Arrays", "asList"),
+            Some(LibraryCollectionFactoryContract {
+                id: LibraryApiContractId::JavaCollectionFactory(
+                    JavaCollectionFactoryKind::ArraysAsList,
+                ),
+                callee: LibraryApiCalleeContract::JavaUtilStaticMember {
+                    receiver: "Arrays",
+                    method: "asList",
+                },
+                result: LibraryCollectionFactoryResult::VariadicElements {
+                    single_arg_spreads_array: true,
+                },
+            })
+        );
+        assert_eq!(
+            library_ruby_set_factory_contract(Lang::Ruby, "Set", "new", 1),
+            Some(LibraryCollectionFactoryContract {
+                id: LibraryApiContractId::RubySetFactory,
+                callee: LibraryApiCalleeContract::RubyRequireStaticMember {
+                    receiver: "Set",
+                    method: "new",
+                    required_module: "set",
+                    shadow_root: "Set",
+                },
+                result: LibraryCollectionFactoryResult::SequenceArgument,
+            })
+        );
+        assert_eq!(
+            library_js_like_map_constructor_contract(Lang::TypeScript, "Map"),
+            Some(LibraryMapFactoryContract {
+                id: LibraryApiContractId::JsLikeMapConstructor,
+                callee: LibraryApiCalleeContract::JsGlobalConstructor {
+                    receiver: "Map",
+                    requires_unshadowed_global: true,
+                },
+                result: LibraryMapFactoryResult::EntrySequence {
+                    entry_seq_tag: SEQ_VALUE_COLLECTION,
+                },
+            })
+        );
+        assert_eq!(
+            library_free_name_collection_factory_contract(Lang::JavaScript, "list"),
+            None
+        );
+        assert_eq!(
+            library_java_map_factory_contract(Lang::Java, "List", "of"),
+            None
+        );
     }
 
     #[test]

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -63,6 +63,15 @@ The current implemented kinds are:
 | `Guard` | multi-obligation guard proof facts such as the first JS/TS record-shape guard contract |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, record guard, or Go composite map literal |
 
+`LibraryApiContract` is deliberately not listed here yet. It is currently an
+internal `nose-semantics` contract layer that names first-party library/API
+identity, callee obligations, shadow/import requirements, and result semantics.
+Existing evidence kinds such as `Symbol`, `Import`, `Source`, and
+`SequenceSurface` prove those obligations; the contract decides whether the
+facts are enough to admit an exact or value-graph path. A future external pack
+schema may expose library API contracts, but providers still emit facts and
+contracts rather than exact-clone verdicts.
+
 ## Consumption Rules
 
 Consumers should go through `nose-semantics` helpers rather than scanning raw IL

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -97,10 +97,11 @@ and pack ecosystem.
   local shadow safety, and the Rust frontend no longer lowers bare `None`
   directly to null before that proof.
 - Java collection/map factory selectors, Python free-name/imported collection
-  factories, Rust std collection/map factory paths, and Ruby `Set.new` moved
-  behind shared `nose-semantics` contracts. Normalize, strict exact gates, and
-  corpus import proof now consume the same selector source while keeping local
-  import, require, shadow, mutation, and entry-shape proof at the caller.
+  factories, Rust std collection/map factory paths, Ruby `Set.new`, and JS-like
+  `new Map`/`new Set` moved behind internal `LibraryApiContract` rows in
+  `nose-semantics`. Normalize and strict exact gates now consume the same API
+  identity/result source while keeping local import, require, shadow, mutation,
+  constructor-syntax, and entry-shape proof at the caller.
 - Java empty `ArrayList`/`LinkedList` constructor lowering now consumes a
   `java.util` constructor contract instead of a raw simple-name check. Simple
   names need import proof and no local type shadow before they can seed exact
@@ -308,8 +309,16 @@ Remaining in this phase:
   versioned pack-facing effect/place evidence records.
 - Continue replacing any remaining local exact-fragment proof helpers with
   versioned pack-facing evidence records.
-- Move collection/map factory recognition into `LibraryApiContract` records.
-- Make value-graph and strict exact gates consume the same contract source.
+- Continue moving library API recognition into `LibraryApiContract` records.
+  The first internal slice covers collection/map factories, selected
+  constructors, Java `Map.entry`, and the shared shadow/import/result
+  obligations consumed by normalize and strict exact gates. Remaining work is to
+  cover non-factory API surfaces such as map-key views/wrappers, lookup/default
+  methods, static-global helpers, iterator adapters, and reductions.
+- Keep value-graph and strict exact gates on the same contract source. Factory
+  gates now share `LibraryApiContract` identity/result rows; method/view gates
+  still use narrower first-party contract helpers and should move behind the
+  same API-contract facade before the external pack boundary stabilizes.
 - Remove the remaining raw import/module proof IL payload storage after import
   and symbol evidence records can carry every consumer obligation, including
   module export dependencies, scope, rebinding, and mutation proof. Value-graph

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -99,14 +99,19 @@ migrated.
   normalize/detect still perform the local scope shadow check. The Rust
   frontend preserves bare `None` as a name rather than lowering it directly to
   null, so Option absence is admitted only through the contract.
-- Collection and map factory contracts have started moving into the facade.
-  Shared rows now cover Python free-name factories (`list`, `set`,
-  `frozenset`, `tuple`), Python imported `collections.deque`, Rust
-  `std::collections::{HashSet,BTreeSet,VecDeque,HashMap,BTreeMap}::from`,
-  Java `List.of`/`Set.of`/`Arrays.asList`, Java `Map.of`/`Map.ofEntries`/
-  `Map.entry`, and Ruby `require "set"; Set.new(...)`. Callers still prove the
-  local import, require, shadowing, entry-shape, mutation, and exact-safety
-  obligations.
+- Collection and map factory identity now has an internal `LibraryApiContract`
+  shape in `nose-semantics`. It separates API identity from result eligibility,
+  so callers can distinguish "this is Java `Arrays.asList`" from "this argument
+  can be canonicalized as a membership collection." Shared contracts cover
+  Python free-name factories (`list`, `set`, `frozenset`, `tuple`), Python
+  imported `collections.deque`, Rust
+  `std::collections::{HashSet,BTreeSet,VecDeque,HashMap,BTreeMap}::from`, Rust
+  `vec!`/`Vec::new`, Java `List.of`/`Set.of`/`Arrays.asList`, Java `Map.of`/
+  `Map.ofEntries`/`Map.entry`, Ruby `require "set"; Set.new(...)`, and JS-like
+  `new Set(...)`/`new Map(...)`. Normalize and strict exact gates consume this
+  shared contract source while still proving local import, require, shadowing,
+  constructor syntax, entry-shape, mutation, and exact-safety obligations at the
+  caller.
 - Java empty collection constructor contracts cover `new ArrayList<>()` and
   `new LinkedList<>()` only for the Java `java.util` list types. Simple names
   require `java.util` import proof and no local type declaration with the same


### PR DESCRIPTION
## What changed

- Added an internal `LibraryApiContract` layer in `nose-semantics` for first-party library API identity, callee obligations, shadow/import requirements, and result semantics.
- Migrated collection/map factory consumers in value graph, idiom canonicalization, and strict exact gates to consume the shared contract source.
- Covered Python free/imported collection factories, Rust std collection/map factories plus `vec!`/`Vec::new`, Java collection/map factories and `Map.entry`, Ruby `Set.new`, and JS-like `new Set`/`new Map`.
- Updated semantic-kernel docs to distinguish the implemented internal contract layer from future external pack/evidence schema work.

## Why

This is the next large migration slice for #109. It moves library API recognition away from scattered selector/name checks and toward a pack-shaped contract boundary while preserving local proof obligations at the call sites.

The contract separates API identity from result eligibility. For example, proving Java `Arrays.asList` is not by itself enough to canonicalize a single argument as a membership collection; value graph still keeps the existing array-provenance condition.

## Notes

While validating the migration, the existing literal membership CLI test caught a recall regression for Python `collections.deque` direct import/alias forms. The issue was that a missing free-name factory contract incorrectly closed the entire strict-exact Python collection factory gate before imported-symbol proof could run. This PR fixes that by treating “no free-name contract” as a false branch, not as failure of the imported factory branch.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --release`
- `cargo test --release`
- `awiki lint --root docs`
- `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `./scripts/check-duplication.sh`
