### PR TITLE
semantics: add producer evidence contracts

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -17,7 +17,8 @@ use nose_semantics::{
     domain_evidence_for_param as semantic_domain_evidence_for_param, exact_java_return_this,
     exact_java_this_field, exact_non_overloadable_index_assignment,
     exact_non_overloadable_index_assignment_parts, exact_static_membership_predicate_operator,
-    go_zero_map_default_kind, go_zero_map_lookup_contract, imported_binding_symbol,
+    go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
+    go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract, imported_binding_symbol,
     imported_member_symbol, library_api_free_name_shadow_safe,
     library_free_name_collection_factory_contract, library_free_name_map_factory_contract,
     library_imported_collection_factory_contracts, library_iterator_identity_adapter_contract,
@@ -27,12 +28,13 @@ use nose_semantics::{
     library_map_get_contract, library_map_key_view_contract, library_map_key_view_wrapper_contract,
     library_method_call_contract, library_regex_test_contract, library_ruby_set_factory_contract,
     library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
-    nullish_global_contract, qualified_global_symbol, record_shape_guard_for_node, semantics,
-    seq_surface_contract_for_node, source_fact_at_node, source_operator_at_node,
-    static_index_membership_contract, typeof_operator_contract, unshadowed_global_symbol,
-    DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind, LibraryApiCalleeContract,
-    LibraryCollectionFactoryResult, LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs,
-    MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
+    nullish_global_contract, own_property_guard_for_node, qualified_global_symbol,
+    record_shape_guard_for_node, semantics, seq_surface_contract_for_node, source_fact_at_node,
+    source_operator_at_node, static_index_membership_contract, typeof_operator_contract,
+    unshadowed_global_symbol, DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind,
+    LibraryApiCalleeContract, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
+    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
+    StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1218,7 +1220,9 @@ fn strict_exact_nullish_global_safe(il: &Il, interner: &Interner, node: NodeId) 
 fn strict_exact_safe_seq(il: &Il, interner: &Interner, node: NodeId) -> bool {
     if let Payload::Name(tag) = il.node(node).payload {
         match interner.resolve(tag) {
-            "own_property_guard" => return strict_exact_own_property_guard_seq_safe(il, node),
+            "own_property_guard" => {
+                return strict_exact_own_property_guard_seq_safe(il, interner, node);
+            }
             "record_guard" => return record_shape_guard_for_node(il, interner, node),
             _ => {}
         }
@@ -1227,10 +1231,8 @@ fn strict_exact_safe_seq(il: &Il, interner: &Interner, node: NodeId) -> bool {
         .is_some_and(|contract| contract.exact_tree_safe)
 }
 
-fn strict_exact_own_property_guard_seq_safe(il: &Il, node: NodeId) -> bool {
-    ["Object.hasOwn", "Object.prototype.hasOwnProperty.call"]
-        .into_iter()
-        .any(|path| qualified_global_symbol(il, node, path))
+fn strict_exact_own_property_guard_seq_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    own_property_guard_for_node(il, interner, node)
 }
 
 fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, node: NodeId) -> bool {
@@ -2422,29 +2424,18 @@ fn strict_exact_go_literal_zero_map_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    let Some(contract) = go_zero_map_lookup_contract(il.meta.lang) else {
-        return false;
-    };
-    if il.kind(node) != NodeKind::Seq {
-        return false;
-    }
-    let Payload::Name(name) = il.node(node).payload else {
-        return false;
-    };
-    if interner.resolve(name) != contract.map_literal_tag || il.children(node).is_empty() {
+    if go_zero_map_literal_contract_for_node(il, interner, node).is_none()
+        || il.children(node).is_empty()
+    {
         return false;
     }
     let mut value_kind = None;
     il.children(node).iter().all(|&entry| {
-        if il.kind(entry) != NodeKind::Seq {
+        if go_zero_map_entry_contract_for_node(il, interner, entry).is_none() {
             return false;
         }
-        let Payload::Name(entry_name) = il.node(entry).payload else {
-            return false;
-        };
         let kv = il.children(entry);
-        if interner.resolve(entry_name) != contract.entry_tag
-            || kv.len() != 2
+        if kv.len() != 2
             || !matches!(il.node(kv[0]).payload, Payload::LitStr(_))
             || !strict_exact_safe_tree(il, interner, facts, kv[0])
         {

--- a/crates/nose-frontend/src/java.rs
+++ b/crates/nose-frontend/src/java.rs
@@ -11,7 +11,10 @@ use nose_il::{
     FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, ParamSemantic, Payload,
     Span, UnitKind,
 };
-use nose_semantics::{java_collection_constructor_contract, JavaCollectionConstructorKind};
+use nose_semantics::{
+    library_java_collection_constructor_contract, LibraryApiCalleeContract,
+    LibraryCollectionFactoryResult,
+};
 use tree_sitter::Node as TsNode;
 
 pub(crate) fn lower(
@@ -731,26 +734,35 @@ fn lower_empty_java_collection_constructor(
 ) -> Option<NodeId> {
     let ty = node.child_by_field_name("type")?;
     let type_name = java_constructor_type_name(lo.text(ty));
-    let contract = java_collection_constructor_contract(lo.lang, &type_name, arg_count)?;
-    let uses_simple_type = type_name == contract.simple_type;
+    let contract = library_java_collection_constructor_contract(lo.lang, &type_name, arg_count)?;
+    let LibraryApiCalleeContract::JavaUtilConstructor {
+        simple_type,
+        module,
+        requires_import_for_simple_type,
+        requires_no_local_type_shadow,
+        ..
+    } = contract.callee
+    else {
+        return None;
+    };
+    let uses_simple_type = type_name == simple_type;
     if uses_simple_type {
         let root = java_root(node);
-        if contract.requires_import_for_simple_type
-            && !java_tree_resolves_simple_type(lo, root, contract.module, contract.simple_type)
+        if requires_import_for_simple_type
+            && !java_tree_resolves_simple_type(lo, root, module, simple_type)
         {
             return None;
         }
-        if contract.requires_no_local_type_shadow
-            && java_tree_declares_type(lo, root, contract.simple_type)
-        {
+        if requires_no_local_type_shadow && java_tree_declares_type(lo, root, simple_type) {
             return None;
         }
     }
-    match contract.kind {
-        JavaCollectionConstructorKind::EmptyList => {
+    match contract.result {
+        LibraryCollectionFactoryResult::EmptySequence => {
             let tag = lo.sym("array");
             Some(lo.add(NodeKind::Seq, Payload::Name(tag), span, &[]))
         }
+        _ => None,
     }
 }
 

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -1113,7 +1113,15 @@ fn lower_own_property_guard_call(lo: &mut Lowering, node: TsNode) -> Option<Node
         span,
         &[receiver, key, own, present],
     );
-    lo.record_qualified_global_symbol(span, NodeKind::Seq, contract.path);
+    let api_dependency = lo.record_qualified_global_symbol(span, NodeKind::Seq, contract.path);
+    lo.record_evidence_with_dependencies(
+        EvidenceAnchor::sequence(span),
+        EvidenceKind::Guard(GuardEvidenceKind::JsOwnProperty {
+            api_path_hash: stable_symbol_hash(contract.path),
+        }),
+        "own_property_guard_js_api",
+        vec![api_dependency],
+    );
     Some(guard)
 }
 
@@ -2002,6 +2010,18 @@ mod tests {
             .collect()
     }
 
+    fn js_own_property_guard_evidence(il: &Il) -> Vec<&nose_il::EvidenceRecord> {
+        il.evidence
+            .iter()
+            .filter(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::Guard(GuardEvidenceKind::JsOwnProperty { .. })
+                )
+            })
+            .collect()
+    }
+
     fn switch_labels_for_return(src: &str, expected_return: i64) -> Vec<i64> {
         let interner = Interner::new();
         let il = crate::lower_source(
@@ -2138,6 +2158,31 @@ mod tests {
     }
 
     #[test]
+    fn js_own_property_guards_emit_guard_evidence_with_api_dependencies() {
+        let il = lower_js(
+            "function hasOwn(value) { return Object.hasOwn(value, \"ready\"); }
+             function hasOwnCall(value) { return Object.prototype.hasOwnProperty.call(value, \"ready\"); }",
+        );
+
+        let guards = js_own_property_guard_evidence(&il);
+        assert_eq!(guards.len(), 2);
+        assert!(guards.iter().any(|record| {
+            matches!(
+                record.kind,
+                EvidenceKind::Guard(GuardEvidenceKind::JsOwnProperty { api_path_hash })
+                    if api_path_hash == stable_symbol_hash("Object.hasOwn")
+            ) && record.dependencies.len() == 1
+        }));
+        assert!(guards.iter().any(|record| {
+            matches!(
+                record.kind,
+                EvidenceKind::Guard(GuardEvidenceKind::JsOwnProperty { api_path_hash })
+                    if api_path_hash == stable_symbol_hash("Object.prototype.hasOwnProperty.call")
+            ) && record.dependencies.len() == 1
+        }));
+    }
+
+    #[test]
     fn js_record_shape_guards_emit_guard_evidence_with_api_dependencies() {
         let il = lower_js(
             "function direct(value) {
@@ -2227,5 +2272,6 @@ mod tests {
             qualified_global_evidence_count(&il, "Array.from", NodeKind::Field),
             0
         );
+        assert!(js_own_property_guard_evidence(&il).is_empty());
     }
 }

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -346,6 +346,9 @@ pub enum GuardEvidenceKind {
         null_check: JsRecordGuardNullCheck,
         comparison: JsRecordGuardComparison,
     },
+    JsOwnProperty {
+        api_path_hash: u64,
+    },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
@@ -360,6 +363,7 @@ pub enum SequenceSurfaceKind {
     RecordGuard,
     OwnPropertyGuard,
     GoCompositeMapLiteral,
+    GoMapEntry,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -52,7 +52,8 @@ use nose_semantics::{
     builder_append_method_contract, builtin_tag, construct_syntax_proof,
     domain_evidence_for_param as semantic_domain_evidence_for_param,
     exact_static_membership_predicate_operator, free_function_builtin_contract,
-    go_zero_map_default_kind, go_zero_map_lookup_contract, import_fact_evidence_rhs,
+    go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
+    go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract, import_fact_evidence_rhs,
     imported_namespace_symbol, library_api_free_name_shadow_safe,
     library_free_name_collection_factory_contracts, library_free_name_map_factory_contracts,
     library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
@@ -63,18 +64,19 @@ use nose_semantics::{
     library_map_key_view_wrapper_contract_by_hash, library_method_call_contract,
     library_ruby_set_factory_contract_by_hash, library_rust_vec_macro_factory_contract,
     library_rust_vec_new_factory_contract, nullish_global_contract,
-    qualified_global_symbol_at_span, record_shape_guard_for_node, reduction_builtin_contract,
-    rust_option_and_then_contract, rust_option_none_sentinel_contract,
-    rust_option_some_constructor_contract, scalar_integer_method_contract, semantics,
-    seq_surface_contract_for_node, source_operator_at_node, static_index_membership_contract,
-    unshadowed_global_symbol, BuiltinArgContract, CardinalityPredicate, CardinalityThreshold,
-    ComparisonLaw, DomainEvidence, GoZeroMapDefaultKind, ImportFactKind,
-    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
-    JavaMapFactoryKind, LibraryApiCalleeContract, LibraryCollectionFactoryResult,
-    LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
-    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract,
-    StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD,
-    SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
+    own_property_guard_evidence_at_span, qualified_global_symbol_at_span,
+    record_shape_guard_for_node, reduction_builtin_contract, rust_option_and_then_contract,
+    rust_option_none_sentinel_contract, rust_option_some_constructor_contract,
+    scalar_integer_method_contract, semantics, seq_surface_contract_for_node,
+    source_operator_at_node, static_index_membership_contract, unshadowed_global_symbol,
+    BuiltinArgContract, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
+    GoZeroMapDefaultKind, ImportFactKind, ImportedNamespaceFunctionSemantic,
+    IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind,
+    LibraryApiCalleeContract, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
+    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
+    ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract, StaticIndexMembershipKind,
+    SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR,
+    SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -1516,11 +1518,8 @@ impl<'a> Builder<'a> {
         expr: NodeId,
         args: &[ValueId],
     ) -> Option<ValueId> {
-        let contract = go_zero_map_lookup_contract(self.il.meta.lang)?;
-        let Payload::Name(name) = self.il.node(expr).payload else {
-            return None;
-        };
-        if self.interner.resolve(name) != contract.map_literal_tag || args.is_empty() {
+        let contract = go_zero_map_literal_contract_for_node(self.il, self.interner, expr)?;
+        if args.is_empty() {
             return None;
         }
         let entry_nodes = self.il.children(expr).to_vec();
@@ -1531,15 +1530,7 @@ impl<'a> Builder<'a> {
         let mut value_kind = None;
         let mut default = None;
         for (&entry_node_id, &entry_value) in entry_nodes.iter().zip(args.iter()) {
-            if self.il.kind(entry_node_id) != NodeKind::Seq {
-                return None;
-            }
-            let Payload::Name(entry_name) = self.il.node(entry_node_id).payload else {
-                return None;
-            };
-            if self.interner.resolve(entry_name) != contract.entry_tag {
-                return None;
-            }
+            go_zero_map_entry_contract_for_node(self.il, self.interner, entry_node_id)?;
             let kv_nodes = self.il.children(entry_node_id);
             if kv_nodes.len() != 2
                 || !matches!(self.il.node(kv_nodes[0]).payload, Payload::LitStr(_))
@@ -6624,10 +6615,8 @@ impl<'a> Builder<'a> {
     }
 
     fn proven_own_property_guard_value(&self, value: ValueId) -> bool {
-        let span = self.node_span[value as usize];
-        ["Object.hasOwn", "Object.prototype.hasOwnProperty.call"]
-            .into_iter()
-            .any(|path| qualified_global_symbol_at_span(self.il, span, NodeKind::Seq, path))
+        self.node_span[value as usize]
+            .is_some_and(|span| own_property_guard_evidence_at_span(self.il, span))
     }
 
     fn map_lookup_value_matches(&mut self, value: ValueId, map: ValueId, key: ValueId) -> bool {

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -270,6 +270,7 @@ pub fn sequence_surface_kind_for_tag(lang: Lang, tag: Option<&str>) -> Option<Se
         Some("composite_literal") if lang == Lang::Go => {
             Some(SequenceSurfaceKind::GoCompositeMapLiteral)
         }
+        Some("keyed_element") if lang == Lang::Go => Some(SequenceSurfaceKind::GoMapEntry),
         _ => None,
     }
 }
@@ -350,6 +351,13 @@ fn seq_surface_contract_for_tag(
             map_entry_list: false,
             imported_literal: false,
         },
+        SequenceSurfaceKind::GoMapEntry => SeqSurfaceContract {
+            value_tag: stable_symbol_hash("keyed_element"),
+            exact_tree_safe: false,
+            membership_collection: false,
+            map_entry_list: false,
+            imported_literal: false,
+        },
     };
     Some((kind, contract))
 }
@@ -396,6 +404,29 @@ fn sequence_surface_evidence_at_sequence_span(
     )
 }
 
+fn sequence_surface_evidence_matches_node(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    expected: SequenceSurfaceKind,
+) -> bool {
+    if il.kind(node) != NodeKind::Seq {
+        return false;
+    }
+    let raw_tag = match il.node(node).payload {
+        Payload::None => None,
+        Payload::Name(name) => Some(interner.resolve(name)),
+        _ => return false,
+    };
+    if sequence_surface_kind_for_tag(il.meta.lang, raw_tag) != Some(expected) {
+        return false;
+    }
+    matches!(
+        sequence_surface_evidence_at_sequence_span(il, il.node(node).span),
+        EvidenceResolution::Found(kind) if kind == expected
+    )
+}
+
 fn guard_evidence_at_sequence_span(il: &Il, span: Span) -> EvidenceResolution<GuardEvidenceKind> {
     let mut found = None;
     for record in &il.evidence {
@@ -429,6 +460,9 @@ fn guard_evidence_dependencies_valid(
     match kind {
         GuardEvidenceKind::JsRecordShape { null_check, .. } => {
             js_record_shape_guard_dependencies_valid(il, record, null_check, span)
+        }
+        GuardEvidenceKind::JsOwnProperty { api_path_hash } => {
+            js_own_property_guard_dependencies_valid(il, record, api_path_hash, span)
         }
     }
 }
@@ -467,6 +501,43 @@ fn js_record_shape_guard_dependencies_valid(
         }
     }
     has_array_is_array && has_boolean
+}
+
+fn js_own_property_guard_api_path_hash_supported(path_hash: u64) -> bool {
+    path_hash == stable_symbol_hash("Object.hasOwn")
+        || path_hash == stable_symbol_hash("Object.prototype.hasOwnProperty.call")
+}
+
+fn js_own_property_guard_dependencies_valid(
+    il: &Il,
+    record: &EvidenceRecord,
+    api_path_hash: u64,
+    span: Span,
+) -> bool {
+    if !js_own_property_guard_api_path_hash_supported(api_path_hash) {
+        return false;
+    }
+    let mut has_api = false;
+    for id in &record.dependencies {
+        let Some(dependency) = il.evidence.get(id.0 as usize) else {
+            return false;
+        };
+        if dependency.id != *id
+            || dependency.status != EvidenceStatus::Asserted
+            || !dependency.anchor.matches_span(span)
+        {
+            return false;
+        }
+        match dependency.kind {
+            EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal { path_hash })
+                if path_hash == api_path_hash =>
+            {
+                has_api = true;
+            }
+            _ => return false,
+        }
+    }
+    has_api
 }
 
 /// Prove that a lowered `Seq("record_guard")` denotes the first-party JS-like
@@ -541,6 +612,72 @@ fn record_shape_guard_subject_matches(
         Payload::Cid(_) => true,
         _ => false,
     }
+}
+
+/// Prove that a lowered `Seq("own_property_guard")` denotes a first-party
+/// JS-like own-property test such as `Object.hasOwn(obj, key)`. The surface tag
+/// is not enough: exact consumers require matching sequence evidence, dedicated
+/// guard evidence, and a supported qualified-global API dependency.
+pub fn own_property_guard_for_node(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    own_property_guard_evidence_for_node(il, interner, node).is_some()
+}
+
+pub fn own_property_guard_evidence_for_node(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<GuardEvidenceKind> {
+    if il.kind(node) != NodeKind::Seq || !js_like_lang(il.meta.lang) {
+        return None;
+    }
+    let span = il.node(node).span;
+    if !matches!(
+        sequence_surface_evidence_at_sequence_span(il, span),
+        EvidenceResolution::Found(SequenceSurfaceKind::OwnPropertyGuard)
+    ) {
+        return None;
+    }
+    match guard_evidence_at_sequence_span(il, span) {
+        EvidenceResolution::Found(evidence @ GuardEvidenceKind::JsOwnProperty { .. })
+            if own_property_guard_sequence_matches(il, interner, node) =>
+        {
+            Some(evidence)
+        }
+        EvidenceResolution::Found(_)
+        | EvidenceResolution::Ambiguous
+        | EvidenceResolution::Missing => None,
+    }
+}
+
+pub fn own_property_guard_evidence_at_span(il: &Il, span: Span) -> bool {
+    if !js_like_lang(il.meta.lang)
+        || !matches!(
+            sequence_surface_evidence_at_sequence_span(il, span),
+            EvidenceResolution::Found(SequenceSurfaceKind::OwnPropertyGuard)
+        )
+    {
+        return false;
+    }
+    matches!(
+        guard_evidence_at_sequence_span(il, span),
+        EvidenceResolution::Found(GuardEvidenceKind::JsOwnProperty { .. })
+    )
+}
+
+fn own_property_guard_sequence_matches(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    let Payload::Name(tag) = il.node(node).payload else {
+        return false;
+    };
+    if sequence_surface_kind_for_tag(il.meta.lang, Some(interner.resolve(tag)))
+        != Some(SequenceSurfaceKind::OwnPropertyGuard)
+    {
+        return false;
+    }
+    let [_, _, own, present] = il.children(node) else {
+        return false;
+    };
+    literal_string_hash(il, *own) == Some(stable_symbol_hash("own"))
+        && literal_string_hash(il, *present) == Some(stable_symbol_hash("present"))
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -2549,6 +2686,31 @@ pub fn go_zero_map_lookup_contract(lang: Lang) -> Option<GoZeroMapLookupContract
     })
 }
 
+pub fn go_zero_map_literal_contract_for_node(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<GoZeroMapLookupContract> {
+    let contract = go_zero_map_lookup_contract(il.meta.lang)?;
+    sequence_surface_evidence_matches_node(
+        il,
+        interner,
+        node,
+        SequenceSurfaceKind::GoCompositeMapLiteral,
+    )
+    .then_some(contract)
+}
+
+pub fn go_zero_map_entry_contract_for_node(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<GoZeroMapLookupContract> {
+    let contract = go_zero_map_lookup_contract(il.meta.lang)?;
+    sequence_surface_evidence_matches_node(il, interner, node, SequenceSurfaceKind::GoMapEntry)
+        .then_some(contract)
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum GoZeroMapDefaultKind {
     Int,
@@ -3018,6 +3180,7 @@ pub enum LibraryApiContractId {
     RustVecMacroFactory,
     RustVecNewFactory,
     JavaCollectionFactory(JavaCollectionFactoryKind),
+    JavaCollectionConstructor(JavaCollectionConstructorKind),
     JavaMapFactory(JavaMapFactoryKind),
     JavaMapEntryFactory,
     RubySetFactory,
@@ -3073,6 +3236,13 @@ pub enum LibraryApiCalleeContract {
     JavaUtilStaticMember {
         receiver: &'static str,
         method: &'static str,
+    },
+    JavaUtilConstructor {
+        simple_type: &'static str,
+        qualified_type: &'static str,
+        module: &'static str,
+        requires_import_for_simple_type: bool,
+        requires_no_local_type_shadow: bool,
     },
     RubyRequireStaticMember {
         receiver: &'static str,
@@ -3372,6 +3542,25 @@ pub fn library_java_collection_factory_contract_by_hash(
         (stable_symbol_hash(method) == method_hash)
             .then(|| library_java_collection_factory_contract(lang, receiver, method))
             .flatten()
+    })
+}
+
+pub fn library_java_collection_constructor_contract(
+    lang: Lang,
+    type_name: &str,
+    arg_count: usize,
+) -> Option<LibraryCollectionFactoryContract> {
+    let contract = java_collection_constructor_contract(lang, type_name, arg_count)?;
+    Some(LibraryCollectionFactoryContract {
+        id: LibraryApiContractId::JavaCollectionConstructor(contract.kind),
+        callee: LibraryApiCalleeContract::JavaUtilConstructor {
+            simple_type: contract.simple_type,
+            qualified_type: contract.qualified_type,
+            module: contract.module,
+            requires_import_for_simple_type: contract.requires_import_for_simple_type,
+            requires_no_local_type_shadow: contract.requires_no_local_type_shadow,
+        },
+        result: LibraryCollectionFactoryResult::EmptySequence,
     })
 }
 
@@ -4222,7 +4411,13 @@ mod tests {
         assert!(!go_map.membership_collection);
         assert!(!go_map.imported_literal);
 
+        let go_entry = seq_surface_contract(Lang::Go, Some("keyed_element")).unwrap();
+        assert_eq!(go_entry.value_tag, stable_symbol_hash("keyed_element"));
+        assert!(!go_entry.exact_tree_safe);
+        assert!(!go_entry.membership_collection);
+
         assert!(seq_surface_contract(Lang::Python, Some("composite_literal")).is_none());
+        assert!(seq_surface_contract(Lang::Python, Some("keyed_element")).is_none());
         assert!(imported_literal_seq_tag_safe(Lang::Python, "dictionary"));
         assert!(!imported_literal_seq_tag_safe(Lang::Ruby, "hash"));
     }
@@ -4337,6 +4532,267 @@ mod tests {
             EvidenceStatus::Asserted,
             dependencies.iter().copied().map(EvidenceId).collect(),
         )
+    }
+
+    fn js_own_property_guard_il(interner: &Interner) -> (Il, NodeId) {
+        let mut b = IlBuilder::new(FileId(0));
+        let tag = interner.intern("own_property_guard");
+        let receiver = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("value")),
+            sp(22),
+            &[],
+        );
+        let key = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("ready")),
+            sp(22),
+            &[],
+        );
+        let own = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("own")),
+            sp(22),
+            &[],
+        );
+        let present = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("present")),
+            sp(22),
+            &[],
+        );
+        let guard = b.add(
+            NodeKind::Seq,
+            Payload::Name(tag),
+            sp(22),
+            &[receiver, key, own, present],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(22), &[guard]);
+        (finish_il(b, root, Lang::JavaScript), guard)
+    }
+
+    fn qualified_global_dependency(
+        id: u32,
+        span: Span,
+        path: &str,
+        status: EvidenceStatus,
+    ) -> EvidenceRecord {
+        evidence(
+            id,
+            EvidenceAnchor::source_span(span),
+            EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+                path_hash: stable_symbol_hash(path),
+            }),
+            status,
+        )
+    }
+
+    fn own_property_guard_record(
+        id: u32,
+        span: Span,
+        path: &str,
+        status: EvidenceStatus,
+        dependencies: &[u32],
+    ) -> EvidenceRecord {
+        evidence_with_dependencies(
+            id,
+            EvidenceAnchor::sequence(span),
+            EvidenceKind::Guard(GuardEvidenceKind::JsOwnProperty {
+                api_path_hash: stable_symbol_hash(path),
+            }),
+            status,
+            dependencies.iter().copied().map(EvidenceId).collect(),
+        )
+    }
+
+    #[test]
+    fn own_property_guard_requires_dedicated_guard_evidence() {
+        let interner = Interner::new();
+        let (mut il, guard) = js_own_property_guard_il(&interner);
+
+        assert!(!own_property_guard_for_node(&il, &interner, guard));
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(22)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::OwnPropertyGuard),
+            EvidenceStatus::Asserted,
+        ));
+        assert!(!own_property_guard_for_node(&il, &interner, guard));
+
+        il.evidence.push(qualified_global_dependency(
+            1,
+            sp(22),
+            "Object.hasOwn",
+            EvidenceStatus::Asserted,
+        ));
+        assert!(!own_property_guard_for_node(&il, &interner, guard));
+
+        il.evidence.push(own_property_guard_record(
+            2,
+            sp(22),
+            "Object.hasOwn",
+            EvidenceStatus::Asserted,
+            &[1],
+        ));
+        assert!(own_property_guard_for_node(&il, &interner, guard));
+        assert!(own_property_guard_evidence_at_span(&il, sp(22)));
+    }
+
+    #[test]
+    fn own_property_guard_validates_api_dependencies() {
+        let interner = Interner::new();
+        let (mut il, guard) = js_own_property_guard_il(&interner);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(22)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::OwnPropertyGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(qualified_global_dependency(
+            1,
+            sp(22),
+            "Array.from",
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(own_property_guard_record(
+            2,
+            sp(22),
+            "Object.hasOwn",
+            EvidenceStatus::Asserted,
+            &[1],
+        ));
+        assert!(!own_property_guard_for_node(&il, &interner, guard));
+
+        let (mut il, guard) = js_own_property_guard_il(&interner);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(22)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::OwnPropertyGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(qualified_global_dependency(
+            1,
+            sp(22),
+            "Object.hasOwn",
+            EvidenceStatus::Ambiguous,
+        ));
+        il.evidence.push(own_property_guard_record(
+            2,
+            sp(22),
+            "Object.hasOwn",
+            EvidenceStatus::Asserted,
+            &[1],
+        ));
+        assert!(!own_property_guard_for_node(&il, &interner, guard));
+
+        let (mut il, guard) = js_own_property_guard_il(&interner);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(22)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::OwnPropertyGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(qualified_global_dependency(
+            1,
+            sp(22),
+            "value.hasOwnProperty",
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(own_property_guard_record(
+            2,
+            sp(22),
+            "value.hasOwnProperty",
+            EvidenceStatus::Asserted,
+            &[1],
+        ));
+        assert!(!own_property_guard_for_node(&il, &interner, guard));
+    }
+
+    #[test]
+    fn own_property_guard_rejects_ambiguous_guard_evidence() {
+        let interner = Interner::new();
+        let (mut il, guard) = js_own_property_guard_il(&interner);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(22)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::OwnPropertyGuard),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(qualified_global_dependency(
+            1,
+            sp(22),
+            "Object.hasOwn",
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(qualified_global_dependency(
+            2,
+            sp(22),
+            "Object.prototype.hasOwnProperty.call",
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(own_property_guard_record(
+            3,
+            sp(22),
+            "Object.hasOwn",
+            EvidenceStatus::Asserted,
+            &[1],
+        ));
+        il.evidence.push(own_property_guard_record(
+            4,
+            sp(22),
+            "Object.prototype.hasOwnProperty.call",
+            EvidenceStatus::Asserted,
+            &[2],
+        ));
+        assert!(!own_property_guard_for_node(&il, &interner, guard));
+    }
+
+    #[test]
+    fn go_zero_map_surface_helpers_require_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let key = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("ready")),
+            sp(32),
+            &[],
+        );
+        let value = b.add(NodeKind::Lit, Payload::LitInt(1), sp(32), &[]);
+        let entry = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("keyed_element")),
+            sp(32),
+            &[key, value],
+        );
+        let map = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("composite_literal")),
+            sp(31),
+            &[entry],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(31), &[map]);
+        let mut il = finish_il(b, root, Lang::Go);
+
+        assert!(go_zero_map_literal_contract_for_node(&il, &interner, map).is_none());
+        assert!(go_zero_map_entry_contract_for_node(&il, &interner, entry).is_none());
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(31)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::GoCompositeMapLiteral),
+            EvidenceStatus::Asserted,
+        ));
+        assert!(go_zero_map_literal_contract_for_node(&il, &interner, map).is_some());
+        assert!(go_zero_map_entry_contract_for_node(&il, &interner, entry).is_none());
+
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::sequence(sp(32)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::GoMapEntry),
+            EvidenceStatus::Asserted,
+        ));
+        assert!(go_zero_map_entry_contract_for_node(&il, &interner, entry).is_some());
     }
 
     #[test]
