### PR TITLE
semantics: add effect/place evidence substrate

### DIFF
--- a/crates/nose-detect/src/fragment/conditional_guard.rs
+++ b/crates/nose-detect/src/fragment/conditional_guard.rs
@@ -11,8 +11,8 @@ use super::oracle::free_input_cids;
 use super::{Exit, FragmentKind};
 use nose_il::{Il, Interner, NodeId, NodeKind, Payload};
 use nose_semantics::{
-    builder_append_call_args, exact_java_this_field, exact_non_overloadable_index_assignment,
-    exact_non_overloadable_index_assignment_parts, semantics,
+    builder_append_call_args, exact_non_overloadable_index_assignment,
+    exact_non_overloadable_index_assignment_parts, exact_self_field_write_assignment, semantics,
 };
 use rustc_hash::FxHashSet;
 
@@ -506,12 +506,7 @@ fn assignment_effect_site(il: &Il, interner: &Interner, node: NodeId) -> Option<
 
 fn self_field_assignment_site(il: &Il, interner: &Interner, node: NodeId) -> Option<EffectSite> {
     let kids = il.children(node);
-    if semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        && kids.len() == 2
-        && exact_java_this_field(il, interner, kids[0])
-    {
+    if kids.len() == 2 && exact_self_field_write_assignment(il, interner, node) {
         let place = super::recognize::resolve_place(il, interner, kids[0]);
         return place
             .is_exact_safe()

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -17,7 +17,10 @@ use super::contract::{Effect, EffectSite, FragmentContract};
 use super::oracle::free_input_cids;
 use super::{Exit, FragmentKind, Place};
 use nose_il::{stable_symbol_hash, Il, Interner, NodeId, NodeKind, Payload};
-use nose_semantics::{builder_append_call, exact_java_this_field, exact_java_this_var, semantics};
+use nose_semantics::{
+    builder_append_call, exact_java_this_var, exact_non_overloadable_index_assignment,
+    exact_self_field_write_assignment,
+};
 
 /// Fragment kinds that have been migrated onto the contract path. The differential gate
 /// compares the predicate and contract paths over exactly this set; everything outside it
@@ -105,11 +108,7 @@ fn recognize_assignment_effect(
         return None;
     }
     let target = kids[0];
-    if semantics(il.meta.lang)
-        .exact_fragments()
-        .non_overloadable_index_assignment()
-        && il.kind(target) == NodeKind::Index
-    {
+    if exact_non_overloadable_index_assignment(il, node) {
         // An index write is observable in the effect trace (key and value are recorded), so
         // it carries no receiver-identity obligation and records no `Place` on the contract.
         // The write target is identity, not proof; surfacing it is a separate diagnostic
@@ -121,11 +120,7 @@ fn recognize_assignment_effect(
             EffectSite::observable(Effect::IndexWrite),
         ));
     }
-    if semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        && exact_java_this_field(il, interner, target)
-    {
+    if exact_self_field_write_assignment(il, interner, node) {
         let place = resolve_place(il, interner, target);
         // Field-write final state is keyed by receiver+field place, so the write is exact-safe
         // only with a proven receiver. The `this.field` recognizer guarantees this; assert the
@@ -226,7 +221,10 @@ mod tests {
     use super::*;
     use crate::fragment::{fragment_behavior, Place};
     use crate::units::{build_parent_index, exact_statement_fragment_root};
-    use nose_il::{FileId, Lang, Span};
+    use nose_il::{
+        EffectEvidenceKind, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
+        EvidenceProvenance, EvidenceRecord, EvidenceStatus, FileId, Lang, Span,
+    };
     use nose_normalize::{normalize, NormalizeOptions, Value};
 
     /// Walk `il` exactly as the real fragment collector does (skipping `Lambda` subtrees),
@@ -313,6 +311,38 @@ mod tests {
         );
     }
 
+    fn index_assignment_node(il: &Il) -> NodeId {
+        il.nodes
+            .iter()
+            .enumerate()
+            .find_map(|(idx, node)| {
+                let id = NodeId(idx as u32);
+                (node.kind == NodeKind::Assign
+                    && il
+                        .children(id)
+                        .first()
+                        .is_some_and(|&target| il.kind(target) == NodeKind::Index))
+                .then_some(id)
+            })
+            .expect("fixture should contain an index assignment")
+    }
+
+    fn add_effect_evidence(il: &mut Il, node: NodeId, kind: EffectEvidenceKind) {
+        let id = EvidenceId(il.evidence.len() as u32);
+        il.evidence.push(EvidenceRecord {
+            id,
+            anchor: EvidenceAnchor::node(il.node(node).span, il.kind(node)),
+            kind: EvidenceKind::Effect(kind),
+            provenance: EvidenceProvenance {
+                emitter: EvidenceEmitter::External,
+                pack_hash: None,
+                rule_hash: None,
+            },
+            dependencies: Vec::new(),
+            status: EvidenceStatus::Asserted,
+        });
+    }
+
     #[test]
     fn differential_direct_return_and_throw() {
         // Accepted: top-level computed return / throw.
@@ -354,6 +384,41 @@ mod tests {
         // Expression-statement effect: an append/push call.
         assert_paths_agree("function f(xs, v){ xs.push(v + 1); }", Lang::JavaScript);
         assert_paths_agree("def f(xs, v):\n    xs.append(v + 1)\n", Lang::Python);
+    }
+
+    #[test]
+    fn index_assignment_contract_uses_effect_evidence_gate() {
+        let interner = Interner::new();
+        let raw = nose_frontend::lower_source(
+            FileId(0),
+            "t",
+            b"class C { int[] a; void f(int i, int v){ a[i] = v; } }",
+            Lang::Java,
+            &interner,
+        )
+        .expect("lowering should succeed");
+        let mut il = normalize(&raw, &interner, &NormalizeOptions::default());
+        let parents = build_parent_index(&il);
+        let assign = index_assignment_node(&il);
+        assert_eq!(
+            exact_statement_fragment_root(&il, assign, &parents, &interner),
+            Some(FragmentKind::IndexAssignEffect)
+        );
+        assert_eq!(
+            recognize_contract(&il, assign, &parents, &interner).map(|contract| contract.kind),
+            Some(FragmentKind::IndexAssignEffect)
+        );
+
+        add_effect_evidence(
+            &mut il,
+            assign,
+            EffectEvidenceKind::SelfFieldWrite { field_hash: 1 },
+        );
+        assert_eq!(
+            exact_statement_fragment_root(&il, assign, &parents, &interner),
+            None
+        );
+        assert!(recognize_contract(&il, assign, &parents, &interner).is_none());
     }
 
     #[test]

--- a/crates/nose-detect/src/fragment/self_field_body.rs
+++ b/crates/nose-detect/src/fragment/self_field_body.rs
@@ -11,7 +11,7 @@ use super::contract::{Effect, EffectSite, FragmentContract};
 use super::oracle::free_input_cids;
 use super::{Exit, FragmentKind};
 use nose_il::{Il, Interner, NodeId, NodeKind};
-use nose_semantics::{exact_java_return_this, exact_java_this_field, semantics};
+use nose_semantics::{exact_java_return_this, exact_self_field_write_assignment};
 
 pub(crate) fn recognize_self_field_body(
     il: &Il,
@@ -19,11 +19,7 @@ pub(crate) fn recognize_self_field_body(
     parents: &[Option<NodeId>],
     node: NodeId,
 ) -> Option<FragmentContract> {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        || il.kind(node) != NodeKind::Block
-    {
+    if il.kind(node) != NodeKind::Block {
         return None;
     }
     let func = parents.get(node.0 as usize).copied().flatten()?;
@@ -117,7 +113,7 @@ fn self_field_assign(
     effects: &mut Vec<EffectSite>,
 ) -> Option<()> {
     let kids = il.children(node);
-    if kids.len() != 2 || !exact_java_this_field(il, interner, kids[0]) {
+    if kids.len() != 2 || !exact_self_field_write_assignment(il, interner, node) {
         return None;
     }
     let place = super::recognize::resolve_place(il, interner, kids[0]);

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -15,8 +15,8 @@ use nose_normalize::{
 use nose_semantics::{
     builder_append_call_args, construct_syntax_proof,
     domain_evidence_for_param as semantic_domain_evidence_for_param, exact_java_return_this,
-    exact_java_this_field, exact_non_overloadable_index_assignment,
-    exact_non_overloadable_index_assignment_parts, exact_static_membership_predicate_operator,
+    exact_non_overloadable_index_assignment, exact_non_overloadable_index_assignment_parts,
+    exact_self_field_write_assignment, exact_static_membership_predicate_operator,
     go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
     go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract, imported_binding_symbol,
     imported_literal_producer_evidence_for_node, imported_member_symbol,
@@ -3309,15 +3309,7 @@ fn exact_index_assignment_fragment_root(il: &Il, node: NodeId) -> bool {
 // `this.field = ...`; arbitrary receivers such as `other.field = ...` need a
 // receiver-place proof fact before they can be exact fragments.
 fn exact_self_field_assignment_fragment_root(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        || il.kind(node) != NodeKind::Assign
-    {
-        return false;
-    }
-    let kids = il.children(node);
-    kids.len() == 2 && exact_java_this_field(il, interner, kids[0])
+    exact_self_field_write_assignment(il, interner, node)
 }
 
 fn exact_java_return_this_fragment_root(il: &Il, interner: &Interner, node: NodeId) -> bool {

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -3,11 +3,11 @@
 //! mechanics live in one place.
 
 use nose_il::{
-    stable_symbol_hash, DomainEvidence, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
-    EvidenceProvenance, EvidenceRecord, EvidenceStatus, FileId, FileMeta, Il, IlBuilder,
-    ImportEvidenceKind, Interner, Lang, LoopKind, NodeId, NodeKind, Op, ParamSemantic,
-    ParamTypeFact, Payload, SourceFact, SourceFactKind, Span, Symbol, SymbolEvidenceKind, Unit,
-    UnitKind,
+    stable_symbol_hash, Builtin, DomainEvidence, EffectEvidenceKind, EvidenceAnchor,
+    EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance, EvidenceRecord, EvidenceStatus,
+    FileId, FileMeta, Il, IlBuilder, ImportEvidenceKind, Interner, Lang, LoopKind, NodeId,
+    NodeKind, Op, ParamSemantic, ParamTypeFact, Payload, PlaceEvidenceKind, SourceFact,
+    SourceFactKind, Span, Symbol, SymbolEvidenceKind, Unit, UnitKind,
 };
 use nose_semantics::{import_fact_tag, sequence_surface_kind_for_tag, ImportFactKind};
 use tree_sitter::Node as TsNode;
@@ -70,6 +70,7 @@ impl<'a> Lowering<'a> {
         children: &[NodeId],
     ) -> NodeId {
         let id = self.b.add(kind, payload, span, children);
+        self.record_core_semantic_evidence(kind, payload, span, children);
         if kind == NodeKind::Seq {
             let tag = match payload {
                 Payload::None => None,
@@ -85,6 +86,109 @@ impl<'a> Lowering<'a> {
             }
         }
         id
+    }
+
+    fn record_core_semantic_evidence(
+        &mut self,
+        kind: NodeKind,
+        payload: Payload,
+        span: Span,
+        children: &[NodeId],
+    ) {
+        match kind {
+            NodeKind::Var if self.lang == Lang::Java => {
+                if matches!(payload, Payload::Name(name) if self.interner.resolve(name) == "this") {
+                    self.record_evidence(
+                        EvidenceAnchor::node(span, kind),
+                        EvidenceKind::Place(PlaceEvidenceKind::SelfReceiver),
+                        "place_self_receiver",
+                    );
+                }
+            }
+            NodeKind::Call => {
+                if matches!(payload, Payload::Builtin(Builtin::Append)) && children.len() == 2 {
+                    self.record_evidence(
+                        EvidenceAnchor::node(span, kind),
+                        EvidenceKind::Effect(EffectEvidenceKind::BuilderAppendCall),
+                        "effect_builder_append",
+                    );
+                }
+            }
+            NodeKind::Field if self.lang == Lang::Java => {
+                if let (Payload::Name(field), [receiver]) = (payload, children) {
+                    if let Some(receiver_evidence) = self.self_receiver_evidence_id(*receiver) {
+                        let field_hash = stable_symbol_hash(self.interner.resolve(field));
+                        self.record_evidence_with_dependencies(
+                            EvidenceAnchor::node(span, kind),
+                            EvidenceKind::Place(PlaceEvidenceKind::SelfField { field_hash }),
+                            "place_self_field",
+                            vec![receiver_evidence],
+                        );
+                    }
+                }
+            }
+            NodeKind::Assign => {
+                if let [target, _value] = children {
+                    if self.non_overloadable_index_assignment_target(*target) {
+                        self.record_evidence(
+                            EvidenceAnchor::node(span, kind),
+                            EvidenceKind::Effect(EffectEvidenceKind::NonOverloadableIndexWrite),
+                            "effect_non_overloadable_index_write",
+                        );
+                    } else if let Some((field_hash, place_evidence)) =
+                        self.self_field_assignment_target(*target)
+                    {
+                        self.record_evidence_with_dependencies(
+                            EvidenceAnchor::node(span, kind),
+                            EvidenceKind::Effect(EffectEvidenceKind::SelfFieldWrite { field_hash }),
+                            "effect_self_field_write",
+                            vec![place_evidence],
+                        );
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn node_is_java_this_var(&self, node: NodeId) -> bool {
+        self.lang == Lang::Java
+            && self.b.kind(node) == NodeKind::Var
+            && matches!(self.b.payload(node), Payload::Name(name) if self.interner.resolve(name) == "this")
+    }
+
+    fn self_receiver_evidence_id(&self, node: NodeId) -> Option<EvidenceId> {
+        if !self.node_is_java_this_var(node) {
+            return None;
+        }
+        let span = self.b.node(node).span;
+        self.evidence.iter().find_map(|record| {
+            (record.anchor == EvidenceAnchor::node(span, NodeKind::Var)
+                && record.kind == EvidenceKind::Place(PlaceEvidenceKind::SelfReceiver)
+                && record.status == EvidenceStatus::Asserted)
+                .then_some(record.id)
+        })
+    }
+
+    fn non_overloadable_index_assignment_target(&self, node: NodeId) -> bool {
+        matches!(self.lang, Lang::C | Lang::Go | Lang::Java) && self.b.kind(node) == NodeKind::Index
+    }
+
+    fn self_field_assignment_target(&self, node: NodeId) -> Option<(u64, EvidenceId)> {
+        if self.lang != Lang::Java || self.b.kind(node) != NodeKind::Field {
+            return None;
+        }
+        let Payload::Name(field) = self.b.payload(node) else {
+            return None;
+        };
+        let span = self.b.node(node).span;
+        let field_hash = stable_symbol_hash(self.interner.resolve(field));
+        self.evidence.iter().find_map(|record| {
+            (record.anchor == EvidenceAnchor::node(span, NodeKind::Field)
+                && record.kind == EvidenceKind::Place(PlaceEvidenceKind::SelfField { field_hash })
+                && record.status == EvidenceStatus::Asserted)
+                .then_some((field_hash, record.id))
+        })
     }
 
     pub(crate) fn record_param_semantic(&mut self, span: Span, semantic: ParamSemantic) {
@@ -1072,6 +1176,10 @@ mod tests {
         Span::new(FileId(0), 0, 1, 1, 1)
     }
 
+    fn sp_at(line: u32) -> Span {
+        Span::new(FileId(0), line, line + 1, line, line)
+    }
+
     #[test]
     fn import_lowering_emits_symbol_identity_evidence_for_aliases() {
         let interner = Interner::new();
@@ -1093,5 +1201,80 @@ mod tests {
             EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace { module_hash })
                 if module_hash == stable_symbol_hash("math")
         )));
+    }
+
+    #[test]
+    fn core_lowering_emits_effect_and_place_evidence() {
+        let interner = Interner::new();
+        let mut lo = Lowering::new(FileId(0), b"", Lang::Java, &interner);
+
+        let receiver = lo.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("this")),
+            sp_at(1),
+            &[],
+        );
+        let field = lo.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("value")),
+            sp_at(2),
+            &[receiver],
+        );
+        let value = lo.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("next")),
+            sp_at(3),
+            &[],
+        );
+        let assign = lo.add(NodeKind::Assign, Payload::None, sp_at(4), &[field, value]);
+        let index = lo.add(NodeKind::Index, Payload::None, sp_at(5), &[receiver, value]);
+        let index_assign = lo.add(NodeKind::Assign, Payload::None, sp_at(6), &[index, value]);
+        let append = lo.add(
+            NodeKind::Call,
+            Payload::Builtin(Builtin::Append),
+            sp_at(7),
+            &[receiver, value],
+        );
+
+        let field_hash = stable_symbol_hash("value");
+        let self_receiver = lo
+            .evidence
+            .iter()
+            .find(|record| {
+                record.anchor == EvidenceAnchor::node(sp_at(1), NodeKind::Var)
+                    && record.kind == EvidenceKind::Place(PlaceEvidenceKind::SelfReceiver)
+            })
+            .expect("Java this should emit self-receiver place evidence");
+        let self_field = lo
+            .evidence
+            .iter()
+            .find(|record| {
+                record.anchor == EvidenceAnchor::node(sp_at(2), NodeKind::Field)
+                    && record.kind
+                        == EvidenceKind::Place(PlaceEvidenceKind::SelfField { field_hash })
+            })
+            .expect("Java this.field should emit self-field place evidence");
+        assert_eq!(self_field.dependencies, vec![self_receiver.id]);
+        let self_field_write = lo
+            .evidence
+            .iter()
+            .find(|record| {
+                record.anchor == EvidenceAnchor::node(sp_at(4), NodeKind::Assign)
+                    && record.kind
+                        == EvidenceKind::Effect(EffectEvidenceKind::SelfFieldWrite { field_hash })
+            })
+            .expect("Java this.field assignment should emit self-field write evidence");
+        assert_eq!(self_field_write.dependencies, vec![self_field.id]);
+        assert!(lo.evidence.iter().any(|record| {
+            record.anchor == EvidenceAnchor::node(sp_at(6), NodeKind::Assign)
+                && record.kind
+                    == EvidenceKind::Effect(EffectEvidenceKind::NonOverloadableIndexWrite)
+        }));
+        assert!(lo.evidence.iter().any(|record| {
+            record.anchor == EvidenceAnchor::node(sp_at(7), NodeKind::Call)
+                && record.kind == EvidenceKind::Effect(EffectEvidenceKind::BuilderAppendCall)
+        }));
+        assert_ne!(assign, index_assign);
+        assert_ne!(append, receiver);
     }
 }

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -21,12 +21,12 @@ pub use ident::{
 };
 pub use intern::{stable_symbol_hash, symbol_index, Interner, Symbol, FNV_OFFSET_BASIS, FNV_PRIME};
 pub use node::{
-    Builtin, DomainEvidence, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
-    EvidenceProvenance, EvidenceRecord, EvidenceStatus, GuardEvidenceKind, HoFKind,
+    Builtin, DomainEvidence, EffectEvidenceKind, EvidenceAnchor, EvidenceEmitter, EvidenceId,
+    EvidenceKind, EvidenceProvenance, EvidenceRecord, EvidenceStatus, GuardEvidenceKind, HoFKind,
     ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, LitClass, LoopKind, Node,
-    NodeId, NodeKind, Op, ParamSemantic, ParamTypeFact, Payload, SequenceSurfaceKind,
-    SourceCallKind, SourceFact, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
-    SymbolEvidenceKind,
+    NodeId, NodeKind, Op, ParamSemantic, ParamTypeFact, Payload, PlaceEvidenceKind,
+    SequenceSurfaceKind, SourceCallKind, SourceFact, SourceFactKind, SourceLiteralKind,
+    SourceOperatorKind, SymbolEvidenceKind,
 };
 pub use span::{FileId, FileMeta, Lang, Span};
 
@@ -198,6 +198,28 @@ impl IlBuilder {
     /// Number of nodes allocated so far.
     pub fn len(&self) -> usize {
         self.nodes.len()
+    }
+
+    #[inline]
+    pub fn node(&self, id: NodeId) -> &Node {
+        &self.nodes[id.0 as usize]
+    }
+
+    #[inline]
+    pub fn kind(&self, id: NodeId) -> NodeKind {
+        self.node(id).kind
+    }
+
+    #[inline]
+    pub fn payload(&self, id: NodeId) -> Payload {
+        self.node(id).payload
+    }
+
+    #[inline]
+    pub fn children(&self, id: NodeId) -> &[NodeId] {
+        let n = self.node(id);
+        let s = n.child_start as usize;
+        &self.edges[s..s + n.child_len as usize]
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -362,6 +362,19 @@ pub enum GuardEvidenceKind {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum PlaceEvidenceKind {
+    SelfReceiver,
+    SelfField { field_hash: u64 },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum EffectEvidenceKind {
+    BuilderAppendCall,
+    NonOverloadableIndexWrite,
+    SelfFieldWrite { field_hash: u64 },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub enum SequenceSurfaceKind {
     Untagged,
     Collection,
@@ -383,6 +396,8 @@ pub enum EvidenceKind {
     Import(ImportEvidenceKind),
     Symbol(SymbolEvidenceKind),
     Guard(GuardEvidenceKind),
+    Place(PlaceEvidenceKind),
+    Effect(EffectEvidenceKind),
     SequenceSurface(SequenceSurfaceKind),
 }
 

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -7,11 +7,11 @@
 //! approve exact clone matches directly.
 
 use nose_il::{
-    contains_js_identifier, stable_symbol_hash, Builtin, EvidenceAnchor, EvidenceEmitter,
-    EvidenceId, EvidenceKind, EvidenceRecord, EvidenceStatus, GuardEvidenceKind, HoFKind, Il,
-    ImportEvidenceKind, Interner, Lang, LitClass, NodeId, NodeKind, Op, ParamSemantic, Payload,
-    SequenceSurfaceKind, SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
-    Span, SymbolEvidenceKind,
+    contains_js_identifier, stable_symbol_hash, Builtin, EffectEvidenceKind, EvidenceAnchor,
+    EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceRecord, EvidenceStatus, GuardEvidenceKind,
+    HoFKind, Il, ImportEvidenceKind, Interner, Lang, LitClass, NodeId, NodeKind, Op, ParamSemantic,
+    Payload, PlaceEvidenceKind, SequenceSurfaceKind, SourceCallKind, SourceFactKind,
+    SourceLiteralKind, SourceOperatorKind, Span, SymbolEvidenceKind,
 };
 
 pub use nose_il::DomainEvidence;
@@ -72,6 +72,32 @@ fn unique_evidence_at<T: Copy + Eq>(
             continue;
         };
         if record.status != EvidenceStatus::Asserted {
+            return EvidenceResolution::Ambiguous;
+        }
+        match found {
+            None => found = Some(value),
+            Some(existing) if existing == value => {}
+            Some(_) => return EvidenceResolution::Ambiguous,
+        }
+    }
+    found.map_or(EvidenceResolution::Missing, EvidenceResolution::Found)
+}
+
+fn unique_asserted_evidence_at<T: Copy + Eq>(
+    il: &Il,
+    anchor_matches: impl Fn(EvidenceAnchor) -> bool,
+    project: impl Fn(EvidenceKind) -> Option<T>,
+) -> EvidenceResolution<T> {
+    let mut found = None;
+    for record in &il.evidence {
+        if !anchor_matches(record.anchor) {
+            continue;
+        }
+        let Some(value) = project(record.kind) else {
+            continue;
+        };
+        if record.status != EvidenceStatus::Asserted || !evidence_dependencies_asserted(il, record)
+        {
             return EvidenceResolution::Ambiguous;
         }
         match found {
@@ -1612,8 +1638,61 @@ impl FragmentSemantics {
     }
 }
 
+fn effect_evidence_for_node(il: &Il, node: NodeId) -> EvidenceResolution<EffectEvidenceKind> {
+    let span = il.node(node).span;
+    let kind = il.kind(node);
+    unique_asserted_evidence_at(
+        il,
+        |anchor| {
+            matches!(
+                anchor,
+                EvidenceAnchor::Node {
+                    span: anchor_span,
+                    kind: anchor_kind,
+                } if anchor_span == span && anchor_kind == kind
+            )
+        },
+        |evidence| match evidence {
+            EvidenceKind::Effect(effect) => Some(effect),
+            _ => None,
+        },
+    )
+}
+
+fn place_evidence_for_node(il: &Il, node: NodeId) -> EvidenceResolution<PlaceEvidenceKind> {
+    let span = il.node(node).span;
+    let kind = il.kind(node);
+    unique_asserted_evidence_at(
+        il,
+        |anchor| {
+            matches!(
+                anchor,
+                EvidenceAnchor::Node {
+                    span: anchor_span,
+                    kind: anchor_kind,
+                } if anchor_span == span && anchor_kind == kind
+            )
+        },
+        |evidence| match evidence {
+            EvidenceKind::Place(place) => Some(place),
+            _ => None,
+        },
+    )
+}
+
 /// Exact Java `this` receiver proof for first-party self-field fragments.
 pub fn exact_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    match place_evidence_for_node(il, node) {
+        EvidenceResolution::Found(PlaceEvidenceKind::SelfReceiver) => {
+            return il.kind(node) == NodeKind::Var;
+        }
+        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => return false,
+        EvidenceResolution::Missing => {}
+    }
+    legacy_exact_java_this_var(il, interner, node)
+}
+
+fn legacy_exact_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
     semantics(il.meta.lang)
         .exact_fragments()
         .java_this_field_place()
@@ -1623,6 +1702,29 @@ pub fn exact_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
 
 /// Exact Java `this.field` place proof for receiver-aware field-write fingerprints.
 pub fn exact_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    match place_evidence_for_node(il, node) {
+        EvidenceResolution::Found(PlaceEvidenceKind::SelfField { field_hash }) => {
+            if il.kind(node) != NodeKind::Field {
+                return false;
+            }
+            let Payload::Name(field) = il.node(node).payload else {
+                return false;
+            };
+            if stable_symbol_hash(interner.resolve(field)) != field_hash {
+                return false;
+            }
+            return il
+                .children(node)
+                .first()
+                .is_some_and(|&receiver| exact_java_this_var(il, interner, receiver));
+        }
+        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => return false,
+        EvidenceResolution::Missing => {}
+    }
+    legacy_exact_java_this_field(il, interner, node)
+}
+
+fn legacy_exact_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
     if !semantics(il.meta.lang)
         .exact_fragments()
         .java_this_field_place()
@@ -1659,10 +1761,25 @@ pub fn exact_non_overloadable_index_assignment_parts(
     il: &Il,
     node: NodeId,
 ) -> Option<(NodeId, Option<NodeId>, NodeId)> {
-    if !semantics(il.meta.lang)
+    match effect_evidence_for_node(il, node) {
+        EvidenceResolution::Found(EffectEvidenceKind::NonOverloadableIndexWrite) => {
+            return syntactic_index_assignment_parts(il, node);
+        }
+        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => return None,
+        EvidenceResolution::Missing => {}
+    }
+    semantics(il.meta.lang)
         .exact_fragments()
         .non_overloadable_index_assignment()
-    {
+        .then_some(())
+        .and_then(|()| syntactic_index_assignment_parts(il, node))
+}
+
+fn syntactic_index_assignment_parts(
+    il: &Il,
+    node: NodeId,
+) -> Option<(NodeId, Option<NodeId>, NodeId)> {
+    if il.kind(node) != NodeKind::Assign {
         return None;
     }
     let kids = il.children(node);
@@ -1675,6 +1792,44 @@ pub fn exact_non_overloadable_index_assignment_parts(
 
 pub fn exact_non_overloadable_index_assignment(il: &Il, node: NodeId) -> bool {
     exact_non_overloadable_index_assignment_parts(il, node).is_some()
+}
+
+pub fn exact_self_field_write_assignment(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    match effect_evidence_for_node(il, node) {
+        EvidenceResolution::Found(EffectEvidenceKind::SelfFieldWrite { field_hash }) => {
+            return syntactic_self_field_write_assignment(il, interner, node, Some(field_hash));
+        }
+        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => return false,
+        EvidenceResolution::Missing => {}
+    }
+    semantics(il.meta.lang)
+        .exact_fragments()
+        .java_this_field_place()
+        && syntactic_self_field_write_assignment(il, interner, node, None)
+}
+
+fn syntactic_self_field_write_assignment(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    expected_field_hash: Option<u64>,
+) -> bool {
+    if il.kind(node) != NodeKind::Assign {
+        return false;
+    }
+    let kids = il.children(node);
+    if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Field {
+        return false;
+    }
+    if let Some(expected) = expected_field_hash {
+        let Payload::Name(field) = il.node(kids[0]).payload else {
+            return false;
+        };
+        if stable_symbol_hash(interner.resolve(field)) != expected {
+            return false;
+        }
+    }
+    exact_java_this_field(il, interner, kids[0])
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -3082,6 +3237,17 @@ pub fn builder_append_call_args(
     _interner: &Interner,
     node: NodeId,
 ) -> Option<(NodeId, NodeId)> {
+    match effect_evidence_for_node(il, node) {
+        EvidenceResolution::Found(EffectEvidenceKind::BuilderAppendCall) => {
+            return syntactic_append_call_args(il, node);
+        }
+        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => return None,
+        EvidenceResolution::Missing => {}
+    }
+    canonical_append_call_args(il, node)
+}
+
+fn canonical_append_call_args(il: &Il, node: NodeId) -> Option<(NodeId, NodeId)> {
     if il.kind(node) != NodeKind::Call {
         return None;
     }
@@ -3090,6 +3256,21 @@ pub fn builder_append_call_args(
         return (kids.len() == 2).then(|| (kids[0], kids[1]));
     }
     None
+}
+
+fn syntactic_append_call_args(il: &Il, node: NodeId) -> Option<(NodeId, NodeId)> {
+    if let Some(parts) = canonical_append_call_args(il, node) {
+        return Some(parts);
+    }
+    if il.kind(node) != NodeKind::Call {
+        return None;
+    }
+    let kids = il.children(node);
+    if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Field {
+        return None;
+    }
+    let receiver = il.children(kids[0]).first().copied()?;
+    Some((receiver, kids[1]))
 }
 
 pub fn builder_append_call(il: &Il, interner: &Interner, node: NodeId) -> bool {
@@ -7113,6 +7294,176 @@ mod tests {
             builder_append_call_args(&rust_il, &interner, push_call),
             None
         );
+    }
+
+    #[test]
+    fn effect_evidence_can_prove_non_overloadable_index_write() {
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(NodeKind::Var, Payload::Cid(1), sp(1), &[]);
+        let key = b.add(NodeKind::Var, Payload::Cid(2), sp(1), &[]);
+        let target = b.add(NodeKind::Index, Payload::None, sp(1), &[receiver, key]);
+        let value = b.add(NodeKind::Var, Payload::Cid(3), sp(1), &[]);
+        let assign = b.add(NodeKind::Assign, Payload::None, sp(9), &[target, value]);
+        let mut il = finish_il(b, assign, Lang::Ruby);
+
+        assert_eq!(
+            exact_non_overloadable_index_assignment_parts(&il, assign),
+            None
+        );
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(9), NodeKind::Assign),
+            EvidenceKind::Effect(EffectEvidenceKind::NonOverloadableIndexWrite),
+            EvidenceStatus::Asserted,
+        ));
+        assert_eq!(
+            exact_non_overloadable_index_assignment_parts(&il, assign),
+            Some((receiver, Some(key), value))
+        );
+
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(sp(9), NodeKind::Assign),
+            EvidenceKind::Effect(EffectEvidenceKind::SelfFieldWrite { field_hash: 1 }),
+            EvidenceStatus::Asserted,
+        ));
+        assert_eq!(
+            exact_non_overloadable_index_assignment_parts(&il, assign),
+            None
+        );
+
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(NodeKind::Var, Payload::Cid(1), sp(1), &[]);
+        let key = b.add(NodeKind::Var, Payload::Cid(2), sp(1), &[]);
+        let target = b.add(NodeKind::Index, Payload::None, sp(1), &[receiver, key]);
+        let value = b.add(NodeKind::Var, Payload::Cid(3), sp(1), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(10), &[target, value]);
+        let mut non_assign = finish_il(b, call, Lang::Ruby);
+        non_assign.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(10), NodeKind::Call),
+            EvidenceKind::Effect(EffectEvidenceKind::NonOverloadableIndexWrite),
+            EvidenceStatus::Asserted,
+        ));
+        assert_eq!(
+            exact_non_overloadable_index_assignment_parts(&non_assign, call),
+            None
+        );
+    }
+
+    #[test]
+    fn append_effect_evidence_can_prove_raw_method_call() {
+        let interner = Interner::default();
+        let append = interner.intern("append");
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(NodeKind::Var, Payload::Cid(1), sp(1), &[]);
+        let value = b.add(NodeKind::Var, Payload::Cid(2), sp(1), &[]);
+        let method = b.add(NodeKind::Field, Payload::Name(append), sp(2), &[receiver]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(3), &[method, value]);
+        let mut il = finish_il(b, call, Lang::Ruby);
+
+        assert_eq!(builder_append_call_args(&il, &interner, call), None);
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(3), NodeKind::Call),
+            EvidenceKind::Effect(EffectEvidenceKind::BuilderAppendCall),
+            EvidenceStatus::Asserted,
+        ));
+        assert_eq!(
+            builder_append_call_args(&il, &interner, call),
+            Some((receiver, value))
+        );
+
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(sp(3), NodeKind::Call),
+            EvidenceKind::Effect(EffectEvidenceKind::NonOverloadableIndexWrite),
+            EvidenceStatus::Asserted,
+        ));
+        assert_eq!(builder_append_call_args(&il, &interner, call), None);
+    }
+
+    #[test]
+    fn place_evidence_is_authoritative_for_self_field_proof() {
+        let interner = Interner::default();
+        let this = interner.intern("this");
+        let field_name = interner.intern("value");
+        let field_hash = stable_symbol_hash("value");
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(NodeKind::Var, Payload::Name(this), sp(1), &[]);
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(field_name),
+            sp(2),
+            &[receiver],
+        );
+        let value = b.add(NodeKind::Var, Payload::Cid(1), sp(3), &[]);
+        let assign = b.add(NodeKind::Assign, Payload::None, sp(4), &[field, value]);
+        let mut il = finish_il(b, assign, Lang::Ruby);
+
+        assert!(!exact_java_this_field(&il, &interner, field));
+        assert!(!exact_self_field_write_assignment(&il, &interner, assign));
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(1), NodeKind::Var),
+            EvidenceKind::Place(PlaceEvidenceKind::SelfReceiver),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            1,
+            EvidenceAnchor::node(sp(2), NodeKind::Field),
+            EvidenceKind::Place(PlaceEvidenceKind::SelfField { field_hash }),
+            EvidenceStatus::Asserted,
+            vec![EvidenceId(0)],
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            2,
+            EvidenceAnchor::node(sp(4), NodeKind::Assign),
+            EvidenceKind::Effect(EffectEvidenceKind::SelfFieldWrite { field_hash }),
+            EvidenceStatus::Asserted,
+            vec![EvidenceId(1)],
+        ));
+        assert!(exact_java_this_field(&il, &interner, field));
+        assert!(exact_self_field_write_assignment(&il, &interner, assign));
+
+        il.evidence.push(evidence(
+            3,
+            EvidenceAnchor::node(sp(2), NodeKind::Field),
+            EvidenceKind::Place(PlaceEvidenceKind::SelfReceiver),
+            EvidenceStatus::Asserted,
+        ));
+        assert!(!exact_java_this_field(&il, &interner, field));
+        assert!(!exact_self_field_write_assignment(&il, &interner, assign));
+
+        let other = interner.intern("other");
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(NodeKind::Var, Payload::Name(other), sp(5), &[]);
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(field_name),
+            sp(6),
+            &[receiver],
+        );
+        let value = b.add(NodeKind::Var, Payload::Cid(1), sp(7), &[]);
+        let assign = b.add(NodeKind::Assign, Payload::None, sp(8), &[field, value]);
+        let mut il = finish_il(b, assign, Lang::Ruby);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(6), NodeKind::Field),
+            EvidenceKind::Place(PlaceEvidenceKind::SelfField { field_hash }),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(sp(8), NodeKind::Assign),
+            EvidenceKind::Effect(EffectEvidenceKind::SelfFieldWrite { field_hash }),
+            EvidenceStatus::Asserted,
+        ));
+        assert!(!exact_java_this_field(&il, &interner, field));
+        assert!(!exact_self_field_write_assignment(&il, &interner, assign));
     }
 
     #[test]

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -13,8 +13,8 @@ can satisfy an exact-channel precondition.
 
 ## Goal
 
