### PR TITLE
[codex] Harden library API occurrence evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ wiki so claims have one source of truth:
 - [Clone types](docs/clone-types.md)
 - [Benchmark](docs/benchmark.md)
 - [Architecture](docs/architecture.md)
+- [Semantic kernel](docs/semantic-kernel.md)
 - [Scan JSON schema](docs/scan-json.md)
 
 ## License

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -1342,6 +1342,22 @@ fn strict_exact_typeof_operator_safe(
         && strict_exact_call_args_safe(il, interner, facts, node)
 }
 
+fn library_api_evidence_or_legacy(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    id: nose_semantics::LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+    arg_count: usize,
+    legacy: impl FnOnce() -> bool,
+) -> bool {
+    match library_api_contract_evidence_for_call(il, interner, node, id, callee, arg_count) {
+        LibraryApiEvidenceStatus::Admitted => true,
+        LibraryApiEvidenceStatus::Rejected => false,
+        LibraryApiEvidenceStatus::Missing => legacy(),
+    }
+}
+
 fn strict_exact_regex_test_safe(
     il: &Il,
     interner: &Interner,
@@ -1358,21 +1374,16 @@ fn strict_exact_regex_test_safe(
     let Some(&receiver) = il.children(callee).first() else {
         return Some(false);
     };
-    match library_api_contract_evidence_for_call(
+    if !library_api_evidence_or_legacy(
         il,
         interner,
         node,
         contract.id,
         contract.callee,
         il.children(node).len().saturating_sub(1),
+        || source_fact_at_node(il, receiver, contract.result.required_receiver_fact),
     ) {
-        LibraryApiEvidenceStatus::Admitted => {}
-        LibraryApiEvidenceStatus::Rejected => return Some(false),
-        LibraryApiEvidenceStatus::Missing => {
-            if !source_fact_at_node(il, receiver, contract.result.required_receiver_fact) {
-                return Some(false);
-            }
-        }
+        return Some(false);
     }
     Some(strict_exact_call_args_safe(il, interner, facts, node))
 }
@@ -1402,27 +1413,21 @@ fn strict_exact_js_array_is_array_safe(
     ) else {
         return false;
     };
-    match library_api_contract_evidence_for_call(
+    if !library_api_evidence_or_legacy(
         il,
         interner,
         node,
         contract.id,
         contract.callee,
         arg_count,
-    ) {
-        LibraryApiEvidenceStatus::Admitted => {}
-        LibraryApiEvidenceStatus::Rejected => return false,
-        LibraryApiEvidenceStatus::Missing => {
+        || {
             let result = contract.result;
-            if result.requires_unshadowed_receiver
-                && !unshadowed_global_symbol(il, interner, receiver, result.receiver)
-            {
-                return false;
-            }
-            if !qualified_global_symbol(il, callee, result.qualified_path) {
-                return false;
-            }
-        }
+            (!result.requires_unshadowed_receiver
+                || unshadowed_global_symbol(il, interner, receiver, result.receiver))
+                && qualified_global_symbol(il, callee, result.qualified_path)
+        },
+    ) {
+        return false;
     }
     strict_exact_call_args_safe(il, interner, facts, node)
 }
@@ -1998,20 +2003,19 @@ fn strict_exact_python_collection_factory_safe(
             else {
                 return false;
             };
-            match library_api_contract_evidence_for_call(
+            library_api_evidence_or_legacy(
                 il,
                 interner,
                 node,
                 contract.id,
                 contract.callee,
                 1,
-            ) {
-                LibraryApiEvidenceStatus::Admitted => true,
-                LibraryApiEvidenceStatus::Rejected => false,
-                LibraryApiEvidenceStatus::Missing => strict_exact_python_imported_factory_name(
-                    il, interner, kids[0], module, exported,
-                ),
-            }
+                || {
+                    strict_exact_python_imported_factory_name(
+                        il, interner, kids[0], module, exported,
+                    )
+                },
+            )
         });
     (builtin || imported_stdlib_factory)
         && strict_exact_membership_collection_safe(il, interner, facts, kids[1])
@@ -2235,21 +2239,16 @@ fn strict_exact_java_collection_factory_safe(
             else {
                 return None;
             };
-            match library_api_contract_evidence_for_call(
+            library_api_evidence_or_legacy(
                 il,
                 interner,
                 node,
                 contract.id,
                 contract.callee,
                 kids.len().saturating_sub(1),
-            ) {
-                LibraryApiEvidenceStatus::Admitted => Some(contract),
-                LibraryApiEvidenceStatus::Rejected => None,
-                LibraryApiEvidenceStatus::Missing => {
-                    strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
-                        .then_some(contract)
-                }
-            }
+                || strict_exact_java_std_var_name(il, interner, receiver, expected_receiver),
+            )
+            .then_some(contract)
         })
     else {
         return false;
@@ -2307,68 +2306,87 @@ fn strict_exact_java_std_var_name(
     imported_binding_symbol(il, interner, node, "java.util", expected)
 }
 
+fn java_util_static_member_call<'a>(
+    il: &'a Il,
+    interner: &'a Interner,
+    node: NodeId,
+) -> Option<(&'a str, NodeId, &'a [NodeId])> {
+    if il.kind(node) != NodeKind::Call {
+        return None;
+    }
+    let kids = il.children(node);
+    let (&callee, args) = kids.split_first()?;
+    if il.kind(callee) != NodeKind::Field {
+        return None;
+    }
+    let Payload::Name(method) = il.node(callee).payload else {
+        return None;
+    };
+    let receiver = il.children(callee).first().copied()?;
+    Some((interner.resolve(method), receiver, args))
+}
+
+fn java_util_static_member_evidence_or_legacy(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    contract_id: nose_semantics::LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+    receiver: NodeId,
+    legacy: impl FnOnce() -> bool,
+) -> bool {
+    let LibraryApiCalleeContract::JavaUtilStaticMember {
+        receiver: expected_receiver,
+        ..
+    } = callee
+    else {
+        return false;
+    };
+    let arg_count = il.children(node).len().saturating_sub(1);
+    library_api_evidence_or_legacy(il, interner, node, contract_id, callee, arg_count, || {
+        legacy() || strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
+    })
+}
+
 fn strict_exact_java_map_factory_safe(
     il: &Il,
     interner: &Interner,
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    if !semantics(il.meta.lang).stdlib().java_map_factories() || il.kind(node) != NodeKind::Call {
+    if !semantics(il.meta.lang).stdlib().java_map_factories() {
         return false;
     }
-    let kids = il.children(node);
-    if kids.is_empty() || il.kind(kids[0]) != NodeKind::Field {
-        return false;
-    }
-    let Payload::Name(method) = il.node(kids[0]).payload else {
+    let Some((method, receiver, args)) = java_util_static_member_call(il, interner, node) else {
         return false;
     };
-    let Some(&receiver) = il.children(kids[0]).first() else {
-        return false;
-    };
-    let method = interner.resolve(method);
     let Some(contract) = library_java_map_factory_contract(il.meta.lang, "Map", method) else {
-        return false;
-    };
-    let LibraryApiCalleeContract::JavaUtilStaticMember {
-        receiver: expected_receiver,
-        ..
-    } = contract.callee
-    else {
         return false;
     };
     let snapshot_proven =
         imported_literal_snapshot_evidence_at_span(il, il.node(node).span, NodeKind::Call);
-    match library_api_contract_evidence_for_call(
+    if !java_util_static_member_evidence_or_legacy(
         il,
         interner,
         node,
         contract.id,
         contract.callee,
-        kids.len().saturating_sub(1),
+        receiver,
+        || snapshot_proven,
     ) {
-        LibraryApiEvidenceStatus::Admitted => {}
-        LibraryApiEvidenceStatus::Rejected => return false,
-        LibraryApiEvidenceStatus::Missing => {
-            if !snapshot_proven
-                && !strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
-            {
-                return false;
-            }
-        }
+        return false;
     }
     let LibraryMapFactoryResult::JavaFactory { kind } = contract.result else {
         return false;
     };
     match kind {
         JavaMapFactoryKind::Of => {
-            let entries = &kids[1..];
-            entries.len() % 2 == 0
-                && entries
+            args.len() % 2 == 0
+                && args
                     .iter()
                     .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
         }
-        JavaMapFactoryKind::OfEntries => kids.iter().skip(1).all(|&entry| {
+        JavaMapFactoryKind::OfEntries => args.iter().all(|&entry| {
             strict_exact_java_map_entry_safe(il, interner, facts, entry, snapshot_proven)
         }),
     }
@@ -2381,50 +2399,27 @@ fn strict_exact_java_map_entry_safe(
     node: NodeId,
     snapshot_proven: bool,
 ) -> bool {
-    if il.kind(node) != NodeKind::Call {
-        return false;
-    }
-    let kids = il.children(node);
-    if kids.len() != 3 || il.kind(kids[0]) != NodeKind::Field {
-        return false;
-    }
-    let Payload::Name(method) = il.node(kids[0]).payload else {
+    let Some((method, receiver, args)) = java_util_static_member_call(il, interner, node) else {
         return false;
     };
-    let method = interner.resolve(method);
-    let Some(&receiver) = il.children(kids[0]).first() else {
+    if args.len() != 2 {
         return false;
-    };
+    }
     let Some(contract) = library_java_map_entry_contract(il.meta.lang, "Map", method) else {
         return false;
     };
-    let LibraryApiCalleeContract::JavaUtilStaticMember {
-        receiver: expected_receiver,
-        ..
-    } = contract.callee
-    else {
-        return false;
-    };
-    match library_api_contract_evidence_for_call(
+    if !java_util_static_member_evidence_or_legacy(
         il,
         interner,
         node,
         contract.id,
         contract.callee,
-        2,
+        receiver,
+        || snapshot_proven,
     ) {
-        LibraryApiEvidenceStatus::Admitted => {}
-        LibraryApiEvidenceStatus::Rejected => return false,
-        LibraryApiEvidenceStatus::Missing => {
-            if !snapshot_proven
-                && !strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
-            {
-                return false;
-            }
-        }
+        return false;
     }
-    kids.iter()
-        .skip(1)
+    args.iter()
         .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
 }
 
@@ -4199,6 +4194,26 @@ mod tests {
         }
     }
 
+    fn library_api_contract_evidence(
+        id: u32,
+        call_span: Span,
+        contract_id: nose_semantics::LibraryApiContractId,
+        callee: LibraryApiCalleeContract,
+        arity: u16,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceRecord {
+        evidence(
+            id,
+            EvidenceAnchor::node(call_span, NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(contract_id),
+                callee_hash: library_api_callee_contract_hash(callee),
+                arity,
+            }),
+            dependencies,
+        )
+    }
+
     fn js_new_set_il(interner: &Interner) -> (Il, NodeId) {
         let mut b = IlBuilder::new(FileId(0));
         let set = b.add(
@@ -4258,14 +4273,12 @@ mod tests {
         ));
 
         let wrong = library_js_like_map_constructor_contract(Lang::JavaScript, "Map").unwrap();
-        il.evidence.push(evidence(
+        il.evidence.push(library_api_contract_evidence(
             3,
-            EvidenceAnchor::node(sp(13), NodeKind::Call),
-            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
-                contract_hash: library_api_contract_id_hash(wrong.id),
-                callee_hash: library_api_callee_contract_hash(wrong.callee),
-                arity: 1,
-            }),
+            sp(13),
+            wrong.id,
+            wrong.callee,
+            1,
             vec![EvidenceId(0), EvidenceId(1)],
         ));
         let facts = StrictFacts::collect(&il, &interner);
@@ -4275,14 +4288,12 @@ mod tests {
 
         let (mut il, call) = js_new_set_il(&interner);
         let set = library_js_like_set_constructor_contract(Lang::JavaScript, "Set").unwrap();
-        il.evidence.push(evidence(
+        il.evidence.push(library_api_contract_evidence(
             3,
-            EvidenceAnchor::node(sp(13), NodeKind::Call),
-            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
-                contract_hash: library_api_contract_id_hash(set.id),
-                callee_hash: library_api_callee_contract_hash(set.callee),
-                arity: 1,
-            }),
+            sp(13),
+            set.id,
+            set.callee,
+            1,
             vec![EvidenceId(0), EvidenceId(1)],
         ));
         let facts = StrictFacts::collect(&il, &interner);
@@ -4365,14 +4376,12 @@ mod tests {
             binding_symbol,
             vec![EvidenceId(0)],
         ));
-        il.evidence.push(evidence(
+        il.evidence.push(library_api_contract_evidence(
             2,
-            EvidenceAnchor::node(sp(25), NodeKind::Call),
-            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
-                contract_hash: library_api_contract_id_hash(contract.id),
-                callee_hash: library_api_callee_contract_hash(contract.callee),
-                arity: 2,
-            }),
+            sp(25),
+            contract.id,
+            contract.callee,
+            2,
             vec![EvidenceId(1)],
         ));
         let facts = StrictFacts::collect(&il, &interner);
@@ -4383,14 +4392,12 @@ mod tests {
 
         let wrong = library_js_like_set_constructor_contract(Lang::JavaScript, "Set").unwrap();
         il.evidence.pop();
-        il.evidence.push(evidence(
+        il.evidence.push(library_api_contract_evidence(
             2,
-            EvidenceAnchor::node(sp(25), NodeKind::Call),
-            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
-                contract_hash: library_api_contract_id_hash(wrong.id),
-                callee_hash: library_api_callee_contract_hash(wrong.callee),
-                arity: 2,
-            }),
+            sp(25),
+            wrong.id,
+            wrong.callee,
+            2,
             vec![EvidenceId(1)],
         ));
         let facts = StrictFacts::collect(&il, &interner);

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -19,7 +19,7 @@ use nose_semantics::{
     exact_self_field_write_assignment, exact_static_membership_predicate_operator,
     go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
     go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract, imported_binding_symbol,
-    imported_literal_producer_evidence_for_node, imported_member_symbol,
+    imported_literal_snapshot_evidence_at_span, imported_member_symbol,
     library_api_contract_evidence_for_call, library_api_free_name_shadow_safe,
     library_free_name_collection_factory_contract, library_free_name_map_factory_contract,
     library_imported_collection_factory_contracts, library_iterator_identity_adapter_contract,
@@ -1354,15 +1354,27 @@ fn strict_exact_regex_test_safe(
         il.meta.lang,
         method,
         il.children(node).len().saturating_sub(1),
-    )?
-    .result;
+    )?;
     let Some(&receiver) = il.children(callee).first() else {
         return Some(false);
     };
-    Some(
-        source_fact_at_node(il, receiver, contract.required_receiver_fact)
-            && strict_exact_call_args_safe(il, interner, facts, node),
-    )
+    match library_api_contract_evidence_for_call(
+        il,
+        interner,
+        node,
+        contract.id,
+        contract.callee,
+        il.children(node).len().saturating_sub(1),
+    ) {
+        LibraryApiEvidenceStatus::Admitted => {}
+        LibraryApiEvidenceStatus::Rejected => return Some(false),
+        LibraryApiEvidenceStatus::Missing => {
+            if !source_fact_at_node(il, receiver, contract.result.required_receiver_fact) {
+                return Some(false);
+            }
+        }
+    }
+    Some(strict_exact_call_args_safe(il, interner, facts, node))
 }
 
 fn strict_exact_js_array_is_array_safe(
@@ -1986,7 +1998,20 @@ fn strict_exact_python_collection_factory_safe(
             else {
                 return false;
             };
-            strict_exact_python_imported_factory_name(il, interner, kids[0], module, exported)
+            match library_api_contract_evidence_for_call(
+                il,
+                interner,
+                node,
+                contract.id,
+                contract.callee,
+                1,
+            ) {
+                LibraryApiEvidenceStatus::Admitted => true,
+                LibraryApiEvidenceStatus::Rejected => false,
+                LibraryApiEvidenceStatus::Missing => strict_exact_python_imported_factory_name(
+                    il, interner, kids[0], module, exported,
+                ),
+            }
         });
     (builtin || imported_stdlib_factory)
         && strict_exact_membership_collection_safe(il, interner, facts, kids[1])
@@ -2210,8 +2235,21 @@ fn strict_exact_java_collection_factory_safe(
             else {
                 return None;
             };
-            strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
-                .then_some(contract)
+            match library_api_contract_evidence_for_call(
+                il,
+                interner,
+                node,
+                contract.id,
+                contract.callee,
+                kids.len().saturating_sub(1),
+            ) {
+                LibraryApiEvidenceStatus::Admitted => Some(contract),
+                LibraryApiEvidenceStatus::Rejected => None,
+                LibraryApiEvidenceStatus::Missing => {
+                    strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
+                        .then_some(contract)
+                }
+            }
         })
     else {
         return false;
@@ -2299,11 +2337,25 @@ fn strict_exact_java_map_factory_safe(
     else {
         return false;
     };
-    let provider_proven = imported_literal_producer_evidence_for_node(il, node);
-    if !provider_proven
-        && !strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
-    {
-        return false;
+    let snapshot_proven =
+        imported_literal_snapshot_evidence_at_span(il, il.node(node).span, NodeKind::Call);
+    match library_api_contract_evidence_for_call(
+        il,
+        interner,
+        node,
+        contract.id,
+        contract.callee,
+        kids.len().saturating_sub(1),
+    ) {
+        LibraryApiEvidenceStatus::Admitted => {}
+        LibraryApiEvidenceStatus::Rejected => return false,
+        LibraryApiEvidenceStatus::Missing => {
+            if !snapshot_proven
+                && !strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
+            {
+                return false;
+            }
+        }
     }
     let LibraryMapFactoryResult::JavaFactory { kind } = contract.result else {
         return false;
@@ -2317,7 +2369,7 @@ fn strict_exact_java_map_factory_safe(
                     .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
         }
         JavaMapFactoryKind::OfEntries => kids.iter().skip(1).all(|&entry| {
-            strict_exact_java_map_entry_safe(il, interner, facts, entry, provider_proven)
+            strict_exact_java_map_entry_safe(il, interner, facts, entry, snapshot_proven)
         }),
     }
 }
@@ -2327,7 +2379,7 @@ fn strict_exact_java_map_entry_safe(
     interner: &Interner,
     facts: &StrictFacts,
     node: NodeId,
-    provider_proven: bool,
+    snapshot_proven: bool,
 ) -> bool {
     if il.kind(node) != NodeKind::Call {
         return false;
@@ -2353,11 +2405,27 @@ fn strict_exact_java_map_entry_safe(
     else {
         return false;
     };
-    (provider_proven || strict_exact_java_std_var_name(il, interner, receiver, expected_receiver))
-        && kids
-            .iter()
-            .skip(1)
-            .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
+    match library_api_contract_evidence_for_call(
+        il,
+        interner,
+        node,
+        contract.id,
+        contract.callee,
+        2,
+    ) {
+        LibraryApiEvidenceStatus::Admitted => {}
+        LibraryApiEvidenceStatus::Rejected => return false,
+        LibraryApiEvidenceStatus::Missing => {
+            if !snapshot_proven
+                && !strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
+            {
+                return false;
+            }
+        }
+    }
+    kids.iter()
+        .skip(1)
+        .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
 }
 
 fn strict_exact_map_constructor_entries_safe(
@@ -4097,13 +4165,14 @@ mod tests {
     use super::*;
     use nose_il::{
         EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
-        EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, LibraryApiEvidenceKind,
-        SequenceSurfaceKind, SourceCallKind, SourceFactKind, Span, SymbolEvidenceKind,
+        EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, ImportEvidenceKind,
+        LibraryApiEvidenceKind, SequenceSurfaceKind, SourceCallKind, SourceFactKind, Span,
+        SymbolEvidenceKind, UnitKind,
     };
     use nose_semantics::{
         library_api_callee_contract_hash, library_api_contract_id_hash,
-        library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
-        FIRST_PARTY_PACK_ID,
+        library_java_collection_factory_contract, library_js_like_map_constructor_contract,
+        library_js_like_set_constructor_contract, FIRST_PARTY_PACK_ID,
     };
 
     fn sp(line: u32) -> Span {
@@ -4220,5 +4289,223 @@ mod tests {
         assert!(strict_exact_set_constructor_collection_safe(
             &il, &interner, &facts, call
         ));
+    }
+
+    #[test]
+    fn strict_exact_java_collection_factory_uses_library_api_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let list = interner.intern("List");
+        let lhs = b.add(NodeKind::Var, Payload::Name(list), sp(20), &[]);
+        let rhs = b.add(NodeKind::Seq, Payload::None, sp(20), &[]);
+        let import = b.add(NodeKind::Assign, Payload::None, sp(20), &[lhs, rhs]);
+        let receiver = b.add(NodeKind::Var, Payload::Name(list), sp(21), &[]);
+        let factory_callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("of")),
+            sp(22),
+            &[receiver],
+        );
+        let left = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("red")),
+            sp(23),
+            &[],
+        );
+        let right = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("blue")),
+            sp(24),
+            &[],
+        );
+        let factory = b.add(
+            NodeKind::Call,
+            Payload::None,
+            sp(25),
+            &[factory_callee, left, right],
+        );
+        let contains_callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("contains")),
+            sp(26),
+            &[factory],
+        );
+        let value = b.add(NodeKind::Var, Payload::Cid(0), sp(27), &[]);
+        let contains = b.add(
+            NodeKind::Call,
+            Payload::None,
+            sp(28),
+            &[contains_callee, value],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(20), &[import, contains]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.java".into(),
+                lang: Lang::Java,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        let contract = library_java_collection_factory_contract(Lang::Java, "List", "of")
+            .expect("List.of contract");
+        let binding_symbol = EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+            module_hash: stable_symbol_hash("java.util"),
+            exported_hash: stable_symbol_hash("List"),
+        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(sp(20), stable_symbol_hash("List")),
+            binding_symbol,
+            Vec::new(),
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(sp(21), NodeKind::Var),
+            binding_symbol,
+            vec![EvidenceId(0)],
+        ));
+        il.evidence.push(evidence(
+            2,
+            EvidenceAnchor::node(sp(25), NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(contract.id),
+                callee_hash: library_api_callee_contract_hash(contract.callee),
+                arity: 2,
+            }),
+            vec![EvidenceId(1)],
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(strict_exact_java_collection_factory_safe(
+            &il, &interner, &facts, factory
+        ));
+        assert!(strict_exact_safe_tree(&il, &interner, &facts, contains));
+
+        let wrong = library_js_like_set_constructor_contract(Lang::JavaScript, "Set").unwrap();
+        il.evidence.pop();
+        il.evidence.push(evidence(
+            2,
+            EvidenceAnchor::node(sp(25), NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(wrong.id),
+                callee_hash: library_api_callee_contract_hash(wrong.callee),
+                arity: 2,
+            }),
+            vec![EvidenceId(1)],
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(!strict_exact_java_collection_factory_safe(
+            &il, &interner, &facts, factory
+        ));
+        assert!(!strict_exact_safe_tree(&il, &interner, &facts, contains));
+    }
+
+    #[test]
+    fn strict_exact_java_map_provider_proof_does_not_replace_receiver_identity() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("FakeMap")),
+            sp(30),
+            &[],
+        );
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("of")),
+            sp(31),
+            &[receiver],
+        );
+        let key = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("k")),
+            sp(32),
+            &[],
+        );
+        let value = b.add(NodeKind::Lit, Payload::LitInt(1), sp(33), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(34), &[callee, key, value]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(34), &[call]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.java".into(),
+                lang: Lang::Java,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(34), NodeKind::Call),
+            EvidenceKind::Import(ImportEvidenceKind::ImmutableLiteralExport {
+                module_hash: stable_symbol_hash("t"),
+                exported_hash: stable_symbol_hash("VALUES"),
+                root_kind: NodeKind::Call,
+            }),
+            Vec::new(),
+        ));
+
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(!strict_exact_java_map_factory_safe(
+            &il, &interner, &facts, call
+        ));
+    }
+
+    fn lowered_java_unit(src: &str, interner: &Interner, kind: UnitKind, name: &str) -> UnitFeat {
+        let raw =
+            nose_frontend::lower_source(FileId(0), "T.java", src.as_bytes(), Lang::Java, interner)
+                .expect("lower Java source");
+        let il =
+            nose_normalize::normalize(&raw, interner, &nose_normalize::NormalizeOptions::default());
+        let seeds = crate::minhash::seeds(64);
+        let units = extract(&il, interner, &seeds, 1, 1, true, false);
+        units
+            .into_iter()
+            .find(|unit| unit.kind == kind && unit.name.as_deref() == Some(name))
+            .expect("requested Java unit")
+    }
+
+    fn lowered_java_method_unit(src: &str, interner: &Interner) -> UnitFeat {
+        lowered_java_unit(src, interner, UnitKind::Method, "f")
+    }
+
+    #[test]
+    fn lowered_java_static_collection_factories_share_exact_fingerprint() {
+        let interner = Interner::new();
+        let list = lowered_java_method_unit(
+            "import java.util.List;\n\nclass JavaListOf { static boolean f(String value, String other) { return List.of(\"red\", \"blue\").contains(value); } }\n",
+            &interner,
+        );
+        let set = lowered_java_method_unit(
+            "import java.util.Set;\n\nclass JavaSetOf { static boolean f(String value, String other) { return Set.of(\"red\", \"blue\").contains(value); } }\n",
+            &interner,
+        );
+        let arrays = lowered_java_method_unit(
+            "import java.util.Arrays;\n\nclass JavaArraysAsList { static boolean f(String value, String other) { return Arrays.asList(\"red\", \"blue\").contains(value); } }\n",
+            &interner,
+        );
+        let module_method = lowered_java_unit(
+            "import java.util.List;\n\nclass ModuleList {\n    static final List<String> VALUES = List.of(\"red\", \"blue\");\n\n    static boolean moduleList(String value, String other) {\n        return VALUES.contains(value);\n    }\n}\n",
+            &interner,
+            UnitKind::Method,
+            "moduleList",
+        );
+        assert!(list.exact_safe, "List.of method must stay exact-safe");
+        assert!(set.exact_safe, "Set.of method must stay exact-safe");
+        assert!(
+            arrays.exact_safe,
+            "Arrays.asList method must stay exact-safe"
+        );
+        assert!(
+            module_method.exact_safe,
+            "class-level List.of binding must stay exact-safe"
+        );
+        assert!(
+            list.value.len() >= EXACT_VALUE_MIN,
+            "List.of method should produce a dense semantic fingerprint"
+        );
+        assert_eq!(list.value, set.value);
+        assert_eq!(list.value, arrays.value);
+        assert_eq!(list.value, module_method.value);
     }
 }

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -226,21 +226,7 @@ impl<'a> Lowering<'a> {
         callee: NodeId,
         arg_count: usize,
     ) -> Option<LibraryApiEvidencePlan> {
-        if self.b.kind(callee) != NodeKind::Field {
-            return None;
-        }
-        let Payload::Name(method) = self.b.payload(callee) else {
-            return None;
-        };
-        let receiver_node = self.b.children(callee).first().copied()?;
-        let Payload::Name(receiver_name) = self.b.payload(receiver_node) else {
-            return None;
-        };
-        if self.b.kind(receiver_node) != NodeKind::Var {
-            return None;
-        }
-        let receiver = self.interner.resolve(receiver_name);
-        let method = self.interner.resolve(method);
+        let (receiver_node, receiver, method) = self.static_member_callee(callee)?;
         let contract = library_js_array_is_array_contract(self.lang, receiver, method, arg_count)
             .map(|contract| {
                 (
@@ -272,6 +258,27 @@ impl<'a> Lowering<'a> {
             dependencies.push(self.unshadowed_global_evidence_id(receiver_node, contract.4)?);
         }
         Some((contract.0, contract.1, dependencies, contract.5))
+    }
+
+    fn static_member_callee(&self, callee: NodeId) -> Option<(NodeId, &str, &str)> {
+        if self.b.kind(callee) != NodeKind::Field {
+            return None;
+        }
+        let Payload::Name(method) = self.b.payload(callee) else {
+            return None;
+        };
+        let receiver_node = self.b.children(callee).first().copied()?;
+        if self.b.kind(receiver_node) != NodeKind::Var {
+            return None;
+        }
+        let Payload::Name(receiver_name) = self.b.payload(receiver_node) else {
+            return None;
+        };
+        Some((
+            receiver_node,
+            self.interner.resolve(receiver_name),
+            self.interner.resolve(method),
+        ))
     }
 
     fn static_global_function_api_contract(
@@ -397,53 +404,19 @@ impl<'a> Lowering<'a> {
         callee: NodeId,
         arg_count: usize,
     ) -> Option<LibraryApiEvidencePlan> {
-        if self.b.kind(callee) != NodeKind::Field {
-            return None;
-        }
-        let Payload::Name(method) = self.b.payload(callee) else {
-            return None;
-        };
-        let receiver_node = self.b.children(callee).first().copied()?;
-        if self.b.kind(receiver_node) != NodeKind::Var {
-            return None;
-        }
-        let Payload::Name(receiver_name) = self.b.payload(receiver_node) else {
-            return None;
-        };
-        let receiver = self.interner.resolve(receiver_name);
-        let method = self.interner.resolve(method);
-        let (id, callee_contract, expected_receiver, rule) =
+        let (receiver_node, receiver, method) = self.static_member_callee(callee)?;
+        let (id, callee_contract, rule) =
             library_java_collection_factory_contract(self.lang, receiver, method)
                 .map(|contract| {
-                    let LibraryApiCalleeContract::JavaUtilStaticMember {
-                        receiver: expected_receiver,
-                        ..
-                    } = contract.callee
-                    else {
-                        unreachable!("java collection factories use JavaUtilStaticMember")
-                    };
                     (
                         contract.id,
                         contract.callee,
-                        expected_receiver,
                         "library_api_java_collection_factory",
                     )
                 })
                 .or_else(|| {
                     library_java_map_factory_contract(self.lang, receiver, method).map(|contract| {
-                        let LibraryApiCalleeContract::JavaUtilStaticMember {
-                            receiver: expected_receiver,
-                            ..
-                        } = contract.callee
-                        else {
-                            unreachable!("java map factories use JavaUtilStaticMember")
-                        };
-                        (
-                            contract.id,
-                            contract.callee,
-                            expected_receiver,
-                            "library_api_java_map_factory",
-                        )
+                        (contract.id, contract.callee, "library_api_java_map_factory")
                     })
                 })
                 .or_else(|| {
@@ -451,17 +424,9 @@ impl<'a> Lowering<'a> {
                         .then(|| library_java_map_entry_contract(self.lang, receiver, method))
                         .flatten()
                         .map(|contract| {
-                            let LibraryApiCalleeContract::JavaUtilStaticMember {
-                                receiver: expected_receiver,
-                                ..
-                            } = contract.callee
-                            else {
-                                unreachable!("java map entries use JavaUtilStaticMember")
-                            };
                             (
                                 contract.id,
                                 contract.callee,
-                                expected_receiver,
                                 "library_api_java_map_entry_factory",
                             )
                         })
@@ -471,21 +436,30 @@ impl<'a> Lowering<'a> {
                         self.lang, receiver, method, arg_count,
                     )
                     .map(|contract| {
-                        let LibraryApiCalleeContract::JavaUtilStaticMember {
-                            receiver: expected_receiver,
-                            ..
-                        } = contract.callee
-                        else {
-                            unreachable!("java static adapters use JavaUtilStaticMember")
-                        };
                         (
                             contract.id,
                             contract.callee,
-                            expected_receiver,
                             "library_api_java_static_collection_adapter",
                         )
                     })
                 })?;
+        self.java_util_static_member_evidence_plan(receiver_node, id, callee_contract, rule)
+    }
+
+    fn java_util_static_member_evidence_plan(
+        &mut self,
+        receiver_node: NodeId,
+        id: LibraryApiContractId,
+        callee_contract: LibraryApiCalleeContract,
+        rule: &'static str,
+    ) -> Option<LibraryApiEvidencePlan> {
+        let LibraryApiCalleeContract::JavaUtilStaticMember {
+            receiver: expected_receiver,
+            ..
+        } = callee_contract
+        else {
+            return None;
+        };
         let dependency = self.record_imported_binding_symbol_for_node(
             receiver_node,
             "java.util",

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -11,10 +11,13 @@ use nose_il::{
 };
 use nose_semantics::{
     import_fact_tag, library_api_callee_contract_hash, library_api_contract_id_hash,
-    library_js_array_is_array_contract, library_js_boolean_coercion_contract,
-    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
-    library_map_key_view_wrapper_contract, sequence_surface_kind_for_tag, ImportFactKind,
-    LibraryApiCalleeContract, LibraryApiContractId,
+    library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
+    library_java_collection_factory_contract, library_java_map_entry_contract,
+    library_java_map_factory_contract, library_js_array_is_array_contract,
+    library_js_boolean_coercion_contract, library_js_like_map_constructor_contract,
+    library_js_like_set_constructor_contract, library_map_key_view_wrapper_contract,
+    library_regex_test_contract, library_static_collection_adapter_contract,
+    sequence_surface_kind_for_tag, ImportFactKind, LibraryApiCalleeContract, LibraryApiContractId,
 };
 use tree_sitter::Node as TsNode;
 
@@ -189,7 +192,7 @@ impl<'a> Lowering<'a> {
     }
 
     fn library_api_contract_for_call(
-        &self,
+        &mut self,
         span: Span,
         callee: NodeId,
         arg_count: usize,
@@ -201,6 +204,18 @@ impl<'a> Lowering<'a> {
             return Some(result);
         }
         if let Some(result) = self.static_global_function_api_contract(callee, arg_count) {
+            return Some(result);
+        }
+        if let Some(result) = self.imported_collection_factory_api_contract(callee, arg_count) {
+            return Some(result);
+        }
+        if let Some(result) = self.imported_namespace_function_api_contract(callee, arg_count) {
+            return Some(result);
+        }
+        if let Some(result) = self.java_util_static_member_api_contract(callee, arg_count) {
+            return Some(result);
+        }
+        if let Some(result) = self.regex_literal_method_api_contract(callee, arg_count) {
             return Some(result);
         }
         self.js_global_constructor_api_contract(span, callee, arg_count)
@@ -285,6 +300,230 @@ impl<'a> Lowering<'a> {
         ))
     }
 
+    fn imported_collection_factory_api_contract(
+        &mut self,
+        callee: NodeId,
+        arg_count: usize,
+    ) -> Option<LibraryApiEvidencePlan> {
+        if arg_count != 1 {
+            return None;
+        }
+        match self.b.kind(callee) {
+            NodeKind::Var => {
+                let Payload::Name(name) = self.b.payload(callee) else {
+                    return None;
+                };
+                let exported = self.interner.resolve(name);
+                library_imported_collection_factory_contracts(self.lang).find_map(|contract| {
+                    let LibraryApiCalleeContract::ImportedBinding {
+                        module,
+                        exported: expected,
+                    } = contract.callee
+                    else {
+                        return None;
+                    };
+                    if exported != expected {
+                        return None;
+                    }
+                    let dependency =
+                        self.record_imported_binding_symbol_for_node(callee, module, expected)?;
+                    Some((
+                        contract.id,
+                        contract.callee,
+                        vec![dependency],
+                        "library_api_imported_collection_factory",
+                    ))
+                })
+            }
+            NodeKind::Field => {
+                let Payload::Name(method) = self.b.payload(callee) else {
+                    return None;
+                };
+                let method = self.interner.resolve(method);
+                let receiver = self.b.children(callee).first().copied()?;
+                library_imported_collection_factory_contracts(self.lang).find_map(|contract| {
+                    let LibraryApiCalleeContract::ImportedBinding { module, exported } =
+                        contract.callee
+                    else {
+                        return None;
+                    };
+                    if method != exported {
+                        return None;
+                    }
+                    let dependency =
+                        self.record_imported_namespace_symbol_for_node(receiver, module)?;
+                    Some((
+                        contract.id,
+                        contract.callee,
+                        vec![dependency],
+                        "library_api_imported_collection_factory",
+                    ))
+                })
+            }
+            _ => None,
+        }
+    }
+
+    fn imported_namespace_function_api_contract(
+        &mut self,
+        callee: NodeId,
+        arg_count: usize,
+    ) -> Option<LibraryApiEvidencePlan> {
+        if self.b.kind(callee) != NodeKind::Field {
+            return None;
+        }
+        let Payload::Name(method) = self.b.payload(callee) else {
+            return None;
+        };
+        let function = self.interner.resolve(method);
+        let contract =
+            library_imported_namespace_function_contract(self.lang, function, arg_count)?;
+        let LibraryApiCalleeContract::ImportedNamespaceFunction { module, .. } = contract.callee
+        else {
+            return None;
+        };
+        let receiver = self.b.children(callee).first().copied()?;
+        let dependency = self.record_imported_namespace_symbol_for_node(receiver, module)?;
+        Some((
+            contract.id,
+            contract.callee,
+            vec![dependency],
+            "library_api_imported_namespace_function",
+        ))
+    }
+
+    fn java_util_static_member_api_contract(
+        &mut self,
+        callee: NodeId,
+        arg_count: usize,
+    ) -> Option<LibraryApiEvidencePlan> {
+        if self.b.kind(callee) != NodeKind::Field {
+            return None;
+        }
+        let Payload::Name(method) = self.b.payload(callee) else {
+            return None;
+        };
+        let receiver_node = self.b.children(callee).first().copied()?;
+        if self.b.kind(receiver_node) != NodeKind::Var {
+            return None;
+        }
+        let Payload::Name(receiver_name) = self.b.payload(receiver_node) else {
+            return None;
+        };
+        let receiver = self.interner.resolve(receiver_name);
+        let method = self.interner.resolve(method);
+        let (id, callee_contract, expected_receiver, rule) =
+            library_java_collection_factory_contract(self.lang, receiver, method)
+                .map(|contract| {
+                    let LibraryApiCalleeContract::JavaUtilStaticMember {
+                        receiver: expected_receiver,
+                        ..
+                    } = contract.callee
+                    else {
+                        unreachable!("java collection factories use JavaUtilStaticMember")
+                    };
+                    (
+                        contract.id,
+                        contract.callee,
+                        expected_receiver,
+                        "library_api_java_collection_factory",
+                    )
+                })
+                .or_else(|| {
+                    library_java_map_factory_contract(self.lang, receiver, method).map(|contract| {
+                        let LibraryApiCalleeContract::JavaUtilStaticMember {
+                            receiver: expected_receiver,
+                            ..
+                        } = contract.callee
+                        else {
+                            unreachable!("java map factories use JavaUtilStaticMember")
+                        };
+                        (
+                            contract.id,
+                            contract.callee,
+                            expected_receiver,
+                            "library_api_java_map_factory",
+                        )
+                    })
+                })
+                .or_else(|| {
+                    (arg_count == 2)
+                        .then(|| library_java_map_entry_contract(self.lang, receiver, method))
+                        .flatten()
+                        .map(|contract| {
+                            let LibraryApiCalleeContract::JavaUtilStaticMember {
+                                receiver: expected_receiver,
+                                ..
+                            } = contract.callee
+                            else {
+                                unreachable!("java map entries use JavaUtilStaticMember")
+                            };
+                            (
+                                contract.id,
+                                contract.callee,
+                                expected_receiver,
+                                "library_api_java_map_entry_factory",
+                            )
+                        })
+                })
+                .or_else(|| {
+                    library_static_collection_adapter_contract(
+                        self.lang, receiver, method, arg_count,
+                    )
+                    .map(|contract| {
+                        let LibraryApiCalleeContract::JavaUtilStaticMember {
+                            receiver: expected_receiver,
+                            ..
+                        } = contract.callee
+                        else {
+                            unreachable!("java static adapters use JavaUtilStaticMember")
+                        };
+                        (
+                            contract.id,
+                            contract.callee,
+                            expected_receiver,
+                            "library_api_java_static_collection_adapter",
+                        )
+                    })
+                })?;
+        let dependency = self.record_imported_binding_symbol_for_node(
+            receiver_node,
+            "java.util",
+            expected_receiver,
+        )?;
+        Some((id, callee_contract, vec![dependency], rule))
+    }
+
+    fn regex_literal_method_api_contract(
+        &self,
+        callee: NodeId,
+        arg_count: usize,
+    ) -> Option<LibraryApiEvidencePlan> {
+        if self.b.kind(callee) != NodeKind::Field {
+            return None;
+        }
+        let Payload::Name(method) = self.b.payload(callee) else {
+            return None;
+        };
+        let method = self.interner.resolve(method);
+        let contract = library_regex_test_contract(self.lang, method, arg_count)?;
+        let LibraryApiCalleeContract::RegexLiteralMethod {
+            required_receiver_fact,
+            ..
+        } = contract.callee
+        else {
+            return None;
+        };
+        let receiver = self.b.children(callee).first().copied()?;
+        let dependency = self.source_fact_evidence_id(receiver, required_receiver_fact)?;
+        Some((
+            contract.id,
+            contract.callee,
+            vec![dependency],
+            "library_api_regex_literal_method",
+        ))
+    }
+
     fn js_global_constructor_api_contract(
         &self,
         span: Span,
@@ -334,10 +573,85 @@ impl<'a> Lowering<'a> {
         Some((contract.0, contract.1, dependencies, contract.3))
     }
 
+    fn source_fact_evidence_id(
+        &self,
+        node: NodeId,
+        expected: SourceFactKind,
+    ) -> Option<EvidenceId> {
+        let span = self.b.node(node).span;
+        self.evidence.iter().find_map(|record| {
+            (record.anchor == EvidenceAnchor::source_span(span)
+                && record.kind == EvidenceKind::Source(expected)
+                && record.status == EvidenceStatus::Asserted)
+                .then_some(record.id)
+        })
+    }
+
     fn source_call_evidence_id(&self, span: Span, call: SourceCallKind) -> Option<EvidenceId> {
         self.evidence.iter().find_map(|record| {
             (record.anchor == EvidenceAnchor::source_span(span)
                 && record.kind == EvidenceKind::Source(SourceFactKind::Call(call))
+                && record.status == EvidenceStatus::Asserted)
+                .then_some(record.id)
+        })
+    }
+
+    fn record_imported_binding_symbol_for_node(
+        &mut self,
+        node: NodeId,
+        module: &str,
+        exported: &str,
+    ) -> Option<EvidenceId> {
+        let expected = SymbolEvidenceKind::ImportedBinding {
+            module_hash: stable_symbol_hash(module),
+            exported_hash: stable_symbol_hash(exported),
+        };
+        let dependency = self.binding_symbol_evidence_id(node, expected)?;
+        Some(self.record_evidence_with_dependencies(
+            EvidenceAnchor::node(self.b.node(node).span, NodeKind::Var),
+            EvidenceKind::Symbol(expected),
+            "symbol_imported_binding_occurrence",
+            vec![dependency],
+        ))
+    }
+
+    fn record_imported_namespace_symbol_for_node(
+        &mut self,
+        node: NodeId,
+        module: &str,
+    ) -> Option<EvidenceId> {
+        let expected = SymbolEvidenceKind::ImportedNamespace {
+            module_hash: stable_symbol_hash(module),
+        };
+        let dependency = self.binding_symbol_evidence_id(node, expected)?;
+        Some(self.record_evidence_with_dependencies(
+            EvidenceAnchor::node(self.b.node(node).span, NodeKind::Var),
+            EvidenceKind::Symbol(expected),
+            "symbol_imported_namespace_occurrence",
+            vec![dependency],
+        ))
+    }
+
+    fn binding_symbol_evidence_id(
+        &self,
+        node: NodeId,
+        expected: SymbolEvidenceKind,
+    ) -> Option<EvidenceId> {
+        if self.b.kind(node) != NodeKind::Var {
+            return None;
+        }
+        let Payload::Name(local) = self.b.payload(node) else {
+            return None;
+        };
+        let local_hash = stable_symbol_hash(self.interner.resolve(local));
+        self.evidence.iter().find_map(|record| {
+            (matches!(
+                record.anchor,
+                EvidenceAnchor::Binding {
+                    local_hash: anchor_hash,
+                    ..
+                } if anchor_hash == local_hash
+            ) && record.kind == EvidenceKind::Symbol(expected)
                 && record.status == EvidenceStatus::Asserted)
                 .then_some(record.id)
         })
@@ -1421,6 +1735,130 @@ mod tests {
             EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace { module_hash })
                 if module_hash == stable_symbol_hash("math")
         )));
+    }
+
+    fn library_api_evidence_count(lo: &Lowering, contract_hash: u64, callee_hash: u64) -> usize {
+        lo.evidence
+            .iter()
+            .filter(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                        contract_hash: actual_contract,
+                        callee_hash: actual_callee,
+                        ..
+                    }) if actual_contract == contract_hash && actual_callee == callee_hash
+                )
+            })
+            .count()
+    }
+
+    #[test]
+    fn core_lowering_emits_import_backed_library_api_occurrences() {
+        let interner = Interner::new();
+        let mut lo = Lowering::new(FileId(0), b"", Lang::Python, &interner);
+        import_binding(&mut lo, sp_at(1), "deque", "collections", "deque");
+        let callee = lo.var("deque", sp_at(2));
+        let seq = lo.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp_at(3),
+            &[],
+        );
+        lo.add(NodeKind::Call, Payload::None, sp_at(4), &[callee, seq]);
+
+        let contract = nose_semantics::library_imported_collection_factory_contract(
+            Lang::Python,
+            "collections",
+            "deque",
+        )
+        .expect("deque contract");
+        assert_eq!(
+            library_api_evidence_count(
+                &lo,
+                library_api_contract_id_hash(contract.id),
+                library_api_callee_contract_hash(contract.callee),
+            ),
+            1
+        );
+
+        let mut lo = Lowering::new(FileId(0), b"", Lang::Python, &interner);
+        import_namespace(&mut lo, sp_at(10), "math", "math");
+        let math = lo.var("math", sp_at(11));
+        let callee = lo.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("prod")),
+            sp_at(12),
+            &[math],
+        );
+        let seq = lo.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp_at(13),
+            &[],
+        );
+        lo.add(NodeKind::Call, Payload::None, sp_at(14), &[callee, seq]);
+        let contract = library_imported_namespace_function_contract(Lang::Python, "prod", 1)
+            .expect("math.prod contract");
+        assert_eq!(
+            library_api_evidence_count(
+                &lo,
+                library_api_contract_id_hash(contract.id),
+                library_api_callee_contract_hash(contract.callee),
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn core_lowering_emits_java_and_regex_library_api_occurrences() {
+        let interner = Interner::new();
+        let mut lo = Lowering::new(FileId(0), b"", Lang::Java, &interner);
+        import_binding(&mut lo, sp_at(1), "List", "java.util", "List");
+        let list = lo.var("List", sp_at(2));
+        let callee = lo.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("of")),
+            sp_at(3),
+            &[list],
+        );
+        let item = lo.int_lit("1", sp_at(4));
+        lo.add(NodeKind::Call, Payload::None, sp_at(5), &[callee, item]);
+        let contract = library_java_collection_factory_contract(Lang::Java, "List", "of")
+            .expect("List.of contract");
+        assert_eq!(
+            library_api_evidence_count(
+                &lo,
+                library_api_contract_id_hash(contract.id),
+                library_api_callee_contract_hash(contract.callee),
+            ),
+            1
+        );
+
+        let mut lo = Lowering::new(FileId(0), b"", Lang::JavaScript, &interner);
+        let regex = lo.str_lit("/x/", sp_at(10));
+        lo.record_source_fact(
+            sp_at(10),
+            SourceFactKind::Literal(nose_il::SourceLiteralKind::Regex),
+        );
+        let callee = lo.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("test")),
+            sp_at(11),
+            &[regex],
+        );
+        let subject = lo.var("subject", sp_at(12));
+        lo.add(NodeKind::Call, Payload::None, sp_at(13), &[callee, subject]);
+        let contract =
+            library_regex_test_contract(Lang::JavaScript, "test", 1).expect("regex test contract");
+        assert_eq!(
+            library_api_evidence_count(
+                &lo,
+                library_api_contract_id_hash(contract.id),
+                library_api_callee_contract_hash(contract.callee),
+            ),
+            1
+        );
     }
 
     #[test]

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -10,14 +10,15 @@
 use nose_il::{contains_js_identifier, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
 use nose_semantics::{
     domain_evidence_for_param, free_function_builtin_contract, imported_binding_symbol,
-    imported_namespace_symbol, library_api_free_name_shadow_safe,
-    library_free_name_map_factory_contract, library_iterator_identity_adapter_contract,
-    library_map_get_contract, library_map_key_view_contract, library_method_call_contract,
+    imported_namespace_symbol, library_api_contract_evidence_for_call,
+    library_api_free_name_shadow_safe, library_free_name_map_factory_contract,
+    library_iterator_identity_adapter_contract, library_map_get_contract,
+    library_map_key_view_contract, library_method_call_contract,
     library_static_collection_adapter_contract, method_hof_contract,
     rust_option_some_constructor_contract, seq_surface_contract_for_node, unshadowed_global_symbol,
-    BuiltinArgContract, DomainEvidence, LibraryApiCalleeContract, LibraryMapFactoryResult,
-    MapKeyViewKind, MethodBuiltinArgs, MethodCallContract, MethodReceiverContract,
-    MethodSemanticContract, SEQ_VALUE_MAP,
+    BuiltinArgContract, DomainEvidence, LibraryApiCalleeContract, LibraryApiEvidenceStatus,
+    LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs, MethodCallContract,
+    MethodReceiverContract, MethodSemanticContract, SEQ_VALUE_MAP,
 };
 
 /// The result of inspecting a `Call`: it canonicalizes to a builtin, to a
@@ -416,9 +417,9 @@ fn unwrap_iter(old: &Il, interner: &Interner, node: NodeId) -> NodeId {
                 if let Payload::Name(s) = old.node(callee).payload {
                     let method = interner.resolve(s);
                     if let Some(&base) = old.children(callee).first() {
-                        if let Some(arg) =
-                            static_collection_adapter_arg(old, interner, base, method, call_kids)
-                        {
+                        if let Some(arg) = static_collection_adapter_arg(
+                            old, interner, node, base, method, call_kids,
+                        ) {
                             return arg;
                         }
                     }
@@ -465,7 +466,7 @@ fn exact_protocol_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool 
     let Some(&receiver) = old.children(callee).first() else {
         return false;
     };
-    if let Some(arg) = static_collection_adapter_arg(old, interner, receiver, method, kids) {
+    if let Some(arg) = static_collection_adapter_arg(old, interner, node, receiver, method, kids) {
         return exact_collection_receiver(old, interner, arg);
     }
     if let Some(contract) = library_method_call_contract(old.meta.lang, method, kids.len() - 1) {
@@ -494,6 +495,7 @@ fn exact_collection_param(old: &Il, node: NodeId) -> bool {
 fn static_collection_adapter_arg(
     old: &Il,
     interner: &Interner,
+    call: NodeId,
     receiver: NodeId,
     method: &str,
     call_kids: &[NodeId],
@@ -505,11 +507,29 @@ fn static_collection_adapter_arg(
         method,
         call_kids.len().saturating_sub(1),
     )?;
-    let contract = contract.result;
-    if file_defines_type_name(old, interner, receiver_name)
-        || !imported_binding_symbol(old, interner, receiver, contract.module, contract.exported)
-    {
-        return None;
+    match library_api_contract_evidence_for_call(
+        old,
+        interner,
+        call,
+        contract.id,
+        contract.callee,
+        call_kids.len().saturating_sub(1),
+    ) {
+        LibraryApiEvidenceStatus::Admitted => {}
+        LibraryApiEvidenceStatus::Rejected => return None,
+        LibraryApiEvidenceStatus::Missing => {
+            if file_defines_type_name(old, interner, receiver_name)
+                || !imported_binding_symbol(
+                    old,
+                    interner,
+                    receiver,
+                    contract.result.module,
+                    contract.result.exported,
+                )
+            {
+                return None;
+            }
+        }
     }
     call_kids.get(1).copied()
 }

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -8593,7 +8593,7 @@ mod tests {
         import_fact_tag, library_api_callee_contract_hash, library_api_contract_id_hash,
         library_imported_collection_factory_contract, library_java_collection_factory_contract,
         library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
-        FIRST_PARTY_PACK_ID,
+        LibraryApiContractId, FIRST_PARTY_PACK_ID,
     };
 
     fn sp(line: u32) -> Span {
@@ -8634,6 +8634,100 @@ mod tests {
             dependencies,
             status: EvidenceStatus::Asserted,
         }
+    }
+
+    fn imported_binding_symbol(module: &str, exported: &str) -> EvidenceKind {
+        EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+            module_hash: stable_symbol_hash(module),
+            exported_hash: stable_symbol_hash(exported),
+        })
+    }
+
+    fn imported_namespace_symbol_kind(module: &str) -> EvidenceKind {
+        EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace {
+            module_hash: stable_symbol_hash(module),
+        })
+    }
+
+    fn push_imported_binding_use(
+        il: &mut Il,
+        binding_id: u32,
+        binding_span: Span,
+        occurrence_id: u32,
+        occurrence_span: Span,
+        module: &str,
+        exported: &str,
+    ) {
+        let symbol = imported_binding_symbol(module, exported);
+        il.evidence.push(evidence(
+            binding_id,
+            EvidenceAnchor::binding(binding_span, stable_symbol_hash(exported)),
+            symbol,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            occurrence_id,
+            EvidenceAnchor::node(occurrence_span, NodeKind::Var),
+            symbol,
+            vec![EvidenceId(binding_id)],
+        ));
+    }
+
+    fn push_imported_namespace_use(
+        il: &mut Il,
+        binding_id: u32,
+        binding_span: Span,
+        occurrence_id: u32,
+        occurrence_span: Span,
+        module: &str,
+    ) {
+        let symbol = imported_namespace_symbol_kind(module);
+        il.evidence.push(evidence(
+            binding_id,
+            EvidenceAnchor::binding(binding_span, stable_symbol_hash(module)),
+            symbol,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            occurrence_id,
+            EvidenceAnchor::node(occurrence_span, NodeKind::Var),
+            symbol,
+            vec![EvidenceId(binding_id)],
+        ));
+    }
+
+    fn collection_sequence_evidence(id: u32, span: Span) -> EvidenceRecord {
+        evidence(
+            id,
+            EvidenceAnchor::sequence(span),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+        )
+    }
+
+    fn library_api_contract_evidence(
+        id: u32,
+        call_span: Span,
+        contract_id: LibraryApiContractId,
+        callee: LibraryApiCalleeContract,
+        arity: u16,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceRecord {
+        evidence_with_dependencies(
+            id,
+            EvidenceAnchor::node(call_span, NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(contract_id),
+                callee_hash: library_api_callee_contract_hash(callee),
+                arity,
+            }),
+            dependencies,
+        )
+    }
+
+    fn eval_proven_collection_op(il: &Il, interner: &Interner, call: NodeId) -> Option<ValOp> {
+        let mut builder = Builder::new(il, interner);
+        let raw = builder.eval(call, &FxHashMap::default());
+        builder
+            .proven_collection_value(raw)
+            .map(|value| builder.nodes[value as usize].op.clone())
     }
 
     #[derive(Clone, Copy)]
@@ -8907,56 +9001,28 @@ mod tests {
         let contract =
             library_imported_collection_factory_contract(Lang::Python, "collections", "deque")
                 .expect("deque contract");
-        let binding_symbol = EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
-            module_hash: stable_symbol_hash("collections"),
-            exported_hash: stable_symbol_hash("deque"),
-        });
-        il.evidence.push(evidence(
-            0,
-            EvidenceAnchor::binding(sp(60), stable_symbol_hash("deque")),
-            binding_symbol,
-        ));
-        il.evidence.push(evidence_with_dependencies(
-            1,
-            EvidenceAnchor::node(sp(61), NodeKind::Var),
-            binding_symbol,
-            vec![EvidenceId(0)],
-        ));
-        il.evidence.push(evidence(
-            2,
-            EvidenceAnchor::sequence(sp(63)),
-            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
-        ));
-        il.evidence.push(evidence_with_dependencies(
+        push_imported_binding_use(&mut il, 0, sp(60), 1, sp(61), "collections", "deque");
+        il.evidence.push(collection_sequence_evidence(2, sp(63)));
+        il.evidence.push(library_api_contract_evidence(
             3,
-            EvidenceAnchor::node(sp(64), NodeKind::Call),
-            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
-                contract_hash: library_api_contract_id_hash(contract.id),
-                callee_hash: library_api_callee_contract_hash(contract.callee),
-                arity: 1,
-            }),
+            sp(64),
+            contract.id,
+            contract.callee,
+            1,
             vec![EvidenceId(1)],
         ));
-        let mut builder = Builder::new(&il, &interner);
-        let raw = builder.eval(call, &FxHashMap::default());
-        let admitted = builder
-            .proven_collection_value(raw)
+        let admitted = eval_proven_collection_op(&il, &interner, call)
             .expect("admitted LibraryApi evidence should prove the factory");
-        assert!(matches!(
-            builder.nodes[admitted as usize].op,
-            ValOp::Seq(SEQ_VALUE_COLLECTION)
-        ));
+        assert!(matches!(admitted, ValOp::Seq(SEQ_VALUE_COLLECTION)));
 
         let wrong = library_js_like_set_constructor_contract(Lang::JavaScript, "Set").unwrap();
         il.evidence.pop();
-        il.evidence.push(evidence_with_dependencies(
+        il.evidence.push(library_api_contract_evidence(
             3,
-            EvidenceAnchor::node(sp(64), NodeKind::Call),
-            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
-                contract_hash: library_api_contract_id_hash(wrong.id),
-                callee_hash: library_api_callee_contract_hash(wrong.callee),
-                arity: 1,
-            }),
+            sp(64),
+            wrong.id,
+            wrong.callee,
+            1,
             vec![EvidenceId(1)],
         ));
         let mut builder = Builder::new(&il, &interner);
@@ -8991,40 +9057,18 @@ mod tests {
         let mut il = finish_test_il(b, root, Lang::Java);
         let contract = library_java_collection_factory_contract(Lang::Java, "List", "of")
             .expect("List.of contract");
-        let binding_symbol = EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
-            module_hash: stable_symbol_hash("java.util"),
-            exported_hash: stable_symbol_hash("List"),
-        });
-        il.evidence.push(evidence(
-            0,
-            EvidenceAnchor::binding(sp(70), stable_symbol_hash("List")),
-            binding_symbol,
-        ));
-        il.evidence.push(evidence_with_dependencies(
-            1,
-            EvidenceAnchor::node(sp(71), NodeKind::Var),
-            binding_symbol,
-            vec![EvidenceId(0)],
-        ));
-        il.evidence.push(evidence_with_dependencies(
+        push_imported_binding_use(&mut il, 0, sp(70), 1, sp(71), "java.util", "List");
+        il.evidence.push(library_api_contract_evidence(
             2,
-            EvidenceAnchor::node(sp(75), NodeKind::Call),
-            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
-                contract_hash: library_api_contract_id_hash(contract.id),
-                callee_hash: library_api_callee_contract_hash(contract.callee),
-                arity: 2,
-            }),
+            sp(75),
+            contract.id,
+            contract.callee,
+            2,
             vec![EvidenceId(1)],
         ));
-        let mut builder = Builder::new(&il, &interner);
-        let raw = builder.eval(call, &FxHashMap::default());
-        let admitted = builder
-            .proven_collection_value(raw)
+        let admitted = eval_proven_collection_op(&il, &interner, call)
             .expect("admitted LibraryApi evidence should prove the Java factory");
-        assert!(matches!(
-            builder.nodes[admitted as usize].op,
-            ValOp::Seq(SEQ_VALUE_COLLECTION)
-        ));
+        assert!(matches!(admitted, ValOp::Seq(SEQ_VALUE_COLLECTION)));
     }
 
     #[test]
@@ -9075,9 +9119,6 @@ mod tests {
         let contract =
             library_imported_collection_factory_contract(Lang::Python, "collections", "deque")
                 .expect("deque contract");
-        let namespace_symbol = EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace {
-            module_hash: stable_symbol_hash("collections"),
-        });
         il.evidence.push(evidence(
             0,
             EvidenceAnchor::sequence(sp(80)),
@@ -9085,30 +9126,14 @@ mod tests {
                 module_hash: stable_symbol_hash("collections"),
             }),
         ));
-        il.evidence.push(evidence(
-            1,
-            EvidenceAnchor::binding(sp(80), stable_symbol_hash("collections")),
-            namespace_symbol,
-        ));
-        il.evidence.push(evidence_with_dependencies(
-            2,
-            EvidenceAnchor::node(sp(81), NodeKind::Var),
-            namespace_symbol,
-            vec![EvidenceId(1)],
-        ));
-        il.evidence.push(evidence(
-            3,
-            EvidenceAnchor::sequence(sp(84)),
-            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
-        ));
-        il.evidence.push(evidence_with_dependencies(
+        push_imported_namespace_use(&mut il, 1, sp(80), 2, sp(81), "collections");
+        il.evidence.push(collection_sequence_evidence(3, sp(84)));
+        il.evidence.push(library_api_contract_evidence(
             4,
-            EvidenceAnchor::node(sp(85), NodeKind::Call),
-            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
-                contract_hash: library_api_contract_id_hash(contract.id),
-                callee_hash: library_api_callee_contract_hash(contract.callee),
-                arity: 1,
-            }),
+            sp(85),
+            contract.id,
+            contract.callee,
+            1,
             vec![EvidenceId(2)],
         ));
         let mut builder = Builder::new(&il, &interner);
@@ -9235,11 +9260,7 @@ mod tests {
                 name_hash: stable_symbol_hash("Set"),
             }),
         ));