@@ -5219,6 +5675,22 @@ mod tests {
             })
         );
         assert_eq!(
+            library_java_collection_constructor_contract(Lang::Java, "ArrayList", 0),
+            Some(LibraryCollectionFactoryContract {
+                id: LibraryApiContractId::JavaCollectionConstructor(
+                    JavaCollectionConstructorKind::EmptyList,
+                ),
+                callee: LibraryApiCalleeContract::JavaUtilConstructor {
+                    simple_type: "ArrayList",
+                    qualified_type: "java.util.ArrayList",
+                    module: "java.util",
+                    requires_import_for_simple_type: true,
+                    requires_no_local_type_shadow: true,
+                },
+                result: LibraryCollectionFactoryResult::EmptySequence,
+            })
+        );
+        assert_eq!(
             library_ruby_set_factory_contract(Lang::Ruby, "Set", "new", 1),
             Some(LibraryCollectionFactoryContract {
                 id: LibraryApiContractId::RubySetFactory,
@@ -5960,6 +6432,14 @@ mod tests {
         );
         assert_eq!(
             java_collection_constructor_contract(Lang::JavaScript, "ArrayList", 0),
+            None
+        );
+        assert_eq!(
+            library_java_collection_constructor_contract(Lang::Java, "ArrayList", 1),
+            None
+        );
+        assert_eq!(
+            library_java_collection_constructor_contract(Lang::JavaScript, "ArrayList", 0),
             None
         );
         assert_eq!(

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -13,8 +13,8 @@ can satisfy an exact-channel precondition.
 
 ## Goal
 
-- Give source, domain, import, symbol-identity, and sequence-surface proof facts
-  one shared shape.
+- Give source, domain, import, symbol-identity, guard, and sequence-surface proof
+  facts one shared shape.
 - Make facts carry stable ids, anchors, provenance, dependencies, and status.
 - Keep exact matching fail-closed when evidence is missing, ambiguous, or
   conflicting.
@@ -60,8 +60,8 @@ The current implemented kinds are:
 | `Domain` | receiver/value domain such as collection, map, option, string, integer, or byte array |
 | `Import` | static import binding and namespace proof |
 | `Symbol` | resolved or proven symbol identity, with record kinds for unshadowed globals, static imported binding/namespace aliases, and selected qualified global API paths |
-| `Guard` | multi-obligation guard proof facts such as the first JS/TS record-shape guard contract |
-| `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, record guard, or Go composite map literal |
+| `Guard` | multi-obligation guard proof facts such as JS/TS record-shape and own-property guard contracts |
+| `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, guard surfaces, Go composite map literals, or Go map entries |
 
 `LibraryApiContract` is deliberately not listed here yet. It is currently an
 internal `nose-semantics` contract layer that names first-party library/API
@@ -116,6 +116,14 @@ match the lowered sequence. Generic `SequenceSurface(RecordGuard)` is therefore
 not `exact_tree_safe`; missing, ambiguous, conflicting, wrong-kind, wrong-anchor,
 or dependency-broken guard evidence keeps the exact path closed.
 
+JS/TS own-property guards follow the same rule. `Seq("own_property_guard")` and
+`SequenceSurface(OwnPropertyGuard)` are only the lowered shape; exact and
+value-graph consumers require `Guard::JsOwnProperty` with an asserted dependency
+on one supported qualified-global API path, currently `Object.hasOwn` or
+`Object.prototype.hasOwnProperty.call`. Object method spellings such as
+`value.hasOwnProperty(...)`, shadowed `Object` roots, missing dependencies, or
+ambiguous guard evidence remain closed.
+
 ## Current Producers
 
 First-party frontends now mirror these facts into `EvidenceRecord`:
@@ -131,12 +139,16 @@ First-party frontends now mirror these facts into `EvidenceRecord`:
   evidence at the lowered node anchor: own-property guards at their
   `Seq("own_property_guard")` node, and static member expressions such as
   `Array.from` and `Array.isArray` at their `Field` node;
+- JS/TS own-property guard lowering emits `Guard::JsOwnProperty` evidence for
+  the lowered `Seq("own_property_guard")`, with an asserted `QualifiedGlobal`
+  dependency for the admitted API path;
 - JS/TS record-shape guard lowering emits `Guard::JsRecordShape` evidence for
   the lowered `Seq("record_guard")`, including the shared subject hash, the
   null/truthiness clause kind, whether JS loose equality was admitted, and
   asserted dependencies for the required `Array.isArray` API proof plus optional
   `Boolean` proof;
-- lowered `Seq` surfaces emit `SequenceSurface` evidence.
+- lowered `Seq` surfaces emit `SequenceSurface` evidence, including Go map
+  literal and Go map-entry surfaces where those tags carry first-party meaning.
 
 The older `ParamTypeFact`, `SourceFact`, and raw import `Seq` shapes remain as
 compatibility mirrors. First-party JS/TS record-shape guards now have dedicated
@@ -164,9 +176,9 @@ callers:
   exact gates, and `undefined` nullish-default handling, with compatibility
   fallback only when no relevant evidence record exists;
 - qualified-global symbol proof for selected JS/TS API paths: own-property
-  guard normalization and strict exact safety require evidence for
-  `Object.hasOwn` or `Object.prototype.hasOwnProperty.call`, and map-key view
-  wrappers require evidence for `Array.from`;
+  guard evidence depends on `Object.hasOwn` or
+  `Object.prototype.hasOwnProperty.call`, and map-key view wrappers require
+  evidence for `Array.from`;
 - `LibraryApiContract` consumers for factory and selected non-factory API
   surfaces now use these evidence helpers for their local obligations. The
   contract rows name API identity and result semantics, while `Symbol`,
@@ -176,11 +188,18 @@ callers:
   `SequenceSurface(RecordGuard)` and `Guard::JsRecordShape`; raw
   `Seq("record_guard")` cannot enter the proof-bearing exact/value-graph path by
   tag spelling alone;
+- JS/TS own-property guard exact admission and value-graph map-default
+  normalization require both `SequenceSurface(OwnPropertyGuard)` and
+  `Guard::JsOwnProperty`; raw `Seq("own_property_guard")` plus a path-shaped
+  spelling is not proof by itself;
 - sequence-surface admission for normalize/value-graph/detect exact paths where
   the surface contract is independently exact-safe; guard surfaces use their
-  dedicated guard helper instead.
+  dedicated guard helper instead. Go zero-map literal lookup also requires
+  `SequenceSurface(GoCompositeMapLiteral)` and `SequenceSurface(GoMapEntry)`,
+  so `composite_literal`/`keyed_element` tag spelling alone no longer admits the
+  exact map-default path.
 
 Field/place/effect facts, receiver/protocol evidence beyond parameter domains,
-full scope-resolution and namespace-member evidence, broader guard evidence and
-dependency validation, report-level provenance, and external manifest loading
-are still open work.
+full scope-resolution and namespace-member evidence, broader guard evidence,
+cross-module imported-literal snapshot provenance and evidence copying,
+report-level provenance, and external manifest loading are still open work.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -103,9 +103,9 @@ and pack ecosystem.
   identity/result source while keeping local import, require, shadow, mutation,
   constructor-syntax, and entry-shape proof at the caller.
 - Java empty `ArrayList`/`LinkedList` constructor lowering now consumes a
-  `java.util` constructor contract instead of a raw simple-name check. Simple
-  names need import proof and no local type shadow before they can seed exact
-  builder-loop equivalence.
+  `LibraryApiContract` `java.util` constructor row instead of a raw simple-name
+  check. Simple names need import proof and no local type shadow before they can
+  seed exact builder-loop equivalence.
 - Membership and map-key membership recognition now uses language-scoped method
   contracts before normalization or strict exact matching assigns containment
   semantics. This intentionally closes old name-only paths such as JavaScript
@@ -123,8 +123,9 @@ and pack ecosystem.
 - Map key-view recognition moved behind contracts that distinguish collection
   views from iterator views. JS-like `Map.keys()` now requires an
   `Array.from(...)` wrapper before exact membership can consume it.
-- Go composite map literal/default-zero lookup recognition moved behind a shared
-  contract for literal/entry tags and supported zero-default payload classes.
+- Go composite map literal/default-zero lookup recognition moved behind shared
+  contracts for the outer literal surface, per-entry surface, and supported
+  zero-default payload classes.
 - Map `get(key)` lookup surfaces for Java, Rust, and JS-like typed/proven maps
   moved behind an explicit map-get contract. Defaulting surfaces continue through
   the existing `GetOrDefault` method contract.
@@ -241,10 +242,10 @@ and pack ecosystem.
   `Field(Var(global), method)` shape through symbol-proof contracts instead.
 - Selected JS/TS qualified static global paths now emit `QualifiedGlobal`
   evidence. `Object.hasOwn` and
-  `Object.prototype.hasOwnProperty.call` gate own-property guard normalization
-  and strict exact safety, while `Array.from` gates JS-like map-key iterator
-  wrappers. `Array.isArray` emits the same path evidence for strict exact call
-  gates. Full namespace-member resolution remains open.
+  `Object.prototype.hasOwnProperty.call` are dependencies of own-property guard
+  evidence, while `Array.from` gates JS-like map-key iterator wrappers.
+  `Array.isArray` emits the same path evidence for strict exact call gates. Full
+  namespace-member resolution remains open.
 - Value-graph import identity now consumes sequence `Import` evidence into
   dedicated internal `ImportNamespace`/`ImportBinding` value ops instead of
   treating raw `ValOp::Seq(import_*)` shapes as proof objects. Imported
@@ -255,6 +256,15 @@ and pack ecosystem.
   Strict exact and value-graph paths require that evidence plus
   `SequenceSurface(RecordGuard)`, so raw `Seq("record_guard")` no longer acts as
   a proof object by tag spelling.
+- JS/TS own-property guards now emit dedicated `Guard::JsOwnProperty` evidence
+  with an asserted supported `QualifiedGlobal` API dependency. Strict exact and
+  value-graph map-default paths require that evidence plus
+  `SequenceSurface(OwnPropertyGuard)`, so raw `Seq("own_property_guard")` no
+  longer acts as proof by tag spelling or API-looking text.
+- Go zero-map literal/default lookup now requires evidence for both
+  `SequenceSurface(GoCompositeMapLiteral)` and `SequenceSurface(GoMapEntry)`.
+  The compatibility tags still exist as lowered surfaces, but exact admission no
+  longer comes from raw `composite_literal`/`keyed_element` strings alone.
 - Non-factory library/API surfaces started moving into `LibraryApiContract`
   identity/result rows. Map-key views and wrappers, map `get`/defaulting method
   calls, selected static JS-like helpers, regex-literal `.test`, Python
@@ -318,19 +328,20 @@ Remaining in this phase:
   versioned pack-facing evidence records.
 - Continue moving library API recognition into `LibraryApiContract` records.
   The first internal slice covers collection/map factories, selected
-  constructors, Java `Map.entry`, and the shared shadow/import/result
+  constructors, Java empty collection constructors, Java `Map.entry`, and the
+  shared shadow/import/result
   obligations consumed by normalize and strict exact gates. The next slice moved
   selected non-factory surfaces behind the same identity/result facade: map-key
   views and wrappers, map `get`, map defaulting method calls, static JS-like
   helpers, regex-literal `.test`, Python `math.prod`, promise `.then`, iterator
   identity adapters, Java `Arrays.stream`, and existing language-scoped method
   call contracts.
-- Keep value-graph and strict exact gates on the same contract source. Factory
-  and selected method/view/adapter gates now share `LibraryApiContract`
-  identity/result rows. Remaining API work is to move producer-side API evidence
-  and raw sequence/tag dependencies into explicit evidence records, then cover
-  broader reduction/HOF and ecosystem APIs only after demand, receiver, and
-  effect obligations are expressible.
+- Keep value-graph and strict exact gates on the same contract source. Factory,
+  constructor, and selected method/view/adapter gates now share
+  `LibraryApiContract` identity/result rows. Remaining API work is to move
+  imported-literal producer provenance and other raw sequence/tag dependencies
+  into explicit evidence records, then cover broader reduction/HOF and ecosystem
+  APIs only after demand, receiver, and effect obligations are expressible.
 - Remove the remaining raw import/module proof IL payload storage after import
   and symbol evidence records can carry every consumer obligation, including
   module export dependencies, scope, rebinding, and mutation proof. Value-graph
@@ -338,11 +349,13 @@ Remaining in this phase:
   selected JS/TS `QualifiedGlobal` paths are covered, but general
   qualified-member, namespace export identity, and cross-module dependency
   evidence are not.
-- Generalize dedicated guard evidence beyond the first JS/TS record-shape
-  contract, including richer source-clause records, API dependency validation,
-  subject/place identity, and truthiness/null semantics.
+- Generalize dedicated guard evidence beyond the first JS/TS record-shape and
+  own-property contracts, including richer source-clause records, API dependency
+  validation, subject/place identity, and truthiness/null semantics.
 - Expand the first `SequenceSurface` evidence into sequence/aggregate records for
-  factories, nested entries, iterator views, and exported-literal eligibility.
+  factories, more nested entries, iterator views, and exported-literal
+  eligibility. Go map literal entries are the first exact consumer that now
+  requires per-entry surface evidence.
 - Expand domain evidence from parameter annotations into receiver/protocol
   evidence records for exact collection/map/set/option/string/integer proofs,
   immutable local/module bindings, and mutation exclusion.

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -9,11 +9,11 @@ Snapshot date: 2026-06-08, current implementation after the semantic-kernel
 foundation and follow-up facade migrations through receiver-aware field state
 sequence-surface contracts, proof-backed append fragment evidence, and the first
 operator-law contracts, typed import facts, and source-fact gates for construct,
-literal, equality/operator provenance, and the first shared evidence-record
-substrate for source, domain, import, symbol-identity, and sequence-surface
-facts. Library/API identity is now consolidated further through internal
-`LibraryApiContract` rows for both factory and selected non-factory method/view
-surfaces.
+literal, equality/operator provenance, and the shared evidence-record substrate
+for source, domain, import, symbol-identity, guard, and sequence-surface facts.
+Library/API identity is now consolidated further through internal
+`LibraryApiContract` rows for factory, constructor, and selected non-factory
+method/view surfaces.
 
 ## What exists today
 
@@ -102,19 +102,20 @@ migrated.
   normalize/detect still perform the local scope shadow check. The Rust
   frontend preserves bare `None` as a name rather than lowering it directly to
   null, so Option absence is admitted only through the contract.
-- Collection and map factory identity now has an internal `LibraryApiContract`
+- Collection factory, map factory, and selected constructor identity now have an
+  internal `LibraryApiContract`
   shape in `nose-semantics`. It separates API identity from result eligibility,
   so callers can distinguish "this is Java `Arrays.asList`" from "this argument
   can be canonicalized as a membership collection." Shared contracts cover
   Python free-name factories (`list`, `set`, `frozenset`, `tuple`), Python
   imported `collections.deque`, Rust
   `std::collections::{HashSet,BTreeSet,VecDeque,HashMap,BTreeMap}::from`, Rust
-  `vec!`/`Vec::new`, Java `List.of`/`Set.of`/`Arrays.asList`, Java `Map.of`/
-  `Map.ofEntries`/`Map.entry`, Ruby `require "set"; Set.new(...)`, and JS-like
-  `new Set(...)`/`new Map(...)`. Normalize and strict exact gates consume this
-  shared contract source while still proving local import, require, shadowing,
-  constructor syntax, entry-shape, mutation, and exact-safety obligations at the
-  caller.
+  `vec!`/`Vec::new`, Java `List.of`/`Set.of`/`Arrays.asList`, Java
+  `new ArrayList<>()`/`new LinkedList<>()`, Java `Map.of`/`Map.ofEntries`/
+  `Map.entry`, Ruby `require "set"; Set.new(...)`, and JS-like `new Set(...)`/
+  `new Map(...)`. Normalize and strict exact gates consume this shared contract
+  source while still proving local import, require, shadowing, constructor
+  syntax, entry-shape, mutation, and exact-safety obligations at the caller.
 - Selected non-factory library/API surfaces also consume `LibraryApiContract`
   rows before normalize, value-graph, or strict exact paths assign semantics.
   Current rows cover map-key views and wrappers, Java/Rust/JS-like map `get`,
@@ -127,11 +128,12 @@ migrated.
   import/symbol identity, source facts, exact-safe arguments, fallback demand
   shape, and mutation safety.
 - Java empty collection constructor contracts cover `new ArrayList<>()` and
-  `new LinkedList<>()` only for the Java `java.util` list types. Simple names
-  require `java.util` import proof and no local type declaration with the same
-  simple name. A `java.util.*` wildcard import is not enough when another
-  package explicitly imports the same simple type; fully-qualified
-  `java.util.*List` names carry the namespace proof in the selector itself.
+  `new LinkedList<>()` through `LibraryApiContract` rows only for the Java
+  `java.util` list types. Simple names require `java.util` import proof and no
+  local type declaration with the same simple name. A `java.util.*` wildcard
+  import is not enough when another package explicitly imports the same simple
+  type; fully-qualified `java.util.*List` names carry the namespace proof in the
+  selector itself.
 - Builder append contracts are separate from arbitrary method calls. A selector
   such as `push`, `append`, or `add` is not proof by itself. First-party
   frontend/normalize paths must prove the receiver or active-builder contract and
@@ -228,16 +230,26 @@ migrated.
   `Guard::JsRecordShape` evidence, including subject identity, null/truthiness
   form, comparison form, and asserted API dependencies for `Array.isArray` plus
   optional `Boolean`.
+- JS/TS own-property guards are also evidence-backed. The frontend emits
+  `Guard::JsOwnProperty` for admitted `Object.hasOwn(obj, key)` and
+  `Object.prototype.hasOwnProperty.call(obj, key)` surfaces, with a dependency
+  on the corresponding `QualifiedGlobal` proof. Strict exact and value-graph
+  map-default paths require both `SequenceSurface(OwnPropertyGuard)` and that
+  dedicated guard evidence; raw `Seq("own_property_guard")`, object method
+  spellings, and shadowed `Object` roots stay closed.
 - JS-like `undefined` is no longer frontend-collapsed to null unconditionally.
   It is preserved as a name and only treated as the nullish sentinel through an
   unshadowed-global contract. Value-graph defaulting and strict exact-safe gates
   consume that same proof, so temp-bound `Map.get(...)` defaulting can stay open
   without admitting shadowed `undefined` bindings.
-- Go literal map default lookup is represented by a shared contract for the
-  `composite_literal`/`keyed_element` surface and the supported zero-default
-  payload classes. Go `composite_literal` no longer falls back to a generic
-  collection sequence tag; it is consumed only by the Go map contract or left as
-  a distinct surface.
+- Go literal map default lookup is represented by shared contracts for both the
+  outer `composite_literal` and per-entry `keyed_element` sequence surfaces plus
+  the supported zero-default payload classes. Normalize and strict exact paths
+  require matching `SequenceSurface(GoCompositeMapLiteral)` and
+  `SequenceSurface(GoMapEntry)` evidence, so raw tag spelling alone is not
+  enough. Go `composite_literal` no longer falls back to a generic collection
+  sequence tag; it is consumed only by the Go map contract or left as a distinct
+  surface.
 - Static JS-like `indexOf`/`findIndex` membership requires a receiver whose
   sequence surface has membership-collection admission. Untagged sequence
   expressions, destructuring surfaces, and other positional groupings do not
@@ -292,10 +304,10 @@ Semantic knowledge still appears in several forms outside the facade:
   provenance, and external pack manifests remain open;
 - language-specific import, symbol, or module proof mechanics that are still
   local to frontend, normalize, detect, or value-graph callers;
-- JS/TS record-shape guards now have a first dedicated `Guard::JsRecordShape`
-  record consumed by strict exact and value-graph paths. The recognizer is still
-  first-party JS/TS lowering code, and broader guard families, richer
-  source-clause dependency records, and pack-facing dependency validation remain
+- JS/TS record-shape and own-property guards now have dedicated `Guard` evidence
+  records consumed by strict exact and value-graph paths. The recognizers are
+  still first-party JS/TS lowering code, and broader guard families, richer
+  source/API dependency records, and pack-facing dependency validation remain
   open;
 - IL still stores import facts as `Seq("import_binding")` /
   `Seq("import_namespace")` payloads for compatibility. Frontends also emit
@@ -303,6 +315,9 @@ Semantic knowledge still appears in several forms outside the facade:
   but the raw IL storage shape and some compatibility consumers have not been
   removed;
 - module/import proof logic for immutable sibling-module literal bindings;
+- imported-literal snapshot provenance and evidence copying for cross-file
+  replacement, especially avoiding raw import `Seq` fallback when provider
+  evidence is missing or ambiguous;
 - type facts and coarse type inference used to gate numeric and collection laws;
 - named value-graph rule modules that still consume internal `Builder` facts
   instead of versioned `LawPack` records;


### PR DESCRIPTION
## Summary

- add dedicated `Guard::JsOwnProperty` evidence and route JS/TS own-property exact/value-graph consumers through semantic guard helpers
- require evidence-backed Go map literal and per-entry `SequenceSurface` facts before zero-map literal/default lookup enters exact/value-graph paths
- promote Java empty `ArrayList`/`LinkedList` constructors into `LibraryApiContract` rows while preserving import and local type-shadow obligations
- update semantic-kernel snapshot, roadmap, and evidence-record docs; record imported-literal snapshot provenance as the next producer-evidence slice

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --release`
- `cargo test --release`
- `awiki lint --root docs`
- `python3 scripts/check-formal-obligations.py --self-test`
- `python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `./scripts/check-duplication.sh`
- `git diff --check`