-- Give source, domain, import, symbol-identity, guard, and sequence-surface proof
-  facts one shared shape.
+- Give source, domain, import, symbol-identity, guard, place/effect, and
+  sequence-surface proof facts one shared shape.
 - Make facts carry stable ids, anchors, provenance, dependencies, and status.
 - Keep exact matching fail-closed when evidence is missing, ambiguous, or
   conflicting.
@@ -35,8 +35,8 @@ can satisfy an exact-channel precondition.
   helpers.
 - Do not certify external pack claims. nose validates record shape and fails
   closed; providers own their claims, and users own opt-in decisions.
-- Do not model place/effect/demand evidence completely in this slice. Those are
-  next consumers of the same record substrate.
+- Do not model demand evidence or every place/effect family in this slice. The
+  current place/effect records cover the first exact-fragment substrate only.
 
 ## Record Shape
 
@@ -61,6 +61,8 @@ The current implemented kinds are:
 | `Import` | static import binding/namespace proof and imported-literal snapshot provenance |
 | `Symbol` | resolved or proven symbol identity, with record kinds for unshadowed globals, static imported binding/namespace aliases, and selected qualified global API paths |
 | `Guard` | multi-obligation guard proof facts such as JS/TS record-shape and own-property guard contracts |
+| `Place` | fixed receiver/place facts currently covering `SelfReceiver` and `SelfField` |
+| `Effect` | observable effect facts currently covering canonical builder append calls, non-overloadable index writes, and fixed self-field writes |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, guard surfaces, Go composite map literals, or Go map entries |
 
 `LibraryApiContract` is deliberately not listed here yet. It is currently an