-        il.evidence.push(evidence(
-            2,
-            EvidenceAnchor::sequence(sp(72)),
-            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
-        ));
+        il.evidence.push(collection_sequence_evidence(2, sp(72)));
         (il, call)
     }
 
@@ -9256,14 +9277,12 @@ mod tests {
         ));
 
         let wrong = library_js_like_map_constructor_contract(Lang::JavaScript, "Map").unwrap();
-        il.evidence.push(evidence_with_dependencies(
+        il.evidence.push(library_api_contract_evidence(
             3,
-            EvidenceAnchor::node(sp(73), NodeKind::Call),
-            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
-                contract_hash: library_api_contract_id_hash(wrong.id),
-                callee_hash: library_api_callee_contract_hash(wrong.callee),
-                arity: 1,
-            }),
+            sp(73),
+            wrong.id,
+            wrong.callee,
+            1,
             vec![EvidenceId(0), EvidenceId(1)],
         ));
         let mut builder = Builder::new(&il, &interner);
@@ -9275,14 +9294,12 @@ mod tests {
 
         let (mut il, call) = js_new_set_il(&interner);
         let set = library_js_like_set_constructor_contract(Lang::JavaScript, "Set").unwrap();
-        il.evidence.push(evidence_with_dependencies(
+        il.evidence.push(library_api_contract_evidence(
             3,
-            EvidenceAnchor::node(sp(73), NodeKind::Call),
-            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
-                contract_hash: library_api_contract_id_hash(set.id),
-                callee_hash: library_api_callee_contract_hash(set.callee),
-                arity: 1,
-            }),
+            sp(73),
+            set.id,
+            set.callee,
+            1,
             vec![EvidenceId(0), EvidenceId(1)],
         ));
         let mut builder = Builder::new(&il, &interner);

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -54,7 +54,7 @@ use nose_semantics::{
     exact_static_membership_predicate_operator, free_function_builtin_contract,
     go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
     go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract, import_fact_evidence_rhs,
-    imported_literal_producer_evidence_at_span, imported_namespace_symbol,
+    imported_literal_snapshot_evidence_at_span, imported_namespace_symbol,
     library_api_contract_evidence_at_call_span, library_api_contract_evidence_for_call,
     library_api_free_name_shadow_safe, library_free_name_collection_factory_contracts,
     library_free_name_map_factory_contracts, library_imported_collection_factory_contracts,
@@ -73,11 +73,12 @@ use nose_semantics::{
     BuiltinArgContract, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
     GoZeroMapDefaultKind, ImportFactKind, ImportedNamespaceFunctionSemantic,
     IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind,
-    LibraryApiCalleeContract, LibraryApiEvidenceStatus, LibraryCollectionFactoryResult,
-    LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
-    MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract,
-    StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD,
-    SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
+    LibraryApiCalleeContract, LibraryApiEvidenceStatus, LibraryApiSpanEvidenceQuery,
+    LibraryCollectionFactoryResult, LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs,
+    MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
+    SeqSurfaceContract, StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP,
+    SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE,
+    SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -927,7 +928,24 @@ impl<'a> Builder<'a> {
                 else {
                     return false;
                 };
-                s.is_import_binding_value(callee, module, exported)
+                let receiver = match s.nodes[callee as usize].op {
+                    ValOp::Field(_) => s.nodes[callee as usize].args.first().copied(),
+                    _ => None,
+                };
+                match s.library_api_evidence_for_value_call(
+                    value,
+                    callee,
+                    receiver,
+                    contract.id,
+                    contract.callee,
+                    1,
+                ) {
+                    LibraryApiEvidenceStatus::Admitted => true,
+                    LibraryApiEvidenceStatus::Rejected => false,
+                    LibraryApiEvidenceStatus::Missing => {
+                        s.is_import_binding_value(callee, module, exported)
+                    }
+                }
             })
         })
     }
