### PR TITLE
semantics: add library API occurrence evidence

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -20,22 +20,22 @@ use nose_semantics::{
     go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
     go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract, imported_binding_symbol,
     imported_literal_producer_evidence_for_node, imported_member_symbol,
-    library_api_free_name_shadow_safe, library_free_name_collection_factory_contract,
-    library_free_name_map_factory_contract, library_imported_collection_factory_contracts,
-    library_iterator_identity_adapter_contract, library_java_collection_factory_contract,
-    library_java_map_entry_contract, library_java_map_factory_contract,
-    library_js_array_is_array_contract, library_js_like_map_constructor_contract,
-    library_js_like_set_constructor_contract, library_map_get_contract,
-    library_map_key_view_contract, library_map_key_view_wrapper_contract,
+    library_api_contract_evidence_for_call, library_api_free_name_shadow_safe,
+    library_free_name_collection_factory_contract, library_free_name_map_factory_contract,
+    library_imported_collection_factory_contracts, library_iterator_identity_adapter_contract,
+    library_java_collection_factory_contract, library_java_map_entry_contract,
+    library_java_map_factory_contract, library_js_array_is_array_contract,
+    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
+    library_map_get_contract, library_map_key_view_contract, library_map_key_view_wrapper_contract,
     library_method_call_contract, library_regex_test_contract, library_ruby_set_factory_contract,
     library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
     nullish_global_contract, own_property_guard_for_node, qualified_global_symbol,
     record_shape_guard_for_node, semantics, seq_surface_contract_for_node, source_fact_at_node,
     source_operator_at_node, static_index_membership_contract, typeof_operator_contract,
     unshadowed_global_symbol, DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind,
-    LibraryApiCalleeContract, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
-    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
-    StaticIndexMembershipKind,
+    LibraryApiCalleeContract, LibraryApiEvidenceStatus, LibraryCollectionFactoryResult,
+    LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
+    MethodSemanticContract, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1381,22 +1381,36 @@ fn strict_exact_js_array_is_array_safe(
     else {
         return false;
     };
+    let arg_count = il.children(node).len().saturating_sub(1);
     let Some(contract) = library_js_array_is_array_contract(
         il.meta.lang,
         interner.resolve(receiver_name),
         method,
-        il.children(node).len().saturating_sub(1),
+        arg_count,
     ) else {
         return false;
     };
-    let contract = contract.result;
-    if contract.requires_unshadowed_receiver
-        && !unshadowed_global_symbol(il, interner, receiver, contract.receiver)
-    {
-        return false;
-    }
-    if !qualified_global_symbol(il, callee, contract.qualified_path) {
-        return false;
+    match library_api_contract_evidence_for_call(
+        il,
+        interner,
+        node,
+        contract.id,
+        contract.callee,
+        arg_count,
+    ) {
+        LibraryApiEvidenceStatus::Admitted => {}
+        LibraryApiEvidenceStatus::Rejected => return false,
+        LibraryApiEvidenceStatus::Missing => {
+            let result = contract.result;
+            if result.requires_unshadowed_receiver
+                && !unshadowed_global_symbol(il, interner, receiver, result.receiver)
+            {
+                return false;
+            }
+            if !qualified_global_symbol(il, callee, result.qualified_path) {
+                return false;
+            }
+        }
     }
     strict_exact_call_args_safe(il, interner, facts, node)
 }
@@ -1797,11 +1811,25 @@ fn strict_exact_map_key_view_collection_safe(
     else {
         return false;
     };
-    let contract = contract.result;
-    qualified_global_symbol(il, kids[0], contract.qualified_path)
-        && strict_exact_map_key_view_safe_matching(il, interner, facts, kids[1], |kind| {
-            kind == MapKeyViewKind::Iterator
-        })
+    match library_api_contract_evidence_for_call(
+        il,
+        interner,
+        node,
+        contract.id,
+        contract.callee,
+        1,
+    ) {
+        LibraryApiEvidenceStatus::Admitted => {}
+        LibraryApiEvidenceStatus::Rejected => return false,
+        LibraryApiEvidenceStatus::Missing => {
+            if !qualified_global_symbol(il, kids[0], contract.result.qualified_path) {
+                return false;
+            }
+        }
+    }
+    strict_exact_map_key_view_safe_matching(il, interner, facts, kids[1], |kind| {
+        kind == MapKeyViewKind::Iterator
+    })
 }
 
 fn strict_exact_literal_collection_receiver_safe(
@@ -1886,9 +1914,25 @@ fn strict_exact_set_constructor_collection_safe(
     else {
         return false;
     };
-    receiver == "Set"
-        && (!requires_unshadowed_global || unshadowed_global_symbol(il, interner, callee, receiver))
-        && strict_exact_static_non_float_collection(il, interner, collection)
+    match library_api_contract_evidence_for_call(
+        il,
+        interner,
+        node,
+        contract.id,
+        contract.callee,
+        1,
+    ) {
+        LibraryApiEvidenceStatus::Admitted => {}
+        LibraryApiEvidenceStatus::Rejected => return false,
+        LibraryApiEvidenceStatus::Missing => {
+            if requires_unshadowed_global
+                && !unshadowed_global_symbol(il, interner, callee, receiver)
+            {
+                return false;
+            }
+        }
+    }
+    receiver == "Set" && strict_exact_static_non_float_collection(il, interner, collection)
 }
 
 fn strict_exact_python_collection_factory_safe(
@@ -2340,12 +2384,29 @@ fn strict_exact_map_constructor_entries_safe(
     else {
         return false;
     };
+    match library_api_contract_evidence_for_call(
+        il,
+        interner,
+        node,
+        contract.id,
+        contract.callee,
+        1,
+    ) {
+        LibraryApiEvidenceStatus::Admitted => {}
+        LibraryApiEvidenceStatus::Rejected => return false,
+        LibraryApiEvidenceStatus::Missing => {
+            if requires_unshadowed_global
+                && !unshadowed_global_symbol(il, interner, callee, receiver)
+            {
+                return false;
+            }
+        }
+    }
     receiver == "Map"
         && matches!(
             contract.result,
             LibraryMapFactoryResult::EntrySequence { .. }
         )
-        && (!requires_unshadowed_global || unshadowed_global_symbol(il, interner, callee, receiver))
         && strict_exact_map_entries_safe(il, interner, facts, entries)
 }
 
@@ -4028,5 +4089,136 @@ fn collect_pre(il: &Il, root: NodeId, out: &mut Vec<NodeId>) {
     out.push(root);
     for &c in il.children(root) {
         collect_pre(il, c, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nose_il::{
+        EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
+        EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, LibraryApiEvidenceKind,
+        SequenceSurfaceKind, SourceCallKind, SourceFactKind, Span, SymbolEvidenceKind,
+    };
+    use nose_semantics::{
+        library_api_callee_contract_hash, library_api_contract_id_hash,
+        library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
+        FIRST_PARTY_PACK_ID,
+    };
+
+    fn sp(line: u32) -> Span {
+        Span::new(FileId(0), line, line, line, line)
+    }
+
+    fn evidence(
+        id: u32,
+        anchor: EvidenceAnchor,
+        kind: EvidenceKind,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceRecord {
+        EvidenceRecord {
+            id: EvidenceId(id),
+            anchor,
+            kind,
+            provenance: EvidenceProvenance {
+                emitter: EvidenceEmitter::FirstParty,
+                pack_hash: Some(stable_symbol_hash(FIRST_PARTY_PACK_ID)),
+                rule_hash: Some(stable_symbol_hash("test")),
+            },
+            dependencies,
+            status: EvidenceStatus::Asserted,
+        }
+    }
+
+    fn js_new_set_il(interner: &Interner) -> (Il, NodeId) {
+        let mut b = IlBuilder::new(FileId(0));
+        let set = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("Set")),
+            sp(10),
+            &[],
+        );
+        let one = b.add(NodeKind::Lit, Payload::LitInt(1), sp(11), &[]);
+        let array = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(12),
+            &[one],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(13), &[set, array]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(13), &[call]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.js".into(),
+                lang: Lang::JavaScript,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::source_span(sp(13)),
+            EvidenceKind::Source(SourceFactKind::Call(SourceCallKind::Construct)),
+            Vec::new(),
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(sp(10), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("Set"),
+            }),
+            Vec::new(),
+        ));
+        il.evidence.push(evidence(
+            2,
+            EvidenceAnchor::sequence(sp(12)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+            Vec::new(),
+        ));
+        (il, call)
+    }
+
+    #[test]
+    fn strict_exact_js_constructor_closes_on_conflicting_api_evidence() {
+        let interner = Interner::new();
+        let (mut il, call) = js_new_set_il(&interner);
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(strict_exact_set_constructor_collection_safe(
+            &il, &interner, &facts, call
+        ));
+
+        let wrong = library_js_like_map_constructor_contract(Lang::JavaScript, "Map").unwrap();
+        il.evidence.push(evidence(
+            3,
+            EvidenceAnchor::node(sp(13), NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(wrong.id),
+                callee_hash: library_api_callee_contract_hash(wrong.callee),
+                arity: 1,
+            }),
+            vec![EvidenceId(0), EvidenceId(1)],
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(!strict_exact_set_constructor_collection_safe(
+            &il, &interner, &facts, call
+        ));
+
+        let (mut il, call) = js_new_set_il(&interner);
+        let set = library_js_like_set_constructor_contract(Lang::JavaScript, "Set").unwrap();
+        il.evidence.push(evidence(
+            3,
+            EvidenceAnchor::node(sp(13), NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(set.id),
+                callee_hash: library_api_callee_contract_hash(set.callee),
+                arity: 1,
+            }),
+            vec![EvidenceId(0), EvidenceId(1)],
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(strict_exact_set_constructor_collection_safe(
+            &il, &interner, &facts, call
+        ));
     }
 }

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -1294,9 +1294,8 @@ fn lower_new(lo: &mut Lowering, node: TsNode) -> NodeId {
             kids.push(lower_expr(lo, a));
         }
     }
-    let call = lo.add(NodeKind::Call, Payload::None, span, &kids);
     lo.record_source_fact(span, SourceFactKind::Call(SourceCallKind::Construct));
-    call
+    lo.add(NodeKind::Call, Payload::None, span, &kids)
 }
 
 fn lower_binary(lo: &mut Lowering, node: TsNode) -> NodeId {
@@ -1949,7 +1948,13 @@ mod tests {
     use super::*;
     use nose_il::{
         stable_symbol_hash, EvidenceAnchor, EvidenceKind, FileId, GuardEvidenceKind, Interner,
-        JsRecordGuardComparison, JsRecordGuardNullCheck, SymbolEvidenceKind,
+        JsRecordGuardComparison, JsRecordGuardNullCheck, LibraryApiEvidenceKind,
+        SymbolEvidenceKind,
+    };
+    use nose_semantics::{
+        library_api_callee_contract_hash, library_api_contract_id_hash,
+        library_js_array_is_array_contract, library_js_like_map_constructor_contract,
+        library_js_like_set_constructor_contract, library_map_key_view_wrapper_contract,
     };
 
     fn lower_js(src: &str) -> Il {
@@ -1996,6 +2001,39 @@ mod tests {
                 )
             })
             .count()
+    }
+
+    fn library_api_evidence_count(
+        il: &Il,
+        contract_hash: u64,
+        callee_hash: u64,
+        arity: u16,
+    ) -> usize {
+        il.evidence
+            .iter()
+            .filter(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                        contract_hash: actual_contract,
+                        callee_hash: actual_callee,
+                        arity: actual_arity,
+                    }) if actual_contract == contract_hash
+                        && actual_callee == callee_hash
+                        && actual_arity == arity
+                )
+            })
+            .count()
+    }
+
+    fn library_api_dependency_counts(il: &Il) -> Vec<usize> {
+        il.evidence
+            .iter()
+            .filter_map(|record| {
+                matches!(record.kind, EvidenceKind::LibraryApi(_))
+                    .then_some(record.dependencies.len())
+            })
+            .collect()
     }
 
     fn js_record_shape_guard_evidence(il: &Il) -> Vec<&nose_il::EvidenceRecord> {
@@ -2100,6 +2138,40 @@ mod tests {
                 "missing global evidence for {name}"
             );
         }
