### PR TITLE
[codex] Gate LibraryApi occurrence semantics

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -1124,10 +1124,13 @@ fn abstraction_witness_summary(witness: &nose_detect::AbstractionWitness) -> Str
     let holes = witness
         .holes
         .iter()
-        .map(|hole| format!("{} {}->{}", hole.kind, hole.left, hole.right))
+        .map(|hole| format!("{} {} {}->{}", hole.kind, hole.role, hole.left, hole.right))
         .collect::<Vec<_>>()
         .join(", ");
-    format!("{} · {} · {}", witness.reason_code, holes, caveats)
+    format!(
+        "{}:{} · {} · {} · {}",
+        witness.basis, witness.members_checked, witness.reason_code, holes, caveats
+    )
 }
 
 /// Lines you'd actually delete by extracting one shared copy. For same-language

--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -9520,8 +9520,23 @@ fn abstraction_mode_reports_numeric_literal_witness() {
     let family = family_with_all(&abstraction, &["a/sum.py", "b/sum.py"])
         .unwrap_or_else(|| panic!("abstraction mode should report the pair: {abstraction}"));
     let witness = &family["abstraction_witness"];
+    assert_eq!(witness["claim"], "weak-refactoring-template");
+    assert_eq!(witness["basis"], "family");
+    assert_eq!(witness["members_checked"], 2);
     assert_eq!(witness["reason_code"], "type-parametric");
+    assert_eq!(witness["template_format"], "normalized-il-preorder");
     assert_eq!(witness["holes"][0]["kind"], "literal");
+    assert_eq!(witness["holes"][0]["role"], "leaf");
+    assert_eq!(
+        witness["holes"][0]["observed"]
+            .as_array()
+            .map(|values| values.len()),
+        Some(2)
+    );
+    assert!(
+        witness["holes"][0]["template_index"].as_u64().is_some(),
+        "hole should point back into the normalized template: {witness}"
+    );
     assert_eq!(witness["holes"][0]["left"], "int-literal");
     assert_eq!(witness["holes"][0]["right"], "float-literal");
     assert!(
@@ -9573,9 +9588,13 @@ fn abstraction_mode_reports_same_class_literal_without_numeric_caveat() {
             panic!("abstraction mode should report the literal pair: {abstraction}")
         });
     let witness = &family["abstraction_witness"];
+    assert_eq!(witness["basis"], "family");
+    assert_eq!(witness["members_checked"], 2);
     assert_eq!(witness["reason_code"], "literal-abstracted");
+    assert_eq!(witness["holes"][0]["role"], "leaf");
     assert_eq!(witness["holes"][0]["left"], "int-literal");
     assert_eq!(witness["holes"][0]["right"], "int-literal");
+    assert_eq!(witness["holes"][0]["observed"][0], "int-literal");
     assert!(
         witness["caveats"].as_array().is_some_and(|c| c.is_empty()),
         "same-class literal abstraction should not invent a numeric-domain caveat: {witness}"

--- a/crates/nose-detect/src/abstraction.rs
+++ b/crates/nose-detect/src/abstraction.rs
@@ -1,0 +1,370 @@
+//! Typed weak-claim witnesses for the experimental `abstraction` scan surface.
+//!
+//! This module owns the anti-unification policy. Unit extraction only records the
+//! pre-order token stream; deciding whether a token difference is a meaningful
+//! refactoring-template hole lives here so future type/domain/operator holes do
+//! not get mixed back into ordinary unit feature extraction.
+
+use nose_il::{Il, Interner, Lang, LitClass, NodeId, NodeKind, Payload, UnitKind};
+use nose_normalize::node_tag_valued;
+
+use crate::{AbstractionHole, AbstractionWitness};
+
+const CLAIM: &str = "weak-refactoring-template";
+const BASIS_FAMILY: &str = "family";
+const TEMPLATE_FORMAT: &str = "normalized-il-preorder";
+
+#[derive(Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub(crate) struct WitnessToken {
+    kind: NodeKind,
+    arity: u16,
+    shape_tag: u64,
+    exact_tag: u64,
+    literal: Option<LiteralClass>,
+    line: u32,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+enum LiteralClass {
+    Int,
+    Float,
+    Str,
+}
+
+impl LiteralClass {
+    fn label(self) -> &'static str {
+        match self {
+            LiteralClass::Int => "int-literal",
+            LiteralClass::Float => "float-literal",
+            LiteralClass::Str => "string-literal",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum HoleKind {
+    Literal,
+}
+
+impl HoleKind {
+    fn label(self) -> &'static str {
+        match self {
+            HoleKind::Literal => "literal",
+        }
+    }
+
+    fn role(self) -> &'static str {
+        match self {
+            HoleKind::Literal => "leaf",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ReasonCode {
+    TypeParametric,
+    LiteralAbstracted,
+}
+
+impl ReasonCode {
+    fn label(self) -> &'static str {
+        match self {
+            ReasonCode::TypeParametric => "type-parametric",
+            ReasonCode::LiteralAbstracted => "literal-abstracted",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Caveat {
+    NumericDomainSensitive,
+}
+
+impl Caveat {
+    fn label(self) -> &'static str {
+        match self {
+            Caveat::NumericDomainSensitive => "numeric-domain-sensitive",
+        }
+    }
+}
+
+struct HoleDecision {
+    kind: HoleKind,
+    reason_code: ReasonCode,
+    caveats: Vec<Caveat>,
+}
+
+struct HoleMatch {
+    template_index: usize,
+    left: WitnessToken,
+    right: WitnessToken,
+    decision: HoleDecision,
+    observed: Vec<LiteralClass>,
+}
+
+pub(crate) fn token_for(il: &Il, interner: &Interner, nid: NodeId, shape_tag: u64) -> WitnessToken {
+    let n = il.node(nid);
+    WitnessToken {
+        kind: n.kind,
+        arity: il.children(nid).len().min(u16::MAX as usize) as u16,
+        shape_tag,
+        exact_tag: node_tag_valued(n.kind, n.payload, interner),
+        literal: literal_class(n.payload),
+        line: n.span.start_line,
+    }
+}
+
+pub(crate) fn family_witness(
+    units: &[(Lang, UnitKind, &[WitnessToken])],
+) -> Option<AbstractionWitness> {
+    if units.len() < 2 {
+        return None;
+    }
+
+    let &(base_lang, base_kind, base_tokens) = units.first()?;
+    if base_tokens.is_empty() {
+        return None;
+    }
+
+    let mut hole_index = None;
+    for &(lang, kind, tokens) in units {
+        if lang != base_lang || kind != base_kind || tokens.len() != base_tokens.len() {
+            return None;
+        }
+        for (idx, (base, token)) in base_tokens.iter().zip(tokens).enumerate() {
+            if same_token(base, token) {
+                continue;
+            }
+            match hole_index {
+                Some(existing) if existing != idx => return None,
+                Some(_) => {}
+                None => hole_index = Some(idx),
+            }
+        }
+    }
+
+    let hole_index = hole_index?;
+    let left = base_tokens[hole_index];
+    let right = units
+        .iter()
+        .map(|(_, _, tokens)| tokens[hole_index])
+        .find(|token| !same_token(&left, token))?;
+    let hole_tokens = units
+        .iter()
+        .map(|(_, _, tokens)| tokens[hole_index])
+        .collect::<Vec<_>>();
+    let decision = literal_family_hole(&hole_tokens)?;
+    let observed = observed_literal_classes(&hole_tokens)?;
+
+    Some(render_witness(
+        BASIS_FAMILY,
+        units.len(),
+        base_tokens,
+        HoleMatch {
+            template_index: hole_index,
+            left,
+            right,
+            decision,
+            observed,
+        },
+    ))
+}
+
+fn render_witness(
+    basis: &'static str,
+    members_checked: usize,
+    tokens: &[WitnessToken],
+    hole: HoleMatch,
+) -> AbstractionWitness {
+    let template = render_template(tokens, hole.template_index, hole.decision.kind);
+    AbstractionWitness {
+        claim: CLAIM,
+        basis,
+        members_checked: members_checked.min(u32::MAX as usize) as u32,
+        reason_code: hole.decision.reason_code.label(),
+        template_format: TEMPLATE_FORMAT,
+        template,
+        holes: vec![AbstractionHole {
+            index: 1,
+            template_index: hole.template_index as u32,
+            kind: hole.decision.kind.label(),
+            role: hole.decision.kind.role(),
+            left: hole.left.literal.expect("literal witness left").label(),
+            right: hole.right.literal.expect("literal witness right").label(),
+            observed: hole
+                .observed
+                .iter()
+                .map(|literal| literal.label())
+                .collect(),
+            left_line: hole.left.line,
+            right_line: hole.right.line,
+        }],
+        caveats: hole
+            .decision
+            .caveats
+            .iter()
+            .map(|caveat| caveat.label())
+            .collect(),
+    }
+}
+
+fn same_token(left: &WitnessToken, right: &WitnessToken) -> bool {
+    left.kind == right.kind && left.arity == right.arity && left.exact_tag == right.exact_tag
+}
+
+fn literal_family_hole(tokens: &[WitnessToken]) -> Option<HoleDecision> {
+    let first = tokens.first()?;
+    for token in tokens {
+        if token.kind != NodeKind::Lit || token.arity != 0 || token.literal.is_none() {
+            return None;
+        }
+    }
+
+    let observed = observed_literal_classes(tokens)?;
+    let numeric_only = observed
+        .iter()
+        .all(|literal| matches!(literal, LiteralClass::Int | LiteralClass::Float));
+    let same_shape = tokens
+        .iter()
+        .all(|token| token.shape_tag == first.shape_tag);
+    if !same_shape && !numeric_only {
+        return None;
+    }
+
+    match observed.as_slice() {
+        [LiteralClass::Int, LiteralClass::Float] => Some(HoleDecision {
+            kind: HoleKind::Literal,
+            reason_code: ReasonCode::TypeParametric,
+            caveats: vec![Caveat::NumericDomainSensitive],
+        }),
+        [LiteralClass::Int] | [LiteralClass::Float] | [LiteralClass::Str] => Some(HoleDecision {
+            kind: HoleKind::Literal,
+            reason_code: ReasonCode::LiteralAbstracted,
+            caveats: Vec::new(),
+        }),
+        _ => None,
+    }
+}
+
+fn observed_literal_classes(tokens: &[WitnessToken]) -> Option<Vec<LiteralClass>> {
+    let mut observed = tokens
+        .iter()
+        .map(|token| token.literal)
+        .collect::<Option<Vec<_>>>()?;
+    observed.sort_unstable();
+    observed.dedup();
+    Some(observed)
+}
+
+fn literal_class(payload: Payload) -> Option<LiteralClass> {
+    match payload {
+        Payload::LitInt(_) | Payload::Lit(LitClass::Int) => Some(LiteralClass::Int),
+        Payload::LitFloat(_) | Payload::Lit(LitClass::Float) => Some(LiteralClass::Float),
+        Payload::LitStr(_) | Payload::Lit(LitClass::Str) => Some(LiteralClass::Str),
+        _ => None,
+    }
+}
+
+fn render_template(
+    tokens: &[WitnessToken],
+    hole_template_index: usize,
+    hole_kind: HoleKind,
+) -> Vec<String> {
+    tokens
+        .iter()
+        .enumerate()
+        .map(|(idx, token)| {
+            if idx == hole_template_index {
+                format!("<hole 1: {}>", hole_kind.label())
+            } else {
+                token_label(token).to_string()
+            }
+        })
+        .collect()
+}
+
+fn token_label(token: &WitnessToken) -> &'static str {
+    match token.literal {
+        Some(LiteralClass::Int) => "Lit<Int>",
+        Some(LiteralClass::Float) => "Lit<Float>",
+        Some(LiteralClass::Str) => "Lit<String>",
+        None => match token.kind {
+            NodeKind::Module => "Module",
+            NodeKind::Func => "Func",
+            NodeKind::Param => "Param",
+            NodeKind::Block => "Block",
+            NodeKind::Assign => "Assign",
+            NodeKind::ExprStmt => "ExprStmt",
+            NodeKind::Return => "Return",
+            NodeKind::If => "If",
+            NodeKind::Loop => "Loop",
+            NodeKind::Break => "Break",
+            NodeKind::Continue => "Continue",
+            NodeKind::Throw => "Throw",
+            NodeKind::Try => "Try",
+            NodeKind::Var => "Var",
+            NodeKind::Lit => "Lit",
+            NodeKind::BinOp => "BinOp",
+            NodeKind::UnOp => "UnOp",
+            NodeKind::Call => "Call",
+            NodeKind::Index => "Index",
+            NodeKind::Field => "Field",
+            NodeKind::Lambda => "Lambda",
+            NodeKind::Seq => "Seq",
+            NodeKind::HoF => "HoF",
+            NodeKind::Raw => "Raw",
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(kind: NodeKind, exact_tag: u64) -> WitnessToken {
+        WitnessToken {
+            kind,
+            arity: 0,
+            shape_tag: exact_tag,
+            exact_tag,
+            literal: None,
+            line: 1,
+        }
+    }
+
+    fn int_lit(exact_tag: u64, line: u32) -> WitnessToken {
+        WitnessToken {
+            kind: NodeKind::Lit,
+            arity: 0,
+            shape_tag: 100,
+            exact_tag,
+            literal: Some(LiteralClass::Int),
+            line,
+        }
+    }
+
+    #[test]
+    fn family_witness_rejects_mixed_hole_positions() {
+        let base = [node(NodeKind::Return, 1), int_lit(10, 2), int_lit(20, 3)];
+        let first_literal_changed = [node(NodeKind::Return, 1), int_lit(11, 2), int_lit(20, 3)];
+        let second_literal_changed = [node(NodeKind::Return, 1), int_lit(10, 2), int_lit(21, 3)];
+        let units = [
+            (Lang::Python, UnitKind::Function, base.as_slice()),
+            (
+                Lang::Python,
+                UnitKind::Function,
+                first_literal_changed.as_slice(),
+            ),
+            (
+                Lang::Python,
+                UnitKind::Function,
+                second_literal_changed.as_slice(),
+            ),
+        ];
+
+        assert!(
+            family_witness(&units).is_none(),
+            "one weak witness must not cover more than one template hole"
+        );
+    }
+}

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -6,6 +6,7 @@
 //! → scoring/acceptance → union-find clustering. The [`Detector`] trait makes the unit
 //! scorer pluggable so simhash / tf-idf / graph variants can be compared later.
 
+mod abstraction;
 mod align;
 mod cluster;
 mod contiguous;
@@ -559,7 +560,11 @@ pub struct DupPair {
 
 #[derive(Serialize, Clone, PartialEq, Eq, Debug)]
 pub struct AbstractionWitness {
+    pub claim: &'static str,
+    pub basis: &'static str,
+    pub members_checked: u32,
     pub reason_code: &'static str,
+    pub template_format: &'static str,
     pub template: Vec<String>,
     pub holes: Vec<AbstractionHole>,
     pub caveats: Vec<&'static str>,
@@ -568,9 +573,12 @@ pub struct AbstractionWitness {
 #[derive(Serialize, Clone, PartialEq, Eq, Debug)]
 pub struct AbstractionHole {
     pub index: u32,
+    pub template_index: u32,
     pub kind: &'static str,
+    pub role: &'static str,
     pub left: &'static str,
     pub right: &'static str,
+    pub observed: Vec<&'static str>,
     pub left_line: u32,
     pub right_line: u32,
 }
@@ -964,27 +972,6 @@ pub fn detect_from_units(
         e.0 += s;
         e.1 += 1;
     }
-    let mut abstraction_by_root: rustc_hash::FxHashMap<
-        usize,
-        (f64, usize, usize, AbstractionWitness),
-    > = rustc_hash::FxHashMap::default();
-    if opts.abstraction_witnesses {
-        for &(i, j, s) in &accepted {
-            if let Some(witness) = units::abstraction_witness(&units[i], &units[j]) {
-                let root = uf.find(i);
-                let replace =
-                    abstraction_by_root
-                        .get(&root)
-                        .is_none_or(|(best_score, best_i, best_j, _)| {
-                            s.total_cmp(best_score).is_gt()
-                                || (s == *best_score && (i, j) < (*best_i, *best_j))
-                        });
-                if replace {
-                    abstraction_by_root.insert(root, (s, i, j, witness));
-                }
-            }
-        }
-    }
     let groups: Vec<Group> = raw_groups
         .iter()
         .map(|members| {
@@ -1010,9 +997,11 @@ pub fn detect_from_units(
             Group {
                 score: round3(score),
                 members: locs,
-                abstraction_witness: abstraction_by_root
-                    .get(&root)
-                    .map(|(_, _, _, witness)| witness.clone()),
+                abstraction_witness: if opts.abstraction_witnesses {
+                    units::abstraction_family_witness(members.iter().map(|&m| &units[m]))
+                } else {
+                    None
+                },
             }
         })
         .collect();

--- a/crates/nose-detect/src/report.rs
+++ b/crates/nose-detect/src/report.rs
@@ -62,8 +62,8 @@ pub struct RefactorFamily {
     /// `extractability` so the default ranking honors it too.
     pub discount: f64,
     /// Experimental weak-claim witness for `abstraction` mode. This records a typed
-    /// template and caveats for near candidates that share structure but differ by one
-    /// supported literal leaf. It is not a semantic-equivalence proof.
+    /// template and caveats for near families that share structure but differ by one
+    /// supported literal leaf position. It is not a semantic-equivalence proof.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub abstraction_witness: Option<AbstractionWitness>,
 }

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -6,8 +6,8 @@
 use crate::abstraction;
 use crate::fragment::{FragmentKind, ProofFacts};
 use nose_il::{
-    stable_symbol_hash, Builtin, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op,
-    Payload, Symbol, UnitKind,
+    Builtin, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload, Symbol,
+    UnitKind,
 };
 use nose_normalize::{
     module_facts::{collect_module_mutations, mutating_method_name},
@@ -19,24 +19,22 @@ use nose_semantics::{
     exact_non_overloadable_index_assignment, exact_non_overloadable_index_assignment_parts,
     exact_self_field_write_assignment, exact_static_membership_predicate_operator,
     go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
-    go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract, imported_binding_symbol,
-    imported_literal_snapshot_evidence_at_span, imported_member_symbol,
-    library_api_contract_evidence_for_call, library_api_free_name_shadow_safe,
-    library_free_name_collection_factory_contract, library_free_name_map_factory_contract,
-    library_imported_collection_factory_contracts, library_iterator_identity_adapter_contract,
-    library_java_collection_factory_contract, library_java_map_entry_contract,
-    library_java_map_factory_contract, library_js_array_is_array_contract,
-    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
-    library_map_get_contract, library_map_key_view_contract, library_map_key_view_wrapper_contract,
+    go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract,
+    library_api_contract_evidence_for_call, library_free_name_collection_factory_contract,
+    library_free_name_map_factory_contract, library_imported_collection_factory_contracts,
+    library_iterator_identity_adapter_contract, library_java_collection_factory_contract,
+    library_java_map_entry_contract, library_java_map_factory_contract,
+    library_js_array_is_array_contract, library_js_like_map_constructor_contract,
+    library_js_like_set_constructor_contract, library_map_get_contract,
+    library_map_key_view_contract, library_map_key_view_wrapper_contract,
     library_method_call_contract, library_regex_test_contract, library_ruby_set_factory_contract,
     library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
-    nullish_global_contract, own_property_guard_for_node, qualified_global_symbol,
-    record_shape_guard_for_node, semantics, seq_surface_contract_for_node, source_fact_at_node,
-    source_operator_at_node, static_index_membership_contract, typeof_operator_contract,
-    unshadowed_global_symbol, DomainEvidence, IndexMembershipThreshold, JavaMapFactoryKind,
-    LibraryApiCalleeContract, LibraryApiEvidenceStatus, LibraryCollectionFactoryResult,
-    LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract,
-    MethodSemanticContract, StaticIndexMembershipKind,
+    nullish_global_contract, own_property_guard_for_node, record_shape_guard_for_node, semantics,
+    seq_surface_contract_for_node, source_operator_at_node, static_index_membership_contract,
+    typeof_operator_contract, unshadowed_global_symbol, DomainEvidence, IndexMembershipThreshold,
+    JavaMapFactoryKind, LibraryApiCalleeContract, LibraryApiEvidenceStatus,
+    LibraryCollectionFactoryResult, LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs,
+    MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1386,20 +1384,18 @@ fn strict_exact_typeof_operator_safe(
         && strict_exact_call_args_safe(il, interner, facts, node)
 }
 
-fn library_api_evidence_or_legacy(
+fn library_api_evidence_required(
     il: &Il,
     interner: &Interner,
     node: NodeId,
     id: nose_semantics::LibraryApiContractId,
     callee: LibraryApiCalleeContract,
     arg_count: usize,
-    legacy: impl FnOnce() -> bool,
 ) -> bool {
-    match library_api_contract_evidence_for_call(il, interner, node, id, callee, arg_count) {
-        LibraryApiEvidenceStatus::Admitted => true,
-        LibraryApiEvidenceStatus::Rejected => false,
-        LibraryApiEvidenceStatus::Missing => legacy(),
-    }
+    matches!(
+        library_api_contract_evidence_for_call(il, interner, node, id, callee, arg_count),
+        LibraryApiEvidenceStatus::Admitted
+    )
 }
 
 fn strict_exact_regex_test_safe(
@@ -1407,7 +1403,7 @@ fn strict_exact_regex_test_safe(
     interner: &Interner,
     facts: &StrictFacts,
     node: NodeId,
-    callee: NodeId,
+    _callee: NodeId,
     method: &str,
 ) -> Option<bool> {
     let contract = library_regex_test_contract(
@@ -1415,17 +1411,13 @@ fn strict_exact_regex_test_safe(
         method,
         il.children(node).len().saturating_sub(1),
     )?;
-    let Some(&receiver) = il.children(callee).first() else {
-        return Some(false);
-    };
-    if !library_api_evidence_or_legacy(
+    if !library_api_evidence_required(
         il,
         interner,
         node,
         contract.id,
         contract.callee,
         il.children(node).len().saturating_sub(1),
-        || source_fact_at_node(il, receiver, contract.result.required_receiver_fact),
     ) {
         return Some(false);
     }
@@ -1457,20 +1449,7 @@ fn strict_exact_js_array_is_array_safe(
     ) else {
         return false;
     };
-    if !library_api_evidence_or_legacy(
-        il,
-        interner,
-        node,
-        contract.id,
-        contract.callee,
-        arg_count,
-        || {
-            let result = contract.result;
-            (!result.requires_unshadowed_receiver
-                || unshadowed_global_symbol(il, interner, receiver, result.receiver))
-                && qualified_global_symbol(il, callee, result.qualified_path)
-        },
-    ) {
+    if !library_api_evidence_required(il, interner, node, contract.id, contract.callee, arg_count) {
         return false;
     }
     strict_exact_call_args_safe(il, interner, facts, node)
@@ -1872,21 +1851,8 @@ fn strict_exact_map_key_view_collection_safe(
     else {
         return false;
     };
-    match library_api_contract_evidence_for_call(
-        il,
-        interner,
-        node,
-        contract.id,
-        contract.callee,
-        1,
-    ) {
-        LibraryApiEvidenceStatus::Admitted => {}
-        LibraryApiEvidenceStatus::Rejected => return false,
-        LibraryApiEvidenceStatus::Missing => {
-            if !qualified_global_symbol(il, kids[0], contract.result.qualified_path) {
-                return false;
-            }
-        }
+    if !library_api_evidence_required(il, interner, node, contract.id, contract.callee, 1) {
+        return false;
     }
     strict_exact_map_key_view_safe_matching(il, interner, facts, kids[1], |kind| {
         kind == MapKeyViewKind::Iterator
@@ -1960,7 +1926,7 @@ fn strict_exact_set_constructor_collection_safe(
     if !construct_syntax_proof(il, node) {
         return false;
     };
-    let Some((callee, name, collection)) = strict_exact_two_arg_var_call(il, node) else {
+    let Some((_callee, name, collection)) = strict_exact_two_arg_var_call(il, node) else {
         return false;
     };
     let Some(contract) =
@@ -1968,30 +1934,11 @@ fn strict_exact_set_constructor_collection_safe(
     else {
         return false;
     };
-    let LibraryApiCalleeContract::JsGlobalConstructor {
-        receiver,
-        requires_unshadowed_global,
-    } = contract.callee
-    else {
+    let LibraryApiCalleeContract::JsGlobalConstructor { receiver, .. } = contract.callee else {
         return false;
     };
-    match library_api_contract_evidence_for_call(
-        il,
-        interner,
-        node,
-        contract.id,
-        contract.callee,
-        1,
-    ) {
-        LibraryApiEvidenceStatus::Admitted => {}
-        LibraryApiEvidenceStatus::Rejected => return false,
-        LibraryApiEvidenceStatus::Missing => {
-            if requires_unshadowed_global
-                && !unshadowed_global_symbol(il, interner, callee, receiver)
-            {
-                return false;
-            }
-        }
+    if !library_api_evidence_required(il, interner, node, contract.id, contract.callee, 1) {
+        return false;
     }
     receiver == "Set" && strict_exact_static_non_float_collection(il, interner, collection)
 }
@@ -2019,20 +1966,14 @@ fn strict_exact_python_collection_factory_safe(
                 let name = interner.resolve(name);
                 library_free_name_collection_factory_contract(il.meta.lang, name).is_some_and(
                     |contract| {
-                        let LibraryApiCalleeContract::FreeName {
-                            name: expected_name,
-                            shadow,
-                        } = contract.callee
-                        else {
-                            return false;
-                        };
-                        expected_name == name
-                            && library_api_free_name_shadow_safe(
-                                il.meta.lang,
-                                name,
-                                shadow,
-                                |candidate| file_defines_name(il, interner, candidate),
-                            )
+                        library_api_evidence_required(
+                            il,
+                            interner,
+                            node,
+                            contract.id,
+                            contract.callee,
+                            1,
+                        )
                     },
                 )
             }
@@ -2043,36 +1984,13 @@ fn strict_exact_python_collection_factory_safe(
     };
     let imported_stdlib_factory =
         library_imported_collection_factory_contracts(il.meta.lang).any(|contract| {
-            let LibraryApiCalleeContract::ImportedBinding { module, exported } = contract.callee
-            else {
+            let LibraryApiCalleeContract::ImportedBinding { .. } = contract.callee else {
                 return false;
             };
-            library_api_evidence_or_legacy(
-                il,
-                interner,
-                node,
-                contract.id,
-                contract.callee,
-                1,
-                || {
-                    strict_exact_python_imported_factory_name(
-                        il, interner, kids[0], module, exported,
-                    )
-                },
-            )
+            library_api_evidence_required(il, interner, node, contract.id, contract.callee, 1)
         });
     (builtin || imported_stdlib_factory)
         && strict_exact_membership_collection_safe(il, interner, facts, kids[1])
-}
-
-fn strict_exact_python_imported_factory_name(
-    il: &Il,
-    interner: &Interner,
-    callee: NodeId,
-    module: &str,
-    exported: &str,
-) -> bool {
-    imported_member_symbol(il, interner, callee, module, exported)
 }
 
 fn strict_exact_ruby_set_factory_safe(
@@ -2106,50 +2024,13 @@ fn strict_exact_ruby_set_factory_safe(
     else {
         return false;
     };
-    let LibraryApiCalleeContract::RubyRequireStaticMember {
-        receiver: expected_receiver,
-        required_module,
-        shadow_root,
-        ..
-    } = contract.callee
-    else {
+    let LibraryApiCalleeContract::RubyRequireStaticMember { .. } = contract.callee else {
         return false;
     };
-    ruby_file_requires_module(il, interner, required_module)
-        && !file_defines_name(il, interner, shadow_root)
-        && strict_exact_callee_name(il, interner, receiver, expected_receiver)
-        && strict_exact_membership_collection_safe(il, interner, facts, kids[1])
-}
-
-fn ruby_file_requires_module(il: &Il, interner: &Interner, module: &str) -> bool {
-    if !semantics(il.meta.lang).stdlib().ruby_set_factory() {
+    if !library_api_evidence_required(il, interner, node, contract.id, contract.callee, 1) {
         return false;
     }
-    let expected = stable_symbol_hash(module);
-    top_level_statements(il).iter().any(|&stmt| {
-        let expr = if il.kind(stmt) == NodeKind::ExprStmt {
-            il.children(stmt).first().copied()
-        } else {
-            Some(stmt)
-        };
-        let Some(call) = expr else {
-            return false;
-        };
-        if il.kind(call) != NodeKind::Call {
-            return false;
-        }
-        let kids = il.children(call);
-        if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Var {
-            return false;
-        }
-        let Payload::Name(callee) = il.node(kids[0]).payload else {
-            return false;
-        };
-        if interner.resolve(callee) != "require" {
-            return false;
-        }
-        matches!(il.node(kids[1]).payload, Payload::LitStr(hash) if hash == expected)
-    })
+    strict_exact_membership_collection_safe(il, interner, facts, kids[1])
 }
 
 fn strict_exact_rust_vec_macro_collection_safe(
@@ -2163,23 +2044,25 @@ fn strict_exact_rust_vec_macro_collection_safe(
         return false;
     }
     let kids = il.children(node);
-    let Some(&callee) = kids.first() else {
+    if kids.is_empty() {
         return false;
-    };
+    }
     let Some(contract) = library_rust_vec_macro_factory_contract(il.meta.lang, "vec") else {
         return false;
     };
-    let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+    if !library_api_evidence_required(
+        il,
+        interner,
+        node,
+        contract.id,
+        contract.callee,
+        kids.len().saturating_sub(1),
+    ) {
         return false;
-    };
-    strict_exact_callee_name(il, interner, callee, name)
-        && library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
-            file_defines_name(il, interner, candidate)
-        })
-        && kids
-            .iter()
-            .skip(1)
-            .all(|&kid| strict_exact_safe_tree(il, interner, facts, kid))
+    }
+    kids.iter()
+        .skip(1)
+        .all(|&kid| strict_exact_safe_tree(il, interner, facts, kid))
 }
 
 /// `Vec::new()` (no args) is always the empty vector — the value graph already models it as
@@ -2198,19 +2081,11 @@ fn strict_exact_rust_vec_new_safe(il: &Il, interner: &Interner, node: NodeId) ->
     let Payload::Name(name) = il.node(kids[0]).payload else {
         return false;
     };
-    strict_exact_rust_vec_new_name(il, interner, interner.resolve(name))
-}
-
-fn strict_exact_rust_vec_new_name(il: &Il, interner: &Interner, text: &str) -> bool {
-    library_rust_vec_new_factory_contract(il.meta.lang, text).is_some_and(|contract| {
-        let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
-            return false;
-        };
-        name == text
-            && library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
-                file_defines_name(il, interner, candidate)
-            })
-    })
+    library_rust_vec_new_factory_contract(il.meta.lang, interner.resolve(name)).is_some_and(
+        |contract| {
+            library_api_evidence_required(il, interner, node, contract.id, contract.callee, 0)
+        },
+    )
 }
 
 fn strict_exact_rust_std_collection_factory_safe(
@@ -2232,18 +2107,10 @@ fn strict_exact_rust_std_collection_factory_safe(
     let Some(contract) = library_free_name_collection_factory_contract(il.meta.lang, name) else {
         return false;
     };
-    let LibraryApiCalleeContract::FreeName {
-        name: expected_name,
-        shadow,
-    } = contract.callee
-    else {
+    let LibraryApiCalleeContract::FreeName { .. } = contract.callee else {
         return false;
     };
-    if expected_name != name
-        || !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
-            file_defines_name(il, interner, candidate)
-        })
-    {
+    if !library_api_evidence_required(il, interner, node, contract.id, contract.callee, 1) {
         return false;
     }
     strict_exact_membership_collection_safe(il, interner, facts, collection)
@@ -2267,7 +2134,7 @@ fn strict_exact_java_collection_factory_safe(
     let Payload::Name(method) = il.node(kids[0]).payload else {
         return false;
     };
-    let Some(&receiver) = il.children(kids[0]).first() else {
+    let Some(&_receiver) = il.children(kids[0]).first() else {
         return false;
     };
     let method = interner.resolve(method);
@@ -2276,21 +2143,16 @@ fn strict_exact_java_collection_factory_safe(
         .find_map(|receiver_name| {
             let contract =
                 library_java_collection_factory_contract(il.meta.lang, receiver_name, method)?;
-            let LibraryApiCalleeContract::JavaUtilStaticMember {
-                receiver: expected_receiver,
-                ..
-            } = contract.callee
-            else {
+            let LibraryApiCalleeContract::JavaUtilStaticMember { .. } = contract.callee else {
                 return None;
             };
-            library_api_evidence_or_legacy(
+            library_api_evidence_required(
                 il,
                 interner,
                 node,
                 contract.id,
                 contract.callee,
                 kids.len().saturating_sub(1),
-                || strict_exact_java_std_var_name(il, interner, receiver, expected_receiver),
             )
             .then_some(contract)
         })
@@ -2306,48 +2168,6 @@ fn strict_exact_java_collection_factory_safe(
     kids.iter()
         .skip(1)
         .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
-}
-
-fn java_file_defines_type_name(il: &Il, interner: &Interner, name: &str) -> bool {
-    if !semantics(il.meta.lang)
-        .modules()
-        .java_type_declarations_shadow_stdlib()
-    {
-        return false;
-    }
-    il.units.iter().any(|unit| {
-        unit.kind == UnitKind::Class
-            && unit
-                .name
-                .is_some_and(|symbol| interner.resolve(symbol) == name)
-    })
-}
-
-fn file_defines_name(il: &Il, interner: &Interner, name: &str) -> bool {
-    top_level_statements(il).iter().any(|&stmt| {
-        assignment_name(il, stmt).is_some_and(|symbol| interner.resolve(symbol) == name)
-    }) || il.units.iter().any(|unit| {
-        unit.name
-            .is_some_and(|symbol| interner.resolve(symbol) == name)
-    }) || il.nodes.iter().any(|node| {
-        matches!(node.kind, NodeKind::Module | NodeKind::Block)
-            && matches!(node.payload, Payload::Name(symbol) if interner.resolve(symbol) == name)
-    })
-}
-
-fn strict_exact_java_std_var_name(
-    il: &Il,
-    interner: &Interner,
-    node: NodeId,
-    expected: &str,
-) -> bool {
-    if il.kind(node) != NodeKind::Var {
-        return false;
-    }
-    if java_file_defines_type_name(il, interner, expected) {
-        return false;
-    }
-    imported_binding_symbol(il, interner, node, "java.util", expected)
 }
 
 fn java_util_static_member_call<'a>(
@@ -2370,26 +2190,15 @@ fn java_util_static_member_call<'a>(
     Some((interner.resolve(method), receiver, args))
 }
 
-fn java_util_static_member_evidence_or_legacy(
+fn java_util_static_member_evidence_required(
     il: &Il,
     interner: &Interner,
     node: NodeId,
     contract_id: nose_semantics::LibraryApiContractId,
     callee: LibraryApiCalleeContract,
-    receiver: NodeId,
-    legacy: impl FnOnce() -> bool,
 ) -> bool {
-    let LibraryApiCalleeContract::JavaUtilStaticMember {
-        receiver: expected_receiver,
-        ..
-    } = callee
-    else {
-        return false;
-    };
     let arg_count = il.children(node).len().saturating_sub(1);
-    library_api_evidence_or_legacy(il, interner, node, contract_id, callee, arg_count, || {
-        legacy() || strict_exact_java_std_var_name(il, interner, receiver, expected_receiver)
-    })
+    library_api_evidence_required(il, interner, node, contract_id, callee, arg_count)
 }
 
 fn strict_exact_java_map_factory_safe(
@@ -2401,23 +2210,14 @@ fn strict_exact_java_map_factory_safe(
     if !semantics(il.meta.lang).stdlib().java_map_factories() {
         return false;
     }
-    let Some((method, receiver, args)) = java_util_static_member_call(il, interner, node) else {
+    let Some((method, _receiver, args)) = java_util_static_member_call(il, interner, node) else {
         return false;
     };
     let Some(contract) = library_java_map_factory_contract(il.meta.lang, "Map", method) else {
         return false;
     };
-    let snapshot_proven =
-        imported_literal_snapshot_evidence_at_span(il, il.node(node).span, NodeKind::Call);
-    if !java_util_static_member_evidence_or_legacy(
-        il,
-        interner,
-        node,
-        contract.id,
-        contract.callee,
-        receiver,
-        || snapshot_proven,
-    ) {
+    if !java_util_static_member_evidence_required(il, interner, node, contract.id, contract.callee)
+    {
         return false;
     }
     let LibraryMapFactoryResult::JavaFactory { kind } = contract.result else {
@@ -2430,9 +2230,9 @@ fn strict_exact_java_map_factory_safe(
                     .iter()
                     .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
         }
-        JavaMapFactoryKind::OfEntries => args.iter().all(|&entry| {
-            strict_exact_java_map_entry_safe(il, interner, facts, entry, snapshot_proven)
-        }),
+        JavaMapFactoryKind::OfEntries => args
+            .iter()
+            .all(|&entry| strict_exact_java_map_entry_safe(il, interner, facts, entry)),
     }
 }
 
@@ -2441,9 +2241,8 @@ fn strict_exact_java_map_entry_safe(
     interner: &Interner,
     facts: &StrictFacts,
     node: NodeId,
-    snapshot_proven: bool,
 ) -> bool {
-    let Some((method, receiver, args)) = java_util_static_member_call(il, interner, node) else {
+    let Some((method, _receiver, args)) = java_util_static_member_call(il, interner, node) else {
         return false;
     };
     if args.len() != 2 {
@@ -2452,15 +2251,8 @@ fn strict_exact_java_map_entry_safe(
     let Some(contract) = library_java_map_entry_contract(il.meta.lang, "Map", method) else {
         return false;
     };
-    if !java_util_static_member_evidence_or_legacy(
-        il,
-        interner,
-        node,
-        contract.id,
-        contract.callee,
-        receiver,
-        || snapshot_proven,
-    ) {
+    if !java_util_static_member_evidence_required(il, interner, node, contract.id, contract.callee)
+    {
         return false;
     }
     args.iter()
@@ -2476,7 +2268,7 @@ fn strict_exact_map_constructor_entries_safe(
     if !construct_syntax_proof(il, node) {
         return false;
     }
-    let Some((callee, name, entries)) = strict_exact_two_arg_var_call(il, node) else {
+    let Some((_callee, name, entries)) = strict_exact_two_arg_var_call(il, node) else {
         return false;
     };
     let Some(contract) =
@@ -2484,30 +2276,11 @@ fn strict_exact_map_constructor_entries_safe(
     else {
         return false;
     };
-    let LibraryApiCalleeContract::JsGlobalConstructor {
-        receiver,
-        requires_unshadowed_global,
-    } = contract.callee
-    else {
+    let LibraryApiCalleeContract::JsGlobalConstructor { receiver, .. } = contract.callee else {
         return false;
     };
-    match library_api_contract_evidence_for_call(
-        il,
-        interner,
-        node,
-        contract.id,
-        contract.callee,
-        1,
-    ) {
-        LibraryApiEvidenceStatus::Admitted => {}
-        LibraryApiEvidenceStatus::Rejected => return false,
-        LibraryApiEvidenceStatus::Missing => {
-            if requires_unshadowed_global
-                && !unshadowed_global_symbol(il, interner, callee, receiver)
-            {
-                return false;
-            }
-        }
+    if !library_api_evidence_required(il, interner, node, contract.id, contract.callee, 1) {
+        return false;
     }
     receiver == "Map"
         && matches!(
@@ -2533,22 +2306,16 @@ fn strict_exact_rust_std_map_factory_safe(
     let Some(contract) = library_free_name_map_factory_contract(il.meta.lang, name) else {
         return false;
     };
-    let LibraryApiCalleeContract::FreeName {
-        name: expected_name,
-        shadow,
-    } = contract.callee
-    else {
+    let LibraryApiCalleeContract::FreeName { .. } = contract.callee else {
         return false;
     };
-    if expected_name != name
-        || !matches!(
-            contract.result,
-            LibraryMapFactoryResult::EntrySequence { .. }
-        )
-        || !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
-            file_defines_name(il, interner, candidate)
-        })
-    {
+    if !matches!(
+        contract.result,
+        LibraryMapFactoryResult::EntrySequence { .. }
+    ) {
+        return false;
+    }
+    if !library_api_evidence_required(il, interner, node, contract.id, contract.callee, 1) {
         return false;
     }
     strict_exact_map_entries_safe(il, interner, facts, entries)
@@ -2637,16 +2404,6 @@ fn strict_exact_call_args_safe(
         .iter()
         .skip(1)
         .all(|&arg| strict_exact_safe_tree(il, interner, facts, arg))
-}
-
-fn strict_exact_callee_name(il: &Il, interner: &Interner, callee: NodeId, expected: &str) -> bool {
-    if il.kind(callee) != NodeKind::Var {
-        return false;
-    }
-    let Payload::Name(name) = il.node(callee).payload else {
-        return false;
-    };
-    interner.resolve(name) == expected
 }
 
 fn strict_exact_callee_identity(il: &Il, facts: &StrictFacts, callee: NodeId) -> bool {
@@ -4203,10 +3960,10 @@ fn collect_pre(il: &Il, root: NodeId, out: &mut Vec<NodeId>) {
 mod tests {
     use super::*;
     use nose_il::{
-        EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
-        EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, ImportEvidenceKind,
-        LibraryApiEvidenceKind, SequenceSurfaceKind, SourceCallKind, SourceFactKind, Span,
-        SymbolEvidenceKind, UnitKind,
+        stable_symbol_hash, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
+        EvidenceProvenance, EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder,
+        ImportEvidenceKind, LibraryApiEvidenceKind, SequenceSurfaceKind, SourceCallKind,
+        SourceFactKind, Span, SymbolEvidenceKind, UnitKind,
     };
     use nose_semantics::{
         library_api_callee_contract_hash, library_api_contract_id_hash,
@@ -4308,11 +4065,11 @@ mod tests {
     }
 
     #[test]
-    fn strict_exact_js_constructor_closes_on_conflicting_api_evidence() {
+    fn strict_exact_js_constructor_requires_library_api_evidence() {
         let interner = Interner::new();
         let (mut il, call) = js_new_set_il(&interner);
         let facts = StrictFacts::collect(&il, &interner);
-        assert!(strict_exact_set_constructor_collection_safe(
+        assert!(!strict_exact_set_constructor_collection_safe(
             &il, &interner, &facts, call
         ));
 
@@ -4342,6 +4099,68 @@ mod tests {
         ));
         let facts = StrictFacts::collect(&il, &interner);
         assert!(strict_exact_set_constructor_collection_safe(
+            &il, &interner, &facts, call
+        ));
+    }
+
+    #[test]
+    fn strict_exact_python_builtin_factory_requires_library_api_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let callee = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("list")),
+            sp(40),
+            &[],
+        );
+        let item = b.add(NodeKind::Lit, Payload::LitInt(1), sp(41), &[]);
+        let seq = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(42),
+            &[item],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(43), &[callee, seq]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(39), &[call]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.py".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(42)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+            Vec::new(),
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(!strict_exact_python_collection_factory_safe(
+            &il, &interner, &facts, call
+        ));
+
+        let contract = library_free_name_collection_factory_contract(Lang::Python, "list").unwrap();
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(sp(40), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("list"),
+            }),
+            Vec::new(),
+        ));
+        il.evidence.push(library_api_contract_evidence(
+            2,
+            sp(43),
+            contract.id,
+            contract.callee,
+            1,
+            vec![EvidenceId(1)],
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(strict_exact_python_collection_factory_safe(
             &il, &interner, &facts, call
         ));
     }
@@ -4420,6 +4239,12 @@ mod tests {
             binding_symbol,
             vec![EvidenceId(0)],
         ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(!strict_exact_java_collection_factory_safe(
+            &il, &interner, &facts, factory
+        ));
+        assert!(!strict_exact_safe_tree(&il, &interner, &facts, contains));
+
         il.evidence.push(library_api_contract_evidence(
             2,
             sp(25),

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -3,6 +3,7 @@
 //! tag combined with its children's tags), a pre-order **linearization** of node
 //! tags for alignment, and a **MinHash** signature for candidate generation.
 
+use crate::abstraction;
 use crate::fragment::{FragmentKind, ProofFacts};
 use nose_il::{
     stable_symbol_hash, Builtin, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op,
@@ -10,7 +11,7 @@ use nose_il::{
 };
 use nose_normalize::{
     module_facts::{collect_module_mutations, mutating_method_name},
-    node_tag, node_tag_valued,
+    node_tag,
 };
 use nose_semantics::{
     builder_append_call_args, construct_syntax_proof,
@@ -72,7 +73,7 @@ pub struct UnitFeat {
     /// only by `0` vs `1` can be explained as one literal hole without weakening the
     /// exact semantic fingerprint.
     #[serde(default)]
-    pub(crate) abstraction_tokens: Vec<AbstractionToken>,
+    pub(crate) abstraction_tokens: Vec<abstraction::WitnessToken>,
     /// Sorted multiset of literal (`Const`) value hashes. A high `lits/value`
     /// ratio marks a "data-table" unit (constant-dominated, e.g. a locale map),
     /// where the constants must match for a clone.
@@ -109,187 +110,14 @@ pub struct UnitFeat {
     pub proof_facts: Option<ProofFacts>,
 }
 
-#[derive(Clone, Copy, serde::Serialize, serde::Deserialize)]
-pub(crate) struct AbstractionToken {
-    kind: NodeKind,
-    arity: u16,
-    shape_tag: u64,
-    exact_tag: u64,
-    literal: Option<AbstractionLiteral>,
-    line: u32,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-enum AbstractionLiteral {
-    Int,
-    Float,
-    Str,
-}
-
-impl AbstractionLiteral {
-    fn label(self) -> &'static str {
-        match self {
-            AbstractionLiteral::Int => "int-literal",
-            AbstractionLiteral::Float => "float-literal",
-            AbstractionLiteral::Str => "string-literal",
-        }
-    }
-}
-
-fn abstraction_literal(payload: Payload) -> Option<AbstractionLiteral> {
-    match payload {
-        Payload::LitInt(_) | Payload::Lit(LitClass::Int) => Some(AbstractionLiteral::Int),
-        Payload::LitFloat(_) | Payload::Lit(LitClass::Float) => Some(AbstractionLiteral::Float),
-        Payload::LitStr(_) | Payload::Lit(LitClass::Str) => Some(AbstractionLiteral::Str),
-        _ => None,
-    }
-}
-
-fn abstraction_token(
-    il: &Il,
-    interner: &Interner,
-    nid: NodeId,
-    shape_tag: u64,
-) -> AbstractionToken {
-    let n = il.node(nid);
-    AbstractionToken {
-        kind: n.kind,
-        arity: il.children(nid).len().min(u16::MAX as usize) as u16,
-        shape_tag,
-        exact_tag: node_tag_valued(n.kind, n.payload, interner),
-        literal: abstraction_literal(n.payload),
-        line: n.span.start_line,
-    }
-}
-
-pub(crate) fn abstraction_witness(a: &UnitFeat, b: &UnitFeat) -> Option<crate::AbstractionWitness> {
-    if a.lang != b.lang || a.kind != b.kind {
-        return None;
-    }
-    if a.abstraction_tokens.len() != b.abstraction_tokens.len() || a.abstraction_tokens.is_empty() {
-        return None;
-    }
-
-    let mut hole_index = None;
-    let mut reason_code = None;
-    let mut caveats: Vec<&'static str> = Vec::new();
-    for (idx, (left, right)) in a
-        .abstraction_tokens
-        .iter()
-        .zip(&b.abstraction_tokens)
-        .enumerate()
-    {
-        if same_abstraction_token(left, right) {
-            continue;
-        }
-        if hole_index.is_some() {
-            return None;
-        }
-        let (reason, hole_caveats) = literal_hole_reason(left, right)?;
-        hole_index = Some(idx);
-        reason_code = Some(reason);
-        caveats = hole_caveats;
-    }
-
-    let hole_index = hole_index?;
-    let left = a.abstraction_tokens[hole_index];
-    let right = b.abstraction_tokens[hole_index];
-    let template = a
-        .abstraction_tokens
-        .iter()
-        .enumerate()
-        .map(|(idx, token)| {
-            if idx == hole_index {
-                "<hole 1: literal>".to_string()
-            } else {
-                abstraction_token_label(token).to_string()
-            }
-        })
-        .collect();
-
-    Some(crate::AbstractionWitness {
-        reason_code: reason_code?,
-        template,
-        holes: vec![crate::AbstractionHole {
-            index: 1,
-            kind: "literal",
-            left: left.literal?.label(),
-            right: right.literal?.label(),
-            left_line: left.line,
-            right_line: right.line,
-        }],
-        caveats,
-    })
-}
-
-fn same_abstraction_token(a: &AbstractionToken, b: &AbstractionToken) -> bool {
-    a.kind == b.kind && a.arity == b.arity && a.exact_tag == b.exact_tag
-}
-
-fn literal_hole_reason(
-    a: &AbstractionToken,
-    b: &AbstractionToken,
-) -> Option<(&'static str, Vec<&'static str>)> {
-    if a.kind != NodeKind::Lit || b.kind != NodeKind::Lit || a.arity != 0 || b.arity != 0 {
-        return None;
-    }
-    let left = a.literal?;
-    let right = b.literal?;
-    let shape_compatible = a.shape_tag == b.shape_tag
-        || matches!(
-            (left, right),
-            (AbstractionLiteral::Int, AbstractionLiteral::Float)
-                | (AbstractionLiteral::Float, AbstractionLiteral::Int)
-        );
-    if !shape_compatible {
-        return None;
-    }
-    match (left, right) {
-        (AbstractionLiteral::Int, AbstractionLiteral::Float)
-        | (AbstractionLiteral::Float, AbstractionLiteral::Int) => {
-            Some(("type-parametric", vec!["numeric-domain-sensitive"]))
-        }
-        (AbstractionLiteral::Int, AbstractionLiteral::Int)
-        | (AbstractionLiteral::Float, AbstractionLiteral::Float)
-        | (AbstractionLiteral::Str, AbstractionLiteral::Str) => {
-            Some(("literal-abstracted", Vec::new()))
-        }
-        _ => None,
-    }
-}
-
-fn abstraction_token_label(token: &AbstractionToken) -> &'static str {
-    match token.literal {
-        Some(AbstractionLiteral::Int) => "Lit<Int>",
-        Some(AbstractionLiteral::Float) => "Lit<Float>",
-        Some(AbstractionLiteral::Str) => "Lit<String>",
-        None => match token.kind {
-            NodeKind::Module => "Module",
-            NodeKind::Func => "Func",
-            NodeKind::Param => "Param",
-            NodeKind::Block => "Block",
-            NodeKind::Assign => "Assign",
-            NodeKind::ExprStmt => "ExprStmt",
-            NodeKind::Return => "Return",
-            NodeKind::If => "If",
-            NodeKind::Loop => "Loop",
-            NodeKind::Break => "Break",
-            NodeKind::Continue => "Continue",
-            NodeKind::Throw => "Throw",
-            NodeKind::Try => "Try",
-            NodeKind::Var => "Var",
-            NodeKind::Lit => "Lit",
-            NodeKind::Call => "Call",
-            NodeKind::BinOp => "BinOp",
-            NodeKind::UnOp => "UnOp",
-            NodeKind::Index => "Index",
-            NodeKind::Field => "Field",
-            NodeKind::Lambda => "Lambda",
-            NodeKind::Seq => "Seq",
-            NodeKind::HoF => "HoF",
-            NodeKind::Raw => "Raw",
-        },
-    }
+pub(crate) fn abstraction_family_witness<'a>(
+    members: impl IntoIterator<Item = &'a UnitFeat>,
+) -> Option<crate::AbstractionWitness> {
+    let units = members
+        .into_iter()
+        .map(|unit| (unit.lang, unit.kind, unit.abstraction_tokens.as_slice()))
+        .collect::<Vec<_>>();
+    abstraction::family_witness(&units)
 }
 
 const SEED: u64 = 0x9E37_79B9_7F4A_7C15;
@@ -733,7 +561,7 @@ pub(crate) fn extract(
                 let tag = node_tag(n.kind, n.payload, interner);
                 linear.push(tag);
                 if features.abstraction_witnesses {
-                    abstraction_tokens.push(abstraction_token(il, interner, nid, tag));
+                    abstraction_tokens.push(abstraction::token_for(il, interner, nid, tag));
                 }
                 let mut shape = tag;
                 for &c in il.children(nid) {
@@ -757,7 +585,7 @@ pub(crate) fn extract(
                 .map(|&nid| {
                     let n = il.node(nid);
                     let tag = node_tag(n.kind, n.payload, interner);
-                    abstraction_token(il, interner, nid, tag)
+                    abstraction::token_for(il, interner, nid, tag)
                 })
                 .collect();
             (Vec::new(), Vec::new(), Vec::new(), abstraction_tokens)
@@ -4746,11 +4574,48 @@ mod tests {
             !left.abstraction_tokens.is_empty() && !right.abstraction_tokens.is_empty(),
             "abstraction witnesses need their own tokens even when shape features are off"
         );
-        let witness = abstraction_witness(&left, &right)
+        let witness = abstraction_family_witness([&left, &right])
             .expect("one changed integer literal should produce an abstraction witness");
+        assert_eq!(witness.basis, "family");
+        assert_eq!(witness.members_checked, 2);
         assert_eq!(witness.reason_code, "literal-abstracted");
         assert_eq!(witness.holes[0].left, "int-literal");
         assert_eq!(witness.holes[0].right, "int-literal");
+    }
+
+    #[test]
+    fn abstraction_family_witness_requires_one_shared_hole_position() {
+        let interner = Interner::new();
+        let base = lowered_java_unit_with_features(
+            "class Base { static int f(int x) { int a = 1; int b = 2; return x + a + b; } }\n",
+            &interner,
+            UnitKind::Method,
+            "f",
+            false,
+            true,
+        );
+        let same_hole = lowered_java_unit_with_features(
+            "class SameHole { static int f(int x) { int a = 3; int b = 2; return x + a + b; } }\n",
+            &interner,
+            UnitKind::Method,
+            "f",
+            false,
+            true,
+        );
+        let also_same_hole = lowered_java_unit_with_features(
+            "class AlsoSameHole { static int f(int x) { int a = 4; int b = 2; return x + a + b; } }\n",
+            &interner,
+            UnitKind::Method,
+            "f",
+            false,
+            true,
+        );
+        let witness = abstraction_family_witness([&base, &same_hole, &also_same_hole])
+            .expect("same literal position across the family should produce a witness");
+        assert_eq!(witness.basis, "family");
+        assert_eq!(witness.members_checked, 3);
+        assert_eq!(witness.reason_code, "literal-abstracted");
+        assert_eq!(witness.holes[0].observed, vec!["int-literal"]);
     }
 
     #[test]

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -11,12 +11,15 @@ use nose_il::{
 };
 use nose_semantics::{
     library_api_callee_contract_hash, library_api_contract_id_hash,
-    library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
-    library_java_collection_factory_contract, library_java_map_entry_contract,
-    library_java_map_factory_contract, library_js_array_is_array_contract,
-    library_js_boolean_coercion_contract, library_js_like_map_constructor_contract,
-    library_js_like_set_constructor_contract, library_map_key_view_wrapper_contract,
-    library_regex_test_contract, library_static_collection_adapter_contract,
+    library_api_free_name_shadow_safe, library_free_name_collection_factory_contract,
+    library_free_name_map_factory_contract, library_imported_collection_factory_contracts,
+    library_imported_namespace_function_contract, library_java_collection_factory_contract,
+    library_java_map_entry_contract, library_java_map_factory_contract,
+    library_js_array_is_array_contract, library_js_boolean_coercion_contract,
+    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
+    library_map_key_view_wrapper_contract, library_regex_test_contract,
+    library_ruby_set_factory_contract, library_rust_vec_macro_factory_contract,
+    library_rust_vec_new_factory_contract, library_static_collection_adapter_contract,
     sequence_surface_kind_for_tag, ImportFactKind, LibraryApiCalleeContract, LibraryApiContractId,
 };
 use tree_sitter::Node as TsNode;
@@ -317,10 +320,6 @@ impl<'a> Lowering<'a> {
         }
         match self.b.kind(callee) {
             NodeKind::Var => {
-                let Payload::Name(name) = self.b.payload(callee) else {
-                    return None;
-                };
-                let exported = self.interner.resolve(name);
                 library_imported_collection_factory_contracts(self.lang).find_map(|contract| {
                     let LibraryApiCalleeContract::ImportedBinding {
                         module,
@@ -329,9 +328,6 @@ impl<'a> Lowering<'a> {
                     else {
                         return None;
                     };
-                    if exported != expected {
-                        return None;
-                    }
                     let dependency =
                         self.record_imported_binding_symbol_for_node(callee, module, expected)?;
                     Some((
@@ -1109,8 +1105,423 @@ pub(crate) fn lower_file_with_setup(
     il.param_type_facts = param_type_facts;
     il.evidence = evidence;
     il.source_facts = source_facts;
+    record_post_lower_library_api_evidence(&mut il, interner);
     drop_suppressed_units(&mut il, src);
     Ok(il)
+}
+
+fn record_post_lower_library_api_evidence(il: &mut Il, interner: &Interner) {
+    let calls: Vec<NodeId> = il
+        .nodes
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, node)| {
+            (node.kind == NodeKind::Call && node.payload == Payload::None)
+                .then_some(NodeId(idx as u32))
+        })
+        .collect();
+    for call in calls {
+        if record_post_lower_free_name_library_api(il, interner, call) {
+            continue;
+        }
+        record_post_lower_ruby_static_member_library_api(il, interner, call);
+    }
+}
+
+fn record_post_lower_free_name_library_api(il: &mut Il, interner: &Interner, call: NodeId) -> bool {
+    let kids = il.children(call);
+    let Some((&callee, args)) = kids.split_first() else {
+        return false;
+    };
+    let Some(callee_name) = post_lower_var_name(il, interner, callee) else {
+        return false;
+    };
+    let arg_count = args.len();
+    let contract = (arg_count == 1)
+        .then(|| library_free_name_collection_factory_contract(il.meta.lang, callee_name))
+        .flatten()
+        .map(|contract| {
+            (
+                contract.id,
+                contract.callee,
+                "library_api_free_name_collection_factory",
+            )
+        })
+        .or_else(|| {
+            (arg_count == 1)
+                .then(|| library_free_name_map_factory_contract(il.meta.lang, callee_name))
+                .flatten()
+                .map(|contract| {
+                    (
+                        contract.id,
+                        contract.callee,
+                        "library_api_free_name_map_factory",
+                    )
+                })
+        })
+        .or_else(|| {
+            library_rust_vec_macro_factory_contract(il.meta.lang, callee_name).map(|contract| {
+                (
+                    contract.id,
+                    contract.callee,
+                    "library_api_rust_vec_macro_factory",
+                )
+            })
+        })
+        .or_else(|| {
+            (arg_count == 0)
+                .then(|| library_rust_vec_new_factory_contract(il.meta.lang, callee_name))
+                .flatten()
+                .map(|contract| {
+                    (
+                        contract.id,
+                        contract.callee,
+                        "library_api_rust_vec_new_factory",
+                    )
+                })
+        });
+    let Some((id, callee_contract, rule)) = contract else {
+        return false;
+    };
+    if il.meta.lang == Lang::Python
+        && post_lower_has_raw_marker(il, interner, "python_wildcard_import")
+    {
+        return false;
+    }
+    let mut dependencies = Vec::new();
+    match callee_contract {
+        LibraryApiCalleeContract::FreeName { name, shadow } => {
+            if !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+                post_lower_file_defines_name_visible_at(
+                    il,
+                    interner,
+                    candidate,
+                    il.node(callee).span,
+                )
+            }) {
+                return false;
+            }
+            let Some(dependency) = post_lower_unshadowed_symbol_evidence_id(il, callee, name)
+            else {
+                return false;
+            };
+            dependencies.push(dependency);
+        }
+        LibraryApiCalleeContract::RustMacro { name, shadow } => {
+            if !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+                post_lower_file_defines_name_visible_at(
+                    il,
+                    interner,
+                    candidate,
+                    il.node(callee).span,
+                )
+            }) {
+                return false;
+            }
+            let Some(source_dependency) =
+                post_lower_source_call_evidence_id(il, call, SourceCallKind::MacroInvocation)
+            else {
+                return false;
+            };
+            let Some(symbol_dependency) =
+                post_lower_unshadowed_symbol_evidence_id(il, callee, name)
+            else {
+                return false;
+            };
+            dependencies.push(source_dependency);
+            dependencies.push(symbol_dependency);
+        }
+        _ => return false,
+    }
+    post_lower_library_api_evidence_id(
+        il,
+        call,
+        id,
+        callee_contract,
+        arg_count,
+        rule,
+        dependencies,
+    );
+    true
+}
+
+fn record_post_lower_ruby_static_member_library_api(
+    il: &mut Il,
+    interner: &Interner,
+    call: NodeId,
+) -> bool {
+    let kids = il.children(call);
+    let Some((&callee, args)) = kids.split_first() else {
+        return false;
+    };
+    let arg_count = args.len();
+    if il.kind(callee) != NodeKind::Field {
+        return false;
+    }
+    let Payload::Name(method) = il.node(callee).payload else {
+        return false;
+    };
+    let method = interner.resolve(method);
+    let Some(&receiver) = il.children(callee).first() else {
+        return false;
+    };
+    let Some(receiver_name) = post_lower_var_name(il, interner, receiver) else {
+        return false;
+    };
+    let Some(contract) =
+        library_ruby_set_factory_contract(il.meta.lang, receiver_name, method, arg_count)
+    else {
+        return false;
+    };
+    let LibraryApiCalleeContract::RubyRequireStaticMember {
+        receiver: expected_receiver,
+        required_module,
+        shadow_root,
+        ..
+    } = contract.callee
+    else {
+        return false;
+    };
+    if post_lower_file_defines_name_visible_at(il, interner, shadow_root, il.node(receiver).span) {
+        return false;
+    }
+    let Some(receiver_dependency) =
+        post_lower_unshadowed_symbol_evidence_id(il, receiver, expected_receiver)
+    else {
+        return false;
+    };
+    let Some(require_dependency) =
+        post_lower_required_module_evidence_id(il, interner, required_module, il.node(call).span)
+    else {
+        return false;
+    };
+    post_lower_library_api_evidence_id(
+        il,
+        call,
+        contract.id,
+        contract.callee,
+        arg_count,
+        "library_api_ruby_require_static_member",
+        vec![receiver_dependency, require_dependency],
+    );
+    true
+}
+
+fn post_lower_var_name<'a>(il: &Il, interner: &'a Interner, node: NodeId) -> Option<&'a str> {
+    if il.kind(node) != NodeKind::Var {
+        return None;
+    }
+    match il.node(node).payload {
+        Payload::Name(symbol) => Some(interner.resolve(symbol)),
+        _ => None,
+    }
+}
+
+fn post_lower_unshadowed_symbol_evidence_id(
+    il: &mut Il,
+    node: NodeId,
+    expected: &str,
+) -> Option<EvidenceId> {
+    let span = il.node(node).span;
+    let anchor = EvidenceAnchor::node(span, NodeKind::Var);
+    let kind = EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+        name_hash: stable_symbol_hash(expected),
+    });
+    post_lower_find_or_push_evidence(
+        il,
+        anchor,
+        kind,
+        "symbol_unshadowed_global_post_lower",
+        vec![],
+    )
+}
+
+fn post_lower_required_module_evidence_id(
+    il: &mut Il,
+    interner: &Interner,
+    module: &str,
+    use_span: Span,
+) -> Option<EvidenceId> {
+    if il.meta.lang != Lang::Ruby {
+        return None;
+    }
+    let module_hash = stable_symbol_hash(module);
+    let (require_call, require_callee) =
+        post_lower_top_level_statements(il)
+            .into_iter()
+            .find_map(|stmt| {
+                let expr = if il.kind(stmt) == NodeKind::ExprStmt {
+                    il.children(stmt).first().copied()
+                } else {
+                    Some(stmt)
+                }?;
+                let callee =
+                    post_lower_require_call_callee_if_matches(il, interner, expr, module_hash)?;
+                let require_span = il.node(expr).span;
+                (require_span.file == use_span.file && require_span.end_byte <= use_span.start_byte)
+                    .then_some((expr, callee))
+            })?;
+    if post_lower_file_defines_name_visible_at(
+        il,
+        interner,
+        "require",
+        il.node(require_callee).span,
+    ) {
+        return None;
+    }
+    let require_dependency =
+        post_lower_unshadowed_symbol_evidence_id(il, require_callee, "require")?;
+    post_lower_find_or_push_evidence(
+        il,
+        EvidenceAnchor::source_span(il.node(require_call).span),
+        EvidenceKind::Import(ImportEvidenceKind::Require { module_hash }),
+        "ruby_require_module",
+        vec![require_dependency],
+    )
+}
+
+fn post_lower_require_call_callee_if_matches(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    module_hash: u64,
+) -> Option<NodeId> {
+    if il.kind(call) != NodeKind::Call {
+        return None;
+    }
+    let kids = il.children(call);
+    if kids.len() != 2 {
+        return None;
+    }
+    (matches!(post_lower_var_name(il, interner, kids[0]), Some("require"))
+        && matches!(il.node(kids[1]).payload, Payload::LitStr(hash) if hash == module_hash))
+    .then_some(kids[0])
+}
+
+fn post_lower_library_api_evidence_id(
+    il: &mut Il,
+    call: NodeId,
+    id: LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+    arg_count: usize,
+    rule: &str,
+    dependencies: Vec<EvidenceId>,
+) -> EvidenceId {
+    post_lower_find_or_push_evidence(
+        il,
+        EvidenceAnchor::node(il.node(call).span, NodeKind::Call),
+        EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+            contract_hash: library_api_contract_id_hash(id),
+            callee_hash: library_api_callee_contract_hash(callee),
+            arity: arg_count as u16,
+        }),
+        rule,
+        dependencies,
+    )
+    .expect("post-lower LibraryApi evidence insertion should always produce an id")
+}
+
+fn post_lower_find_or_push_evidence(
+    il: &mut Il,
+    anchor: EvidenceAnchor,
+    kind: EvidenceKind,
+    rule: &str,
+    dependencies: Vec<EvidenceId>,
+) -> Option<EvidenceId> {
+    if let Some(id) = il.evidence.iter().find_map(|record| {
+        (record.anchor == anchor
+            && record.kind == kind
+            && record.status == EvidenceStatus::Asserted
+            && record.dependencies == dependencies)
+            .then_some(record.id)
+    }) {
+        return Some(id);
+    }
+    let id = EvidenceId(il.evidence.len() as u32);
+    il.evidence.push(EvidenceRecord {
+        id,
+        anchor,
+        kind,
+        provenance: EvidenceProvenance {
+            emitter: EvidenceEmitter::FirstParty,
+            pack_hash: Some(stable_symbol_hash(nose_semantics::FIRST_PARTY_PACK_ID)),
+            rule_hash: Some(stable_symbol_hash(rule)),
+        },
+        dependencies,
+        status: EvidenceStatus::Asserted,
+    });
+    Some(id)
+}
+
+fn post_lower_top_level_statements(il: &Il) -> Vec<NodeId> {
+    let Some(root) = il.nodes.get(il.root.0 as usize) else {
+        return Vec::new();
+    };
+    if root.kind != NodeKind::Module {
+        return il.children(il.root).to_vec();
+    }
+    il.children(il.root).to_vec()
+}
+
+fn post_lower_source_call_evidence_id(
+    il: &Il,
+    node: NodeId,
+    call: SourceCallKind,
+) -> Option<EvidenceId> {
+    let anchor = EvidenceAnchor::source_span(il.node(node).span);
+    il.evidence.iter().find_map(|record| {
+        (record.anchor == anchor
+            && record.kind == EvidenceKind::Source(SourceFactKind::Call(call))
+            && record.status == EvidenceStatus::Asserted)
+            .then_some(record.id)
+    })
+}
+
+fn post_lower_has_raw_marker(il: &Il, interner: &Interner, marker: &str) -> bool {
+    il.nodes.iter().any(|node| {
+        node.kind == NodeKind::Raw
+            && matches!(node.payload, Payload::Name(symbol) if interner.resolve(symbol) == marker)
+    })
+}
+
+fn post_lower_file_defines_name_visible_at(
+    il: &Il,
+    interner: &Interner,
+    name: &str,
+    occurrence_span: Span,
+) -> bool {
+    let name_hash = stable_symbol_hash(name);
+    il.units.iter().any(|unit| {
+        il.node(unit.root).span.file == occurrence_span.file
+            && unit
+                .name
+                .is_some_and(|symbol| stable_symbol_hash(interner.resolve(symbol)) == name_hash)
+    }) || il.nodes.iter().enumerate().any(|(idx, node)| {
+        node.span.file == occurrence_span.file
+            && match node.kind {
+                NodeKind::Module | NodeKind::Block | NodeKind::Param => {
+                    post_lower_node_defines_name(il, interner, NodeId(idx as u32), name_hash)
+                }
+                NodeKind::Assign => il
+                    .children(NodeId(idx as u32))
+                    .first()
+                    .copied()
+                    .is_some_and(|lhs| post_lower_node_defines_name(il, interner, lhs, name_hash)),
+                _ => false,
+            }
+    })
+}
+
+fn post_lower_node_defines_name(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    name_hash: u64,
+) -> bool {
+    matches!(
+        il.node(node).payload,
+        Payload::Name(symbol) if stable_symbol_hash(interner.resolve(symbol)) == name_hash
+    )
 }
 
 fn normalize_type_text(text: &str) -> String {
@@ -1709,7 +2120,15 @@ mod tests {
     }
 
     fn library_api_evidence_count(lo: &Lowering, contract_hash: u64, callee_hash: u64) -> usize {
-        lo.evidence
+        library_api_evidence_count_in_records(&lo.evidence, contract_hash, callee_hash)
+    }
+
+    fn library_api_evidence_count_in_records(
+        evidence: &[EvidenceRecord],
+        contract_hash: u64,
+        callee_hash: u64,
+    ) -> usize {
+        evidence
             .iter()
             .filter(|record| {
                 matches!(
@@ -1754,21 +2173,40 @@ mod tests {
         );
 
         let mut lo = Lowering::new(FileId(0), b"", Lang::Python, &interner);
-        import_namespace(&mut lo, sp_at(10), "math", "math");
-        let math = lo.var("math", sp_at(11));
+        import_binding(&mut lo, sp_at(10), "Values", "collections", "deque");
+        let callee = lo.var("Values", sp_at(11));
+        let seq = lo.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp_at(12),
+            &[],
+        );
+        lo.add(NodeKind::Call, Payload::None, sp_at(13), &[callee, seq]);
+        assert_eq!(
+            library_api_evidence_count(
+                &lo,
+                library_api_contract_id_hash(contract.id),
+                library_api_callee_contract_hash(contract.callee),
+            ),
+            1
+        );
+
+        let mut lo = Lowering::new(FileId(0), b"", Lang::Python, &interner);
+        import_namespace(&mut lo, sp_at(20), "math", "math");
+        let math = lo.var("math", sp_at(21));
         let callee = lo.add(
             NodeKind::Field,
             Payload::Name(interner.intern("prod")),
-            sp_at(12),
+            sp_at(22),
             &[math],
         );
         let seq = lo.add(
             NodeKind::Seq,
             Payload::Name(interner.intern("array")),
-            sp_at(13),
+            sp_at(23),
             &[],
         );
-        lo.add(NodeKind::Call, Payload::None, sp_at(14), &[callee, seq]);
+        lo.add(NodeKind::Call, Payload::None, sp_at(24), &[callee, seq]);
         let contract = library_imported_namespace_function_contract(Lang::Python, "prod", 1)
             .expect("math.prod contract");
         assert_eq!(
@@ -1778,6 +2216,233 @@ mod tests {
                 library_api_callee_contract_hash(contract.callee),
             ),
             1
+        );
+    }
+
+    #[test]
+    fn python_lowering_emits_library_api_for_aliased_imported_collection_factory() {
+        let interner = Interner::new();
+        let il = crate::lower_source(
+            FileId(0),
+            "alias.py",
+            b"from collections import deque as Values\n\n\
+def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        let contract = nose_semantics::library_imported_collection_factory_contract(
+            Lang::Python,
+            "collections",
+            "deque",
+        )
+        .expect("deque contract");
+
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &il.evidence,
+                library_api_contract_id_hash(contract.id),
+                library_api_callee_contract_hash(contract.callee),
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn post_lowering_emits_free_name_and_require_library_api_occurrences() {
+        let interner = Interner::new();
+
+        let py = crate::lower_source(
+            FileId(0),
+            "builtin.py",
+            b"def f(values):\n    return list(values)\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        let py_contract =
+            library_free_name_collection_factory_contract(Lang::Python, "list").unwrap();
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &py.evidence,
+                library_api_contract_id_hash(py_contract.id),
+                library_api_callee_contract_hash(py_contract.callee),
+            ),
+            1
+        );
+
+        let shadowed_py = crate::lower_source(
+            FileId(0),
+            "shadowed.py",
+            b"def f(list, values):\n    return list(values)\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &shadowed_py.evidence,
+                library_api_contract_id_hash(py_contract.id),
+                library_api_callee_contract_hash(py_contract.callee),
+            ),
+            0
+        );
+
+        let wildcard_py = crate::lower_source(
+            FileId(0),
+            "wildcard.py",
+            b"from custom import *\n\ndef f(values):\n    return list(values)\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &wildcard_py.evidence,
+                library_api_contract_id_hash(py_contract.id),
+                library_api_callee_contract_hash(py_contract.callee),
+            ),
+            0
+        );
+
+        let rust = crate::lower_source(
+            FileId(0),
+            "vec.rs",
+            b"fn f() { let xs = Vec::new(); }",
+            Lang::Rust,
+            &interner,
+        )
+        .expect("rust lowering should succeed");
+        let rust_contract = library_rust_vec_new_factory_contract(Lang::Rust, "Vec::new").unwrap();
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &rust.evidence,
+                library_api_contract_id_hash(rust_contract.id),
+                library_api_callee_contract_hash(rust_contract.callee),
+            ),
+            1
+        );
+
+        let rust_macro = crate::lower_source(
+            FileId(0),
+            "vec_macro.rs",
+            b"fn f() { let xs = vec![1, 2]; }",
+            Lang::Rust,
+            &interner,
+        )
+        .expect("rust lowering should succeed");
+        let rust_macro_contract =
+            library_rust_vec_macro_factory_contract(Lang::Rust, "vec").unwrap();
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &rust_macro.evidence,
+                library_api_contract_id_hash(rust_macro_contract.id),
+                library_api_callee_contract_hash(rust_macro_contract.callee),
+            ),
+            1
+        );
+
+        let rust_function_call = crate::lower_source(
+            FileId(0),
+            "vec_function.rs",
+            b"fn f(vec: fn(i32) -> Vec<i32>) { let xs = vec(1); }",
+            Lang::Rust,
+            &interner,
+        )
+        .expect("rust lowering should succeed");
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &rust_function_call.evidence,
+                library_api_contract_id_hash(rust_macro_contract.id),
+                library_api_callee_contract_hash(rust_macro_contract.callee),
+            ),
+            0
+        );
+
+        let rust_shadowed_macro = crate::lower_source(
+            FileId(0),
+            "vec_shadowed_macro.rs",
+            b"macro_rules! vec { ($($x:expr),*) => { custom_vec![$($x),*] }; }\nfn f() { let xs = vec![1, 2]; }",
+            Lang::Rust,
+            &interner,
+        )
+        .expect("rust lowering should succeed");
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &rust_shadowed_macro.evidence,
+                library_api_contract_id_hash(rust_macro_contract.id),
+                library_api_callee_contract_hash(rust_macro_contract.callee),
+            ),
+            0
+        );
+
+        let ruby = crate::lower_source(
+            FileId(0),
+            "set.rb",
+            b"require \"set\"\n\ndef f(values)\n  Set.new(values)\nend\n",
+            Lang::Ruby,
+            &interner,
+        )
+        .expect("ruby lowering should succeed");
+        let ruby_contract = library_ruby_set_factory_contract(Lang::Ruby, "Set", "new", 1).unwrap();
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &ruby.evidence,
+                library_api_contract_id_hash(ruby_contract.id),
+                library_api_callee_contract_hash(ruby_contract.callee),
+            ),
+            1
+        );
+
+        let missing_require = crate::lower_source(
+            FileId(0),
+            "set_missing_require.rb",
+            b"def f(values)\n  Set.new(values)\nend\n",
+            Lang::Ruby,
+            &interner,
+        )
+        .expect("ruby lowering should succeed");
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &missing_require.evidence,
+                library_api_contract_id_hash(ruby_contract.id),
+                library_api_callee_contract_hash(ruby_contract.callee),
+            ),
+            0
+        );
+
+        let late_require = crate::lower_source(
+            FileId(0),
+            "set_late_require.rb",
+            b"def f(values)\n  Set.new(values)\nend\n\nrequire \"set\"\n",
+            Lang::Ruby,
+            &interner,
+        )
+        .expect("ruby lowering should succeed");
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &late_require.evidence,
+                library_api_contract_id_hash(ruby_contract.id),
+                library_api_callee_contract_hash(ruby_contract.callee),
+            ),
+            0
+        );
+
+        let shadowed_require = crate::lower_source(
+            FileId(0),
+            "set_shadowed_require.rb",
+            b"def require(name)\n  name\nend\n\nrequire \"set\"\n\ndef f(values)\n  Set.new(values)\nend\n",
+            Lang::Ruby,
+            &interner,
+        )
+        .expect("ruby lowering should succeed");
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &shadowed_require.evidence,
+                library_api_contract_id_hash(ruby_contract.id),
+                library_api_callee_contract_hash(ruby_contract.callee),
+            ),
+            0
         );
     }
 

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -13,11 +13,11 @@ use nose_il::{
     NodeId, NodeKind, Payload, Span, Symbol, UnitKind,
 };
 use nose_semantics::{
-    import_fact_evidence_rhs, imported_binding_symbol, library_api_free_name_shadow_safe,
+    import_fact_evidence_rhs, library_api_contract_evidence_for_call,
     library_free_name_map_factory_contract, library_java_map_entry_contract,
     library_java_map_factory_contract, semantics, seq_surface_contract_evidence_for_node,
     ImportFactKind, ImportedMapFactoryContract, JavaMapFactoryKind, LibraryApiCalleeContract,
-    LibraryMapFactoryResult, FIRST_PARTY_PACK_ID,
+    LibraryApiEvidenceStatus, LibraryMapFactoryResult, FIRST_PARTY_PACK_ID,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::Path;
@@ -411,20 +411,14 @@ fn java_map_factory_call_safe(il: &Il, interner: &Interner, call: NodeId) -> boo
     let Some((&callee, args)) = kids.split_first() else {
         return false;
     };
-    let Some((receiver_node, method)) = field_method_on_var(il, interner, callee, "Map") else {
+    let Some((_receiver_node, method)) = field_method_on_var(il, interner, callee, "Map") else {
         return false;
     };
     let Some(contract) = library_java_map_factory_contract(il.meta.lang, "Map", method) else {
         return false;
     };
-    let LibraryApiCalleeContract::JavaUtilStaticMember {
-        receiver: expected_receiver,
-        ..
-    } = contract.callee
-    else {
-        return false;
-    };
-    if !java_util_static_receiver_safe(il, interner, receiver_node, expected_receiver) {
+    if !java_util_static_member_evidence_required(il, interner, call, contract.id, contract.callee)
+    {
         return false;
     }
     let LibraryMapFactoryResult::JavaFactory { kind } = contract.result else {
@@ -451,20 +445,14 @@ fn java_map_entry_call_safe(il: &Il, interner: &Interner, call: NodeId) -> bool 
     if kids.len() != 3 {
         return false;
     }
-    let Some((receiver_node, method)) = field_method_on_var(il, interner, kids[0], "Map") else {
+    let Some((_receiver_node, method)) = field_method_on_var(il, interner, kids[0], "Map") else {
         return false;
     };
     let Some(contract) = library_java_map_entry_contract(il.meta.lang, "Map", method) else {
         return false;
     };
-    let LibraryApiCalleeContract::JavaUtilStaticMember {
-        receiver: expected_receiver,
-        ..
-    } = contract.callee
-    else {
-        return false;
-    };
-    if !java_util_static_receiver_safe(il, interner, receiver_node, expected_receiver) {
+    if !java_util_static_member_evidence_required(il, interner, call, contract.id, contract.callee)
+    {
         return false;
     }
     literal_export_value_safe(il, interner, kids[1])
@@ -482,22 +470,39 @@ fn rust_std_map_factory_call_safe(il: &Il, interner: &Interner, call: NodeId) ->
     let Some(contract) = library_free_name_map_factory_contract(il.meta.lang, name) else {
         return false;
     };
-    let LibraryApiCalleeContract::FreeName {
-        name: contract_name,
-        shadow,
-    } = contract.callee
-    else {
+    let LibraryApiCalleeContract::FreeName { .. } = contract.callee else {
         return false;
     };
-    if !library_api_free_name_shadow_safe(il.meta.lang, contract_name, shadow, |candidate| {
-        file_defines_name(il, interner, candidate)
-    }) {
+    if !matches!(
+        library_api_contract_evidence_for_call(il, interner, call, contract.id, contract.callee, 1,),
+        LibraryApiEvidenceStatus::Admitted
+    ) {
         return false;
     }
     let LibraryMapFactoryResult::EntrySequence { .. } = contract.result else {
         return false;
     };
     literal_export_value_safe(il, interner, kids[1])
+}
+
+fn java_util_static_member_evidence_required(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    contract_id: nose_semantics::LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+) -> bool {
+    matches!(
+        library_api_contract_evidence_for_call(
+            il,
+            interner,
+            call,
+            contract_id,
+            callee,
+            il.children(call).len().saturating_sub(1),
+        ),
+        LibraryApiEvidenceStatus::Admitted
+    )
 }
 
 fn field_method_on_var<'a>(
@@ -529,37 +534,6 @@ fn var_text<'a>(il: &Il, interner: &'a Interner, node: NodeId) -> Option<&'a str
         return None;
     };
     Some(interner.resolve(name))
-}
-
-fn java_util_static_receiver_safe(
-    il: &Il,
-    interner: &Interner,
-    receiver: NodeId,
-    expected_receiver: &str,
-) -> bool {
-    !java_file_defines_type_name(il, interner, expected_receiver)
-        && imported_binding_symbol(il, interner, receiver, "java.util", expected_receiver)
-}
-
-fn file_defines_name(il: &Il, interner: &Interner, expected: &str) -> bool {
-    collect_top_level_statements(il).iter().any(|&stmt| {
-        assignment_name(il, stmt).is_some_and(|symbol| interner.resolve(symbol) == expected)
-    }) || il.units.iter().any(|unit| {
-        unit.name
-            .is_some_and(|symbol| interner.resolve(symbol) == expected)
-    }) || il.nodes.iter().any(|node| {
-        matches!(node.kind, NodeKind::Module | NodeKind::Block)
-            && matches!(node.payload, Payload::Name(symbol) if interner.resolve(symbol) == expected)
-    })
-}
-
-fn java_file_defines_type_name(il: &Il, interner: &Interner, expected: &str) -> bool {
-    il.units.iter().any(|unit| {
-        unit.kind == UnitKind::Class
-            && unit
-                .name
-                .is_some_and(|name| interner.resolve(name) == expected)
-    })
 }
 
 fn binding_mutated(il: &Il, interner: &Interner, name: Symbol, defining_stmt: NodeId) -> bool {
@@ -775,22 +749,36 @@ fn snapshot_subtree(il: &Il, root: NodeId) -> SubtreeSnapshot {
 
 fn snapshot_evidence(il: &Il, nodes: &[SnapshotNode]) -> Vec<SnapshotEvidence> {
     let spans: FxHashSet<Span> = nodes.iter().map(|node| node.span).collect();
-    let candidates: FxHashMap<EvidenceId, &EvidenceRecord> = il
+    let asserted: FxHashMap<EvidenceId, &EvidenceRecord> = il
         .evidence
         .iter()
-        .filter(|record| {
-            record.status == EvidenceStatus::Asserted
-                && spans.contains(&evidence_anchor_span(record.anchor))
-        })
+        .filter(|record| record.status == EvidenceStatus::Asserted)
         .map(|record| (record.id, record))
         .collect();
-    let mut kept: FxHashSet<EvidenceId> = candidates.keys().copied().collect();
+    let mut kept: FxHashSet<EvidenceId> = asserted
+        .values()
+        .filter(|record| spans.contains(&evidence_anchor_span(record.anchor)))
+        .map(|record| record.id)
+        .collect();
+
+    let mut stack: Vec<EvidenceId> = kept.iter().copied().collect();
+    while let Some(id) = stack.pop() {
+        let Some(record) = asserted.get(&id) else {
+            continue;
+        };
+        for &dependency in &record.dependencies {
+            if asserted.contains_key(&dependency) && kept.insert(dependency) {
+                stack.push(dependency);
+            }
+        }
+    }
+
     loop {
         let rejected: Vec<EvidenceId> = kept
             .iter()
             .copied()
             .filter(|id| {
-                candidates
+                asserted
                     .get(id)
                     .is_some_and(|record| record.dependencies.iter().any(|dep| !kept.contains(dep)))
             })
@@ -896,47 +884,33 @@ fn append_snapshot(il: &mut Il, snapshot: &SubtreeSnapshot) -> AppendedSnapshot 
             .collect();
         let child_start = il.edges.len() as u32;
         il.edges.extend_from_slice(&children);
-        let mut span = snapshot_node.span;
-        span.file = il.file;
         let id = NodeId(il.nodes.len() as u32);
         il.nodes.push(Node {
             kind: snapshot_node.kind,
             payload: snapshot_node.payload,
-            span,
+            span: snapshot_node.span,
             child_start,
             child_len: children.len() as u32,
         });
         new_ids[idx] = id;
     }
+    let source_evidence: FxHashMap<EvidenceId, &SnapshotEvidence> = snapshot
+        .evidence
+        .iter()
+        .map(|evidence| (evidence.source_id, evidence))
+        .collect();
     let mut evidence_id_map = FxHashMap::default();
-    for (idx, evidence) in snapshot.evidence.iter().enumerate() {
-        evidence_id_map.insert(
-            evidence.source_id,
-            EvidenceId((il.evidence.len() + idx) as u32),
-        );
-    }
     let mut copied_evidence = Vec::with_capacity(snapshot.evidence.len());
     for evidence in &snapshot.evidence {
-        let id = evidence_id_map[&evidence.source_id];
-        let dependencies = evidence
-            .dependencies
-            .iter()
-            .map(|dependency| {
-                evidence_id_map
-                    .get(dependency)
-                    .copied()
-                    .expect("snapshot evidence dependency must be closed")
-            })
-            .collect();
-        il.evidence.push(EvidenceRecord {
-            id,
-            anchor: remap_anchor_file(evidence.anchor, il.file),
-            kind: evidence.kind,
-            provenance: evidence.provenance,
-            dependencies,
-            status: evidence.status,
-        });
-        copied_evidence.push(id);
+        let id = append_snapshot_evidence(
+            il,
+            &source_evidence,
+            &mut evidence_id_map,
+            evidence.source_id,
+        );
+        if !copied_evidence.contains(&id) {
+            copied_evidence.push(id);
+        }
     }
     AppendedSnapshot {
         root: new_ids[snapshot.root],
@@ -944,29 +918,69 @@ fn append_snapshot(il: &mut Il, snapshot: &SubtreeSnapshot) -> AppendedSnapshot 
     }
 }
 
-fn remap_anchor_file(anchor: EvidenceAnchor, file: nose_il::FileId) -> EvidenceAnchor {
-    match anchor {
-        EvidenceAnchor::SourceSpan(span) => EvidenceAnchor::SourceSpan(remap_span_file(span, file)),
-        EvidenceAnchor::Node { span, kind } => EvidenceAnchor::Node {
-            span: remap_span_file(span, file),
-            kind,
-        },
-        EvidenceAnchor::Param { span } => EvidenceAnchor::Param {
-            span: remap_span_file(span, file),
-        },
-        EvidenceAnchor::Binding { span, local_hash } => EvidenceAnchor::Binding {
-            span: remap_span_file(span, file),
-            local_hash,
-        },
-        EvidenceAnchor::Sequence { span } => EvidenceAnchor::Sequence {
-            span: remap_span_file(span, file),
-        },
+fn append_snapshot_evidence(
+    il: &mut Il,
+    source_evidence: &FxHashMap<EvidenceId, &SnapshotEvidence>,
+    evidence_id_map: &mut FxHashMap<EvidenceId, EvidenceId>,
+    source_id: EvidenceId,
+) -> EvidenceId {
+    if let Some(id) = evidence_id_map.get(&source_id).copied() {
+        return id;
     }
+    let evidence = source_evidence
+        .get(&source_id)
+        .copied()
+        .expect("snapshot evidence dependency must be closed");
+    let dependencies: Vec<EvidenceId> = evidence
+        .dependencies
+        .iter()
+        .map(|dependency| {
+            append_snapshot_evidence(il, source_evidence, evidence_id_map, *dependency)
+        })
+        .collect();
+    let anchor = evidence.anchor;
+    let id = existing_snapshot_evidence_id(
+        il,
+        anchor,
+        evidence.kind,
+        evidence.provenance,
+        &dependencies,
+        evidence.status,
+    )
+    .unwrap_or_else(|| {
+        let id = EvidenceId(il.evidence.len() as u32);
+        il.evidence.push(EvidenceRecord {
+            id,
+            anchor,
+            kind: evidence.kind,
+            provenance: evidence.provenance,
+            dependencies,
+            status: evidence.status,
+        });
+        id
+    });
+    evidence_id_map.insert(source_id, id);
+    id
 }
 
-fn remap_span_file(mut span: Span, file: nose_il::FileId) -> Span {
-    span.file = file;
-    span
+fn existing_snapshot_evidence_id(
+    il: &Il,
+    anchor: EvidenceAnchor,
+    kind: EvidenceKind,
+    provenance: EvidenceProvenance,
+    dependencies: &[EvidenceId],
+    status: EvidenceStatus,
+) -> Option<EvidenceId> {
+    il.evidence
+        .iter()
+        .find(|record| {
+            record.anchor == anchor
+                && record.kind == kind
+                && record.provenance == provenance
+                && record.dependencies == dependencies
+                && record.status == status
+        })
+        .map(|record| record.id)
 }
 
 fn replace_assignment_rhs(il: &mut Il, stmt: NodeId, rhs: NodeId) {
@@ -1111,6 +1125,203 @@ mod tests {
         );
     }
 
+    fn java_provider_and_importer(provider_src: &str, interner: &Interner) -> (Il, Il) {
+        java_provider_and_importer_src(
+            provider_src,
+            "import static Tables.LOOKUP;\nclass Consumer {}",
+            interner,
+        )
+    }
+
+    fn java_provider_and_importer_src(
+        provider_src: &str,
+        importer_src: &str,
+        interner: &Interner,
+    ) -> (Il, Il) {
+        let provider = crate::lower_source(
+            FileId(0),
+            "Tables.java",
+            provider_src.as_bytes(),
+            Lang::Java,
+            interner,
+        )
+        .expect("lower Java provider");
+        let importer = crate::lower_source(
+            FileId(1),
+            "Consumer.java",
+            importer_src.as_bytes(),
+            Lang::Java,
+            interner,
+        )
+        .expect("lower Java importer");
+        (provider, importer)
+    }
+
+    fn snapshot_count(il: &Il) -> usize {
+        il.evidence
+            .iter()
+            .filter(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::Import(ImportEvidenceKind::ImportedLiteralSnapshot { .. })
+                )
+            })
+            .count()
+    }
+
+    fn resolve_importer(provider: Il, importer: Il, interner: &Interner) -> Il {
+        let mut files = vec![provider, importer];
+        resolve_imported_immutable_bindings(&mut files, interner);
+        files.remove(1)
+    }
+
+    fn resolve_snapshot_count(provider: Il, importer: Il, interner: &Interner) -> usize {
+        snapshot_count(&resolve_importer(provider, importer, interner))
+    }
+
+    fn remove_library_api_evidence_by_rule(il: &mut Il, rule: &str) {
+        let rule_hash = stable_symbol_hash(rule);
+        il.evidence.retain(|record| {
+            !matches!(record.kind, EvidenceKind::LibraryApi(_))
+                || record.provenance.rule_hash != Some(rule_hash)
+        });
+    }
+
+    #[test]
+    fn java_map_provider_requires_library_api_evidence_for_snapshot() {
+        let interner = Interner::new();
+        let provider_src = "import java.util.Map;\nclass Tables { static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2); }\n";
+        let (provider, importer) = java_provider_and_importer(provider_src, &interner);
+        assert_eq!(
+            resolve_snapshot_count(provider.clone(), importer.clone(), &interner),
+            1
+        );
+
+        let mut missing_api = provider;
+        remove_library_api_evidence_by_rule(&mut missing_api, "library_api_java_map_factory");
+        assert_eq!(
+            resolve_snapshot_count(missing_api, importer, &interner),
+            0,
+            "java.util import/symbol proof must not prove provider Map.of without LibraryApi evidence"
+        );
+    }
+
+    #[test]
+    fn java_map_provider_snapshot_copies_library_api_dependency_closure() {
+        let interner = Interner::new();
+        let provider_src = "import java.util.Map;\nclass Tables { static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2); }\n";
+        let (provider, importer) = java_provider_and_importer(provider_src, &interner);
+        let importer = resolve_importer(provider, importer, &interner);
+        let api_rule = stable_symbol_hash("library_api_java_map_factory");
+        let api = importer
+            .evidence
+            .iter()
+            .find(|record| {
+                matches!(record.kind, EvidenceKind::LibraryApi(_))
+                    && record.provenance.rule_hash == Some(api_rule)
+            })
+            .expect("copied Java Map.of snapshot should retain LibraryApi evidence");
+
+        let occurrence = api
+            .dependencies
+            .iter()
+            .filter_map(|id| importer.evidence.get(id.0 as usize))
+            .find(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+                        module_hash,
+                        exported_hash,
+                    }) if module_hash == stable_symbol_hash("java.util")
+                        && exported_hash == stable_symbol_hash("Map")
+                )
+            })
+            .expect("copied LibraryApi evidence should keep its imported-symbol dependency");
+        assert!(
+            occurrence.dependencies.iter().any(|id| {
+                importer.evidence.get(id.0 as usize).is_some_and(|record| {
+                    matches!(
+                        record.kind,
+                        EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+                            module_hash,
+                            exported_hash,
+                        }) if module_hash == stable_symbol_hash("java.util")
+                            && exported_hash == stable_symbol_hash("Map")
+                    )
+                })
+            }),
+            "copied occurrence proof should keep the provider binding-anchor dependency"
+        );
+    }
+
+    #[test]
+    fn java_map_provider_snapshot_replaces_import_used_by_lookup_method() {
+        let interner = Interner::new();
+        let provider_src = "import java.util.Map;\nclass Tables { static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2); }\n";
+        let importer_src = "import static Tables.LOOKUP;\nclass Consumer { static int lookup(String key, String other) { return LOOKUP.getOrDefault(key, 0); } }\n";
+        let (provider, importer) =
+            java_provider_and_importer_src(provider_src, importer_src, &interner);
+        let importer = resolve_importer(provider, importer, &interner);
+        assert_eq!(snapshot_count(&importer), 1);
+        let import_stmt = collect_top_level_statements(&importer)
+            .into_iter()
+            .find(|&stmt| {
+                assignment_name(&importer, stmt)
+                    .is_some_and(|name| interner.resolve(name) == "LOOKUP")
+            })
+            .expect("static import assignment should remain as replacement anchor");
+        let rhs = assignment_rhs(&importer, import_stmt).expect("import assignment rhs");
+        assert_eq!(importer.kind(rhs), NodeKind::Call);
+        assert_eq!(
+            importer.node(rhs).span.file,
+            FileId(0),
+            "copied provider RHS keeps provider source origin so importer-local scopes cannot shadow it"
+        );
+        let contract =
+            library_java_map_factory_contract(Lang::Java, "Map", "of").expect("Map.of contract");
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &importer,
+                &interner,
+                rhs,
+                contract.id,
+                contract.callee,
+                4
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        );
+    }
+
+    #[test]
+    fn java_map_of_entries_provider_requires_outer_and_entry_library_api_evidence() {
+        let interner = Interner::new();
+        let provider_src = "import java.util.Map;\nclass Tables { static final Map<String, Integer> LOOKUP = Map.ofEntries(Map.entry(\"red\", 1), Map.entry(\"blue\", 2)); }\n";
+        let (provider, importer) = java_provider_and_importer(provider_src, &interner);
+        assert_eq!(
+            resolve_snapshot_count(provider.clone(), importer.clone(), &interner),
+            1
+        );
+
+        let mut missing_outer = provider.clone();
+        remove_library_api_evidence_by_rule(&mut missing_outer, "library_api_java_map_factory");
+        assert_eq!(
+            resolve_snapshot_count(missing_outer, importer.clone(), &interner),
+            0,
+            "Map.ofEntries provider proof must require the outer LibraryApi evidence"
+        );
+
+        let mut missing_entry = provider;
+        remove_library_api_evidence_by_rule(
+            &mut missing_entry,
+            "library_api_java_map_entry_factory",
+        );
+        assert_eq!(
+            resolve_snapshot_count(missing_entry, importer, &interner),
+            0,
+            "Map.ofEntries provider proof must require every nested Map.entry LibraryApi evidence"
+        );
+    }
+
     fn coordinate_import_binding_assignment(
         file: FileId,
         lang: Lang,
@@ -1229,7 +1440,7 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_append_copies_relevant_evidence_with_remapped_file_spans() {
+    fn snapshot_append_copies_relevant_evidence_with_source_origin_spans() {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
         let span = Span::new(FileId(0), 4, 12, 1, 1);
@@ -1303,6 +1514,11 @@ mod tests {
         );
         let appended = append_snapshot(&mut importer, &snapshot);
 
+        assert_eq!(
+            importer.node(appended.root).span.file,
+            FileId(0),
+            "copied provider nodes keep provider source origin so importer-local scopes do not shadow them"
+        );
         assert_eq!(appended.evidence.len(), 3);
         assert!(
             importer
@@ -1323,7 +1539,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             copied_surface.anchor,
-            EvidenceAnchor::sequence(Span::new(FileId(1), 4, 12, 1, 1))
+            EvidenceAnchor::sequence(Span::new(FileId(0), 4, 12, 1, 1))
         );
         assert_eq!(copied_surface.provenance, test_provenance("surface"));
 

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -120,7 +120,7 @@ fn lower_static_import(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     if let Some(rest) = text.strip_prefix("from ") {
         let (module, names) = rest.split_once(" import ")?;
         if names.trim() == "*" {
-            return None;
+            return Some(lo.raw("python_wildcard_import", span, &[]));
         }
         for part in names.split(',').map(str::trim).filter(|p| !p.is_empty()) {
             let (exported, local) = py_import_specifier(part);

--- a/crates/nose-frontend/src/rust.rs
+++ b/crates/nose-frontend/src/rust.rs
@@ -47,9 +47,9 @@ fn lower_item(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
         "use_declaration" | "extern_crate_declaration" => Some(
             lower_static_import(lo, node).unwrap_or_else(|| crate::lower::import_tokens(lo, node)),
         ),
-        // type aliases, macro defs, attributes: no behavior to model
+        "macro_definition" => Some(lower_macro_definition_shadow(lo, node)),
+        // type aliases, attributes: no behavior to model
         "type_item"
-        | "macro_definition"
         | "attribute_item"
         | "inner_attribute_item"
         // trait method/const declarations without a body: no behavior to model
@@ -613,9 +613,8 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         | "trait_bounds"
         | "type_binding"
         | "constrained_type_parameter" => lo.empty_block(span),
-        "macro_definition" | "line_comment" | "block_comment" | "attribute_item" => {
-            lo.empty_block(span)
-        }
+        "macro_definition" => lower_macro_definition_shadow(lo, node),
+        "line_comment" | "block_comment" | "attribute_item" => lo.empty_block(span),
         _ => {
             let kids: Vec<NodeId> = Lowering::named_children(node)
                 .into_iter()
@@ -731,6 +730,10 @@ fn lower_macro(lo: &mut Lowering, node: TsNode) -> NodeId {
     if macro_name.is_some_and(|name| name.trim_end_matches('!') == "panic") {
         return lo.add(NodeKind::Throw, Payload::None, span, &args);
     }
+    lo.record_source_fact(
+        span,
+        nose_il::SourceFactKind::Call(nose_il::SourceCallKind::MacroInvocation),
+    );
     let callee = lo.add(
         NodeKind::Var,
         name.map(Payload::Name).unwrap_or(Payload::None),
@@ -740,6 +743,30 @@ fn lower_macro(lo: &mut Lowering, node: TsNode) -> NodeId {
     let mut kids = vec![callee];
     kids.extend(args);
     lo.add(NodeKind::Call, Payload::None, span, &kids)
+}
+
+fn lower_macro_definition_shadow(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let name = rust_macro_definition_name(lo, node).map(|name| lo.sym(name));
+    lo.add(
+        NodeKind::Block,
+        name.map(Payload::Name).unwrap_or(Payload::None),
+        span,
+        &[],
+    )
+}
+
+fn rust_macro_definition_name<'a>(lo: &Lowering<'a>, node: TsNode<'a>) -> Option<&'a str> {
+    if let Some(name) = node.child_by_field_name("name") {
+        return Some(lo.text(name).trim());
+    }
+    let text = lo.text(node).trim_start();
+    let rest = text.strip_prefix("macro_rules!")?.trim_start();
+    let name = rest
+        .split(|c: char| c == '{' || c == '(' || c == '[' || c.is_whitespace())
+        .next()?
+        .trim();
+    (!name.is_empty()).then_some(name)
 }
 
 /// Macro arguments are an unparsed token stream: nested `()`/`[]`/`{}` are sub-

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -302,6 +302,9 @@ pub enum ImportEvidenceKind {
     Namespace {
         module_hash: u64,
     },
+    Require {
+        module_hash: u64,
+    },
     ImmutableLiteralExport {
         module_hash: u64,
         exported_hash: u64,
@@ -453,6 +456,7 @@ pub enum SourceOperatorKind {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub enum SourceCallKind {
     Construct,
+    MacroInvocation,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -9,9 +9,8 @@
 
 use nose_il::{contains_js_identifier, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
 use nose_semantics::{
-    domain_evidence_for_param, free_function_builtin_contract, imported_binding_symbol,
-    imported_namespace_symbol, library_api_contract_evidence_for_call,
-    library_api_free_name_shadow_safe, library_free_name_map_factory_contract,
+    domain_evidence_for_param, free_function_builtin_contract, imported_namespace_symbol,
+    library_api_contract_evidence_for_call, library_free_name_map_factory_contract,
     library_iterator_identity_adapter_contract, library_map_get_contract,
     library_map_key_view_contract, library_method_call_contract,
     library_static_collection_adapter_contract, method_hof_contract,
@@ -517,19 +516,7 @@ fn static_collection_adapter_arg(
     ) {
         LibraryApiEvidenceStatus::Admitted => {}
         LibraryApiEvidenceStatus::Rejected => return None,
-        LibraryApiEvidenceStatus::Missing => {
-            if file_defines_type_name(old, interner, receiver_name)
-                || !imported_binding_symbol(
-                    old,
-                    interner,
-                    receiver,
-                    contract.result.module,
-                    contract.result.exported,
-                )
-            {
-                return None;
-            }
-        }
+        LibraryApiEvidenceStatus::Missing => return None,
     }
     call_kids.get(1).copied()
 }
@@ -740,17 +727,23 @@ fn rust_std_map_factory_call(old: &Il, interner: &Interner, node: NodeId) -> boo
     let Some(contract) = library_free_name_map_factory_contract(old.meta.lang, callee) else {
         return false;
     };
-    let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+    let LibraryApiCalleeContract::FreeName { .. } = contract.callee else {
         return false;
     };
     let LibraryMapFactoryResult::EntrySequence { entry_seq_tag } = contract.result else {
         return false;
     };
-    name == callee
-        && library_api_free_name_shadow_safe(old.meta.lang, name, shadow, |candidate| {
-            file_defines_name(old, interner, candidate)
-        })
-        && map_factory_entries_match_surface(old, interner, kids[1], entry_seq_tag)
+    matches!(
+        library_api_contract_evidence_for_call(
+            old,
+            interner,
+            node,
+            contract.id,
+            contract.callee,
+            1,
+        ),
+        LibraryApiEvidenceStatus::Admitted
+    ) && map_factory_entries_match_surface(old, interner, kids[1], entry_seq_tag)
 }
 
 fn map_factory_entries_match_surface(
@@ -822,14 +815,6 @@ fn symbol_defines_name(old: &Il, interner: &Interner, symbol: nose_il::Symbol, n
             .modules()
             .js_like_shadowed_module_bindings()
             && contains_js_identifier(text, name))
-}
-
-fn file_defines_type_name(old: &Il, interner: &Interner, name: &str) -> bool {
-    old.units
-        .iter()
-        .filter(|unit| matches!(unit.kind, nose_il::UnitKind::Class))
-        .filter_map(|unit| unit.name)
-        .any(|symbol| interner.resolve(symbol) == name)
 }
 
 fn name_of<'a>(old: &Il, interner: &'a Interner, id: NodeId) -> Option<&'a str> {
@@ -945,8 +930,8 @@ mod tests {
     use nose_il::{
         EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
         EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, ImportEvidenceKind, Lang,
-        ParamSemantic, ParamTypeFact, SequenceSurfaceKind, Span, SymbolEvidenceKind, Unit,
-        UnitKind,
+        LibraryApiEvidenceKind, ParamSemantic, ParamTypeFact, SequenceSurfaceKind, Span,
+        SymbolEvidenceKind, Unit, UnitKind,
     };
 
     fn sp() -> Span {
@@ -959,6 +944,16 @@ mod tests {
         kind: EvidenceKind,
         status: EvidenceStatus,
     ) -> EvidenceRecord {
+        evidence_with_dependencies(id, anchor, kind, status, Vec::new())
+    }
+
+    fn evidence_with_dependencies(
+        id: u32,
+        anchor: EvidenceAnchor,
+        kind: EvidenceKind,
+        status: EvidenceStatus,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceRecord {
         EvidenceRecord {
             id: EvidenceId(id),
             anchor,
@@ -968,7 +963,7 @@ mod tests {
                 pack_hash: Some(stable_symbol_hash(nose_semantics::FIRST_PARTY_PACK_ID)),
                 rule_hash: Some(stable_symbol_hash("test")),
             },
-            dependencies: Vec::new(),
+            dependencies,
             status,
         }
     }
@@ -1589,18 +1584,50 @@ mod tests {
         (il, interner, call)
     }
 
+    fn push_rust_hash_map_library_api_evidence(il: &mut Il) {
+        let contract =
+            library_free_name_map_factory_contract(Lang::Rust, "std::collections::HashMap::from")
+                .expect("Rust HashMap::from contract");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("std::collections::HashMap::from"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            1,
+            EvidenceAnchor::node(sp(), NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: nose_semantics::library_api_contract_id_hash(contract.id),
+                callee_hash: nose_semantics::library_api_callee_contract_hash(contract.callee),
+                arity: 1,
+            }),
+            EvidenceStatus::Asserted,
+            vec![EvidenceId(0)],
+        ));
+    }
+
     #[test]
     fn rust_std_map_factory_requires_entry_surface_and_shadow_proof() {
-        let (il, interner, call) = rust_hash_map_from_call("tuple", false);
+        let (mut il, interner, call) = rust_hash_map_from_call("tuple", false);
+        assert!(
+            !rust_std_map_factory_call(&il, &interner, call),
+            "raw Rust std path proof must not prove the migrated factory"
+        );
+        push_rust_hash_map_library_api_evidence(&mut il);
         assert!(rust_std_map_factory_call(&il, &interner, call));
 
-        let (il, interner, call) = rust_hash_map_from_call("array", false);
+        let (mut il, interner, call) = rust_hash_map_from_call("array", false);
+        push_rust_hash_map_library_api_evidence(&mut il);
         assert!(
             !rust_std_map_factory_call(&il, &interner, call),
             "HashMap::from exact map proof requires tuple-shaped entries"
         );
 
-        let (il, interner, call) = rust_hash_map_from_call("tuple", true);
+        let (mut il, interner, call) = rust_hash_map_from_call("tuple", true);
+        push_rust_hash_map_library_api_evidence(&mut il);
         assert!(
             !rust_std_map_factory_call(&il, &interner, call),
             "a local std binding must close the Rust stdlib factory path"

--- a/crates/nose-normalize/src/module_facts.rs
+++ b/crates/nose-normalize/src/module_facts.rs
@@ -77,6 +77,25 @@ pub(crate) fn collect_module_mutations_in_scope(
     is_top_level: &[bool],
     local_scope: &[bool],
 ) -> FxHashSet<Symbol> {
+    let direct_definitions = direct_assignment_definitions_in_scope(il, is_top_level, local_scope);
+    collect_module_mutations_in_scope_with_direct_definitions(
+        il,
+        interner,
+        candidates,
+        is_top_level,
+        local_scope,
+        &direct_definitions,
+    )
+}
+
+pub(crate) fn collect_module_mutations_in_scope_with_direct_definitions(
+    il: &Il,
+    interner: &Interner,
+    candidates: &FxHashSet<Symbol>,
+    is_top_level: &[bool],
+    local_scope: &[bool],
+    direct_definitions: &FxHashSet<NodeId>,
+) -> FxHashSet<Symbol> {
     let mut mutated = FxHashSet::default();
     if candidates.is_empty() {
         return mutated;
@@ -119,7 +138,7 @@ pub(crate) fn collect_module_mutations_in_scope(
                 if let Some(lhs) = il.children(node_id).first().copied() {
                     let direct_top_level_definition =
                         is_top_level.get(idx).copied().unwrap_or(false)
-                            && assignment_name_in_scope(il, node_id, local_scope).is_some();
+                            && direct_definitions.contains(&node_id);
                     if !direct_top_level_definition {
                         collect_unshadowed_node_symbols(
                             il,
@@ -136,6 +155,23 @@ pub(crate) fn collect_module_mutations_in_scope(
         }
     }
     mutated
+}
+
+fn direct_assignment_definitions_in_scope(
+    il: &Il,
+    is_top_level: &[bool],
+    local_scope: &[bool],
+) -> FxHashSet<NodeId> {
+    il.nodes
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, _)| {
+            let node = NodeId(idx as u32);
+            (is_top_level.get(idx).copied().unwrap_or(false)
+                && assignment_name_in_scope(il, node, local_scope).is_some())
+            .then_some(node)
+        })
+        .collect()
 }
 
 pub fn shadowed_js_like_module_binding_nodes_for_symbol(

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -39,8 +39,9 @@ mod rules;
 
 use crate::combine;
 use crate::module_facts::{
-    assignment_name_in_scope, collect_all_node_symbols_in_scope, collect_module_mutations_in_scope,
-    local_scope_nodes, mutating_method_name, node_symbol_in_scope,
+    assignment_name_in_scope, collect_all_node_symbols_in_scope,
+    collect_module_mutations_in_scope_with_direct_definitions, local_scope_nodes,
+    mutating_method_name, node_symbol_in_scope,
     shadowed_js_like_module_binding_nodes_for_symbol_in_scope, top_level_statements_for,
 };
 use crate::types::Ty;
@@ -54,31 +55,30 @@ use nose_semantics::{
     exact_static_membership_predicate_operator, free_function_builtin_contract,
     go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
     go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract, import_fact_evidence_rhs,
-    imported_literal_snapshot_evidence_at_span, imported_namespace_symbol,
+    imported_literal_producer_evidence_for_node, imported_namespace_symbol,
     library_api_contract_evidence_at_call_span, library_api_contract_evidence_for_call,
-    library_api_free_name_shadow_safe, library_free_name_collection_factory_contracts,
-    library_free_name_map_factory_contracts, library_imported_collection_factory_contracts,
-    library_imported_namespace_function_contract, library_iterator_identity_adapter_contract,
-    library_java_collection_factory_contract_by_hash, library_java_map_entry_contract_by_hash,
-    library_java_map_factory_contract_by_hash, library_js_like_map_constructor_contract,
-    library_js_like_set_constructor_contract, library_map_get_contract_by_hash,
-    library_map_key_view_contract_by_hash, library_map_key_view_wrapper_contract_by_hash,
-    library_method_call_contract, library_ruby_set_factory_contract_by_hash,
-    library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
-    nullish_global_contract, own_property_guard_evidence_at_span, qualified_global_symbol_at_span,
-    record_shape_guard_for_node, reduction_builtin_contract, rust_option_and_then_contract,
-    rust_option_none_sentinel_contract, rust_option_some_constructor_contract,
-    scalar_integer_method_contract, semantics, seq_surface_contract_for_node,
-    source_operator_at_node, static_index_membership_contract, unshadowed_global_symbol,
-    BuiltinArgContract, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
-    GoZeroMapDefaultKind, ImportFactKind, ImportedNamespaceFunctionSemantic,
-    IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind,
-    LibraryApiCalleeContract, LibraryApiEvidenceStatus, LibraryApiSpanEvidenceQuery,
-    LibraryCollectionFactoryResult, LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs,
-    MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
-    SeqSurfaceContract, StaticIndexMembershipKind, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP,
-    SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE,
-    SEQ_VALUE_UNTAGGED,
+    library_free_name_collection_factory_contracts, library_free_name_map_factory_contracts,
+    library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
+    library_iterator_identity_adapter_contract, library_java_collection_factory_contract_by_hash,
+    library_java_map_entry_contract_by_hash, library_java_map_factory_contract_by_hash,
+    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
+    library_map_get_contract_by_hash, library_map_key_view_contract_by_hash,
+    library_map_key_view_wrapper_contract_by_hash, library_method_call_contract,
+    library_ruby_set_factory_contract_by_hash, library_rust_vec_macro_factory_contract,
+    library_rust_vec_new_factory_contract, nullish_global_contract,
+    own_property_guard_evidence_at_span, record_shape_guard_for_node, reduction_builtin_contract,
+    rust_option_and_then_contract, rust_option_none_sentinel_contract,
+    rust_option_some_constructor_contract, scalar_integer_method_contract, semantics,
+    seq_surface_contract_for_node, source_operator_at_node, static_index_membership_contract,
+    unshadowed_global_symbol, BuiltinArgContract, CardinalityPredicate, CardinalityThreshold,
+    ComparisonLaw, DomainEvidence, GoZeroMapDefaultKind, ImportFactKind,
+    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
+    JavaMapFactoryKind, LibraryApiCalleeContract, LibraryApiEvidenceStatus,
+    LibraryApiSpanEvidenceQuery, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
+    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
+    ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract, StaticIndexMembershipKind,
+    SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR,
+    SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock;
@@ -219,13 +219,13 @@ impl ModuleSeedContext {
 
         let mut assignment_counts: FxHashMap<Symbol, usize> = FxHashMap::default();
         for &stmt in &top_level {
-            if let Some(name) = assignment_name_in_scope(il, stmt, &local_scope) {
+            if let Some(name) = module_seed_assignment_name(il, stmt, &local_scope) {
                 *assignment_counts.entry(name).or_insert(0) += 1;
             }
         }
         let mut assignment_deps: FxHashMap<Symbol, FxHashSet<Symbol>> = FxHashMap::default();
         for &stmt in &top_level {
-            let Some(name) = assignment_name_in_scope(il, stmt, &local_scope) else {
+            let Some(name) = module_seed_assignment_name(il, stmt, &local_scope) else {
                 continue;
             };
             if let Some(&rhs) = il.children(stmt).get(1) {
@@ -243,12 +243,18 @@ impl ModuleSeedContext {
                 (count == 1 && !unit_symbols.contains(&name)).then_some(name)
             })
             .collect();
-        let mutated_bindings = collect_module_mutations_in_scope(
+        let direct_definitions: FxHashSet<NodeId> = top_level
+            .iter()
+            .copied()
+            .filter(|&stmt| module_seed_assignment_name(il, stmt, &local_scope).is_some())
+            .collect();
+        let mutated_bindings = collect_module_mutations_in_scope_with_direct_definitions(
             il,
             interner,
             &candidate_names,
             &is_top_level,
             &local_scope,
+            &direct_definitions,
         );
 
         Self {
@@ -276,6 +282,32 @@ impl ModuleSeedContext {
             }
         }
         required
+    }
+}
+
+fn module_seed_assignment_name(il: &Il, stmt: NodeId, local_scope: &[bool]) -> Option<Symbol> {
+    assignment_name_in_scope(il, stmt, local_scope)
+        .or_else(|| evidence_backed_raw_assignment_name(il, stmt))
+}
+
+fn evidence_backed_raw_assignment_name(il: &Il, stmt: NodeId) -> Option<Symbol> {
+    if il.kind(stmt) != NodeKind::Assign {
+        return None;
+    }
+    let kids = il.children(stmt);
+    if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Var {
+        return None;
+    }
+    let Payload::Name(symbol) = il.node(kids[0]).payload else {
+        return None;
+    };
+    let rhs = kids[1];
+    if import_fact_evidence_rhs(il, rhs).is_some()
+        || imported_literal_producer_evidence_for_node(il, rhs)
+    {
+        Some(symbol)
+    } else {
+        None
     }
 }
 
@@ -908,13 +940,21 @@ impl<'a> Builder<'a> {
             else {
                 return false;
             };
-            let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+            let LibraryApiCalleeContract::FreeName { name, .. } = contract.callee else {
                 return false;
             };
             s.is_free_name_value(callee, name)
-                && library_api_free_name_shadow_safe(s.il.meta.lang, name, shadow, |candidate| {
-                    s.file_defines_name(candidate)
-                })
+                && matches!(
+                    s.library_api_evidence_for_value_call(
+                        value,
+                        callee,
+                        None,
+                        contract.id,
+                        contract.callee,
+                        1,
+                    ),
+                    LibraryApiEvidenceStatus::Admitted
+                )
         })
     }
 
@@ -923,9 +963,7 @@ impl<'a> Builder<'a> {
     fn proven_python_deque_collection_value(&self, value: ValueId) -> Option<ValueId> {
         self.collection_factory_seq(value, |s, callee| {
             library_imported_collection_factory_contracts(s.il.meta.lang).any(|contract| {
-                let LibraryApiCalleeContract::ImportedBinding { module, exported } =
-                    contract.callee
-                else {
+                let LibraryApiCalleeContract::ImportedBinding { .. } = contract.callee else {
                     return false;
                 };
                 let receiver = match s.nodes[callee as usize].op {
@@ -942,9 +980,7 @@ impl<'a> Builder<'a> {
                 ) {
                     LibraryApiEvidenceStatus::Admitted => true,
                     LibraryApiEvidenceStatus::Rejected => false,
-                    LibraryApiEvidenceStatus::Missing => {
-                        s.is_import_binding_value(callee, module, exported)
-                    }
+                    LibraryApiEvidenceStatus::Missing => false,
                 }
             })
         })
@@ -978,11 +1014,7 @@ impl<'a> Builder<'a> {
                     receiver_name,
                     method,
                 )?;
-                let LibraryApiCalleeContract::JavaUtilStaticMember {
-                    receiver: expected_receiver,
-                    ..
-                } = contract.callee
-                else {
+                let LibraryApiCalleeContract::JavaUtilStaticMember { .. } = contract.callee else {
                     return None;
                 };
                 match self.library_api_evidence_for_value_call(
@@ -995,9 +1027,7 @@ impl<'a> Builder<'a> {
                 ) {
                     LibraryApiEvidenceStatus::Admitted => Some(contract),
                     LibraryApiEvidenceStatus::Rejected => None,
-                    LibraryApiEvidenceStatus::Missing => self
-                        .is_imported_java_util_name(receiver, expected_receiver)
-                        .then_some(contract),
+                    LibraryApiEvidenceStatus::Missing => None,
                 }
             })?;
         // A single argument to a varargs collection factory (`Arrays.asList(x)`,
@@ -1024,8 +1054,8 @@ impl<'a> Builder<'a> {
     }
 
     fn proven_ruby_set_factory_value(&self, value: ValueId) -> Option<ValueId> {
-        self.collection_factory_seq(value, |s, callee| {
-            let callee = &s.nodes[callee as usize];
+        self.collection_factory_seq(value, |s, callee_value| {
+            let callee = &s.nodes[callee_value as usize];
             let ValOp::Field(method) = callee.op else {
                 return false;
             };
@@ -1034,19 +1064,24 @@ impl<'a> Builder<'a> {
             else {
                 return false;
             };
-            let LibraryApiCalleeContract::RubyRequireStaticMember {
-                receiver,
-                required_module,
-                shadow_root,
-                ..
-            } = contract.callee
+            let LibraryApiCalleeContract::RubyRequireStaticMember { receiver, .. } =
+                contract.callee
             else {
                 return false;
             };
             callee.args.len() == 1
-                && s.ruby_file_requires_module(required_module)
-                && !s.file_defines_name(shadow_root)
                 && s.is_free_name_value(callee.args[0], receiver)
+                && matches!(
+                    s.library_api_evidence_for_value_call(
+                        value,
+                        callee_value,
+                        Some(callee.args[0]),
+                        contract.id,
+                        contract.callee,
+                        1,
+                    ),
+                    LibraryApiEvidenceStatus::Admitted
+                )
         })
     }
 
@@ -1063,22 +1098,25 @@ impl<'a> Builder<'a> {
         }
         let args = node.args.clone();
         let contract = library_rust_vec_macro_factory_contract(self.il.meta.lang, "vec")?;
-        let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+        let LibraryApiCalleeContract::RustMacro { name, .. } = contract.callee else {
             return None;
         };
         if !self.is_free_name_value(args[0], name)
-            || !library_api_free_name_shadow_safe(self.il.meta.lang, name, shadow, |candidate| {
-                self.file_defines_name(candidate)
-            })
+            || !matches!(
+                self.library_api_evidence_for_value_call(
+                    value,
+                    args[0],
+                    None,
+                    contract.id,
+                    contract.callee,
+                    args.len().saturating_sub(1),
+                ),
+                LibraryApiEvidenceStatus::Admitted
+            )
         {
             return None;
         }
         Some(self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), args[1..].to_vec()))
-    }
-
-    fn is_imported_java_util_name(&self, value: ValueId, name: &str) -> bool {
-        !self.java_file_defines_type_name(name)
-            && self.is_import_binding_value(value, "java.util", name)
     }
 
     fn is_import_namespace_expr(
@@ -1100,6 +1138,7 @@ impl<'a> Builder<'a> {
         )
     }
 
+    #[cfg(test)]
     fn is_import_binding_value(&self, value: ValueId, module: &str, exported: &str) -> bool {
         let node = &self.nodes[value as usize];
         matches!(
@@ -1136,21 +1175,6 @@ impl<'a> Builder<'a> {
             .modules()
             .go_import_namespace_facts()
             && imported_namespace_symbol(self.il, self.interner, expr, module)
-    }
-
-    fn java_file_defines_type_name(&self, name: &str) -> bool {
-        if !semantics(self.il.meta.lang)
-            .modules()
-            .java_type_declarations_shadow_stdlib()
-        {
-            return false;
-        }
-        self.il.units.iter().any(|unit| {
-            unit.kind == UnitKind::Class
-                && unit
-                    .name
-                    .is_some_and(|symbol| self.interner.resolve(symbol) == name)
-        })
     }
 
     fn file_defines_name(&self, name: &str) -> bool {
@@ -1191,37 +1215,6 @@ impl<'a> Builder<'a> {
     fn symbol_defines_name(&self, symbol: Symbol, name: &str) -> bool {
         let text = self.interner.resolve(symbol);
         text == name || (self.is_js_like_lang() && contains_js_identifier(text, name))
-    }
-
-    fn ruby_file_requires_module(&self, module: &str) -> bool {
-        if !semantics(self.il.meta.lang).stdlib().ruby_set_factory() {
-            return false;
-        }
-        let expected = stable_symbol_hash(module);
-        self.top_level_statements().iter().any(|&stmt| {
-            let expr = if self.il.kind(stmt) == NodeKind::ExprStmt {
-                self.il.children(stmt).first().copied()
-            } else {
-                Some(stmt)
-            };
-            let Some(call) = expr else {
-                return false;
-            };
-            if self.il.kind(call) != NodeKind::Call {
-                return false;
-            }
-            let kids = self.il.children(call);
-            if kids.len() != 2 || self.il.kind(kids[0]) != NodeKind::Var {
-                return false;
-            }
-            let Payload::Name(callee) = self.il.node(kids[0]).payload else {
-                return false;
-            };
-            if self.interner.resolve(callee) != "require" {
-                return false;
-            }
-            matches!(self.il.node(kids[1]).payload, Payload::LitStr(hash) if hash == expected)
-        })
     }
 
     fn proven_collection_value(&mut self, value: ValueId) -> Option<ValueId> {
@@ -1360,15 +1353,20 @@ impl<'a> Builder<'a> {
         }
         let entry_tag =
             library_free_name_map_factory_contracts(self.il.meta.lang).find_map(|contract| {
-                let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+                let LibraryApiCalleeContract::FreeName { name, .. } = contract.callee else {
                     return None;
                 };
                 if !self.is_free_name_value(callee, name)
-                    || !library_api_free_name_shadow_safe(
-                        self.il.meta.lang,
-                        name,
-                        shadow,
-                        |candidate| self.file_defines_name(candidate),
+                    || !matches!(
+                        self.library_api_evidence_for_value_call(
+                            value,
+                            callee,
+                            None,
+                            contract.id,
+                            contract.callee,
+                            1,
+                        ),
+                        LibraryApiEvidenceStatus::Admitted
                     )
                 {
                     return None;
@@ -1416,11 +1414,7 @@ impl<'a> Builder<'a> {
             return None;
         }
         let contract = library_java_map_factory_contract_by_hash(self.il.meta.lang, "Map", method)?;
-        let LibraryApiCalleeContract::JavaUtilStaticMember {
-            receiver: expected_receiver,
-            ..
-        } = contract.callee
-        else {
+        let LibraryApiCalleeContract::JavaUtilStaticMember { .. } = contract.callee else {
             return None;
         };
         let api_status = self.library_api_evidence_for_value_call(
@@ -1431,17 +1425,10 @@ impl<'a> Builder<'a> {
             contract.callee,
             args.len().saturating_sub(1),
         );
-        let snapshot_proven = self.imported_literal_snapshot_proven(value, NodeKind::Call);
         match api_status {
             LibraryApiEvidenceStatus::Admitted => {}
             LibraryApiEvidenceStatus::Rejected => return None,
-            LibraryApiEvidenceStatus::Missing => {
-                if !snapshot_proven
-                    && !self.is_imported_java_util_name(callee.args[0], expected_receiver)
-                {
-                    return None;
-                }
-            }
+            LibraryApiEvidenceStatus::Missing => return None,
         }
         let LibraryMapFactoryResult::JavaFactory { kind } = contract.result else {
             return None;
@@ -1460,7 +1447,7 @@ impl<'a> Builder<'a> {
         if kind == JavaMapFactoryKind::OfEntries {
             let mut canonical_entries = Vec::with_capacity(args.len().saturating_sub(1));
             for entry in args.iter().skip(1).copied() {
-                let kv = self.proven_java_map_entry_pair(entry, snapshot_proven)?;
+                let kv = self.proven_java_map_entry_pair(entry)?;
                 canonical_entries.push(self.mk(ValOp::Seq(SEQ_VALUE_PAIR), kv));
             }
             return Some(self.mk(ValOp::Seq(SEQ_VALUE_MAP), canonical_entries));
@@ -1468,11 +1455,7 @@ impl<'a> Builder<'a> {
         None
     }
 
-    fn proven_java_map_entry_pair(
-        &self,
-        value: ValueId,
-        snapshot_proven: bool,
-    ) -> Option<Vec<ValueId>> {
+    fn proven_java_map_entry_pair(&self, value: ValueId) -> Option<Vec<ValueId>> {
         let node = &self.nodes[value as usize];
         if !matches!(node.op, ValOp::Call(0)) || node.args.len() != 3 {
             return None;
@@ -1483,11 +1466,7 @@ impl<'a> Builder<'a> {
             return None;
         };
         let contract = library_java_map_entry_contract_by_hash(self.il.meta.lang, "Map", method)?;
-        let LibraryApiCalleeContract::JavaUtilStaticMember {
-            receiver: expected_receiver,
-            ..
-        } = contract.callee
-        else {
+        let LibraryApiCalleeContract::JavaUtilStaticMember { .. } = contract.callee else {
             return None;
         };
         if callee.args.len() != 1 {
@@ -1503,20 +1482,9 @@ impl<'a> Builder<'a> {
         ) {
             LibraryApiEvidenceStatus::Admitted => {}
             LibraryApiEvidenceStatus::Rejected => return None,
-            LibraryApiEvidenceStatus::Missing => {
-                if !snapshot_proven
-                    && !self.is_imported_java_util_name(callee.args[0], expected_receiver)
-                {
-                    return None;
-                }
-            }
+            LibraryApiEvidenceStatus::Missing => return None,
         }
         Some(args[1..].to_vec())
-    }
-
-    fn imported_literal_snapshot_proven(&self, value: ValueId, kind: NodeKind) -> bool {
-        self.node_span[value as usize]
-            .is_some_and(|span| imported_literal_snapshot_evidence_at_span(self.il, span, kind))
     }
 
     fn library_api_evidence_for_value_call(
@@ -1568,11 +1536,7 @@ impl<'a> Builder<'a> {
         if let Some(contract) =
             library_js_like_set_constructor_contract(self.il.meta.lang, constructor)
         {
-            let LibraryApiCalleeContract::JsGlobalConstructor {
-                receiver,
-                requires_unshadowed_global,
-            } = contract.callee
-            else {
+            let LibraryApiCalleeContract::JsGlobalConstructor { .. } = contract.callee else {
                 return None;
             };
             match library_api_contract_evidence_for_call(
@@ -1585,13 +1549,7 @@ impl<'a> Builder<'a> {
             ) {
                 LibraryApiEvidenceStatus::Admitted => {}
                 LibraryApiEvidenceStatus::Rejected => return None,
-                LibraryApiEvidenceStatus::Missing => {
-                    if requires_unshadowed_global
-                        && !unshadowed_global_symbol(self.il, self.interner, kids[0], receiver)
-                    {
-                        return None;
-                    }
-                }
+                LibraryApiEvidenceStatus::Missing => return None,
             }
             if !self.is_static_non_float_collection_expr(kids[1]) {
                 return None;
@@ -1599,11 +1557,7 @@ impl<'a> Builder<'a> {
             return Some(self.eval_membership_collection(kids[1], env));
         }
         let contract = library_js_like_map_constructor_contract(self.il.meta.lang, constructor)?;
-        let LibraryApiCalleeContract::JsGlobalConstructor {
-            receiver,
-            requires_unshadowed_global,
-        } = contract.callee
-        else {
+        let LibraryApiCalleeContract::JsGlobalConstructor { .. } = contract.callee else {
             return None;
         };
         match library_api_contract_evidence_for_call(
@@ -1616,13 +1570,7 @@ impl<'a> Builder<'a> {
         ) {
             LibraryApiEvidenceStatus::Admitted => {}
             LibraryApiEvidenceStatus::Rejected => return None,
-            LibraryApiEvidenceStatus::Missing => {
-                if requires_unshadowed_global
-                    && !unshadowed_global_symbol(self.il, self.interner, kids[0], receiver)
-                {
-                    return None;
-                }
-            }
+            LibraryApiEvidenceStatus::Missing => return None,
         }
         let LibraryMapFactoryResult::EntrySequence { entry_seq_tag } = contract.result else {
             return None;
@@ -1805,16 +1753,7 @@ impl<'a> Builder<'a> {
             ) {
                 LibraryApiEvidenceStatus::Admitted => {}
                 LibraryApiEvidenceStatus::Rejected => return None,
-                LibraryApiEvidenceStatus::Missing => {
-                    if !qualified_global_symbol_at_span(
-                        self.il,
-                        self.node_span[args[0] as usize],
-                        NodeKind::Field,
-                        contract.result.qualified_path,
-                    ) {
-                        return None;
-                    }
-                }
+                LibraryApiEvidenceStatus::Missing => return None,
             }
             return self.proven_map_key_view_value_matching(args[1], MapKeyViewKind::Iterator);
         }
@@ -3000,7 +2939,7 @@ impl<'a> Builder<'a> {
     }
 
     fn assignment_name(&self, stmt: NodeId) -> Option<Symbol> {
-        assignment_name_in_scope(self.il, stmt, &self.local_scope_nodes)
+        module_seed_assignment_name(self.il, stmt, &self.local_scope_nodes)
     }
 
     fn unit_defines_symbol(&self, symbol: Symbol) -> bool {
@@ -7004,7 +6943,6 @@ impl<'a> Builder<'a> {
             self.interner.resolve(name),
             kids.len().saturating_sub(1),
         )?;
-        let base = *self.il.children(callee).first()?;
         match library_api_contract_evidence_for_call(
             self.il,
             self.interner,
@@ -7015,11 +6953,7 @@ impl<'a> Builder<'a> {
         ) {
             LibraryApiEvidenceStatus::Admitted => {}
             LibraryApiEvidenceStatus::Rejected => return None,
-            LibraryApiEvidenceStatus::Missing => {
-                if !self.is_import_namespace_expr(base, contract.result.module, env) {
-                    return None;
-                }
-            }
+            LibraryApiEvidenceStatus::Missing => return None,
         }
         let ImportedNamespaceFunctionSemantic::ProductReduction { op, identity } =
             contract.result.semantic;
@@ -7472,13 +7406,28 @@ impl<'a> Builder<'a> {
         Some((receiver, kids[1]))
     }
 
-    fn is_rust_vec_new_call(&self, callee: NodeId) -> bool {
+    fn is_rust_vec_new_call(&self, call: NodeId, callee: NodeId) -> bool {
         let (NodeKind::Var, Payload::Name(name)) =
             (self.il.kind(callee), self.il.node(callee).payload)
         else {
             return false;
         };
-        self.rust_vec_new_name(self.interner.resolve(name))
+        let Some(contract) =
+            library_rust_vec_new_factory_contract(self.il.meta.lang, self.interner.resolve(name))
+        else {
+            return false;
+        };
+        matches!(
+            library_api_contract_evidence_for_call(
+                self.il,
+                self.interner,
+                call,
+                contract.id,
+                contract.callee,
+                0,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        )
     }
 
     fn rust_option_some_name(&self, text: &str) -> bool {
@@ -7497,18 +7446,6 @@ impl<'a> Builder<'a> {
             return false;
         };
         self.rust_option_none_name(self.interner.resolve(name))
-    }
-
-    fn rust_vec_new_name(&self, text: &str) -> bool {
-        library_rust_vec_new_factory_contract(self.il.meta.lang, text).is_some_and(|contract| {
-            let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
-                return false;
-            };
-            name == text
-                && library_api_free_name_shadow_safe(self.il.meta.lang, name, shadow, |candidate| {
-                    self.file_defines_name(candidate)
-                })
-        })
     }
 
     fn is_null_literal(&self, node: NodeId) -> bool {
@@ -7919,7 +7856,7 @@ impl<'a> Builder<'a> {
                 if let Some(r) = self.eval_rust_map_get_is_some_call(&kids, env) {
                     return r;
                 }
-                if kids.len() == 1 && self.is_rust_vec_new_call(kids[0]) {
+                if kids.len() == 1 && self.is_rust_vec_new_call(expr, kids[0]) {
                     return self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), vec![]);
                 }
                 if let Some(v) = self.eval_js_like_constructed_collection_or_map(expr, &kids, env) {
@@ -8591,9 +8528,10 @@ mod tests {
     };
     use nose_semantics::{
         library_api_callee_contract_hash, library_api_contract_id_hash,
+        library_free_name_collection_factory_contract,
         library_imported_collection_factory_contract, library_java_collection_factory_contract,
-        library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
-        LibraryApiContractId, FIRST_PARTY_PACK_ID,
+        library_java_map_factory_contract, library_js_like_map_constructor_contract,
+        library_js_like_set_constructor_contract, LibraryApiContractId, FIRST_PARTY_PACK_ID,
     };
 
     fn sp(line: u32) -> Span {
@@ -8728,6 +8666,54 @@ mod tests {
         builder
             .proven_collection_value(raw)
             .map(|value| builder.nodes[value as usize].op.clone())
+    }
+
+    #[test]
+    fn free_name_collection_factory_value_graph_requires_library_api_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let callee = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("list")),
+            sp(20),
+            &[],
+        );
+        let item = b.add(NodeKind::Lit, Payload::LitInt(1), sp(21), &[]);
+        let seq = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(22),
+            &[item],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(23), &[callee, seq]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(19), &[call]);
+        let mut il = finish_test_il(b, root, Lang::Python);
+        il.evidence.push(collection_sequence_evidence(0, sp(22)));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(sp(20), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("list"),
+            }),
+        ));
+        assert!(
+            eval_proven_collection_op(&il, &interner, call).is_none(),
+            "symbol proof alone must not prove the migrated free-name factory"
+        );
+
+        let contract = library_free_name_collection_factory_contract(Lang::Python, "list").unwrap();
+        il.evidence.push(library_api_contract_evidence(
+            2,
+            sp(23),
+            contract.id,
+            contract.callee,
+            1,
+            vec![EvidenceId(1)],
+        ));
+        assert!(matches!(
+            eval_proven_collection_op(&il, &interner, call),
+            Some(ValOp::Seq(SEQ_VALUE_COLLECTION))
+        ));
     }
 
     #[derive(Clone, Copy)]
@@ -8994,6 +8980,10 @@ mod tests {
                 .expect("deque contract");
         push_imported_binding_use(&mut il, 0, sp(60), 1, sp(61), "collections", "deque");
         il.evidence.push(collection_sequence_evidence(2, sp(63)));
+        assert!(
+            eval_proven_collection_op(&il, &interner, call).is_none(),
+            "import symbol proof alone must not prove the migrated stdlib factory"
+        );
         il.evidence.push(library_api_contract_evidence(
             3,
             sp(64),
@@ -9049,6 +9039,10 @@ mod tests {
         let contract = library_java_collection_factory_contract(Lang::Java, "List", "of")
             .expect("List.of contract");
         push_imported_binding_use(&mut il, 0, sp(70), 1, sp(71), "java.util", "List");
+        assert!(
+            eval_proven_collection_op(&il, &interner, call).is_none(),
+            "java.util import proof alone must not prove the migrated Java factory"
+        );
         il.evidence.push(library_api_contract_evidence(
             2,
             sp(75),
@@ -9060,6 +9054,330 @@ mod tests {
         let admitted = eval_proven_collection_op(&il, &interner, call)
             .expect("admitted LibraryApi evidence should prove the Java factory");
         assert!(matches!(admitted, ValOp::Seq(SEQ_VALUE_COLLECTION)));
+    }
+
+    #[test]
+    fn java_map_factory_value_graph_uses_library_api_after_import_seed() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let map = interner.intern("Map");
+        let lookup = interner.intern("LOOKUP");
+        let import_lhs = b.add(NodeKind::Var, Payload::Name(map), sp(100), &[]);
+        let module = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("java.util")),
+            sp(100),
+            &[],
+        );
+        let exported = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("Map")),
+            sp(100),
+            &[],
+        );
+        let import_rhs = b.add(NodeKind::Seq, Payload::None, sp(100), &[module, exported]);
+        let import = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            sp(100),
+            &[import_lhs, import_rhs],
+        );
+        let receiver = b.add(NodeKind::Var, Payload::Name(map), sp(101), &[]);
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("of")),
+            sp(102),
+            &[receiver],
+        );
+        let red = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("red")),
+            sp(103),
+            &[],
+        );
+        let one = b.add(NodeKind::Lit, Payload::LitInt(1), sp(104), &[]);
+        let blue = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("blue")),
+            sp(105),
+            &[],
+        );
+        let two = b.add(NodeKind::Lit, Payload::LitInt(2), sp(106), &[]);
+        let call = b.add(
+            NodeKind::Call,
+            Payload::None,
+            sp(107),
+            &[callee, red, one, blue, two],
+        );
+        let lookup_lhs = b.add(NodeKind::Var, Payload::Name(lookup), sp(108), &[]);
+        let lookup_assign = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            sp(108),
+            &[lookup_lhs, call],
+        );
+        let lookup_ref = b.add(NodeKind::Var, Payload::Name(lookup), sp(109), &[]);
+        let root = b.add(
+            NodeKind::Module,
+            Payload::None,
+            sp(100),
+            &[import, lookup_assign, lookup_ref],
+        );
+        let mut il = finish_test_il(b, root, Lang::Java);
+        let contract =
+            library_java_map_factory_contract(Lang::Java, "Map", "of").expect("Map.of contract");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(100)),
+            EvidenceKind::Import(ImportEvidenceKind::Binding {
+                module_hash: stable_symbol_hash("java.util"),
+                exported_hash: stable_symbol_hash("Map"),
+            }),
+        ));
+        push_imported_binding_use(&mut il, 1, sp(100), 2, sp(101), "java.util", "Map");
+        il.evidence.push(library_api_contract_evidence(
+            3,
+            sp(107),
+            contract.id,
+            contract.callee,
+            4,
+            vec![EvidenceId(2)],
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            4,
+            EvidenceAnchor::node(sp(107), NodeKind::Call),
+            EvidenceKind::Import(ImportEvidenceKind::ImportedLiteralSnapshot {
+                module_hash: stable_symbol_hash("LookupProvider"),
+                exported_hash: stable_symbol_hash("LOOKUP"),
+                root_kind: NodeKind::Call,
+            }),
+            vec![EvidenceId(3)],
+        ));
+
+        let mut builder = Builder::new(&il, &interner);
+        assert!(!builder.unit_defines_symbol(lookup));
+        assert!(
+            !builder.module_binding_mutated(lookup),
+            "read-only getOrDefault use must not mark LOOKUP as mutated"
+        );
+        builder.seed_module_value_bindings();
+        let raw = builder.eval(call, &FxHashMap::default());
+        let raw_args = builder.nodes[raw as usize].args.clone();
+        let raw_callee = raw_args[0];
+        let raw_receiver = builder.nodes[raw_callee as usize].args.first().copied();
+        assert_eq!(
+            builder.library_api_evidence_for_value_call(
+                raw,
+                raw_callee,
+                raw_receiver,
+                contract.id,
+                contract.callee,
+                4
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        );
+        assert!(matches!(
+            builder
+                .proven_map_value(raw)
+                .map(|value| builder.nodes[value as usize].op.clone()),
+            Some(ValOp::Seq(SEQ_VALUE_MAP))
+        ));
+        let proven = builder.eval(lookup_ref, &FxHashMap::default());
+        assert!(
+            builder.global_env.contains_key(&lookup),
+            "LOOKUP should be seeded as an immutable module binding"
+        );
+        assert!(
+            matches!(builder.nodes[proven as usize].op, ValOp::Seq(SEQ_VALUE_MAP)),
+            "expected LOOKUP to seed as map"
+        );
+    }
+
+    #[test]
+    fn normalized_java_static_import_map_binding_feeds_get_or_default() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let map = interner.intern("Map");
+        let lookup = interner.intern("LOOKUP");
+        let lookup_method = interner.intern("lookup");
+
+        let import_lhs = b.add(NodeKind::Var, Payload::Cid(0), sp(130), &[]);
+        let module = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("java.util")),
+            sp(130),
+            &[],
+        );
+        let exported = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("Map")),
+            sp(130),
+            &[],
+        );
+        let import_rhs = b.add(NodeKind::Seq, Payload::None, sp(130), &[module, exported]);
+        let import = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            sp(130),
+            &[import_lhs, import_rhs],
+        );
+
+        let receiver = b.add(NodeKind::Var, Payload::Cid(0), sp(131), &[]);
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("of")),
+            sp(132),
+            &[receiver],
+        );
+        let red = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("red")),
+            sp(133),
+            &[],
+        );
+        let one = b.add(NodeKind::Lit, Payload::LitInt(1), sp(134), &[]);
+        let blue = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("blue")),
+            sp(135),
+            &[],
+        );
+        let two = b.add(NodeKind::Lit, Payload::LitInt(2), sp(136), &[]);
+        let map_of = b.add(
+            NodeKind::Call,
+            Payload::None,
+            sp(137),
+            &[callee, red, one, blue, two],
+        );
+        let lookup_lhs = b.add(NodeKind::Var, Payload::Cid(1), sp(138), &[]);
+        let lookup_assign = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            sp(138),
+            &[lookup_lhs, map_of],
+        );
+
+        let key_param = b.add(NodeKind::Param, Payload::Cid(2), sp(139), &[]);
+        let other_param = b.add(NodeKind::Param, Payload::Cid(3), sp(139), &[]);
+        let lookup_receiver = b.add(NodeKind::Var, Payload::Name(lookup), sp(140), &[]);
+        let get_or_default = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("getOrDefault")),
+            sp(141),
+            &[lookup_receiver],
+        );
+        let key_ref = b.add(NodeKind::Var, Payload::Cid(2), sp(142), &[]);
+        let fallback = b.add(NodeKind::Lit, Payload::LitInt(0), sp(143), &[]);
+        let get_call = b.add(
+            NodeKind::Call,
+            Payload::None,
+            sp(144),
+            &[get_or_default, key_ref, fallback],
+        );
+        let ret = b.add(NodeKind::Return, Payload::None, sp(144), &[get_call]);
+        let body = b.add(NodeKind::Block, Payload::None, sp(144), &[ret]);
+        let func = b.add(
+            NodeKind::Func,
+            Payload::None,
+            sp(139),
+            &[key_param, other_param, body],
+        );
+        let root = b.add(
+            NodeKind::Module,
+            Payload::None,
+            sp(130),
+            &[import, lookup_assign, func],
+        );
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "JavaImported.java".into(),
+                lang: Lang::Java,
+            },
+            vec![Unit {
+                root: func,
+                kind: UnitKind::Method,
+                name: Some(lookup_method),
+            }],
+            vec![map, lookup],
+        );
+        let contract =
+            library_java_map_factory_contract(Lang::Java, "Map", "of").expect("Map.of contract");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(130)),
+            EvidenceKind::Import(ImportEvidenceKind::Binding {
+                module_hash: stable_symbol_hash("java.util"),
+                exported_hash: stable_symbol_hash("Map"),
+            }),
+        ));
+        push_imported_binding_use(&mut il, 1, sp(130), 2, sp(131), "java.util", "Map");
+        il.evidence.push(library_api_contract_evidence(
+            3,
+            sp(137),
+            contract.id,
+            contract.callee,
+            4,
+            vec![EvidenceId(2)],
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            4,
+            EvidenceAnchor::node(sp(137), NodeKind::Call),
+            EvidenceKind::Import(ImportEvidenceKind::ImportedLiteralSnapshot {
+                module_hash: stable_symbol_hash("Tables"),
+                exported_hash: stable_symbol_hash("LOOKUP"),
+                root_kind: NodeKind::Call,
+            }),
+            vec![EvidenceId(3)],
+        ));
+
+        let mut builder = Builder::new(&il, &interner);
+        builder.seed_module_value_bindings();
+        assert!(
+            builder.global_env.contains_key(&lookup),
+            "normalized static import binding should seed the copied map value"
+        );
+
+        let mut env = FxHashMap::default();
+        env.insert(2, builder.mk(ValOp::Input(0), vec![]));
+        env.insert(3, builder.mk(ValOp::Input(1), vec![]));
+        let value = builder.eval(get_call, &env);
+        let node = &builder.nodes[value as usize];
+        assert!(matches!(
+            node.op,
+            ValOp::Call(tag) if tag == builtin_tag(Builtin::GetOrDefault)
+        ));
+        assert!(matches!(
+            builder.nodes[node.args[0] as usize].op,
+            ValOp::Seq(SEQ_VALUE_MAP)
+        ));
+    }
+
+    #[test]
+    fn raw_name_module_assignment_without_evidence_is_not_seeded() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let table = interner.intern("TABLE");
+        let lhs = b.add(NodeKind::Var, Payload::Name(table), sp(120), &[]);
+        let item = b.add(NodeKind::Lit, Payload::LitInt(1), sp(120), &[]);
+        let rhs = b.add(NodeKind::Seq, Payload::None, sp(120), &[item]);
+        let assign = b.add(NodeKind::Assign, Payload::None, sp(120), &[lhs, rhs]);
+        let table_ref = b.add(NodeKind::Var, Payload::Name(table), sp(121), &[]);
+        let root = b.add(
+            NodeKind::Module,
+            Payload::None,
+            sp(120),
+            &[assign, table_ref],
+        );
+        let il = finish_test_il(b, root, Lang::JavaScript);
+        let mut builder = Builder::new(&il, &interner);
+
+        builder.seed_module_value_bindings();
+
+        assert!(
+            !builder.global_env.contains_key(&table),
+            "raw Name assignments need first-party import or imported-literal evidence"
+        );
     }
 
     #[test]
@@ -9113,6 +9431,13 @@ mod tests {
         ));
         push_imported_namespace_use(&mut il, 1, sp(80), 2, sp(81), "collections");
         il.evidence.push(collection_sequence_evidence(3, sp(84)));
+        let mut builder = Builder::new(&il, &interner);
+        builder.seed_module_value_bindings();
+        let raw = builder.eval(call, &FxHashMap::default());
+        assert!(
+            builder.proven_collection_value(raw).is_none(),
+            "namespace import proof alone must not prove the migrated stdlib factory"
+        );
         il.evidence.push(library_api_contract_evidence(
             4,
             sp(85),
@@ -9250,14 +9575,14 @@ mod tests {
     }
 
     #[test]
-    fn js_constructor_value_graph_closes_on_conflicting_api_evidence() {
+    fn js_constructor_value_graph_requires_library_api_evidence() {
         let interner = Interner::new();
         let (mut il, call) = js_new_set_il(&interner);
 
         let mut builder = Builder::new(&il, &interner);
-        let legacy_proven = builder.eval(call, &FxHashMap::default());
-        assert!(matches!(
-            builder.nodes[legacy_proven as usize].op,
+        let missing = builder.eval(call, &FxHashMap::default());
+        assert!(!matches!(
+            builder.nodes[missing as usize].op,
             ValOp::Seq(SEQ_VALUE_COLLECTION)
         ));
 

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -1091,7 +1091,7 @@ fn imported_symbol(
     let Some(local_hash) = node_name_hash(il, interner, node) else {
         return false;
     };
-    if unit_defines_hash(il, interner, local_hash) {
+    if unit_defines_hash_visible_at(il, interner, local_hash, il.node(node).span) {
         return false;
     }
     let statements = top_level_statements(il);
@@ -1167,6 +1167,20 @@ fn unit_defines_hash(il: &Il, interner: &Interner, name_hash: u64) -> bool {
     })
 }
 
+fn unit_defines_hash_visible_at(
+    il: &Il,
+    interner: &Interner,
+    name_hash: u64,
+    occurrence_span: Span,
+) -> bool {
+    il.units.iter().any(|unit| {
+        il.node(unit.root).span.file == occurrence_span.file
+            && unit
+                .name
+                .is_some_and(|symbol| stable_symbol_hash(interner.resolve(symbol)) == name_hash)
+    })
+}
+
 fn file_defines_name(il: &Il, interner: &Interner, name: &str) -> bool {
     let name_hash = stable_symbol_hash(name);
     il.units.iter().any(|unit| {
@@ -1188,6 +1202,34 @@ fn file_defines_name(il: &Il, interner: &Interner, name: &str) -> bool {
                 .is_some_and(|lhs| node_defines_name(il, interner, lhs, name, name_hash)),
             _ => false,
         })
+}
+
+fn file_defines_name_visible_at(
+    il: &Il,
+    interner: &Interner,
+    name: &str,
+    occurrence_span: Span,
+) -> bool {
+    let name_hash = stable_symbol_hash(name);
+    il.units.iter().any(|unit| {
+        il.node(unit.root).span.file == occurrence_span.file
+            && unit.name.is_some_and(|symbol| {
+                symbol_defines_name(il.meta.lang, interner.resolve(symbol), name, name_hash)
+            })
+    }) || il.nodes.iter().enumerate().any(|(idx, node)| {
+        node.span.file == occurrence_span.file
+            && match node.kind {
+                NodeKind::Module | NodeKind::Block | NodeKind::Param => {
+                    node_defines_name(il, interner, NodeId(idx as u32), name, name_hash)
+                }
+                NodeKind::Assign => il
+                    .children(NodeId(idx as u32))
+                    .first()
+                    .copied()
+                    .is_some_and(|lhs| node_defines_name(il, interner, lhs, name, name_hash)),
+                _ => false,
+            }
+    })
 }
 
 fn node_defines_name(
@@ -3550,6 +3592,10 @@ pub enum LibraryApiCalleeContract {
         name: &'static str,
         shadow: LibraryApiShadowPolicy,
     },
+    RustMacro {
+        name: &'static str,
+        shadow: LibraryApiShadowPolicy,
+    },
     ImportedBinding {
         module: &'static str,
         exported: &'static str,
@@ -3614,6 +3660,7 @@ pub fn library_api_callee_contract_hash(callee: LibraryApiCalleeContract) -> u64
 fn library_api_callee_contract_key(callee: LibraryApiCalleeContract) -> String {
     match callee {
         LibraryApiCalleeContract::FreeName { name, .. } => format!("free_name:{name}"),
+        LibraryApiCalleeContract::RustMacro { name, .. } => format!("rust_macro:{name}"),
         LibraryApiCalleeContract::ImportedBinding { module, exported } => {
             format!("imported_binding:{module}:{exported}")
         }
@@ -3942,6 +3989,9 @@ fn library_api_callee_shape_matches(
         return false;
     };
     match callee {
+        LibraryApiCalleeContract::FreeName { .. } | LibraryApiCalleeContract::RustMacro { .. } => {
+            il.kind(callee_node) == NodeKind::Var
+        }
         LibraryApiCalleeContract::JsGlobalConstructor { receiver, .. } => {
             var_name_matches(il, interner, callee_node, receiver)
         }
@@ -3955,6 +4005,16 @@ fn library_api_callee_shape_matches(
                 return false;
             };
             actual_receiver == receiver && actual_method == method
+        }
+        LibraryApiCalleeContract::RubyRequireStaticMember { method, .. } => {
+            if il.kind(callee_node) != NodeKind::Field {
+                return false;
+            }
+            let Some(&receiver) = il.children(callee_node).first() else {
+                return false;
+            };
+            il.kind(receiver) == NodeKind::Var
+                && field_method_matches(il, interner, callee_node, method)
         }
         LibraryApiCalleeContract::RegexLiteralMethod { method, .. } => {
             field_method_matches(il, interner, callee_node, method)
@@ -3990,6 +4050,23 @@ fn library_api_dependencies_match_callee(
         return false;
     };
     match callee {
+        LibraryApiCalleeContract::FreeName { name, shadow } => {
+            dependency_has_unshadowed_global_node(il, record, callee_node, name)
+                && library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+                    file_defines_name_visible_at(il, interner, candidate, il.node(callee_node).span)
+                })
+        }
+        LibraryApiCalleeContract::RustMacro { name, shadow } => {
+            dependency_has_source_call(
+                il,
+                record,
+                il.node(node).span,
+                SourceCallKind::MacroInvocation,
+            ) && dependency_has_unshadowed_global_node(il, record, callee_node, name)
+                && library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+                    file_defines_name_visible_at(il, interner, candidate, il.node(callee_node).span)
+                })
+        }
         LibraryApiCalleeContract::JsGlobalConstructor {
             receiver,
             requires_unshadowed_global,
@@ -4012,7 +4089,36 @@ fn library_api_dependencies_match_callee(
                 receiver_node,
                 "java.util",
                 receiver,
-            ) && !unit_defines_hash(il, interner, stable_symbol_hash(receiver))
+            ) && !unit_defines_hash_visible_at(
+                il,
+                interner,
+                stable_symbol_hash(receiver),
+                il.node(receiver_node).span,
+            )
+        }
+        LibraryApiCalleeContract::RubyRequireStaticMember {
+            receiver,
+            required_module,
+            shadow_root,
+            ..
+        } => {
+            let Some(receiver_node) = il.children(callee_node).first().copied() else {
+                return false;
+            };
+            dependency_has_unshadowed_global_node(il, record, receiver_node, receiver)
+                && dependency_has_required_module_before(
+                    record,
+                    il,
+                    interner,
+                    required_module,
+                    il.node(node).span,
+                )
+                && !file_defines_name_visible_at(
+                    il,
+                    interner,
+                    shadow_root,
+                    il.node(receiver_node).span,
+                )
         }
         LibraryApiCalleeContract::RegexLiteralMethod {
             required_receiver_fact,
@@ -4063,6 +4169,25 @@ fn library_api_dependencies_match_callee_at_span(
     record: &EvidenceRecord,
 ) -> bool {
     match callee {
+        LibraryApiCalleeContract::FreeName { name, shadow } => {
+            callee_span.is_some_and(|span| {
+                dependency_has_unshadowed_global_anchor(il, record, span, NodeKind::Var, name)
+            }) && library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+                callee_span
+                    .is_some_and(|span| file_defines_name_visible_at(il, interner, candidate, span))
+            })
+        }
+        LibraryApiCalleeContract::RustMacro { name, shadow } => {
+            dependency_has_source_call(il, record, call_span, SourceCallKind::MacroInvocation)
+                && callee_span.is_some_and(|span| {
+                    dependency_has_unshadowed_global_anchor(il, record, span, NodeKind::Var, name)
+                })
+                && library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+                    callee_span.is_some_and(|span| {
+                        file_defines_name_visible_at(il, interner, candidate, span)
+                    })
+                })
+        }
         LibraryApiCalleeContract::JsGlobalConstructor {
             receiver,
             requires_unshadowed_global,
@@ -4124,7 +4249,29 @@ fn library_api_dependencies_match_callee_at_span(
                     receiver,
                 )
             };
-            receiver_proven && !unit_defines_hash(il, interner, stable_symbol_hash(receiver))
+            receiver_proven
+                && if let Some(span) = receiver_span {
+                    !unit_defines_hash_visible_at(il, interner, stable_symbol_hash(receiver), span)
+                } else {
+                    !unit_defines_hash(il, interner, stable_symbol_hash(receiver))
+                }
+        }
+        LibraryApiCalleeContract::RubyRequireStaticMember {
+            receiver,
+            required_module,
+            shadow_root,
+            ..
+        } => {
+            receiver_span.is_some_and(|span| {
+                dependency_has_unshadowed_global_anchor(il, record, span, NodeKind::Var, receiver)
+            }) && dependency_has_required_module_before(
+                record,
+                il,
+                interner,
+                required_module,
+                call_span,
+            ) && receiver_span
+                .is_some_and(|span| !file_defines_name_visible_at(il, interner, shadow_root, span))
         }
         LibraryApiCalleeContract::RegexLiteralMethod {
             required_receiver_fact,
@@ -4223,7 +4370,9 @@ fn imported_member_callee_shape_matches(
     exported: &str,
 ) -> bool {
     match il.kind(node) {
-        NodeKind::Var => var_name_matches(il, interner, node, exported),
+        // Aliased imports are proven by the imported-binding dependency, not by
+        // comparing the local callee spelling to the exported API name.
+        NodeKind::Var => true,
         NodeKind::Field => field_method_matches(il, interner, node, exported),
         _ => false,
     }
@@ -4284,6 +4433,72 @@ fn dependency_has_source_fact_anchor(
         ),
         EvidenceResolution::Found(fact) if fact == expected
     ) && dependency_has_asserted_record(il, record, anchor, EvidenceKind::Source(expected))
+}
+
+fn dependency_has_required_module_before(
+    record: &EvidenceRecord,
+    il: &Il,
+    interner: &Interner,
+    module: &str,
+    call_span: Span,
+) -> bool {
+    let expected = EvidenceKind::Import(ImportEvidenceKind::Require {
+        module_hash: stable_symbol_hash(module),
+    });
+    record.dependencies.iter().any(|id| {
+        il.evidence.get(id.0 as usize).is_some_and(|dependency| {
+            dependency.id == *id
+                && dependency.status == EvidenceStatus::Asserted
+                && dependency.kind == expected
+                && require_dependency_is_before_call(dependency, call_span)
+                && require_dependency_has_unshadowed_require(il, interner, dependency)
+        })
+    })
+}
+
+fn require_dependency_is_before_call(require_record: &EvidenceRecord, call_span: Span) -> bool {
+    matches!(
+        require_record.anchor,
+        EvidenceAnchor::SourceSpan(span)
+            if span.file == call_span.file && span.end_byte <= call_span.start_byte
+    )
+}
+
+fn require_dependency_has_unshadowed_require(
+    il: &Il,
+    interner: &Interner,
+    require_record: &EvidenceRecord,
+) -> bool {
+    let require_span = match require_record.anchor {
+        EvidenceAnchor::SourceSpan(span) => span,
+        _ => return false,
+    };
+    require_record.dependencies.iter().any(|id| {
+        let Some(dependency) = il.evidence.get(id.0 as usize) else {
+            return false;
+        };
+        let expected = SymbolEvidenceKind::UnshadowedGlobal {
+            name_hash: stable_symbol_hash("require"),
+        };
+        let EvidenceAnchor::Node {
+            span,
+            kind: NodeKind::Var,
+        } = dependency.anchor
+        else {
+            return false;
+        };
+        dependency.id == *id
+            && dependency.status == EvidenceStatus::Asserted
+            && dependency.kind == EvidenceKind::Symbol(expected)
+            && span.file == require_span.file
+            && span.start_byte >= require_span.start_byte
+            && span.end_byte <= require_span.end_byte
+            && !file_defines_name_visible_at(il, interner, "require", span)
+            && matches!(
+                symbol_evidence_at_node_anchor(il, span, NodeKind::Var),
+                EvidenceResolution::Found(actual) if actual == expected
+            )
+    })
 }
 
 fn dependency_has_unshadowed_global_node(
@@ -4551,7 +4766,7 @@ fn imported_occurrence_symbol_dependencies_valid(
     else {
         return false;
     };
-    if unit_defines_hash(il, interner, local_hash) {
+    if unit_defines_hash_visible_at(il, interner, local_hash, occurrence_span) {
         return false;
     }
     if !matches!(
@@ -4996,7 +5211,7 @@ pub fn library_rust_vec_macro_factory_contract(
 ) -> Option<LibraryCollectionFactoryContract> {
     (lang == Lang::Rust && name == "vec").then_some(LibraryCollectionFactoryContract {
         id: LibraryApiContractId::RustVecMacroFactory,
-        callee: LibraryApiCalleeContract::FreeName {
+        callee: LibraryApiCalleeContract::RustMacro {
             name: "vec",
             shadow: LibraryApiShadowPolicy::SameName,
         },
@@ -7164,7 +7379,7 @@ mod tests {
     fn library_api_evidence_resolution_accepts_import_and_source_backed_callees() {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
-        let local = interner.intern("deque");
+        let local = interner.intern("Values");
         let lhs = b.add(NodeKind::Var, Payload::Name(local), sp(10), &[]);
         let rhs = b.add(NodeKind::Seq, Payload::None, sp(10), &[]);
         let import = b.add(NodeKind::Assign, Payload::None, sp(10), &[lhs, rhs]);
@@ -7187,7 +7402,7 @@ mod tests {
         });
         il.evidence.push(evidence(
             0,
-            EvidenceAnchor::binding(sp(10), stable_symbol_hash("deque")),
+            EvidenceAnchor::binding(sp(10), stable_symbol_hash("Values")),
             binding_symbol,
             EvidenceStatus::Asserted,
         ));
@@ -7255,6 +7470,163 @@ mod tests {
             contract.callee,
             EvidenceStatus::Asserted,
             &[0],
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &il,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        );
+    }
+
+    #[test]
+    fn library_api_evidence_resolution_accepts_free_name_and_require_backed_callees() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let callee = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("list")),
+            sp(40),
+            &[],
+        );
+        let arg = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(41),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(42), &[callee, arg]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(39), &[call]);
+        let mut il = finish_il(b, root, Lang::Python);
+        let contract = library_free_name_collection_factory_contract(Lang::Python, "list")
+            .expect("Python list contract");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(40), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("list"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(library_api_record(
+            1,
+            sp(42),
+            contract.id,
+            contract.callee,
+            EvidenceStatus::Asserted,
+            &[0],
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &il,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        );
+        assert_eq!(
+            library_api_contract_evidence_at_call_span(
+                &il,
+                &interner,
+                LibraryApiSpanEvidenceQuery {
+                    call_span: Some(sp(42)),
+                    callee_span: Some(sp(40)),
+                    receiver_span: None,
+                    id: contract.id,
+                    callee: contract.callee,
+                    arg_count: 1,
+                },
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        );
+
+        let mut b = IlBuilder::new(FileId(0));
+        let require_callee = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("require")),
+            sp(48),
+            &[],
+        );
+        let require_arg = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("set")),
+            sp(48),
+            &[],
+        );
+        let require_call = b.add(
+            NodeKind::Call,
+            Payload::None,
+            sp(48),
+            &[require_callee, require_arg],
+        );
+        let set = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("Set")),
+            sp(50),
+            &[],
+        );
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("new")),
+            sp(51),
+            &[set],
+        );
+        let arg = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(52),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(53), &[callee, arg]);
+        let root = b.add(
+            NodeKind::Module,
+            Payload::None,
+            sp(49),
+            &[require_call, call],
+        );
+        let mut il = finish_il(b, root, Lang::Ruby);
+        let contract =
+            library_ruby_set_factory_contract(Lang::Ruby, "Set", "new", 1).expect("Set.new");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(50), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("Set"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(sp(48), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("require"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            2,
+            EvidenceAnchor::source_span(sp(48)),
+            EvidenceKind::Import(ImportEvidenceKind::Require {
+                module_hash: stable_symbol_hash("set"),
+            }),
+            EvidenceStatus::Asserted,
+            vec![EvidenceId(1)],
+        ));
+        il.evidence.push(library_api_record(
+            3,
+            sp(53),
+            contract.id,
+            contract.callee,
+            EvidenceStatus::Asserted,
+            &[0, 2],
         ));
         assert_eq!(
             library_api_contract_evidence_for_call(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,8 +65,9 @@ source ──tree-sitter──▶ raw IL ──normalize──▶ canonical IL �
    scores candidates with structural alignment (RANSAC) plus weighted shape/value
    Jaccard and accepts above the inline `near:T` threshold (default `near:0.70`), and
    `syntax` emits duplicated runs above the line/token floors. Experimental
-   `abstraction` then filters accepted near-style pairs to same-language, single
-   supported literal-leaf holes and attaches a weak witness instead of an exact claim.
+   `abstraction` then checks same-language near-style families for one shared
+   supported literal-leaf hole position and attaches a weak witness instead of an
+   exact claim.
 6. **Cluster & rank**: union-find over accepted pairs/runs forms clone groups, which
    are grouped into **families** and sorted by refactoring value (removable lines
    × similarity × cross-module/-file/-language spread). See [usage](usage.md) for how the

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -149,8 +149,8 @@ Each type maps to a detection channel by evidence surface: **Type-1 and token-le
 copy floors → `syntax`**, identifier/type-normalized **Type-2 → `semantic` or `near`**,
 literal-varied Type-2 and **Type-3 → `near`** (fuzzy; the threshold rides on the mode,
 `near:0.8`), and exact **Type-4 → `semantic`**. The experimental
-`abstraction[:T]` mode is a weak witness layer over a narrow `near` subset; it does not
-feed `semantic` or `verify`. The default is `syntax,semantic`; see
+`abstraction[:T]` mode is a weak family-wide witness layer over a narrow `near` subset;
+it does not feed `semantic` or `verify`. The default is `syntax,semantic`; see
 [usage → Scan modes](usage.md#scan-modes) for the full table and how to compose channels.
 
 The taxonomy is usually stated within a single language; because every language lowers to

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -57,14 +57,14 @@ The current implemented kinds are:
 
 | kind | purpose |
 |---|---|
-| `Source` | construct syntax, regex literal provenance, and source operator family |
+| `Source` | construct syntax, Rust macro invocation syntax, regex literal provenance, and source operator family |
 | `Domain` | receiver/value domain such as collection, map, option, string, integer, or byte array |
-| `Import` | static import binding/namespace proof and imported-literal snapshot provenance |
+| `Import` | static import binding/namespace proof, Ruby `require` module proof, and imported-literal snapshot provenance |
 | `Symbol` | resolved or proven symbol identity, with record kinds for unshadowed globals, static imported binding/namespace aliases, and selected qualified global API paths |
 | `Guard` | multi-obligation guard proof facts such as JS/TS record-shape and own-property guard contracts |
 | `Place` | fixed receiver/place facts currently covering `SelfReceiver` and `SelfField` |
 | `Effect` | observable effect facts currently covering canonical builder append calls, non-overloadable index writes, and fixed self-field writes |
-| `LibraryApi` | proof that a specific call occurrence matches a language/API contract coordinate, currently for selected JS-like static/global APIs plus selected import/source-backed Python, Java, and regex APIs |
+| `LibraryApi` | proof that a specific call occurrence matches a language/API contract coordinate, currently for selected JS-like static/global APIs plus selected Python, Rust, Ruby, Java, and regex APIs |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, guard surfaces, Go composite map literals, or Go map entries |
 
 `LibraryApi` evidence is an occurrence fact, not the whole contract. It records
@@ -75,6 +75,31 @@ and the remaining obligations. Existing evidence kinds such as `Symbol`,
 contract decides whether the facts are enough to admit an exact or value-graph
 path. A future external pack schema may expose library API contracts, but
 providers still emit facts and contracts rather than exact-clone verdicts.
+
+Current first-party `LibraryApi` callee coordinates are intentionally specific:
+
+- `QualifiedGlobal`-backed coordinates, such as `StaticGlobalMethod` and
+  `StaticGlobalFunction`, name an allowed language/API path and depend on
+  matching symbol evidence for the anchored call occurrence.
+- `ImportedBinding` and `ImportedNamespaceFunction` name a module/export or
+  namespace/function identity and depend on import-backed call-site symbol
+  evidence. They do not infer semantics from the local alias spelling.
+- `FreeName` names a language-scoped free identifier, such as Python `list` or
+  Rust `Vec`, and depends on `Symbol(UnshadowedGlobal)` evidence at the callee
+  anchor plus the contract's shadow policy.
+- `JavaUtilStaticMember` names selected Java `java.util` static factory/adaptor
+  calls and depends on matching Java import-binding evidence plus source-origin
+  local type shadow checks.
+- `RustMacro` names a Rust macro invocation, currently `vec!`, and depends on
+  both `Source::Call(MacroInvocation)` at the call span and
+  `Symbol(UnshadowedGlobal)` evidence at the macro callee anchor.
+- `RubyRequireStaticMember` names a Ruby receiver/method pair, currently
+  `Set.new`, and depends on both an unshadowed receiver symbol and a matching
+  earlier `Import::Require` module fact whose own dependency proves the
+  `require` callee identity.
+- `JsGlobalConstructor` and `RegexLiteralMethod` name APIs whose identity
+  includes source provenance, such as construct syntax or regex-literal receiver
+  proof.
 
 ## Consumption Rules
 
@@ -143,13 +168,17 @@ legacy language-gated fallback.
 Library API evidence follows the same fail-closed rule. If a call carries
 `LibraryApi` evidence for a selected API occurrence, consumers must validate the
 contract id, callee coordinate, arity, dependencies, dependency anchors, and call
-shape before using legacy name/symbol fallback. A conflicting, ambiguous,
-wrong-callee-anchor, wrong-dependency-anchor, or dependency-broken API record on
-the queried call closes that API path. A record anchored to another call is
-irrelevant to this lookup and leaves the compatibility path available. The
-record proves only API identity; exact consumers still separately prove
-receiver/domain facts, source-surface requirements, argument safety, result
-shape, mutation safety, and demand/effect obligations.
+shape. A conflicting, ambiguous, wrong-callee-anchor, wrong-dependency-anchor, or
+dependency-broken API record on the queried call closes that API path. A record
+anchored to another call is irrelevant to this lookup and leaves compatibility
+policy to the queried surface. For selected surfaces that already have
+first-party occurrence producers, missing `LibraryApi` evidence is also closed:
+older symbol/source/import facts remain dependencies of the occurrence proof,
+not alternate API-identity proofs. Compatibility fallback is reserved for
+contract rows whose occurrence producer is not modeled yet. The record proves
+only API identity; exact consumers still separately prove receiver/domain facts,
+source-surface requirements, argument safety, result shape, mutation safety, and
+demand/effect obligations.
 
 Imported API occurrence evidence is not a broad name guess. A call-site
 `Symbol(ImportedBinding)` or `Symbol(ImportedNamespace)` dependency must itself
@@ -167,6 +196,9 @@ First-party frontends now mirror these facts into `EvidenceRecord`:
 - source-origin facts become `Source` evidence;
 - import binding and namespace lowering emits `Import` evidence for the proof RHS
   and `Symbol` evidence for the local alias identity;
+- selected top-level Ruby literal `require "module"` calls that occur before a
+  selected library API use emit `Import::Require` evidence for the required
+  module, with an asserted `UnshadowedGlobal("require")` dependency;
 - JS/TS static-global value occurrences that remain as `Var` nodes, such as
   member receivers, call callees, constructors, and `undefined`, emit
   `UnshadowedGlobal` symbol evidence when the frontend proves no local shadow;
@@ -190,18 +222,25 @@ First-party frontends now mirror these facts into `EvidenceRecord`:
   write proof back to the receiver proof;
 - first-party lowering emits `LibraryApi` evidence for selected API calls that
   remain as raw call nodes: JS-like `Array.from(...)`, `Array.isArray(...)`,
-  `Boolean(...)`, `new Map(...)`, and `new Set(...)`; Python
-  `collections.deque(...)` through imported binding/namespace proof; Python
-  `math.prod(...)` through imported namespace proof; Java `java.util` static
-  factories/adapters including `List.of`, `Set.of`, `Arrays.asList`, `Map.of`,
-  `Map.ofEntries`, `Map.entry`, and `Arrays.stream`; and JS-like regex-literal
-  `.test(...)`. These records depend on the relevant `QualifiedGlobal`,
-  `UnshadowedGlobal`, import-backed call-site `Symbol`, construct-syntax
+  `Boolean(...)`, `new Map(...)`, and `new Set(...)`; Python builtin collection
+  factories such as `list(...)` when the callee has an unshadowed free-name
+  proof; Python `collections.deque(...)` through imported binding/namespace
+  proof; Python `math.prod(...)` through imported namespace proof; Rust
+  `vec!(...)` when macro-invocation source syntax and macro-name shadow policy
+  are proven, `Vec::new()`, and selected `std::collections::*::from(...)`
+  factory paths when their root-shadow policy is proven; Ruby
+  earlier top-level `require "set"; Set.new(...)` through `Import::Require`
+  plus unshadowed `require` and `Set` proof; Java `java.util` static
+  factories/adapters including
+  `List.of`, `Set.of`, `Arrays.asList`, `Map.of`, `Map.ofEntries`, `Map.entry`,
+  and `Arrays.stream`; and JS-like regex-literal `.test(...)`. These records
+  depend on the relevant `QualifiedGlobal`, `UnshadowedGlobal`,
+  import-backed call-site `Symbol`, `Import::Require`, construct-syntax
   `Source`, or regex-literal `Source` evidence. Calls collapsed into specialized
   guard surfaces emit their guard evidence instead. Shadowed roots, unsupported
-  arities, unsupported static paths, raw free-name/path factories without a
-  resolved symbol fact, and Ruby `require`-based APIs without require evidence
-  do not emit API occurrence evidence;
+  arities, unsupported static paths, unresolved free-name/path factories, and
+  Ruby require-backed APIs without require evidence do not emit API occurrence
+  evidence;
 - lowered `Seq` surfaces emit `SequenceSurface` evidence, including Go map
   literal and Go map-entry surfaces where those tags carry first-party meaning.
 
@@ -222,9 +261,10 @@ callers:
 - import proof parsing for compatibility helpers, with value-graph import
   identity and imported literal replacement consuming evidence-only facts;
 - cross-file imported literal replacement copies the provider's closed evidence
-  subgraph into the importer with remapped anchors/dependency ids, then records
-  `Import(ImportedLiteralSnapshot)` provenance that depends on the importer
-  import proof and copied provider evidence;
+  subgraph into the importer while preserving provider source-origin spans and
+  rewiring dependency ids, then records `Import(ImportedLiteralSnapshot)`
+  provenance that depends on the importer import proof and copied provider
+  evidence;
 - imported namespace/binding symbol proof for normalize idiom admission,
   value-graph namespace fallbacks, and strict exact gates, without raw assignment
   fallback;
@@ -240,13 +280,15 @@ callers:
   `Object.prototype.hasOwnProperty.call`, and map-key view wrappers require
   evidence for `Array.from`;
 - selected `LibraryApiContract` consumers now consult `LibraryApi` occurrence
-  evidence first for the migrated JS-like, Python imported, Java static, and
-  regex-literal surfaces; conflicting or dependency-broken API evidence keeps
-  the value-graph, idiom, and strict exact paths closed. When no relevant API
-  evidence is present, the current compatibility path still uses the older
-  symbol/source proof helpers. Other factory and method/view contract rows still
-  name API identity/result semantics while local consumers prove their current
-  `Symbol`, `Import`, `Source`, `Domain`, and `SequenceSurface` obligations;
+  evidence first for the migrated JS-like, Python builtin/imported, Rust
+  free-name/path, Ruby require-backed, Java static, and regex-literal surfaces;
+  conflicting or dependency-broken API evidence keeps
+  the value-graph, idiom, and strict exact paths closed. Missing API evidence is
+  now also closed for those producer-covered surfaces; older symbol/source proof
+  helpers remain dependency inputs to `LibraryApi` evidence, not fallback API
+  proofs. Other factory and method/view contract rows still name API
+  identity/result semantics while local consumers prove their current `Symbol`,
+  `Import`, `Source`, `Domain`, and `SequenceSurface` obligations;
 - JS/TS record-shape guard exact admission and value-graph tagging require both
   `SequenceSurface(RecordGuard)` and `Guard::JsRecordShape`; raw
   `Seq("record_guard")` cannot enter the proof-bearing exact/value-graph path by
@@ -267,8 +309,7 @@ callers:
   or conflicting evidence keeps the exact path closed.
 
 Broader field/place/effect facts, `LibraryApi` occurrence evidence for remaining
-free-name/path/receiver-method APIs, receiver/protocol evidence beyond parameter
-domains, full scope-resolution and namespace-member evidence, require/import
-evidence for surfaces such as Ruby `Set.new`, broader guard evidence, general
-cross-module dependency manifests, report-level provenance, and external
-manifest loading are still open work.
+receiver-method APIs and unmodeled stdlib/ecosystem APIs, receiver/protocol
+evidence beyond parameter domains, full scope-resolution and namespace-member
+evidence, broader guard evidence, general cross-module dependency manifests,
+report-level provenance, and external manifest loading are still open work.

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -201,17 +201,21 @@ reason, not exact-fragment proof.
 `abstraction_witness` is present only for the hidden experimental
 `scan --mode abstraction[:T]` surface. It is a sibling claim to `semantic`, not a
 relaxed semantic clone verdict: the family is a refactoring-template candidate whose
-representative pair has identical normalized structure except for one supported literal
-leaf. Operator swaps, call-shape differences, and multi-hole diffs do not receive a
-witness.
+members have identical normalized structure except for one shared supported literal
+leaf position. Operator swaps, call-shape differences, and multi-hole or inconsistent
+family diffs do not receive a witness.
 
 The object has:
 
 | field | type | meaning |
 |---|---|---|
+| `claim` | string | Claim class for this object. Current value: `weak-refactoring-template`. |
+| `basis` | string | Scope of evidence used to build the witness. Current scan output value: `family`, meaning every reported family member was checked against the same template hole. |
+| `members_checked` | integer | Number of family members checked when building the witness. |
 | `reason_code` | string | Stable weak-template reason. Current values are `type-parametric` for int/float literal holes and `literal-abstracted` for same-class int, float, or string literal holes. |
+| `template_format` | string | Encoding used by `template`. Current value: `normalized-il-preorder`. |
 | `template` | array of strings | Pre-order normalized IL template tokens with `<hole 1: literal>` at the abstracted leaf. This is intentionally internal and machine-oriented, not source text. |
-| `holes` | array | Typed hole metadata for the representative pair. v1 emits exactly one hole. |
+| `holes` | array | Typed hole metadata for the family witness. v1 emits exactly one hole. |
 | `caveats` | array of strings | Caveats attached to the weak claim. `numeric-domain-sensitive` is emitted for int/float literal holes. |
 
 Each `holes[]` item has:
@@ -219,9 +223,12 @@ Each `holes[]` item has:
 | field | type | meaning |
 |---|---|---|
 | `index` | integer | 1-based hole index in the template. |
+| `template_index` | integer | 0-based index into the `template` array, so tooling can join the hole metadata back to the machine template. |
 | `kind` | string | Hole kind; currently `literal`. |
+| `role` | string | Structural role of the hole. Current value: `leaf`. |
 | `left` | string | Left representative leaf class, such as `int-literal`, `float-literal`, or `string-literal`. |
 | `right` | string | Right representative leaf class. |
+| `observed` | array of strings | Unique literal classes observed at this hole across the checked family. |
 | `left_line` | integer | Source line for the left representative leaf when known. |
 | `right_line` | integer | Source line for the right representative leaf when known. |
 

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -118,12 +118,14 @@ and pack ecosystem.
 - Cross-file immutable import replacement now copies the provider's closed
   evidence subgraph required by the exported literal expression, preserving
   provider-side stdlib proofs such as `java.util.Map` for Java static imports
-  only when that provider evidence exists. Replacement records
-  `ImportedLiteralSnapshot` provenance depending on the importer static import
-  proof and copied provider evidence. Static import identity now requires
-  `EvidenceRecord::Import`; frontends keep only untagged coordinate sequences
-  in the assignment carrier, and raw sequence spelling no longer proves
-  cross-file replacement or value-graph import identity.
+  only when that provider evidence exists. Copied provider nodes/evidence keep
+  provider source-origin spans while dependency ids are rewired in the importer,
+  so importer-local declarations do not shadow provider-proven API occurrences.
+  Replacement records `ImportedLiteralSnapshot` provenance depending on the
+  importer static import proof and copied provider evidence. Static import
+  identity now requires `EvidenceRecord::Import`; frontends keep only untagged
+  coordinate sequences in the assignment carrier, and raw sequence spelling no
+  longer proves cross-file replacement or value-graph import identity.
 - JS-like `Map`/`Set` constructor contracts now require construct-syntax proof.
   They were initially closed while construct-vs-call evidence was missing; the
   source-fact slice reopened proof-backed `new Map(...)`/`new Set(...)` while
@@ -204,10 +206,10 @@ and pack ecosystem.
   import proof, and strict exact gates initially moved behind that shared facade
   instead of parsing raw import `Seq` tags locally.
 - Imported immutable literal replacement now consumes evidence-only import facts,
-  copies provider evidence with remapped anchors/dependency ids, and records
-  `ImportedLiteralSnapshot` provenance. This closes raw import-tag fallback and
-  missing-provider-proof cases such as Java `Map.of(...)` without
-  `import java.util.Map`.
+  copies provider evidence with preserved source-origin anchors and rewired
+  dependency ids, and records `ImportedLiteralSnapshot` provenance. This closes
+  raw import-tag fallback and missing-provider-proof cases such as Java
+  `Map.of(...)` without `import java.util.Map`.
 - TypeScript type-only imports no longer emit runtime import facts: whole
   `import type ...` declarations and type-only named specifiers stay outside
   exact library/API proof.
@@ -304,6 +306,24 @@ and pack ecosystem.
   dependencies when spans survive normalization, and Java map provider proofs no
   longer replace current receiver identity except for imported literal snapshots
   already validated in the provider module.
+- The follow-up LibraryApi fallback-closure slice made those producer-covered
+  surfaces require admitted occurrence evidence. Missing `LibraryApi` evidence
+  now closes value-graph, idiom, strict exact, and Java map provider snapshot
+  paths for JS-like static/global APIs, Python imported `collections.deque`,
+  Python `math.prod`, Java `java.util` static factories/adapters, and JS-like
+  regex-literal `.test`. The older import/symbol/source facts remain
+  dependencies, not fallback API-identity proofs. Python aliased imports such as
+  `from collections import deque as Values; Values(...)` are preserved by
+  resolving the occurrence through imported-binding evidence rather than by
+  comparing the local name to the exported API name.
+- The same fallback-closure slice extended occurrence evidence to selected
+  free-name and require-backed factories: Python builtin collection factories,
+  Rust `vec!`, `Vec::new`, and selected `std::collections::*::from` factories,
+  plus Ruby `require "set"; Set.new(...)`. First-party lowering now emits
+  `UnshadowedGlobal`, macro-invocation `Source`, or earlier top-level
+  `Import::Require` dependencies for those occurrences, and value-graph, idiom,
+  strict exact, and provider snapshot consumers require admitted `LibraryApi`
+  evidence instead of raw selector/path/require scans.
 - An experimental `abstraction` scan mode landed as a weak sibling claim over a
   narrow `near` subset. It emits typed literal-hole witnesses and caveats for
   refactoring-template candidates, but does not feed `semantic`, `verify`, or exact
@@ -375,7 +395,11 @@ Remaining in this phase:
   versioned pack-facing evidence records, especially broader field/read/write
   place facts and receiver-sensitive mutation/effect proofs.
 - Continue moving library API recognition into `LibraryApiContract` rows and
-  `LibraryApi` occurrence evidence.
+  `LibraryApi` occurrence evidence. The already producer-covered occurrence
+  surfaces are now fail-closed on missing evidence; remaining work is producer
+  coverage for Java constructors, broad receiver-method families, and
+  ecosystem APIs whose receiver/domain/demand obligations are not yet
+  expressible.
   The first internal slice covers collection/map factories, selected
   constructors, Java empty collection constructors, Java `Map.entry`, and the
   shared shadow/import/result
@@ -385,19 +409,20 @@ Remaining in this phase:
   helpers, regex-literal `.test`, Python `math.prod`, promise `.then`, iterator
   identity adapters, Java `Arrays.stream`, and existing language-scoped method
   call contracts. Occurrence-evidence slices now cover selected JS-like
-  static/global APIs, import-backed Python factories/functions, Java `java.util`
+  static/global APIs, Python builtin/import-backed factories/functions, Rust
+  free-name/path factories, Ruby require-backed factories, Java `java.util`
   static factories/adapters, and JS regex literals. Remaining stdlib and
   ecosystem APIs still need dependency-backed occurrence records before they
   become pack-facing.
 - Keep value-graph and strict exact gates on the same contract source. Factory,
   constructor, and selected method/view/adapter gates now share
   `LibraryApiContract` identity/result rows, and selected JS-like,
-  import-backed Python, Java `java.util`, and regex calls now additionally share
-  `LibraryApi` occurrence evidence. Remaining API work is to move raw
-  sequence/tag, Ruby `require`, Rust free-name/path-root, Java constructor, and
-  broad receiver-method proof dependencies into explicit evidence records, then
-  cover broader reduction/HOF and ecosystem APIs only after demand, receiver,
-  and effect obligations are expressible.
+  Python builtin/import-backed, Rust free-name/path, Ruby require-backed, Java
+  `java.util`, and regex calls now additionally share `LibraryApi` occurrence
+  evidence. Remaining API work is to move raw sequence/tag, Java constructor,
+  and broad receiver-method proof dependencies into explicit evidence records,
+  then cover broader reduction/HOF and ecosystem APIs only after demand,
+  receiver, and effect obligations are expressible.
 - Remove the remaining raw import/module proof IL payload storage after import
   and symbol evidence records can carry every consumer obligation, including
   module export dependencies, scope, rebinding, and mutation proof. Value-graph

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -308,6 +308,15 @@ and pack ecosystem.
   narrow `near` subset. It emits typed literal-hole witnesses and caveats for
   refactoring-template candidates, but does not feed `semantic`, `verify`, or exact
   kernel admission.
+- The abstraction witness policy is now separated from unit feature extraction as
+  a small internal witness kernel. The current accepted hole remains literal-only,
+  but the model records claim class, family evidence basis, checked member count,
+  template format, hole role, template index, and observed literal classes so future
+  type/domain/operator witnesses have a single owner.
+- Abstraction scan output now requires family-wide hole agreement: every reported
+  family member must fit the same normalized IL template with the same literal-leaf
+  hole position. Mixed connected components are not given a weak witness merely
+  because one representative pair looked actionable.
 
 ## Phase 0: documentation and vocabulary (landed)
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -8,13 +8,14 @@ record substrate is described in [evidence-records](evidence-records.md).
 Snapshot date: 2026-06-08. The current implementation has an internal
 semantic-kernel facade, receiver-aware field state, sequence-surface contracts,
 proof-backed append fragment evidence, operator-law contracts, typed import
-facts, source-fact gates for construct/literal/operator provenance, and a shared
+facts, source-fact gates for construct/macro/literal/operator provenance, and a shared
 evidence-record substrate for source, domain, import, symbol-identity, guard,
 place/effect, selected library API occurrence, and sequence-surface facts.
 Library/API identity is consolidated through internal `LibraryApiContract` rows
 for factory, constructor, and selected non-factory method/view surfaces, with
-occurrence evidence covering selected JS-like static/global APIs plus selected
-import/source-backed Python, Java, and JS regex API calls.
+occurrence evidence covering selected JS-like static/global APIs, Python
+builtin/import-backed APIs, Rust free-name/path APIs, Ruby require-backed APIs,
+Java `java.util` APIs, and JS regex API calls.
 
 ## What exists today
 
@@ -77,10 +78,11 @@ migrated.
 - Source facts are now first-class internal evidence for source distinctions that
   the shared IL erases. JS/TS frontends emit construct syntax, regex literal,
   strict/loose equality, strict/loose inequality, and `instanceof` facts. Python
-  emits value equality/inequality and identity equality/inequality facts. These
-  are mirrored into `EvidenceRecord::Source`; the older `SourceFact` vector
-  remains a compatibility fallback. Normalize and detect consume source facts
-  only where a semantic contract requires that exact source surface.
+  emits value equality/inequality and identity equality/inequality facts, and
+  Rust emits macro invocation syntax for selected macro-backed APIs. These are
+  mirrored into `EvidenceRecord::Source`; the older `SourceFact` vector remains
+  a compatibility fallback. Normalize and detect consume source facts only where
+  a semantic contract requires that exact source surface.
 - Free-function builtin contracts are language- and arity-constrained and require
   unshadowed builtin/global proof before exact lowering.
 - Method contracts carry receiver obligations such as exact collection, exact
@@ -122,8 +124,12 @@ migrated.
   `new ArrayList<>()`/`new LinkedList<>()`, Java `Map.of`/`Map.ofEntries`/
   `Map.entry`, Ruby `require "set"; Set.new(...)`, and JS-like `new Set(...)`/
   `new Map(...)`. Normalize and strict exact gates consume this shared contract
-  source while still proving local import, require, shadowing, constructor
-  syntax, entry-shape, mutation, and exact-safety obligations at the caller.
+  source. Producer-covered surfaces additionally require admitted `LibraryApi`
+  occurrence evidence whose dependencies carry the local import, earlier
+  top-level require, unshadowed-global, macro-invocation source,
+  construct-syntax, or regex-literal proof. Receiver/domain, entry-shape,
+  mutation, demand, and exact-safety obligations remain separate contract checks
+  at the consumer.
 - Selected non-factory library/API surfaces also consume `LibraryApiContract`
   rows before normalize, value-graph, or strict exact paths assign semantics.
   Current rows cover map-key views and wrappers, Java/Rust/JS-like map `get`,
@@ -138,21 +144,34 @@ migrated.
 - Selected API call occurrences now also have `LibraryApi` evidence records when
   they remain as raw call nodes. First-party lowering emits occurrence evidence
   for JS-like `Array.from(...)`, `Array.isArray(...)`, `Boolean(...)`,
-  `new Map(...)`, and `new Set(...)`; Python `collections.deque(...)` when the
-  callee is proven through `from collections import deque` or
-  `import collections; collections.deque(...)`; Python `import math;
-  math.prod(...)`; Java `java.util` static factories/adapters such as `List.of`,
-  `Set.of`, `Arrays.asList`, `Map.of`, `Map.ofEntries`, `Map.entry`, and
-  `Arrays.stream`; and JS-like regex-literal `.test(...)`. These records depend
-  on the relevant `QualifiedGlobal`, `UnshadowedGlobal`, import-backed
-  call-site `Symbol`, construct-syntax `Source`, or regex-literal `Source`
-  evidence. Calls collapsed into specialized guard surfaces emit guard evidence
-  instead. `nose-semantics` resolves these records with a three-state result:
-  admitted, missing, or rejected. Value-graph, idiom, and strict exact consumers
-  for the migrated surfaces consult this occurrence evidence first; conflicting
-  or dependency-broken API evidence closes the legacy path. The record proves
-  API identity only; receiver/domain, source, exact-safe argument, result-shape,
-  and mutation obligations remain separate.
+  `new Map(...)`, and `new Set(...)`; Python builtin collection factories such
+  as `list(...)` when the callee is proven as an unshadowed free name; Python
+  `collections.deque(...)` when the callee is proven through
+  `from collections import deque`, an alias such as
+  `from collections import deque as Values`, or `import collections;
+  collections.deque(...)`; Python `import math; math.prod(...)`; Rust
+  `vec!(...)` when source syntax proves a macro invocation, `Vec::new()`, and selected
+  `std::collections::{HashSet,BTreeSet,VecDeque,HashMap,BTreeMap}::from(...)`
+  factory paths when their root-shadow policy is proven; Ruby
+  `require "set"; Set.new(...)` when an earlier top-level `Import::Require("set")`
+  depends on unshadowed `require` proof and unshadowed `Set` receiver proof
+  exists; Java `java.util` static
+  factories/adapters such as `List.of`, `Set.of`, `Arrays.asList`, `Map.of`,
+  `Map.ofEntries`, `Map.entry`, and `Arrays.stream`; and JS-like regex-literal
+  `.test(...)`. These records depend on the relevant `QualifiedGlobal`,
+  `UnshadowedGlobal`, import-backed call-site `Symbol`, `Import::Require`,
+  macro-invocation `Source`, construct-syntax `Source`, or regex-literal
+  `Source` evidence. Calls
+  collapsed into specialized guard surfaces emit guard evidence instead.
+  `nose-semantics` resolves these records with a three-state result: admitted,
+  missing, or rejected. Value-graph, idiom, strict exact, and provider snapshot
+  consumers for these producer-covered surfaces require admitted occurrence
+  evidence; missing, conflicting, or dependency-broken API evidence keeps the
+  exact path closed. Older import/symbol/source facts are still required
+  dependencies of the occurrence evidence, but they no longer act as fallback
+  API-identity proof for these surfaces. The record proves API identity only;
+  receiver/domain, source, exact-safe argument, result-shape, and mutation
+  obligations remain separate.
 - Java empty collection constructor contracts cover `new ArrayList<>()` and
   `new LinkedList<>()` through `LibraryApiContract` rows only for the Java
   `java.util` list types. Simple names require `java.util` import proof and no
@@ -204,12 +223,14 @@ migrated.
 - Cross-file immutable import replacement now copies the provider's closed
   evidence subgraph for the exported literal expression, so a Java static import
   of `LOOKUP = Map.of(...)` carries the provider's `java.util.Map` proof into
-  the importing file only when the provider emitted that import proof. The
-  copied evidence remaps anchors/dependency ids to the importer file, and the
-  replacement records `ImportedLiteralSnapshot` provenance depending on the
-  importer static import proof plus copied provider evidence. Provider and
-  importer module-binding mutation proof now rejects direct binding mutations
-  and direct place writes such as
+  the importing file only when the provider emitted that import proof. Copied
+  provider nodes and evidence anchors keep provider source-origin spans, while
+  copied dependency ids are rewired inside the importer IL; this prevents
+  importer-local scopes or same-named classes from shadowing provider-proven API
+  occurrences. The replacement records `ImportedLiteralSnapshot` provenance
+  depending on the importer static import proof plus copied provider evidence.
+  Provider and importer module-binding mutation proof now rejects direct binding
+  mutations and direct place writes such as
   `LOOKUP.clear()`, `LOOKUP.push(...)`, and `LOOKUP[key] = value`, and
   provider-side opaque argument escapes such as `mutate(LOOKUP)`, before
   imported literal provenance can enter exact matching.
@@ -358,9 +379,9 @@ Semantic knowledge still appears in several forms outside the facade:
   still local to `nose-frontend`;
 - module/import proof logic for immutable sibling-module literal bindings is
   still local to `nose-frontend`, although replacement now copies the provider's
-  closed evidence subgraph into the importer, remaps spans/dependency ids, and
-  records `ImportedLiteralSnapshot` provenance tied to the importer static
-  import proof;
+  closed evidence subgraph into the importer, preserves provider source-origin
+  spans, rewires dependency ids, and records `ImportedLiteralSnapshot`
+  provenance tied to the importer static import proof;
 - type facts and coarse type inference used to gate numeric and collection laws;
 - named value-graph rule modules that still consume internal `Builder` facts
   instead of versioned `LawPack` records;
@@ -369,10 +390,10 @@ Semantic knowledge still appears in several forms outside the facade:
 - duplicated receiver/domain and library/API proof gates in desugaring,
   idiom lowering, value-graph, and strict exact paths. `LibraryApi` occurrence
   evidence now reduces this for selected JS-like static/global APIs,
-  import-backed Python factories/functions, Java `java.util` static
-  factories/adapters, and JS regex literals, but Rust free-name/path factories,
-  Ruby `require "set"; Set.new(...)`, Java empty constructors, and broad
-  receiver-method surfaces still rely on contract rows plus local proof.
+  Python builtin/import-backed factories/functions, Rust free-name/path
+  factories, Ruby `require "set"; Set.new(...)`, Java `java.util` static
+  factories/adapters, and JS regex literals, but Java empty constructors and
+  broad receiver-method surfaces still rely on contract rows plus local proof.
 
 These are valuable, but they do not yet share one complete semantic contract
 language.
@@ -436,41 +457,5 @@ this worktree because the required evidence is not yet modeled:
 These reduce recall in affected cases, but they are the correct precision trade
 until packs can emit the missing facts.
 
-## Known migration targets
-
-The first high-value targets for semantic-kernel extraction are:
-
-- broader pack-facing field/place/effect evidence for all field reads and
-  writes, building on the initial append/index/self-field effect substrate and
-  the receiver-aware value-graph field state now used for same-unit caching;
-- full import/module fact migration beyond raw payload removal: provider/export
-  dependency records, module scope, wildcard/conflict handling, copied evidence
-  provenance, and pack-facing validation still need to move behind explicit
-  extension contracts;
-- richer sequence/aggregate evidence for factories, nested entries, iterator
-  views, and exported-literal eligibility beyond the current first
-  `SequenceSurface` substrate;
-- broader `LibraryApi` occurrence evidence for remaining Java/Rust/Python/Ruby
-  stdlib factories, map get/defaulting, iterator adapters, and method-call
-  surfaces that still need receiver/domain, require/import, or path-root proof
-  records before they can move beyond contract rows plus local proof;
-- generalized guard evidence beyond the first JS/TS record-shape contract,
-  including richer source/API dependency records and validation;
-- dependency, scope, and ambiguity validation before evidence records become a
-  stable external extension surface;
-- resolved symbol facts for Java/Rust stdlib factories instead of the current
-  path/name plus shadow-proof contracts;
-- nested collection element proofs for iterator chains and builder convergence;
-- Promise/future/thenable receiver facts;
-- receiver/protocol evidence records beyond parameter-domain facts, including
-  exact collection/map/set/option/string/integer receiver proofs, immutable
-  local/module bindings, and mutation exclusion;
-- demand/protocol contracts that distinguish eager arrays, lazy iterators,
-  streams, callbacks, futures/promises, and call-by-need thunks;
-- demand/error contracts for language-core oracle behavior such as non-iterable
-  `for`/`foreach` evaluation;
-- LawPack-facing ids for named value-graph rules, with the existing formal
-  obligation metadata kept as the first-party proof boundary;
-- module export visibility, path resolution, and mutation proof;
-- provenance fields in scan JSON for pack id, contract id, law id, and evidence
-  status.
+Remaining migration targets are tracked in
+[semantic-kernel-roadmap](semantic-kernel-roadmap.md).

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -45,9 +45,9 @@ matches must be fail-closed and false merges are bugs.
 
 An experimental `abstraction` scan mode now exists as a weak sibling surface over
 `near`, not as an exact semantic relaxation. It keeps only same-language candidates
-whose normalized IL differs by exactly one supported literal leaf and emits an
-`abstraction_witness` with a typed hole, a reason code, and caveats such as
-`numeric-domain-sensitive`.
+whose family-wide normalized IL differs by exactly one shared supported literal leaf
+position and emits an `abstraction_witness` with a typed hole, a reason code, checked
+member count, observed literal classes, and caveats such as `numeric-domain-sensitive`.
 
 ## Implemented facade contracts
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -147,6 +147,10 @@ claim is weaker than `semantic`: it reports a refactoring-template witness with 
 typed hole and caveats such as `numeric-domain-sensitive`; it does not say the two
 copies are behavior-equivalent. Use `--format json --top 0` to consume the
 `abstraction_witness` field documented in [scan-json](scan-json.md#abstraction-witnesses).
+The witness is built from normalized IL, not line-level `--show proposal` text; its
+template is machine-oriented today and carries typed hole metadata for tooling. A
+reported abstraction family must share one literal-leaf hole position across all
+members; mixed families with different changed positions are left unwitnessed.
 When `near:T` and `abstraction:T` are combined in one scan, they share one fuzzy
 acceptance threshold; giving different inline values is rejected instead of silently
 choosing the last one.


### PR DESCRIPTION
## Summary

- require admitted `LibraryApi` occurrence evidence for producer-covered APIs across strict exact, value graph, idioms, and provider snapshot paths
- extend first-party occurrence producers for Python builtin factories, Rust `vec!`/`Vec::new`/`std::collections::*::from`, and Ruby `require "set"; Set.new(...)`
- harden evidence dependencies: imported binding aliases, provider-source spans, Rust macro invocation source proof, Python wildcard import closure, Ruby `require` identity and before-use ordering
- preserve the latest family-wide abstraction witness kernel from local `main`
- update semantic-kernel snapshot, roadmap, and evidence-record docs so current state and remaining work stay separated

Refs #109.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --release`
- `./scripts/check-duplication.sh`
- `awiki lint --root docs`
- `git diff --check --cached && git diff --check`
- `python3 scripts/check-formal-obligations.py --self-test && python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * Abstraction 스캔 모드에서 약한 증거(witness)에 추가 메타데이터 포함: basis, members_checked, template_format 필드 추가
  * 홀(hole) 정보에 역할(role) 및 관찰된 값 데이터 추가로 템플릿 정합도 향상

* **Bug Fixes**
  * 라이브러리 API 증거 게이팅 규칙 정교화로 안전성 판정 정확도 개선
  * 파이썬 와일드카드 import, Rust 매크로 정의, Ruby require 문 처리 개선

* **Documentation**
  * JSON 스키마 및 아키텍처 문서 업데이트로 abstraction witness 구조 명시
  * 라이브러리 API 증거 처리 메커니즘 상세 문서화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->