@@ -967,8 +985,20 @@ impl<'a> Builder<'a> {
                 else {
                     return None;
                 };
-                self.is_imported_java_util_name(receiver, expected_receiver)
-                    .then_some(contract)
+                match self.library_api_evidence_for_value_call(
+                    value,
+                    args[0],
+                    Some(receiver),
+                    contract.id,
+                    contract.callee,
+                    args.len().saturating_sub(1),
+                ) {
+                    LibraryApiEvidenceStatus::Admitted => Some(contract),
+                    LibraryApiEvidenceStatus::Rejected => None,
+                    LibraryApiEvidenceStatus::Missing => self
+                        .is_imported_java_util_name(receiver, expected_receiver)
+                        .then_some(contract),
+                }
             })?;
         // A single argument to a varargs collection factory (`Arrays.asList(x)`,
         // `List.of(x)`, `Set.of(x)`) is ambiguous: when `x` is an array it is spread
@@ -1393,9 +1423,25 @@ impl<'a> Builder<'a> {
         else {
             return None;
         };
-        let provider_proven = self.imported_literal_producer_proven(value, NodeKind::Call);
-        if !provider_proven && !self.is_imported_java_util_name(callee.args[0], expected_receiver) {
-            return None;
+        let api_status = self.library_api_evidence_for_value_call(
+            value,
+            args[0],
+            Some(callee.args[0]),
+            contract.id,
+            contract.callee,
+            args.len().saturating_sub(1),
+        );
+        let snapshot_proven = self.imported_literal_snapshot_proven(value, NodeKind::Call);
+        match api_status {
+            LibraryApiEvidenceStatus::Admitted => {}
+            LibraryApiEvidenceStatus::Rejected => return None,
+            LibraryApiEvidenceStatus::Missing => {
+                if !snapshot_proven
+                    && !self.is_imported_java_util_name(callee.args[0], expected_receiver)
+                {
+                    return None;
+                }
+            }
         }
         let LibraryMapFactoryResult::JavaFactory { kind } = contract.result else {
             return None;
@@ -1414,7 +1460,7 @@ impl<'a> Builder<'a> {
         if kind == JavaMapFactoryKind::OfEntries {
             let mut canonical_entries = Vec::with_capacity(args.len().saturating_sub(1));
             for entry in args.iter().skip(1).copied() {
-                let kv = self.proven_java_map_entry_pair(entry, provider_proven)?;
+                let kv = self.proven_java_map_entry_pair(entry, snapshot_proven)?;
                 canonical_entries.push(self.mk(ValOp::Seq(SEQ_VALUE_PAIR), kv));
             }
             return Some(self.mk(ValOp::Seq(SEQ_VALUE_MAP), canonical_entries));
@@ -1425,7 +1471,7 @@ impl<'a> Builder<'a> {
     fn proven_java_map_entry_pair(
         &self,
         value: ValueId,
-        provider_proven: bool,
+        snapshot_proven: bool,
     ) -> Option<Vec<ValueId>> {
         let node = &self.nodes[value as usize];
         if !matches!(node.op, ValOp::Call(0)) || node.args.len() != 3 {
@@ -1447,15 +1493,60 @@ impl<'a> Builder<'a> {
         if callee.args.len() != 1 {
             return None;
         }
-        if !provider_proven && !self.is_imported_java_util_name(callee.args[0], expected_receiver) {
-            return None;
+        match self.library_api_evidence_for_value_call(
+            value,
+            args[0],
+            Some(callee.args[0]),
+            contract.id,
+            contract.callee,
+            2,
+        ) {
+            LibraryApiEvidenceStatus::Admitted => {}
+            LibraryApiEvidenceStatus::Rejected => return None,
+            LibraryApiEvidenceStatus::Missing => {
+                if !snapshot_proven
+                    && !self.is_imported_java_util_name(callee.args[0], expected_receiver)
+                {
+                    return None;
+                }
+            }
         }
         Some(args[1..].to_vec())
     }
 
-    fn imported_literal_producer_proven(&self, value: ValueId, kind: NodeKind) -> bool {
+    fn imported_literal_snapshot_proven(&self, value: ValueId, kind: NodeKind) -> bool {
         self.node_span[value as usize]
-            .is_some_and(|span| imported_literal_producer_evidence_at_span(self.il, span, kind))
+            .is_some_and(|span| imported_literal_snapshot_evidence_at_span(self.il, span, kind))
+    }
+
+    fn library_api_evidence_for_value_call(
+        &self,
+        value: ValueId,
+        callee: ValueId,
+        receiver: Option<ValueId>,
+        id: nose_semantics::LibraryApiContractId,
+        callee_contract: LibraryApiCalleeContract,
+        arg_count: usize,
+    ) -> LibraryApiEvidenceStatus {
+        library_api_contract_evidence_at_call_span(
+            self.il,
+            self.interner,
+            LibraryApiSpanEvidenceQuery {
+                call_span: self.node_span[value as usize],
+                callee_span: self.library_api_value_span(callee),
+                receiver_span: receiver.and_then(|receiver| self.library_api_value_span(receiver)),
+                id,
+                callee: callee_contract,
+                arg_count,
+            },
+        )
+    }
+
+    fn library_api_value_span(&self, value: ValueId) -> Option<Span> {
+        match self.nodes[value as usize].op {
+            ValOp::ImportBinding { .. } | ValOp::ImportNamespace { .. } => None,
+            _ => self.node_span[value as usize],
+        }
     }
 
     fn eval_js_like_constructed_collection_or_map(
@@ -1702,12 +1793,15 @@ impl<'a> Builder<'a> {
                 .and_then(|&receiver| self.node_span[receiver as usize]);
             match library_api_contract_evidence_at_call_span(
                 self.il,
-                self.node_span[value as usize],
-                self.node_span[args[0] as usize],
-                receiver_span,
-                contract.id,
-                contract.callee,
-                1,
+                self.interner,
+                LibraryApiSpanEvidenceQuery {
+                    call_span: self.node_span[value as usize],
+                    callee_span: self.node_span[args[0] as usize],
+                    receiver_span,
+                    id: contract.id,
+                    callee: contract.callee,
+                    arg_count: 1,
+                },
             ) {
                 LibraryApiEvidenceStatus::Admitted => {}
                 LibraryApiEvidenceStatus::Rejected => return None,
@@ -4231,8 +4325,30 @@ impl<'a> Builder<'a> {
                     self.param_domain = saved_param_domain;
                 }
                 NodeKind::Block => self.process_container(c, env),
+                NodeKind::Assign => self.process_container_assignment(c, env),
                 _ => self.process_stmt(c, env),
             }
+        }
+    }
+
+    fn process_container_assignment(&mut self, stmt: NodeId, env: &mut FxHashMap<u32, ValueId>) {
+        let binding = self.il.children(stmt).first().copied().and_then(|lhs| {
+            match (self.il.kind(lhs), self.il.node(lhs).payload) {
+                (NodeKind::Var, Payload::Cid(cid)) => self
+                    .il
+                    .cid_names
+                    .get(cid as usize)
+                    .copied()
+                    .map(|name| (cid, name)),
+                _ => None,
+            }
+        });
+        self.process_stmt(stmt, env);
+        let Some((cid, name)) = binding else {
+            return;
+        };
+        if let Some(&value) = env.get(&cid) {
+            self.global_env.insert(name, value);
         }
     }
 
@@ -6872,6 +6988,7 @@ impl<'a> Builder<'a> {
 
     fn eval_product_call(
         &mut self,
+        expr: NodeId,
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
@@ -6886,14 +7003,26 @@ impl<'a> Builder<'a> {
             self.il.meta.lang,
             self.interner.resolve(name),
             kids.len().saturating_sub(1),
-        )?
-        .result;
+        )?;
         let base = *self.il.children(callee).first()?;
-        if !self.is_import_namespace_expr(base, contract.module, env) {
-            return None;
+        match library_api_contract_evidence_for_call(
+            self.il,
+            self.interner,
+            expr,
+            contract.id,
+            contract.callee,
+            kids.len().saturating_sub(1),
+        ) {
+            LibraryApiEvidenceStatus::Admitted => {}
+            LibraryApiEvidenceStatus::Rejected => return None,
+            LibraryApiEvidenceStatus::Missing => {
+                if !self.is_import_namespace_expr(base, contract.result.module, env) {
+                    return None;
+                }
+            }
         }
         let ImportedNamespaceFunctionSemantic::ProductReduction { op, identity } =
-            contract.semantic;
+            contract.result.semantic;
         let coll = self.eval(*kids.get(1)?, env);
         let (coll_op, args) = {
             let n = &self.nodes[coll as usize];
@@ -7778,7 +7907,7 @@ impl<'a> Builder<'a> {
                 if let Some(r) = self.eval_count_call(&kids, env) {
                     return r;
                 }
-                if let Some(r) = self.eval_product_call(&kids, env) {
+                if let Some(r) = self.eval_product_call(expr, &kids, env) {
                     return r;
                 }
                 if let Some(r) = self.eval_proven_integer_method_call(&kids, env) {
@@ -8462,6 +8591,7 @@ mod tests {
     };
     use nose_semantics::{
         import_fact_tag, library_api_callee_contract_hash, library_api_contract_id_hash,
+        library_imported_collection_factory_contract, library_java_collection_factory_contract,
         library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
         FIRST_PARTY_PACK_ID,
     };
@@ -8753,6 +8883,244 @@ mod tests {
         let mut builder = Builder::new(&il, &interner);
         let proven = builder.eval(field, &FxHashMap::default());
         assert!(builder.is_import_binding_value(proven, "math", "prod"));
+    }
+
+    #[test]
+    fn imported_collection_factory_value_graph_uses_library_api_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let local = interner.intern("deque");
+        let lhs = b.add(NodeKind::Var, Payload::Name(local), sp(60), &[]);
+        let rhs = b.add(NodeKind::Seq, Payload::None, sp(60), &[]);
+        let import = b.add(NodeKind::Assign, Payload::None, sp(60), &[lhs, rhs]);
+        let callee = b.add(NodeKind::Var, Payload::Name(local), sp(61), &[]);
+        let item = b.add(NodeKind::Lit, Payload::LitInt(1), sp(62), &[]);
+        let seq = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(63),
+            &[item],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(64), &[callee, seq]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(60), &[import, call]);
+        let mut il = finish_test_il(b, root, Lang::Python);
+        let contract =
+            library_imported_collection_factory_contract(Lang::Python, "collections", "deque")
+                .expect("deque contract");
+        let binding_symbol = EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+            module_hash: stable_symbol_hash("collections"),
+            exported_hash: stable_symbol_hash("deque"),
+        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(sp(60), stable_symbol_hash("deque")),
+            binding_symbol,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            1,
+            EvidenceAnchor::node(sp(61), NodeKind::Var),
+            binding_symbol,
+            vec![EvidenceId(0)],
+        ));
+        il.evidence.push(evidence(
+            2,
+            EvidenceAnchor::sequence(sp(63)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            3,
+            EvidenceAnchor::node(sp(64), NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(contract.id),
+                callee_hash: library_api_callee_contract_hash(contract.callee),
+                arity: 1,
+            }),
+            vec![EvidenceId(1)],
+        ));
+        let mut builder = Builder::new(&il, &interner);
+        let raw = builder.eval(call, &FxHashMap::default());
+        let admitted = builder
+            .proven_collection_value(raw)
+            .expect("admitted LibraryApi evidence should prove the factory");
+        assert!(matches!(
+            builder.nodes[admitted as usize].op,
+            ValOp::Seq(SEQ_VALUE_COLLECTION)
+        ));
+
+        let wrong = library_js_like_set_constructor_contract(Lang::JavaScript, "Set").unwrap();
+        il.evidence.pop();
+        il.evidence.push(evidence_with_dependencies(
+            3,
+            EvidenceAnchor::node(sp(64), NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(wrong.id),
+                callee_hash: library_api_callee_contract_hash(wrong.callee),
+                arity: 1,
+            }),
+            vec![EvidenceId(1)],
+        ));
+        let mut builder = Builder::new(&il, &interner);
+        let raw = builder.eval(call, &FxHashMap::default());
+        assert!(builder.proven_collection_value(raw).is_none());
+    }
+
+    #[test]
+    fn java_collection_factory_value_graph_uses_library_api_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let local = interner.intern("List");
+        let lhs = b.add(NodeKind::Var, Payload::Name(local), sp(70), &[]);
+        let rhs = b.add(NodeKind::Seq, Payload::None, sp(70), &[]);
+        let import = b.add(NodeKind::Assign, Payload::None, sp(70), &[lhs, rhs]);
+        let receiver = b.add(NodeKind::Var, Payload::Name(local), sp(71), &[]);
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("of")),
+            sp(72),
+            &[receiver],
+        );
+        let left = b.add(NodeKind::Lit, Payload::LitInt(1), sp(73), &[]);
+        let right = b.add(NodeKind::Lit, Payload::LitInt(2), sp(74), &[]);
+        let call = b.add(
+            NodeKind::Call,
+            Payload::None,
+            sp(75),
+            &[callee, left, right],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(70), &[import, call]);
+        let mut il = finish_test_il(b, root, Lang::Java);
+        let contract = library_java_collection_factory_contract(Lang::Java, "List", "of")
+            .expect("List.of contract");
+        let binding_symbol = EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+            module_hash: stable_symbol_hash("java.util"),
+            exported_hash: stable_symbol_hash("List"),
+        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(sp(70), stable_symbol_hash("List")),
+            binding_symbol,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            1,
+            EvidenceAnchor::node(sp(71), NodeKind::Var),
+            binding_symbol,
+            vec![EvidenceId(0)],
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            2,
+            EvidenceAnchor::node(sp(75), NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(contract.id),
+                callee_hash: library_api_callee_contract_hash(contract.callee),
+                arity: 2,
+            }),
+            vec![EvidenceId(1)],
+        ));
+        let mut builder = Builder::new(&il, &interner);
+        let raw = builder.eval(call, &FxHashMap::default());
+        let admitted = builder
+            .proven_collection_value(raw)
+            .expect("admitted LibraryApi evidence should prove the Java factory");
+        assert!(matches!(
+            builder.nodes[admitted as usize].op,
+            ValOp::Seq(SEQ_VALUE_COLLECTION)
+        ));
+    }
+
+    #[test]
+    fn namespace_collection_factory_value_graph_uses_library_api_evidence_after_seed() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let local = interner.intern("collections");
+        let namespace_tag = interner.intern(import_fact_tag(ImportFactKind::Namespace));
+        let lhs = b.add(NodeKind::Var, Payload::Cid(0), sp(80), &[]);
+        let module = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("collections")),
+            sp(80),
+            &[],
+        );
+        let rhs = b.add(
+            NodeKind::Seq,
+            Payload::Name(namespace_tag),
+            sp(80),
+            &[module],
+        );
+        let import = b.add(NodeKind::Assign, Payload::None, sp(80), &[lhs, rhs]);
+        let receiver = b.add(NodeKind::Var, Payload::Name(local), sp(81), &[]);
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("deque")),
+            sp(82),
+            &[receiver],
+        );
+        let item = b.add(NodeKind::Lit, Payload::LitInt(1), sp(83), &[]);
+        let seq = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(84),
+            &[item],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(85), &[callee, seq]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(80), &[import, call]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.py".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            vec![local],
+        );
+        let contract =
+            library_imported_collection_factory_contract(Lang::Python, "collections", "deque")
+                .expect("deque contract");
+        let namespace_symbol = EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace {
+            module_hash: stable_symbol_hash("collections"),
+        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(80)),
+            EvidenceKind::Import(ImportEvidenceKind::Namespace {
+                module_hash: stable_symbol_hash("collections"),
+            }),
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::binding(sp(80), stable_symbol_hash("collections")),
+            namespace_symbol,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            2,
+            EvidenceAnchor::node(sp(81), NodeKind::Var),
+            namespace_symbol,
+            vec![EvidenceId(1)],
+        ));
+        il.evidence.push(evidence(
+            3,
+            EvidenceAnchor::sequence(sp(84)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            4,
+            EvidenceAnchor::node(sp(85), NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(contract.id),
+                callee_hash: library_api_callee_contract_hash(contract.callee),
+                arity: 1,
+            }),
+            vec![EvidenceId(2)],
+        ));
+        let mut builder = Builder::new(&il, &interner);
+        builder.seed_module_value_bindings();
+        let raw = builder.eval(call, &FxHashMap::default());
+        let admitted = builder
+            .proven_collection_value(raw)
+            .expect("namespace LibraryApi evidence should survive seeded import values");
+        assert!(matches!(
+            builder.nodes[admitted as usize].op,
+            ValOp::Seq(SEQ_VALUE_COLLECTION)
+        ));
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -5618,7 +5618,7 @@ mod tests {
         EvidenceRecord, EvidenceStatus, FileId, FileMeta, GuardEvidenceKind, IlBuilder,
         ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck,
         LibraryApiEvidenceKind, ParamSemantic, ParamTypeFact, SequenceSurfaceKind, SourceFact,
-        Span, SymbolEvidenceKind, Unit, UnitKind,
+        Span, Symbol, SymbolEvidenceKind, Unit, UnitKind,
     };
 
     const ALL_LANGS: &[Lang] = &[
@@ -6993,6 +6993,60 @@ mod tests {
         )
     }
 