@@ -124,6 +126,17 @@ on one supported qualified-global API path, currently `Object.hasOwn` or
 `value.hasOwnProperty(...)`, shadowed `Object` roots, missing dependencies, or
 ambiguous guard evidence remain closed.
 
+Place and effect evidence are also authoritative where present. For example,
+raw method selectors such as `push`, `append`, or `add` do not prove an append
+effect; a consumer needs `Effect(BuilderAppendCall)` or the legacy canonical
+`Builtin::Append` compatibility path when no effect evidence exists. Likewise,
+non-overloadable index writes and fixed self-field writes are admitted through
+`Effect` records, with `Place(SelfReceiver)` and `Place(SelfField)` proving the
+receiver/place side. First-party `Place(SelfField)` depends on the matching
+`Place(SelfReceiver)`, and `Effect(SelfFieldWrite)` depends on the matching
+`Place(SelfField)`. Conflicting or ambiguous place/effect evidence blocks the
+legacy language-gated fallback.
+
 ## Current Producers
 
 First-party frontends now mirror these facts into `EvidenceRecord`:
@@ -147,14 +160,21 @@ First-party frontends now mirror these facts into `EvidenceRecord`:
   null/truthiness clause kind, whether JS loose equality was admitted, and
   asserted dependencies for the required `Array.isArray` API proof plus optional
   `Boolean` proof;
