### PR TITLE
semantics: centralize receiver domain evidence

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -14,8 +14,7 @@ use nose_normalize::{
     node_tag,
 };
 use nose_semantics::{
-    builder_append_call_args, construct_syntax_proof,
-    domain_evidence_for_param as semantic_domain_evidence_for_param, exact_java_return_this,
+    builder_append_call_args, construct_syntax_proof, exact_java_return_this,
     exact_non_overloadable_index_assignment, exact_non_overloadable_index_assignment_parts,
     exact_self_field_write_assignment, exact_static_membership_predicate_operator,
     go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
@@ -31,10 +30,11 @@ use nose_semantics::{
     library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
     nullish_global_contract, own_property_guard_for_node, record_shape_guard_for_node, semantics,
     seq_surface_contract_for_node, source_operator_at_node, static_index_membership_contract,
-    typeof_operator_contract, unshadowed_global_symbol, DomainEvidence, IndexMembershipThreshold,
-    JavaMapFactoryKind, LibraryApiCalleeContract, LibraryApiEvidenceStatus,
-    LibraryCollectionFactoryResult, LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs,
-    MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
+    typeof_operator_contract, unshadowed_global_symbol, DomainRequirement,
+    IndexMembershipThreshold, JavaMapFactoryKind, LibraryApiCalleeContract,
+    LibraryApiEvidenceStatus, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
+    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
+    StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1723,29 +1723,19 @@ fn strict_exact_iterator_identity_adapter_node_safe(
 }
 
 fn strict_exact_typed_set_param_receiver_safe(il: &Il, receiver: NodeId) -> bool {
-    strict_exact_typed_param_receiver_safe(il, receiver, DomainEvidence::is_set)
+    strict_exact_typed_receiver_safe(il, receiver, DomainRequirement::Set)
 }
 
 fn strict_exact_typed_collection_param_receiver_safe(il: &Il, receiver: NodeId) -> bool {
-    strict_exact_typed_param_receiver_safe(il, receiver, DomainEvidence::is_array_collection_or_set)
+    strict_exact_typed_receiver_safe(il, receiver, DomainRequirement::ArrayCollectionOrSet)
 }
 
-fn strict_exact_typed_param_receiver_safe(
+fn strict_exact_typed_receiver_safe(
     il: &Il,
     receiver: NodeId,
-    accepts: impl Fn(DomainEvidence) -> bool,
+    requirement: DomainRequirement,
 ) -> bool {
-    if il.kind(receiver) != NodeKind::Var {
-        return false;
-    }
-    let Payload::Cid(receiver_cid) = il.node(receiver).payload else {
-        return false;
-    };
-    il.nodes.iter().enumerate().any(|(idx, node)| {
-        node.kind == NodeKind::Param
-            && matches!(node.payload, Payload::Cid(param_cid) if param_cid == receiver_cid)
-            && semantic_domain_evidence_for_param(il, NodeId(idx as u32)).is_some_and(&accepts)
-    })
+    nose_semantics::receiver_satisfies_domain(il, receiver, requirement)
 }
 
 fn strict_exact_proven_collection_receiver_safe(
@@ -1766,7 +1756,7 @@ fn strict_exact_proven_collection_receiver_safe(
 }
 
 fn strict_exact_typed_map_param_receiver_safe(il: &Il, receiver: NodeId) -> bool {
-    strict_exact_typed_param_receiver_safe(il, receiver, DomainEvidence::is_map)
+    strict_exact_typed_receiver_safe(il, receiver, DomainRequirement::Map)
 }
 
 fn strict_exact_proven_map_receiver_safe(il: &Il, facts: &StrictFacts, receiver: NodeId) -> bool {
@@ -4062,6 +4052,65 @@ mod tests {
             Vec::new(),
         ));
         (il, call)
+    }
+
+    fn ts_contains_call_il(interner: &Interner) -> (Il, NodeId, Span) {
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver_span = sp(50);
+        let receiver = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("xs")),
+            receiver_span,
+            &[],
+        );
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("includes")),
+            sp(51),
+            &[receiver],
+        );
+        let item = b.add(NodeKind::Lit, Payload::LitInt(7), sp(52), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(53), &[callee, item]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(49), &[call]);
+        let il = b.finish(
+            root,
+            FileMeta {
+                path: "t.ts".into(),
+                lang: Lang::TypeScript,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        (il, call, receiver_span)
+    }
+
+    #[test]
+    fn strict_exact_contains_consumes_receiver_domain_evidence() {
+        let interner = Interner::new();
+        let (mut il, call, receiver_span) = ts_contains_call_il(&interner);
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(!strict_exact_safe_tree(&il, &interner, &facts, call));
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(receiver_span, NodeKind::Var),
+            EvidenceKind::Domain(nose_semantics::DomainEvidence::Collection),
+            Vec::new(),
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(strict_exact_safe_tree(&il, &interner, &facts, call));
+
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(receiver_span, NodeKind::Var),
+            EvidenceKind::Domain(nose_semantics::DomainEvidence::Map),
+            Vec::new(),
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(
+            !strict_exact_safe_tree(&il, &interner, &facts, call),
+            "conflicting receiver-domain evidence must close strict exact fallback"
+        );
     }
 
     #[test]

--- a/crates/nose-normalize/src/desugar.rs
+++ b/crates/nose-normalize/src/desugar.rs
@@ -14,7 +14,7 @@
 use crate::idioms::{canon_call, CallCanon};
 use crate::NormalizeOptions;
 use nose_il::{Il, IlBuilder, Interner, LoopKind, NodeId, NodeKind, Payload};
-use nose_semantics::{domain_evidence_for_param, seq_surface_contract_for_node, DomainEvidence};
+use nose_semantics::{seq_surface_contract_for_node, DomainRequirement};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 pub(crate) fn run(old: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il {
@@ -267,7 +267,7 @@ impl Rebuilder<'_> {
 
 fn property_receiver_exact_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
     seq_receiver_exact_collection_safe(il, interner, node)
-        || domain_evidence_for_var(il, node).is_some_and(DomainEvidence::is_array_or_collection)
+        || nose_semantics::receiver_satisfies_domain(il, node, DomainRequirement::ArrayOrCollection)
         || property_receiver_exact_hof_node(il, interner, node)
         || property_receiver_exact_hof_call(il, interner, node)
 }
@@ -278,20 +278,6 @@ fn seq_receiver_exact_collection_safe(il: &Il, interner: &Interner, node: NodeId
     }
     seq_surface_contract_for_node(il, interner, node)
         .is_some_and(|contract| contract.membership_collection)
-}
-
-fn domain_evidence_for_var(il: &Il, node: NodeId) -> Option<DomainEvidence> {
-    if il.kind(node) != NodeKind::Var {
-        return None;
-    }
-    let Payload::Cid(cid) = il.node(node).payload else {
-        return None;
-    };
-    il.nodes.iter().enumerate().find_map(|(idx, candidate)| {
-        (candidate.kind == NodeKind::Param && candidate.payload == Payload::Cid(cid))
-            .then(|| domain_evidence_for_param(il, NodeId(idx as u32)))
-            .flatten()
-    })
 }
 
 fn property_receiver_exact_hof_call(il: &Il, interner: &Interner, node: NodeId) -> bool {

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -9,13 +9,13 @@
 
 use nose_il::{contains_js_identifier, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
 use nose_semantics::{
-    domain_evidence_for_param, free_function_builtin_contract, imported_namespace_symbol,
+    free_function_builtin_contract, imported_namespace_symbol,
     library_api_contract_evidence_for_call, library_free_name_map_factory_contract,
     library_iterator_identity_adapter_contract, library_map_get_contract,
     library_map_key_view_contract, library_method_call_contract,
     library_static_collection_adapter_contract, method_hof_contract,
     rust_option_some_constructor_contract, seq_surface_contract_for_node, unshadowed_global_symbol,
-    BuiltinArgContract, DomainEvidence, LibraryApiCalleeContract, LibraryApiEvidenceStatus,
+    BuiltinArgContract, DomainRequirement, LibraryApiCalleeContract, LibraryApiEvidenceStatus,
     LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs, MethodCallContract,
     MethodReceiverContract, MethodSemanticContract, SEQ_VALUE_MAP,
 };
@@ -488,7 +488,7 @@ fn exact_protocol_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool 
 }
 
 fn exact_collection_param(old: &Il, node: NodeId) -> bool {
-    domain_evidence_for_var(old, node).is_some_and(DomainEvidence::is_array_collection_or_set)
+    nose_semantics::receiver_satisfies_domain(old, node, DomainRequirement::ArrayCollectionOrSet)
 }
 
 fn static_collection_adapter_arg(
@@ -522,11 +522,11 @@ fn static_collection_adapter_arg(
 }
 
 fn exact_set_param(old: &Il, node: NodeId) -> bool {
-    domain_evidence_for_var(old, node).is_some_and(DomainEvidence::is_set)
+    nose_semantics::receiver_satisfies_domain(old, node, DomainRequirement::Set)
 }
 
 fn exact_map_param(old: &Il, node: NodeId) -> bool {
-    domain_evidence_for_var(old, node).is_some_and(DomainEvidence::is_map)
+    nose_semantics::receiver_satisfies_domain(old, node, DomainRequirement::Map)
 }
 
 fn exact_map_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
@@ -534,109 +534,7 @@ fn exact_map_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
 }
 
 fn exact_option_param(old: &Il, node: NodeId) -> bool {
-    domain_evidence_for_var(old, node).is_some_and(DomainEvidence::is_option)
-}
-
-fn domain_evidence_for_var(old: &Il, node: NodeId) -> Option<DomainEvidence> {
-    if old.kind(node) != NodeKind::Var {
-        return None;
-    }
-    let param_span = match old.node(node).payload {
-        Payload::Cid(cid) => old.nodes.iter().find_map(|candidate| {
-            (candidate.kind == NodeKind::Param && candidate.payload == Payload::Cid(cid))
-                .then_some(candidate.span)
-        }),
-        Payload::Name(name) => {
-            let (scope, span) = nearest_named_param_scope(old, node, name)?;
-            if name_is_assigned_in_scope(old, name, scope) {
-                return None;
-            }
-            Some(span)
-        }
-        _ => None,
-    };
-    param_span.and_then(|span| {
-        old.nodes.iter().enumerate().find_map(|(idx, candidate)| {
-            (candidate.kind == NodeKind::Param && candidate.span == span)
-                .then(|| domain_evidence_for_param(old, NodeId(idx as u32)))
-                .flatten()
-        })
-    })
-}
-
-fn nearest_named_param_scope(
-    old: &Il,
-    node: NodeId,
-    name: nose_il::Symbol,
-) -> Option<(NodeId, nose_il::Span)> {
-    let target = old.node(node).span;
-    let mut best: Option<(u32, NodeId, nose_il::Span)> = None;
-    for (idx, candidate) in old.nodes.iter().enumerate() {
-        if !matches!(candidate.kind, NodeKind::Func | NodeKind::Lambda) {
-            continue;
-        }
-        if !span_contains(candidate.span, target) {
-            continue;
-        }
-        let scope = NodeId(idx as u32);
-        let Some(param_span) = old.children(scope).iter().find_map(|&child| {
-            (old.kind(child) == NodeKind::Param && old.node(child).payload == Payload::Name(name))
-                .then_some(old.node(child).span)
-        }) else {
-            continue;
-        };
-        let width = candidate
-            .span
-            .end_byte
-            .saturating_sub(candidate.span.start_byte);
-        if best.is_none_or(|(best_width, _, _)| width < best_width) {
-            best = Some((width, scope, param_span));
-        }
-    }
-    best.map(|(_, scope, span)| (scope, span))
-}
-
-fn name_is_assigned_in_scope(old: &Il, name: nose_il::Symbol, scope: NodeId) -> bool {
-    old.nodes.iter().enumerate().any(|(idx, node)| {
-        if node.kind != NodeKind::Assign {
-            return false;
-        }
-        let id = NodeId(idx as u32);
-        if nearest_scope(old, id) != Some(scope) {
-            return false;
-        }
-        let Some(&lhs) = old.children(id).first() else {
-            return false;
-        };
-        old.kind(lhs) == NodeKind::Var && old.node(lhs).payload == Payload::Name(name)
-    })
-}
-
-fn nearest_scope(old: &Il, node: NodeId) -> Option<NodeId> {
-    let target = old.node(node).span;
-    let mut best: Option<(u32, NodeId)> = None;
-    for (idx, candidate) in old.nodes.iter().enumerate() {
-        if !matches!(candidate.kind, NodeKind::Func | NodeKind::Lambda) {
-            continue;
-        }
-        if !span_contains(candidate.span, target) {
-            continue;
-        }
-        let width = candidate
-            .span
-            .end_byte
-            .saturating_sub(candidate.span.start_byte);
-        if best.is_none_or(|(best_width, _)| width < best_width) {
-            best = Some((width, NodeId(idx as u32)));
-        }
-    }
-    best.map(|(_, scope)| scope)
-}
-
-fn span_contains(outer: nose_il::Span, inner: nose_il::Span) -> bool {
-    outer.file == inner.file
-        && outer.start_byte <= inner.start_byte
-        && outer.end_byte >= inner.end_byte
+    nose_semantics::receiver_satisfies_domain(old, node, DomainRequirement::Option)
 }
 
 fn exact_collection_literal(old: &Il, interner: &Interner, node: NodeId) -> bool {
@@ -674,10 +572,7 @@ fn exact_string_receiver(old: &Il, node: NodeId) -> bool {
     matches!(
         old.node(node).payload,
         Payload::LitStr(_) | Payload::Lit(nose_il::LitClass::Str)
-    ) || matches!(
-        domain_evidence_for_var(old, node),
-        Some(domain) if domain.is_string()
-    )
+    ) || nose_semantics::receiver_satisfies_domain(old, node, DomainRequirement::String)
 }
 
 fn literal_string_receiver(old: &Il, node: NodeId) -> bool {
@@ -688,10 +583,7 @@ fn exact_integer_receiver(old: &Il, node: NodeId) -> bool {
     matches!(
         old.node(node).payload,
         Payload::LitInt(_) | Payload::Lit(nose_il::LitClass::Int)
-    ) || matches!(
-        domain_evidence_for_var(old, node),
-        Some(domain) if domain.is_integer()
-    )
+    ) || nose_semantics::receiver_satisfies_domain(old, node, DomainRequirement::Integer)
 }
 
 fn rust_option_some_name(old: &Il, interner: &Interner, text: &str) -> bool {
@@ -936,6 +828,10 @@ mod tests {
 
     fn sp() -> Span {
         Span::new(FileId(0), 1, 1, 1, 1)
+    }
+
+    fn sp_at(start: u32, end: u32, line: u32) -> Span {
+        Span::new(FileId(0), start, end, line, line)
     }
 
     fn evidence(
@@ -1264,6 +1160,55 @@ mod tests {
         (il, interner, call)
     }
 
+    fn receiver_domain_method_call_il(
+        domain: nose_semantics::DomainEvidence,
+    ) -> (Il, Interner, NodeId, Span) {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver_span = sp_at(20, 22, 2);
+        let receiver = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("xs")),
+            receiver_span,
+            &[],
+        );
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("some")),
+            sp_at(23, 28, 2),
+            &[receiver],
+        );
+        let func = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("f")),
+            sp_at(29, 30, 2),
+            &[],
+        );
+        let call = b.add(
+            NodeKind::Call,
+            Payload::None,
+            sp_at(20, 31, 2),
+            &[field, func],
+        );
+        let root = b.add(NodeKind::Module, Payload::None, sp_at(0, 40, 1), &[call]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.ts".to_string(),
+                lang: Lang::TypeScript,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(receiver_span, NodeKind::Var),
+            EvidenceKind::Domain(domain),
+            EvidenceStatus::Asserted,
+        ));
+        (il, interner, call, receiver_span)
+    }
+
     fn console_log_il(shadow_console: bool) -> (Il, Interner, NodeId) {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
@@ -1501,6 +1446,32 @@ mod tests {
                 arg_olds
             } if arg_olds.len() == 2
         ));