+    fn java_list_of_import_evidence_il(
+        interner: &Interner,
+        import_in_root: bool,
+    ) -> (Il, NodeId, NodeId, Symbol, LibraryCollectionFactoryContract) {
+        let mut b = IlBuilder::new(FileId(0));
+        let local = interner.intern("List");
+        let lhs = b.add(NodeKind::Var, Payload::Name(local), sp(30), &[]);
+        let rhs = b.add(NodeKind::Seq, Payload::None, sp(30), &[]);
+        let import = b.add(NodeKind::Assign, Payload::None, sp(30), &[lhs, rhs]);
+        let receiver = b.add(NodeKind::Var, Payload::Name(local), sp(31), &[]);
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("of")),
+            sp(32),
+            &[receiver],
+        );
+        let arg = b.add(NodeKind::Lit, Payload::LitInt(1), sp(33), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(34), &[callee, arg]);
+        let root = if import_in_root {
+            b.add(NodeKind::Module, Payload::None, sp(29), &[import, call])
+        } else {
+            b.add(NodeKind::Func, Payload::None, sp(35), &[call])
+        };
+        let mut il = finish_il(b, root, Lang::Java);
+        let contract = library_java_collection_factory_contract(Lang::Java, "List", "of")
+            .expect("List.of contract");
+        let binding_symbol = EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+            module_hash: stable_symbol_hash("java.util"),
+            exported_hash: stable_symbol_hash("List"),
+        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(sp(30), stable_symbol_hash("List")),
+            binding_symbol,
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            1,
+            EvidenceAnchor::node(sp(31), NodeKind::Var),
+            binding_symbol,
+            EvidenceStatus::Asserted,
+            vec![EvidenceId(0)],
+        ));
+        il.evidence.push(library_api_record(
+            2,
+            sp(34),
+            contract.id,
+            contract.callee,
+            EvidenceStatus::Asserted,
+            &[1],
+        ));
+        (il, call, root, local, contract)
+    }
+
     #[test]
     fn library_api_evidence_resolution_is_dependency_backed_and_fail_closed() {
         let interner = Interner::new();
@@ -7351,49 +7405,8 @@ mod tests {
     #[test]
     fn library_api_evidence_resolution_accepts_import_binding_outside_unit_root() {
         let interner = Interner::new();
-        let mut b = IlBuilder::new(FileId(0));
-        let local = interner.intern("List");
-        let lhs = b.add(NodeKind::Var, Payload::Name(local), sp(30), &[]);
-        let rhs = b.add(NodeKind::Seq, Payload::None, sp(30), &[]);
-        let _import = b.add(NodeKind::Assign, Payload::None, sp(30), &[lhs, rhs]);
-        let receiver = b.add(NodeKind::Var, Payload::Name(local), sp(31), &[]);
-        let callee = b.add(
-            NodeKind::Field,
-            Payload::Name(interner.intern("of")),
-            sp(32),
-            &[receiver],
-        );
-        let arg = b.add(NodeKind::Lit, Payload::LitInt(1), sp(33), &[]);
-        let call = b.add(NodeKind::Call, Payload::None, sp(34), &[callee, arg]);
-        let root = b.add(NodeKind::Func, Payload::None, sp(35), &[call]);
-        let mut il = finish_il(b, root, Lang::Java);
-        let contract = library_java_collection_factory_contract(Lang::Java, "List", "of")
-            .expect("List.of contract");
-        let binding_symbol = EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
-            module_hash: stable_symbol_hash("java.util"),
-            exported_hash: stable_symbol_hash("List"),
-        });
-        il.evidence.push(evidence(
-            0,
-            EvidenceAnchor::binding(sp(30), stable_symbol_hash("List")),
-            binding_symbol,
-            EvidenceStatus::Asserted,
-        ));
-        il.evidence.push(evidence_with_dependencies(
-            1,
-            EvidenceAnchor::node(sp(31), NodeKind::Var),
-            binding_symbol,
-            EvidenceStatus::Asserted,
-            vec![EvidenceId(0)],
-        ));
-        il.evidence.push(library_api_record(
-            2,
-            sp(34),
-            contract.id,
-            contract.callee,
-            EvidenceStatus::Asserted,
-            &[1],
-        ));
+        let (mut il, call, _root, _local, contract) =
+            java_list_of_import_evidence_il(&interner, false);
         assert_eq!(
             library_api_contract_evidence_for_call(
                 &il,
@@ -7461,49 +7474,8 @@ mod tests {
     #[test]
     fn library_api_evidence_resolution_rejects_shadowed_java_static_members() {
         let interner = Interner::new();
-        let mut b = IlBuilder::new(FileId(0));
-        let local = interner.intern("List");
-        let lhs = b.add(NodeKind::Var, Payload::Name(local), sp(30), &[]);
-        let rhs = b.add(NodeKind::Seq, Payload::None, sp(30), &[]);
-        let import = b.add(NodeKind::Assign, Payload::None, sp(30), &[lhs, rhs]);
-        let receiver = b.add(NodeKind::Var, Payload::Name(local), sp(31), &[]);
-        let callee = b.add(
-            NodeKind::Field,
-            Payload::Name(interner.intern("of")),
-            sp(32),
-            &[receiver],
-        );
-        let arg = b.add(NodeKind::Lit, Payload::LitInt(1), sp(33), &[]);
-        let call = b.add(NodeKind::Call, Payload::None, sp(34), &[callee, arg]);
-        let root = b.add(NodeKind::Module, Payload::None, sp(29), &[import, call]);
-        let mut il = finish_il(b, root, Lang::Java);
-        let contract = library_java_collection_factory_contract(Lang::Java, "List", "of")
-            .expect("List.of contract");
-        let binding_symbol = EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
-            module_hash: stable_symbol_hash("java.util"),
-            exported_hash: stable_symbol_hash("List"),
-        });
-        il.evidence.push(evidence(
-            0,
-            EvidenceAnchor::binding(sp(30), stable_symbol_hash("List")),
-            binding_symbol,
-            EvidenceStatus::Asserted,
-        ));
-        il.evidence.push(evidence_with_dependencies(
-            1,
-            EvidenceAnchor::node(sp(31), NodeKind::Var),
-            binding_symbol,
-            EvidenceStatus::Asserted,
-            vec![EvidenceId(0)],
-        ));
-        il.evidence.push(library_api_record(
-            2,
-            sp(34),
-            contract.id,
-            contract.callee,
-            EvidenceStatus::Asserted,
-            &[1],
-        ));
+        let (mut il, call, root, local, contract) =
+            java_list_of_import_evidence_il(&interner, true);
         assert_eq!(
             library_api_contract_evidence_for_call(
                 &il,

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -846,6 +846,22 @@ pub fn imported_literal_producer_evidence_at_span(il: &Il, span: Span, kind: Nod
     })
 }
 
+pub fn imported_literal_snapshot_evidence_at_span(il: &Il, span: Span, kind: NodeKind) -> bool {
+    il.evidence.iter().any(|record| {
+        record.status == EvidenceStatus::Asserted
+            && first_party_record(record)
+            && record.anchor == EvidenceAnchor::node(span, kind)
+            && matches!(
+                record.kind,
+                EvidenceKind::Import(ImportEvidenceKind::ImportedLiteralSnapshot {
+                    root_kind,
+                    ..
+                }) if root_kind == kind
+            )
+            && evidence_dependencies_asserted(il, record)
+    })
+}
+
 pub fn imported_literal_producer_evidence_for_node(il: &Il, node: NodeId) -> bool {
     imported_literal_producer_evidence_at_span(il, il.node(node).span, il.kind(node))
 }
@@ -1001,6 +1017,43 @@ fn symbol_identity_at_node_matches(
     }
 }
 
+fn imported_symbol_identity_at_node_matches(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    expected: SymbolEvidenceKind,
+) -> EvidenceResolution<bool> {
+    let span = il.node(node).span;
+    let kind = il.kind(node);
+    let mut found = None;
+    let mut dependencies_valid = true;
+    for record in &il.evidence {
+        if record.anchor != EvidenceAnchor::node(span, kind) {
+            continue;
+        }
+        let EvidenceKind::Symbol(actual) = record.kind else {
+            continue;
+        };
+        if record.status != EvidenceStatus::Asserted {
+            return EvidenceResolution::Ambiguous;
+        }
+        match found {
+            None => found = Some(actual),
+            Some(existing) if existing == actual => {}
+            Some(_) => return EvidenceResolution::Ambiguous,
+        }
+        if actual == expected
+            && !imported_occurrence_symbol_dependencies_valid(il, interner, record, expected)
+        {
+            dependencies_valid = false;
+        }
+    }
+    let Some(actual) = found else {
+        return EvidenceResolution::Missing;
+    };
+    EvidenceResolution::Found(actual == expected && dependencies_valid)
+}
+
 fn binding_identity_matches(
     il: &Il,
     local_hash: u64,
@@ -1128,7 +1181,7 @@ fn imported_symbol(
     if il.kind(node) != NodeKind::Var {
         return false;
     }
-    match symbol_identity_at_node_matches(il, node, expected) {
+    match imported_symbol_identity_at_node_matches(il, interner, node, expected) {
         EvidenceResolution::Found(matches) => return matches,
         EvidenceResolution::Ambiguous => return false,
         EvidenceResolution::Missing => {}
@@ -3869,6 +3922,16 @@ pub enum LibraryApiEvidenceStatus {
     Rejected,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryApiSpanEvidenceQuery {
+    pub call_span: Option<Span>,
+    pub callee_span: Option<Span>,
+    pub receiver_span: Option<Span>,
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub arg_count: usize,
+}
+
 pub fn library_api_contract_evidence_for_call(
     il: &Il,
     interner: &Interner,
@@ -3900,7 +3963,7 @@ pub fn library_api_contract_evidence_for_call(
             || api != expected
             || !evidence_dependencies_asserted(il, record)
             || !library_api_callee_shape_matches(il, interner, node, callee)
-            || !library_api_dependencies_match_callee(il, node, callee, record)
+            || !library_api_dependencies_match_callee(il, interner, node, callee, record)
         {
             return LibraryApiEvidenceStatus::Rejected;
         }
@@ -3917,23 +3980,19 @@ pub fn library_api_contract_evidence_for_call(
 
 pub fn library_api_contract_evidence_at_call_span(
     il: &Il,
-    span: Option<Span>,
-    callee_span: Option<Span>,
-    receiver_span: Option<Span>,
-    id: LibraryApiContractId,
-    callee: LibraryApiCalleeContract,
-    arg_count: usize,
+    interner: &Interner,
+    query: LibraryApiSpanEvidenceQuery,
 ) -> LibraryApiEvidenceStatus {
-    let Some(span) = span else {
+    let Some(span) = query.call_span else {
         return LibraryApiEvidenceStatus::Missing;
     };
-    if arg_count > u16::MAX as usize {
+    if query.arg_count > u16::MAX as usize {
         return LibraryApiEvidenceStatus::Rejected;
     }
     let expected = LibraryApiEvidenceKind::Contract {
-        contract_hash: library_api_contract_id_hash(id),
-        callee_hash: library_api_callee_contract_hash(callee),
-        arity: arg_count as u16,
+        contract_hash: library_api_contract_id_hash(query.id),
+        callee_hash: library_api_callee_contract_hash(query.callee),
+        arity: query.arg_count as u16,
     };
     let mut saw_library_api_evidence = false;
     let mut admitted = false;
@@ -3950,10 +4009,11 @@ pub fn library_api_contract_evidence_at_call_span(
             || !evidence_dependencies_asserted(il, record)
             || !library_api_dependencies_match_callee_at_span(
                 il,
+                interner,
                 span,
-                callee_span,
-                receiver_span,
-                callee,
+                query.callee_span,
+                query.receiver_span,
+                query.callee,
                 record,
             )
         {
@@ -3983,6 +4043,23 @@ fn library_api_callee_shape_matches(
         LibraryApiCalleeContract::JsGlobalConstructor { receiver, .. } => {
             var_name_matches(il, interner, callee_node, receiver)
         }
+        LibraryApiCalleeContract::ImportedBinding { exported, .. } => {
+            imported_member_callee_shape_matches(il, interner, callee_node, exported)
+        }
+        LibraryApiCalleeContract::JavaUtilStaticMember { receiver, method } => {
+            let Some((actual_receiver, actual_method)) =
+                static_member_callee_parts(il, interner, callee_node)
+            else {
+                return false;
+            };
+            actual_receiver == receiver && actual_method == method
+        }
+        LibraryApiCalleeContract::RegexLiteralMethod { method, .. } => {
+            field_method_matches(il, interner, callee_node, method)
+        }
+        LibraryApiCalleeContract::ImportedNamespaceFunction { function, .. } => {
+            field_method_matches(il, interner, callee_node, function)
+        }
         LibraryApiCalleeContract::StaticGlobalMethod {
             receiver, method, ..
         } => {
@@ -4002,6 +4079,7 @@ fn library_api_callee_shape_matches(
 
 fn library_api_dependencies_match_callee(
     il: &Il,
+    interner: &Interner,
     node: NodeId,
     callee: LibraryApiCalleeContract,
     record: &EvidenceRecord,
@@ -4017,6 +4095,37 @@ fn library_api_dependencies_match_callee(
             dependency_has_source_call(il, record, il.node(node).span, SourceCallKind::Construct)
                 && (!requires_unshadowed_global
                     || dependency_has_unshadowed_global_node(il, record, callee_node, receiver))
+        }
+        LibraryApiCalleeContract::ImportedBinding { module, exported } => {
+            dependency_has_imported_member_node(il, interner, record, callee_node, module, exported)
+        }
+        LibraryApiCalleeContract::JavaUtilStaticMember { receiver, .. } => {
+            let Some(receiver_node) = il.children(callee_node).first().copied() else {
+                return false;
+            };
+            dependency_has_imported_binding_node(
+                il,
+                interner,
+                record,
+                receiver_node,
+                "java.util",
+                receiver,
+            ) && !unit_defines_hash(il, interner, stable_symbol_hash(receiver))
+        }
+        LibraryApiCalleeContract::RegexLiteralMethod {
+            required_receiver_fact,
+            ..
+        } => {
+            let Some(receiver_node) = il.children(callee_node).first().copied() else {
+                return false;
+            };
+            dependency_has_source_fact_node(il, record, receiver_node, required_receiver_fact)
+        }
+        LibraryApiCalleeContract::ImportedNamespaceFunction { module, .. } => {
+            let Some(receiver_node) = il.children(callee_node).first().copied() else {
+                return false;
+            };
+            dependency_has_imported_namespace_node(il, interner, record, receiver_node, module)
         }
         LibraryApiCalleeContract::StaticGlobalMethod {
             receiver,
@@ -4044,6 +4153,7 @@ fn library_api_dependencies_match_callee(
 
 fn library_api_dependencies_match_callee_at_span(
     il: &Il,
+    interner: &Interner,
     call_span: Span,
     callee_span: Option<Span>,
     receiver_span: Option<Span>,
@@ -4066,6 +4176,73 @@ fn library_api_dependencies_match_callee_at_span(
                             receiver,
                         )
                     }))
+        }
+        LibraryApiCalleeContract::ImportedBinding { module, exported } => {
+            if let Some(span) = receiver_span {
+                dependency_has_imported_namespace_anchor(
+                    il,
+                    interner,
+                    record,
+                    span,
+                    NodeKind::Var,
+                    module,
+                )
+            } else if let Some(span) = callee_span {
+                dependency_has_imported_binding_anchor(
+                    il,
+                    interner,
+                    record,
+                    span,
+                    NodeKind::Var,
+                    module,
+                    exported,
+                ) || dependency_has_imported_namespace_dependency(il, interner, record, module)
+            } else {
+                dependency_has_imported_binding_dependency(il, interner, record, module, exported)
+                    || dependency_has_imported_namespace_dependency(il, interner, record, module)
+            }
+        }
+        LibraryApiCalleeContract::JavaUtilStaticMember { receiver, .. } => {
+            let receiver_proven = if let Some(span) = receiver_span {
+                dependency_has_imported_binding_anchor(
+                    il,
+                    interner,
+                    record,
+                    span,
+                    NodeKind::Var,
+                    "java.util",
+                    receiver,
+                )
+            } else {
+                dependency_has_imported_binding_dependency(
+                    il,
+                    interner,
+                    record,
+                    "java.util",
+                    receiver,
+                )
+            };
+            receiver_proven && !unit_defines_hash(il, interner, stable_symbol_hash(receiver))
+        }
+        LibraryApiCalleeContract::RegexLiteralMethod {
+            required_receiver_fact,
+            ..
+        } => receiver_span.is_some_and(|span| {
+            dependency_has_source_fact_anchor(il, record, span, required_receiver_fact)
+        }),
+        LibraryApiCalleeContract::ImportedNamespaceFunction { module, .. } => {
+            if let Some(span) = receiver_span {
+                dependency_has_imported_namespace_anchor(
+                    il,
+                    interner,
+                    record,
+                    span,
+                    NodeKind::Var,
+                    module,
+                )
+            } else {
+                dependency_has_imported_namespace_dependency(il, interner, record, module)
+            }
         }
         LibraryApiCalleeContract::StaticGlobalMethod {
             receiver,
@@ -4130,11 +4307,31 @@ fn static_member_callee_parts<'a>(
         return None;
     };
     let receiver = il.children(node).first().copied()?;
-    let Payload::Name(receiver_name) = il.node(receiver).payload else {
+    if il.kind(receiver) != NodeKind::Var {
         return None;
-    };
-    (il.kind(receiver) == NodeKind::Var)
-        .then(|| (interner.resolve(receiver_name), interner.resolve(method)))
+    }
+    let receiver_name = node_name(il, interner, receiver)?;
+    Some((receiver_name, interner.resolve(method)))
+}
+
+fn imported_member_callee_shape_matches(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    exported: &str,
+) -> bool {
+    match il.kind(node) {
+        NodeKind::Var => var_name_matches(il, interner, node, exported),
+        NodeKind::Field => field_method_matches(il, interner, node, exported),
+        _ => false,
+    }
+}
+
+fn field_method_matches(il: &Il, interner: &Interner, node: NodeId, expected: &str) -> bool {
+    matches!(
+        (il.kind(node), il.node(node).payload),
+        (NodeKind::Field, Payload::Name(method)) if interner.resolve(method) == expected
+    )
 }
 
 fn dependency_has_source_call(
@@ -4156,6 +4353,35 @@ fn dependency_has_source_call(
         ),
         EvidenceResolution::Found(call) if call == expected
     ) && dependency_has_asserted_record(il, record, anchor, kind)
+}
+
+fn dependency_has_source_fact_node(
+    il: &Il,
+    record: &EvidenceRecord,
+    node: NodeId,
+    expected: SourceFactKind,
+) -> bool {
+    dependency_has_source_fact_anchor(il, record, il.node(node).span, expected)
+}
+
+fn dependency_has_source_fact_anchor(
+    il: &Il,
+    record: &EvidenceRecord,
+    span: Span,
+    expected: SourceFactKind,
+) -> bool {
+    let anchor = EvidenceAnchor::source_span(span);
+    matches!(
+        unique_evidence_at(
+            il,
+            |candidate| candidate == anchor,
+            |evidence| match evidence {
+                EvidenceKind::Source(fact) => Some(fact),
+                _ => None,
+            },
+        ),
+        EvidenceResolution::Found(fact) if fact == expected
+    ) && dependency_has_asserted_record(il, record, anchor, EvidenceKind::Source(expected))
 }
 
 fn dependency_has_unshadowed_global_node(
@@ -4226,6 +4452,342 @@ fn dependency_has_qualified_global_anchor(
         EvidenceAnchor::node(span, kind),
         EvidenceKind::Symbol(expected_kind),
     )
+}
+
+fn dependency_has_imported_member_node(
+    il: &Il,
+    interner: &Interner,
+    record: &EvidenceRecord,
+    node: NodeId,
+    module: &str,
+    exported: &str,
+) -> bool {
+    match il.kind(node) {
+        NodeKind::Var => {
+            dependency_has_imported_binding_node(il, interner, record, node, module, exported)
+        }
+        NodeKind::Field => {
+            let Some(receiver) = il.children(node).first().copied() else {
+                return false;
+            };
+            dependency_has_imported_namespace_node(il, interner, record, receiver, module)
+        }
+        _ => false,
+    }
+}
+
+fn dependency_has_imported_binding_node(
+    il: &Il,
+    interner: &Interner,
+    record: &EvidenceRecord,
+    node: NodeId,
+    module: &str,
+    exported: &str,
+) -> bool {
+    dependency_has_imported_binding_anchor(
+        il,
+        interner,
+        record,
+        il.node(node).span,
+        il.kind(node),
+        module,
+        exported,
+    )
+}
+
+fn dependency_has_imported_binding_anchor(
+    il: &Il,
+    interner: &Interner,
+    record: &EvidenceRecord,
+    span: Span,
+    kind: NodeKind,
+    module: &str,
+    exported: &str,
+) -> bool {
+    let expected = SymbolEvidenceKind::ImportedBinding {
+        module_hash: stable_symbol_hash(module),
+        exported_hash: stable_symbol_hash(exported),
+    };
+    dependency_has_imported_symbol_anchor(il, interner, record, span, kind, expected)
+}
+
+fn dependency_has_imported_namespace_node(
+    il: &Il,
+    interner: &Interner,
+    record: &EvidenceRecord,
+    node: NodeId,
+    module: &str,
+) -> bool {
+    dependency_has_imported_namespace_anchor(
+        il,
+        interner,
+        record,
+        il.node(node).span,
+        il.kind(node),
+        module,
+    )
+}
+
+fn dependency_has_imported_namespace_anchor(
+    il: &Il,
+    interner: &Interner,
+    record: &EvidenceRecord,
+    span: Span,
+    kind: NodeKind,
+    module: &str,
+) -> bool {
+    let expected = SymbolEvidenceKind::ImportedNamespace {
+        module_hash: stable_symbol_hash(module),
+    };
+    dependency_has_imported_symbol_anchor(il, interner, record, span, kind, expected)
+}
+
+fn dependency_has_imported_binding_dependency(
+    il: &Il,
+    interner: &Interner,
+    record: &EvidenceRecord,
+    module: &str,
+    exported: &str,
+) -> bool {
+    let expected = SymbolEvidenceKind::ImportedBinding {
+        module_hash: stable_symbol_hash(module),
+        exported_hash: stable_symbol_hash(exported),
+    };
+    dependency_has_imported_symbol_dependency(il, interner, record, expected)
+}
+
+fn dependency_has_imported_namespace_dependency(
+    il: &Il,
+    interner: &Interner,
+    record: &EvidenceRecord,
+    module: &str,
+) -> bool {
+    let expected = SymbolEvidenceKind::ImportedNamespace {
+        module_hash: stable_symbol_hash(module),
+    };
+    dependency_has_imported_symbol_dependency(il, interner, record, expected)
+}
+
+fn dependency_has_imported_symbol_dependency(
+    il: &Il,
+    interner: &Interner,
+    record: &EvidenceRecord,
+    expected: SymbolEvidenceKind,
+) -> bool {
+    record.dependencies.iter().any(|&id| {
+        let Some(dependency) = evidence_record_by_id(il, id) else {
+            return false;
+        };
+        dependency.status == EvidenceStatus::Asserted
+            && dependency.kind == EvidenceKind::Symbol(expected)
+            && matches!(
+                dependency.anchor,
+                EvidenceAnchor::Node {
+                    kind: NodeKind::Var,
+                    ..
+                }
+            )
+            && imported_occurrence_symbol_dependencies_valid(il, interner, dependency, expected)
+    })
+}
+
+fn dependency_has_imported_symbol_anchor(
+    il: &Il,
+    interner: &Interner,
+    record: &EvidenceRecord,
+    span: Span,
+    kind: NodeKind,
+    expected: SymbolEvidenceKind,
+) -> bool {
+    if kind != NodeKind::Var {
+        return false;
+    }
+    if !matches!(
+        symbol_evidence_at_node_anchor(il, span, kind),
+        EvidenceResolution::Found(actual) if actual == expected
+    ) {
+        return false;
+    }
+    let Some(symbol_record) = record.dependencies.iter().find_map(|&id| {
+        let dependency = evidence_record_by_id(il, id)?;
+        (dependency.anchor == EvidenceAnchor::node(span, kind)
+            && dependency.status == EvidenceStatus::Asserted
+            && dependency.kind == EvidenceKind::Symbol(expected))
+        .then_some(dependency)
+    }) else {
+        return false;
+    };
+    imported_occurrence_symbol_dependencies_valid(il, interner, symbol_record, expected)
+}
+
+fn imported_occurrence_symbol_dependencies_valid(
+    il: &Il,
+    interner: &Interner,
+    symbol_record: &EvidenceRecord,
+    expected: SymbolEvidenceKind,
+) -> bool {
+    let EvidenceAnchor::Node {
+        span: occurrence_span,
+        kind: NodeKind::Var,
+    } = symbol_record.anchor
+    else {
+        return false;
+    };
+    let Some(binding_record) = symbol_record.dependencies.iter().find_map(|&id| {
+        let dependency = evidence_record_by_id(il, id)?;
+        (dependency.status == EvidenceStatus::Asserted
+            && dependency.kind == EvidenceKind::Symbol(expected)
+            && matches!(dependency.anchor, EvidenceAnchor::Binding { .. }))
+        .then_some(dependency)
+    }) else {
+        return false;
+    };
+    let EvidenceAnchor::Binding {
+        span: binding_span,
+        local_hash,
+    } = binding_record.anchor
+    else {
+        return false;
+    };
+    if unit_defines_hash(il, interner, local_hash) {
+        return false;
+    }
+    if !matches!(
+        binding_identity_matches(il, local_hash, binding_span, expected),
+        EvidenceResolution::Found(true)
+    ) {
+        return false;
+    }
+    if !binding_has_no_visible_conflicting_assignment(il, interner, local_hash, binding_span) {
+        return false;
+    }
+    if !binding_has_no_visible_local_shadow(il, interner, local_hash, binding_span, occurrence_span)
+    {
+        return false;
+    }
+    binding_symbol_evidence_consistent_for_local(il, local_hash, expected)
+}
+
+fn binding_has_no_visible_conflicting_assignment(
+    il: &Il,
+    interner: &Interner,
+    local_hash: u64,
+    binding_span: Span,
+) -> bool {
+    top_level_statements(il)
+        .into_iter()
+        .filter(|&stmt| assignment_alias_hash(il, interner, stmt) == Some(local_hash))
+        .all(|stmt| il.node(stmt).span == binding_span)
+}
+
+fn binding_has_no_visible_local_shadow(
+    il: &Il,
+    interner: &Interner,
+    local_hash: u64,
+    binding_span: Span,
+    occurrence_span: Span,
+) -> bool {
+    let Some(function_span) = innermost_enclosing_function_span(il, occurrence_span) else {
+        return true;
+    };
+    let occurrence_cid = var_cid_at_span(il, occurrence_span);
+    !il.nodes.iter().enumerate().any(|(idx, node)| {
+        let node_id = NodeId(idx as u32);
+        if !span_contains(function_span, node.span)
+            || node.span == binding_span
+            || node.span.start_byte > occurrence_span.start_byte
+            || innermost_enclosing_function_span(il, node.span) != Some(function_span)
+        {
+            return false;
+        }
+        match node.kind {
+            NodeKind::Param => node_cid(il, node_id)
+                .zip(occurrence_cid)
+                .is_some_and(|(param_cid, occurrence_cid)| param_cid == occurrence_cid),
+            NodeKind::Assign => {
+                assignment_lhs_cid(il, node_id)
+                    .zip(occurrence_cid)
+                    .is_some_and(|(lhs_cid, occurrence_cid)| lhs_cid == occurrence_cid)
+                    || assignment_lhs_raw_name_hash(il, interner, node_id) == Some(local_hash)
+            }
+            _ => false,
+        }
+    })
+}
+
+fn innermost_enclosing_function_span(il: &Il, span: Span) -> Option<Span> {
+    il.nodes
+        .iter()
+        .filter_map(|node| {
+            (node.kind == NodeKind::Func && span_contains(node.span, span)).then_some(node.span)
+        })
+        .min_by_key(|span| span.end_byte.saturating_sub(span.start_byte))
+}
+
+fn span_contains(outer: Span, inner: Span) -> bool {
+    outer.file == inner.file
+        && outer.start_byte <= inner.start_byte
+        && inner.end_byte <= outer.end_byte
+}
+
+fn var_cid_at_span(il: &Il, span: Span) -> Option<u32> {
+    il.nodes
+        .iter()
+        .enumerate()
+        .find_map(|(idx, node)| {
+            (node.kind == NodeKind::Var && node.span == span).then_some(NodeId(idx as u32))
+        })
+        .and_then(|node| node_cid(il, node))
+}
+
+fn node_cid(il: &Il, node: NodeId) -> Option<u32> {
+    match il.node(node).payload {
+        Payload::Cid(cid) => Some(cid),
+        _ => None,
+    }
+}
+
+fn assignment_lhs_cid(il: &Il, stmt: NodeId) -> Option<u32> {
+    let (lhs, _) = assignment_parts(il, stmt)?;
+    (il.kind(lhs) == NodeKind::Var)
+        .then(|| node_cid(il, lhs))
+        .flatten()
+}
+
+fn assignment_lhs_raw_name_hash(il: &Il, interner: &Interner, stmt: NodeId) -> Option<u64> {
+    let (lhs, _) = assignment_parts(il, stmt)?;
+    match il.node(lhs).payload {
+        Payload::Name(symbol) => Some(stable_symbol_hash(interner.resolve(symbol))),
+        _ => None,
+    }
+}
+
+fn binding_symbol_evidence_consistent_for_local(
+    il: &Il,
+    local_hash: u64,
+    expected: SymbolEvidenceKind,
+) -> bool {
+    let mut saw_symbol = false;
+    for record in &il.evidence {
+        let EvidenceAnchor::Binding {
+            local_hash: anchor_hash,
+            ..
+        } = record.anchor
+        else {
+            continue;
+        };
+        if anchor_hash != local_hash {
+            continue;
+        }
+        let EvidenceKind::Symbol(symbol) = record.kind else {
+            continue;
+        };
+        if record.status != EvidenceStatus::Asserted || symbol != expected {
+            return false;
+        }
+        saw_symbol = true;
+    }
+    saw_symbol
 }
 
 fn dependency_has_asserted_record(
@@ -6146,9 +6708,10 @@ mod tests {
     }
 
     #[test]
-    fn direct_symbol_evidence_proves_imported_namespace_without_raw_assignment() {
+    fn imported_occurrence_symbol_evidence_requires_binding_dependency() {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
+        let local_hash = stable_symbol_hash("m");
         let receiver = b.add(
             NodeKind::Var,
             Payload::Name(interner.intern("m")),
@@ -6164,6 +6727,27 @@ mod tests {
                 module_hash: stable_symbol_hash("math"),
             }),
             EvidenceStatus::Asserted,
+        ));
+
+        assert!(!imported_namespace_symbol(&il, &interner, receiver, "math"));
+
+        il.evidence.clear();
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(sp(19), local_hash),
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace {
+                module_hash: stable_symbol_hash("math"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            1,
+            EvidenceAnchor::node(sp(20), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace {
+                module_hash: stable_symbol_hash("math"),
+            }),
+            EvidenceStatus::Asserted,
+            vec![EvidenceId(0)],
         ));
 
         assert!(imported_namespace_symbol(&il, &interner, receiver, "math"));
@@ -6466,36 +7050,45 @@ mod tests {
         assert_eq!(
             library_api_contract_evidence_at_call_span(
                 &il,
-                Some(il.node(call).span),
-                Some(il.node(callee).span),
-                Some(il.node(array).span),
-                contract.id,
-                contract.callee,
-                1,
+                &interner,
+                LibraryApiSpanEvidenceQuery {
+                    call_span: Some(il.node(call).span),
+                    callee_span: Some(il.node(callee).span),
+                    receiver_span: Some(il.node(array).span),
+                    id: contract.id,
+                    callee: contract.callee,
+                    arg_count: 1,
+                },
             ),
             LibraryApiEvidenceStatus::Admitted
         );
         assert_eq!(
             library_api_contract_evidence_at_call_span(
                 &il,
-                Some(il.node(call).span),
-                Some(sp(99)),
-                Some(il.node(array).span),
-                contract.id,
-                contract.callee,
-                1,
+                &interner,
+                LibraryApiSpanEvidenceQuery {
+                    call_span: Some(il.node(call).span),
+                    callee_span: Some(sp(99)),
+                    receiver_span: Some(il.node(array).span),
+                    id: contract.id,
+                    callee: contract.callee,
+                    arg_count: 1,
+                },
             ),
             LibraryApiEvidenceStatus::Rejected
         );
         assert_eq!(
             library_api_contract_evidence_at_call_span(
                 &il,
-                Some(il.node(call).span),
-                Some(il.node(callee).span),
-                Some(sp(99)),
-                contract.id,
-                contract.callee,
-                1,
+                &interner,
+                LibraryApiSpanEvidenceQuery {
+                    call_span: Some(il.node(call).span),
+                    callee_span: Some(il.node(callee).span),
+                    receiver_span: Some(sp(99)),
+                    id: contract.id,
+                    callee: contract.callee,
+                    arg_count: 1,
+                },
             ),
             LibraryApiEvidenceStatus::Rejected
         );
@@ -6643,6 +7236,301 @@ mod tests {
                 1,
             ),
             LibraryApiEvidenceStatus::Missing
+        );
+    }
+
+    #[test]
+    fn library_api_evidence_resolution_accepts_import_and_source_backed_callees() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let local = interner.intern("deque");
+        let lhs = b.add(NodeKind::Var, Payload::Name(local), sp(10), &[]);
+        let rhs = b.add(NodeKind::Seq, Payload::None, sp(10), &[]);
+        let import = b.add(NodeKind::Assign, Payload::None, sp(10), &[lhs, rhs]);
+        let callee = b.add(NodeKind::Var, Payload::Name(local), sp(11), &[]);
+        let arg = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(12),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(13), &[callee, arg]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(9), &[import, call]);
+        let mut il = finish_il(b, root, Lang::Python);
+        let contract =
+            library_imported_collection_factory_contract(Lang::Python, "collections", "deque")
+                .expect("deque contract");
+        let binding_symbol = EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+            module_hash: stable_symbol_hash("collections"),
+            exported_hash: stable_symbol_hash("deque"),
+        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(sp(10), stable_symbol_hash("deque")),
+            binding_symbol,
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            1,
+            EvidenceAnchor::node(sp(11), NodeKind::Var),
+            binding_symbol,
+            EvidenceStatus::Asserted,
+            vec![EvidenceId(0)],
+        ));
+        il.evidence.push(library_api_record(
+            2,
+            sp(13),
+            contract.id,
+            contract.callee,
+            EvidenceStatus::Asserted,
+            &[1],
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &il,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        );
+
+        let mut b = IlBuilder::new(FileId(0));
+        let regex = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("/x/")),
+            sp(20),
+            &[],
+        );
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("test")),
+            sp(21),
+            &[regex],
+        );
+        let arg = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("s")),
+            sp(22),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(23), &[callee, arg]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(19), &[call]);
+        let mut il = finish_il(b, root, Lang::JavaScript);
+        let contract =
+            library_regex_test_contract(Lang::JavaScript, "test", 1).expect("regex contract");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::source_span(sp(20)),
+            EvidenceKind::Source(SourceFactKind::Literal(SourceLiteralKind::Regex)),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(library_api_record(
+            1,
+            sp(23),
+            contract.id,
+            contract.callee,
+            EvidenceStatus::Asserted,
+            &[0],
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &il,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        );
+    }
+
+    #[test]
+    fn library_api_evidence_resolution_accepts_import_binding_outside_unit_root() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let local = interner.intern("List");
+        let lhs = b.add(NodeKind::Var, Payload::Name(local), sp(30), &[]);
+        let rhs = b.add(NodeKind::Seq, Payload::None, sp(30), &[]);
+        let _import = b.add(NodeKind::Assign, Payload::None, sp(30), &[lhs, rhs]);
+        let receiver = b.add(NodeKind::Var, Payload::Name(local), sp(31), &[]);
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("of")),
+            sp(32),
+            &[receiver],
+        );
+        let arg = b.add(NodeKind::Lit, Payload::LitInt(1), sp(33), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(34), &[callee, arg]);
+        let root = b.add(NodeKind::Func, Payload::None, sp(35), &[call]);
+        let mut il = finish_il(b, root, Lang::Java);
+        let contract = library_java_collection_factory_contract(Lang::Java, "List", "of")
+            .expect("List.of contract");
+        let binding_symbol = EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+            module_hash: stable_symbol_hash("java.util"),
+            exported_hash: stable_symbol_hash("List"),
+        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(sp(30), stable_symbol_hash("List")),
+            binding_symbol,
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            1,
+            EvidenceAnchor::node(sp(31), NodeKind::Var),
+            binding_symbol,
+            EvidenceStatus::Asserted,
+            vec![EvidenceId(0)],
+        ));
+        il.evidence.push(library_api_record(
+            2,
+            sp(34),
+            contract.id,
+            contract.callee,
+            EvidenceStatus::Asserted,
+            &[1],
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &il,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        );
+        assert_eq!(
+            library_api_contract_evidence_at_call_span(
+                &il,
+                &interner,
+                LibraryApiSpanEvidenceQuery {
+                    call_span: Some(sp(34)),
+                    callee_span: Some(sp(32)),
+                    receiver_span: Some(sp(30)),
+                    id: contract.id,
+                    callee: contract.callee,
+                    arg_count: 1,
+                },
+            ),
+            LibraryApiEvidenceStatus::Rejected
+        );
+        assert_eq!(
+            library_api_contract_evidence_at_call_span(
+                &il,
+                &interner,
+                LibraryApiSpanEvidenceQuery {
+                    call_span: Some(sp(34)),
+                    callee_span: Some(sp(32)),
+                    receiver_span: None,
+                    id: contract.id,
+                    callee: contract.callee,
+                    arg_count: 1,
+                },
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        );
+
+        il.evidence.push(evidence(
+            3,
+            EvidenceAnchor::binding(sp(36), stable_symbol_hash("List")),
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+                module_hash: stable_symbol_hash("other.module"),
+                exported_hash: stable_symbol_hash("List"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &il,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Rejected
+        );
+    }
+
+    #[test]
+    fn library_api_evidence_resolution_rejects_shadowed_java_static_members() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let local = interner.intern("List");
+        let lhs = b.add(NodeKind::Var, Payload::Name(local), sp(30), &[]);
+        let rhs = b.add(NodeKind::Seq, Payload::None, sp(30), &[]);
+        let import = b.add(NodeKind::Assign, Payload::None, sp(30), &[lhs, rhs]);
+        let receiver = b.add(NodeKind::Var, Payload::Name(local), sp(31), &[]);
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("of")),
+            sp(32),
+            &[receiver],
+        );
+        let arg = b.add(NodeKind::Lit, Payload::LitInt(1), sp(33), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(34), &[callee, arg]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(29), &[import, call]);
+        let mut il = finish_il(b, root, Lang::Java);
+        let contract = library_java_collection_factory_contract(Lang::Java, "List", "of")
+            .expect("List.of contract");
+        let binding_symbol = EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+            module_hash: stable_symbol_hash("java.util"),
+            exported_hash: stable_symbol_hash("List"),
+        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(sp(30), stable_symbol_hash("List")),
+            binding_symbol,
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            1,
+            EvidenceAnchor::node(sp(31), NodeKind::Var),
+            binding_symbol,
+            EvidenceStatus::Asserted,
+            vec![EvidenceId(0)],
+        ));
+        il.evidence.push(library_api_record(
+            2,
+            sp(34),
+            contract.id,
+            contract.callee,
+            EvidenceStatus::Asserted,
+            &[1],
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &il,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        );
+
+        il.units.push(Unit {
+            root,
+            kind: UnitKind::Class,
+            name: Some(local),
+        });
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &il,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Rejected
         );
     }
 

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -6,10 +6,11 @@ remaining work are tracked in
 [semantic-kernel-roadmap](semantic-kernel-roadmap.md). Source-origin facts are
 covered in [source-facts](source-facts.md).
 
-Evidence records are the internal substrate that lets language and library packs
-emit proof facts without giving those packs authority to approve exact clones.
-They are facts, not verdicts. Contracts in `nose-semantics` decide whether a fact
-can satisfy an exact-channel precondition.
+Evidence records are the internal substrate that lets current first-party
+frontends, and future language/library packs, emit proof facts without giving
+those producers authority to approve exact clones. They are facts, not verdicts.
+Contracts in `nose-semantics` decide whether a fact can satisfy an exact-channel
+precondition.
 
 ## Goal
 
@@ -63,7 +64,7 @@ The current implemented kinds are:
 | `Guard` | multi-obligation guard proof facts such as JS/TS record-shape and own-property guard contracts |
 | `Place` | fixed receiver/place facts currently covering `SelfReceiver` and `SelfField` |
 | `Effect` | observable effect facts currently covering canonical builder append calls, non-overloadable index writes, and fixed self-field writes |
-| `LibraryApi` | proof that a specific call occurrence matches a language/API contract coordinate, currently for selected JS-like static/global APIs |
+| `LibraryApi` | proof that a specific call occurrence matches a language/API contract coordinate, currently for selected JS-like static/global APIs plus selected import/source-backed Python, Java, and regex APIs |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, guard surfaces, Go composite map literals, or Go map entries |
 
 `LibraryApi` evidence is an occurrence fact, not the whole contract. It records
@@ -149,6 +150,14 @@ record proves only API identity; exact consumers still separately prove
 receiver/domain facts, source-surface requirements, argument safety, result
 shape, mutation safety, and demand/effect obligations.
 
+Imported API occurrence evidence is not a broad name guess. A call-site
+`Symbol(ImportedBinding)` or `Symbol(ImportedNamespace)` dependency must itself
+depend on the matching binding-anchor symbol, pass rebinding and local/parameter
+shadow checks, and match the current receiver/callee span when that span is
+available. If normalization erases an import occurrence into a seeded import
+value, consumers pass no occurrence span and rely on that validated dependency
+instead of accepting an unrelated imported symbol elsewhere in the file.
+
 ## Current Producers
 
 First-party frontends now mirror these facts into `EvidenceRecord`:
@@ -178,14 +187,20 @@ First-party frontends now mirror these facts into `EvidenceRecord`:
   writes, and `Effect(BuilderAppendCall)` for canonical `Builtin::Append`.
   Self-field place/write evidence records include dependencies that link the
   write proof back to the receiver proof;
-- first-party JS/TS lowering emits `LibraryApi` evidence for selected
-  static/global API calls that remain as raw call nodes: `Array.from(...)`,
-  `Array.isArray(...)`, `Boolean(...)`, `new Map(...)`, and `new Set(...)`.
-  These records depend on the relevant `QualifiedGlobal`, `UnshadowedGlobal`,
-  and/or construct-syntax `Source` evidence. Calls collapsed into specialized
-  guard surfaces emit their guard evidence instead. Shadowed roots, plain
-  `Map(...)`/`Set(...)` calls, and unsupported static paths do not emit API
-  occurrence evidence;
+- first-party lowering emits `LibraryApi` evidence for selected API calls that
+  remain as raw call nodes: JS-like `Array.from(...)`, `Array.isArray(...)`,
+  `Boolean(...)`, `new Map(...)`, and `new Set(...)`; Python
+  `collections.deque(...)` through imported binding/namespace proof; Python
+  `math.prod(...)` through imported namespace proof; Java `java.util` static
+  factories/adapters including `List.of`, `Set.of`, `Arrays.asList`, `Map.of`,
+  `Map.ofEntries`, `Map.entry`, and `Arrays.stream`; and JS-like regex-literal
+  `.test(...)`. These records depend on the relevant `QualifiedGlobal`,
+  `UnshadowedGlobal`, import-backed call-site `Symbol`, construct-syntax
+  `Source`, or regex-literal `Source` evidence. Calls collapsed into specialized
+  guard surfaces emit their guard evidence instead. Shadowed roots, unsupported
+  arities, unsupported static paths, raw free-name/path factories without a
+  resolved symbol fact, and Ruby `require`-based APIs without require evidence
+  do not emit API occurrence evidence;
 - lowered `Seq` surfaces emit `SequenceSurface` evidence, including Go map
   literal and Go map-entry surfaces where those tags carry first-party meaning.
 
@@ -223,13 +238,13 @@ callers:
   guard evidence depends on `Object.hasOwn` or
   `Object.prototype.hasOwnProperty.call`, and map-key view wrappers require
   evidence for `Array.from`;
-- selected JS-like `LibraryApiContract` consumers now consult `LibraryApi`
-  occurrence evidence first for `Array.from`, `Array.isArray`, `Boolean`,
-  `new Map`, and `new Set`; conflicting or dependency-broken API evidence keeps
-  the value-graph and strict exact paths closed. When no relevant API evidence is
-  present, the current compatibility path still uses the older symbol/source
-  proof helpers. Other factory and method/view contract rows still name API
-  identity/result semantics while local consumers prove their current
+- selected `LibraryApiContract` consumers now consult `LibraryApi` occurrence
+  evidence first for the migrated JS-like, Python imported, Java static, and
+  regex-literal surfaces; conflicting or dependency-broken API evidence keeps
+  the value-graph, idiom, and strict exact paths closed. When no relevant API
+  evidence is present, the current compatibility path still uses the older
+  symbol/source proof helpers. Other factory and method/view contract rows still
+  name API identity/result semantics while local consumers prove their current
   `Symbol`, `Import`, `Source`, `Domain`, and `SequenceSurface` obligations;
 - JS/TS record-shape guard exact admission and value-graph tagging require both
   `SequenceSurface(RecordGuard)` and `Guard::JsRecordShape`; raw
@@ -250,8 +265,9 @@ callers:
   language-gated helper only when no relevant evidence record exists. Ambiguous
   or conflicting evidence keeps the exact path closed.
 
-Broader field/place/effect facts, `LibraryApi` occurrence evidence beyond the
-selected JS-like static/global APIs, receiver/protocol evidence beyond parameter
-domains, full scope-resolution and namespace-member evidence, broader guard
-evidence, general cross-module dependency manifests, report-level provenance,
-and external manifest loading are still open work.
+Broader field/place/effect facts, `LibraryApi` occurrence evidence for remaining
+free-name/path/receiver-method APIs, receiver/protocol evidence beyond parameter
+domains, full scope-resolution and namespace-member evidence, require/import
+evidence for surfaces such as Ruby `Set.new`, broader guard evidence, general
+cross-module dependency manifests, report-level provenance, and external
+manifest loading are still open work.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -13,9 +13,11 @@ and pack ecosystem.
    into nose, but they should use the same pack contracts as external languages.
 
 2. **nose certifies only first-party packs.** External pack providers own their
-   semantic claims. Users own the decision to enable them. nose owns the extension
-   contract, validation of pack structure, fail-closed execution, and provenance
-   reporting.
+   semantic claims. Users own the decision to enable them. nose owns the
+   extension contract, schema and structural validation, fail-closed execution,
+   and provenance reporting. Semantic correctness, conformance evidence, and
+   enablement risk for external packs stay with the provider and user, except
+   for first-party/default packs that nose ships and tests.
 
 3. **Packs emit evidence, not verdicts.** A pack can emit facts, contracts, and
    protocol operations. It cannot mint fingerprints, bypass laws, or approve exact
@@ -287,6 +289,19 @@ and pack ecosystem.
   `new Set`; value-graph and strict exact consumers for those surfaces consult
   it first and close legacy fallback on conflicting, ambiguous, or
   dependency-broken records.
+- The next `LibraryApi` occurrence evidence slice extended the same
+  dependency-backed path to selected import/source-backed APIs: Python
+  `collections.deque`, Python `math.prod`, Java `java.util` static
+  factories/adapters (`List.of`, `Set.of`, `Arrays.asList`, `Map.of`,
+  `Map.ofEntries`, `Map.entry`, `Arrays.stream`), and JS-like regex-literal
+  `.test`. Producers emit call-site `Symbol` dependencies for imported
+  binding/namespace occurrences or `Source` dependencies for regex literals;
+  value-graph, idiom, and strict exact consumers consult these records first and
+  close fallback on rejected records. Imported occurrence symbols now require
+  binding-anchor dependencies, rebinding/local-shadow validation, span-matched
+  dependencies when spans survive normalization, and Java map provider proofs no
+  longer replace current receiver identity except for imported literal snapshots
+  already validated in the provider module.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -354,16 +369,20 @@ Remaining in this phase:
   views and wrappers, map `get`, map defaulting method calls, static JS-like
   helpers, regex-literal `.test`, Python `math.prod`, promise `.then`, iterator
   identity adapters, Java `Arrays.stream`, and existing language-scoped method
-  call contracts. The first occurrence-evidence slice covers selected JS-like
-  static/global APIs only; broader stdlib and ecosystem APIs still need
-  dependency-backed occurrence records before they become pack-facing.
+  call contracts. Occurrence-evidence slices now cover selected JS-like
+  static/global APIs, import-backed Python factories/functions, Java `java.util`
+  static factories/adapters, and JS regex literals. Remaining stdlib and
+  ecosystem APIs still need dependency-backed occurrence records before they
+  become pack-facing.
 - Keep value-graph and strict exact gates on the same contract source. Factory,
   constructor, and selected method/view/adapter gates now share
-  `LibraryApiContract` identity/result rows, and selected JS-like static/global
-  calls now additionally share `LibraryApi` occurrence evidence. Remaining API
-  work is to move remaining raw sequence/tag and local callee-proof dependencies
-  into explicit evidence records, then cover broader reduction/HOF and ecosystem
-  APIs only after demand, receiver, and effect obligations are expressible.
+  `LibraryApiContract` identity/result rows, and selected JS-like,
+  import-backed Python, Java `java.util`, and regex calls now additionally share
+  `LibraryApi` occurrence evidence. Remaining API work is to move raw
+  sequence/tag, Ruby `require`, Rust free-name/path-root, Java constructor, and
+  broad receiver-method proof dependencies into explicit evidence records, then
+  cover broader reduction/HOF and ecosystem APIs only after demand, receiver,
+  and effect obligations are expressible.
 - Remove the remaining raw import/module proof IL payload storage after import
   and symbol evidence records can carry every consumer obligation, including
   module export dependencies, scope, rebinding, and mutation proof. Value-graph

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -5,16 +5,16 @@ implementation shape; planned work and decision history live in
 [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The internal evidence
 record substrate is described in [evidence-records](evidence-records.md).
 
-Snapshot date: 2026-06-08, current implementation after the semantic-kernel
-foundation and follow-up facade migrations through receiver-aware field state
-sequence-surface contracts, proof-backed append fragment evidence, and the first
-operator-law contracts, typed import facts, and source-fact gates for construct,
-literal, equality/operator provenance, and the shared evidence-record substrate
-for source, domain, import, symbol-identity, guard, place/effect, selected
-library API occurrence, and sequence-surface facts. Library/API identity is now
-consolidated further through internal `LibraryApiContract` rows for factory,
-constructor, and selected non-factory method/view surfaces, with the first
-occurrence evidence vertical covering selected JS-like static/global APIs.
+Snapshot date: 2026-06-08. The current implementation has an internal
+semantic-kernel facade, receiver-aware field state, sequence-surface contracts,
+proof-backed append fragment evidence, operator-law contracts, typed import
+facts, source-fact gates for construct/literal/operator provenance, and a shared
+evidence-record substrate for source, domain, import, symbol-identity, guard,
+place/effect, selected library API occurrence, and sequence-surface facts.
+Library/API identity is consolidated through internal `LibraryApiContract` rows
+for factory, constructor, and selected non-factory method/view surfaces, with
+occurrence evidence covering selected JS-like static/global APIs plus selected
+import/source-backed Python, Java, and JS regex API calls.
 
 ## What exists today
 
@@ -129,19 +129,24 @@ migrated.
   identity and result obligations; local consumers still prove receiver domain,
   import/symbol identity, source facts, exact-safe arguments, fallback demand
   shape, and mutation safety.
-- Selected JS-like API call occurrences now also have `LibraryApi` evidence
-  records when they remain as raw call nodes. First-party lowering emits
-  occurrence evidence for `Array.from(...)`, `Array.isArray(...)`,
-  `Boolean(...)`, `new Map(...)`, and `new Set(...)`, depending on the relevant
-  `QualifiedGlobal`, `UnshadowedGlobal`, and/or construct-syntax `Source`
+- Selected API call occurrences now also have `LibraryApi` evidence records when
+  they remain as raw call nodes. First-party lowering emits occurrence evidence
+  for JS-like `Array.from(...)`, `Array.isArray(...)`, `Boolean(...)`,
+  `new Map(...)`, and `new Set(...)`; Python `collections.deque(...)` when the
+  callee is proven through `from collections import deque` or
+  `import collections; collections.deque(...)`; Python `import math;
+  math.prod(...)`; Java `java.util` static factories/adapters such as `List.of`,
+  `Set.of`, `Arrays.asList`, `Map.of`, `Map.ofEntries`, `Map.entry`, and
+  `Arrays.stream`; and JS-like regex-literal `.test(...)`. These records depend
+  on the relevant `QualifiedGlobal`, `UnshadowedGlobal`, import-backed
+  call-site `Symbol`, construct-syntax `Source`, or regex-literal `Source`
   evidence. Calls collapsed into specialized guard surfaces emit guard evidence
   instead. `nose-semantics` resolves these records with a three-state result:
-  admitted, missing, or rejected. Value-graph and strict exact consumers for
-  `Array.from(map.keys())`, `Array.isArray`, and JS-like `new Map`/`new Set`
-  consult this occurrence evidence first; conflicting or dependency-broken API
-  evidence closes the legacy path. The record proves API identity only;
-  receiver/domain, source, exact-safe argument, result-shape, and mutation
-  obligations remain separate.
+  admitted, missing, or rejected. Value-graph, idiom, and strict exact consumers
+  for the migrated surfaces consult this occurrence evidence first; conflicting
+  or dependency-broken API evidence closes the legacy path. The record proves
+  API identity only; receiver/domain, source, exact-safe argument, result-shape,
+  and mutation obligations remain separate.
 - Java empty collection constructor contracts cover `new ArrayList<>()` and
   `new LinkedList<>()` through `LibraryApiContract` rows only for the Java
   `java.util` list types. Simple names require `java.util` import proof and no
@@ -354,10 +359,12 @@ Semantic knowledge still appears in several forms outside the facade:
 - hard-coded oracle evaluation rules for eager calls, short-circuit operators,
   HOFs, nullish defaulting, recursion, and effect traces;
 - duplicated receiver/domain and library/API proof gates in desugaring,
-  idiom lowering, value-graph, and strict exact paths. The first JS-like
-  `LibraryApi` occurrence evidence reduces this for selected static/global APIs,
-  but Python/Java/Rust/Ruby factory and method occurrences still mostly rely on
-  contract rows plus local proof.
+  idiom lowering, value-graph, and strict exact paths. `LibraryApi` occurrence
+  evidence now reduces this for selected JS-like static/global APIs,
+  import-backed Python factories/functions, Java `java.util` static
+  factories/adapters, and JS regex literals, but Rust free-name/path factories,
+  Ruby `require "set"; Set.new(...)`, Java empty constructors, and broad
+  receiver-method surfaces still rely on contract rows plus local proof.
 
 These are valuable, but they do not yet share one complete semantic contract
 language.
@@ -379,8 +386,9 @@ language.
 
 - Language semantics are not first-class. Many rules ask "which language is this?"
   instead of "which semantic capability has been proven?"
-- Library semantics are embedded in engine code rather than declared as versioned
-  API contracts.
+- Library semantics are still compiled into engine/first-party facade code.
+  Internal `LibraryApiContract` rows exist, but they are not yet versioned
+  external pack manifest contracts.
 - Evaluation strategy is not a shared model. Eager, short-circuit, pull-lazy,
   call-by-need, async, and observable behavior are not represented by a common
   demand/effect abstraction.
@@ -432,10 +440,10 @@ The first high-value targets for semantic-kernel extraction are:
 - richer sequence/aggregate evidence for factories, nested entries, iterator
   views, and exported-literal eligibility beyond the current first
   `SequenceSurface` substrate;
-- broader `LibraryApi` occurrence evidence for Java/Rust/Python/Ruby stdlib
-  factories, imported namespace functions, map get/defaulting, iterator
-  adapters, and method-call surfaces now represented only by contract rows plus
-  local proof;
+- broader `LibraryApi` occurrence evidence for remaining Java/Rust/Python/Ruby
+  stdlib factories, map get/defaulting, iterator adapters, and method-call
+  surfaces that still need receiver/domain, require/import, or path-root proof
+  records before they can move beyond contract rows plus local proof;
 - generalized guard evidence beyond the first JS/TS record-shape contract,
   including richer source/API dependency records and validation;
 - dependency, scope, and ambiguity validation before evidence records become a


### PR DESCRIPTION
## Summary
- extend first-party `LibraryApi` occurrence evidence to selected import/source-backed Python, Java `java.util`, and regex APIs
- require imported occurrence symbols to be binding-dependent, shadow-safe, and span-matched when spans survive normalization
- keep Java map provider proof limited to imported literal snapshots and document pack/provider responsibility boundaries

## Tracking
- Updates #109

## Validation
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `awiki lint --root docs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서
* Semantic kernel 위키 항목 링크 추가

## 개선사항
* 라이브러리 API 검출 정확도 향상으로 더 정밀한 코드 분석 지원
* 임포트 기반 API 및 다양한 언어 패턴(Python, Java, JavaScript) 감지 범위 확대
* 컬렉션 팩토리, 정적 어댑터, 정규식 메서드 등 추가 API 유형 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->