+- first-party lowering emits `Place(SelfReceiver)` for Java `this`,
+  `Place(SelfField)` for Java `this.field`, `Effect(SelfFieldWrite)` for Java
+  `this.field = ...`, `Effect(NonOverloadableIndexWrite)` for C/Go/Java index
+  writes, and `Effect(BuilderAppendCall)` for canonical `Builtin::Append`.
+  Self-field place/write evidence records include dependencies that link the
+  write proof back to the receiver proof;
 - lowered `Seq` surfaces emit `SequenceSurface` evidence, including Go map
   literal and Go map-entry surfaces where those tags carry first-party meaning.
 
 The older `ParamTypeFact`, `SourceFact`, and raw import `Seq` shapes remain as
 compatibility mirrors. First-party JS/TS record-shape guards now have dedicated
-guard evidence, but broader guard families, richer source-clause dependencies,
-and general evidence validation remain open. These mirrors are not the desired
-pack boundary.
+guard evidence, and exact-fragment append/index/self-field gates now have the
+first place/effect evidence substrate. Broader guard families, richer
+source-clause dependencies, richer receiver/place families, and general evidence
+validation remain open. These mirrors are not the desired pack boundary.
 
 ## Current Consumers
 
@@ -201,9 +221,13 @@ callers:
   dedicated guard helper instead. Go zero-map literal lookup also requires
   `SequenceSurface(GoCompositeMapLiteral)` and `SequenceSurface(GoMapEntry)`,
   so `composite_literal`/`keyed_element` tag spelling alone no longer admits the