+        let map = library_js_like_map_constructor_contract(Lang::JavaScript, "Map").unwrap();
+        assert!(
+            library_api_evidence_count(
+                &il,
+                library_api_contract_id_hash(map.id),
+                library_api_callee_contract_hash(map.callee),
+                1,
+            ) >= 1
+        );
+        let set = library_js_like_set_constructor_contract(Lang::JavaScript, "Set").unwrap();
+        assert!(
+            library_api_evidence_count(
+                &il,
+                library_api_contract_id_hash(set.id),
+                library_api_callee_contract_hash(set.callee),
+                1,
+            ) >= 1
+        );
+        let is_array =
+            library_js_array_is_array_contract(Lang::JavaScript, "Array", "isArray", 1).unwrap();
+        assert!(
+            library_api_evidence_count(
+                &il,
+                library_api_contract_id_hash(is_array.id),
+                library_api_callee_contract_hash(is_array.callee),
+                1,
+            ) >= 1
+        );
+        assert!(
+            library_api_dependency_counts(&il)
+                .into_iter()
+                .all(|count| count >= 2),
+            "selected JS API evidence should depend on source/symbol proof"
+        );
         assert!(
             !il.nodes
                 .iter()
@@ -2153,6 +2225,28 @@ mod tests {
         );
         assert_eq!(
             qualified_global_evidence_count(&il, "Array.isArray", NodeKind::Field),
+            1
+        );
+        let from =
+            library_map_key_view_wrapper_contract(Lang::JavaScript, "Array", "from", 1).unwrap();
+        let is_array =
+            library_js_array_is_array_contract(Lang::JavaScript, "Array", "isArray", 1).unwrap();
+        assert_eq!(
+            library_api_evidence_count(
+                &il,
+                library_api_contract_id_hash(from.id),
+                library_api_callee_contract_hash(from.callee),
+                1,
+            ),
+            1
+        );
+        assert_eq!(
+            library_api_evidence_count(
+                &il,
+                library_api_contract_id_hash(is_array.id),
+                library_api_callee_contract_hash(is_array.callee),
+                1,
+            ),
             1
         );
     }
@@ -2271,6 +2365,12 @@ mod tests {
         assert_eq!(
             qualified_global_evidence_count(&il, "Array.from", NodeKind::Field),
             0
+        );
+        assert!(
+            il.evidence
+                .iter()
+                .all(|record| !matches!(record.kind, EvidenceKind::LibraryApi(_))),
+            "shadowed JS static globals must not emit API contract evidence"
         );
         assert!(js_own_property_guard_evidence(&il).is_empty());
     }

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -5,12 +5,25 @@
 use nose_il::{
     stable_symbol_hash, Builtin, DomainEvidence, EffectEvidenceKind, EvidenceAnchor,
     EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance, EvidenceRecord, EvidenceStatus,
-    FileId, FileMeta, Il, IlBuilder, ImportEvidenceKind, Interner, Lang, LoopKind, NodeId,
-    NodeKind, Op, ParamSemantic, ParamTypeFact, Payload, PlaceEvidenceKind, SourceFact,
-    SourceFactKind, Span, Symbol, SymbolEvidenceKind, Unit, UnitKind,
+    FileId, FileMeta, Il, IlBuilder, ImportEvidenceKind, Interner, Lang, LibraryApiEvidenceKind,
+    LoopKind, NodeId, NodeKind, Op, ParamSemantic, ParamTypeFact, Payload, PlaceEvidenceKind,
+    SourceCallKind, SourceFact, SourceFactKind, Span, Symbol, SymbolEvidenceKind, Unit, UnitKind,
 };
-use nose_semantics::{import_fact_tag, sequence_surface_kind_for_tag, ImportFactKind};
+use nose_semantics::{
+    import_fact_tag, library_api_callee_contract_hash, library_api_contract_id_hash,
+    library_js_array_is_array_contract, library_js_boolean_coercion_contract,
+    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
+    library_map_key_view_wrapper_contract, sequence_surface_kind_for_tag, ImportFactKind,
+    LibraryApiCalleeContract, LibraryApiContractId,
+};
 use tree_sitter::Node as TsNode;
+
+type LibraryApiEvidencePlan = (
+    LibraryApiContractId,
+    LibraryApiCalleeContract,
+    Vec<EvidenceId>,
+    &'static str,
+);
 
 /// Mutable state threaded through a single file's lowering.
 pub(crate) struct Lowering<'a> {
@@ -113,6 +126,9 @@ impl<'a> Lowering<'a> {
                         "effect_builder_append",
                     );
                 }
