### PR TITLE
[codex] Remove raw import proof payloads

### DIFF
--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -10,7 +10,7 @@ use nose_il::{
     SourceCallKind, SourceFact, SourceFactKind, Span, Symbol, SymbolEvidenceKind, Unit, UnitKind,
 };
 use nose_semantics::{
-    import_fact_tag, library_api_callee_contract_hash, library_api_contract_id_hash,
+    library_api_callee_contract_hash, library_api_contract_id_hash,
     library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
     library_java_collection_factory_contract, library_java_map_entry_contract,
     library_java_map_factory_contract, library_js_array_is_array_contract,
@@ -970,11 +970,9 @@ pub(crate) fn import_namespace(lo: &mut Lowering, span: Span, local: &str, modul
     import_fact(lo, span, local, ImportFactKind::Namespace, &[module])
 }
 
-/// Shared shape of the static-import proof facts: `local = Seq[tag](str_lit(c) for c in
-/// coords)`. Both `import_binding` and `import_namespace` build this exact form, differing
-/// only in the Seq tag and the coordinate count. The node-allocation order — lhs var, then
-/// each coordinate string, then the Seq, then the Assign — is preserved identically to the
-/// original two functions.
+/// Shared shape of static-import proof facts. The assignment remains in IL so
+/// import text participates in the syntax/near floor, but the `Seq` payload is
+/// deliberately untagged: semantic proof lives only in the evidence records.
 fn import_fact(
     lo: &mut Lowering,
     span: Span,
@@ -984,8 +982,7 @@ fn import_fact(
 ) -> NodeId {
     let lhs = lo.var(local, span);
     let strs: Vec<NodeId> = coords.iter().map(|c| lo.str_lit(c, span)).collect();
-    let tag = lo.sym(import_fact_tag(kind));
-    let rhs = lo.add(NodeKind::Seq, Payload::Name(tag), span, &strs);
+    let rhs = lo.add(NodeKind::Seq, Payload::None, span, &strs);
     let evidence_kind = match kind {
         ImportFactKind::Binding if coords.len() == 2 => {
             EvidenceKind::Import(ImportEvidenceKind::Binding {

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -1,9 +1,10 @@
 //! Corpus-level import proof facts that need more than one lowered file.
 //!
-//! Frontends lower a static import as `local = import_binding(module, exported)`.
-//! Once the whole corpus is available, a sibling module can prove that this binding
-//! names a single immutable literal value. In that narrow case we replace the import
-//! fact RHS with a cloned literal subtree, so the existing per-file value-graph
+//! Frontends lower a static import as an assignment whose RHS carries only module
+//! coordinates; `EvidenceKind::Import` records prove those coordinates. Once the
+//! whole corpus is available, a sibling module can prove that this binding names a
+//! single immutable literal value. In that narrow case we replace the import fact
+//! RHS with a cloned literal subtree, so the existing per-file value-graph
 //! module-binding seed can reuse its mutation and canonicalization logic.
 
 use nose_il::{
@@ -1110,7 +1111,7 @@ mod tests {
         );
     }
 
-    fn raw_import_binding_assignment(
+    fn coordinate_import_binding_assignment(
         file: FileId,
         lang: Lang,
     ) -> (Il, Interner, Span, NodeId, NodeId) {
@@ -1131,8 +1132,7 @@ mod tests {
             span,
             &[],
         );
-        let tag = interner.intern(nose_semantics::import_fact_tag(ImportFactKind::Binding));
-        let rhs = b.add(NodeKind::Seq, Payload::Name(tag), span, &[module, exported]);
+        let rhs = b.add(NodeKind::Seq, Payload::None, span, &[module, exported]);
         let assign = b.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs]);
         let root = b.add(NodeKind::Module, Payload::None, span, &[assign]);
         let il = b.finish(
@@ -1174,11 +1174,11 @@ mod tests {
     #[test]
     fn import_binding_key_requires_asserted_import_evidence() {
         let (mut il, _interner, span, assign, _rhs) =
-            raw_import_binding_assignment(FileId(0), Lang::Java);
+            coordinate_import_binding_assignment(FileId(0), Lang::Java);
         assert_eq!(
             import_binding_key(&il, assign),
             None,
-            "raw import_binding Seq tags must not prove import coordinates"
+            "raw import coordinate Seqs must not prove import identity"
         );
 
         add_import_binding_evidence(&mut il, span, EvidenceStatus::Asserted);
@@ -1189,9 +1189,9 @@ mod tests {
     }
 
     #[test]
-    fn import_binding_key_rejects_ambiguous_import_evidence_even_with_raw_seq() {
+    fn import_binding_key_rejects_ambiguous_import_evidence_even_with_coordinates() {
         let (mut il, _interner, span, assign, _rhs) =
-            raw_import_binding_assignment(FileId(0), Lang::Java);
+            coordinate_import_binding_assignment(FileId(0), Lang::Java);
         add_import_binding_evidence(&mut il, span, EvidenceStatus::Ambiguous);
 
         assert_eq!(
@@ -1202,9 +1202,9 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_append_does_not_mint_import_or_symbol_evidence_from_raw_seq() {
+    fn snapshot_append_does_not_mint_import_or_symbol_evidence_from_coordinates() {
         let (provider, _interner, _span, assign, _rhs) =
-            raw_import_binding_assignment(FileId(0), Lang::Java);
+            coordinate_import_binding_assignment(FileId(0), Lang::Java);
         let snapshot = snapshot_subtree(&provider, assign);
 
         let mut b = IlBuilder::new(FileId(1));
@@ -1396,10 +1396,9 @@ mod tests {
             import_span,
             &[],
         );
-        let import_tag = interner.intern(nose_semantics::import_fact_tag(ImportFactKind::Binding));
         let import_rhs = b.add(
             NodeKind::Seq,
-            Payload::Name(import_tag),
+            Payload::None,
             import_span,
             &[module, exported],
         );

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -390,8 +390,6 @@ pub enum SequenceSurfaceKind {
     Tuple,
     Map,
     Pair,
-    ImportBinding,
-    ImportNamespace,
     RecordGuard,
     OwnPropertyGuard,
     GoCompositeMapLiteral,

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -948,7 +948,6 @@ mod tests {
         ParamSemantic, ParamTypeFact, SequenceSurfaceKind, Span, SymbolEvidenceKind, Unit,
         UnitKind,
     };
-    use nose_semantics::{import_fact_tag, ImportFactKind};
 
     fn sp() -> Span {
         Span::new(FileId(0), 1, 1, 1, 1)
@@ -1329,8 +1328,7 @@ mod tests {
                 sp(),
                 &[],
             );
-            let tag = interner.intern(import_fact_tag(ImportFactKind::Namespace));
-            let rhs = b.add(NodeKind::Seq, Payload::Name(tag), sp(), &[module]);
+            let rhs = b.add(NodeKind::Seq, Payload::None, sp(), &[module]);
             module_kids.push(b.add(NodeKind::Assign, Payload::None, sp(), &[lhs, rhs]));
         }
         let receiver = b.add(

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -8590,7 +8590,7 @@ mod tests {
         SourceFactKind, Span, SymbolEvidenceKind, Unit, UnitKind,
     };
     use nose_semantics::{
-        import_fact_tag, library_api_callee_contract_hash, library_api_contract_id_hash,
+        library_api_callee_contract_hash, library_api_contract_id_hash,
         library_imported_collection_factory_contract, library_java_collection_factory_contract,
         library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
         LibraryApiContractId, FIRST_PARTY_PACK_ID,
@@ -8896,7 +8896,6 @@ mod tests {
     fn import_binding_value_requires_sequence_evidence() {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
-        let tag = interner.intern(import_fact_tag(ImportFactKind::Binding));
         let module = b.add(
             NodeKind::Lit,
             Payload::LitStr(stable_symbol_hash("collections")),
@@ -8909,18 +8908,16 @@ mod tests {
             sp(40),
             &[],
         );
-        let binding = b.add(
-            NodeKind::Seq,
-            Payload::Name(tag),
-            sp(40),
-            &[module, exported],
-        );
+        let binding = b.add(NodeKind::Seq, Payload::None, sp(40), &[module, exported]);
         let root = b.add(NodeKind::Block, Payload::None, sp(40), &[binding]);
         let mut il = finish_test_il(b, root, Lang::Python);
 
         let mut builder = Builder::new(&il, &interner);
         let raw = builder.eval(binding, &FxHashMap::default());
-        assert!(matches!(builder.nodes[raw as usize].op, ValOp::Seq(_)));
+        assert!(matches!(
+            builder.nodes[raw as usize].op,
+            ValOp::Seq(SEQ_VALUE_UNTAGGED)
+        ));
         assert!(!builder.is_import_binding_value(raw, "collections", "deque"));
 
         il.evidence.push(evidence(
@@ -8944,7 +8941,6 @@ mod tests {
     fn namespace_member_import_binding_requires_proven_namespace_value() {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
-        let namespace_tag = interner.intern(import_fact_tag(ImportFactKind::Namespace));
         let prod = interner.intern("prod");
         let module = b.add(
             NodeKind::Lit,
@@ -8952,12 +8948,7 @@ mod tests {
             sp(50),
             &[],
         );
-        let namespace = b.add(
-            NodeKind::Seq,
-            Payload::Name(namespace_tag),
-            sp(50),
-            &[module],
-        );
+        let namespace = b.add(NodeKind::Seq, Payload::None, sp(50), &[module]);
         let field = b.add(NodeKind::Field, Payload::Name(prod), sp(51), &[namespace]);
         let root = b.add(NodeKind::Block, Payload::None, sp(50), &[field]);
         let mut il = finish_test_il(b, root, Lang::Python);
@@ -9076,7 +9067,6 @@ mod tests {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
         let local = interner.intern("collections");
-        let namespace_tag = interner.intern(import_fact_tag(ImportFactKind::Namespace));
         let lhs = b.add(NodeKind::Var, Payload::Cid(0), sp(80), &[]);
         let module = b.add(
             NodeKind::Lit,
@@ -9084,12 +9074,7 @@ mod tests {
             sp(80),
             &[],
         );
-        let rhs = b.add(
-            NodeKind::Seq,
-            Payload::Name(namespace_tag),
-            sp(80),
-            &[module],
-        );
+        let rhs = b.add(NodeKind::Seq, Payload::None, sp(80), &[module]);
         let import = b.add(NodeKind::Assign, Payload::None, sp(80), &[lhs, rhs]);
         let receiver = b.add(NodeKind::Var, Payload::Name(local), sp(81), &[]);
         let callee = b.add(

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -258,13 +258,8 @@ pub const SEQ_VALUE_COLLECTION: u64 = 1;
 pub const SEQ_VALUE_TUPLE: u64 = 2;
 pub const SEQ_VALUE_MAP: u64 = 3;
 pub const SEQ_VALUE_PAIR: u64 = 4;
-pub const SEQ_VALUE_IMPORT_BINDING: u64 = 5;
-pub const SEQ_VALUE_IMPORT_NAMESPACE: u64 = 6;
 pub const SEQ_VALUE_RECORD_GUARD: u64 = 7;
 pub const SEQ_VALUE_OWN_PROPERTY_GUARD: u64 = 8;
-
-pub const IMPORT_BINDING_TAG: &str = "import_binding";
-pub const IMPORT_NAMESPACE_TAG: &str = "import_namespace";
 
 /// Kernel contract for a lowered `Seq` surface tag.
 ///
@@ -289,8 +284,6 @@ pub fn sequence_surface_kind_for_tag(lang: Lang, tag: Option<&str>) -> Option<Se
         Some("tuple" | "tuple_expression") => Some(SequenceSurfaceKind::Tuple),
         Some("dictionary" | "object" | "hash") => Some(SequenceSurfaceKind::Map),
         Some("pair") => Some(SequenceSurfaceKind::Pair),
-        Some(IMPORT_BINDING_TAG) => Some(SequenceSurfaceKind::ImportBinding),
-        Some(IMPORT_NAMESPACE_TAG) => Some(SequenceSurfaceKind::ImportNamespace),
         Some("record_guard") => Some(SequenceSurfaceKind::RecordGuard),
         Some("own_property_guard") => Some(SequenceSurfaceKind::OwnPropertyGuard),
         Some("composite_literal") if lang == Lang::Go => {
@@ -337,20 +330,6 @@ fn seq_surface_contract_for_tag(
         },
         SequenceSurfaceKind::Pair => SeqSurfaceContract {
             value_tag: SEQ_VALUE_PAIR,
-            exact_tree_safe: true,
-            membership_collection: false,
-            map_entry_list: false,
-            imported_literal: false,
-        },
-        SequenceSurfaceKind::ImportBinding => SeqSurfaceContract {
-            value_tag: SEQ_VALUE_IMPORT_BINDING,
-            exact_tree_safe: true,
-            membership_collection: false,
-            map_entry_list: false,
-            imported_literal: false,
-        },
-        SequenceSurfaceKind::ImportNamespace => SeqSurfaceContract {
-            value_tag: SEQ_VALUE_IMPORT_NAMESPACE,
             exact_tree_safe: true,
             membership_collection: false,
             map_entry_list: false,
@@ -739,9 +718,6 @@ pub enum ImportFactKind {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct ImportFactContract {
     pub kind: ImportFactKind,
-    pub tag: &'static str,
-    pub coordinate_count: usize,
-    pub value_tag: u64,
     pub channel: ChannelEligibility,
 }
 
@@ -749,31 +725,13 @@ pub fn import_fact_contract(kind: ImportFactKind) -> ImportFactContract {
     match kind {
         ImportFactKind::Binding => ImportFactContract {
             kind,
-            tag: IMPORT_BINDING_TAG,
-            coordinate_count: 2,
-            value_tag: SEQ_VALUE_IMPORT_BINDING,
             channel: ChannelEligibility::ExactProven,
         },
         ImportFactKind::Namespace => ImportFactContract {
             kind,
-            tag: IMPORT_NAMESPACE_TAG,
-            coordinate_count: 1,
-            value_tag: SEQ_VALUE_IMPORT_NAMESPACE,
             channel: ChannelEligibility::ExactProven,
         },
     }
-}
-
-pub fn import_fact_contract_for_tag(tag: &str) -> Option<ImportFactContract> {
-    match tag {
-        IMPORT_BINDING_TAG => Some(import_fact_contract(ImportFactKind::Binding)),
-        IMPORT_NAMESPACE_TAG => Some(import_fact_contract(ImportFactKind::Namespace)),
-        _ => None,
-    }
-}
-
-pub fn import_fact_tag(kind: ImportFactKind) -> &'static str {
-    import_fact_contract(kind).tag
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -808,9 +766,9 @@ fn import_fact_evidence_at_sequence_span(il: &Il, span: Span) -> EvidenceResolut
     )
 }
 
-/// Evidence-only import fact resolution for semantic consumers. This intentionally
-/// does not parse the legacy raw `Seq("import_*")` payload: callers that use this
-/// helper are relying on a provider-owned evidence record, not on tag spelling.
+/// Evidence-only import fact resolution for semantic consumers. Import proof is
+/// intentionally not encoded in the lowered `Seq` payload; callers rely on a
+/// provider-owned evidence record, not on tag spelling.
 pub fn import_fact_evidence_rhs(il: &Il, rhs: NodeId) -> Option<ImportFact> {
     if il.kind(rhs) != NodeKind::Seq {
         return None;
@@ -895,62 +853,6 @@ fn evidence_record_by_id(il: &Il, id: EvidenceId) -> Option<&EvidenceRecord> {
         .get(id.0 as usize)
         .filter(|record| record.id == id)
         .or_else(|| il.evidence.iter().find(|record| record.id == id))
-}
-
-pub fn import_fact_rhs(il: &Il, interner: &Interner, rhs: NodeId) -> Option<ImportFact> {
-    if il.kind(rhs) != NodeKind::Seq {
-        return None;
-    }
-    match import_fact_evidence_at_sequence_span(il, il.node(rhs).span) {
-        EvidenceResolution::Found(fact) => return Some(fact),
-        EvidenceResolution::Ambiguous => return None,
-        EvidenceResolution::Missing => {}
-    }
-    let Payload::Name(tag) = il.node(rhs).payload else {
-        return None;
-    };
-    let contract = import_fact_contract_for_tag(interner.resolve(tag))?;
-    let coords = il.children(rhs);
-    if coords.len() != contract.coordinate_count {
-        return None;
-    }
-    let module_hash = literal_string_hash(il, coords[0])?;
-    let exported_hash = match contract.kind {
-        ImportFactKind::Binding => Some(literal_string_hash(il, coords[1])?),
-        ImportFactKind::Namespace => None,
-    };
-    Some(ImportFact {
-        kind: contract.kind,
-        module_hash,
-        exported_hash,
-    })
-}
-
-pub fn import_binding_rhs_matches(
-    il: &Il,
-    interner: &Interner,
-    rhs: NodeId,
-    module: &str,
-    exported: &str,
-) -> bool {
-    import_fact_rhs(il, interner, rhs).is_some_and(|fact| {
-        fact.kind == ImportFactKind::Binding
-            && fact.module_hash == stable_symbol_hash(module)
-            && fact.exported_hash == Some(stable_symbol_hash(exported))
-    })
-}
-
-pub fn import_namespace_rhs_matches(
-    il: &Il,
-    interner: &Interner,
-    rhs: NodeId,
-    module: &str,
-) -> bool {
-    import_fact_rhs(il, interner, rhs).is_some_and(|fact| {
-        fact.kind == ImportFactKind::Namespace
-            && fact.module_hash == stable_symbol_hash(module)
-            && fact.exported_hash.is_none()
-    })
 }
 
 fn symbol_evidence_at_node(il: &Il, node: NodeId) -> EvidenceResolution<SymbolEvidenceKind> {
@@ -6505,11 +6407,8 @@ mod tests {
     }
 
     #[test]
-    fn import_fact_contracts_parse_typed_binding_and_namespace_proofs() {
-        let interner = Interner::new();
+    fn import_fact_contracts_resolve_evidence_only_binding_and_namespace_proofs() {
         let mut b = IlBuilder::new(FileId(0));
-        let binding_tag = interner.intern(import_fact_tag(ImportFactKind::Binding));
-        let namespace_tag = interner.intern(import_fact_tag(ImportFactKind::Namespace));
         let collections = b.add(
             NodeKind::Lit,
             Payload::LitStr(stable_symbol_hash("collections")),
@@ -6522,70 +6421,70 @@ mod tests {
             sp(1),
             &[],
         );
-        let binding = b.add(
-            NodeKind::Seq,
-            Payload::Name(binding_tag),
-            sp(1),
-            &[collections, deque],
-        );
+        let binding = b.add(NodeKind::Seq, Payload::None, sp(1), &[collections, deque]);
         let math = b.add(
             NodeKind::Lit,
             Payload::LitStr(stable_symbol_hash("math")),
             sp(2),
             &[],
         );
-        let namespace = b.add(NodeKind::Seq, Payload::Name(namespace_tag), sp(2), &[math]);
-        let malformed_binding = b.add(NodeKind::Seq, Payload::Name(binding_tag), sp(3), &[math]);
+        let namespace = b.add(NodeKind::Seq, Payload::None, sp(2), &[math]);
+        let raw_coordinates = b.add(NodeKind::Seq, Payload::None, sp(3), &[math]);
         let root = b.add(
             NodeKind::Module,
             Payload::None,
             sp(1),
-            &[binding, namespace, malformed_binding],
+            &[binding, namespace, raw_coordinates],
         );
-        let il = finish_il(b, root, Lang::Python);
+        let mut il = finish_il(b, root, Lang::Python);
 
         assert_eq!(
             import_fact_contract(ImportFactKind::Binding).channel,
             ChannelEligibility::ExactProven
         );
-        assert!(import_binding_rhs_matches(
-            &il,
-            &interner,
-            binding,
-            "collections",
-            "deque"
-        ));
         assert_eq!(import_fact_evidence_rhs(&il, binding), None);
-        assert!(!import_binding_rhs_matches(
-            &il,
-            &interner,
-            namespace,
-            "collections",
-            "deque"
+        assert_eq!(import_fact_evidence_rhs(&il, namespace), None);
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(1)),
+            EvidenceKind::Import(ImportEvidenceKind::Binding {
+                module_hash: stable_symbol_hash("collections"),
+                exported_hash: stable_symbol_hash("deque"),
+            }),
+            EvidenceStatus::Asserted,
         ));
-        assert!(!import_binding_rhs_matches(
-            &il,
-            &interner,
-            malformed_binding,
-            "math",
-            "prod"
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::sequence(sp(2)),
+            EvidenceKind::Import(ImportEvidenceKind::Namespace {
+                module_hash: stable_symbol_hash("math"),
+            }),
+            EvidenceStatus::Asserted,
         ));
-        assert!(import_namespace_rhs_matches(
-            &il, &interner, namespace, "math"
-        ));
-        assert!(!import_namespace_rhs_matches(
-            &il,
-            &interner,
-            binding,
-            "collections"
-        ));
+
+        assert_eq!(
+            import_fact_evidence_rhs(&il, binding),
+            Some(ImportFact {
+                kind: ImportFactKind::Binding,
+                module_hash: stable_symbol_hash("collections"),
+                exported_hash: Some(stable_symbol_hash("deque")),
+            })
+        );
+        assert_eq!(
+            import_fact_evidence_rhs(&il, namespace),
+            Some(ImportFact {
+                kind: ImportFactKind::Namespace,
+                module_hash: stable_symbol_hash("math"),
+                exported_hash: None,
+            })
+        );
+        assert_eq!(import_fact_evidence_rhs(&il, raw_coordinates), None);
     }
 
     #[test]
-    fn import_evidence_records_are_fail_closed_before_raw_seq_fallback() {
-        let interner = Interner::new();
+    fn ambiguous_import_evidence_stays_closed_without_raw_seq_fallback() {
         let mut b = IlBuilder::new(FileId(0));
-        let binding_tag = interner.intern(import_fact_tag(ImportFactKind::Binding));
         let module = b.add(
             NodeKind::Lit,
             Payload::LitStr(stable_symbol_hash("collections")),
@@ -6598,12 +6497,7 @@ mod tests {
             sp(10),
             &[],
         );
-        let binding = b.add(
-            NodeKind::Seq,
-            Payload::Name(binding_tag),
-            sp(10),
-            &[module, exported],
-        );
+        let binding = b.add(NodeKind::Seq, Payload::None, sp(10), &[module, exported]);
         let root = b.add(NodeKind::Module, Payload::None, sp(10), &[binding]);
         let mut il = finish_il(b, root, Lang::Python);
         il.evidence.push(evidence(
@@ -6615,16 +6509,14 @@ mod tests {
             EvidenceStatus::Asserted,
         ));
 
-        assert!(!import_binding_rhs_matches(
-            &il,
-            &interner,
-            binding,
-            "collections",
-            "deque"
-        ));
-        assert!(import_namespace_rhs_matches(
-            &il, &interner, binding, "math"
-        ));
+        assert_eq!(
+            import_fact_evidence_rhs(&il, binding),
+            Some(ImportFact {
+                kind: ImportFactKind::Namespace,
+                module_hash: stable_symbol_hash("math"),
+                exported_hash: None,
+            })
+        );
 
         il.evidence.push(evidence(
             1,
@@ -6635,7 +6527,6 @@ mod tests {
             }),
             EvidenceStatus::Asserted,
         ));
-        assert_eq!(import_fact_rhs(&il, &interner, binding), None);
         assert_eq!(import_fact_evidence_rhs(&il, binding), None);
     }
 
@@ -6644,7 +6535,6 @@ mod tests {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
         let local = interner.intern("deque");
-        let binding_tag = interner.intern(import_fact_tag(ImportFactKind::Binding));
         let module = b.add(
             NodeKind::Lit,
             Payload::LitStr(stable_symbol_hash("collections")),
@@ -6658,12 +6548,7 @@ mod tests {
             &[],
         );
         let lhs = b.add(NodeKind::Var, Payload::Name(local), sp(30), &[]);
-        let rhs = b.add(
-            NodeKind::Seq,
-            Payload::Name(binding_tag),
-            sp(30),
-            &[module, exported],
-        );
+        let rhs = b.add(NodeKind::Seq, Payload::None, sp(30), &[module, exported]);
         let assignment = b.add(NodeKind::Assign, Payload::None, sp(30), &[lhs, rhs]);
         let use_site = b.add(NodeKind::Var, Payload::Name(local), sp(31), &[]);
         let root = b.add(
@@ -6674,13 +6559,7 @@ mod tests {
         );
         let mut il = finish_il(b, root, Lang::Python);
 
-        assert!(import_binding_rhs_matches(
-            &il,
-            &interner,
-            rhs,
-            "collections",
-            "deque"
-        ));
+        assert_eq!(import_fact_evidence_rhs(&il, rhs), None);
         assert!(!imported_binding_symbol(
             &il,
             &interner,
@@ -6771,13 +6650,7 @@ mod tests {
             sp(21),
             &[],
         );
-        let namespace_tag = interner.intern(import_fact_tag(ImportFactKind::Namespace));
-        let rhs = b.add(
-            NodeKind::Seq,
-            Payload::Name(namespace_tag),
-            sp(21),
-            &[module],
-        );
+        let rhs = b.add(NodeKind::Seq, Payload::None, sp(21), &[module]);
         let assign = b.add(NodeKind::Assign, Payload::None, sp(21), &[lhs, rhs]);
         let receiver = b.add(NodeKind::Var, Payload::Name(local), sp(22), &[]);
         let root = b.add(NodeKind::Module, Payload::None, sp(21), &[assign, receiver]);
@@ -6806,13 +6679,7 @@ mod tests {
             sp(24),
             &[],
         );
-        let namespace_tag = interner.intern(import_fact_tag(ImportFactKind::Namespace));
-        let rhs = b.add(
-            NodeKind::Seq,
-            Payload::Name(namespace_tag),
-            sp(24),
-            &[module],
-        );
+        let rhs = b.add(NodeKind::Seq, Payload::None, sp(24), &[module]);
         let import_assign = b.add(NodeKind::Assign, Payload::None, sp(24), &[lhs, rhs]);
         let rebound_lhs = b.add(NodeKind::Var, Payload::Name(local), sp(25), &[]);
         let rebound_rhs = b.add(NodeKind::Lit, Payload::LitInt(0), sp(25), &[]);

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -90,13 +90,14 @@ side tables.
 - Compatibility fallback is allowed only when no relevant evidence record exists,
   and only for explicitly legacy compatibility helpers.
 
-This is stricter than a name or tag check. For example, a raw
-`Seq("import_binding")` is still serialized for compatibility, but import
-contracts first consult `Import` evidence. If that evidence is ambiguous, exact
-import proof stays closed instead of falling back to the raw sequence payload.
-Value-graph import identity goes further: it consumes only sequence `Import`
-evidence and materializes dedicated internal import values, never raw
-`ValOp::Seq("import_*")` proof objects.
+This is stricter than a name or tag check. For example, static import lowering
+keeps an assignment RHS with only untagged module/export coordinate literals;
+the coordinates are not a proof channel. Import contracts consume only
+`Import` evidence. If that evidence is missing or ambiguous, exact import proof
+stays closed instead of falling back to the raw sequence shape. Value-graph
+import identity likewise consumes only sequence `Import` evidence and
+materializes dedicated internal import values, never raw `ValOp::Seq` proof
+objects.
 
 Symbol identity follows the same rule. A method selector such as `abs` or a
 receiver spelling such as `Math` is not proof. Exact consumers must require a

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -120,8 +120,10 @@ and pack ecosystem.
   provider-side stdlib proofs such as `java.util.Map` for Java static imports
   only when that provider evidence exists. Replacement records
   `ImportedLiteralSnapshot` provenance depending on the importer static import
-  proof and copied provider evidence, and raw `Seq("import_binding")` spelling
-  no longer proves cross-file replacement.
+  proof and copied provider evidence. Static import identity now requires
+  `EvidenceRecord::Import`; frontends keep only untagged coordinate sequences
+  in the assignment carrier, and raw sequence spelling no longer proves
+  cross-file replacement or value-graph import identity.
 - JS-like `Map`/`Set` constructor contracts now require construct-syntax proof.
   They were initially closed while construct-vs-call evidence was missing; the
   source-fact slice reopened proof-backed `new Map(...)`/`new Set(...)` while

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -297,13 +297,14 @@ migrated.
   shadowed constructor names remain exact-closed.
 - Static import proof facts now have a typed `ImportFactKind`/`ImportFact`
   facade in `nose-semantics`. First-party frontends emit import binding and
-  namespace facts through that contract. Value-graph import identity consumes
-  sequence `Import` evidence into dedicated `ImportNamespace`/`ImportBinding`
-  value ops, so raw import `Seq` payloads can no longer become proof-bearing
-  value nodes by tag shape. Imported literal replacement also consumes
-  evidence-only import facts; raw `Seq("import_binding")` payloads remain as
-  compatibility mirrors, but missing or ambiguous `Import` evidence no longer
-  proves a cross-file replacement.
+  namespace facts through that contract. The lowered RHS keeps only structural
+  coordinate literals; proof lives in `EvidenceRecord::Import` and binding
+  `Symbol` evidence. Value-graph import identity consumes sequence `Import`
+  evidence into dedicated `ImportNamespace`/`ImportBinding` value ops, so raw
+  import coordinate sequences can no longer become proof-bearing value nodes by
+  tag shape. Imported literal replacement also consumes evidence-only import
+  facts; missing or ambiguous `Import` evidence no longer proves a cross-file
+  replacement.
 - Symbol identity evidence now covers static imported binding/namespace aliases
   and JS/TS static-global value occurrences such as `Math`, `console`, `Array`,
   `Map`, `Set`, and `undefined` when the frontend proves no local shadow.
@@ -343,11 +344,12 @@ Semantic knowledge still appears in several forms outside the facade:
   still first-party JS/TS lowering code, and broader guard families, richer
   source/API dependency records, and pack-facing dependency validation remain
   open;
-- IL still stores import facts as `Seq("import_binding")` /
-  `Seq("import_namespace")` payloads for compatibility. Frontends also emit
-  `EvidenceRecord::Import`, and value-graph import identity plus imported
-  literal replacement are now evidence-only, but the raw IL storage shape and
-  some compatibility consumers have not been removed;
+- IL no longer stores import proof as `Seq("import_binding")` /
+  `Seq("import_namespace")` payloads. Frontends keep an assignment plus
+  untagged coordinate literals for structural similarity and nearby syntax, but
+  import identity is proven only by `EvidenceRecord::Import` and associated
+  `Symbol` evidence. Module/export dependency and provider-scope validation are
+  still local to `nose-frontend`;
 - module/import proof logic for immutable sibling-module literal bindings is
   still local to `nose-frontend`, although replacement now copies the provider's
   closed evidence subgraph into the importer, remaps spans/dependency ids, and
@@ -435,8 +437,10 @@ The first high-value targets for semantic-kernel extraction are:
 - broader pack-facing field/place/effect evidence for all field reads and
   writes, building on the initial append/index/self-field effect substrate and
   the receiver-aware value-graph field state now used for same-unit caching;
-- full import/module fact migration to remove the remaining raw
-  `Seq("import_binding")` and `Seq("import_namespace")` compatibility payloads;
+- full import/module fact migration beyond raw payload removal: provider/export
+  dependency records, module scope, wildcard/conflict handling, copied evidence
+  provenance, and pack-facing validation still need to move behind explicit
+  extension contracts;
 - richer sequence/aggregate evidence for factories, nested entries, iterator
   views, and exported-literal eligibility beyond the current first
   `SequenceSurface` substrate;


### PR DESCRIPTION
## Summary

This PR removes the remaining raw import proof payload channel from the semantic kernel migration.

Static import assignments still keep an untagged coordinate `Seq` so import text participates in syntax/near matching, but semantic import identity now lives only in explicit evidence:

- `EvidenceKind::Import` proves import binding/namespace coordinates.
- binding `Symbol` evidence proves imported alias identity.
- value graph `ImportBinding` / `ImportNamespace` values are materialized only from import evidence.
- raw coordinate `Seq`s no longer prove cross-file imported literal replacement or import identity by tag shape.

## Changes

- Removed `SequenceSurfaceKind::{ImportBinding, ImportNamespace}` and their value tags.
- Removed raw import tag constants and raw import parsing helpers from `nose-semantics`.
- Lowered import RHS nodes now use `Payload::None` instead of `Seq("import_binding")` / `Seq("import_namespace")` payload tags.
- Updated module import, value graph, idiom, and semantics tests to assert evidence-only behavior.
- Updated semantic kernel and evidence docs to reflect the new snapshot and the remaining import/module migration work.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --release`
- `./scripts/check-duplication.sh` (20 / budget 21)
- `awiki lint --root docs`
- `git diff --check`
- `python3 scripts/check-formal-obligations.py --self-test`
- `python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`

Tracking: #109