-  exact map-default path.
+  exact map-default path;
+- exact-fragment append, non-overloadable index-write, and self-field-write
+  gates now consult `Effect`/`Place` evidence first, falling back to the legacy
+  language-gated helper only when no relevant evidence record exists. Ambiguous
+  or conflicting evidence keeps the exact path closed.
 
-Field/place/effect facts, receiver/protocol evidence beyond parameter domains,
-full scope-resolution and namespace-member evidence, broader guard evidence,
-general cross-module dependency manifests, report-level provenance, and external
-manifest loading are still open work.
+Broader field/place/effect facts, receiver/protocol evidence beyond parameter
+domains, full scope-resolution and namespace-member evidence, broader guard
+evidence, general cross-module dependency manifests, report-level provenance,
+and external manifest loading are still open work.

--- a/docs/fragment-contracts.md
+++ b/docs/fragment-contracts.md
@@ -94,8 +94,9 @@ name. Exact append fragments consume canonical `Builtin::Append` evidence:
 frontends and normalizers must first prove the language/library receiver or
 active-builder contract for the specific surface (`Array.push`, Python
 `list.append`, Java builder `add`, Rust builder `push`, etc.) and lower it to
-that canonical form. A raw selector-only call can still be compared under the
-separate opaque-call policy as `Other`, but it does not prove append semantics.
+that canonical form, or a pack/frontend must attach `Effect(BuilderAppendCall)`
+to the call. A raw selector-only call can still be compared under the separate
+opaque-call policy as `Other`, but it does not prove append semantics.
 
 A field write is the one case whose final-state slot is receiver-bearing, so a field write is
 exact-safe only when its receiver resolves to a proven place. This is exactly why a fixed