+    }
+
+    #[test]
+    fn method_bool_reduction_consumes_receiver_domain_evidence() {
+        let (il, interner, call, _) =
+            receiver_domain_method_call_il(nose_semantics::DomainEvidence::Collection);
+        assert!(matches!(
+            canon_call(&il, &interner, call),
+            CallCanon::Builtin {
+                op: Builtin::Any,
+                arg_olds
+            } if arg_olds.len() == 2
+        ));
+
+        let (mut il, interner, call, receiver_span) =
+            receiver_domain_method_call_il(nose_semantics::DomainEvidence::Collection);
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(receiver_span, NodeKind::Var),
+            EvidenceKind::Domain(nose_semantics::DomainEvidence::Map),
+            EvidenceStatus::Asserted,
+        ));
+        assert!(
+            matches!(canon_call(&il, &interner, call), CallCanon::None),
+            "conflicting receiver-domain evidence must not fall back to selector matching"
+        );
     }
 
     #[test]

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -71,7 +71,7 @@ use nose_semantics::{
     rust_option_some_constructor_contract, scalar_integer_method_contract, semantics,
     seq_surface_contract_for_node, source_operator_at_node, static_index_membership_contract,
     unshadowed_global_symbol, BuiltinArgContract, CardinalityPredicate, CardinalityThreshold,
-    ComparisonLaw, DomainEvidence, GoZeroMapDefaultKind, ImportFactKind,
+    ComparisonLaw, DomainEvidence, DomainRequirement, GoZeroMapDefaultKind, ImportFactKind,
     ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
     JavaMapFactoryKind, LibraryApiCalleeContract, LibraryApiEvidenceStatus,
     LibraryApiSpanEvidenceQuery, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
@@ -819,33 +819,23 @@ impl<'a> Builder<'a> {
     }
 
     fn domain_evidence_of_expr(&self, expr: NodeId) -> Option<DomainEvidence> {
-        if self.il.kind(expr) != NodeKind::Var {
-            return None;
-        }
-        let Payload::Cid(cid) = self.il.node(expr).payload else {
-            return None;
-        };
-        self.param_domain.get(&cid).copied()
+        nose_semantics::domain_evidence_for_receiver(self.il, expr)
     }
 
     fn is_collection_param_expr(&self, expr: NodeId) -> bool {
-        self.domain_evidence_of_expr(expr)
-            .is_some_and(DomainEvidence::is_collection_or_set)
+        nose_semantics::receiver_satisfies_domain(self.il, expr, DomainRequirement::CollectionOrSet)
     }
 
     fn is_set_param_expr(&self, expr: NodeId) -> bool {
-        self.domain_evidence_of_expr(expr)
-            .is_some_and(DomainEvidence::is_set)
+        nose_semantics::receiver_satisfies_domain(self.il, expr, DomainRequirement::Set)
     }
 
     fn is_map_param_expr(&self, expr: NodeId) -> bool {
-        self.domain_evidence_of_expr(expr)
-            .is_some_and(DomainEvidence::is_map)
+        nose_semantics::receiver_satisfies_domain(self.il, expr, DomainRequirement::Map)
     }
 
     fn is_integer_param_expr(&self, expr: NodeId) -> bool {
-        self.domain_evidence_of_expr(expr)
-            .is_some_and(DomainEvidence::is_integer)
+        nose_semantics::receiver_satisfies_domain(self.il, expr, DomainRequirement::Integer)
     }
 
     /// Whether `value` is a parameter (an `Input`) carrying the given proof-gate domain.
@@ -8666,6 +8656,69 @@ mod tests {
         builder
             .proven_collection_value(raw)
             .map(|value| builder.nodes[value as usize].op.clone())
+    }
+
+    fn receiver_domain_contains_call_il() -> (Il, Interner, NodeId, Span) {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver_span = sp(30);
+        let receiver = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("xs")),
+            receiver_span,
+            &[],
+        );
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("includes")),
+            sp(31),
+            &[receiver],
+        );
+        let item = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("item")),
+            sp(32),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(33), &[callee, item]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(29), &[call]);
+        let il = finish_test_il(b, root, Lang::TypeScript);
+        (il, interner, call, receiver_span)
+    }
+
+    fn eval_op(il: &Il, interner: &Interner, node: NodeId) -> ValOp {
+        let mut builder = Builder::new(il, interner);
+        let value = builder.eval(node, &FxHashMap::default());
+        builder.nodes[value as usize].op.clone()
+    }
+
+    #[test]
+    fn membership_call_consumes_receiver_domain_evidence() {
+        let (mut il, interner, call, receiver_span) = receiver_domain_contains_call_il();
+        assert!(
+            !matches!(eval_op(&il, &interner, call), ValOp::Bin(op) if op == Op::In as u32),
+            "method selector alone must not prove collection membership"
+        );
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(receiver_span, NodeKind::Var),
+            EvidenceKind::Domain(DomainEvidence::Collection),
+        ));
+        assert!(matches!(
+            eval_op(&il, &interner, call),
+            ValOp::Bin(op) if op == Op::In as u32
+        ));
+
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(receiver_span, NodeKind::Var),
+            EvidenceKind::Domain(DomainEvidence::Map),
+        ));
+        assert!(
+            !matches!(eval_op(&il, &interner, call), ValOp::Bin(op) if op == Op::In as u32),
+            "conflicting receiver-domain evidence must close the exact membership rewrite"
+        );
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -11,7 +11,7 @@ use nose_il::{
     EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceRecord, EvidenceStatus, GuardEvidenceKind,
     HoFKind, Il, ImportEvidenceKind, Interner, Lang, LibraryApiEvidenceKind, LitClass, NodeId,
     NodeKind, Op, ParamSemantic, Payload, PlaceEvidenceKind, SequenceSurfaceKind, SourceCallKind,
-    SourceFactKind, SourceLiteralKind, SourceOperatorKind, Span, SymbolEvidenceKind,
+    SourceFactKind, SourceLiteralKind, SourceOperatorKind, Span, Symbol, SymbolEvidenceKind,
 };
 
 pub use nose_il::DomainEvidence;
