### PR TITLE
semantics: route method APIs through library contracts

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -18,21 +18,21 @@ use nose_semantics::{
     exact_java_this_field, exact_non_overloadable_index_assignment,
     exact_non_overloadable_index_assignment_parts, exact_static_membership_predicate_operator,
     go_zero_map_default_kind, go_zero_map_lookup_contract, imported_binding_symbol,
-    imported_member_symbol, iterator_identity_adapter_contract, js_array_is_array_contract,
-    library_api_free_name_shadow_safe, library_free_name_collection_factory_contract,
-    library_free_name_map_factory_contract, library_imported_collection_factory_contracts,
+    imported_member_symbol, library_api_free_name_shadow_safe,
+    library_free_name_collection_factory_contract, library_free_name_map_factory_contract,
+    library_imported_collection_factory_contracts, library_iterator_identity_adapter_contract,
     library_java_collection_factory_contract, library_java_map_entry_contract,
-    library_java_map_factory_contract, library_js_like_map_constructor_contract,
-    library_js_like_set_constructor_contract, library_ruby_set_factory_contract,
+    library_java_map_factory_contract, library_js_array_is_array_contract,
+    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
+    library_map_get_contract, library_map_key_view_contract, library_map_key_view_wrapper_contract,
+    library_method_call_contract, library_regex_test_contract, library_ruby_set_factory_contract,
     library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
-    map_get_contract, map_key_view_contract, map_key_view_wrapper_contract, method_call_contract,
-    nullish_global_contract, qualified_global_symbol, record_shape_guard_for_node,
-    regex_test_contract, semantics, seq_surface_contract_for_node, source_fact_at_node,
-    source_operator_at_node, static_index_membership_contract, typeof_operator_contract,
-    unshadowed_global_symbol, DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind,
-    LibraryApiCalleeContract, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
-    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
-    StaticIndexMembershipKind,
+    nullish_global_contract, qualified_global_symbol, record_shape_guard_for_node, semantics,
+    seq_surface_contract_for_node, source_fact_at_node, source_operator_at_node,
+    static_index_membership_contract, typeof_operator_contract, unshadowed_global_symbol,
+    DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind, LibraryApiCalleeContract,
+    LibraryCollectionFactoryResult, LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs,
+    MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1347,11 +1347,12 @@ fn strict_exact_regex_test_safe(
     callee: NodeId,
     method: &str,
 ) -> Option<bool> {
-    let contract = regex_test_contract(
+    let contract = library_regex_test_contract(
         il.meta.lang,
         method,
         il.children(node).len().saturating_sub(1),
-    )?;
+    )?
+    .result;
     let Some(&receiver) = il.children(callee).first() else {
         return Some(false);
     };
@@ -1377,7 +1378,7 @@ fn strict_exact_js_array_is_array_safe(
     else {
         return false;
     };
-    let Some(contract) = js_array_is_array_contract(
+    let Some(contract) = library_js_array_is_array_contract(
         il.meta.lang,
         interner.resolve(receiver_name),
         method,
@@ -1385,6 +1386,7 @@ fn strict_exact_js_array_is_array_safe(
     ) else {
         return false;
     };
+    let contract = contract.result;
     if contract.requires_unshadowed_receiver
         && !unshadowed_global_symbol(il, interner, receiver, contract.receiver)
     {
@@ -1404,13 +1406,14 @@ fn strict_exact_collection_contains_call_safe(
     callee: NodeId,
     method: &str,
 ) -> bool {
-    let Some(contract) = method_call_contract(
+    let Some(contract) = library_method_call_contract(
         il.meta.lang,
         method,
         il.children(node).len().saturating_sub(1),
     ) else {
         return false;
     };
+    let contract = contract.result;
     if contract.semantic != MethodSemanticContract::Builtin(Builtin::Contains)
         || contract.args != MethodBuiltinArgs::FirstThenReceiver
     {
@@ -1452,13 +1455,14 @@ fn strict_exact_map_contains_call_safe(
     callee: NodeId,
     method: &str,
 ) -> bool {
-    let Some(contract) = method_call_contract(
+    let Some(contract) = library_method_call_contract(
         il.meta.lang,
         method,
         il.children(node).len().saturating_sub(1),
     ) else {
         return false;
     };
+    let contract = contract.result;
     if contract.semantic != MethodSemanticContract::Builtin(Builtin::Contains)
         || contract.args != MethodBuiltinArgs::FirstThenReceiver
         || !matches!(
@@ -1488,7 +1492,7 @@ fn strict_exact_map_get_call_safe(
     callee: NodeId,
     method: &str,
 ) -> bool {
-    if map_get_contract(
+    if library_map_get_contract(
         il.meta.lang,
         method,
         il.children(node).len().saturating_sub(1),
@@ -1514,13 +1518,14 @@ fn strict_exact_map_get_default_call_safe(
     callee: NodeId,
     method: &str,
 ) -> bool {
-    let Some(contract) = method_call_contract(
+    let Some(contract) = library_method_call_contract(
         il.meta.lang,
         method,
         il.children(node).len().saturating_sub(1),
     ) else {
         return false;
     };
+    let contract = contract.result;
     if contract.semantic != MethodSemanticContract::Builtin(Builtin::GetOrDefault)
         || contract.receiver != MethodReceiverContract::ExactMap
         || !matches!(
@@ -1604,7 +1609,7 @@ fn strict_exact_iterator_identity_adapter_call_safe(
     let Some(arg_count) = kids.len().checked_sub(1) else {
         return false;
     };
-    if iterator_identity_adapter_contract(il.meta.lang, method, arg_count).is_none() {
+    if library_iterator_identity_adapter_contract(il.meta.lang, method, arg_count).is_none() {
         return false;
     }
     if il.kind(callee) != NodeKind::Field {
@@ -1748,9 +1753,11 @@ fn strict_exact_map_key_view_safe_matching(
     let Payload::Name(method) = il.node(kids[0]).payload else {
         return false;
     };
-    let Some(contract) = map_key_view_contract(il.meta.lang, interner.resolve(method), 0) else {
+    let Some(contract) = library_map_key_view_contract(il.meta.lang, interner.resolve(method), 0)
+    else {
         return false;
     };
+    let contract = contract.result;
     if !accepts(contract.kind) {
         return false;
     }
@@ -1783,10 +1790,11 @@ fn strict_exact_map_key_view_collection_safe(
         return false;
     };
     let Some(contract) =
-        map_key_view_wrapper_contract(il.meta.lang, "Array", interner.resolve(method), 1)
+        library_map_key_view_wrapper_contract(il.meta.lang, "Array", interner.resolve(method), 1)
     else {
         return false;
     };
+    let contract = contract.result;
     qualified_global_symbol(il, kids[0], contract.qualified_path)
         && strict_exact_map_key_view_safe_matching(il, interner, facts, kids[1], |kind| {
             kind == MapKeyViewKind::Iterator

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -10,14 +10,14 @@
 use nose_il::{contains_js_identifier, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
 use nose_semantics::{
     domain_evidence_for_param, free_function_builtin_contract, imported_binding_symbol,
-    imported_namespace_symbol, iterator_identity_adapter_contract,
-    library_api_free_name_shadow_safe, library_free_name_map_factory_contract, map_get_contract,
-    map_key_view_contract, method_call_contract, method_hof_contract,
-    rust_option_some_constructor_contract, seq_surface_contract_for_node,
-    static_collection_adapter_contract, unshadowed_global_symbol, BuiltinArgContract,
-    DomainEvidence, LibraryApiCalleeContract, LibraryMapFactoryResult, MapKeyViewKind,
-    MethodBuiltinArgs, MethodCallContract, MethodReceiverContract, MethodSemanticContract,
-    SEQ_VALUE_MAP,
+    imported_namespace_symbol, library_api_free_name_shadow_safe,
+    library_free_name_map_factory_contract, library_iterator_identity_adapter_contract,
+    library_map_get_contract, library_map_key_view_contract, library_method_call_contract,
+    library_static_collection_adapter_contract, method_hof_contract,
+    rust_option_some_constructor_contract, seq_surface_contract_for_node, unshadowed_global_symbol,
+    BuiltinArgContract, DomainEvidence, LibraryApiCalleeContract, LibraryMapFactoryResult,
+    MapKeyViewKind, MethodBuiltinArgs, MethodCallContract, MethodReceiverContract,
+    MethodSemanticContract, SEQ_VALUE_MAP,
 };
 
 /// The result of inspecting a `Call`: it canonicalizes to a builtin, to a
@@ -85,16 +85,18 @@ pub(crate) fn canon_call(old: &Il, interner: &Interner, call_id: NodeId) -> Call
             if let Payload::Name(s) = cn.payload {
                 let fname = interner.resolve(s);
                 let base = old.children(callee).first().copied();
-                if let Some(contract) = method_call_contract(old.meta.lang, fname, args.len()) {
+                if let Some(contract) =
+                    library_method_call_contract(old.meta.lang, fname, args.len())
+                {
                     let Some(base) = base else {
                         return CallCanon::None;
                     };
                     let Some(proven) =
-                        prove_method_receiver(old, interner, contract.receiver, base, args)
+                        prove_method_receiver(old, interner, contract.result.receiver, base, args)
                     else {
                         return CallCanon::None;
                     };
-                    return apply_method_contract(old, interner, contract, proven, args);
+                    return apply_method_contract(old, interner, contract.result, proven, args);
                 }
             }
         }
@@ -420,7 +422,7 @@ fn unwrap_iter(old: &Il, interner: &Interner, node: NodeId) -> NodeId {
                             return arg;
                         }
                     }
-                    if iterator_identity_adapter_contract(
+                    if library_iterator_identity_adapter_contract(
                         old.meta.lang,
                         method,
                         call_kids.len() - 1,
@@ -466,7 +468,8 @@ fn exact_protocol_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool 
     if let Some(arg) = static_collection_adapter_arg(old, interner, receiver, method, kids) {
         return exact_collection_receiver(old, interner, arg);
     }
-    if let Some(contract) = method_call_contract(old.meta.lang, method, kids.len() - 1) {
+    if let Some(contract) = library_method_call_contract(old.meta.lang, method, kids.len() - 1) {
+        let contract = contract.result;
         if contract.semantic == MethodSemanticContract::Builtin(Builtin::Zip)
             && contract.receiver == MethodReceiverContract::ExactProtocolPairArgument
             && contract.args == MethodBuiltinArgs::RustZip
@@ -475,7 +478,7 @@ fn exact_protocol_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool 
                 && exact_protocol_receiver(old, interner, kids[1]);
         }
     }
-    if iterator_identity_adapter_contract(old.meta.lang, method, kids.len() - 1).is_some() {
+    if library_iterator_identity_adapter_contract(old.meta.lang, method, kids.len() - 1).is_some() {
         return exact_protocol_receiver(old, interner, receiver);
     }
     if method_hof_contract(old.meta.lang, method).is_some() && kids.len() >= 2 {
@@ -496,12 +499,13 @@ fn static_collection_adapter_arg(
     call_kids: &[NodeId],
 ) -> Option<NodeId> {
     let receiver_name = name_of(old, interner, receiver)?;
-    let contract = static_collection_adapter_contract(
+    let contract = library_static_collection_adapter_contract(
         old.meta.lang,
         receiver_name,
         method,
         call_kids.len().saturating_sub(1),
     )?;
+    let contract = contract.result;
     if file_defines_type_name(old, interner, receiver_name)
         || !imported_binding_symbol(old, interner, receiver, contract.module, contract.exported)
     {
@@ -837,7 +841,7 @@ fn map_get_call_parts(old: &Il, interner: &Interner, id: NodeId) -> Option<(Node
     let Payload::Name(method) = old.node(kids[0]).payload else {
         return None;
     };
-    map_get_contract(old.meta.lang, interner.resolve(method), 1)?;
+    library_map_get_contract(old.meta.lang, interner.resolve(method), 1)?;
     let receiver = *old.children(kids[0]).first()?;
     Some((receiver, kids[1]))
 }
@@ -853,7 +857,8 @@ fn key_set_receiver(old: &Il, interner: &Interner, id: NodeId) -> Option<NodeId>
     let Payload::Name(method) = old.node(kids[0]).payload else {
         return None;
     };
-    let contract = map_key_view_contract(old.meta.lang, interner.resolve(method), 0)?;
+    let contract =
+        library_map_key_view_contract(old.meta.lang, interner.resolve(method), 0)?.result;
     if contract.kind != MapKeyViewKind::Collection {
         return None;
     }

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -53,28 +53,28 @@ use nose_semantics::{
     domain_evidence_for_param as semantic_domain_evidence_for_param,
     exact_static_membership_predicate_operator, free_function_builtin_contract,
     go_zero_map_default_kind, go_zero_map_lookup_contract, import_fact_evidence_rhs,
-    imported_namespace_function_contract, imported_namespace_symbol,
-    iterator_identity_adapter_contract, library_api_free_name_shadow_safe,
+    imported_namespace_symbol, library_api_free_name_shadow_safe,
     library_free_name_collection_factory_contracts, library_free_name_map_factory_contracts,
-    library_imported_collection_factory_contracts,
-    library_java_collection_factory_contract_by_hash, library_java_map_entry_contract_by_hash,
-    library_java_map_factory_contract_by_hash, library_js_like_map_constructor_contract,
-    library_js_like_set_constructor_contract, library_ruby_set_factory_contract_by_hash,
-    library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
-    map_get_contract_by_hash, map_key_view_contract_by_hash, map_key_view_wrapper_contract_by_hash,
-    method_call_contract, nullish_global_contract, qualified_global_symbol_at_span,
-    record_shape_guard_for_node, reduction_builtin_contract, rust_option_and_then_contract,
-    rust_option_none_sentinel_contract, rust_option_some_constructor_contract,
-    scalar_integer_method_contract, semantics, seq_surface_contract_for_node,
-    source_operator_at_node, static_index_membership_contract, unshadowed_global_symbol,
-    BuiltinArgContract, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
-    GoZeroMapDefaultKind, ImportFactKind, ImportedNamespaceFunctionSemantic,
-    IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind,
-    LibraryApiCalleeContract, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
-    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
-    ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract, StaticIndexMembershipKind,
-    SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR,
-    SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
+    library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
+    library_iterator_identity_adapter_contract, library_java_collection_factory_contract_by_hash,
+    library_java_map_entry_contract_by_hash, library_java_map_factory_contract_by_hash,
+    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
+    library_map_get_contract_by_hash, library_map_key_view_contract_by_hash,
+    library_map_key_view_wrapper_contract_by_hash, library_method_call_contract,
+    library_ruby_set_factory_contract_by_hash, library_rust_vec_macro_factory_contract,
+    library_rust_vec_new_factory_contract, nullish_global_contract,
+    qualified_global_symbol_at_span, record_shape_guard_for_node, reduction_builtin_contract,
+    rust_option_and_then_contract, rust_option_none_sentinel_contract,
+    rust_option_some_constructor_contract, scalar_integer_method_contract, semantics,
+    seq_surface_contract_for_node, source_operator_at_node, static_index_membership_contract,
+    unshadowed_global_symbol, BuiltinArgContract, CardinalityPredicate, CardinalityThreshold,
+    ComparisonLaw, DomainEvidence, GoZeroMapDefaultKind, ImportFactKind,
+    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
+    JavaMapFactoryKind, LibraryApiCalleeContract, LibraryCollectionFactoryResult,
+    LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
+    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract,
+    StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD,
+    SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -1609,7 +1609,7 @@ impl<'a> Builder<'a> {
         let ValOp::Field(method) = callee.op else {
             return None;
         };
-        map_get_contract_by_hash(self.il.meta.lang, method, args.len().saturating_sub(1))?;
+        library_map_get_contract_by_hash(self.il.meta.lang, method, args.len().saturating_sub(1))?;
         if callee.args.len() != 1 {
             return None;
         }
@@ -1641,7 +1641,8 @@ impl<'a> Builder<'a> {
             let ValOp::Field(method) = callee.op else {
                 return None;
             };
-            let contract = map_key_view_contract_by_hash(self.il.meta.lang, method, 0)?;
+            let contract =
+                library_map_key_view_contract_by_hash(self.il.meta.lang, method, 0)?.result;
             if contract.kind != accepted || callee.args.len() != 1 {
                 return None;
             }
@@ -1657,8 +1658,13 @@ impl<'a> Builder<'a> {
             let ValOp::Field(method) = callee.op else {
                 return None;
             };
-            let contract =
-                map_key_view_wrapper_contract_by_hash(self.il.meta.lang, "Array", method, 1)?;
+            let contract = library_map_key_view_wrapper_contract_by_hash(
+                self.il.meta.lang,
+                "Array",
+                method,
+                1,
+            )?
+            .result;
             if accepted != MapKeyViewKind::Collection
                 || callee.args.len() != 1
                 || !qualified_global_symbol_at_span(
@@ -1701,7 +1707,8 @@ impl<'a> Builder<'a> {
         let receiver = callee_kids.first().copied();
 
         let contract =
-            method_call_contract(self.il.meta.lang, method, kids.len().saturating_sub(1))?;
+            library_method_call_contract(self.il.meta.lang, method, kids.len().saturating_sub(1))?
+                .result;
         if contract.semantic != MethodSemanticContract::Builtin(Builtin::Contains) {
             return None;
         }
@@ -1783,7 +1790,7 @@ impl<'a> Builder<'a> {
             return None;
         };
         let method = self.interner.resolve(name);
-        let contract = method_call_contract(self.il.meta.lang, method, 1)?;
+        let contract = library_method_call_contract(self.il.meta.lang, method, 1)?.result;
         if contract.semantic != MethodSemanticContract::Builtin(Builtin::Contains)
             || contract.args != MethodBuiltinArgs::FirstThenReceiver
             || !matches!(
@@ -1821,11 +1828,12 @@ impl<'a> Builder<'a> {
         let Payload::Name(name) = self.il.node(callee).payload else {
             return None;
         };
-        let contract = method_call_contract(
+        let contract = library_method_call_contract(
             self.il.meta.lang,
             self.interner.resolve(name),
             kids.len().saturating_sub(1),
-        )?;
+        )?
+        .result;
         if contract.semantic != MethodSemanticContract::Builtin(Builtin::GetOrDefault)
             || contract.receiver != MethodReceiverContract::ExactMap
             || !matches!(
@@ -6638,7 +6646,7 @@ impl<'a> Builder<'a> {
         let ValOp::Field(method) = callee.op else {
             return false;
         };
-        if map_get_contract_by_hash(self.il.meta.lang, method, 1).is_none()
+        if library_map_get_contract_by_hash(self.il.meta.lang, method, 1).is_none()
             || callee.args.len() != 1
         {
             return false;
@@ -6791,11 +6799,12 @@ impl<'a> Builder<'a> {
         let Payload::Name(name) = self.il.node(callee).payload else {
             return None;
         };
-        let contract = method_call_contract(
+        let contract = library_method_call_contract(
             self.il.meta.lang,
             self.interner.resolve(name),
             kids.len().saturating_sub(1),
-        )?;
+        )?
+        .result;
         if contract.semantic != MethodSemanticContract::Builtin(Builtin::Len)
             || contract.receiver != MethodReceiverContract::ExactProtocol
             || contract.args != MethodBuiltinArgs::CollectionReduction
@@ -6829,11 +6838,12 @@ impl<'a> Builder<'a> {
         let Payload::Name(name) = self.il.node(callee).payload else {
             return None;
         };
-        let contract = imported_namespace_function_contract(
+        let contract = library_imported_namespace_function_contract(
             self.il.meta.lang,
             self.interner.resolve(name),
             kids.len().saturating_sub(1),
-        )?;
+        )?
+        .result;
         let base = *self.il.children(callee).first()?;
         if !self.is_import_namespace_expr(base, contract.module, env) {
             return None;
@@ -6871,11 +6881,12 @@ impl<'a> Builder<'a> {
         let Payload::Name(method) = self.il.node(kids[0]).payload else {
             return None;
         };
-        let contract = iterator_identity_adapter_contract(
+        let contract = library_iterator_identity_adapter_contract(
             self.il.meta.lang,
             self.interner.resolve(method),
             0,
-        )?;
+        )?
+        .result;
         let base = *self.il.children(kids[0]).first()?;
         let value = self.eval(base, env);
         let value = self.param_domain_value(value);
@@ -6907,7 +6918,9 @@ impl<'a> Builder<'a> {
         let Payload::Name(method) = self.il.node(kids[0]).payload else {
             return None;
         };
-        let contract = method_call_contract(self.il.meta.lang, self.interner.resolve(method), 1)?;
+        let contract =
+            library_method_call_contract(self.il.meta.lang, self.interner.resolve(method), 1)?
+                .result;
         if contract.receiver != MethodReceiverContract::RustMapGetOrExactOption
             || contract.args != MethodBuiltinArgs::RustMapGetOrOptionDefault
         {
@@ -6934,7 +6947,9 @@ impl<'a> Builder<'a> {
         let Payload::Name(method) = self.il.node(kids[0]).payload else {
             return None;
         };
-        let contract = method_call_contract(self.il.meta.lang, self.interner.resolve(method), 0)?;
+        let contract =
+            library_method_call_contract(self.il.meta.lang, self.interner.resolve(method), 0)?
+                .result;
         if contract.receiver != MethodReceiverContract::RustMapGetOrExactOption
             || contract.args != MethodBuiltinArgs::ReceiverOnly
             || contract.semantic != MethodSemanticContract::Builtin(Builtin::IsNotNull)

--- a/crates/nose-normalize/src/value_graph/rules/promise_then.rs
+++ b/crates/nose-normalize/src/value_graph/rules/promise_then.rs
@@ -9,7 +9,7 @@
 
 use super::super::{Builder, ValueId};
 use nose_il::{NodeId, NodeKind, Payload};
-use nose_semantics::{promise_then_contract, AsyncReceiverContract};
+use nose_semantics::{library_promise_then_contract, AsyncReceiverContract};
 use rustc_hash::FxHashMap;
 
 pub(in super::super) fn apply(
@@ -28,7 +28,8 @@ pub(in super::super) fn apply(
     let Payload::Name(s) = builder.il.node(callee).payload else {
         return None;
     };
-    let contract = promise_then_contract(builder.il.meta.lang, builder.interner.resolve(s), 1)?;
+    let contract =
+        library_promise_then_contract(builder.il.meta.lang, builder.interner.resolve(s), 1)?.result;
     let cb = kids[1];
     if builder.il.kind(cb) != NodeKind::Lambda {
         return None;

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -1882,6 +1882,14 @@ pub fn method_call_contract(
     name: &str,
     arg_count: usize,
 ) -> Option<MethodCallContract> {
+    library_method_call_contract(lang, name, arg_count).map(|contract| contract.result)
+}
+
+fn method_call_contract_shape(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<MethodCallContract> {
     use MethodBuiltinArgs as Args;
     use MethodReceiverContract as Receiver;
     use MethodSemanticContract as Semantic;
@@ -2140,18 +2148,7 @@ pub fn promise_then_contract(
     method: &str,
     arg_count: usize,
 ) -> Option<PromiseThenContract> {
-    if matches!(
-        lang,
-        Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html
-    ) && method == "then"
-        && arg_count == 1
-    {
-        Some(PromiseThenContract {
-            receiver: AsyncReceiverContract::ExactPromiseLike,
-        })
-    } else {
-        None
-    }
+    library_promise_then_contract(lang, method, arg_count).map(|contract| contract.result)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -2169,20 +2166,8 @@ pub fn iterator_identity_adapter_contract(
     method: &str,
     arg_count: usize,
 ) -> Option<IteratorIdentityAdapterContract> {
-    if lang == Lang::Rust
-        && arg_count == 0
-        && matches!(
-            method,
-            "iter" | "into_iter" | "iter_mut" | "collect" | "to_vec" | "copied" | "cloned"
-        )
-        || lang == Lang::Java && method == "stream" && arg_count == 0
-    {
-        Some(IteratorIdentityAdapterContract {
-            receiver: IteratorAdapterReceiverContract::ExactIterableValue,
-        })
-    } else {
-        None
-    }
+    library_iterator_identity_adapter_contract(lang, method, arg_count)
+        .map(|contract| contract.result)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -2197,12 +2182,8 @@ pub fn static_collection_adapter_contract(
     method: &str,
     arg_count: usize,
 ) -> Option<StaticCollectionAdapterContract> {
-    (lang == Lang::Java && receiver == "Arrays" && method == "stream" && arg_count == 1).then_some(
-        StaticCollectionAdapterContract {
-            module: "java.util",
-            exported: "Arrays",
-        },
-    )
+    library_static_collection_adapter_contract(lang, receiver, method, arg_count)
+        .map(|contract| contract.result)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -2510,26 +2491,7 @@ pub fn map_key_view_contract(
     method: &str,
     arg_count: usize,
 ) -> Option<MapKeyViewContract> {
-    if arg_count != 0 {
-        return None;
-    }
-    Some(match (lang, method) {
-        (Lang::Python | Lang::Ruby, "keys") => MapKeyViewContract {
-            method: "keys",
-            kind: MapKeyViewKind::Collection,
-        },
-        (Lang::Java, "keySet") => MapKeyViewContract {
-            method: "keySet",
-            kind: MapKeyViewKind::Collection,
-        },
-        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "keys") => {
-            MapKeyViewContract {
-                method: "keys",
-                kind: MapKeyViewKind::Iterator,
-            }
-        }
-        _ => return None,
-    })
+    library_map_key_view_contract(lang, method, arg_count).map(|contract| contract.result)
 }
 
 pub fn map_key_view_contract_by_hash(
@@ -2557,13 +2519,8 @@ pub fn map_key_view_wrapper_contract(
     method: &str,
     arg_count: usize,
 ) -> Option<MapKeyViewWrapperContract> {
-    (js_like_lang(lang) && receiver == "Array" && method == "from" && arg_count == 1).then_some(
-        MapKeyViewWrapperContract {
-            receiver: "Array",
-            method: "from",
-            qualified_path: "Array.from",
-        },
-    )
+    library_map_key_view_wrapper_contract(lang, receiver, method, arg_count)
+        .map(|contract| contract.result)
 }
 
 pub fn map_key_view_wrapper_contract_by_hash(
@@ -2622,22 +2579,7 @@ pub struct MapGetContract {
 }
 
 pub fn map_get_contract(lang: Lang, method: &str, arg_count: usize) -> Option<MapGetContract> {
-    matches!(
-        lang,
-        Lang::Java
-            | Lang::Rust
-            | Lang::JavaScript
-            | Lang::TypeScript
-            | Lang::Vue
-            | Lang::Svelte
-            | Lang::Html
-    )
-    .then_some(())
-    .filter(|_| method == "get" && arg_count == 1)
-    .map(|_| MapGetContract {
-        method: "get",
-        receiver: MethodReceiverContract::ExactMap,
-    })
+    library_map_get_contract(lang, method, arg_count).map(|contract| contract.result)
 }
 
 pub fn map_get_contract_by_hash(
@@ -2740,12 +2682,7 @@ pub fn js_boolean_coercion_contract(
     function: &str,
     arg_count: usize,
 ) -> Option<StaticGlobalFunctionContract> {
-    (js_like_lang(lang) && function == "Boolean" && arg_count == 1).then_some(
-        StaticGlobalFunctionContract {
-            function: "Boolean",
-            requires_unshadowed_function: true,
-        },
-    )
+    library_js_boolean_coercion_contract(lang, function, arg_count).map(|contract| contract.result)
 }
 
 pub fn js_array_is_array_contract(
@@ -2754,14 +2691,8 @@ pub fn js_array_is_array_contract(
     method: &str,
     arg_count: usize,
 ) -> Option<StaticGlobalMethodContract> {
-    (js_like_lang(lang) && receiver == "Array" && method == "isArray" && arg_count == 1).then_some(
-        StaticGlobalMethodContract {
-            receiver: "Array",
-            method: "isArray",
-            qualified_path: "Array.isArray",
-            requires_unshadowed_receiver: true,
-        },
-    )
+    library_js_array_is_array_contract(lang, receiver, method, arg_count)
+        .map(|contract| contract.result)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -2775,10 +2706,7 @@ pub fn regex_test_contract(
     method: &str,
     arg_count: usize,
 ) -> Option<RegexTestContract> {
-    (js_like_lang(lang) && method == "test" && arg_count == 1).then_some(RegexTestContract {
-        method: "test",
-        required_receiver_fact: SourceFactKind::Literal(SourceLiteralKind::Regex),
-    })
+    library_regex_test_contract(lang, method, arg_count).map(|contract| contract.result)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -2865,18 +2793,8 @@ pub fn imported_namespace_function_contract(
     function: &str,
     arg_count: usize,
 ) -> Option<ImportedNamespaceFunctionContract> {
-    Some(match (lang, function, arg_count) {
-        (Lang::Python, "prod", 1 | 2) => ImportedNamespaceFunctionContract {
-            module: "math",
-            function: "prod",
-            receiver: MethodReceiverContract::ImportedNamespace("math"),
-            semantic: ImportedNamespaceFunctionSemantic::ProductReduction {
-                op: Op::Mul,
-                identity: 1,
-            },
-        },
-        _ => return None,
-    })
+    library_imported_namespace_function_contract(lang, function, arg_count)
+        .map(|contract| contract.result)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -3105,6 +3023,17 @@ pub enum LibraryApiContractId {
     RubySetFactory,
     JsLikeSetConstructor,
     JsLikeMapConstructor,
+    MapKeyView(MapKeyViewKind),
+    MapKeyViewWrapper,
+    MapGet,
+    JsArrayIsArray,
+    JsBooleanCoercion,
+    RegexTest,
+    ImportedNamespaceFunction(ImportedNamespaceFunctionSemantic),
+    PromiseThen,
+    IteratorIdentityAdapter,
+    StaticCollectionAdapter,
+    MethodCall(MethodSemanticContract),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -3155,6 +3084,36 @@ pub enum LibraryApiCalleeContract {
         receiver: &'static str,
         requires_unshadowed_global: bool,
     },
+    Method {
+        method: &'static str,
+        receiver: MethodReceiverContract,
+    },
+    StaticGlobalMethod {
+        receiver: &'static str,
+        method: &'static str,
+        qualified_path: &'static str,
+        requires_unshadowed_receiver: bool,
+    },
+    StaticGlobalFunction {
+        function: &'static str,
+        requires_unshadowed_function: bool,
+    },
+    RegexLiteralMethod {
+        method: &'static str,
+        required_receiver_fact: SourceFactKind,
+    },
+    ImportedNamespaceFunction {
+        module: &'static str,
+        function: &'static str,
+    },
+    AsyncMethod {
+        method: &'static str,
+        receiver: AsyncReceiverContract,
+    },
+    IteratorAdapterMethod {
+        method: &'static str,
+        receiver: IteratorAdapterReceiverContract,
+    },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -3189,6 +3148,83 @@ pub struct LibraryMapFactoryContract {
 pub struct LibraryMapEntryFactoryContract {
     pub id: LibraryApiContractId,
     pub callee: LibraryApiCalleeContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryMapKeyViewContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: MapKeyViewContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryMapKeyViewWrapperContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: MapKeyViewWrapperContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryMapGetContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: MapGetContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryStaticGlobalMethodContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: StaticGlobalMethodContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryStaticGlobalFunctionContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: StaticGlobalFunctionContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryRegexTestContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: RegexTestContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryImportedNamespaceFunctionContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: ImportedNamespaceFunctionContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryPromiseThenContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: PromiseThenContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryIteratorIdentityAdapterContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: IteratorIdentityAdapterContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryStaticCollectionAdapterContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: StaticCollectionAdapterContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryMethodCallContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: MethodCallContract,
 }
 
 pub fn library_free_name_collection_factory_contract(
@@ -3488,6 +3524,404 @@ pub fn library_rust_vec_new_factory_contract(
             shadow: LibraryApiShadowPolicy::ExplicitRoot(contract.shadow_root),
         },
         result: LibraryCollectionFactoryResult::EmptySequence,
+    })
+}
+
+pub fn library_map_key_view_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<LibraryMapKeyViewContract> {
+    if arg_count != 0 {
+        return None;
+    }
+    let result = match (lang, method) {
+        (Lang::Python | Lang::Ruby, "keys") => MapKeyViewContract {
+            method: "keys",
+            kind: MapKeyViewKind::Collection,
+        },
+        (Lang::Java, "keySet") => MapKeyViewContract {
+            method: "keySet",
+            kind: MapKeyViewKind::Collection,
+        },
+        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "keys") => {
+            MapKeyViewContract {
+                method: "keys",
+                kind: MapKeyViewKind::Iterator,
+            }
+        }
+        _ => return None,
+    };
+    Some(LibraryMapKeyViewContract {
+        id: LibraryApiContractId::MapKeyView(result.kind),
+        callee: LibraryApiCalleeContract::Method {
+            method: result.method,
+            receiver: MethodReceiverContract::ExactMap,
+        },
+        result,
+    })
+}
+
+pub fn library_map_key_view_contract_by_hash(
+    lang: Lang,
+    method_hash: u64,
+    arg_count: usize,
+) -> Option<LibraryMapKeyViewContract> {
+    ["keys", "keySet"].into_iter().find_map(|method| {
+        (stable_symbol_hash(method) == method_hash)
+            .then(|| library_map_key_view_contract(lang, method, arg_count))
+            .flatten()
+    })
+}
+
+pub fn library_map_key_view_wrapper_contract(
+    lang: Lang,
+    receiver: &str,
+    method: &str,
+    arg_count: usize,
+) -> Option<LibraryMapKeyViewWrapperContract> {
+    if !js_like_lang(lang) || receiver != "Array" || method != "from" || arg_count != 1 {
+        return None;
+    }
+    let result = MapKeyViewWrapperContract {
+        receiver: "Array",
+        method: "from",
+        qualified_path: "Array.from",
+    };
+    Some(LibraryMapKeyViewWrapperContract {
+        id: LibraryApiContractId::MapKeyViewWrapper,
+        callee: LibraryApiCalleeContract::StaticGlobalMethod {
+            receiver: result.receiver,
+            method: result.method,
+            qualified_path: result.qualified_path,
+            requires_unshadowed_receiver: true,
+        },
+        result,
+    })
+}
+
+pub fn library_map_key_view_wrapper_contract_by_hash(
+    lang: Lang,
+    receiver: &str,
+    method_hash: u64,
+    arg_count: usize,
+) -> Option<LibraryMapKeyViewWrapperContract> {
+    (method_hash == stable_symbol_hash("from"))
+        .then(|| library_map_key_view_wrapper_contract(lang, receiver, "from", arg_count))
+        .flatten()
+}
+
+pub fn library_map_get_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<LibraryMapGetContract> {
+    if !matches!(
+        lang,
+        Lang::Java
+            | Lang::Rust
+            | Lang::JavaScript
+            | Lang::TypeScript
+            | Lang::Vue
+            | Lang::Svelte
+            | Lang::Html
+    ) || method != "get"
+        || arg_count != 1
+    {
+        return None;
+    }
+    let result = MapGetContract {
+        method: "get",
+        receiver: MethodReceiverContract::ExactMap,
+    };
+    Some(LibraryMapGetContract {
+        id: LibraryApiContractId::MapGet,
+        callee: LibraryApiCalleeContract::Method {
+            method: result.method,
+            receiver: result.receiver,
+        },
+        result,
+    })
+}
+
+pub fn library_map_get_contract_by_hash(
+    lang: Lang,
+    method_hash: u64,
+    arg_count: usize,
+) -> Option<LibraryMapGetContract> {
+    (method_hash == stable_symbol_hash("get"))
+        .then(|| library_map_get_contract(lang, "get", arg_count))
+        .flatten()
+}
+
+pub fn library_js_array_is_array_contract(
+    lang: Lang,
+    receiver: &str,
+    method: &str,
+    arg_count: usize,
+) -> Option<LibraryStaticGlobalMethodContract> {
+    if !js_like_lang(lang) || receiver != "Array" || method != "isArray" || arg_count != 1 {
+        return None;
+    }
+    let result = StaticGlobalMethodContract {
+        receiver: "Array",
+        method: "isArray",
+        qualified_path: "Array.isArray",
+        requires_unshadowed_receiver: true,
+    };
+    Some(LibraryStaticGlobalMethodContract {
+        id: LibraryApiContractId::JsArrayIsArray,
+        callee: LibraryApiCalleeContract::StaticGlobalMethod {
+            receiver: result.receiver,
+            method: result.method,
+            qualified_path: result.qualified_path,
+            requires_unshadowed_receiver: result.requires_unshadowed_receiver,
+        },
+        result,
+    })
+}
+
+pub fn library_js_boolean_coercion_contract(
+    lang: Lang,
+    function: &str,
+    arg_count: usize,
+) -> Option<LibraryStaticGlobalFunctionContract> {
+    if !js_like_lang(lang) || function != "Boolean" || arg_count != 1 {
+        return None;
+    }
+    let result = StaticGlobalFunctionContract {
+        function: "Boolean",
+        requires_unshadowed_function: true,
+    };
+    Some(LibraryStaticGlobalFunctionContract {
+        id: LibraryApiContractId::JsBooleanCoercion,
+        callee: LibraryApiCalleeContract::StaticGlobalFunction {
+            function: result.function,
+            requires_unshadowed_function: result.requires_unshadowed_function,
+        },
+        result,
+    })
+}
+
+pub fn library_regex_test_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<LibraryRegexTestContract> {
+    if !js_like_lang(lang) || method != "test" || arg_count != 1 {
+        return None;
+    }
+    let result = RegexTestContract {
+        method: "test",
+        required_receiver_fact: SourceFactKind::Literal(SourceLiteralKind::Regex),
+    };
+    Some(LibraryRegexTestContract {
+        id: LibraryApiContractId::RegexTest,
+        callee: LibraryApiCalleeContract::RegexLiteralMethod {
+            method: result.method,
+            required_receiver_fact: result.required_receiver_fact,
+        },
+        result,
+    })
+}
+
+pub fn library_imported_namespace_function_contract(
+    lang: Lang,
+    function: &str,
+    arg_count: usize,
+) -> Option<LibraryImportedNamespaceFunctionContract> {
+    let result = match (lang, function, arg_count) {
+        (Lang::Python, "prod", 1 | 2) => ImportedNamespaceFunctionContract {
+            module: "math",
+            function: "prod",
+            receiver: MethodReceiverContract::ImportedNamespace("math"),
+            semantic: ImportedNamespaceFunctionSemantic::ProductReduction {
+                op: Op::Mul,
+                identity: 1,
+            },
+        },
+        _ => return None,
+    };
+    Some(LibraryImportedNamespaceFunctionContract {
+        id: LibraryApiContractId::ImportedNamespaceFunction(result.semantic),
+        callee: LibraryApiCalleeContract::ImportedNamespaceFunction {
+            module: result.module,
+            function: result.function,
+        },
+        result,
+    })
+}
+
+pub fn library_promise_then_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<LibraryPromiseThenContract> {
+    if !js_like_lang(lang) || method != "then" || arg_count != 1 {
+        return None;
+    }
+    let result = PromiseThenContract {
+        receiver: AsyncReceiverContract::ExactPromiseLike,
+    };
+    Some(LibraryPromiseThenContract {
+        id: LibraryApiContractId::PromiseThen,
+        callee: LibraryApiCalleeContract::AsyncMethod {
+            method: "then",
+            receiver: result.receiver,
+        },
+        result,
+    })
+}
+
+pub fn library_iterator_identity_adapter_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<LibraryIteratorIdentityAdapterContract> {
+    let method = if lang == Lang::Rust && arg_count == 0 {
+        match method {
+            "iter" => "iter",
+            "into_iter" => "into_iter",
+            "iter_mut" => "iter_mut",
+            "collect" => "collect",
+            "to_vec" => "to_vec",
+            "copied" => "copied",
+            "cloned" => "cloned",
+            _ => return None,
+        }
+    } else if lang == Lang::Java && method == "stream" && arg_count == 0 {
+        "stream"
+    } else {
+        return None;
+    };
+    let result = IteratorIdentityAdapterContract {
+        receiver: IteratorAdapterReceiverContract::ExactIterableValue,
+    };
+    Some(LibraryIteratorIdentityAdapterContract {
+        id: LibraryApiContractId::IteratorIdentityAdapter,
+        callee: LibraryApiCalleeContract::IteratorAdapterMethod {
+            method,
+            receiver: result.receiver,
+        },
+        result,
+    })
+}
+
+pub fn library_static_collection_adapter_contract(
+    lang: Lang,
+    receiver: &str,
+    method: &str,
+    arg_count: usize,
+) -> Option<LibraryStaticCollectionAdapterContract> {
+    if lang != Lang::Java || receiver != "Arrays" || method != "stream" || arg_count != 1 {
+        return None;
+    }
+    let result = StaticCollectionAdapterContract {
+        module: "java.util",
+        exported: "Arrays",
+    };
+    Some(LibraryStaticCollectionAdapterContract {
+        id: LibraryApiContractId::StaticCollectionAdapter,
+        callee: LibraryApiCalleeContract::JavaUtilStaticMember {
+            receiver: result.exported,
+            method: "stream",
+        },
+        result,
+    })
+}
+
+pub fn library_method_call_contract(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<LibraryMethodCallContract> {
+    let result = method_call_contract_shape(lang, name, arg_count)?;
+    let method = library_method_selector_name(name)?;
+    Some(LibraryMethodCallContract {
+        id: LibraryApiContractId::MethodCall(result.semantic),
+        callee: LibraryApiCalleeContract::Method {
+            method,
+            receiver: result.receiver,
+        },
+        result,
+    })
+}
+
+fn library_method_selector_name(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "__contains__" => "__contains__",
+        "Abs" => "Abs",
+        "Contains" => "Contains",
+        "HasPrefix" => "HasPrefix",
+        "HasSuffix" => "HasSuffix",
+        "Max" => "Max",
+        "Min" => "Min",
+        "Print" => "Print",
+        "Printf" => "Printf",
+        "Println" => "Println",
+        "abs" => "abs",
+        "all" => "all",
+        "all?" => "all?",
+        "allMatch" => "allMatch",
+        "any" => "any",
+        "any?" => "any?",
+        "anyMatch" => "anyMatch",
+        "append" => "append",
+        "collect" => "collect",
+        "contains" => "contains",
+        "containsKey" => "containsKey",
+        "contains_key" => "contains_key",
+        "count" => "count",
+        "debug" => "debug",
+        "empty?" => "empty?",
+        "end_with?" => "end_with?",
+        "endsWith" => "endsWith",
+        "ends_with" => "ends_with",
+        "endswith" => "endswith",
+        "every" => "every",
+        "fetch" => "fetch",
+        "filter" => "filter",
+        "filter_map" => "filter_map",
+        "flatMap" => "flatMap",
+        "flat_map" => "flat_map",
+        "fold" => "fold",
+        "get" => "get",
+        "getOrDefault" => "getOrDefault",
+        "has" => "has",
+        "has_key?" => "has_key?",
+        "include?" => "include?",
+        "includes" => "includes",
+        "info" => "info",
+        "inject" => "inject",
+        "isEmpty" => "isEmpty",
+        "is_empty" => "is_empty",
+        "is_none" => "is_none",
+        "is_some" => "is_some",
+        "join" => "join",
+        "key?" => "key?",
+        "len" => "len",
+        "length" => "length",
+        "log" => "log",
+        "map" => "map",
+        "map_or" => "map_or",
+        "max" => "max",
+        "member?" => "member?",
+        "min" => "min",
+        "nil?" => "nil?",
+        "push" => "push",
+        "reduce" => "reduce",
+        "select" => "select",
+        "size" => "size",
+        "some" => "some",
+        "start_with?" => "start_with?",
+        "startsWith" => "startsWith",
+        "starts_with" => "starts_with",
+        "startswith" => "startswith",
+        "sum" => "sum",
+        "unwrap_or" => "unwrap_or",
+        "unwrap_or_else" => "unwrap_or_else",
+        "zip" => "zip",
+        _ => return None,
     })
 }
 
@@ -4816,6 +5250,256 @@ mod tests {
         );
         assert_eq!(
             library_java_map_factory_contract(Lang::Java, "List", "of"),
+            None
+        );
+    }
+
+    #[test]
+    fn library_non_factory_api_contracts_carry_identity_and_result_obligations() {
+        assert_eq!(
+            library_map_key_view_contract(Lang::TypeScript, "keys", 0),
+            Some(LibraryMapKeyViewContract {
+                id: LibraryApiContractId::MapKeyView(MapKeyViewKind::Iterator),
+                callee: LibraryApiCalleeContract::Method {
+                    method: "keys",
+                    receiver: MethodReceiverContract::ExactMap,
+                },
+                result: MapKeyViewContract {
+                    method: "keys",
+                    kind: MapKeyViewKind::Iterator,
+                },
+            })
+        );
+        assert_eq!(
+            library_map_key_view_wrapper_contract(Lang::JavaScript, "Array", "from", 1),
+            Some(LibraryMapKeyViewWrapperContract {
+                id: LibraryApiContractId::MapKeyViewWrapper,
+                callee: LibraryApiCalleeContract::StaticGlobalMethod {
+                    receiver: "Array",
+                    method: "from",
+                    qualified_path: "Array.from",
+                    requires_unshadowed_receiver: true,
+                },
+                result: MapKeyViewWrapperContract {
+                    receiver: "Array",
+                    method: "from",
+                    qualified_path: "Array.from",
+                },
+            })
+        );
+        assert_eq!(
+            library_map_get_contract(Lang::Rust, "get", 1),
+            Some(LibraryMapGetContract {
+                id: LibraryApiContractId::MapGet,
+                callee: LibraryApiCalleeContract::Method {
+                    method: "get",
+                    receiver: MethodReceiverContract::ExactMap,
+                },
+                result: MapGetContract {
+                    method: "get",
+                    receiver: MethodReceiverContract::ExactMap,
+                },
+            })
+        );
+        assert_eq!(
+            library_js_array_is_array_contract(Lang::JavaScript, "Array", "isArray", 1),
+            Some(LibraryStaticGlobalMethodContract {
+                id: LibraryApiContractId::JsArrayIsArray,
+                callee: LibraryApiCalleeContract::StaticGlobalMethod {
+                    receiver: "Array",
+                    method: "isArray",
+                    qualified_path: "Array.isArray",
+                    requires_unshadowed_receiver: true,
+                },
+                result: StaticGlobalMethodContract {
+                    receiver: "Array",
+                    method: "isArray",
+                    qualified_path: "Array.isArray",
+                    requires_unshadowed_receiver: true,
+                },
+            })
+        );
+        assert_eq!(
+            library_js_boolean_coercion_contract(Lang::TypeScript, "Boolean", 1),
+            Some(LibraryStaticGlobalFunctionContract {
+                id: LibraryApiContractId::JsBooleanCoercion,
+                callee: LibraryApiCalleeContract::StaticGlobalFunction {
+                    function: "Boolean",
+                    requires_unshadowed_function: true,
+                },
+                result: StaticGlobalFunctionContract {
+                    function: "Boolean",
+                    requires_unshadowed_function: true,
+                },
+            })
+        );
+        assert_eq!(
+            library_regex_test_contract(Lang::JavaScript, "test", 1),
+            Some(LibraryRegexTestContract {
+                id: LibraryApiContractId::RegexTest,
+                callee: LibraryApiCalleeContract::RegexLiteralMethod {
+                    method: "test",
+                    required_receiver_fact: SourceFactKind::Literal(SourceLiteralKind::Regex),
+                },
+                result: RegexTestContract {
+                    method: "test",
+                    required_receiver_fact: SourceFactKind::Literal(SourceLiteralKind::Regex),
+                },
+            })
+        );
+        assert_eq!(
+            library_imported_namespace_function_contract(Lang::Python, "prod", 2),
+            Some(LibraryImportedNamespaceFunctionContract {
+                id: LibraryApiContractId::ImportedNamespaceFunction(
+                    ImportedNamespaceFunctionSemantic::ProductReduction {
+                        op: Op::Mul,
+                        identity: 1,
+                    },
+                ),
+                callee: LibraryApiCalleeContract::ImportedNamespaceFunction {
+                    module: "math",
+                    function: "prod",
+                },
+                result: ImportedNamespaceFunctionContract {
+                    module: "math",
+                    function: "prod",
+                    receiver: MethodReceiverContract::ImportedNamespace("math"),
+                    semantic: ImportedNamespaceFunctionSemantic::ProductReduction {
+                        op: Op::Mul,
+                        identity: 1,
+                    },
+                },
+            })
+        );
+        assert_eq!(
+            library_promise_then_contract(Lang::Vue, "then", 1),
+            Some(LibraryPromiseThenContract {
+                id: LibraryApiContractId::PromiseThen,
+                callee: LibraryApiCalleeContract::AsyncMethod {
+                    method: "then",
+                    receiver: AsyncReceiverContract::ExactPromiseLike,
+                },
+                result: PromiseThenContract {
+                    receiver: AsyncReceiverContract::ExactPromiseLike,
+                },
+            })
+        );
+        assert_eq!(
+            library_iterator_identity_adapter_contract(Lang::Rust, "collect", 0),
+            Some(LibraryIteratorIdentityAdapterContract {
+                id: LibraryApiContractId::IteratorIdentityAdapter,
+                callee: LibraryApiCalleeContract::IteratorAdapterMethod {
+                    method: "collect",
+                    receiver: IteratorAdapterReceiverContract::ExactIterableValue,
+                },
+                result: IteratorIdentityAdapterContract {
+                    receiver: IteratorAdapterReceiverContract::ExactIterableValue,
+                },
+            })
+        );
+        assert_eq!(
+            library_static_collection_adapter_contract(Lang::Java, "Arrays", "stream", 1),
+            Some(LibraryStaticCollectionAdapterContract {
+                id: LibraryApiContractId::StaticCollectionAdapter,
+                callee: LibraryApiCalleeContract::JavaUtilStaticMember {
+                    receiver: "Arrays",
+                    method: "stream",
+                },
+                result: StaticCollectionAdapterContract {
+                    module: "java.util",
+                    exported: "Arrays",
+                },
+            })
+        );
+        assert_eq!(
+            library_method_call_contract(Lang::Go, "Contains", 2),
+            Some(LibraryMethodCallContract {
+                id: LibraryApiContractId::MethodCall(MethodSemanticContract::Builtin(
+                    Builtin::Contains,
+                )),
+                callee: LibraryApiCalleeContract::Method {
+                    method: "Contains",
+                    receiver: MethodReceiverContract::ImportedNamespace("slices"),
+                },
+                result: MethodCallContract {
+                    semantic: MethodSemanticContract::Builtin(Builtin::Contains),
+                    receiver: MethodReceiverContract::ImportedNamespace("slices"),
+                    args: MethodBuiltinArgs::GoSliceContains,
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn library_non_factory_api_contracts_reject_raw_name_only_matches() {
+        assert_eq!(
+            library_map_key_view_contract(Lang::JavaScript, "keySet", 0),
+            None
+        );
+        assert_eq!(library_map_key_view_contract(Lang::Python, "keys", 1), None);
+        assert_eq!(
+            library_map_key_view_wrapper_contract(Lang::Python, "Array", "from", 1),
+            None
+        );
+        assert_eq!(
+            library_map_key_view_wrapper_contract(Lang::TypeScript, "Array", "from", 2),
+            None
+        );
+        assert_eq!(library_map_get_contract(Lang::Python, "get", 1), None);
+        assert_eq!(library_map_get_contract(Lang::Rust, "get", 2), None);
+        assert_eq!(
+            library_js_array_is_array_contract(Lang::Python, "Array", "isArray", 1),
+            None
+        );
+        assert_eq!(
+            library_js_array_is_array_contract(Lang::TypeScript, "Array", "isArray", 2),
+            None
+        );
+        assert_eq!(
+            library_js_boolean_coercion_contract(Lang::Python, "Boolean", 1),
+            None
+        );
+        assert_eq!(
+            library_js_boolean_coercion_contract(Lang::JavaScript, "Boolean", 2),
+            None
+        );
+        assert_eq!(library_regex_test_contract(Lang::Ruby, "test", 1), None);
+        assert_eq!(
+            library_imported_namespace_function_contract(Lang::JavaScript, "prod", 1),
+            None
+        );
+        assert_eq!(
+            library_imported_namespace_function_contract(Lang::Python, "prod", 3),
+            None
+        );
+        assert_eq!(library_promise_then_contract(Lang::Python, "then", 1), None);
+        assert_eq!(
+            library_promise_then_contract(Lang::TypeScript, "then", 2),
+            None
+        );
+        assert_eq!(
+            library_iterator_identity_adapter_contract(Lang::JavaScript, "collect", 0),
+            None
+        );
+        assert_eq!(
+            library_iterator_identity_adapter_contract(Lang::Rust, "collect", 1),
+            None
+        );
+        assert_eq!(
+            library_static_collection_adapter_contract(Lang::JavaScript, "Arrays", "stream", 1),
+            None
+        );
+        assert_eq!(
+            library_static_collection_adapter_contract(Lang::Java, "Arrays", "stream", 0),
+            None
+        );
+        assert_eq!(library_method_call_contract(Lang::Python, "min", 2), None);
+        assert_eq!(
+            library_method_call_contract(Lang::JavaScript, "min", 1),
+            None
+        );
+        assert_eq!(
+            library_method_call_contract(Lang::JavaScript, "Contains", 2),
             None
         );
     }

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -167,6 +167,11 @@ callers:
   guard normalization and strict exact safety require evidence for
   `Object.hasOwn` or `Object.prototype.hasOwnProperty.call`, and map-key view
   wrappers require evidence for `Array.from`;
+- `LibraryApiContract` consumers for factory and selected non-factory API
+  surfaces now use these evidence helpers for their local obligations. The
+  contract rows name API identity and result semantics, while `Symbol`,
+  `Import`, `Source`, `Domain`, and `SequenceSurface` records still provide the
+  proof facts consumed by normalize, value-graph, and strict exact gates;
 - JS/TS record-shape guard exact admission and value-graph tagging require both
   `SequenceSurface(RecordGuard)` and `Guard::JsRecordShape`; raw
   `Seq("record_guard")` cannot enter the proof-bearing exact/value-graph path by

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -255,6 +255,13 @@ and pack ecosystem.
   Strict exact and value-graph paths require that evidence plus
   `SequenceSurface(RecordGuard)`, so raw `Seq("record_guard")` no longer acts as
   a proof object by tag spelling.
+- Non-factory library/API surfaces started moving into `LibraryApiContract`
+  identity/result rows. Map-key views and wrappers, map `get`/defaulting method
+  calls, selected static JS-like helpers, regex-literal `.test`, Python
+  `math.prod`, promise `.then`, iterator identity adapters, Java
+  `Arrays.stream`, and existing language-scoped method-call gates now share the
+  same API-contract source across normalize, value-graph, and strict exact
+  consumers.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -312,13 +319,18 @@ Remaining in this phase:
 - Continue moving library API recognition into `LibraryApiContract` records.
   The first internal slice covers collection/map factories, selected
   constructors, Java `Map.entry`, and the shared shadow/import/result
-  obligations consumed by normalize and strict exact gates. Remaining work is to
-  cover non-factory API surfaces such as map-key views/wrappers, lookup/default
-  methods, static-global helpers, iterator adapters, and reductions.
+  obligations consumed by normalize and strict exact gates. The next slice moved
+  selected non-factory surfaces behind the same identity/result facade: map-key
+  views and wrappers, map `get`, map defaulting method calls, static JS-like
+  helpers, regex-literal `.test`, Python `math.prod`, promise `.then`, iterator
+  identity adapters, Java `Arrays.stream`, and existing language-scoped method
+  call contracts.
 - Keep value-graph and strict exact gates on the same contract source. Factory
-  gates now share `LibraryApiContract` identity/result rows; method/view gates
-  still use narrower first-party contract helpers and should move behind the
-  same API-contract facade before the external pack boundary stabilizes.
+  and selected method/view/adapter gates now share `LibraryApiContract`
+  identity/result rows. Remaining API work is to move producer-side API evidence
+  and raw sequence/tag dependencies into explicit evidence records, then cover
+  broader reduction/HOF and ecosystem APIs only after demand, receiver, and
+  effect obligations are expressible.
 - Remove the remaining raw import/module proof IL payload storage after import
   and symbol evidence records can carry every consumer obligation, including
   module export dependencies, scope, rebinding, and mutation proof. Value-graph

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -5,13 +5,15 @@ implementation shape; planned work and decision history live in
 [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The internal evidence
 record substrate is described in [evidence-records](evidence-records.md).
 
-Snapshot date: 2026-06-07, current implementation after the semantic-kernel
+Snapshot date: 2026-06-08, current implementation after the semantic-kernel
 foundation and follow-up facade migrations through receiver-aware field state
 sequence-surface contracts, proof-backed append fragment evidence, and the first
 operator-law contracts, typed import facts, and source-fact gates for construct,
 literal, equality/operator provenance, and the first shared evidence-record
 substrate for source, domain, import, symbol-identity, and sequence-surface
-facts.
+facts. Library/API identity is now consolidated further through internal
+`LibraryApiContract` rows for both factory and selected non-factory method/view
+surfaces.
 
 ## What exists today
 
@@ -85,14 +87,15 @@ migrated.
   `length` is not enough without receiver proof. JS/TS `filter(...).length`
   is admitted only after the receiver has already entered a proven collection/HOF
   value. JS object `.length` remains a property read, not collection cardinality.
-- Promise `.then` has a JS-like surface contract, but exact beta-reduction is
-  closed until a pack/frontend can prove a Promise-like receiver.
+- Promise `.then` has a JS-like library API contract, but exact beta-reduction
+  is closed until a pack/frontend can prove a Promise-like receiver.
 - Rust iterator identity adapters (`iter`, `into_iter`, `collect`, `to_vec`,
-  `copied`, `cloned`) are language-, arity-, and receiver-proof constrained.
-  Normalize's exact protocol receiver admission consumes this same contract
-  instead of accepting same-named methods from other languages.
+  `copied`, `cloned`) are language-, arity-, and receiver-proof constrained
+  through `LibraryApiContract`. Normalize's exact protocol receiver admission
+  consumes this same contract instead of accepting same-named methods from other
+  languages.
 - Rust method `zip(...)` is admitted as a protocol-pair operation only through
-  the Rust `method_call_contract` and exact protocol proof for both sides.
+  the Rust library method-call contract and exact protocol proof for both sides.
 - Rust stdlib path contracts for `Some`/`Option::Some`,
   `None`/`Option::None`, `Option::and_then`, and `Vec::new` carry the exact
   selector and shadow-root requirement through `nose-semantics`;
@@ -112,6 +115,17 @@ migrated.
   shared contract source while still proving local import, require, shadowing,
   constructor syntax, entry-shape, mutation, and exact-safety obligations at the
   caller.
+- Selected non-factory library/API surfaces also consume `LibraryApiContract`
+  rows before normalize, value-graph, or strict exact paths assign semantics.
+  Current rows cover map-key views and wrappers, Java/Rust/JS-like map `get`,
+  Python/Java/Ruby map defaulting through method contracts, Rust
+  `get(...).is_some()`/`unwrap_or(...)`, JS-like `Array.isArray`, `Boolean(...)`,
+  regex-literal `.test(...)`, Python `math.prod`, promise `.then`, Rust/Java
+  iterator adapters, Java `Arrays.stream`, and the language-scoped method-call
+  surfaces already admitted by `method_call_contract`. These rows carry callee
+  identity and result obligations; local consumers still prove receiver domain,
+  import/symbol identity, source facts, exact-safe arguments, fallback demand
+  shape, and mutation safety.
 - Java empty collection constructor contracts cover `new ArrayList<>()` and
   `new LinkedList<>()` only for the Java `java.util` list types. Simple names
   require `java.util` import proof and no local type declaration with the same
@@ -145,11 +159,12 @@ migrated.
   sequence collection case is handled only by the explicit collection profile
   path.
 - Collection reductions such as Rust `Iterator::count()` and Java
-  `Stream.count()` are admitted through exact protocol receiver contracts, not
-  through a bare method-name check.
-- Java stream source adapters are split by proof: `receiver.stream()` requires
-  an exact iterable receiver, while `Arrays.stream(xs)` requires the
-  `java.util.Arrays` import binding and no local `Arrays` type shadow.
+  `Stream.count()` are admitted through library method contracts plus exact
+  protocol receiver proof, not through a bare method-name check.
+- Java stream source adapters are split by proof through library API contracts:
+  `receiver.stream()` requires an exact iterable receiver, while
+  `Arrays.stream(xs)` requires the `java.util.Arrays` import binding and no local
+  `Arrays` type shadow.
 - Cross-file immutable import replacement now preserves import-binding
   dependencies used by the exported literal expression, so a Java static import
   of `LOOKUP = Map.of(...)` carries the provider's `java.util.Map` proof into
@@ -158,20 +173,20 @@ migrated.
   `LOOKUP.clear()`, `LOOKUP.push(...)`, and `LOOKUP[key] = value`, and
   provider-side opaque argument escapes such as `mutate(LOOKUP)`, before
   imported literal provenance can enter exact matching.
-- Membership and map-key membership selectors now consume language-scoped method
-  contracts before normalize/detect treat them as semantic containment. A method
-  named `contains` is Java/Rust collection membership only; JavaScript
-  `.contains(...)` is not accepted as array membership. Map-key examples include
-  Java `Map.containsKey`, Java `keySet().contains`, Rust `contains_key`, Rust
-  `get(key).is_some()`, Ruby `key?`/`has_key?`, Python `__contains__`, and
-  TypeScript `Array.from(map.keys()).includes(key)` when the receiver is a
-  typed/proven map.
-- Map key-view contracts distinguish collection views from iterator views:
+- Membership and map-key membership selectors now consume language-scoped
+  library method contracts before normalize/detect treat them as semantic
+  containment. A method named `contains` is Java/Rust collection membership
+  only; JavaScript `.contains(...)` is not accepted as array membership. Map-key
+  examples include Java `Map.containsKey`, Java `keySet().contains`, Rust
+  `contains_key`, Rust `get(key).is_some()`, Ruby `key?`/`has_key?`, Python
+  `__contains__`, and TypeScript `Array.from(map.keys()).includes(key)` when the
+  receiver is a typed/proven map.
+- Map key-view library contracts distinguish collection views from iterator views:
   Python/Ruby `keys` and Java `keySet` are collection views, while JS-like
   `Map.keys()` is an iterator view and needs the `Array.from(...)` wrapper
   contract plus `QualifiedGlobal("Array.from")` symbol evidence before it can
   feed exact membership.
-- Map lookup surfaces that return a value/option are now explicit contracts for
+- Map lookup surfaces that return a value/option are now explicit library API contracts for
   Java/Rust/JS-like `get(key)` plus an exact-map receiver requirement. Python
   `dict.get(key, default)`, Java `getOrDefault`, and Ruby `fetch` still use the
   `GetOrDefault` method contract. Ruby `fetch(key) { fallback }` carries a


### PR DESCRIPTION
## Summary

- Extend the internal `LibraryApiContract` layer beyond factories to selected non-factory API surfaces: map-key views/wrappers, map `get`, JS static helpers, regex `.test`, Python `math.prod`, promise `.then`, iterator identity adapters, Java `Arrays.stream`, and method-call surfaces.
- Keep existing compatibility wrapper names, but route them through `library_*` contract rows that carry API identity plus result obligations.
- Migrate normalize/value-graph/strict-exact consumers to use the new `library_*` contracts directly instead of narrower method/view helper sources.
- Update semantic-kernel docs and evidence-record notes to reflect the new implemented boundary and remaining producer-evidence work.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --release`
- `cargo test --release`
- `awiki lint --root docs`
- `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `./scripts/check-duplication.sh`
- `git diff --check`

Part of #109.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 계약 기반 검증 로직을 통합 라이브러리 API로 재구조화하여 일관성 있는 계약 처리를 개선했습니다.
  * 여러 의미 분석 함수의 계약 조회 방식을 표준화하여 코드 유지보수성을 향상했습니다.

* **Documentation**
  * 업데이트된 라이브러리 계약 모델과 적용 범위에 대한 설명을 추가했습니다.
  * Phase 2 진행 현황과 향후 확장 계획을 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->