@@ -163,7 +164,7 @@ and adding it to that gate — it does **not** change production output.
 | `DirectReturn`, `DirectThrow` | yes — value/control sinks |
 | `IndexAssignEffect`, `SelfFieldAssign`, `ExprEffect` | yes — single-effect writes |
 | `LoopEffect` | yes — for-each iteration-dependent effect body |
-| `SelfFieldBody` | yes — fixed-`this` Java field-write body |
+| `SelfFieldBody` | yes — fixed self-field-write body |
 | `ConditionalGuard` | yes — recursive branch admissibility matrix |
 
 `LoopEffect` is the first multi-statement-body migration: its independent recognizer lives in
@@ -173,19 +174,21 @@ binding-aware free-input + multi-statement-lowering substrate, with no reuse of 
 acceptance helpers.
 
 `SelfFieldBody` is the only migrated shape whose acceptance boundary intentionally bypasses
-the shared top-level context gate: it proves self-containment through fixed Java `this` field
-writes, allows conditional `this.field = ...` statements, and permits a terminal
-`return this`. That bypass is scoped to this kind only.
+the shared top-level context gate: it proves self-containment through fixed self-field
+writes, allows conditional self-field statements, and permits a terminal `return this` in
+the current first-party Java compatibility path. The evidence path requires matching
+`Effect(SelfFieldWrite)` plus `Place(SelfField)`/`Place(SelfReceiver)` proof. That bypass is
+scoped to this kind only.
 
 `ConditionalGuard` re-expresses the full recursive branch admissibility matrix on the
 contract path: empty branches, direct return/throw/effect branches, branch-local temp
 consumption, bounded ordered effect sequences, loop-effect branches, conditional direct-effect
 branches, and nested conditional guards. After that migration base, `ConditionalGuard` also