@@ -226,10 +226,14 @@ pub fn domain_evidence_from_param_semantic(semantic: ParamSemantic) -> DomainEvi
 }
 
 pub fn domain_evidence_at_span(il: &Il, span: Span) -> Option<DomainEvidence> {
-    match evidence_at_span(il, span, |evidence| match evidence {
-        EvidenceKind::Domain(domain) => Some(domain),
-        _ => None,
-    }) {
+    match unique_asserted_evidence_at(
+        il,
+        |anchor| anchor.matches_span(span),
+        |evidence| match evidence {
+            EvidenceKind::Domain(domain) => Some(domain),
+            _ => None,
+        },
+    ) {
         EvidenceResolution::Found(domain) => Some(domain),
         EvidenceResolution::Ambiguous => None,
         EvidenceResolution::Missing => {
@@ -251,6 +255,212 @@ pub fn domain_evidence_for_param(il: &Il, param: NodeId) -> Option<DomainEvidenc
     (il.kind(param) == NodeKind::Param)
         .then_some(il.node(param).span)
         .and_then(|span| domain_evidence_at_span(il, span))
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum DomainRequirement {
+    Array,
+    ByteArray,
+    Collection,
+    CollectionOrSet,
+    CollectionOrMap,
+    ArrayOrCollection,
+    ArrayCollectionOrSet,
+    Set,
+    SetOrMap,
+    Map,
+    Option,
+    String,
+    Integer,
+    IntegerOrNumber,
+}
+
+impl DomainRequirement {
+    pub fn accepts(self, domain: DomainEvidence) -> bool {
+        match self {
+            DomainRequirement::Array => domain.is_array(),
+            DomainRequirement::ByteArray => domain.is_byte_array(),
+            DomainRequirement::Collection => domain == DomainEvidence::Collection,
+            DomainRequirement::CollectionOrSet => domain.is_collection_or_set(),
+            DomainRequirement::CollectionOrMap => {
+                domain.is_array_collection_or_set() || domain.is_map()
+            }
+            DomainRequirement::ArrayOrCollection => domain.is_array_or_collection(),
+            DomainRequirement::ArrayCollectionOrSet => domain.is_array_collection_or_set(),
+            DomainRequirement::Set => domain.is_set(),
+            DomainRequirement::SetOrMap => domain.is_set() || domain.is_map(),
+            DomainRequirement::Map => domain.is_map(),
+            DomainRequirement::Option => domain.is_option(),
+            DomainRequirement::String => domain.is_string(),
+            DomainRequirement::Integer => domain.is_integer(),
+            DomainRequirement::IntegerOrNumber => domain.is_integer_or_number(),
+        }
+    }
+}
+
+fn domain_evidence_at_exact_anchor(
+    il: &Il,
+    expected: EvidenceAnchor,
+) -> EvidenceResolution<DomainEvidence> {
+    unique_asserted_evidence_at(
+        il,
+        |anchor| anchor == expected,
+        |evidence| match evidence {
+            EvidenceKind::Domain(domain) => Some(domain),
+            _ => None,
+        },
+    )
+}
+
+pub fn domain_evidence_for_node(il: &Il, node: NodeId) -> Option<DomainEvidence> {
+    match domain_evidence_at_exact_anchor(
+        il,
+        EvidenceAnchor::node(il.node(node).span, il.kind(node)),
+    ) {
+        EvidenceResolution::Found(domain) => Some(domain),
+        EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
+    }
+}
+
+pub fn domain_evidence_for_receiver(il: &Il, receiver: NodeId) -> Option<DomainEvidence> {
+    match domain_evidence_at_exact_anchor(
+        il,
+        EvidenceAnchor::node(il.node(receiver).span, il.kind(receiver)),
+    ) {
+        EvidenceResolution::Found(domain) => return Some(domain),
+        EvidenceResolution::Ambiguous => return None,
+        EvidenceResolution::Missing => {}
+    }
+    domain_evidence_for_var_reference(il, receiver)
+}
+
+pub fn domain_evidence_for_var(il: &Il, node: NodeId) -> Option<DomainEvidence> {
+    (il.kind(node) == NodeKind::Var)
+        .then(|| domain_evidence_for_receiver(il, node))
+        .flatten()
+}
+
+pub fn receiver_satisfies_domain(
+    il: &Il,
+    receiver: NodeId,
+    requirement: DomainRequirement,
+) -> bool {
+    domain_evidence_for_receiver(il, receiver).is_some_and(|domain| requirement.accepts(domain))
+}
+
+fn domain_evidence_for_var_reference(il: &Il, node: NodeId) -> Option<DomainEvidence> {
+    if il.kind(node) != NodeKind::Var {
+        return None;
+    }
+    match il.node(node).payload {
+        Payload::Cid(cid) => match nearest_scope(il, node) {
+            Some(scope) => unique_domain_evidence_for_params(
+                il,
+                il.children(scope).iter().copied().filter(move |&child| {
+                    il.kind(child) == NodeKind::Param
+                        && matches!(il.node(child).payload, Payload::Cid(param_cid) if param_cid == cid)
+                }),
+            ),
+            None => unique_domain_evidence_for_params(
+                il,
+                il.nodes.iter().enumerate().filter_map(move |(idx, candidate)| {
+                    (candidate.kind == NodeKind::Param
+                        && matches!(candidate.payload, Payload::Cid(param_cid) if param_cid == cid))
+                    .then_some(NodeId(idx as u32))
+                }),
+            ),
+        },
+        Payload::Name(name) => {
+            let (scope, param) = nearest_named_param_scope(il, node, name)?;
+            if name_is_assigned_in_scope(il, name, scope) {
+                return None;
+            }
+            domain_evidence_for_param(il, param)
+        }
+        _ => None,
+    }
+}
+
+fn unique_domain_evidence_for_params(
+    il: &Il,
+    params: impl Iterator<Item = NodeId>,
+) -> Option<DomainEvidence> {
+    let mut found = None;
+    for param in params {
+        let Some(domain) = domain_evidence_for_param(il, param) else {
+            continue;
+        };
+        match found {
+            None => found = Some(domain),
+            Some(existing) if existing == domain => {}
+            Some(_) => return None,
+        }
+    }
+    found
+}
+
+fn nearest_named_param_scope(il: &Il, node: NodeId, name: Symbol) -> Option<(NodeId, NodeId)> {
+    let target = il.node(node).span;
+    let mut best: Option<(u32, NodeId, NodeId)> = None;
+    for (idx, candidate) in il.nodes.iter().enumerate() {
+        if !matches!(candidate.kind, NodeKind::Func | NodeKind::Lambda) {
+            continue;
+        }
+        if !span_contains(candidate.span, target) {
+            continue;
+        }
+        let scope = NodeId(idx as u32);
+        let Some(param) = il.children(scope).iter().copied().find(|&child| {
+            il.kind(child) == NodeKind::Param && il.node(child).payload == Payload::Name(name)
+        }) else {
+            continue;
+        };
+        let width = candidate
+            .span
+            .end_byte
+            .saturating_sub(candidate.span.start_byte);
+        if best.is_none_or(|(best_width, _, _)| width < best_width) {
+            best = Some((width, scope, param));
+        }
+    }
+    best.map(|(_, scope, param)| (scope, param))
+}
+
+fn name_is_assigned_in_scope(il: &Il, name: Symbol, scope: NodeId) -> bool {
+    il.nodes.iter().enumerate().any(|(idx, node)| {
+        if node.kind != NodeKind::Assign {
+            return false;
+        }
+        let id = NodeId(idx as u32);
+        if nearest_scope(il, id) != Some(scope) {
+            return false;
+        }
+        let Some(&lhs) = il.children(id).first() else {
+            return false;
+        };
+        il.kind(lhs) == NodeKind::Var && il.node(lhs).payload == Payload::Name(name)
+    })
+}
+
+fn nearest_scope(il: &Il, node: NodeId) -> Option<NodeId> {
+    let target = il.node(node).span;
+    let mut best: Option<(u32, NodeId)> = None;
+    for (idx, candidate) in il.nodes.iter().enumerate() {
+        if !matches!(candidate.kind, NodeKind::Func | NodeKind::Lambda) {
+            continue;
+        }
+        if !span_contains(candidate.span, target) {
+            continue;
+        }
+        let width = candidate
+            .span
+            .end_byte
+            .saturating_sub(candidate.span.start_byte);
+        if best.is_none_or(|(best_width, _)| width < best_width) {
+            best = Some((width, NodeId(idx as u32)));
+        }
+    }
+    best.map(|(_, scope)| scope)
 }
 
 pub const SEQ_VALUE_UNTAGGED: u64 = 0;
@@ -2180,6 +2390,44 @@ pub enum MethodReceiverContract {
     UnshadowedGlobal(&'static str),
     ImportedNamespace(&'static str),
     RustMapGetOrExactOption,
+}
+
+pub fn method_receiver_domain_requirement(
+    receiver: MethodReceiverContract,
+) -> Option<DomainRequirement> {
+    match receiver {
+        MethodReceiverContract::ExactCollection
+        | MethodReceiverContract::ExactProtocol
+        | MethodReceiverContract::ExactProtocolPairArgument
+        | MethodReceiverContract::ExactCollectionOrJavaKeySet => {
+            Some(DomainRequirement::ArrayCollectionOrSet)
+        }
+        MethodReceiverContract::ExactOption | MethodReceiverContract::RustMapGetOrExactOption => {
+            Some(DomainRequirement::Option)
+        }
+        MethodReceiverContract::ExactString | MethodReceiverContract::LiteralString => {
+            Some(DomainRequirement::String)
+        }
+        MethodReceiverContract::ExactInteger => Some(DomainRequirement::Integer),
+        MethodReceiverContract::ExactMap => Some(DomainRequirement::Map),
+        MethodReceiverContract::ExactCollectionOrMap
+        | MethodReceiverContract::ExactCollectionOrMapLiteral => {
+            Some(DomainRequirement::CollectionOrMap)
+        }
+        MethodReceiverContract::ExactSetOrMap => Some(DomainRequirement::SetOrMap),
+        MethodReceiverContract::ExactMapLiteral
+        | MethodReceiverContract::UnshadowedGlobal(_)
+        | MethodReceiverContract::ImportedNamespace(_) => None,
+    }
+}
+
+pub fn receiver_satisfies_method_domain(
+    il: &Il,
+    receiver: NodeId,
+    contract: MethodReceiverContract,
+) -> bool {
+    method_receiver_domain_requirement(contract)
+        .is_some_and(|requirement| receiver_satisfies_domain(il, receiver, requirement))
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -5733,7 +5981,7 @@ mod tests {
     use nose_il::{
         EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
         EvidenceRecord, EvidenceStatus, FileId, FileMeta, GuardEvidenceKind, IlBuilder,
-        ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck,
+        ImportEvidenceKind, Interner, JsRecordGuardComparison, JsRecordGuardNullCheck,
         LibraryApiEvidenceKind, ParamSemantic, ParamTypeFact, SequenceSurfaceKind, SourceFact,
         Span, Symbol, SymbolEvidenceKind, Unit, UnitKind,
     };
@@ -5782,6 +6030,10 @@ mod tests {
 
     fn sp(line: u32) -> Span {
         Span::new(FileId(0), line, line, 1, 1)
+    }
+
+    fn span(start: u32, end: u32, line: u32) -> Span {
+        Span::new(FileId(0), start, end, line, line)
     }
 
     fn finish_il(builder: IlBuilder, root: NodeId, lang: Lang) -> Il {
@@ -5859,6 +6111,43 @@ mod tests {
         assert!(!DomainEvidence::Number.is_integer());
         assert!(!DomainEvidence::Array.is_collection_or_set());
         assert!(!DomainEvidence::Set.is_array_or_collection());
+        assert!(DomainRequirement::CollectionOrMap.accepts(DomainEvidence::Array));
+        assert!(DomainRequirement::CollectionOrMap.accepts(DomainEvidence::Map));
+        assert!(DomainRequirement::SetOrMap.accepts(DomainEvidence::Set));
+        assert!(DomainRequirement::SetOrMap.accepts(DomainEvidence::Map));
+        assert!(!DomainRequirement::SetOrMap.accepts(DomainEvidence::Collection));
+    }
+
+    #[test]
+    fn method_receiver_contracts_expose_only_domain_backed_obligations() {
+        assert_eq!(
+            method_receiver_domain_requirement(MethodReceiverContract::ExactCollection),
+            Some(DomainRequirement::ArrayCollectionOrSet)
+        );
+        assert_eq!(
+            method_receiver_domain_requirement(MethodReceiverContract::ExactProtocol),
+            Some(DomainRequirement::ArrayCollectionOrSet)
+        );
+        assert_eq!(
+            method_receiver_domain_requirement(MethodReceiverContract::ExactCollectionOrMap),
+            Some(DomainRequirement::CollectionOrMap)
+        );
+        assert_eq!(
+            method_receiver_domain_requirement(MethodReceiverContract::ExactSetOrMap),
+            Some(DomainRequirement::SetOrMap)
+        );
+        assert_eq!(
+            method_receiver_domain_requirement(MethodReceiverContract::RustMapGetOrExactOption),
+            Some(DomainRequirement::Option)
+        );
+        assert_eq!(
+            method_receiver_domain_requirement(MethodReceiverContract::ExactMapLiteral),
+            None
+        );
+        assert_eq!(
+            method_receiver_domain_requirement(MethodReceiverContract::ImportedNamespace("math")),
+            None
+        );
     }
 
     #[test]
@@ -5908,6 +6197,242 @@ mod tests {
         ));
 
         assert_eq!(domain_evidence_for_param(&il, param), None);
+    }
+
+    #[test]
+    fn receiver_domain_evidence_at_node_is_preferred_over_param_mirror() {
+        let mut b = IlBuilder::new(FileId(0));
+        let param = b.add(NodeKind::Param, Payload::Cid(0), span(10, 12, 1), &[]);
+        let receiver = b.add(NodeKind::Var, Payload::Cid(0), span(20, 22, 2), &[]);
+        let stmt = b.add(
+            NodeKind::ExprStmt,
+            Payload::None,
+            span(20, 22, 2),
+            &[receiver],
+        );
+        let body = b.add(NodeKind::Block, Payload::None, span(18, 24, 2), &[stmt]);
+        let root = b.add(
+            NodeKind::Func,
+            Payload::None,
+            span(0, 30, 1),
+            &[param, body],
+        );
+        let mut il = finish_il(b, root, Lang::TypeScript);
+        il.param_type_facts.push(ParamTypeFact {
+            span: span(10, 12, 1),
+            semantic: ParamSemantic::Set,
+        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(span(20, 22, 2), NodeKind::Var),
+            EvidenceKind::Domain(DomainEvidence::Map),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert_eq!(
+            domain_evidence_for_param(&il, param),
+            Some(DomainEvidence::Set)
+        );
+        assert_eq!(
+            domain_evidence_for_receiver(&il, receiver),
+            Some(DomainEvidence::Map)
+        );
+        assert!(receiver_satisfies_domain(
+            &il,
+            receiver,
+            DomainRequirement::Map
+        ));
+        assert!(!receiver_satisfies_domain(
+            &il,
+            receiver,
+            DomainRequirement::Set
+        ));
+    }
+
+    #[test]
+    fn ambiguous_receiver_domain_evidence_blocks_param_fallback() {
+        let mut b = IlBuilder::new(FileId(0));
+        let param = b.add(NodeKind::Param, Payload::Cid(0), span(10, 12, 1), &[]);
+        let receiver = b.add(NodeKind::Var, Payload::Cid(0), span(20, 22, 2), &[]);
+        let body = b.add(NodeKind::Block, Payload::None, span(18, 24, 2), &[receiver]);
+        let root = b.add(
+            NodeKind::Func,
+            Payload::None,
+            span(0, 30, 1),
+            &[param, body],
+        );
+        let mut il = finish_il(b, root, Lang::TypeScript);
+        il.param_type_facts.push(ParamTypeFact {
+            span: span(10, 12, 1),
+            semantic: ParamSemantic::Map,
+        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(span(20, 22, 2), NodeKind::Var),
+            EvidenceKind::Domain(DomainEvidence::Set),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(span(20, 22, 2), NodeKind::Var),
+            EvidenceKind::Domain(DomainEvidence::Map),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert_eq!(domain_evidence_for_receiver(&il, receiver), None);
+    }
+
+    #[test]
+    fn cid_receiver_domain_uses_nearest_function_scope() {
+        let mut b = IlBuilder::new(FileId(0));
+        let first_param = b.add(NodeKind::Param, Payload::Cid(0), span(10, 12, 1), &[]);
+        let first_body = b.add(NodeKind::Block, Payload::None, span(14, 20, 1), &[]);
+        let first_func = b.add(
+            NodeKind::Func,
+            Payload::None,
+            span(0, 30, 1),
+            &[first_param, first_body],
+        );
+        let second_param = b.add(NodeKind::Param, Payload::Cid(0), span(50, 52, 3), &[]);
+        let receiver = b.add(NodeKind::Var, Payload::Cid(0), span(60, 62, 4), &[]);
+        let stmt = b.add(
+            NodeKind::ExprStmt,
+            Payload::None,
+            span(60, 62, 4),
+            &[receiver],
+        );
+        let second_body = b.add(NodeKind::Block, Payload::None, span(58, 66, 4), &[stmt]);
+        let second_func = b.add(
+            NodeKind::Func,
+            Payload::None,
+            span(40, 80, 3),
+            &[second_param, second_body],
+        );
+        let root = b.add(
+            NodeKind::Module,
+            Payload::None,
+            span(0, 90, 1),
+            &[first_func, second_func],
+        );
+        let mut il = finish_il(b, root, Lang::TypeScript);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::param(span(10, 12, 1)),
+            EvidenceKind::Domain(DomainEvidence::Collection),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::param(span(50, 52, 3)),
+            EvidenceKind::Domain(DomainEvidence::Map),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert_eq!(
+            domain_evidence_for_receiver(&il, receiver),
+            Some(DomainEvidence::Map)
+        );
+    }
+
+    #[test]
+    fn dependency_broken_receiver_domain_evidence_blocks_param_fallback() {
+        let mut b = IlBuilder::new(FileId(0));
+        let param = b.add(NodeKind::Param, Payload::Cid(0), span(10, 12, 1), &[]);
+        let receiver = b.add(NodeKind::Var, Payload::Cid(0), span(20, 22, 2), &[]);
+        let body = b.add(NodeKind::Block, Payload::None, span(18, 24, 2), &[receiver]);
+        let root = b.add(
+            NodeKind::Func,
+            Payload::None,
+            span(0, 30, 1),
+            &[param, body],
+        );
+        let mut il = finish_il(b, root, Lang::TypeScript);
+        il.param_type_facts.push(ParamTypeFact {
+            span: span(10, 12, 1),
+            semantic: ParamSemantic::Set,
+        });
+        il.evidence.push(evidence_with_dependencies(
+            0,
+            EvidenceAnchor::node(span(20, 22, 2), NodeKind::Var),
+            EvidenceKind::Domain(DomainEvidence::Map),
+            EvidenceStatus::Asserted,
+            vec![EvidenceId(99)],
+        ));
+
+        assert_eq!(domain_evidence_for_receiver(&il, receiver), None);
+    }
+
+    #[test]
+    fn named_receiver_domain_requires_unassigned_param_scope() {
+        let interner = Interner::new();
+        let xs = interner.intern("xs");
+        let mut b = IlBuilder::new(FileId(0));
+        let param = b.add(NodeKind::Param, Payload::Name(xs), span(10, 12, 1), &[]);
+        let receiver = b.add(NodeKind::Var, Payload::Name(xs), span(40, 42, 3), &[]);
+        let stmt = b.add(
+            NodeKind::ExprStmt,
+            Payload::None,
+            span(40, 42, 3),
+            &[receiver],
+        );
+        let body = b.add(NodeKind::Block, Payload::None, span(20, 50, 2), &[stmt]);
+        let root = b.add(
+            NodeKind::Func,
+            Payload::None,
+            span(0, 60, 1),
+            &[param, body],
+        );
+        let mut il = finish_il(b, root, Lang::TypeScript);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::param(span(10, 12, 1)),
+            EvidenceKind::Domain(DomainEvidence::Collection),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert_eq!(
+            domain_evidence_for_receiver(&il, receiver),
+            Some(DomainEvidence::Collection)
+        );
+
+        let mut b = IlBuilder::new(FileId(0));
+        let param = b.add(NodeKind::Param, Payload::Name(xs), span(10, 12, 1), &[]);
+        let lhs = b.add(NodeKind::Var, Payload::Name(xs), span(24, 26, 2), &[]);
+        let rhs = b.add(NodeKind::Lit, Payload::LitInt(1), span(29, 30, 2), &[]);
+        let assign = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            span(24, 30, 2),
+            &[lhs, rhs],
+        );
+        let receiver = b.add(NodeKind::Var, Payload::Name(xs), span(40, 42, 3), &[]);
+        let stmt = b.add(
+            NodeKind::ExprStmt,
+            Payload::None,
+            span(40, 42, 3),
+            &[receiver],
+        );
+        let body = b.add(
+            NodeKind::Block,
+            Payload::None,
+            span(20, 50, 2),
+            &[assign, stmt],
+        );
+        let root = b.add(
+            NodeKind::Func,
+            Payload::None,
+            span(0, 60, 1),
+            &[param, body],
+        );
+        let mut il = finish_il(b, root, Lang::TypeScript);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::param(span(10, 12, 1)),
+            EvidenceKind::Domain(DomainEvidence::Collection),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert_eq!(domain_evidence_for_receiver(&il, receiver), None);
     }
 
     #[test]

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -58,7 +58,7 @@ The current implemented kinds are:
 | kind | purpose |
 |---|---|
 | `Source` | construct syntax, Rust macro invocation syntax, regex literal provenance, and source operator family |
-| `Domain` | receiver/value domain such as collection, map, option, string, integer, or byte array |
+| `Domain` | parameter, receiver-expression, or value/binding domain such as collection, map, option, string, integer, or byte array |
 | `Import` | static import binding/namespace proof, Ruby `require` module proof, and imported-literal snapshot provenance |
 | `Symbol` | resolved or proven symbol identity, with record kinds for unshadowed globals, static imported binding/namespace aliases, and selected qualified global API paths |
 | `Guard` | multi-obligation guard proof facts such as JS/TS record-shape and own-property guard contracts |
@@ -132,6 +132,19 @@ import evidence does not by itself prove every use of the same local name; if th
 alias is rebound or ambiguous, the exact path stays closed until a node-level
 symbol fact or stronger scope-resolution evidence exists.
 
+Domain evidence follows the same fail-closed rule. First-party parameter
+annotations still mirror into `Domain` evidence on `Param` anchors, but
+`nose-semantics` now also resolves `Domain` evidence on exact receiver-expression
+node anchors before consulting parameter compatibility facts. A conflicting,
+ambiguous, or dependency-broken receiver-domain record closes that receiver proof
+and must not fall back to `ParamTypeFact` or selector spelling. When a receiver is
+an alpha-renamed parameter reference, lookup is constrained to the nearest
+function/lambda scope so same-numbered parameter ids from other units do not
+prove the current receiver. Method receiver contracts expose their domain-backed
+obligations through `DomainRequirement`; obligations such as imported namespace,
+unshadowed global, exact map literal, and future demand/effect constraints remain
+separate checks.
+
 Qualified global identity is also evidence, not a selector guess. The current
 first-party JS/TS producer emits `QualifiedGlobal` only for selected static paths
 whose root is proven unshadowed, such as `Object.hasOwn`,
@@ -192,7 +205,10 @@ instead of accepting an unrelated imported symbol elsewhere in the file.
 
 First-party frontends now mirror these facts into `EvidenceRecord`:
 
-- parameter semantic annotations become `Domain` evidence;
+- parameter semantic annotations become `Domain` evidence. Current first-party
+  frontends do not yet emit receiver-expression `Domain` evidence directly, but
+  the internal consumer contract already accepts exact node-anchored receiver
+  facts for future packs and inference producers;
 - source-origin facts become `Source` evidence;
 - import binding and namespace lowering emits `Import` evidence for the proof RHS
   and `Symbol` evidence for the local alias identity;
@@ -257,7 +273,12 @@ The first migrated consumers are the shared semantic helpers and their direct
 callers:
 
 - source-fact lookup for construct syntax, regex literal, and operator provenance;
-- parameter domain lookup used by normalize and strict exact receiver gates;
+- receiver-domain lookup used by desugaring, normalize idiom canonicalization,
+  value-graph membership/property/map/integer gates, and strict exact receiver
+  gates. Consumers ask `nose-semantics` whether a receiver satisfies a
+  `DomainRequirement`, so node-anchored receiver evidence, scoped parameter
+  evidence, ambiguity handling, and compatibility fallback are no longer
+  reimplemented separately in each crate;
 - import proof parsing for compatibility helpers, with value-graph import
   identity and imported literal replacement consuming evidence-only facts;
 - cross-file imported literal replacement copies the provider's closed evidence
@@ -309,7 +330,9 @@ callers:
   or conflicting evidence keeps the exact path closed.
 
 Broader field/place/effect facts, `LibraryApi` occurrence evidence for remaining
-receiver-method APIs and unmodeled stdlib/ecosystem APIs, receiver/protocol
-evidence beyond parameter domains, full scope-resolution and namespace-member
-evidence, broader guard evidence, general cross-module dependency manifests,
-report-level provenance, and external manifest loading are still open work.
+receiver-method APIs and unmodeled stdlib/ecosystem APIs, producer coverage for
+receiver-expression domain evidence, immutable local/module binding domain
+evidence, full protocol/demand/effect receiver obligations, full
+scope-resolution and namespace-member evidence, broader guard evidence, general
+cross-module dependency manifests, report-level provenance, and external
+manifest loading are still open work.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -324,6 +324,16 @@ and pack ecosystem.
   `Import::Require` dependencies for those occurrences, and value-graph, idiom,
   strict exact, and provider snapshot consumers require admitted `LibraryApi`
   evidence instead of raw selector/path/require scans.
+- Receiver-domain proof consumption moved behind a shared `DomainRequirement`
+  resolver in `nose-semantics`. `Domain` evidence can now be consumed at exact
+  receiver node anchors before scoped parameter compatibility evidence, and
+  ambiguous/conflicting/dependency-broken receiver facts close fallback.
+  Desugaring, normalize idiom canonicalization, value-graph membership,
+  property, map, and integer gates, and strict exact receiver gates now share
+  this resolver instead of each re-scanning parameter ids or names locally.
+  `MethodReceiverContract` exposes the subset of receiver obligations that are
+  domain-backed, while imported namespace, unshadowed global, map-literal,
+  demand, and effect obligations remain separate checks.
 - An experimental `abstraction` scan mode landed as a weak sibling claim over a
   narrow `near` subset. It emits typed literal-hole witnesses and caveats for
   refactoring-template candidates, but does not feed `semantic`, `verify`, or exact
@@ -437,9 +447,12 @@ Remaining in this phase:
   factories, more nested entries, iterator views, and exported-literal
   eligibility. Go map literal entries are the first exact consumer that now
   requires per-entry surface evidence.
-- Expand domain evidence from parameter annotations into receiver/protocol
-  evidence records for exact collection/map/set/option/string/integer proofs,
-  immutable local/module bindings, and mutation exclusion.
+- Continue expanding domain evidence beyond parameter annotations. The shared
+  receiver-domain consumer contract now accepts exact node-anchored receiver
+  facts, but first-party producers still mostly emit parameter-derived domain
+  evidence. Remaining work is producer coverage for inferred receiver domains,
+  immutable local/module binding domain evidence, mutation exclusion, and
+  protocol-specific receiver facts that include demand/effect obligations.
 - Turn named value-graph rule modules into LawPack-facing law ids/contracts while
   retaining formal-obligation metadata as the first-party proof boundary.
 - Add receiver/place facts so field read/write and property contracts are not

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -8,8 +8,9 @@ record substrate is described in [evidence-records](evidence-records.md).
 Snapshot date: 2026-06-08. The current implementation has an internal
 semantic-kernel facade, receiver-aware field state, sequence-surface contracts,
 proof-backed append fragment evidence, operator-law contracts, typed import
-facts, source-fact gates for construct/macro/literal/operator provenance, and a shared
-evidence-record substrate for source, domain, import, symbol-identity, guard,
+facts, source-fact gates for construct/macro/literal/operator provenance,
+receiver-domain evidence resolution, and a shared evidence-record substrate for
+source, domain, import, symbol-identity, guard,
 place/effect, selected library API occurrence, and sequence-surface facts.
 Library/API identity is consolidated through internal `LibraryApiContract` rows
 for factory, constructor, and selected non-factory method/view surfaces, with
@@ -89,10 +90,15 @@ migrated.
   protocol, exact option, exact string, exact primitive integer, exact map literal,
   imported namespace, or unshadowed global.
 - Source-level `ParamSemantic` facts are mirrored into
-  `EvidenceRecord::Domain`, and normalize/detect receiver-domain gates consume
-  domain evidence through `nose-semantics` helpers. This preserves the current
-  Array/Collection/Set/Map/Option/String/Integer/Number/ByteArray distinctions
-  while moving the proof storage toward the pack-facing evidence substrate.
+  `EvidenceRecord::Domain`, and `nose-semantics` now resolves receiver-domain
+  evidence through a shared `DomainRequirement` contract. Consumers check exact
+  receiver node evidence first, then scoped parameter evidence, and fail closed
+  on ambiguous/conflicting/dependency-broken records before any compatibility
+  fallback. Desugaring, normalize idiom canonicalization, value-graph receiver
+  gates, and strict exact receiver gates consume this same helper layer. This
+  preserves the current Array/Collection/Set/Map/Option/String/Integer/Number
+  and ByteArray distinctions while opening the internal boundary for future packs
+  or inference passes to attach receiver-expression domain facts directly.
 - Property builtin contracts are language-constrained; a selector such as
   `length` is not enough without receiver proof. JS/TS `filter(...).length`
   is admitted only after the receiver has already entered a proven collection/HOF


### PR DESCRIPTION
## Summary

Moves receiver/domain proof consumption onto a shared semantic-kernel resolver instead of scattering parameter-CID/name checks across normalize and detect.

- add `DomainRequirement` and receiver-domain lookup helpers in `nose-semantics`
- allow `Domain` evidence on exact receiver node anchors before scoped parameter compatibility fallback
- fail closed on ambiguous, conflicting, or dependency-broken receiver-domain evidence
- scope alpha-renamed parameter lookup to the nearest function/lambda
- expose the domain-backed subset of `MethodReceiverContract`
- migrate desugaring, normalize idiom canonicalization, value-graph receiver gates, and strict exact receiver gates to the shared resolver
- update semantic-kernel snapshot, roadmap, and evidence-record docs

Tracks #109.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --release`
- `./scripts/check-duplication.sh`
- `awiki lint --root docs`
- `git diff --check`
- `python3 scripts/check-formal-obligations.py --self-test`
- `python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`

## Remaining Work

Producer coverage for inferred receiver-domain facts, immutable local/module binding domain evidence, broader protocol facts with demand/effect obligations, and remaining receiver-method API occurrence evidence remain for later large slices.