+                if matches!(payload, Payload::None) {
+                    self.record_library_api_evidence_for_call(span, children);
+                }
             }
             NodeKind::Field if self.lang == Lang::Java => {
                 if let (Payload::Name(field), [receiver]) = (payload, children) {
@@ -149,6 +165,210 @@ impl<'a> Lowering<'a> {
             }
             _ => {}
         }
+    }
+
+    fn record_library_api_evidence_for_call(&mut self, span: Span, children: &[NodeId]) {
+        let Some((&callee, args)) = children.split_first() else {
+            return;
+        };
+        let arg_count = args.len();
+        if let Some((id, callee_contract, dependencies, rule)) =
+            self.library_api_contract_for_call(span, callee, arg_count)
+        {
+            self.record_evidence_with_dependencies(
+                EvidenceAnchor::node(span, NodeKind::Call),
+                EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                    contract_hash: library_api_contract_id_hash(id),
+                    callee_hash: library_api_callee_contract_hash(callee_contract),
+                    arity: arg_count as u16,
+                }),
+                rule,
+                dependencies,
+            );
+        }
+    }
+
+    fn library_api_contract_for_call(
+        &self,
+        span: Span,
+        callee: NodeId,
+        arg_count: usize,
+    ) -> Option<LibraryApiEvidencePlan> {
+        if arg_count > u16::MAX as usize {
+            return None;
+        }
+        if let Some(result) = self.static_global_method_api_contract(callee, arg_count) {
+            return Some(result);
+        }
+        if let Some(result) = self.static_global_function_api_contract(callee, arg_count) {
+            return Some(result);
+        }
+        self.js_global_constructor_api_contract(span, callee, arg_count)
+    }
+
+    fn static_global_method_api_contract(
+        &self,
+        callee: NodeId,
+        arg_count: usize,
+    ) -> Option<LibraryApiEvidencePlan> {
+        if self.b.kind(callee) != NodeKind::Field {
+            return None;
+        }
+        let Payload::Name(method) = self.b.payload(callee) else {
+            return None;
+        };
+        let receiver_node = self.b.children(callee).first().copied()?;
+        let Payload::Name(receiver_name) = self.b.payload(receiver_node) else {
+            return None;
+        };
+        if self.b.kind(receiver_node) != NodeKind::Var {
+            return None;
+        }
+        let receiver = self.interner.resolve(receiver_name);
+        let method = self.interner.resolve(method);
+        let contract = library_js_array_is_array_contract(self.lang, receiver, method, arg_count)
+            .map(|contract| {
+                (
+                    contract.id,
+                    contract.callee,
+                    contract.result.qualified_path,
+                    contract.result.requires_unshadowed_receiver,
+                    contract.result.receiver,
+                    "library_api_js_array_is_array",
+                )
+            })
+            .or_else(|| {
+                library_map_key_view_wrapper_contract(self.lang, receiver, method, arg_count).map(
+                    |contract| {
+                        (
+                            contract.id,
+                            contract.callee,
+                            contract.result.qualified_path,
+                            true,
+                            contract.result.receiver,
+                            "library_api_map_key_view_wrapper",
+                        )
+                    },
+                )
+            })?;
+        let qualified = self.qualified_global_evidence_id(callee, contract.2)?;
+        let mut dependencies = vec![qualified];
+        if contract.3 {
+            dependencies.push(self.unshadowed_global_evidence_id(receiver_node, contract.4)?);
+        }
+        Some((contract.0, contract.1, dependencies, contract.5))
+    }
+
+    fn static_global_function_api_contract(
+        &self,
+        callee: NodeId,
+        arg_count: usize,
+    ) -> Option<LibraryApiEvidencePlan> {
+        let Payload::Name(function) = self.b.payload(callee) else {
+            return None;
+        };
+        if self.b.kind(callee) != NodeKind::Var {
+            return None;
+        }
+        let function = self.interner.resolve(function);
+        let contract = library_js_boolean_coercion_contract(self.lang, function, arg_count)?;
+        let mut dependencies = Vec::new();
+        if contract.result.requires_unshadowed_function {
+            dependencies
+                .push(self.unshadowed_global_evidence_id(callee, contract.result.function)?);
+        }
+        Some((
+            contract.id,
+            contract.callee,
+            dependencies,
+            "library_api_js_boolean_coercion",
+        ))
+    }
+
+    fn js_global_constructor_api_contract(
+        &self,
+        span: Span,
+        callee: NodeId,
+        arg_count: usize,
+    ) -> Option<LibraryApiEvidencePlan> {
+        let Payload::Name(receiver) = self.b.payload(callee) else {
+            return None;
+        };
+        if self.b.kind(callee) != NodeKind::Var {
+            return None;
+        }
+        let receiver = self.interner.resolve(receiver);
+        let contract = library_js_like_set_constructor_contract(self.lang, receiver)
+            .filter(|_| arg_count == 1)
+            .map(|contract| {
+                (
+                    contract.id,
+                    contract.callee,
+                    receiver,
+                    "library_api_js_set_constructor",
+                )
+            })
+            .or_else(|| {
+                library_js_like_map_constructor_contract(self.lang, receiver)
+                    .filter(|_| arg_count == 1)
+                    .map(|contract| {
+                        (
+                            contract.id,
+                            contract.callee,
+                            receiver,
+                            "library_api_js_map_constructor",
+                        )
+                    })
+            })?;
+        let source = self.source_call_evidence_id(span, SourceCallKind::Construct)?;
+        let mut dependencies = vec![source];
+        if let LibraryApiCalleeContract::JsGlobalConstructor {
+            requires_unshadowed_global,
+            ..
+        } = contract.1
+        {
+            if requires_unshadowed_global {
+                dependencies.push(self.unshadowed_global_evidence_id(callee, contract.2)?);
+            }
+        }
+        Some((contract.0, contract.1, dependencies, contract.3))
+    }
+
+    fn source_call_evidence_id(&self, span: Span, call: SourceCallKind) -> Option<EvidenceId> {
+        self.evidence.iter().find_map(|record| {
+            (record.anchor == EvidenceAnchor::source_span(span)
+                && record.kind == EvidenceKind::Source(SourceFactKind::Call(call))
+                && record.status == EvidenceStatus::Asserted)
+                .then_some(record.id)
+        })
+    }
+
+    fn unshadowed_global_evidence_id(&self, node: NodeId, name: &str) -> Option<EvidenceId> {
+        let span = self.b.node(node).span;
+        let kind = self.b.kind(node);
+        self.evidence.iter().find_map(|record| {
+            (record.anchor == EvidenceAnchor::node(span, kind)
+                && record.kind
+                    == EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                        name_hash: stable_symbol_hash(name),
+                    })
+                && record.status == EvidenceStatus::Asserted)
+                .then_some(record.id)
+        })
+    }
+
+    fn qualified_global_evidence_id(&self, node: NodeId, path: &str) -> Option<EvidenceId> {
+        let span = self.b.node(node).span;
+        let kind = self.b.kind(node);
+        self.evidence.iter().find_map(|record| {
+            (record.anchor == EvidenceAnchor::node(span, kind)
+                && record.kind
+                    == EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+                        path_hash: stable_symbol_hash(path),
+                    })
+                && record.status == EvidenceStatus::Asserted)
+                .then_some(record.id)
+        })
     }
 
     fn node_is_java_this_var(&self, node: NodeId) -> bool {

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -23,10 +23,10 @@ pub use intern::{stable_symbol_hash, symbol_index, Interner, Symbol, FNV_OFFSET_
 pub use node::{
     Builtin, DomainEvidence, EffectEvidenceKind, EvidenceAnchor, EvidenceEmitter, EvidenceId,
     EvidenceKind, EvidenceProvenance, EvidenceRecord, EvidenceStatus, GuardEvidenceKind, HoFKind,
-    ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, LitClass, LoopKind, Node,
-    NodeId, NodeKind, Op, ParamSemantic, ParamTypeFact, Payload, PlaceEvidenceKind,
-    SequenceSurfaceKind, SourceCallKind, SourceFact, SourceFactKind, SourceLiteralKind,
-    SourceOperatorKind, SymbolEvidenceKind,
+    ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, LibraryApiEvidenceKind,
+    LitClass, LoopKind, Node, NodeId, NodeKind, Op, ParamSemantic, ParamTypeFact, Payload,
+    PlaceEvidenceKind, SequenceSurfaceKind, SourceCallKind, SourceFact, SourceFactKind,
+    SourceLiteralKind, SourceOperatorKind, SymbolEvidenceKind,
 };
 pub use span::{FileId, FileMeta, Lang, Span};
 

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -375,6 +375,15 @@ pub enum EffectEvidenceKind {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum LibraryApiEvidenceKind {
+    Contract {
+        contract_hash: u64,
+        callee_hash: u64,
+        arity: u16,
+    },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub enum SequenceSurfaceKind {
     Untagged,
     Collection,
@@ -398,6 +407,7 @@ pub enum EvidenceKind {
     Guard(GuardEvidenceKind),
     Place(PlaceEvidenceKind),
     Effect(EffectEvidenceKind),
+    LibraryApi(LibraryApiEvidenceKind),
     SequenceSurface(SequenceSurfaceKind),
 }
 

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -55,6 +55,7 @@ use nose_semantics::{
     go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
     go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract, import_fact_evidence_rhs,
     imported_literal_producer_evidence_at_span, imported_namespace_symbol,
+    library_api_contract_evidence_at_call_span, library_api_contract_evidence_for_call,
     library_api_free_name_shadow_safe, library_free_name_collection_factory_contracts,
     library_free_name_map_factory_contracts, library_imported_collection_factory_contracts,
     library_imported_namespace_function_contract, library_iterator_identity_adapter_contract,
@@ -72,11 +73,11 @@ use nose_semantics::{
     BuiltinArgContract, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
     GoZeroMapDefaultKind, ImportFactKind, ImportedNamespaceFunctionSemantic,
     IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind,
-    LibraryApiCalleeContract, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
-    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
-    ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract, StaticIndexMembershipKind,
-    SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR,
-    SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
+    LibraryApiCalleeContract, LibraryApiEvidenceStatus, LibraryCollectionFactoryResult,
+    LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
+    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract,
+    StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD,
+    SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -1483,10 +1484,23 @@ impl<'a> Builder<'a> {
             else {
                 return None;
             };
-            if requires_unshadowed_global
-                && !unshadowed_global_symbol(self.il, self.interner, kids[0], receiver)
-            {
-                return None;
+            match library_api_contract_evidence_for_call(
+                self.il,
+                self.interner,
+                expr,
+                contract.id,
+                contract.callee,
+                1,
+            ) {
+                LibraryApiEvidenceStatus::Admitted => {}
+                LibraryApiEvidenceStatus::Rejected => return None,
+                LibraryApiEvidenceStatus::Missing => {
+                    if requires_unshadowed_global
+                        && !unshadowed_global_symbol(self.il, self.interner, kids[0], receiver)
+                    {
+                        return None;
+                    }
+                }
             }
             if !self.is_static_non_float_collection_expr(kids[1]) {
                 return None;
@@ -1501,10 +1515,23 @@ impl<'a> Builder<'a> {
         else {
             return None;
         };
-        if requires_unshadowed_global
-            && !unshadowed_global_symbol(self.il, self.interner, kids[0], receiver)
-        {
-            return None;
+        match library_api_contract_evidence_for_call(
+            self.il,
+            self.interner,
+            expr,
+            contract.id,
+            contract.callee,
+            1,
+        ) {
+            LibraryApiEvidenceStatus::Admitted => {}
+            LibraryApiEvidenceStatus::Rejected => return None,
+            LibraryApiEvidenceStatus::Missing => {
+                if requires_unshadowed_global
+                    && !unshadowed_global_symbol(self.il, self.interner, kids[0], receiver)
+                {
+                    return None;
+                }
+            }
         }
         let LibraryMapFactoryResult::EntrySequence { entry_seq_tag } = contract.result else {
             return None;
@@ -1665,18 +1692,35 @@ impl<'a> Builder<'a> {
                 "Array",
                 method,
                 1,
-            )?
-            .result;
-            if accepted != MapKeyViewKind::Collection
-                || callee.args.len() != 1
-                || !qualified_global_symbol_at_span(
-                    self.il,
-                    self.node_span[args[0] as usize],
-                    NodeKind::Field,
-                    contract.qualified_path,
-                )
-            {
+            )?;
+            if accepted != MapKeyViewKind::Collection || callee.args.len() != 1 {
                 return None;
+            }
+            let receiver_span = callee
+                .args
+                .first()
+                .and_then(|&receiver| self.node_span[receiver as usize]);
+            match library_api_contract_evidence_at_call_span(
+                self.il,
+                self.node_span[value as usize],
+                self.node_span[args[0] as usize],
+                receiver_span,
+                contract.id,
+                contract.callee,
+                1,
+            ) {
+                LibraryApiEvidenceStatus::Admitted => {}
+                LibraryApiEvidenceStatus::Rejected => return None,
+                LibraryApiEvidenceStatus::Missing => {
+                    if !qualified_global_symbol_at_span(
+                        self.il,
+                        self.node_span[args[0] as usize],
+                        NodeKind::Field,
+                        contract.result.qualified_path,
+                    ) {
+                        return None;
+                    }
+                }
             }
             return self.proven_map_key_view_value_matching(args[1], MapKeyViewKind::Iterator);
         }
@@ -8412,10 +8456,15 @@ mod tests {
     use nose_il::{
         EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
         EvidenceRecord, EvidenceStatus, FileId, FileMeta, GuardEvidenceKind, IlBuilder,
-        ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, Lang, ParamSemantic,
-        ParamTypeFact, SequenceSurfaceKind, Span, SymbolEvidenceKind, Unit, UnitKind,
+        ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, Lang,
+        LibraryApiEvidenceKind, ParamSemantic, ParamTypeFact, SequenceSurfaceKind, SourceCallKind,
+        SourceFactKind, Span, SymbolEvidenceKind, Unit, UnitKind,
     };
-    use nose_semantics::{import_fact_tag, FIRST_PARTY_PACK_ID};
+    use nose_semantics::{
+        import_fact_tag, library_api_callee_contract_hash, library_api_contract_id_hash,
+        library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
+        FIRST_PARTY_PACK_ID,
+    };
 
     fn sp(line: u32) -> Span {
         Span::new(FileId(0), line, line, line, line)
@@ -8434,6 +8483,15 @@ mod tests {
     }
 
     fn evidence(id: u32, anchor: EvidenceAnchor, kind: EvidenceKind) -> EvidenceRecord {
+        evidence_with_dependencies(id, anchor, kind, Vec::new())
+    }
+
+    fn evidence_with_dependencies(
+        id: u32,
+        anchor: EvidenceAnchor,
+        kind: EvidenceKind,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceRecord {
         EvidenceRecord {
             id: EvidenceId(id),
             anchor,
@@ -8443,7 +8501,7 @@ mod tests {
                 pack_hash: Some(stable_symbol_hash(FIRST_PARTY_PACK_ID)),
                 rule_hash: Some(stable_symbol_hash("test")),
             },
-            dependencies: Vec::new(),
+            dependencies,
             status: EvidenceStatus::Asserted,
         }
     }
@@ -8776,6 +8834,94 @@ mod tests {
         assert!(matches!(
             builder.nodes[proven as usize].op,
             ValOp::Seq(SEQ_VALUE_RECORD_GUARD)
+        ));
+    }
+
+    fn js_new_set_il(interner: &Interner) -> (Il, NodeId) {
+        let mut b = IlBuilder::new(FileId(0));
+        let set = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("Set")),
+            sp(70),
+            &[],
+        );
+        let one = b.add(NodeKind::Lit, Payload::LitInt(1), sp(71), &[]);
+        let array = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(72),
+            &[one],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(73), &[set, array]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(73), &[call]);
+        let mut il = finish_test_il(b, root, Lang::JavaScript);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::source_span(sp(73)),
+            EvidenceKind::Source(SourceFactKind::Call(SourceCallKind::Construct)),
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(sp(70), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("Set"),
+            }),
+        ));
+        il.evidence.push(evidence(
+            2,
+            EvidenceAnchor::sequence(sp(72)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+        ));
+        (il, call)
+    }
+
+    #[test]
+    fn js_constructor_value_graph_closes_on_conflicting_api_evidence() {
+        let interner = Interner::new();
+        let (mut il, call) = js_new_set_il(&interner);
+
+        let mut builder = Builder::new(&il, &interner);
+        let legacy_proven = builder.eval(call, &FxHashMap::default());
+        assert!(matches!(
+            builder.nodes[legacy_proven as usize].op,
+            ValOp::Seq(SEQ_VALUE_COLLECTION)
+        ));
+
+        let wrong = library_js_like_map_constructor_contract(Lang::JavaScript, "Map").unwrap();
+        il.evidence.push(evidence_with_dependencies(
+            3,
+            EvidenceAnchor::node(sp(73), NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(wrong.id),
+                callee_hash: library_api_callee_contract_hash(wrong.callee),
+                arity: 1,
+            }),
+            vec![EvidenceId(0), EvidenceId(1)],
+        ));
+        let mut builder = Builder::new(&il, &interner);
+        let rejected = builder.eval(call, &FxHashMap::default());
+        assert!(!matches!(
+            builder.nodes[rejected as usize].op,
+            ValOp::Seq(SEQ_VALUE_COLLECTION)
+        ));
+
+        let (mut il, call) = js_new_set_il(&interner);
+        let set = library_js_like_set_constructor_contract(Lang::JavaScript, "Set").unwrap();
+        il.evidence.push(evidence_with_dependencies(
+            3,
+            EvidenceAnchor::node(sp(73), NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(set.id),
+                callee_hash: library_api_callee_contract_hash(set.callee),
+                arity: 1,
+            }),
+            vec![EvidenceId(0), EvidenceId(1)],
+        ));
+        let mut builder = Builder::new(&il, &interner);
+        let admitted = builder.eval(call, &FxHashMap::default());
+        assert!(matches!(
+            builder.nodes[admitted as usize].op,
+            ValOp::Seq(SEQ_VALUE_COLLECTION)
         ));
     }
 

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -9,9 +9,9 @@
 use nose_il::{
     contains_js_identifier, stable_symbol_hash, Builtin, EffectEvidenceKind, EvidenceAnchor,
     EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceRecord, EvidenceStatus, GuardEvidenceKind,
-    HoFKind, Il, ImportEvidenceKind, Interner, Lang, LitClass, NodeId, NodeKind, Op, ParamSemantic,
-    Payload, PlaceEvidenceKind, SequenceSurfaceKind, SourceCallKind, SourceFactKind,
-    SourceLiteralKind, SourceOperatorKind, Span, SymbolEvidenceKind,
+    HoFKind, Il, ImportEvidenceKind, Interner, Lang, LibraryApiEvidenceKind, LitClass, NodeId,
+    NodeKind, Op, ParamSemantic, Payload, PlaceEvidenceKind, SequenceSurfaceKind, SourceCallKind,
+    SourceFactKind, SourceLiteralKind, SourceOperatorKind, Span, SymbolEvidenceKind,
 };
 
 pub use nose_il::DomainEvidence;
@@ -3464,6 +3464,107 @@ pub enum LibraryApiContractId {
     MethodCall(MethodSemanticContract),
 }
 
+pub fn library_api_contract_id_hash(id: LibraryApiContractId) -> u64 {
+    stable_symbol_hash(&library_api_contract_id_key(id))
+}
+
+fn library_api_contract_id_key(id: LibraryApiContractId) -> String {
+    match id {
+        LibraryApiContractId::PythonBuiltinCollectionFactory => {
+            "python.builtin.collection_factory".into()
+        }
+        LibraryApiContractId::PythonImportedCollectionFactory => {
+            "python.imported.collection_factory".into()
+        }
+        LibraryApiContractId::RustStdCollectionFactory => "rust.std.collection_factory".into(),
+        LibraryApiContractId::RustStdMapFactory => "rust.std.map_factory".into(),
+        LibraryApiContractId::RustVecMacroFactory => "rust.vec.macro_factory".into(),
+        LibraryApiContractId::RustVecNewFactory => "rust.vec.new_factory".into(),
+        LibraryApiContractId::JavaCollectionFactory(kind) => {
+            format!(
+                "java.collection_factory.{}",
+                java_collection_factory_kind_key(kind)
+            )
+        }
+        LibraryApiContractId::JavaCollectionConstructor(kind) => {
+            format!(
+                "java.collection_constructor.{}",
+                java_collection_constructor_kind_key(kind)
+            )
+        }
+        LibraryApiContractId::JavaMapFactory(kind) => {
+            format!("java.map_factory.{}", java_map_factory_kind_key(kind))
+        }
+        LibraryApiContractId::JavaMapEntryFactory => "java.map_entry_factory".into(),
+        LibraryApiContractId::RubySetFactory => "ruby.set_factory".into(),
+        LibraryApiContractId::JsLikeSetConstructor => "js_like.set.constructor".into(),
+        LibraryApiContractId::JsLikeMapConstructor => "js_like.map.constructor".into(),
+        LibraryApiContractId::MapKeyView(kind) => {
+            format!("map_key_view.{}", map_key_view_kind_key(kind))
+        }
+        LibraryApiContractId::MapKeyViewWrapper => "map_key_view.wrapper".into(),
+        LibraryApiContractId::MapGet => "map.get".into(),
+        LibraryApiContractId::JsArrayIsArray => "js_like.array.is_array".into(),
+        LibraryApiContractId::JsBooleanCoercion => "js_like.boolean.coercion".into(),
+        LibraryApiContractId::RegexTest => "js_like.regex.test".into(),
+        LibraryApiContractId::ImportedNamespaceFunction(semantic) => {
+            format!(
+                "imported_namespace_function.{}",
+                imported_namespace_function_semantic_key(semantic)
+            )
+        }
+        LibraryApiContractId::PromiseThen => "js_like.promise.then".into(),
+        LibraryApiContractId::IteratorIdentityAdapter => "iterator.identity_adapter".into(),
+        LibraryApiContractId::StaticCollectionAdapter => "static.collection_adapter".into(),
+        LibraryApiContractId::MethodCall(semantic) => {
+            format!("method_call.{}", method_semantic_contract_key(semantic))
+        }
+    }
+}
+
+fn java_collection_factory_kind_key(kind: JavaCollectionFactoryKind) -> &'static str {
+    match kind {
+        JavaCollectionFactoryKind::ListOf => "list_of",
+        JavaCollectionFactoryKind::SetOf => "set_of",
+        JavaCollectionFactoryKind::ArraysAsList => "arrays_as_list",
+    }
+}
+
+fn java_collection_constructor_kind_key(kind: JavaCollectionConstructorKind) -> &'static str {
+    match kind {
+        JavaCollectionConstructorKind::EmptyList => "empty_list",
+    }
+}
+
+fn java_map_factory_kind_key(kind: JavaMapFactoryKind) -> &'static str {
+    match kind {
+        JavaMapFactoryKind::Of => "of",
+        JavaMapFactoryKind::OfEntries => "of_entries",
+    }
+}
+
+fn map_key_view_kind_key(kind: MapKeyViewKind) -> &'static str {
+    match kind {
+        MapKeyViewKind::Collection => "collection",
+        MapKeyViewKind::Iterator => "iterator",
+    }
+}
+
+fn imported_namespace_function_semantic_key(semantic: ImportedNamespaceFunctionSemantic) -> String {
+    match semantic {
+        ImportedNamespaceFunctionSemantic::ProductReduction { op, identity } => {
+            format!("product_reduction.{}.{}", op as u32, identity)
+        }
+    }
+}
+
+fn method_semantic_contract_key(semantic: MethodSemanticContract) -> String {
+    match semantic {
+        MethodSemanticContract::Builtin(builtin) => format!("builtin.{}", builtin as u32),
+        MethodSemanticContract::HoF(hof) => format!("hof.{}", hof as u32),
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum LibraryApiShadowPolicy {
     None,
@@ -3549,6 +3650,105 @@ pub enum LibraryApiCalleeContract {
         method: &'static str,
         receiver: IteratorAdapterReceiverContract,
     },
+}
+
+pub fn library_api_callee_contract_hash(callee: LibraryApiCalleeContract) -> u64 {
+    stable_symbol_hash(&library_api_callee_contract_key(callee))
+}
+
+fn library_api_callee_contract_key(callee: LibraryApiCalleeContract) -> String {
+    match callee {
+        LibraryApiCalleeContract::FreeName { name, .. } => format!("free_name:{name}"),
+        LibraryApiCalleeContract::ImportedBinding { module, exported } => {
+            format!("imported_binding:{module}:{exported}")
+        }
+        LibraryApiCalleeContract::JavaUtilStaticMember { receiver, method } => {
+            format!("java_util_static_member:{receiver}:{method}")
+        }
+        LibraryApiCalleeContract::JavaUtilConstructor {
+            simple_type,
+            qualified_type,
+            module,
+            ..
+        } => format!("java_util_constructor:{module}:{simple_type}:{qualified_type}"),
+        LibraryApiCalleeContract::RubyRequireStaticMember {
+            receiver,
+            method,
+            required_module,
+            ..
+        } => format!("ruby_require_static_member:{required_module}:{receiver}:{method}"),
+        LibraryApiCalleeContract::JsGlobalConstructor { receiver, .. } => {
+            format!("js_global_constructor:{receiver}")
+        }
+        LibraryApiCalleeContract::Method { method, receiver } => {
+            format!("method:{method}:{}", method_receiver_contract_key(receiver))
+        }
+        LibraryApiCalleeContract::StaticGlobalMethod { qualified_path, .. } => {
+            format!("static_global_method:{qualified_path}")
+        }
+        LibraryApiCalleeContract::StaticGlobalFunction { function, .. } => {
+            format!("static_global_function:{function}")
+        }
+        LibraryApiCalleeContract::RegexLiteralMethod { method, .. } => {
+            format!("regex_literal_method:{method}")
+        }
+        LibraryApiCalleeContract::ImportedNamespaceFunction { module, function } => {
+            format!("imported_namespace_function:{module}:{function}")
+        }
+        LibraryApiCalleeContract::AsyncMethod { method, receiver } => {
+            format!(
+                "async_method:{method}:{}",
+                async_receiver_contract_key(receiver)
+            )
+        }
+        LibraryApiCalleeContract::IteratorAdapterMethod { method, receiver } => {
+            format!(
+                "iterator_adapter_method:{method}:{}",
+                iterator_adapter_receiver_contract_key(receiver)
+            )
+        }
+    }
+}
+
+fn method_receiver_contract_key(receiver: MethodReceiverContract) -> String {
+    match receiver {
+        MethodReceiverContract::ExactCollection => "exact_collection".into(),
+        MethodReceiverContract::ExactProtocol => "exact_protocol".into(),
+        MethodReceiverContract::ExactProtocolPairArgument => "exact_protocol_pair_argument".into(),
+        MethodReceiverContract::ExactOption => "exact_option".into(),
+        MethodReceiverContract::ExactString => "exact_string".into(),
+        MethodReceiverContract::ExactInteger => "exact_integer".into(),
+        MethodReceiverContract::ExactMap => "exact_map".into(),
+        MethodReceiverContract::ExactMapLiteral => "exact_map_literal".into(),
+        MethodReceiverContract::ExactCollectionOrMap => "exact_collection_or_map".into(),
+        MethodReceiverContract::ExactCollectionOrMapLiteral => {
+            "exact_collection_or_map_literal".into()
+        }
+        MethodReceiverContract::ExactCollectionOrJavaKeySet => {
+            "exact_collection_or_java_key_set".into()
+        }
+        MethodReceiverContract::ExactSetOrMap => "exact_set_or_map".into(),
+        MethodReceiverContract::LiteralString => "literal_string".into(),
+        MethodReceiverContract::UnshadowedGlobal(name) => format!("unshadowed_global:{name}"),
+        MethodReceiverContract::ImportedNamespace(module) => {
+            format!("imported_namespace:{module}")
+        }
+        MethodReceiverContract::RustMapGetOrExactOption => "rust_map_get_or_exact_option".into(),
+    }
+}
+
+fn async_receiver_contract_key(receiver: AsyncReceiverContract) -> &'static str {
+    match receiver {
+        AsyncReceiverContract::ExactPromiseLike => "exact_promise_like",
+    }
+}
+
+fn iterator_adapter_receiver_contract_key(
+    receiver: IteratorAdapterReceiverContract,
+) -> &'static str {
+    match receiver {
+        IteratorAdapterReceiverContract::ExactIterableValue => "exact_iterable_value",
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -3660,6 +3860,387 @@ pub struct LibraryMethodCallContract {
     pub id: LibraryApiContractId,
     pub callee: LibraryApiCalleeContract,
     pub result: MethodCallContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LibraryApiEvidenceStatus {
+    Missing,
+    Admitted,
+    Rejected,
+}
+
+pub fn library_api_contract_evidence_for_call(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    id: LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+    arg_count: usize,
+) -> LibraryApiEvidenceStatus {
+    if il.kind(node) != NodeKind::Call || arg_count > u16::MAX as usize {
+        return LibraryApiEvidenceStatus::Rejected;
+    }
+    let expected = LibraryApiEvidenceKind::Contract {
+        contract_hash: library_api_contract_id_hash(id),
+        callee_hash: library_api_callee_contract_hash(callee),
+        arity: arg_count as u16,
+    };
+    let span = il.node(node).span;
+    let mut saw_library_api_evidence = false;
+    let mut admitted = false;
+    for record in &il.evidence {
+        if record.anchor != EvidenceAnchor::node(span, NodeKind::Call) {
+            continue;
+        }
+        let EvidenceKind::LibraryApi(api) = record.kind else {
+            continue;
+        };
+        saw_library_api_evidence = true;
+        if record.status != EvidenceStatus::Asserted
+            || api != expected
+            || !evidence_dependencies_asserted(il, record)
+            || !library_api_callee_shape_matches(il, interner, node, callee)
+            || !library_api_dependencies_match_callee(il, node, callee, record)
+        {
+            return LibraryApiEvidenceStatus::Rejected;
+        }
+        admitted = true;
+    }
+    if admitted {
+        LibraryApiEvidenceStatus::Admitted
+    } else if saw_library_api_evidence {
+        LibraryApiEvidenceStatus::Rejected
+    } else {
+        LibraryApiEvidenceStatus::Missing
+    }
+}
+
+pub fn library_api_contract_evidence_at_call_span(
+    il: &Il,
+    span: Option<Span>,
+    callee_span: Option<Span>,
+    receiver_span: Option<Span>,
+    id: LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+    arg_count: usize,
+) -> LibraryApiEvidenceStatus {
+    let Some(span) = span else {
+        return LibraryApiEvidenceStatus::Missing;
+    };
+    if arg_count > u16::MAX as usize {
+        return LibraryApiEvidenceStatus::Rejected;
+    }
+    let expected = LibraryApiEvidenceKind::Contract {
+        contract_hash: library_api_contract_id_hash(id),
+        callee_hash: library_api_callee_contract_hash(callee),
+        arity: arg_count as u16,
+    };
+    let mut saw_library_api_evidence = false;
+    let mut admitted = false;
+    for record in &il.evidence {
+        if record.anchor != EvidenceAnchor::node(span, NodeKind::Call) {
+            continue;
+        }
+        let EvidenceKind::LibraryApi(api) = record.kind else {
+            continue;
+        };
+        saw_library_api_evidence = true;
+        if record.status != EvidenceStatus::Asserted
+            || api != expected
+            || !evidence_dependencies_asserted(il, record)
+            || !library_api_dependencies_match_callee_at_span(
+                il,
+                span,
+                callee_span,
+                receiver_span,
+                callee,
+                record,
+            )
+        {
+            return LibraryApiEvidenceStatus::Rejected;
+        }
+        admitted = true;
+    }
+    if admitted {
+        LibraryApiEvidenceStatus::Admitted
+    } else if saw_library_api_evidence {
+        LibraryApiEvidenceStatus::Rejected
+    } else {
+        LibraryApiEvidenceStatus::Missing
+    }
+}
+
+fn library_api_callee_shape_matches(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    callee: LibraryApiCalleeContract,
+) -> bool {
+    let Some(&callee_node) = il.children(node).first() else {
+        return false;
+    };
+    match callee {
+        LibraryApiCalleeContract::JsGlobalConstructor { receiver, .. } => {
+            var_name_matches(il, interner, callee_node, receiver)
+        }
+        LibraryApiCalleeContract::StaticGlobalMethod {
+            receiver, method, ..
+        } => {
+            let Some((actual_receiver, actual_method)) =
+                static_member_callee_parts(il, interner, callee_node)
+            else {
+                return false;
+            };
+            actual_receiver == receiver && actual_method == method
+        }
+        LibraryApiCalleeContract::StaticGlobalFunction { function, .. } => {
+            var_name_matches(il, interner, callee_node, function)
+        }
+        _ => false,
+    }
+}
+
+fn library_api_dependencies_match_callee(
+    il: &Il,
+    node: NodeId,
+    callee: LibraryApiCalleeContract,
+    record: &EvidenceRecord,
+) -> bool {
+    let Some(&callee_node) = il.children(node).first() else {
+        return false;
+    };
+    match callee {
+        LibraryApiCalleeContract::JsGlobalConstructor {
+            receiver,
+            requires_unshadowed_global,
+        } => {
+            dependency_has_source_call(il, record, il.node(node).span, SourceCallKind::Construct)
+                && (!requires_unshadowed_global
+                    || dependency_has_unshadowed_global_node(il, record, callee_node, receiver))
+        }
+        LibraryApiCalleeContract::StaticGlobalMethod {
+            receiver,
+            qualified_path,
+            requires_unshadowed_receiver,
+            ..
+        } => {
+            let Some(receiver_node) = il.children(callee_node).first().copied() else {
+                return false;
+            };
+            dependency_has_qualified_global_node(il, record, callee_node, qualified_path)
+                && (!requires_unshadowed_receiver
+                    || dependency_has_unshadowed_global_node(il, record, receiver_node, receiver))
+        }
+        LibraryApiCalleeContract::StaticGlobalFunction {
+            function,
+            requires_unshadowed_function,
+        } => {
+            !requires_unshadowed_function
+                || dependency_has_unshadowed_global_node(il, record, callee_node, function)
+        }
+        _ => false,
+    }
+}
+
+fn library_api_dependencies_match_callee_at_span(
+    il: &Il,
+    call_span: Span,
+    callee_span: Option<Span>,
+    receiver_span: Option<Span>,
+    callee: LibraryApiCalleeContract,
+    record: &EvidenceRecord,
+) -> bool {
+    match callee {
+        LibraryApiCalleeContract::JsGlobalConstructor {
+            receiver,
+            requires_unshadowed_global,
+        } => {
+            dependency_has_source_call(il, record, call_span, SourceCallKind::Construct)
+                && (!requires_unshadowed_global
+                    || callee_span.is_some_and(|span| {
+                        dependency_has_unshadowed_global_anchor(
+                            il,
+                            record,
+                            span,
+                            NodeKind::Var,
+                            receiver,
+                        )
+                    }))
+        }
+        LibraryApiCalleeContract::StaticGlobalMethod {
+            receiver,
+            qualified_path,
+            requires_unshadowed_receiver,
+            ..
+        } => {
+            callee_span.is_some_and(|span| {
+                dependency_has_qualified_global_anchor(
+                    il,
+                    record,
+                    span,
+                    NodeKind::Field,
+                    qualified_path,
+                )
+            }) && (!requires_unshadowed_receiver
+                || receiver_span.is_some_and(|span| {
+                    dependency_has_unshadowed_global_anchor(
+                        il,
+                        record,
+                        span,
+                        NodeKind::Var,
+                        receiver,
+                    )
+                }))
+        }
+        LibraryApiCalleeContract::StaticGlobalFunction {
+            function,
+            requires_unshadowed_function,
+        } => {
+            !requires_unshadowed_function
+                || callee_span.is_some_and(|span| {
+                    dependency_has_unshadowed_global_anchor(
+                        il,
+                        record,
+                        span,
+                        NodeKind::Var,
+                        function,
+                    )
+                })
+        }
+        _ => false,
+    }
+}
+
+fn var_name_matches(il: &Il, interner: &Interner, node: NodeId, expected: &str) -> bool {
+    matches!(
+        (il.kind(node), il.node(node).payload),
+        (NodeKind::Var, Payload::Name(name)) if interner.resolve(name) == expected
+    )
+}
+
+fn static_member_callee_parts<'a>(
+    il: &Il,
+    interner: &'a Interner,
+    node: NodeId,
+) -> Option<(&'a str, &'a str)> {
+    if il.kind(node) != NodeKind::Field {
+        return None;
+    }
+    let Payload::Name(method) = il.node(node).payload else {
+        return None;
+    };
+    let receiver = il.children(node).first().copied()?;
+    let Payload::Name(receiver_name) = il.node(receiver).payload else {
+        return None;
+    };
+    (il.kind(receiver) == NodeKind::Var)
+        .then(|| (interner.resolve(receiver_name), interner.resolve(method)))
+}
+
+fn dependency_has_source_call(
+    il: &Il,
+    record: &EvidenceRecord,
+    span: Span,
+    expected: SourceCallKind,
+) -> bool {
+    let anchor = EvidenceAnchor::source_span(span);
+    let kind = EvidenceKind::Source(SourceFactKind::Call(expected));
+    matches!(
+        unique_evidence_at(
+            il,
+            |candidate| candidate == anchor,
+            |evidence| match evidence {
+                EvidenceKind::Source(SourceFactKind::Call(call)) => Some(call),
+                _ => None,
+            },
+        ),
+        EvidenceResolution::Found(call) if call == expected
+    ) && dependency_has_asserted_record(il, record, anchor, kind)
+}
+
+fn dependency_has_unshadowed_global_node(
+    il: &Il,
+    record: &EvidenceRecord,
+    node: NodeId,
+    expected: &str,
+) -> bool {
+    let span = il.node(node).span;
+    let kind = il.kind(node);
+    dependency_has_unshadowed_global_anchor(il, record, span, kind, expected)
+}
+
+fn dependency_has_unshadowed_global_anchor(
+    il: &Il,
+    record: &EvidenceRecord,
+    span: Span,
+    kind: NodeKind,
+    expected: &str,
+) -> bool {
+    let expected_kind = SymbolEvidenceKind::UnshadowedGlobal {
+        name_hash: stable_symbol_hash(expected),
+    };
+    if !matches!(
+        symbol_evidence_at_node_anchor(il, span, kind),
+        EvidenceResolution::Found(actual) if actual == expected_kind
+    ) {
+        return false;
+    }
+    dependency_has_asserted_record(
+        il,
+        record,
+        EvidenceAnchor::node(span, kind),
+        EvidenceKind::Symbol(expected_kind),
+    )
+}
+
+fn dependency_has_qualified_global_node(
+    il: &Il,
+    record: &EvidenceRecord,
+    node: NodeId,
+    expected: &str,
+) -> bool {
+    let span = il.node(node).span;
+    let kind = il.kind(node);
+    dependency_has_qualified_global_anchor(il, record, span, kind, expected)
+}
+
+fn dependency_has_qualified_global_anchor(
+    il: &Il,
+    record: &EvidenceRecord,
+    span: Span,
+    kind: NodeKind,
+    expected: &str,
+) -> bool {
+    let expected_kind = SymbolEvidenceKind::QualifiedGlobal {
+        path_hash: stable_symbol_hash(expected),
+    };
+    if !matches!(
+        symbol_evidence_at_node_anchor(il, span, kind),
+        EvidenceResolution::Found(actual) if actual == expected_kind
+    ) {
+        return false;
+    }
+    dependency_has_asserted_record(
+        il,
+        record,
+        EvidenceAnchor::node(span, kind),
+        EvidenceKind::Symbol(expected_kind),
+    )
+}
+
+fn dependency_has_asserted_record(
+    il: &Il,
+    record: &EvidenceRecord,
+    anchor: EvidenceAnchor,
+    kind: EvidenceKind,
+) -> bool {
+    record.dependencies.iter().any(|&id| {
+        evidence_record_by_id(il, id).is_some_and(|dependency| {
+            dependency.anchor == anchor
+                && dependency.status == EvidenceStatus::Asserted
+                && dependency.kind == kind
+        })
+    })
 }
 
 pub fn library_free_name_collection_factory_contract(
@@ -4473,8 +5054,9 @@ mod tests {
     use nose_il::{
         EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
         EvidenceRecord, EvidenceStatus, FileId, FileMeta, GuardEvidenceKind, IlBuilder,
-        ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, ParamSemantic,
-        ParamTypeFact, SequenceSurfaceKind, SourceFact, Span, SymbolEvidenceKind, Unit, UnitKind,
+        ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck,
+        LibraryApiEvidenceKind, ParamSemantic, ParamTypeFact, SequenceSurfaceKind, SourceFact,
+        Span, SymbolEvidenceKind, Unit, UnitKind,
     };
 
     const ALL_LANGS: &[Lang] = &[
@@ -5779,6 +6361,289 @@ mod tests {
             EvidenceStatus::Asserted,
         ));
         assert!(!qualified_global_symbol(&il, field, "Array.from"));
+    }
+
+    fn js_array_is_array_call_il(interner: &Interner) -> (Il, NodeId, NodeId, NodeId) {
+        let mut b = IlBuilder::new(FileId(0));
+        let array = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("Array")),
+            sp(29),
+            &[],
+        );
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("isArray")),
+            sp(30),
+            &[array],
+        );
+        let value = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("value")),
+            sp(31),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(32), &[callee, value]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(29), &[call]);
+        (finish_il(b, root, Lang::JavaScript), call, callee, array)
+    }
+
+    fn library_api_record(
+        id: u32,
+        span: Span,
+        contract_id: LibraryApiContractId,
+        callee: LibraryApiCalleeContract,
+        status: EvidenceStatus,
+        dependencies: &[u32],
+    ) -> EvidenceRecord {
+        evidence_with_dependencies(
+            id,
+            EvidenceAnchor::node(span, NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(contract_id),
+                callee_hash: library_api_callee_contract_hash(callee),
+                arity: 1,
+            }),
+            status,
+            dependencies.iter().copied().map(EvidenceId).collect(),
+        )
+    }
+
+    #[test]
+    fn library_api_evidence_resolution_is_dependency_backed_and_fail_closed() {
+        let interner = Interner::new();
+        let (mut il, call, callee, array) = js_array_is_array_call_il(&interner);
+        let contract = library_js_array_is_array_contract(Lang::JavaScript, "Array", "isArray", 1)
+            .expect("test contract");
+
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &il,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Missing
+        );
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(il.node(array).span, NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("Array"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(il.node(callee).span, NodeKind::Field),
+            EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+                path_hash: stable_symbol_hash("Array.isArray"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(library_api_record(
+            2,
+            il.node(call).span,
+            contract.id,
+            contract.callee,
+            EvidenceStatus::Asserted,
+            &[0, 1],
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &il,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        );
+        assert_eq!(
+            library_api_contract_evidence_at_call_span(
+                &il,
+                Some(il.node(call).span),
+                Some(il.node(callee).span),
+                Some(il.node(array).span),
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        );
+        assert_eq!(
+            library_api_contract_evidence_at_call_span(
+                &il,
+                Some(il.node(call).span),
+                Some(sp(99)),
+                Some(il.node(array).span),
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Rejected
+        );
+        assert_eq!(
+            library_api_contract_evidence_at_call_span(
+                &il,
+                Some(il.node(call).span),
+                Some(il.node(callee).span),
+                Some(sp(99)),
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Rejected
+        );
+
+        let (mut missing_dep, call, _callee, _array) = js_array_is_array_call_il(&interner);
+        missing_dep.evidence.push(library_api_record(
+            0,
+            missing_dep.node(call).span,
+            contract.id,
+            contract.callee,
+            EvidenceStatus::Asserted,
+            &[],
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &missing_dep,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Rejected
+        );
+
+        let (mut ambiguous_dep, call, callee, array) = js_array_is_array_call_il(&interner);
+        ambiguous_dep.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(ambiguous_dep.node(array).span, NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("Array"),
+            }),
+            EvidenceStatus::Ambiguous,
+        ));
+        ambiguous_dep.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(ambiguous_dep.node(callee).span, NodeKind::Field),
+            EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+                path_hash: stable_symbol_hash("Array.isArray"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        ambiguous_dep.evidence.push(library_api_record(
+            2,
+            ambiguous_dep.node(call).span,
+            contract.id,
+            contract.callee,
+            EvidenceStatus::Asserted,
+            &[0, 1],
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &ambiguous_dep,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Rejected
+        );
+
+        let (mut conflicting_dep, call, callee, array) = js_array_is_array_call_il(&interner);
+        conflicting_dep.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(conflicting_dep.node(array).span, NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("Array"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        conflicting_dep.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(conflicting_dep.node(callee).span, NodeKind::Field),
+            EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+                path_hash: stable_symbol_hash("Array.isArray"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        conflicting_dep.evidence.push(evidence(
+            2,
+            EvidenceAnchor::node(conflicting_dep.node(array).span, NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("Map"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        conflicting_dep.evidence.push(library_api_record(
+            3,
+            conflicting_dep.node(call).span,
+            contract.id,
+            contract.callee,
+            EvidenceStatus::Asserted,
+            &[0, 1],
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &conflicting_dep,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Rejected
+        );
+
+        let boolean = library_js_boolean_coercion_contract(Lang::JavaScript, "Boolean", 1).unwrap();
+        il.evidence.push(library_api_record(
+            3,
+            il.node(call).span,
+            boolean.id,
+            boolean.callee,
+            EvidenceStatus::Asserted,
+            &[0],
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &il,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Rejected
+        );
+
+        let (mut wrong_anchor, call, _callee, _array) = js_array_is_array_call_il(&interner);
+        wrong_anchor.evidence.push(library_api_record(
+            0,
+            sp(99),
+            contract.id,
+            contract.callee,
+            EvidenceStatus::Asserted,
+            &[],
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &wrong_anchor,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Missing
+        );
     }
 
     #[test]

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -13,8 +13,8 @@ can satisfy an exact-channel precondition.
 
 ## Goal
 
-- Give source, domain, import, symbol-identity, guard, place/effect, and
-  sequence-surface proof facts one shared shape.
+- Give source, domain, import, symbol-identity, guard, place/effect, selected
+  library API occurrence, and sequence-surface proof facts one shared shape.
 - Make facts carry stable ids, anchors, provenance, dependencies, and status.
 - Keep exact matching fail-closed when evidence is missing, ambiguous, or
   conflicting.
@@ -63,16 +63,17 @@ The current implemented kinds are:
 | `Guard` | multi-obligation guard proof facts such as JS/TS record-shape and own-property guard contracts |
 | `Place` | fixed receiver/place facts currently covering `SelfReceiver` and `SelfField` |
 | `Effect` | observable effect facts currently covering canonical builder append calls, non-overloadable index writes, and fixed self-field writes |
+| `LibraryApi` | proof that a specific call occurrence matches a language/API contract coordinate, currently for selected JS-like static/global APIs |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, guard surfaces, Go composite map literals, or Go map entries |
 
-`LibraryApiContract` is deliberately not listed here yet. It is currently an
-internal `nose-semantics` contract layer that names first-party library/API
-identity, callee obligations, shadow/import requirements, and result semantics.
-Existing evidence kinds such as `Symbol`, `Import`, `Source`, and
-`SequenceSurface` prove those obligations; the contract decides whether the
-facts are enough to admit an exact or value-graph path. A future external pack
-schema may expose library API contracts, but providers still emit facts and
-contracts rather than exact-clone verdicts.
+`LibraryApi` evidence is an occurrence fact, not the whole contract. It records
+the contract id, callee coordinate, arity, and dependencies for a specific call
+node. `LibraryApiContract` rows in `nose-semantics` still name result semantics
+and the remaining obligations. Existing evidence kinds such as `Symbol`,
+`Import`, `Source`, `Domain`, and `SequenceSurface` prove those obligations; the
+contract decides whether the facts are enough to admit an exact or value-graph
+path. A future external pack schema may expose library API contracts, but
+providers still emit facts and contracts rather than exact-clone verdicts.
 
 ## Consumption Rules
 
@@ -81,8 +82,8 @@ side tables.
 
 - A lookup succeeds only when asserted evidence resolves to exactly one relevant
   fact.
-- Conflicting asserted evidence is treated as missing evidence.
-- `Ambiguous` evidence is treated as missing evidence.
+- Conflicting asserted evidence makes the lookup fail.
+- `Ambiguous` evidence makes the lookup fail.
 - If any relevant ambiguous/conflicting evidence exists, compatibility fallback
   must not reopen the exact path.
 - Compatibility fallback is allowed only when no relevant evidence record exists,
@@ -137,6 +138,17 @@ receiver/place side. First-party `Place(SelfField)` depends on the matching
 `Place(SelfField)`. Conflicting or ambiguous place/effect evidence blocks the
 legacy language-gated fallback.
 
+Library API evidence follows the same fail-closed rule. If a call carries
+`LibraryApi` evidence for a selected API occurrence, consumers must validate the
+contract id, callee coordinate, arity, dependencies, dependency anchors, and call
+shape before using legacy name/symbol fallback. A conflicting, ambiguous,
+wrong-callee-anchor, wrong-dependency-anchor, or dependency-broken API record on
+the queried call closes that API path. A record anchored to another call is
+irrelevant to this lookup and leaves the compatibility path available. The
+record proves only API identity; exact consumers still separately prove
+receiver/domain facts, source-surface requirements, argument safety, result
+shape, mutation safety, and demand/effect obligations.
+
 ## Current Producers
 
 First-party frontends now mirror these facts into `EvidenceRecord`:
@@ -166,6 +178,14 @@ First-party frontends now mirror these facts into `EvidenceRecord`:
   writes, and `Effect(BuilderAppendCall)` for canonical `Builtin::Append`.
   Self-field place/write evidence records include dependencies that link the
   write proof back to the receiver proof;
+- first-party JS/TS lowering emits `LibraryApi` evidence for selected
+  static/global API calls that remain as raw call nodes: `Array.from(...)`,
+  `Array.isArray(...)`, `Boolean(...)`, `new Map(...)`, and `new Set(...)`.
+  These records depend on the relevant `QualifiedGlobal`, `UnshadowedGlobal`,
+  and/or construct-syntax `Source` evidence. Calls collapsed into specialized
+  guard surfaces emit their guard evidence instead. Shadowed roots, plain
+  `Map(...)`/`Set(...)` calls, and unsupported static paths do not emit API
+  occurrence evidence;
 - lowered `Seq` surfaces emit `SequenceSurface` evidence, including Go map
   literal and Go map-entry surfaces where those tags carry first-party meaning.
 
@@ -203,11 +223,14 @@ callers:
   guard evidence depends on `Object.hasOwn` or
   `Object.prototype.hasOwnProperty.call`, and map-key view wrappers require
   evidence for `Array.from`;
-- `LibraryApiContract` consumers for factory and selected non-factory API
-  surfaces now use these evidence helpers for their local obligations. The
-  contract rows name API identity and result semantics, while `Symbol`,
-  `Import`, `Source`, `Domain`, and `SequenceSurface` records still provide the
-  proof facts consumed by normalize, value-graph, and strict exact gates;
+- selected JS-like `LibraryApiContract` consumers now consult `LibraryApi`
+  occurrence evidence first for `Array.from`, `Array.isArray`, `Boolean`,
+  `new Map`, and `new Set`; conflicting or dependency-broken API evidence keeps
+  the value-graph and strict exact paths closed. When no relevant API evidence is
+  present, the current compatibility path still uses the older symbol/source
+  proof helpers. Other factory and method/view contract rows still name API
+  identity/result semantics while local consumers prove their current
+  `Symbol`, `Import`, `Source`, `Domain`, and `SequenceSurface` obligations;
 - JS/TS record-shape guard exact admission and value-graph tagging require both
   `SequenceSurface(RecordGuard)` and `Guard::JsRecordShape`; raw
   `Seq("record_guard")` cannot enter the proof-bearing exact/value-graph path by
@@ -227,7 +250,8 @@ callers:
   language-gated helper only when no relevant evidence record exists. Ambiguous
   or conflicting evidence keeps the exact path closed.
 
-Broader field/place/effect facts, receiver/protocol evidence beyond parameter
+Broader field/place/effect facts, `LibraryApi` occurrence evidence beyond the
+selected JS-like static/global APIs, receiver/protocol evidence beyond parameter
 domains, full scope-resolution and namespace-member evidence, broader guard
 evidence, general cross-module dependency manifests, report-level provenance,
 and external manifest loading are still open work.

--- a/docs/home.md
+++ b/docs/home.md
@@ -52,7 +52,7 @@ You want to *change* nose or understand how it works inside.
 - [architecture](architecture.md) — the crates and the lower → normalize → detect → rank pipeline.
 - [normalization](normalization.md) — the passes that make behaviorally-equivalent code converge (the hard part).
 - [semantic-kernel](semantic-kernel.md) — semantic-kernel and pack architecture: language/library semantics, extension boundaries, responsibility model, and exact-channel eligibility.
-- [evidence-records](evidence-records.md) — the internal pack-facing evidence substrate for source, domain, import, and sequence-surface facts.
+- [evidence-records](evidence-records.md) — the internal pack-facing evidence substrate for source, domain, import, symbol, guard, place/effect, library API, and sequence-surface facts.
 - [source-facts](source-facts.md) — source-origin evidence for semantic contracts: construct syntax, literal/operator provenance, pack boundaries, and fail-closed exact admission.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -281,6 +281,12 @@ and pack ecosystem.
   `Arrays.stream`, and existing language-scoped method-call gates now share the
   same API-contract source across normalize, value-graph, and strict exact
   consumers.
+- The first `LibraryApi` occurrence evidence vertical landed for selected
+  JS-like static/global APIs. First-party lowering emits dependency-backed call
+  evidence for `Array.from`, `Array.isArray`, `Boolean`, `new Map`, and
+  `new Set`; value-graph and strict exact consumers for those surfaces consult
+  it first and close legacy fallback on conflicting, ambiguous, or
+  dependency-broken records.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -338,7 +344,8 @@ Remaining in this phase:
 - Continue replacing remaining local exact-fragment proof helpers with
   versioned pack-facing evidence records, especially broader field/read/write
   place facts and receiver-sensitive mutation/effect proofs.
-- Continue moving library API recognition into `LibraryApiContract` records.
+- Continue moving library API recognition into `LibraryApiContract` rows and
+  `LibraryApi` occurrence evidence.
   The first internal slice covers collection/map factories, selected
   constructors, Java empty collection constructors, Java `Map.entry`, and the
   shared shadow/import/result
@@ -347,13 +354,16 @@ Remaining in this phase:
   views and wrappers, map `get`, map defaulting method calls, static JS-like
   helpers, regex-literal `.test`, Python `math.prod`, promise `.then`, iterator
   identity adapters, Java `Arrays.stream`, and existing language-scoped method
-  call contracts.
+  call contracts. The first occurrence-evidence slice covers selected JS-like
+  static/global APIs only; broader stdlib and ecosystem APIs still need
+  dependency-backed occurrence records before they become pack-facing.
 - Keep value-graph and strict exact gates on the same contract source. Factory,
   constructor, and selected method/view/adapter gates now share
-  `LibraryApiContract` identity/result rows. Remaining API work is to move
-  remaining raw sequence/tag dependencies into explicit evidence records, then
-  cover broader reduction/HOF and ecosystem APIs only after demand, receiver,
-  and effect obligations are expressible.
+  `LibraryApiContract` identity/result rows, and selected JS-like static/global
+  calls now additionally share `LibraryApi` occurrence evidence. Remaining API
+  work is to move remaining raw sequence/tag and local callee-proof dependencies
+  into explicit evidence records, then cover broader reduction/HOF and ecosystem
+  APIs only after demand, receiver, and effect obligations are expressible.
 - Remove the remaining raw import/module proof IL payload storage after import
   and symbol evidence records can carry every consumer obligation, including
   module export dependencies, scope, rebinding, and mutation proof. Value-graph

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -10,10 +10,11 @@ foundation and follow-up facade migrations through receiver-aware field state
 sequence-surface contracts, proof-backed append fragment evidence, and the first
 operator-law contracts, typed import facts, and source-fact gates for construct,
 literal, equality/operator provenance, and the shared evidence-record substrate
-for source, domain, import, symbol-identity, guard, and sequence-surface facts.
-Library/API identity is now consolidated further through internal
-`LibraryApiContract` rows for factory, constructor, and selected non-factory
-method/view surfaces.
+for source, domain, import, symbol-identity, guard, place/effect, selected
+library API occurrence, and sequence-surface facts. Library/API identity is now
+consolidated further through internal `LibraryApiContract` rows for factory,
+constructor, and selected non-factory method/view surfaces, with the first
+occurrence evidence vertical covering selected JS-like static/global APIs.
 
 ## What exists today
 
@@ -52,11 +53,12 @@ migrated.
   channel eligibility. `ChannelEligibility` describes where a fact may be used;
   first-party/default status is pack provenance, not an analysis channel.
 - `Il::evidence` is now the shared internal substrate for source, domain, import,
-  symbol-identity, and sequence-surface proof facts. Records carry ids, stable
-  source anchors, kind, provenance, dependencies, and asserted/ambiguous status.
-  Lookups in `nose-semantics` fail closed on ambiguous or conflicting evidence
-  and use older side tables only as compatibility fallback when no relevant
-  evidence record is present.
+  symbol-identity, guard, place/effect, selected library API occurrence, and
+  sequence-surface proof facts. Records carry ids, stable source anchors, kind,
+  provenance, dependencies, and asserted/ambiguous status. Lookups in
+  `nose-semantics` fail closed on ambiguous or conflicting evidence and use older
+  side tables only as compatibility fallback when no relevant evidence record is
+  present.
 - `OperatorSemantics` now owns the first shared operator contracts:
   comparison-direction transforms, comparison negation, equality operand
   commutativity, comparison-lattice laws, abs/min/max/selection guard laws,
@@ -127,6 +129,19 @@ migrated.
   identity and result obligations; local consumers still prove receiver domain,
   import/symbol identity, source facts, exact-safe arguments, fallback demand
   shape, and mutation safety.
+- Selected JS-like API call occurrences now also have `LibraryApi` evidence
+  records when they remain as raw call nodes. First-party lowering emits
+  occurrence evidence for `Array.from(...)`, `Array.isArray(...)`,
+  `Boolean(...)`, `new Map(...)`, and `new Set(...)`, depending on the relevant
+  `QualifiedGlobal`, `UnshadowedGlobal`, and/or construct-syntax `Source`
+  evidence. Calls collapsed into specialized guard surfaces emit guard evidence
+  instead. `nose-semantics` resolves these records with a three-state result:
+  admitted, missing, or rejected. Value-graph and strict exact consumers for
+  `Array.from(map.keys())`, `Array.isArray`, and JS-like `new Map`/`new Set`
+  consult this occurrence evidence first; conflicting or dependency-broken API
+  evidence closes the legacy path. The record proves API identity only;
+  receiver/domain, source, exact-safe argument, result-shape, and mutation
+  obligations remain separate.
 - Java empty collection constructor contracts cover `new ArrayList<>()` and
   `new LinkedList<>()` through `LibraryApiContract` rows only for the Java
   `java.util` list types. Simple names require `java.util` import proof and no
@@ -339,7 +354,10 @@ Semantic knowledge still appears in several forms outside the facade:
 - hard-coded oracle evaluation rules for eager calls, short-circuit operators,
   HOFs, nullish defaulting, recursion, and effect traces;
 - duplicated receiver/domain and library/API proof gates in desugaring,
-  idiom lowering, value-graph, and strict exact paths.
+  idiom lowering, value-graph, and strict exact paths. The first JS-like
+  `LibraryApi` occurrence evidence reduces this for selected static/global APIs,
+  but Python/Java/Rust/Ruby factory and method occurrences still mostly rely on
+  contract rows plus local proof.
 
 These are valuable, but they do not yet share one complete semantic contract
 language.
@@ -414,6 +432,10 @@ The first high-value targets for semantic-kernel extraction are:
 - richer sequence/aggregate evidence for factories, nested entries, iterator
   views, and exported-literal eligibility beyond the current first
   `SequenceSurface` substrate;
+- broader `LibraryApi` occurrence evidence for Java/Rust/Python/Ruby stdlib
+  factories, imported namespace functions, map get/defaulting, iterator
+  adapters, and method-call surfaces now represented only by contract rows plus
+  local proof;
 - generalized guard evidence beyond the first JS/TS record-shape contract,
   including richer source/API dependency records and validation;
 - dependency, scope, and ambiguity validation before evidence records become a

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -27,8 +27,9 @@ first-party implementation, not a loadable external pack runtime.
 
 Evidence records are one kernel input at that boundary. They preserve facts that
 the IL deliberately abstracts away, but they do not approve semantic equivalence
-by themselves. Source facts are one evidence class; domain, import, and sequence
-surface facts now use the same internal substrate. See
+by themselves. Source facts are one evidence class; domain, import, symbol,
+guard, place/effect, selected library API occurrence, and sequence-surface facts
+now use the same internal substrate. See
 [evidence-records](evidence-records.md) for the record shape and
 [source-facts](source-facts.md) for the source-origin vocabulary.
 


### PR DESCRIPTION
## Summary
- add `LibraryApi` evidence records for selected JS-like static/global API call occurrences
- emit dependency-backed first-party evidence for `Array.from`, `Array.isArray`, `Boolean`, `new Map`, and `new Set` raw calls
- make value-graph and strict exact consumers consult API occurrence evidence first and fail closed on conflicting, ambiguous, wrong-anchor, or dependency-broken records
- update semantic-kernel docs/snapshot/roadmap to document the first occurrence-evidence vertical and remaining broader API-pack work

## Soundness notes
- API evidence proves call/API identity only; receiver/domain/source/result/mutation/exact-argument obligations remain separate
- rejected API evidence does not reopen legacy fallback
- dependency validation now checks exact source/callee/receiver anchors and same-anchor symbol conflicts

## Validation
- `cargo fmt --all --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p nose-semantics library_api -- --nocapture`
- `cargo test -p nose-normalize js_constructor_value_graph_closes_on_conflicting_api_evidence -- --nocapture`
- `cargo test -p nose-detect strict_exact_js_constructor_closes_on_conflicting_api_evidence -- --nocapture`
- `cargo test -p nose-frontend js_ -- --nocapture`
- `cargo test --workspace`
- `cargo test --release`
- `python3 scripts/check-formal-obligations.py --self-test`
- `python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `./scripts/check-duplication.sh`
- `awiki lint --root docs`
- `git diff --check`

Refs #109