-admits a narrow ordered Java self-field branch body: exactly two or three
-`this.field = ...` assignments. The invariant is the same as `SelfFieldAssign` and
-`SelfFieldBody`: every field write resolves to a proven `Place::This` field path, and the
-oracle observes the final field-state map. A sibling branch containing `other.field = ...`
-or an implicit field/local assignment stays rejected because receiver identity is not proven.
+admits a narrow ordered self-field branch body: exactly two or three fixed self-field
+assignments. The invariant is the same as `SelfFieldAssign` and `SelfFieldBody`: every field
+write resolves to a proven `Place::This` field path, and the oracle observes the final
+field-state map. A sibling branch containing `other.field = ...` or an implicit field/local
+assignment stays rejected because receiver identity is not proven.
 The interim "branch-local temp", "ordered multi-effect", and ordered self-field branch
 shapes remain proof mechanisms *inside* existing kinds, not new `FragmentKind` variants or
 reason codes.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -332,9 +332,12 @@ Remaining in this phase:
 - Add scope, dependency, and ambiguity validation for evidence records before
   they become a stable external extension surface.
 - Expand the exact fragment facade from first-party helper functions into
-  versioned pack-facing effect/place evidence records.
-- Continue replacing any remaining local exact-fragment proof helpers with
-  versioned pack-facing evidence records.
+  versioned pack-facing effect/place evidence records. The first substrate now
+  covers canonical append calls, C/Go/Java non-overloadable index writes, and
+  Java self-receiver/self-field writes through `Effect`/`Place` evidence.
+- Continue replacing remaining local exact-fragment proof helpers with
+  versioned pack-facing evidence records, especially broader field/read/write
+  place facts and receiver-sensitive mutation/effect proofs.
 - Continue moving library API recognition into `LibraryApiContract` records.
   The first internal slice covers collection/map factories, selected
   constructors, Java empty collection constructors, Java `Map.entry`, and the

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -151,6 +151,14 @@ migrated.
   but not `b.x`, and final field-write sinks preserve the receiver identity.
   Same-unit value-graph readback uses syntactic receiver/place evidence only; it
   does not assume aliasing or computed call-result receivers.
