### PR TITLE
semantics: preserve imported literal evidence

### DIFF
--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -7777,6 +7777,11 @@ fn scan_mode_semantic_proves_literal_map_default_lookup() {
     )
     .unwrap();
     fs::write(
+        dir.join("module_map_missing_java_import.java"),
+        "class JavaModuleMapMissingImport {\n  static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2);\n\n  static int wrong(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n",
+    )
+    .unwrap();
+    fs::write(
         dir.join("module_map_mutated.js"),
         "const LOOKUP = new Map([[\"red\", 1], [\"blue\", 2]]);\nLOOKUP.set(\"red\", 9);\n\nfunction wrong(key, other) {\n  return LOOKUP.get(key) ?? 0;\n}\n",
     )
@@ -8070,6 +8075,7 @@ fn scan_mode_semantic_proves_literal_map_default_lookup() {
         "wrong_java_map.java",
         "shadowed_java_map.java",
         "local_java_map_type.java",
+        "module_map_missing_java_import.java",
         "module_map_mutated.js",
         "module_map_shadowed.ts",
         "module_map_shadowed.java",

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -4631,6 +4631,11 @@ fn literal_map_default_lookup_converges_with_non_python_imported_bindings() {
     )
     .unwrap();
     std::fs::write(
+        dir.join("JavaImportedWithLocalMapShadow.java"),
+        "import static Tables.LOOKUP;\n\nclass JavaImportedWithLocalMapShadow {\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n\nclass Map {}\n",
+    )
+    .unwrap();
+    std::fs::write(
         dir.join("WrongTables.java"),
         "import java.util.Map;\n\nclass WrongTables {\n  static final Map<String, Integer> LOOKUP = Map.of(\"red\", 9, \"blue\", 2);\n}\n",
     )
@@ -4638,6 +4643,16 @@ fn literal_map_default_lookup_converges_with_non_python_imported_bindings() {
     std::fs::write(
         dir.join("JavaImportedWrongMap.java"),
         "import static WrongTables.LOOKUP;\n\nclass JavaImportedWrongMap {\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("MissingMapImportTables.java"),
+        "class MissingMapImportTables {\n  static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2);\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("JavaImportedMissingMapImport.java"),
+        "import static MissingMapImportTables.LOOKUP;\n\nclass JavaImportedMissingMapImport {\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n",
     )
     .unwrap();
     std::fs::write(
@@ -4685,6 +4700,11 @@ fn literal_map_default_lookup_converges_with_non_python_imported_bindings() {
     );
     assert_eq!(
         local,
+        corpus_value_fp(&corpus, "JavaImportedWithLocalMapShadow.java", "lookup"),
+        "provider-proven Java static import should not be invalidated by importer-local Map shadowing"
+    );
+    assert_eq!(
+        local,
         corpus_value_fp(&corpus, "rust_imported.rs", "lookup"),
         "Rust use-imported const entries should prove the same map/default coordinates"
     );
@@ -4712,6 +4732,11 @@ fn literal_map_default_lookup_converges_with_non_python_imported_bindings() {
         local,
         corpus_value_fp(&corpus, "JavaImportedWrongMap.java", "lookup"),
         "different Java imported map contents must stay distinct"
+    );
+    assert_ne!(
+        local,
+        corpus_value_fp(&corpus, "JavaImportedMissingMapImport.java", "lookup"),
+        "Java imported Map.of provider must require java.util.Map proof"
     );
     assert_ne!(
         local,

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -19,13 +19,14 @@ use nose_semantics::{
     exact_non_overloadable_index_assignment_parts, exact_static_membership_predicate_operator,
     go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
     go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract, imported_binding_symbol,
-    imported_member_symbol, library_api_free_name_shadow_safe,
-    library_free_name_collection_factory_contract, library_free_name_map_factory_contract,
-    library_imported_collection_factory_contracts, library_iterator_identity_adapter_contract,
-    library_java_collection_factory_contract, library_java_map_entry_contract,
-    library_java_map_factory_contract, library_js_array_is_array_contract,
-    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
-    library_map_get_contract, library_map_key_view_contract, library_map_key_view_wrapper_contract,
+    imported_literal_producer_evidence_for_node, imported_member_symbol,
+    library_api_free_name_shadow_safe, library_free_name_collection_factory_contract,
+    library_free_name_map_factory_contract, library_imported_collection_factory_contracts,
+    library_iterator_identity_adapter_contract, library_java_collection_factory_contract,
+    library_java_map_entry_contract, library_java_map_factory_contract,
+    library_js_array_is_array_contract, library_js_like_map_constructor_contract,
+    library_js_like_set_constructor_contract, library_map_get_contract,
+    library_map_key_view_contract, library_map_key_view_wrapper_contract,
     library_method_call_contract, library_regex_test_contract, library_ruby_set_factory_contract,
     library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
     nullish_global_contract, own_property_guard_for_node, qualified_global_symbol,
@@ -2254,7 +2255,10 @@ fn strict_exact_java_map_factory_safe(
     else {
         return false;
     };
-    if !strict_exact_java_std_var_name(il, interner, receiver, expected_receiver) {
+    let provider_proven = imported_literal_producer_evidence_for_node(il, node);
+    if !provider_proven
+        && !strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
+    {
         return false;
     }
     let LibraryMapFactoryResult::JavaFactory { kind } = contract.result else {
@@ -2268,10 +2272,9 @@ fn strict_exact_java_map_factory_safe(
                     .iter()
                     .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
         }
-        JavaMapFactoryKind::OfEntries => kids
-            .iter()
-            .skip(1)
-            .all(|&entry| strict_exact_java_map_entry_safe(il, interner, facts, entry)),
+        JavaMapFactoryKind::OfEntries => kids.iter().skip(1).all(|&entry| {
+            strict_exact_java_map_entry_safe(il, interner, facts, entry, provider_proven)
+        }),
     }
 }
 
@@ -2280,6 +2283,7 @@ fn strict_exact_java_map_entry_safe(
     interner: &Interner,
     facts: &StrictFacts,
     node: NodeId,
+    provider_proven: bool,
 ) -> bool {
     if il.kind(node) != NodeKind::Call {
         return false;
@@ -2305,7 +2309,7 @@ fn strict_exact_java_map_entry_safe(
     else {
         return false;
     };
-    strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
+    (provider_proven || strict_exact_java_std_var_name(il, interner, receiver, expected_receiver))
         && kids
             .iter()
             .skip(1)

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -9,11 +9,14 @@
 use nose_il::{
     stable_symbol_hash, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
     EvidenceProvenance, EvidenceRecord, EvidenceStatus, Il, ImportEvidenceKind, Interner, Node,
-    NodeId, NodeKind, Payload, Span, Symbol, SymbolEvidenceKind, UnitKind,
+    NodeId, NodeKind, Payload, Span, Symbol, UnitKind,
 };
 use nose_semantics::{
-    import_fact_rhs, java_map_entry_contract, java_map_factory_contract, semantics, ImportFactKind,
-    ImportedMapFactoryContract, JavaMapFactoryKind, FIRST_PARTY_PACK_ID,
+    import_fact_evidence_rhs, imported_binding_symbol, library_api_free_name_shadow_safe,
+    library_free_name_map_factory_contract, library_java_map_entry_contract,
+    library_java_map_factory_contract, semantics, seq_surface_contract_evidence_for_node,
+    ImportFactKind, ImportedMapFactoryContract, JavaMapFactoryKind, LibraryApiCalleeContract,
+    LibraryMapFactoryResult, FIRST_PARTY_PACK_ID,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::Path;
@@ -23,6 +26,23 @@ struct ExportedBinding {
     file_idx: usize,
     deps: Vec<SubtreeSnapshot>,
     rhs: NodeId,
+}
+
+#[derive(Clone)]
+struct ImportReplacement {
+    stmt: NodeId,
+    import_evidence: EvidenceId,
+    module_hash: u64,
+    exported_hash: u64,
+    deps: Vec<SubtreeSnapshot>,
+    rhs_snapshot: SubtreeSnapshot,
+}
+
+#[derive(Clone, Copy)]
+struct ImportBindingProof {
+    module_hash: u64,
+    exported_hash: u64,
+    evidence: EvidenceId,
 }
 
 #[derive(Clone)]
@@ -37,6 +57,22 @@ struct SnapshotNode {
 struct SubtreeSnapshot {
     nodes: Vec<SnapshotNode>,
     root: usize,
+    evidence: Vec<SnapshotEvidence>,
+}
+
+#[derive(Clone)]
+struct SnapshotEvidence {
+    source_id: EvidenceId,
+    anchor: EvidenceAnchor,
+    kind: EvidenceKind,
+    provenance: EvidenceProvenance,
+    dependencies: Vec<EvidenceId>,
+    status: EvidenceStatus,
+}
+
+struct AppendedSnapshot {
+    root: NodeId,
+    evidence: Vec<EvidenceId>,
 }
 
 pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &Interner) {
@@ -44,8 +80,17 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
     if exports.is_empty() {
         return;
     }
+    for (&(module_hash, exported_hash), export) in &exports {
+        record_immutable_literal_export_evidence(
+            &mut files[export.file_idx],
+            export.rhs,
+            module_hash,
+            exported_hash,
+            &export.deps,
+        );
+    }
 
-    let replacements: Vec<Vec<(NodeId, Vec<SubtreeSnapshot>, SubtreeSnapshot)>> = files
+    let replacements: Vec<Vec<ImportReplacement>> = files
         .iter()
         .enumerate()
         .map(|(file_idx, il)| {
@@ -53,7 +98,8 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
                 .into_iter()
                 .filter_map(|stmt| {
                     let local = assignment_name(il, stmt)?;
-                    let key = import_binding_key(il, interner, stmt)?;
+                    let proof = import_binding_proof(il, stmt)?;
+                    let key = (proof.module_hash, proof.exported_hash);
                     let export = exports.get(&key)?;
                     if export.file_idx == file_idx {
                         return None;
@@ -61,29 +107,38 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
                     if binding_mutated(il, interner, local, stmt) {
                         return None;
                     }
-                    Some((
+                    Some(ImportReplacement {
                         stmt,
-                        export.deps.clone(),
-                        snapshot_subtree(&files[export.file_idx], export.rhs),
-                    ))
+                        import_evidence: proof.evidence,
+                        module_hash: proof.module_hash,
+                        exported_hash: proof.exported_hash,
+                        deps: export.deps.clone(),
+                        rhs_snapshot: snapshot_subtree(&files[export.file_idx], export.rhs),
+                    })
                 })
                 .collect()
         })
         .collect();
 
     for (file_idx, file_replacements) in replacements.into_iter().enumerate() {
-        for (stmt, deps, snapshot) in file_replacements {
-            for dep in deps {
-                let dep_stmt = append_snapshot(&mut files[file_idx], &dep);
-                mirror_import_fact_evidence_for_assignment(
-                    &mut files[file_idx],
-                    interner,
-                    dep_stmt,
-                );
-                prepend_root_statement(&mut files[file_idx], dep_stmt);
+        for replacement in file_replacements {
+            let mut snapshot_evidence = Vec::new();
+            for dep in replacement.deps {
+                let dep = append_snapshot(&mut files[file_idx], &dep);
+                snapshot_evidence.extend(dep.evidence);
+                prepend_root_statement(&mut files[file_idx], dep.root);
             }
-            let rhs = append_snapshot(&mut files[file_idx], &snapshot);
-            replace_assignment_rhs(&mut files[file_idx], stmt, rhs);
+            let rhs = append_snapshot(&mut files[file_idx], &replacement.rhs_snapshot);
+            snapshot_evidence.extend(rhs.evidence);
+            replace_assignment_rhs(&mut files[file_idx], replacement.stmt, rhs.root);
+            record_imported_literal_snapshot_evidence(
+                &mut files[file_idx],
+                rhs.root,
+                replacement.module_hash,
+                replacement.exported_hash,
+                replacement.import_evidence,
+                snapshot_evidence,
+            );
         }
     }
 }
@@ -176,7 +231,7 @@ fn collect_statement_exports(
             continue;
         }
         let exported = stable_symbol_hash(interner.resolve(name));
-        let deps = import_dependency_snapshots(il, interner, rhs);
+        let deps = import_dependency_snapshots(il, rhs);
         for &module in module_hashes {
             let key = (module, exported);
             if exports
@@ -196,13 +251,12 @@ fn collect_statement_exports(
     }
 }
 
-fn import_dependency_snapshots(il: &Il, interner: &Interner, rhs: NodeId) -> Vec<SubtreeSnapshot> {
+fn import_dependency_snapshots(il: &Il, rhs: NodeId) -> Vec<SubtreeSnapshot> {
     collect_top_level_statements(il)
         .into_iter()
         .filter(|&stmt| {
             assignment_rhs(il, stmt).is_some_and(|dep_rhs| {
-                import_binding_key(il, interner, stmt).is_some()
-                    && il.kind(dep_rhs) == NodeKind::Seq
+                import_binding_key(il, stmt).is_some() && il.kind(dep_rhs) == NodeKind::Seq
             })
         })
         .filter(|&stmt| {
@@ -263,24 +317,53 @@ fn assignment_rhs(il: &Il, stmt: NodeId) -> Option<NodeId> {
         .and_then(|kids| (kids.len() == 2).then_some(kids[1]))
 }
 
-fn import_binding_key(il: &Il, interner: &Interner, stmt: NodeId) -> Option<(u64, u64)> {
+fn import_binding_key(il: &Il, stmt: NodeId) -> Option<(u64, u64)> {
+    let proof = import_binding_proof(il, stmt)?;
+    Some((proof.module_hash, proof.exported_hash))
+}
+
+fn import_binding_proof(il: &Il, stmt: NodeId) -> Option<ImportBindingProof> {
     let rhs = assignment_rhs(il, stmt)?;
-    let fact = import_fact_rhs(il, interner, rhs)?;
-    (fact.kind == ImportFactKind::Binding).then_some((fact.module_hash, fact.exported_hash?))
+    let fact = import_fact_evidence_rhs(il, rhs)?;
+    if fact.kind != ImportFactKind::Binding {
+        return None;
+    }
+    let exported_hash = fact.exported_hash?;
+    let evidence = import_fact_evidence_id_for_rhs(il, rhs)?;
+    Some(ImportBindingProof {
+        module_hash: fact.module_hash,
+        exported_hash,
+        evidence,
+    })
+}
+
+fn import_fact_evidence_id_for_rhs(il: &Il, rhs: NodeId) -> Option<EvidenceId> {
+    let span = il.node(rhs).span;
+    il.evidence.iter().find_map(|record| {
+        if record.status != EvidenceStatus::Asserted
+            || record.anchor != EvidenceAnchor::sequence(span)
+        {
+            return None;
+        }
+        matches!(
+            record.kind,
+            EvidenceKind::Import(
+                ImportEvidenceKind::Binding { .. } | ImportEvidenceKind::Namespace { .. }
+            )
+        )
+        .then_some(record.id)
+    })
 }
 
 fn imported_literal_export_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
     match il.kind(node) {
         NodeKind::Seq => {
-            let Payload::Name(tag) = il.node(node).payload else {
-                return false;
-            };
-            if !nose_semantics::imported_literal_seq_tag_safe(il.meta.lang, interner.resolve(tag)) {
-                return false;
-            }
-            il.children(node)
-                .iter()
-                .all(|&child| literal_export_value_safe(il, interner, child))
+            seq_surface_contract_evidence_for_node(il, interner, node)
+                .is_some_and(|contract| contract.imported_literal)
+                && il
+                    .children(node)
+                    .iter()
+                    .all(|&child| literal_export_value_safe(il, interner, child))
         }
         NodeKind::Call => imported_map_factory_call_safe(il, interner, node),
         _ => false,
@@ -291,7 +374,12 @@ fn literal_export_value_safe(il: &Il, interner: &Interner, node: NodeId) -> bool
     match il.kind(node) {
         NodeKind::Lit => true,
         NodeKind::Seq => {
-            if import_fact_rhs(il, interner, node).is_some() {
+            if import_fact_evidence_rhs(il, node).is_some() {
+                return false;
+            }
+            if !seq_surface_contract_evidence_for_node(il, interner, node)
+                .is_some_and(|contract| contract.exact_tree_safe)
+            {
                 return false;
             }
             il.children(node)
@@ -322,16 +410,26 @@ fn java_map_factory_call_safe(il: &Il, interner: &Interner, call: NodeId) -> boo
     let Some((&callee, args)) = kids.split_first() else {
         return false;
     };
-    let Some(method) = field_method_on_var(il, interner, callee, "Map") else {
+    let Some((receiver_node, method)) = field_method_on_var(il, interner, callee, "Map") else {
         return false;
     };
-    let Some(contract) = java_map_factory_contract(il.meta.lang, "Map", method) else {
+    let Some(contract) = library_java_map_factory_contract(il.meta.lang, "Map", method) else {
         return false;
     };
-    if java_file_defines_type_name(il, interner, contract.receiver) {
+    let LibraryApiCalleeContract::JavaUtilStaticMember {
+        receiver: expected_receiver,
+        ..
+    } = contract.callee
+    else {
+        return false;
+    };
+    if !java_util_static_receiver_safe(il, interner, receiver_node, expected_receiver) {
         return false;
     }
-    match contract.kind {
+    let LibraryMapFactoryResult::JavaFactory { kind } = contract.result else {
+        return false;
+    };
+    match kind {
         JavaMapFactoryKind::Of => {
             args.len() % 2 == 0
                 && args
@@ -352,13 +450,20 @@ fn java_map_entry_call_safe(il: &Il, interner: &Interner, call: NodeId) -> bool 
     if kids.len() != 3 {
         return false;
     }
-    let Some(method) = field_method_on_var(il, interner, kids[0], "Map") else {
+    let Some((receiver_node, method)) = field_method_on_var(il, interner, kids[0], "Map") else {
         return false;
     };
-    if !java_map_entry_contract(il.meta.lang, "Map", method) {
+    let Some(contract) = library_java_map_entry_contract(il.meta.lang, "Map", method) else {
         return false;
-    }
-    if java_file_defines_type_name(il, interner, "Map") {
+    };
+    let LibraryApiCalleeContract::JavaUtilStaticMember {
+        receiver: expected_receiver,
+        ..
+    } = contract.callee
+    else {
+        return false;
+    };
+    if !java_util_static_receiver_safe(il, interner, receiver_node, expected_receiver) {
         return false;
     }
     literal_export_value_safe(il, interner, kids[1])
@@ -373,13 +478,24 @@ fn rust_std_map_factory_call_safe(il: &Il, interner: &Interner, call: NodeId) ->
     let Some(name) = var_text(il, interner, kids[0]) else {
         return false;
     };
-    let factory = semantics(il.meta.lang)
-        .collections()
-        .free_name_map_factories()
-        .find(|factory| factory.names.contains(&name));
-    if factory.is_none() || !free_name_factory_shadow_safe(il, interner, name, false) {
+    let Some(contract) = library_free_name_map_factory_contract(il.meta.lang, name) else {
+        return false;
+    };
+    let LibraryApiCalleeContract::FreeName {
+        name: contract_name,
+        shadow,
+    } = contract.callee
+    else {
+        return false;
+    };
+    if !library_api_free_name_shadow_safe(il.meta.lang, contract_name, shadow, |candidate| {
+        file_defines_name(il, interner, candidate)
+    }) {
         return false;
     }
+    let LibraryMapFactoryResult::EntrySequence { .. } = contract.result else {
+        return false;
+    };
     literal_export_value_safe(il, interner, kids[1])
 }
 
@@ -388,7 +504,7 @@ fn field_method_on_var<'a>(
     interner: &'a Interner,
     node: NodeId,
     receiver: &str,
-) -> Option<&'a str> {
+) -> Option<(NodeId, &'a str)> {
     if il.kind(node) != NodeKind::Field {
         return None;
     }
@@ -396,7 +512,8 @@ fn field_method_on_var<'a>(
         return None;
     };
     let receiver_node = il.children(node).first().copied()?;
-    var_named(il, interner, receiver_node, receiver).then(|| interner.resolve(method))
+    var_named(il, interner, receiver_node, receiver)
+        .then(|| (receiver_node, interner.resolve(method)))
 }
 
 fn var_named(il: &Il, interner: &Interner, node: NodeId, expected: &str) -> bool {
@@ -413,19 +530,14 @@ fn var_text<'a>(il: &Il, interner: &'a Interner, node: NodeId) -> Option<&'a str
     Some(interner.resolve(name))
 }
 
-fn free_name_factory_shadow_safe(
+fn java_util_static_receiver_safe(
     il: &Il,
     interner: &Interner,
-    name: &str,
-    shadow_guard: bool,
+    receiver: NodeId,
+    expected_receiver: &str,
 ) -> bool {
-    if shadow_guard {
-        return !file_defines_name(il, interner, name);
-    }
-    if il.meta.lang == nose_il::Lang::Rust && name.starts_with("std::") {
-        return !file_defines_name(il, interner, "std");
-    }
-    true
+    !java_file_defines_type_name(il, interner, expected_receiver)
+        && imported_binding_symbol(il, interner, receiver, "java.util", expected_receiver)
 }
 
 fn file_defines_name(il: &Il, interner: &Interner, expected: &str) -> bool {
@@ -652,10 +764,128 @@ fn snapshot_subtree(il: &Il, root: NodeId) -> SubtreeSnapshot {
 
     let mut nodes = Vec::new();
     let root = snapshot_node(il, root, &mut nodes);
-    SubtreeSnapshot { nodes, root }
+    let evidence = snapshot_evidence(il, &nodes);
+    SubtreeSnapshot {
+        nodes,
+        root,
+        evidence,
+    }
 }
 
-fn append_snapshot(il: &mut Il, snapshot: &SubtreeSnapshot) -> NodeId {
+fn snapshot_evidence(il: &Il, nodes: &[SnapshotNode]) -> Vec<SnapshotEvidence> {
+    let spans: FxHashSet<Span> = nodes.iter().map(|node| node.span).collect();
+    let candidates: FxHashMap<EvidenceId, &EvidenceRecord> = il
+        .evidence
+        .iter()
+        .filter(|record| {
+            record.status == EvidenceStatus::Asserted
+                && spans.contains(&evidence_anchor_span(record.anchor))
+        })
+        .map(|record| (record.id, record))
+        .collect();
+    let mut kept: FxHashSet<EvidenceId> = candidates.keys().copied().collect();
+    loop {
+        let rejected: Vec<EvidenceId> = kept
+            .iter()
+            .copied()
+            .filter(|id| {
+                candidates
+                    .get(id)
+                    .is_some_and(|record| record.dependencies.iter().any(|dep| !kept.contains(dep)))
+            })
+            .collect();
+        if rejected.is_empty() {
+            break;
+        }
+        for id in rejected {
+            kept.remove(&id);
+        }
+    }
+    il.evidence
+        .iter()
+        .filter(|record| kept.contains(&record.id))
+        .map(|record| SnapshotEvidence {
+            source_id: record.id,
+            anchor: record.anchor,
+            kind: record.kind,
+            provenance: record.provenance,
+            dependencies: record.dependencies.clone(),
+            status: record.status,
+        })
+        .collect()
+}
+
+fn record_immutable_literal_export_evidence(
+    il: &mut Il,
+    rhs: NodeId,
+    module_hash: u64,
+    exported_hash: u64,
+    deps: &[SubtreeSnapshot],
+) -> EvidenceId {
+    let spans = subtree_spans(il, rhs);
+    let mut seen = FxHashSet::default();
+    let mut dependencies = Vec::new();
+    for id in il.evidence.iter().filter_map(|record| {
+        (record.status == EvidenceStatus::Asserted
+            && spans.contains(&evidence_anchor_span(record.anchor))
+            && !matches!(
+                record.kind,
+                EvidenceKind::Import(
+                    ImportEvidenceKind::ImmutableLiteralExport { .. }
+                        | ImportEvidenceKind::ImportedLiteralSnapshot { .. }
+                )
+            ))
+        .then_some(record.id)
+    }) {
+        if seen.insert(id) {
+            dependencies.push(id);
+        }
+    }
+    for id in deps
+        .iter()
+        .flat_map(|dep| dep.evidence.iter().map(|evidence| evidence.source_id))
+    {
+        if seen.insert(id) {
+            dependencies.push(id);
+        }
+    }
+    push_first_party_evidence_with_dependencies(
+        il,
+        EvidenceAnchor::node(il.node(rhs).span, il.kind(rhs)),
+        EvidenceKind::Import(ImportEvidenceKind::ImmutableLiteralExport {
+            module_hash,
+            exported_hash,
+            root_kind: il.kind(rhs),
+        }),
+        "module_immutable_literal_export",
+        dependencies,
+    )
+}
+
+fn subtree_spans(il: &Il, root: NodeId) -> FxHashSet<Span> {
+    fn collect(il: &Il, node: NodeId, out: &mut FxHashSet<Span>) {
+        out.insert(il.node(node).span);
+        for &child in il.children(node) {
+            collect(il, child, out);
+        }
+    }
+
+    let mut spans = FxHashSet::default();
+    collect(il, root, &mut spans);
+    spans
+}
+
+fn evidence_anchor_span(anchor: EvidenceAnchor) -> Span {
+    match anchor {
+        EvidenceAnchor::SourceSpan(span)
+        | EvidenceAnchor::Node { span, .. }
+        | EvidenceAnchor::Param { span }
+        | EvidenceAnchor::Binding { span, .. }
+        | EvidenceAnchor::Sequence { span } => span,
+    }
+}
+
+fn append_snapshot(il: &mut Il, snapshot: &SubtreeSnapshot) -> AppendedSnapshot {
     let mut new_ids = vec![NodeId(0); snapshot.nodes.len()];
     for (idx, snapshot_node) in snapshot.nodes.iter().enumerate() {
         let children: Vec<NodeId> = snapshot_node
@@ -677,7 +907,65 @@ fn append_snapshot(il: &mut Il, snapshot: &SubtreeSnapshot) -> NodeId {
         });
         new_ids[idx] = id;
     }
-    new_ids[snapshot.root]
+    let mut evidence_id_map = FxHashMap::default();
+    for (idx, evidence) in snapshot.evidence.iter().enumerate() {
+        evidence_id_map.insert(
+            evidence.source_id,
+            EvidenceId((il.evidence.len() + idx) as u32),
+        );
+    }
+    let mut copied_evidence = Vec::with_capacity(snapshot.evidence.len());
+    for evidence in &snapshot.evidence {
+        let id = evidence_id_map[&evidence.source_id];
+        let dependencies = evidence
+            .dependencies
+            .iter()
+            .map(|dependency| {
+                evidence_id_map
+                    .get(dependency)
+                    .copied()
+                    .expect("snapshot evidence dependency must be closed")
+            })
+            .collect();
+        il.evidence.push(EvidenceRecord {
+            id,
+            anchor: remap_anchor_file(evidence.anchor, il.file),
+            kind: evidence.kind,
+            provenance: evidence.provenance,
+            dependencies,
+            status: evidence.status,
+        });
+        copied_evidence.push(id);
+    }
+    AppendedSnapshot {
+        root: new_ids[snapshot.root],
+        evidence: copied_evidence,
+    }
+}
+
+fn remap_anchor_file(anchor: EvidenceAnchor, file: nose_il::FileId) -> EvidenceAnchor {
+    match anchor {
+        EvidenceAnchor::SourceSpan(span) => EvidenceAnchor::SourceSpan(remap_span_file(span, file)),
+        EvidenceAnchor::Node { span, kind } => EvidenceAnchor::Node {
+            span: remap_span_file(span, file),
+            kind,
+        },
+        EvidenceAnchor::Param { span } => EvidenceAnchor::Param {
+            span: remap_span_file(span, file),
+        },
+        EvidenceAnchor::Binding { span, local_hash } => EvidenceAnchor::Binding {
+            span: remap_span_file(span, file),
+            local_hash,
+        },
+        EvidenceAnchor::Sequence { span } => EvidenceAnchor::Sequence {
+            span: remap_span_file(span, file),
+        },
+    }
+}
+
+fn remap_span_file(mut span: Span, file: nose_il::FileId) -> Span {
+    span.file = file;
+    span
 }
 
 fn replace_assignment_rhs(il: &mut Il, stmt: NodeId, rhs: NodeId) {
@@ -693,79 +981,44 @@ fn replace_assignment_rhs(il: &mut Il, stmt: NodeId, rhs: NodeId) {
     }
 }
 
-fn mirror_import_fact_evidence_for_assignment(il: &mut Il, interner: &Interner, stmt: NodeId) {
-    if il.kind(stmt) != NodeKind::Assign {
-        return;
+fn record_imported_literal_snapshot_evidence(
+    il: &mut Il,
+    rhs: NodeId,
+    module_hash: u64,
+    exported_hash: u64,
+    import_evidence: EvidenceId,
+    copied_snapshot_evidence: Vec<EvidenceId>,
+) {
+    let mut dependencies = Vec::with_capacity(copied_snapshot_evidence.len() + 1);
+    dependencies.push(import_evidence);
+    for evidence in copied_snapshot_evidence {
+        if !dependencies.contains(&evidence) {
+            dependencies.push(evidence);
+        }
     }
-    let kids = il.children(stmt);
-    let [lhs, rhs] = kids else {
-        return;
-    };
-    let local = match il.node(*lhs).payload {
-        Payload::Name(symbol) => Some(stable_symbol_hash(interner.resolve(symbol))),
-        Payload::Cid(cid) => il
-            .cid_names
-            .get(cid as usize)
-            .map(|&symbol| stable_symbol_hash(interner.resolve(symbol))),
-        _ => None,
-    };
-    let Some(local_hash) = local else {
-        return;
-    };
-    let Some(fact) = import_fact_rhs(il, interner, *rhs) else {
-        return;
-    };
-    let import_kind = match fact.kind {
-        ImportFactKind::Binding => {
-            let Some(exported_hash) = fact.exported_hash else {
-                return;
-            };
-            EvidenceKind::Import(ImportEvidenceKind::Binding {
-                module_hash: fact.module_hash,
-                exported_hash,
-            })
-        }
-        ImportFactKind::Namespace => EvidenceKind::Import(ImportEvidenceKind::Namespace {
-            module_hash: fact.module_hash,
+    push_first_party_evidence_with_dependencies(
+        il,
+        EvidenceAnchor::node(il.node(rhs).span, il.kind(rhs)),
+        EvidenceKind::Import(ImportEvidenceKind::ImportedLiteralSnapshot {
+            module_hash,
+            exported_hash,
+            root_kind: il.kind(rhs),
         }),
-    };
-    let symbol_kind = match fact.kind {
-        ImportFactKind::Binding => {
-            let Some(exported_hash) = fact.exported_hash else {
-                return;
-            };
-            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
-                module_hash: fact.module_hash,
-                exported_hash,
-            })
-        }
-        ImportFactKind::Namespace => EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace {
-            module_hash: fact.module_hash,
-        }),
-    };
-    push_first_party_evidence(
-        il,
-        EvidenceAnchor::sequence(il.node(*rhs).span),
-        import_kind,
-        "module_import_snapshot_import",
-    );
-    push_first_party_evidence(
-        il,
-        EvidenceAnchor::binding(il.node(stmt).span, local_hash),
-        import_kind,
-        "module_import_snapshot_binding_import",
-    );
-    push_first_party_evidence(
-        il,
-        EvidenceAnchor::binding(il.node(stmt).span, local_hash),
-        symbol_kind,
-        "module_import_snapshot_symbol",
+        "module_imported_literal_snapshot",
+        dependencies,
     );
 }
 
-fn push_first_party_evidence(il: &mut Il, anchor: EvidenceAnchor, kind: EvidenceKind, rule: &str) {
+fn push_first_party_evidence_with_dependencies(
+    il: &mut Il,
+    anchor: EvidenceAnchor,
+    kind: EvidenceKind,
+    rule: &str,
+    dependencies: Vec<EvidenceId>,
+) -> EvidenceId {
+    let id = EvidenceId(il.evidence.len() as u32);
     il.evidence.push(EvidenceRecord {
-        id: EvidenceId(il.evidence.len() as u32),
+        id,
         anchor,
         kind,
         provenance: EvidenceProvenance {
@@ -773,9 +1026,10 @@ fn push_first_party_evidence(il: &mut Il, anchor: EvidenceAnchor, kind: Evidence
             pack_hash: Some(stable_symbol_hash(FIRST_PARTY_PACK_ID)),
             rule_hash: Some(stable_symbol_hash(rule)),
         },
-        dependencies: Vec::new(),
+        dependencies,
         status: EvidenceStatus::Asserted,
     });
+    id
 }
 
 fn prepend_root_statement(il: &mut Il, stmt: NodeId) {
@@ -800,7 +1054,7 @@ fn prepend_root_statement(il: &mut Il, stmt: NodeId) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_il::{FileId, FileMeta, IlBuilder, Lang};
+    use nose_il::{FileId, FileMeta, IlBuilder, Lang, SequenceSurfaceKind, SymbolEvidenceKind};
 
     fn module_with_binding_method(method: &str) -> (Il, Interner, Symbol, NodeId) {
         let interner = Interner::new();
@@ -856,11 +1110,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn import_snapshot_assignment_regenerates_import_and_symbol_evidence() {
+    fn raw_import_binding_assignment(
+        file: FileId,
+        lang: Lang,
+    ) -> (Il, Interner, Span, NodeId, NodeId) {
         let interner = Interner::new();
-        let mut b = IlBuilder::new(FileId(0));
-        let span = Span::new(FileId(0), 0, 1, 1, 1);
+        let mut b = IlBuilder::new(file);
+        let span = Span::new(file, 0, 1, 1, 1);
         let map = interner.intern("Map");
         let lhs = b.add(NodeKind::Var, Payload::Name(map), span, &[]);
         let module = b.add(
@@ -879,35 +1135,357 @@ mod tests {
         let rhs = b.add(NodeKind::Seq, Payload::Name(tag), span, &[module, exported]);
         let assign = b.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs]);
         let root = b.add(NodeKind::Module, Payload::None, span, &[assign]);
-        let mut il = b.finish(
+        let il = b.finish(
             root,
             FileMeta {
                 path: "imported.java".into(),
+                lang,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        (il, interner, span, assign, rhs)
+    }
+
+    fn test_provenance(rule: &str) -> EvidenceProvenance {
+        EvidenceProvenance {
+            emitter: EvidenceEmitter::External,
+            pack_hash: Some(stable_symbol_hash("test.pack")),
+            rule_hash: Some(stable_symbol_hash(rule)),
+        }
+    }
+
+    fn add_import_binding_evidence(il: &mut Il, span: Span, status: EvidenceStatus) -> EvidenceId {
+        let id = EvidenceId(il.evidence.len() as u32);
+        il.evidence.push(EvidenceRecord {
+            id,
+            anchor: EvidenceAnchor::sequence(span),
+            kind: EvidenceKind::Import(ImportEvidenceKind::Binding {
+                module_hash: stable_symbol_hash("java.util"),
+                exported_hash: stable_symbol_hash("Map"),
+            }),
+            provenance: test_provenance("import_binding"),
+            dependencies: Vec::new(),
+            status,
+        });
+        id
+    }
+
+    #[test]
+    fn import_binding_key_requires_asserted_import_evidence() {
+        let (mut il, _interner, span, assign, _rhs) =
+            raw_import_binding_assignment(FileId(0), Lang::Java);
+        assert_eq!(
+            import_binding_key(&il, assign),
+            None,
+            "raw import_binding Seq tags must not prove import coordinates"
+        );
+
+        add_import_binding_evidence(&mut il, span, EvidenceStatus::Asserted);
+        assert_eq!(
+            import_binding_key(&il, assign),
+            Some((stable_symbol_hash("java.util"), stable_symbol_hash("Map")))
+        );
+    }
+
+    #[test]
+    fn import_binding_key_rejects_ambiguous_import_evidence_even_with_raw_seq() {
+        let (mut il, _interner, span, assign, _rhs) =
+            raw_import_binding_assignment(FileId(0), Lang::Java);
+        add_import_binding_evidence(&mut il, span, EvidenceStatus::Ambiguous);
+
+        assert_eq!(
+            import_binding_key(&il, assign),
+            None,
+            "ambiguous import evidence must close the imported literal rewrite"
+        );
+    }
+
+    #[test]
+    fn snapshot_append_does_not_mint_import_or_symbol_evidence_from_raw_seq() {
+        let (provider, _interner, _span, assign, _rhs) =
+            raw_import_binding_assignment(FileId(0), Lang::Java);
+        let snapshot = snapshot_subtree(&provider, assign);
+
+        let mut b = IlBuilder::new(FileId(1));
+        let root_span = Span::new(FileId(1), 0, 0, 1, 1);
+        let root = b.add(NodeKind::Module, Payload::None, root_span, &[]);
+        let mut importer = b.finish(
+            root,
+            FileMeta {
+                path: "consumer.java".into(),
                 lang: Lang::Java,
             },
             Vec::new(),
             Vec::new(),
         );
 
-        mirror_import_fact_evidence_for_assignment(&mut il, &interner, assign);
+        let appended = append_snapshot(&mut importer, &snapshot);
+        assert!(
+            appended.evidence.is_empty(),
+            "snapshot append must copy provider evidence, not synthesize import facts from raw tags"
+        );
+        assert_eq!(importer.kind(appended.root), NodeKind::Assign);
+    }
 
-        assert!(il.evidence.iter().any(|record| matches!(
-            record.kind,
-            EvidenceKind::Import(ImportEvidenceKind::Binding {
-                module_hash,
-                exported_hash,
-            }) if record.anchor == EvidenceAnchor::sequence(span)
-                && module_hash == stable_symbol_hash("java.util")
-                && exported_hash == stable_symbol_hash("Map")
-        )));
-        assert!(il.evidence.iter().any(|record| matches!(
-            record.kind,
-            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
-                module_hash,
-                exported_hash,
-            }) if record.anchor == EvidenceAnchor::binding(span, stable_symbol_hash("Map"))
-                && module_hash == stable_symbol_hash("java.util")
-                && exported_hash == stable_symbol_hash("Map")
-        )));
+    #[test]
+    fn snapshot_append_copies_relevant_evidence_with_remapped_file_spans() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let span = Span::new(FileId(0), 4, 12, 1, 1);
+        let lookup = interner.intern("LOOKUP");
+        let lhs = b.add(NodeKind::Var, Payload::Name(lookup), span, &[]);
+        let tag = interner.intern("dictionary");
+        let rhs = b.add(NodeKind::Seq, Payload::Name(tag), span, &[]);
+        let assign = b.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs]);
+        let root = b.add(NodeKind::Module, Payload::None, span, &[assign]);
+        let mut provider = b.finish(
+            root,
+            FileMeta {
+                path: "tables.py".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        provider.evidence.push(EvidenceRecord {
+            id: EvidenceId(0),
+            anchor: EvidenceAnchor::sequence(span),
+            kind: EvidenceKind::SequenceSurface(SequenceSurfaceKind::Map),
+            provenance: test_provenance("surface"),
+            dependencies: Vec::new(),
+            status: EvidenceStatus::Asserted,
+        });
+        provider.evidence.push(EvidenceRecord {
+            id: EvidenceId(1),
+            anchor: EvidenceAnchor::node(span, NodeKind::Seq),
+            kind: EvidenceKind::Import(ImportEvidenceKind::ImmutableLiteralExport {
+                module_hash: stable_symbol_hash("tables"),
+                exported_hash: stable_symbol_hash("LOOKUP"),
+                root_kind: NodeKind::Seq,
+            }),
+            provenance: test_provenance("export"),
+            dependencies: vec![EvidenceId(0)],
+            status: EvidenceStatus::Asserted,
+        });
+        provider.evidence.push(EvidenceRecord {
+            id: EvidenceId(2),
+            anchor: EvidenceAnchor::binding(span, stable_symbol_hash("LOOKUP")),
+            kind: EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+                module_hash: stable_symbol_hash("tables"),
+                exported_hash: stable_symbol_hash("LOOKUP"),
+            }),
+            provenance: test_provenance("symbol"),
+            dependencies: vec![EvidenceId(0)],
+            status: EvidenceStatus::Asserted,
+        });
+        provider.evidence.push(EvidenceRecord {
+            id: EvidenceId(3),
+            anchor: EvidenceAnchor::sequence(span),
+            kind: EvidenceKind::SequenceSurface(SequenceSurfaceKind::Map),
+            provenance: test_provenance("ambiguous_surface"),
+            dependencies: Vec::new(),
+            status: EvidenceStatus::Ambiguous,
+        });
+        let snapshot = snapshot_subtree(&provider, assign);
+
+        let mut b = IlBuilder::new(FileId(1));
+        let root_span = Span::new(FileId(1), 0, 0, 1, 1);
+        let root = b.add(NodeKind::Module, Payload::None, root_span, &[]);
+        let mut importer = b.finish(
+            root,
+            FileMeta {
+                path: "consumer.py".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        let appended = append_snapshot(&mut importer, &snapshot);
+
+        assert_eq!(appended.evidence.len(), 3);
+        assert!(
+            importer
+                .evidence
+                .iter()
+                .all(|record| record.status == EvidenceStatus::Asserted),
+            "snapshot append must not copy ambiguous evidence into asserted provenance dependencies"
+        );
+        let copied_surface = importer
+            .evidence
+            .iter()
+            .find(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::SequenceSurface(SequenceSurfaceKind::Map)
+                )
+            })
+            .unwrap();
+        assert_eq!(
+            copied_surface.anchor,
+            EvidenceAnchor::sequence(Span::new(FileId(1), 4, 12, 1, 1))
+        );
+        assert_eq!(copied_surface.provenance, test_provenance("surface"));
+
+        let copied_export = importer
+            .evidence
+            .iter()
+            .find(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::Import(ImportEvidenceKind::ImmutableLiteralExport { .. })
+                )
+            })
+            .unwrap();
+        assert_eq!(copied_export.dependencies, vec![copied_surface.id]);
+    }
+
+    #[test]
+    fn resolve_imported_literal_records_snapshot_provenance_dependencies() {
+        let interner = Interner::new();
+        let provider_span = Span::new(FileId(0), 4, 24, 1, 1);
+        let lookup = interner.intern("LOOKUP");
+        let mut b = IlBuilder::new(FileId(0));
+        let lhs = b.add(NodeKind::Var, Payload::Name(lookup), provider_span, &[]);
+        let key = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("red")),
+            provider_span,
+            &[],
+        );
+        let value = b.add(NodeKind::Lit, Payload::LitInt(1), provider_span, &[]);
+        let tag = interner.intern("dictionary");
+        let rhs = b.add(
+            NodeKind::Seq,
+            Payload::Name(tag),
+            provider_span,
+            &[key, value],
+        );
+        let assign = b.add(NodeKind::Assign, Payload::None, provider_span, &[lhs, rhs]);
+        let root = b.add(NodeKind::Module, Payload::None, provider_span, &[assign]);
+        let mut provider = b.finish(
+            root,
+            FileMeta {
+                path: "tables.py".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        provider.evidence.push(EvidenceRecord {
+            id: EvidenceId(0),
+            anchor: EvidenceAnchor::sequence(provider_span),
+            kind: EvidenceKind::SequenceSurface(SequenceSurfaceKind::Map),
+            provenance: test_provenance("provider_surface"),
+            dependencies: Vec::new(),
+            status: EvidenceStatus::Asserted,
+        });
+
+        let import_span = Span::new(FileId(1), 0, 24, 1, 1);
+        let mut b = IlBuilder::new(FileId(1));
+        let lhs = b.add(NodeKind::Var, Payload::Name(lookup), import_span, &[]);
+        let module = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("tables")),
+            import_span,
+            &[],
+        );
+        let exported = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("LOOKUP")),
+            import_span,
+            &[],
+        );
+        let import_tag = interner.intern(nose_semantics::import_fact_tag(ImportFactKind::Binding));
+        let import_rhs = b.add(
+            NodeKind::Seq,
+            Payload::Name(import_tag),
+            import_span,
+            &[module, exported],
+        );
+        let import_assign = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            import_span,
+            &[lhs, import_rhs],
+        );
+        let root = b.add(
+            NodeKind::Module,
+            Payload::None,
+            import_span,
+            &[import_assign],
+        );
+        let mut importer = b.finish(
+            root,
+            FileMeta {
+                path: "consumer.py".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        importer.evidence.push(EvidenceRecord {
+            id: EvidenceId(0),
+            anchor: EvidenceAnchor::sequence(import_span),
+            kind: EvidenceKind::Import(ImportEvidenceKind::Binding {
+                module_hash: stable_symbol_hash("tables"),
+                exported_hash: stable_symbol_hash("LOOKUP"),
+            }),
+            provenance: test_provenance("import"),
+            dependencies: Vec::new(),
+            status: EvidenceStatus::Asserted,
+        });
+
+        let mut files = vec![provider, importer];
+        resolve_imported_immutable_bindings(&mut files, &interner);
+        let replaced_rhs = assignment_rhs(&files[1], import_assign).unwrap();
+
+        assert_eq!(files[1].kind(replaced_rhs), NodeKind::Seq);
+        let provenance = files[1]
+            .evidence
+            .iter()
+            .find(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::Import(ImportEvidenceKind::ImportedLiteralSnapshot {
+                        module_hash,
+                        exported_hash,
+                        root_kind: NodeKind::Seq,
+                    }) if module_hash == stable_symbol_hash("tables")
+                        && exported_hash == stable_symbol_hash("LOOKUP")
+                )
+            })
+            .unwrap();
+        assert!(
+            provenance.dependencies.contains(&EvidenceId(0)),
+            "snapshot provenance must depend on the importer static import proof"
+        );
+        assert!(
+            provenance.dependencies.iter().any(|id| {
+                files[1].evidence.get(id.0 as usize).is_some_and(|record| {
+                    matches!(
+                        record.kind,
+                        EvidenceKind::SequenceSurface(SequenceSurfaceKind::Map)
+                    )
+                })
+            }),
+            "snapshot provenance must depend on copied provider surface evidence"
+        );
+        assert!(
+            provenance.dependencies.iter().any(|id| {
+                files[1].evidence.get(id.0 as usize).is_some_and(|record| {
+                    matches!(
+                        record.kind,
+                        EvidenceKind::Import(ImportEvidenceKind::ImmutableLiteralExport {
+                            module_hash,
+                            exported_hash,
+                            root_kind: NodeKind::Seq,
+                        }) if module_hash == stable_symbol_hash("tables")
+                            && exported_hash == stable_symbol_hash("LOOKUP")
+                    )
+                })
+            }),
+            "snapshot provenance must depend on copied provider export evidence"
+        );
     }
 }

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -302,6 +302,16 @@ pub enum ImportEvidenceKind {
     Namespace {
         module_hash: u64,
     },
+    ImmutableLiteralExport {
+        module_hash: u64,
+        exported_hash: u64,
+        root_kind: NodeKind,
+    },
+    ImportedLiteralSnapshot {
+        module_hash: u64,
+        exported_hash: u64,
+        root_kind: NodeKind,
+    },
 }
 
 /// Kernel-facing proof that a source-level symbol denotes a specific global or

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -54,17 +54,17 @@ use nose_semantics::{
     exact_static_membership_predicate_operator, free_function_builtin_contract,
     go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
     go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract, import_fact_evidence_rhs,
-    imported_namespace_symbol, library_api_free_name_shadow_safe,
-    library_free_name_collection_factory_contracts, library_free_name_map_factory_contracts,
-    library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
-    library_iterator_identity_adapter_contract, library_java_collection_factory_contract_by_hash,
-    library_java_map_entry_contract_by_hash, library_java_map_factory_contract_by_hash,
-    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
-    library_map_get_contract_by_hash, library_map_key_view_contract_by_hash,
-    library_map_key_view_wrapper_contract_by_hash, library_method_call_contract,
-    library_ruby_set_factory_contract_by_hash, library_rust_vec_macro_factory_contract,
-    library_rust_vec_new_factory_contract, nullish_global_contract,
-    own_property_guard_evidence_at_span, qualified_global_symbol_at_span,
+    imported_literal_producer_evidence_at_span, imported_namespace_symbol,
+    library_api_free_name_shadow_safe, library_free_name_collection_factory_contracts,
+    library_free_name_map_factory_contracts, library_imported_collection_factory_contracts,
+    library_imported_namespace_function_contract, library_iterator_identity_adapter_contract,
+    library_java_collection_factory_contract_by_hash, library_java_map_entry_contract_by_hash,
+    library_java_map_factory_contract_by_hash, library_js_like_map_constructor_contract,
+    library_js_like_set_constructor_contract, library_map_get_contract_by_hash,
+    library_map_key_view_contract_by_hash, library_map_key_view_wrapper_contract_by_hash,
+    library_method_call_contract, library_ruby_set_factory_contract_by_hash,
+    library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
+    nullish_global_contract, own_property_guard_evidence_at_span, qualified_global_symbol_at_span,
     record_shape_guard_for_node, reduction_builtin_contract, rust_option_and_then_contract,
     rust_option_none_sentinel_contract, rust_option_some_constructor_contract,
     scalar_integer_method_contract, semantics, seq_surface_contract_for_node,
@@ -1392,7 +1392,8 @@ impl<'a> Builder<'a> {
         else {
             return None;
         };
-        if !self.is_imported_java_util_name(callee.args[0], expected_receiver) {
+        let provider_proven = self.imported_literal_producer_proven(value, NodeKind::Call);
+        if !provider_proven && !self.is_imported_java_util_name(callee.args[0], expected_receiver) {
             return None;
         }
         let LibraryMapFactoryResult::JavaFactory { kind } = contract.result else {
@@ -1412,7 +1413,7 @@ impl<'a> Builder<'a> {
         if kind == JavaMapFactoryKind::OfEntries {
             let mut canonical_entries = Vec::with_capacity(args.len().saturating_sub(1));
             for entry in args.iter().skip(1).copied() {
-                let kv = self.proven_java_map_entry_pair(entry)?;
+                let kv = self.proven_java_map_entry_pair(entry, provider_proven)?;
                 canonical_entries.push(self.mk(ValOp::Seq(SEQ_VALUE_PAIR), kv));
             }
             return Some(self.mk(ValOp::Seq(SEQ_VALUE_MAP), canonical_entries));
@@ -1420,7 +1421,11 @@ impl<'a> Builder<'a> {
         None
     }
 
-    fn proven_java_map_entry_pair(&self, value: ValueId) -> Option<Vec<ValueId>> {
+    fn proven_java_map_entry_pair(
+        &self,
+        value: ValueId,
+        provider_proven: bool,
+    ) -> Option<Vec<ValueId>> {
         let node = &self.nodes[value as usize];
         if !matches!(node.op, ValOp::Call(0)) || node.args.len() != 3 {
             return None;
@@ -1438,12 +1443,18 @@ impl<'a> Builder<'a> {
         else {
             return None;
         };
-        if callee.args.len() != 1
-            || !self.is_imported_java_util_name(callee.args[0], expected_receiver)
-        {
+        if callee.args.len() != 1 {
+            return None;
+        }
+        if !provider_proven && !self.is_imported_java_util_name(callee.args[0], expected_receiver) {
             return None;
         }
         Some(args[1..].to_vec())
+    }
+
+    fn imported_literal_producer_proven(&self, value: ValueId, kind: NodeKind) -> bool {
+        self.node_span[value as usize]
+            .is_some_and(|span| imported_literal_producer_evidence_at_span(self.il, span, kind))
     }
 
     fn eval_js_like_constructed_collection_or_map(

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -7,11 +7,11 @@
 //! approve exact clone matches directly.
 
 use nose_il::{
-    contains_js_identifier, stable_symbol_hash, Builtin, EvidenceAnchor, EvidenceKind,
-    EvidenceRecord, EvidenceStatus, GuardEvidenceKind, HoFKind, Il, ImportEvidenceKind, Interner,
-    Lang, LitClass, NodeId, NodeKind, Op, ParamSemantic, Payload, SequenceSurfaceKind,
-    SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind, Span,
-    SymbolEvidenceKind,
+    contains_js_identifier, stable_symbol_hash, Builtin, EvidenceAnchor, EvidenceEmitter,
+    EvidenceId, EvidenceKind, EvidenceRecord, EvidenceStatus, GuardEvidenceKind, HoFKind, Il,
+    ImportEvidenceKind, Interner, Lang, LitClass, NodeId, NodeKind, Op, ParamSemantic, Payload,
+    SequenceSurfaceKind, SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
+    Span, SymbolEvidenceKind,
 };
 
 pub use nose_il::DomainEvidence;
@@ -387,6 +387,30 @@ pub fn seq_surface_contract_for_node(
         }
         EvidenceResolution::Ambiguous => None,
         EvidenceResolution::Missing => seq_surface_contract(il.meta.lang, raw_tag),
+    }
+}
+
+/// Evidence-only `Seq` surface resolution for consumers that must not infer a
+/// semantic surface from tag spelling alone.
+pub fn seq_surface_contract_evidence_for_node(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<SeqSurfaceContract> {
+    if il.kind(node) != NodeKind::Seq {
+        return None;
+    }
+    let raw_tag = match il.node(node).payload {
+        Payload::None => None,
+        Payload::Name(name) => Some(interner.resolve(name)),
+        _ => return None,
+    };
+    let (raw_kind, raw_contract) = seq_surface_contract_for_tag(il.meta.lang, raw_tag)?;
+    match sequence_surface_evidence_at_sequence_span(il, il.node(node).span) {
+        EvidenceResolution::Found(kind) if kind == raw_kind => Some(raw_contract),
+        EvidenceResolution::Found(_)
+        | EvidenceResolution::Ambiguous
+        | EvidenceResolution::Missing => None,
     }
 }
 
@@ -769,6 +793,66 @@ pub fn import_fact_evidence_rhs(il: &Il, rhs: NodeId) -> Option<ImportFact> {
         EvidenceResolution::Found(fact) => Some(fact),
         EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
     }
+}
+
+/// Prove that `span/kind` is a first-party imported-literal producer or copied
+/// snapshot whose recorded dependencies are all asserted. This proof preserves a
+/// provider-scope literal producer after cross-file replacement; consumers must
+/// still check the expression shape/result contract they are about to build.
+pub fn imported_literal_producer_evidence_at_span(il: &Il, span: Span, kind: NodeKind) -> bool {
+    il.evidence.iter().any(|record| {
+        record.status == EvidenceStatus::Asserted
+            && first_party_record(record)
+            && record.anchor == EvidenceAnchor::node(span, kind)
+            && matches!(
+                record.kind,
+                EvidenceKind::Import(
+                    ImportEvidenceKind::ImmutableLiteralExport {
+                        root_kind,
+                        ..
+                    } | ImportEvidenceKind::ImportedLiteralSnapshot {
+                        root_kind,
+                        ..
+                    }
+                ) if root_kind == kind
+            )
+            && evidence_dependencies_asserted(il, record)
+    })
+}
+
+pub fn imported_literal_producer_evidence_for_node(il: &Il, node: NodeId) -> bool {
+    imported_literal_producer_evidence_at_span(il, il.node(node).span, il.kind(node))
+}
+
+fn first_party_record(record: &EvidenceRecord) -> bool {
+    record.provenance.emitter == EvidenceEmitter::FirstParty
+        && record.provenance.pack_hash == Some(stable_symbol_hash(FIRST_PARTY_PACK_ID))
+}
+
+fn evidence_dependencies_asserted(il: &Il, record: &EvidenceRecord) -> bool {
+    let mut stack = record.dependencies.clone();
+    let mut seen = Vec::new();
+    while let Some(id) = stack.pop() {
+        if seen.contains(&id) {
+            continue;
+        }
+        seen.push(id);
+        let Some(dep) = evidence_record_by_id(il, id) else {
+            return false;
+        };
+        if dep.status != EvidenceStatus::Asserted {
+            return false;
+        }
+        stack.extend_from_slice(&dep.dependencies);
+    }
+    true
+}
+
+fn evidence_record_by_id(il: &Il, id: EvidenceId) -> Option<&EvidenceRecord> {
+    il.evidence
+        .get(id.0 as usize)
+        .filter(|record| record.id == id)
+        .or_else(|| il.evidence.iter().find(|record| record.id == id))
 }
 
 pub fn import_fact_rhs(il: &Il, interner: &Interner, rhs: NodeId) -> Option<ImportFact> {

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -58,7 +58,7 @@ The current implemented kinds are:
 |---|---|
 | `Source` | construct syntax, regex literal provenance, and source operator family |
 | `Domain` | receiver/value domain such as collection, map, option, string, integer, or byte array |
-| `Import` | static import binding and namespace proof |
+| `Import` | static import binding/namespace proof and imported-literal snapshot provenance |
 | `Symbol` | resolved or proven symbol identity, with record kinds for unshadowed globals, static imported binding/namespace aliases, and selected qualified global API paths |
 | `Guard` | multi-obligation guard proof facts such as JS/TS record-shape and own-property guard contracts |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, guard surfaces, Go composite map literals, or Go map entries |
@@ -163,8 +163,12 @@ callers:
 
 - source-fact lookup for construct syntax, regex literal, and operator provenance;
 - parameter domain lookup used by normalize and strict exact receiver gates;
-- import proof parsing for compatibility helpers and imported literal
-  replacement, with value-graph import identity consuming evidence-only facts;
+- import proof parsing for compatibility helpers, with value-graph import
+  identity and imported literal replacement consuming evidence-only facts;
+- cross-file imported literal replacement copies the provider's closed evidence
+  subgraph into the importer with remapped anchors/dependency ids, then records
+  `Import(ImportedLiteralSnapshot)` provenance that depends on the importer
+  import proof and copied provider evidence;
 - imported namespace/binding symbol proof for normalize idiom admission,
   value-graph namespace fallbacks, and strict exact gates, without raw assignment
   fallback;
@@ -201,5 +205,5 @@ callers:
 
 Field/place/effect facts, receiver/protocol evidence beyond parameter domains,
 full scope-resolution and namespace-member evidence, broader guard evidence,
-cross-module imported-literal snapshot provenance and evidence copying,
-report-level provenance, and external manifest loading are still open work.
+general cross-module dependency manifests, report-level provenance, and external
+manifest loading are still open work.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -113,9 +113,13 @@ and pack ecosystem.
 - Java stream source adapters are now proof-gated: receiver `.stream()` requires
   exact iterable evidence, and static `Arrays.stream(xs)` requires the
   `java.util.Arrays` import binding with no local `Arrays` type shadow.
-- Cross-file immutable import replacement now copies import-binding dependencies
-  required by the exported literal expression, preserving provider-side stdlib
-  proofs such as `java.util.Map` for Java static imports.
+- Cross-file immutable import replacement now copies the provider's closed
+  evidence subgraph required by the exported literal expression, preserving
+  provider-side stdlib proofs such as `java.util.Map` for Java static imports
+  only when that provider evidence exists. Replacement records
+  `ImportedLiteralSnapshot` provenance depending on the importer static import
+  proof and copied provider evidence, and raw `Seq("import_binding")` spelling
+  no longer proves cross-file replacement.
 - JS-like `Map`/`Set` constructor contracts now require construct-syntax proof.
   They were initially closed while construct-vs-call evidence was missing; the
   source-fact slice reopened proof-backed `new Map(...)`/`new Set(...)` while
@@ -195,6 +199,11 @@ and pack ecosystem.
   imported immutable literal replacement, normalize idiom gates, value-graph
   import proof, and strict exact gates initially moved behind that shared facade
   instead of parsing raw import `Seq` tags locally.
+- Imported immutable literal replacement now consumes evidence-only import facts,
+  copies provider evidence with remapped anchors/dependency ids, and records
+  `ImportedLiteralSnapshot` provenance. This closes raw import-tag fallback and
+  missing-provider-proof cases such as Java `Map.of(...)` without
+  `import java.util.Map`.
 - TypeScript type-only imports no longer emit runtime import facts: whole
   `import type ...` declarations and type-only named specifiers stay outside
   exact library/API proof.
@@ -339,16 +348,16 @@ Remaining in this phase:
 - Keep value-graph and strict exact gates on the same contract source. Factory,
   constructor, and selected method/view/adapter gates now share
   `LibraryApiContract` identity/result rows. Remaining API work is to move
-  imported-literal producer provenance and other raw sequence/tag dependencies
-  into explicit evidence records, then cover broader reduction/HOF and ecosystem
-  APIs only after demand, receiver, and effect obligations are expressible.
+  remaining raw sequence/tag dependencies into explicit evidence records, then
+  cover broader reduction/HOF and ecosystem APIs only after demand, receiver,
+  and effect obligations are expressible.
 - Remove the remaining raw import/module proof IL payload storage after import
   and symbol evidence records can carry every consumer obligation, including
   module export dependencies, scope, rebinding, and mutation proof. Value-graph
   import identity and imported-symbol exact proof are now evidence-only, and
-  selected JS/TS `QualifiedGlobal` paths are covered, but general
-  qualified-member, namespace export identity, and cross-module dependency
-  evidence are not.
+  imported literal replacement copies provider evidence, and selected JS/TS
+  `QualifiedGlobal` paths are covered, but general qualified-member, namespace
+  export identity, and manifest-level cross-module dependency evidence are not.
 - Generalize dedicated guard evidence beyond the first JS/TS record-shape and
   own-property contracts, including richer source-clause records, API dependency
   validation, subject/place identity, and truthiness/null semantics.

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -167,11 +167,15 @@ migrated.
   `receiver.stream()` requires an exact iterable receiver, while
   `Arrays.stream(xs)` requires the `java.util.Arrays` import binding and no local
   `Arrays` type shadow.
-- Cross-file immutable import replacement now preserves import-binding
-  dependencies used by the exported literal expression, so a Java static import
+- Cross-file immutable import replacement now copies the provider's closed
+  evidence subgraph for the exported literal expression, so a Java static import
   of `LOOKUP = Map.of(...)` carries the provider's `java.util.Map` proof into
-  the importing file. Provider and importer module-binding mutation proof now
-  rejects direct binding mutations and direct place writes such as
+  the importing file only when the provider emitted that import proof. The
+  copied evidence remaps anchors/dependency ids to the importer file, and the
+  replacement records `ImportedLiteralSnapshot` provenance depending on the
+  importer static import proof plus copied provider evidence. Provider and
+  importer module-binding mutation proof now rejects direct binding mutations
+  and direct place writes such as
   `LOOKUP.clear()`, `LOOKUP.push(...)`, and `LOOKUP[key] = value`, and
   provider-side opaque argument escapes such as `mutate(LOOKUP)`, before
   imported literal provenance can enter exact matching.
@@ -268,8 +272,10 @@ migrated.
   namespace facts through that contract. Value-graph import identity consumes
   sequence `Import` evidence into dedicated `ImportNamespace`/`ImportBinding`
   value ops, so raw import `Seq` payloads can no longer become proof-bearing
-  value nodes by tag shape. Imported literal replacement still uses the typed
-  compatibility helper while raw IL mirrors remain.
+  value nodes by tag shape. Imported literal replacement also consumes
+  evidence-only import facts; raw `Seq("import_binding")` payloads remain as
+  compatibility mirrors, but missing or ambiguous `Import` evidence no longer
+  proves a cross-file replacement.
 - Symbol identity evidence now covers static imported binding/namespace aliases
   and JS/TS static-global value occurrences such as `Math`, `console`, `Array`,
   `Map`, `Set`, and `undefined` when the frontend proves no local shadow.
@@ -311,13 +317,14 @@ Semantic knowledge still appears in several forms outside the facade:
   open;
 - IL still stores import facts as `Seq("import_binding")` /
   `Seq("import_namespace")` payloads for compatibility. Frontends also emit
-  `EvidenceRecord::Import`, and value-graph import identity is now evidence-only,
-  but the raw IL storage shape and some compatibility consumers have not been
-  removed;
-- module/import proof logic for immutable sibling-module literal bindings;
-- imported-literal snapshot provenance and evidence copying for cross-file
-  replacement, especially avoiding raw import `Seq` fallback when provider
-  evidence is missing or ambiguous;
+  `EvidenceRecord::Import`, and value-graph import identity plus imported
+  literal replacement are now evidence-only, but the raw IL storage shape and
+  some compatibility consumers have not been removed;
+- module/import proof logic for immutable sibling-module literal bindings is
+  still local to `nose-frontend`, although replacement now copies the provider's
+  closed evidence subgraph into the importer, remaps spans/dependency ids, and
+  records `ImportedLiteralSnapshot` provenance tied to the importer static
+  import proof;
 - type facts and coarse type inference used to gate numeric and collection laws;
 - named value-graph rule modules that still consume internal `Builder` facts
   instead of versioned `LawPack` records;


### PR DESCRIPTION
## Summary

- make corpus-level imported literal replacement consume evidence-only import facts instead of raw `Seq("import_binding")` payloads
- copy provider evidence into imported literal snapshots with remapped spans/dependency ids, record `ImmutableLiteralExport` and `ImportedLiteralSnapshot` provenance, and require asserted first-party dependencies when consumers reuse provider-proven producers
- route Java/Rust imported literal producer checks through `LibraryApiContract` identity and preserve provider-side Java `java.util.Map` proof without revalidating it against importer-local shadows
- document the updated snapshot/roadmap/evidence-record state

## Precision/recall notes

- raw import tags and ambiguous import/surface evidence now fail closed for imported literal replacement
- Java `Map.of(...)` providers without `import java.util.Map` stay distinct
- provider-proven Java `Map.of(...)` imported through a static literal binding remains recognized even if the importer declares an unrelated `class Map`

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --release`
- `cargo test --release`
- `awiki lint --root docs`
- `git diff --check`
- `./scripts/check-duplication.sh`
- `python3 scripts/check-formal-obligations.py --self-test`
- `python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`

Progresses #109.