+- Exact-fragment place/effect gates now have the first pack-facing evidence
+  substrate. First-party lowering emits `Place(SelfReceiver)` and
+  `Place(SelfField)` for Java `this`/`this.field`, plus `Effect` evidence for
+  canonical builder append calls, C/Go/Java non-overloadable index writes, and
+  Java self-field writes. Fragment recognizers consume these records first and
+  use legacy language gates only when no relevant place/effect evidence exists.
+  Self-field place/write records depend on the matching receiver/place records,
+  and conflicting or ambiguous place/effect evidence closes the exact path.
 - `SeqSurfaceContract` now centralizes first-party lowered sequence tags and
   keeps separate axes for exact-tree safety, membership-collection admission,
   map-entry-list admission, imported-literal eligibility, and value-graph
@@ -398,7 +406,8 @@ until packs can emit the missing facts.
 
 The first high-value targets for semantic-kernel extraction are:
 
-- pack-facing field/place evidence for all field reads and writes, building on
+- broader pack-facing field/place/effect evidence for all field reads and
+  writes, building on the initial append/index/self-field effect substrate and
   the receiver-aware value-graph field state now used for same-unit caching;
 - full import/module fact migration to remove the remaining raw
   `Seq("import_binding")` and `Seq("import_namespace")` compatibility payloads;


### PR DESCRIPTION
## Summary

- Add first-class `Place` and `Effect` evidence records to the IL evidence model.
- Emit first-party evidence for Java `this`/`this.field`, Java self-field writes, non-overloadable index writes, and builder append calls.
- Route exact fragment helpers and recognizers through evidence-first gates that fail closed on conflicting or ambiguous records, while retaining compatibility fallback when no relevant evidence exists.
- Update semantic kernel docs, roadmap, snapshot, and fragment contract notes for the new substrate.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test --release`
- `cargo test -p nose-semantics`
- `cargo test -p nose-frontend core_lowering_emits_effect_and_place_evidence -- --nocapture`
- `cargo test -p nose-detect fragment::recognize`
- `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py && ./scripts/check-lean-proofs.sh`
- `awiki lint --root docs`
- `git diff --check`
- `./scripts/check-duplication.sh`

Progress for #109.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 의미 기반 증거 기록 시스템을 통해 필드 할당, 배열 접근, 메서드 호출 감지 정확도 향상

* **리팩터링**
  * 코드 패턴 인식 로직 최적화 및 단순화

* **문서**
  * 증거 레코드, 프래그먼트 계약, 의미 커널 아키텍처 관련 문서 정비

<!-- end of auto-generated comment: release notes by coderabbit.ai -->