### PR TITLE
[codex] emit library result domain evidence

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -1735,6 +1735,9 @@ fn strict_exact_typed_receiver_safe(
     receiver: NodeId,
     requirement: DomainRequirement,
 ) -> bool {
+    if il.kind(receiver) != NodeKind::Var {
+        return false;
+    }
     nose_semantics::receiver_satisfies_domain(il, receiver, requirement)
 }
 
@@ -4110,6 +4113,81 @@ mod tests {
         assert!(
             !strict_exact_safe_tree(&il, &interner, &facts, call),
             "conflicting receiver-domain evidence must close strict exact fallback"
+        );
+    }
+
+    #[test]
+    fn strict_exact_contains_does_not_use_result_domain_as_exact_tree_proof() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let factory_callee = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("Set")),
+            sp(40),
+            &[],
+        );
+        let seed = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(41),
+            &[],
+        );
+        let receiver = b.add(
+            NodeKind::Call,
+            Payload::None,
+            sp(42),
+            &[factory_callee, seed],
+        );
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("includes")),
+            sp(43),
+            &[receiver],
+        );
+        let item = b.add(NodeKind::Lit, Payload::LitInt(7), sp(44), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(45), &[callee, item]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(39), &[call]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.ts".into(),
+                lang: Lang::TypeScript,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(
+            !strict_exact_safe_tree(&il, &interner, &facts, call),
+            "call-result receiver must not be collection-like without domain evidence"
+        );
+
+        let api = library_js_like_set_constructor_contract(Lang::TypeScript, "Set").unwrap();
+        il.evidence.push(library_api_contract_evidence(
+            0,
+            sp(42),
+            api.id,
+            api.callee,
+            1,
+            Vec::new(),
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(sp(42), NodeKind::Call),
+            EvidenceKind::Domain(nose_semantics::DomainEvidence::Set),
+            vec![EvidenceId(0)],
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(
+            !strict_exact_safe_tree(&il, &interner, &facts, call),
+            "result-domain evidence proves the call result's receiver domain, not the exact-safety of the receiver expression"
+        );
+
+        il.evidence[0].status = EvidenceStatus::Ambiguous;
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(
+            !strict_exact_safe_tree(&il, &interner, &facts, call),
+            "ambiguous LibraryApi dependency must close strict exact receiver proof"
         );
     }
 

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -11,25 +11,28 @@ use nose_il::{
 };
 use nose_semantics::{
     library_api_callee_contract_hash, library_api_contract_id_hash,
-    library_api_free_name_shadow_safe, library_free_name_collection_factory_contract,
-    library_free_name_map_factory_contract, library_imported_collection_factory_contracts,
-    library_imported_namespace_function_contract, library_java_collection_factory_contract,
-    library_java_map_entry_contract, library_java_map_factory_contract,
-    library_js_array_is_array_contract, library_js_boolean_coercion_contract,
-    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
-    library_map_key_view_wrapper_contract, library_regex_test_contract,
-    library_ruby_set_factory_contract, library_rust_vec_macro_factory_contract,
-    library_rust_vec_new_factory_contract, library_static_collection_adapter_contract,
-    sequence_surface_kind_for_tag, ImportFactKind, LibraryApiCalleeContract, LibraryApiContractId,
+    library_api_free_name_shadow_safe, library_collection_factory_result_domain_for_arity,
+    library_free_name_collection_factory_contract, library_free_name_map_factory_contract,
+    library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
+    library_java_collection_factory_contract, library_java_map_entry_contract,
+    library_java_map_factory_contract, library_js_array_is_array_contract,
+    library_js_boolean_coercion_contract, library_js_like_map_constructor_contract,
+    library_js_like_set_constructor_contract, library_map_factory_result_domain,
+    library_map_key_view_wrapper_contract, library_map_key_view_wrapper_result_domain,
+    library_regex_test_contract, library_ruby_set_factory_contract,
+    library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
+    library_static_collection_adapter_contract, sequence_surface_kind_for_tag, ImportFactKind,
+    LibraryApiCalleeContract, LibraryApiContractId,
 };
 use tree_sitter::Node as TsNode;
 
-type LibraryApiEvidencePlan = (
-    LibraryApiContractId,
-    LibraryApiCalleeContract,
-    Vec<EvidenceId>,
-    &'static str,
-);
+struct LibraryApiEvidencePlan {
+    id: LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+    dependencies: Vec<EvidenceId>,
+    rule: &'static str,
+    result_domain: Option<DomainEvidence>,
+}
 
 /// Mutable state threaded through a single file's lowering.
 pub(crate) struct Lowering<'a> {
@@ -178,18 +181,33 @@ impl<'a> Lowering<'a> {
             return;
         };
         let arg_count = args.len();
-        if let Some((id, callee_contract, dependencies, rule)) =
-            self.library_api_contract_for_call(span, callee, arg_count)
-        {
-            self.record_evidence_with_dependencies(
+        if let Some(plan) = self.library_api_contract_for_call(span, callee, arg_count) {
+            let api = self.record_evidence_with_dependencies(
                 EvidenceAnchor::node(span, NodeKind::Call),
                 EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
-                    contract_hash: library_api_contract_id_hash(id),
-                    callee_hash: library_api_callee_contract_hash(callee_contract),
+                    contract_hash: library_api_contract_id_hash(plan.id),
+                    callee_hash: library_api_callee_contract_hash(plan.callee),
                     arity: arg_count as u16,
                 }),
-                rule,
-                dependencies,
+                plan.rule,
+                plan.dependencies,
+            );
+            self.record_library_api_result_domain(span, plan.result_domain, api);
+        }
+    }
+
+    fn record_library_api_result_domain(
+        &mut self,
+        span: Span,
+        result_domain: Option<DomainEvidence>,
+        api: EvidenceId,
+    ) {
+        if let Some(domain) = result_domain {
+            self.record_evidence_with_dependencies(
+                EvidenceAnchor::node(span, NodeKind::Call),
+                EvidenceKind::Domain(domain),
+                "library_api_result_domain",
+                vec![api],
             );
         }
     }
@@ -239,6 +257,7 @@ impl<'a> Lowering<'a> {
                     contract.result.requires_unshadowed_receiver,
                     contract.result.receiver,
                     "library_api_js_array_is_array",
+                    None,
                 )
             })
             .or_else(|| {
@@ -251,6 +270,7 @@ impl<'a> Lowering<'a> {
                             true,
                             contract.result.receiver,
                             "library_api_map_key_view_wrapper",
+                            Some(library_map_key_view_wrapper_result_domain(contract)),
                         )
                     },
                 )
@@ -260,7 +280,13 @@ impl<'a> Lowering<'a> {
         if contract.3 {
             dependencies.push(self.unshadowed_global_evidence_id(receiver_node, contract.4)?);
         }
-        Some((contract.0, contract.1, dependencies, contract.5))
+        Some(LibraryApiEvidencePlan {
+            id: contract.0,
+            callee: contract.1,
+            dependencies,
+            rule: contract.5,
+            result_domain: contract.6,
+        })
     }
 
     fn static_member_callee(&self, callee: NodeId) -> Option<(NodeId, &str, &str)> {
@@ -302,12 +328,13 @@ impl<'a> Lowering<'a> {
             dependencies
                 .push(self.unshadowed_global_evidence_id(callee, contract.result.function)?);
         }
-        Some((
-            contract.id,
-            contract.callee,
+        Some(LibraryApiEvidencePlan {
+            id: contract.id,
+            callee: contract.callee,
             dependencies,
-            "library_api_js_boolean_coercion",
-        ))
+            rule: "library_api_js_boolean_coercion",
+            result_domain: None,
+        })
     }
 
     fn imported_collection_factory_api_contract(
@@ -330,12 +357,15 @@ impl<'a> Lowering<'a> {
                     };
                     let dependency =
                         self.record_imported_binding_symbol_for_node(callee, module, expected)?;
-                    Some((
-                        contract.id,
-                        contract.callee,
-                        vec![dependency],
-                        "library_api_imported_collection_factory",
-                    ))
+                    Some(LibraryApiEvidencePlan {
+                        id: contract.id,
+                        callee: contract.callee,
+                        dependencies: vec![dependency],
+                        rule: "library_api_imported_collection_factory",
+                        result_domain: library_collection_factory_result_domain_for_arity(
+                            contract, arg_count,
+                        ),
+                    })
                 })
             }
             NodeKind::Field => {
@@ -355,12 +385,15 @@ impl<'a> Lowering<'a> {
                     }
                     let dependency =
                         self.record_imported_namespace_symbol_for_node(receiver, module)?;
-                    Some((
-                        contract.id,
-                        contract.callee,
-                        vec![dependency],
-                        "library_api_imported_collection_factory",
-                    ))
+                    Some(LibraryApiEvidencePlan {
+                        id: contract.id,
+                        callee: contract.callee,
+                        dependencies: vec![dependency],
+                        rule: "library_api_imported_collection_factory",
+                        result_domain: library_collection_factory_result_domain_for_arity(
+                            contract, arg_count,
+                        ),
+                    })
                 })
             }
             _ => None,
@@ -387,12 +420,13 @@ impl<'a> Lowering<'a> {
         };
         let receiver = self.b.children(callee).first().copied()?;
         let dependency = self.record_imported_namespace_symbol_for_node(receiver, module)?;
-        Some((
-            contract.id,
-            contract.callee,
-            vec![dependency],
-            "library_api_imported_namespace_function",
-        ))
+        Some(LibraryApiEvidencePlan {
+            id: contract.id,
+            callee: contract.callee,
+            dependencies: vec![dependency],
+            rule: "library_api_imported_namespace_function",
+            result_domain: None,
+        })
     }
 
     fn java_util_static_member_api_contract(
@@ -401,18 +435,24 @@ impl<'a> Lowering<'a> {
         arg_count: usize,
     ) -> Option<LibraryApiEvidencePlan> {
         let (receiver_node, receiver, method) = self.static_member_callee(callee)?;
-        let (id, callee_contract, rule) =
+        let (id, callee_contract, rule, result_domain) =
             library_java_collection_factory_contract(self.lang, receiver, method)
                 .map(|contract| {
                     (
                         contract.id,
                         contract.callee,
                         "library_api_java_collection_factory",
+                        library_collection_factory_result_domain_for_arity(contract, arg_count),
                     )
                 })
                 .or_else(|| {
                     library_java_map_factory_contract(self.lang, receiver, method).map(|contract| {
-                        (contract.id, contract.callee, "library_api_java_map_factory")
+                        (
+                            contract.id,
+                            contract.callee,
+                            "library_api_java_map_factory",
+                            Some(library_map_factory_result_domain(contract)),
+                        )
                     })
                 })
                 .or_else(|| {
@@ -424,6 +464,7 @@ impl<'a> Lowering<'a> {
                                 contract.id,
                                 contract.callee,
                                 "library_api_java_map_entry_factory",
+                                None,
                             )
                         })
                 })
@@ -436,10 +477,17 @@ impl<'a> Lowering<'a> {
                             contract.id,
                             contract.callee,
                             "library_api_java_static_collection_adapter",
+                            None,
                         )
                     })
                 })?;
-        self.java_util_static_member_evidence_plan(receiver_node, id, callee_contract, rule)
+        self.java_util_static_member_evidence_plan(
+            receiver_node,
+            id,
+            callee_contract,
+            rule,
+            result_domain,
+        )
     }
 
     fn java_util_static_member_evidence_plan(
@@ -448,6 +496,7 @@ impl<'a> Lowering<'a> {
         id: LibraryApiContractId,
         callee_contract: LibraryApiCalleeContract,
         rule: &'static str,
+        result_domain: Option<DomainEvidence>,
     ) -> Option<LibraryApiEvidencePlan> {
         let LibraryApiCalleeContract::JavaUtilStaticMember {
             receiver: expected_receiver,
@@ -461,7 +510,13 @@ impl<'a> Lowering<'a> {
             "java.util",
             expected_receiver,
         )?;
-        Some((id, callee_contract, vec![dependency], rule))
+        Some(LibraryApiEvidencePlan {
+            id,
+            callee: callee_contract,
+            dependencies: vec![dependency],
+            rule,
+            result_domain,
+        })
     }
 
     fn regex_literal_method_api_contract(
@@ -486,12 +541,13 @@ impl<'a> Lowering<'a> {
         };
         let receiver = self.b.children(callee).first().copied()?;
         let dependency = self.source_fact_evidence_id(receiver, required_receiver_fact)?;
-        Some((
-            contract.id,
-            contract.callee,
-            vec![dependency],
-            "library_api_regex_literal_method",
-        ))
+        Some(LibraryApiEvidencePlan {
+            id: contract.id,
+            callee: contract.callee,
+            dependencies: vec![dependency],
+            rule: "library_api_regex_literal_method",
+            result_domain: None,
+        })
     }
 
     fn js_global_constructor_api_contract(
@@ -515,6 +571,7 @@ impl<'a> Lowering<'a> {
                     contract.callee,
                     receiver,
                     "library_api_js_set_constructor",
+                    library_collection_factory_result_domain_for_arity(contract, arg_count),
                 )
             })
             .or_else(|| {
@@ -526,6 +583,7 @@ impl<'a> Lowering<'a> {
                             contract.callee,
                             receiver,
                             "library_api_js_map_constructor",
+                            Some(library_map_factory_result_domain(contract)),
                         )
                     })
             })?;
@@ -540,7 +598,13 @@ impl<'a> Lowering<'a> {
                 dependencies.push(self.unshadowed_global_evidence_id(callee, contract.2)?);
             }
         }
-        Some((contract.0, contract.1, dependencies, contract.3))
+        Some(LibraryApiEvidencePlan {
+            id: contract.0,
+            callee: contract.1,
+            dependencies,
+            rule: contract.3,
+            result_domain: contract.4,
+        })
     }
 
     fn source_fact_evidence_id(
@@ -1145,6 +1209,7 @@ fn record_post_lower_free_name_library_api(il: &mut Il, interner: &Interner, cal
                 contract.id,
                 contract.callee,
                 "library_api_free_name_collection_factory",
+                library_collection_factory_result_domain_for_arity(contract, arg_count),
             )
         })
         .or_else(|| {
@@ -1156,6 +1221,7 @@ fn record_post_lower_free_name_library_api(il: &mut Il, interner: &Interner, cal
                         contract.id,
                         contract.callee,
                         "library_api_free_name_map_factory",
+                        Some(library_map_factory_result_domain(contract)),
                     )
                 })
         })
@@ -1165,6 +1231,7 @@ fn record_post_lower_free_name_library_api(il: &mut Il, interner: &Interner, cal
                     contract.id,
                     contract.callee,
                     "library_api_rust_vec_macro_factory",
+                    library_collection_factory_result_domain_for_arity(contract, arg_count),
                 )
             })
         })
@@ -1177,10 +1244,11 @@ fn record_post_lower_free_name_library_api(il: &mut Il, interner: &Interner, cal
                         contract.id,
                         contract.callee,
                         "library_api_rust_vec_new_factory",
+                        library_collection_factory_result_domain_for_arity(contract, arg_count),
                     )
                 })
         });
-    let Some((id, callee_contract, rule)) = contract else {
+    let Some((id, callee_contract, rule, result_domain)) = contract else {
         return false;
     };
     if il.meta.lang == Lang::Python
@@ -1233,7 +1301,7 @@ fn record_post_lower_free_name_library_api(il: &mut Il, interner: &Interner, cal
         }
         _ => return false,
     }
-    post_lower_library_api_evidence_id(
+    let api = post_lower_library_api_evidence_id(
         il,
         call,
         id,
@@ -1242,6 +1310,7 @@ fn record_post_lower_free_name_library_api(il: &mut Il, interner: &Interner, cal
         rule,
         dependencies,
     );
+    post_lower_record_library_api_result_domain(il, call, result_domain, api);
     true
 }
 
@@ -1295,7 +1364,7 @@ fn record_post_lower_ruby_static_member_library_api(
     else {
         return false;
     };
-    post_lower_library_api_evidence_id(
+    let api = post_lower_library_api_evidence_id(
         il,
         call,
         contract.id,
@@ -1303,6 +1372,12 @@ fn record_post_lower_ruby_static_member_library_api(
         arg_count,
         "library_api_ruby_require_static_member",
         vec![receiver_dependency, require_dependency],
+    );
+    post_lower_record_library_api_result_domain(
+        il,
+        call,
+        library_collection_factory_result_domain_for_arity(contract, arg_count),
+        api,
     );
     true
 }
@@ -1419,6 +1494,23 @@ fn post_lower_library_api_evidence_id(
         dependencies,
     )
     .expect("post-lower LibraryApi evidence insertion should always produce an id")
+}
+
+fn post_lower_record_library_api_result_domain(
+    il: &mut Il,
+    call: NodeId,
+    result_domain: Option<DomainEvidence>,
+    api: EvidenceId,
+) {
+    if let Some(domain) = result_domain {
+        let _ = post_lower_find_or_push_evidence(
+            il,
+            EvidenceAnchor::node(il.node(call).span, NodeKind::Call),
+            EvidenceKind::Domain(domain),
+            "library_api_result_domain",
+            vec![api],
+        );
+    }
 }
 
 fn post_lower_find_or_push_evidence(
@@ -2143,6 +2235,118 @@ mod tests {
             .count()
     }
 
+    fn library_api_evidence_ids_in_records(
+        evidence: &[EvidenceRecord],
+        contract_hash: u64,
+        callee_hash: u64,
+    ) -> Vec<EvidenceId> {
+        evidence
+            .iter()
+            .filter_map(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                        contract_hash: actual_contract,
+                        callee_hash: actual_callee,
+                        ..
+                    }) if actual_contract == contract_hash && actual_callee == callee_hash
+                )
+                .then_some(record.id)
+            })
+            .collect()
+    }
+
+    fn library_api_evidence_ids_at(
+        evidence: &[EvidenceRecord],
+        span: Span,
+        contract_hash: u64,
+        callee_hash: u64,
+        arity: u16,
+    ) -> Vec<EvidenceId> {
+        evidence
+            .iter()
+            .filter_map(|record| {
+                (record.anchor == EvidenceAnchor::node(span, NodeKind::Call)
+                    && matches!(
+                        record.kind,
+                        EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                            contract_hash: actual_contract,
+                            callee_hash: actual_callee,
+                            arity: actual_arity,
+                        }) if actual_contract == contract_hash
+                            && actual_callee == callee_hash
+                            && actual_arity == arity
+                    ))
+                .then_some(record.id)
+            })
+            .collect()
+    }
+
+    fn result_domain_depends_on_api(
+        evidence: &[EvidenceRecord],
+        span: Span,
+        domain: DomainEvidence,
+        api_ids: &[EvidenceId],
+    ) -> bool {
+        evidence.iter().any(|record| {
+            record.anchor == EvidenceAnchor::node(span, NodeKind::Call)
+                && record.kind == EvidenceKind::Domain(domain)
+                && record.dependencies.len() == 1
+                && api_ids.contains(&record.dependencies[0])
+        })
+    }
+
+    fn result_domain_any_count_at(evidence: &[EvidenceRecord], span: Span) -> usize {
+        evidence
+            .iter()
+            .filter(|record| {
+                record.anchor == EvidenceAnchor::node(span, NodeKind::Call)
+                    && matches!(record.kind, EvidenceKind::Domain(_))
+            })
+            .count()
+    }
+
+    fn result_domain_depends_on_any_api(
+        evidence: &[EvidenceRecord],
+        domain: DomainEvidence,
+        api_ids: &[EvidenceId],
+    ) -> bool {
+        evidence.iter().any(|record| {
+            matches!(record.kind, EvidenceKind::Domain(actual) if actual == domain)
+                && record.dependencies.len() == 1
+                && api_ids.contains(&record.dependencies[0])
+        })
+    }
+
+    fn result_domain_record_count(evidence: &[EvidenceRecord], domain: DomainEvidence) -> usize {
+        evidence
+            .iter()
+            .filter(
+                |record| matches!(record.kind, EvidenceKind::Domain(actual) if actual == domain),
+            )
+            .filter(|record| !record.dependencies.is_empty())
+            .count()
+    }
+
+    fn call_node_with_result_domain(il: &Il, domain: DomainEvidence) -> Option<NodeId> {
+        let span = il
+            .evidence
+            .iter()
+            .find_map(|record| match (record.anchor, record.kind) {
+                (
+                    EvidenceAnchor::Node {
+                        span,
+                        kind: NodeKind::Call,
+                    },
+                    EvidenceKind::Domain(actual),
+                ) if actual == domain => Some(span),
+                _ => None,
+            })?;
+        il.nodes.iter().enumerate().find_map(|(idx, node)| {
+            (node.kind == NodeKind::Call && node.span == span).then_some(NodeId(idx as u32))
+        })
+    }
+
     #[test]
     fn core_lowering_emits_import_backed_library_api_occurrences() {
         let interner = Interner::new();
@@ -2216,6 +2420,318 @@ mod tests {
                 library_api_callee_contract_hash(contract.callee),
             ),
             1
+        );
+    }
+
+    #[test]
+    fn core_lowering_emits_result_domain_evidence_for_library_api_factories() {
+        let interner = Interner::new();
+
+        let mut lo = Lowering::new(FileId(0), b"", Lang::Python, &interner);
+        import_binding(&mut lo, sp_at(1), "Values", "collections", "deque");
+        let callee = lo.var("Values", sp_at(2));
+        let seq = lo.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp_at(3),
+            &[],
+        );
+        lo.add(NodeKind::Call, Payload::None, sp_at(4), &[callee, seq]);
+        let deque = nose_semantics::library_imported_collection_factory_contract(
+            Lang::Python,
+            "collections",
+            "deque",
+        )
+        .expect("deque contract");
+        let deque_api = library_api_evidence_ids_in_records(
+            &lo.evidence,
+            library_api_contract_id_hash(deque.id),
+            library_api_callee_contract_hash(deque.callee),
+        );
+        assert!(
+            result_domain_depends_on_api(
+                &lo.evidence,
+                sp_at(4),
+                DomainEvidence::Collection,
+                &deque_api,
+            ),
+            "collections.deque result domain should depend on the admitted LibraryApi occurrence"
+        );
+
+        let mut lo = Lowering::new(FileId(0), b"", Lang::Java, &interner);
+        import_binding(&mut lo, sp_at(10), "List", "java.util", "List");
+        import_binding(&mut lo, sp_at(11), "Set", "java.util", "Set");
+        import_binding(&mut lo, sp_at(12), "Map", "java.util", "Map");
+        import_binding(&mut lo, sp_at(13), "Arrays", "java.util", "Arrays");
+
+        let list = lo.var("List", sp_at(20));
+        let list_callee = lo.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("of")),
+            sp_at(21),
+            &[list],
+        );
+        let item = lo.int_lit("1", sp_at(22));
+        lo.add(
+            NodeKind::Call,
+            Payload::None,
+            sp_at(23),
+            &[list_callee, item],
+        );
+        let list_contract =
+            library_java_collection_factory_contract(Lang::Java, "List", "of").unwrap();
+        let list_api = library_api_evidence_ids_in_records(
+            &lo.evidence,
+            library_api_contract_id_hash(list_contract.id),
+            library_api_callee_contract_hash(list_contract.callee),
+        );
+        assert!(result_domain_depends_on_api(
+            &lo.evidence,
+            sp_at(23),
+            DomainEvidence::Collection,
+            &list_api,
+        ));
+
+        let set = lo.var("Set", sp_at(30));
+        let set_callee = lo.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("of")),
+            sp_at(31),
+            &[set],
+        );
+        let item = lo.int_lit("1", sp_at(32));
+        lo.add(
+            NodeKind::Call,
+            Payload::None,
+            sp_at(33),
+            &[set_callee, item],
+        );
+        let set_contract =
+            library_java_collection_factory_contract(Lang::Java, "Set", "of").unwrap();
+        let set_api = library_api_evidence_ids_in_records(
+            &lo.evidence,
+            library_api_contract_id_hash(set_contract.id),
+            library_api_callee_contract_hash(set_contract.callee),
+        );
+        assert!(result_domain_depends_on_api(
+            &lo.evidence,
+            sp_at(33),
+            DomainEvidence::Set,
+            &set_api,
+        ));
+
+        let map = lo.var("Map", sp_at(40));
+        let map_callee = lo.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("of")),
+            sp_at(41),
+            &[map],
+        );
+        let key = lo.str_lit("\"red\"", sp_at(42));
+        let value = lo.int_lit("1", sp_at(43));
+        lo.add(
+            NodeKind::Call,
+            Payload::None,
+            sp_at(44),
+            &[map_callee, key, value],
+        );
+        let map_contract = library_java_map_factory_contract(Lang::Java, "Map", "of").unwrap();
+        let map_api = library_api_evidence_ids_in_records(
+            &lo.evidence,
+            library_api_contract_id_hash(map_contract.id),
+            library_api_callee_contract_hash(map_contract.callee),
+        );
+        assert!(result_domain_depends_on_api(
+            &lo.evidence,
+            sp_at(44),
+            DomainEvidence::Map,
+            &map_api,
+        ));
+
+        let arrays = lo.var("Arrays", sp_at(46));
+        let as_list_callee = lo.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("asList")),
+            sp_at(47),
+            &[arrays],
+        );
+        let maybe_array = lo.var("items", sp_at(48));
+        lo.add(
+            NodeKind::Call,
+            Payload::None,
+            sp_at(49),
+            &[as_list_callee, maybe_array],
+        );
+        assert_eq!(
+            result_domain_any_count_at(&lo.evidence, sp_at(49)),
+            0,
+            "single-argument Arrays.asList must not emit any result-domain evidence"
+        );
+
+        let arrays = lo.var("Arrays", sp_at(55));
+        let as_list_callee = lo.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("asList")),
+            sp_at(56),
+            &[arrays],
+        );
+        let red = lo.str_lit("\"red\"", sp_at(57));
+        let blue = lo.str_lit("\"blue\"", sp_at(58));
+        lo.add(
+            NodeKind::Call,
+            Payload::None,
+            sp_at(59),
+            &[as_list_callee, red, blue],
+        );
+        let as_list_contract =
+            library_java_collection_factory_contract(Lang::Java, "Arrays", "asList").unwrap();
+        let as_list_api = library_api_evidence_ids_at(
+            &lo.evidence,
+            sp_at(59),
+            library_api_contract_id_hash(as_list_contract.id),
+            library_api_callee_contract_hash(as_list_contract.callee),
+            2,
+        );
+        assert!(result_domain_depends_on_api(
+            &lo.evidence,
+            sp_at(59),
+            DomainEvidence::Collection,
+            &as_list_api,
+        ));
+
+        let map = lo.var("Map", sp_at(50));
+        let entry_callee = lo.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("entry")),
+            sp_at(51),
+            &[map],
+        );
+        let key = lo.str_lit("\"red\"", sp_at(52));
+        let value = lo.int_lit("1", sp_at(53));
+        lo.add(
+            NodeKind::Call,
+            Payload::None,
+            sp_at(54),
+            &[entry_callee, key, value],
+        );
+        let entry_contract = library_java_map_entry_contract(Lang::Java, "Map", "entry").unwrap();
+        assert_eq!(
+            library_api_evidence_count(
+                &lo,
+                library_api_contract_id_hash(entry_contract.id),
+                library_api_callee_contract_hash(entry_contract.callee),
+            ),
+            1
+        );
+        assert_eq!(
+            result_domain_any_count_at(&lo.evidence, sp_at(54)),
+            0,
+            "Map.entry returns an entry value, not any receiver-domain container"
+        );
+
+        let arrays = lo.var("Arrays", sp_at(60));
+        let stream_callee = lo.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("stream")),
+            sp_at(61),
+            &[arrays],
+        );
+        let values = lo.var("values", sp_at(62));
+        lo.add(
+            NodeKind::Call,
+            Payload::None,
+            sp_at(63),
+            &[stream_callee, values],
+        );
+        assert_eq!(
+            result_domain_any_count_at(&lo.evidence, sp_at(63)),
+            0,
+            "Arrays.stream produces a stream/protocol surface, not any receiver-domain container"
+        );
+
+        let mut lo = Lowering::new(FileId(0), b"", Lang::JavaScript, &interner);
+        let set = lo.unshadowed_global_var("Set", sp_at(70));
+        let seq = lo.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp_at(71),
+            &[],
+        );
+        lo.record_source_fact(sp_at(72), SourceFactKind::Call(SourceCallKind::Construct));
+        lo.add(NodeKind::Call, Payload::None, sp_at(72), &[set, seq]);
+        let set_contract = library_js_like_set_constructor_contract(Lang::JavaScript, "Set")
+            .expect("Set constructor");
+        let set_api = library_api_evidence_ids_in_records(
+            &lo.evidence,
+            library_api_contract_id_hash(set_contract.id),
+            library_api_callee_contract_hash(set_contract.callee),
+        );
+        assert!(result_domain_depends_on_api(
+            &lo.evidence,
+            sp_at(72),
+            DomainEvidence::Set,
+            &set_api,
+        ));
+
+        let map = lo.unshadowed_global_var("Map", sp_at(80));
+        let seq = lo.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp_at(81),
+            &[],
+        );
+        lo.record_source_fact(sp_at(82), SourceFactKind::Call(SourceCallKind::Construct));
+        lo.add(NodeKind::Call, Payload::None, sp_at(82), &[map, seq]);
+        let map_contract = library_js_like_map_constructor_contract(Lang::JavaScript, "Map")
+            .expect("Map constructor");
+        let map_api = library_api_evidence_ids_in_records(
+            &lo.evidence,
+            library_api_contract_id_hash(map_contract.id),
+            library_api_callee_contract_hash(map_contract.callee),
+        );
+        assert!(result_domain_depends_on_api(
+            &lo.evidence,
+            sp_at(82),
+            DomainEvidence::Map,
+            &map_api,
+        ));
+
+        let array = lo.unshadowed_global_var("Array", sp_at(90));
+        let from_callee = lo.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("from")),
+            sp_at(91),
+            &[array],
+        );
+        lo.record_qualified_global_symbol(sp_at(91), NodeKind::Field, "Array.from");
+        let iterable = lo.var("iterable", sp_at(92));
+        lo.add(
+            NodeKind::Call,
+            Payload::None,
+            sp_at(93),
+            &[from_callee, iterable],
+        );
+        let from_contract =
+            library_map_key_view_wrapper_contract(Lang::JavaScript, "Array", "from", 1).unwrap();
+        let from_api = library_api_evidence_ids_in_records(
+            &lo.evidence,
+            library_api_contract_id_hash(from_contract.id),
+            library_api_callee_contract_hash(from_contract.callee),
+        );
+        assert!(result_domain_depends_on_api(
+            &lo.evidence,
+            sp_at(93),
+            DomainEvidence::Array,
+            &from_api,
+        ));
+
+        let boolean = lo.unshadowed_global_var("Boolean", sp_at(100));
+        let value = lo.var("value", sp_at(101));
+        lo.add(NodeKind::Call, Payload::None, sp_at(102), &[boolean, value]);
+        assert_eq!(
+            result_domain_any_count_at(&lo.evidence, sp_at(102)),
+            0,
+            "Boolean(...) has LibraryApi identity but no container result-domain"
         );
     }
 
@@ -2443,6 +2959,173 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
                 library_api_callee_contract_hash(ruby_contract.callee),
             ),
             0
+        );
+    }
+
+    #[test]
+    fn post_lowering_emits_result_domains_for_supported_factories() {
+        let interner = Interner::new();
+
+        let py_list = crate::lower_source(
+            FileId(0),
+            "builtin_list.py",
+            b"def f(values):\n    return list(values)\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        let list_contract =
+            library_free_name_collection_factory_contract(Lang::Python, "list").unwrap();
+        let list_api = library_api_evidence_ids_in_records(
+            &py_list.evidence,
+            library_api_contract_id_hash(list_contract.id),
+            library_api_callee_contract_hash(list_contract.callee),
+        );
+        assert!(result_domain_depends_on_any_api(
+            &py_list.evidence,
+            DomainEvidence::Collection,
+            &list_api,
+        ));
+
+        let py_set = crate::lower_source(
+            FileId(0),
+            "builtin_set.py",
+            b"def f(values):\n    return set(values)\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        let set_contract =
+            library_free_name_collection_factory_contract(Lang::Python, "set").unwrap();
+        let set_api = library_api_evidence_ids_in_records(
+            &py_set.evidence,
+            library_api_contract_id_hash(set_contract.id),
+            library_api_callee_contract_hash(set_contract.callee),
+        );
+        assert!(result_domain_depends_on_any_api(
+            &py_set.evidence,
+            DomainEvidence::Set,
+            &set_api,
+        ));
+
+        let shadowed_py = crate::lower_source(
+            FileId(0),
+            "shadowed.py",
+            b"def f(list, values):\n    return list(values)\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        assert_eq!(
+            result_domain_record_count(&shadowed_py.evidence, DomainEvidence::Collection),
+            0,
+            "shadowed list(...) must not emit result-domain evidence"
+        );
+
+        let rust_vec = crate::lower_source(
+            FileId(0),
+            "vec.rs",
+            b"fn f() { let xs = Vec::new(); }",
+            Lang::Rust,
+            &interner,
+        )
+        .expect("rust lowering should succeed");
+        let vec_contract = library_rust_vec_new_factory_contract(Lang::Rust, "Vec::new").unwrap();
+        let vec_api = library_api_evidence_ids_in_records(
+            &rust_vec.evidence,
+            library_api_contract_id_hash(vec_contract.id),
+            library_api_callee_contract_hash(vec_contract.callee),
+        );
+        assert!(result_domain_depends_on_any_api(
+            &rust_vec.evidence,
+            DomainEvidence::Collection,
+            &vec_api,
+        ));
+
+        let rust_map = crate::lower_source(
+            FileId(0),
+            "hash_map.rs",
+            b"fn f() { let xs = std::collections::HashMap::from([(\"red\", 1)]); }",
+            Lang::Rust,
+            &interner,
+        )
+        .expect("rust lowering should succeed");
+        let map_contract =
+            library_free_name_map_factory_contract(Lang::Rust, "std::collections::HashMap::from")
+                .unwrap();
+        let map_api = library_api_evidence_ids_in_records(
+            &rust_map.evidence,
+            library_api_contract_id_hash(map_contract.id),
+            library_api_callee_contract_hash(map_contract.callee),
+        );
+        assert!(result_domain_depends_on_any_api(
+            &rust_map.evidence,
+            DomainEvidence::Map,
+            &map_api,
+        ));
+
+        let ruby = crate::lower_source(
+            FileId(0),
+            "set.rb",
+            b"require \"set\"\n\ndef f(values)\n  Set.new(values)\nend\n",
+            Lang::Ruby,
+            &interner,
+        )
+        .expect("ruby lowering should succeed");
+        let ruby_contract = library_ruby_set_factory_contract(Lang::Ruby, "Set", "new", 1).unwrap();
+        let ruby_api = library_api_evidence_ids_in_records(
+            &ruby.evidence,
+            library_api_contract_id_hash(ruby_contract.id),
+            library_api_callee_contract_hash(ruby_contract.callee),
+        );
+        assert!(result_domain_depends_on_any_api(
+            &ruby.evidence,
+            DomainEvidence::Set,
+            &ruby_api,
+        ));
+
+        let missing_require = crate::lower_source(
+            FileId(0),
+            "set_missing_require.rb",
+            b"def f(values)\n  Set.new(values)\nend\n",
+            Lang::Ruby,
+            &interner,
+        )
+        .expect("ruby lowering should succeed");
+        assert_eq!(
+            result_domain_record_count(&missing_require.evidence, DomainEvidence::Set),
+            0,
+            "Ruby Set.new must not emit result-domain evidence without require proof"
+        );
+    }
+
+    #[test]
+    fn result_domain_evidence_requires_live_library_api_dependency() {
+        let interner = Interner::new();
+        let mut il = crate::lower_source(
+            FileId(0),
+            "set.js",
+            b"function f(value) { return new Set([value]).has(value); }",
+            Lang::JavaScript,
+            &interner,
+        )
+        .expect("js lowering should succeed");
+        let call = call_node_with_result_domain(&il, DomainEvidence::Set)
+            .expect("new Set result should carry Set domain evidence");
+        assert_eq!(
+            nose_semantics::domain_evidence_for_node(&il, call),
+            Some(DomainEvidence::Set)
+        );
+
+        for record in &mut il.evidence {
+            if matches!(record.kind, EvidenceKind::LibraryApi(_)) {
+                record.status = EvidenceStatus::Ambiguous;
+            }
+        }
+        assert_eq!(
+            nose_semantics::domain_evidence_for_node(&il, call),
+            None,
+            "receiver-domain proof must close when the LibraryApi dependency is ambiguous"
         );
     }
 

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -1803,20 +1803,20 @@ impl<'a> Builder<'a> {
                     return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, map]));
                 }
             }
-            let receiver_param_safe = match contract.receiver {
-                MethodReceiverContract::ExactSetOrMap => self.is_set_param_expr(receiver),
-                _ => self.is_collection_param_expr(receiver),
-            };
-            if receiver_param_safe {
-                let collection = self.eval_membership_collection(receiver, env);
-                return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
-            }
             let receiver_value = self.eval(receiver, env);
             if let Some(collection) = self
                 .proven_collection_value(receiver_value)
                 .or_else(|| self.proven_local_collection_binding_value(receiver, env))
             {
                 let collection = self.canonical_membership_collection_value(collection);
+                return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
+            }
+            let receiver_param_safe = match contract.receiver {
+                MethodReceiverContract::ExactSetOrMap => self.is_set_param_expr(receiver),
+                _ => self.is_collection_param_expr(receiver),
+            };
+            if receiver_param_safe {
+                let collection = self.eval_membership_collection(receiver, env);
                 return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
             }
             None
@@ -6752,10 +6752,6 @@ impl<'a> Builder<'a> {
         collection: NodeId,
         env: &FxHashMap<u32, ValueId>,
     ) -> ValueId {
-        if self.is_collection_param_expr(collection) {
-            let value = self.eval(collection, env);
-            return self.mk(ValOp::CollectionParam, vec![value]);
-        }
         if self.il.kind(collection) == NodeKind::Seq {
             if self
                 .seq_surface(collection)
@@ -6771,11 +6767,16 @@ impl<'a> Builder<'a> {
             return self.canonical_membership_collection_value(value);
         }
         let value = self.eval(collection, env);
-        let collection = self
+        if let Some(collection) = self
             .proven_collection_value(value)
             .or_else(|| self.proven_local_collection_binding_value(collection, env))
-            .unwrap_or(value);
-        self.canonical_membership_collection_value(collection)
+        {
+            return self.canonical_membership_collection_value(collection);
+        }
+        if self.is_collection_param_expr(collection) {
+            return self.mk(ValOp::CollectionParam, vec![value]);
+        }
+        self.canonical_membership_collection_value(value)
     }
 
     fn canonical_membership_collection_value(&mut self, value: ValueId) -> ValueId {
@@ -8718,6 +8719,75 @@ mod tests {
         assert!(
             !matches!(eval_op(&il, &interner, call), ValOp::Bin(op) if op == Op::In as u32),
             "conflicting receiver-domain evidence must close the exact membership rewrite"
+        );
+    }
+
+    #[test]
+    fn membership_call_consumes_library_api_result_domain_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let factory_callee = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("list")),
+            sp(40),
+            &[],
+        );
+        let seed = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(41),
+            &[],
+        );
+        let receiver = b.add(
+            NodeKind::Call,
+            Payload::None,
+            sp(42),
+            &[factory_callee, seed],
+        );
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("includes")),
+            sp(43),
+            &[receiver],
+        );
+        let item = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("item")),
+            sp(44),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(45), &[callee, item]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(39), &[call]);
+        let mut il = finish_test_il(b, root, Lang::TypeScript);
+        assert!(
+            !matches!(eval_op(&il, &interner, call), ValOp::Bin(op) if op == Op::In as u32),
+            "call-result receiver must not be collection-like without domain evidence"
+        );
+
+        let api = library_js_like_set_constructor_contract(Lang::TypeScript, "Set").unwrap();
+        il.evidence.push(library_api_contract_evidence(
+            0,
+            sp(42),
+            api.id,
+            api.callee,
+            1,
+            Vec::new(),
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            1,
+            EvidenceAnchor::node(sp(42), NodeKind::Call),
+            EvidenceKind::Domain(DomainEvidence::Set),
+            vec![EvidenceId(0)],
+        ));
+        assert!(matches!(
+            eval_op(&il, &interner, call),
+            ValOp::Bin(op) if op == Op::In as u32
+        ));
+
+        il.evidence[0].status = EvidenceStatus::Ambiguous;
+        assert!(
+            !matches!(eval_op(&il, &interner, call), ValOp::Bin(op) if op == Op::In as u32),
+            "ambiguous LibraryApi dependency must close the call-result receiver proof"
         );
     }
 

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -4049,6 +4049,55 @@ pub struct LibraryMapKeyViewWrapperContract {
     pub result: MapKeyViewWrapperContract,
 }
 
+pub fn library_collection_factory_result_domain(
+    contract: LibraryCollectionFactoryContract,
+) -> DomainEvidence {
+    match contract.id {
+        LibraryApiContractId::PythonBuiltinCollectionFactory => match contract.callee {
+            LibraryApiCalleeContract::FreeName {
+                name: "set" | "frozenset",
+                ..
+            } => DomainEvidence::Set,
+            _ => DomainEvidence::Collection,
+        },
+        LibraryApiContractId::RustStdCollectionFactory => match contract.callee {
+            LibraryApiCalleeContract::FreeName {
+                name: "std::collections::HashSet::from" | "std::collections::BTreeSet::from",
+                ..
+            } => DomainEvidence::Set,
+            _ => DomainEvidence::Collection,
+        },
+        LibraryApiContractId::JavaCollectionFactory(JavaCollectionFactoryKind::SetOf)
+        | LibraryApiContractId::RubySetFactory
+        | LibraryApiContractId::JsLikeSetConstructor => DomainEvidence::Set,
+        _ => DomainEvidence::Collection,
+    }
+}
+
+pub fn library_collection_factory_result_domain_for_arity(
+    contract: LibraryCollectionFactoryContract,
+    arg_count: usize,
+) -> Option<DomainEvidence> {
+    match contract.id {
+        LibraryApiContractId::JavaCollectionFactory(JavaCollectionFactoryKind::ArraysAsList)
+            if arg_count == 1 =>
+        {
+            None
+        }
+        _ => Some(library_collection_factory_result_domain(contract)),
+    }
+}
+
+pub fn library_map_factory_result_domain(_contract: LibraryMapFactoryContract) -> DomainEvidence {
+    DomainEvidence::Map
+}
+
+pub fn library_map_key_view_wrapper_result_domain(
+    _contract: LibraryMapKeyViewWrapperContract,
+) -> DomainEvidence {
+    DomainEvidence::Array
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct LibraryMapGetContract {
     pub id: LibraryApiContractId,
@@ -8477,6 +8526,129 @@ mod tests {
         assert_eq!(
             library_java_map_factory_contract(Lang::Java, "List", "of"),
             None
+        );
+    }
+
+    #[test]
+    fn library_api_result_domain_mapping_is_contract_scoped() {
+        assert_eq!(
+            library_collection_factory_result_domain(
+                library_free_name_collection_factory_contract(Lang::Python, "list").unwrap()
+            ),
+            DomainEvidence::Collection
+        );
+        assert_eq!(
+            library_collection_factory_result_domain(
+                library_free_name_collection_factory_contract(Lang::Python, "set").unwrap()
+            ),
+            DomainEvidence::Set
+        );
+        assert_eq!(
+            library_collection_factory_result_domain(
+                library_free_name_collection_factory_contract(Lang::Python, "frozenset").unwrap()
+            ),
+            DomainEvidence::Set
+        );
+        assert_eq!(
+            library_collection_factory_result_domain(
+                library_imported_collection_factory_contract(Lang::Python, "collections", "deque",)
+                    .unwrap()
+            ),
+            DomainEvidence::Collection
+        );
+        assert_eq!(
+            library_collection_factory_result_domain(
+                library_free_name_collection_factory_contract(
+                    Lang::Rust,
+                    "std::collections::HashSet::from",
+                )
+                .unwrap()
+            ),
+            DomainEvidence::Set
+        );
+        assert_eq!(
+            library_collection_factory_result_domain(
+                library_free_name_collection_factory_contract(
+                    Lang::Rust,
+                    "std::collections::VecDeque::from",
+                )
+                .unwrap()
+            ),
+            DomainEvidence::Collection
+        );
+        assert_eq!(
+            library_collection_factory_result_domain(
+                library_rust_vec_macro_factory_contract(Lang::Rust, "vec").unwrap()
+            ),
+            DomainEvidence::Collection
+        );
+        assert_eq!(
+            library_collection_factory_result_domain(
+                library_java_collection_factory_contract(Lang::Java, "List", "of").unwrap()
+            ),
+            DomainEvidence::Collection
+        );
+        let as_list =
+            library_java_collection_factory_contract(Lang::Java, "Arrays", "asList").unwrap();
+        assert_eq!(
+            library_collection_factory_result_domain_for_arity(as_list, 0),
+            Some(DomainEvidence::Collection)
+        );
+        assert_eq!(
+            library_collection_factory_result_domain_for_arity(as_list, 1),
+            None,
+            "single-argument Arrays.asList has ambiguous element provenance"
+        );
+        assert_eq!(
+            library_collection_factory_result_domain_for_arity(as_list, 2),
+            Some(DomainEvidence::Collection)
+        );
+        assert_eq!(
+            library_collection_factory_result_domain(
+                library_java_collection_factory_contract(Lang::Java, "Set", "of").unwrap()
+            ),
+            DomainEvidence::Set
+        );
+        assert_eq!(
+            library_collection_factory_result_domain(
+                library_ruby_set_factory_contract(Lang::Ruby, "Set", "new", 1).unwrap()
+            ),
+            DomainEvidence::Set
+        );
+        assert_eq!(
+            library_collection_factory_result_domain(
+                library_js_like_set_constructor_contract(Lang::JavaScript, "Set").unwrap()
+            ),
+            DomainEvidence::Set
+        );
+        assert_eq!(
+            library_map_factory_result_domain(
+                library_free_name_map_factory_contract(
+                    Lang::Rust,
+                    "std::collections::HashMap::from",
+                )
+                .unwrap()
+            ),
+            DomainEvidence::Map
+        );
+        assert_eq!(
+            library_map_factory_result_domain(
+                library_java_map_factory_contract(Lang::Java, "Map", "of").unwrap()
+            ),
+            DomainEvidence::Map
+        );
+        assert_eq!(
+            library_map_factory_result_domain(
+                library_js_like_map_constructor_contract(Lang::JavaScript, "Map").unwrap()
+            ),
+            DomainEvidence::Map
+        );
+        assert_eq!(
+            library_map_key_view_wrapper_result_domain(
+                library_map_key_view_wrapper_contract(Lang::JavaScript, "Array", "from", 1)
+                    .unwrap()
+            ),
+            DomainEvidence::Array
         );
     }
 

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -145,6 +145,15 @@ obligations through `DomainRequirement`; obligations such as imported namespace,
 unshadowed global, exact map literal, and future demand/effect constraints remain
 separate checks.
 
+Selected `LibraryApi` result-domain evidence follows the same model. A
+first-party factory call result may carry `Domain(Collection)`, `Domain(Set)`,
+`Domain(Map)`, or `Domain(Array)` only after the call occurrence has admitted
+`LibraryApi` evidence. The `Domain` record depends on that `LibraryApi` record,
+so broken import, source, shadowing, or symbol proof closes the receiver-domain
+claim as well. The result-domain record proves only the container/protocol shape
+of the call result; exact consumers still prove argument safety, entry shape,
+mutation, receiver requirements, and demand/effect obligations separately.
+
 Qualified global identity is also evidence, not a selector guess. The current
 first-party JS/TS producer emits `QualifiedGlobal` only for selected static paths
 whose root is proven unshadowed, such as `Object.hasOwn`,
@@ -205,10 +214,11 @@ instead of accepting an unrelated imported symbol elsewhere in the file.
 
 First-party frontends now mirror these facts into `EvidenceRecord`:
 
-- parameter semantic annotations become `Domain` evidence. Current first-party
-  frontends do not yet emit receiver-expression `Domain` evidence directly, but
-  the internal consumer contract already accepts exact node-anchored receiver
-  facts for future packs and inference producers;
+- parameter semantic annotations become `Domain` evidence. Selected first-party
+  library/API factory calls now also emit receiver-expression `Domain` evidence
+  at the exact call node after their `LibraryApi` occurrence has been admitted.
+  Future packs and inference producers should use the same node-anchored
+  receiver-domain shape instead of selector spelling;
 - source-origin facts become `Source` evidence;
 - import binding and namespace lowering emits `Import` evidence for the proof RHS
   and `Symbol` evidence for the local alias identity;
@@ -257,6 +267,20 @@ First-party frontends now mirror these facts into `EvidenceRecord`:
   arities, unsupported static paths, unresolved free-name/path factories, and
   Ruby require-backed APIs without require evidence do not emit API occurrence
   evidence;
+- selected `LibraryApi` producer-covered result calls emit dependent
+  receiver-expression `Domain` evidence: Python `list`/`tuple` and
+  `collections.deque`, Rust `Vec::new`, `vec!`, and
+  `std::collections::VecDeque::from`, Java `List.of` and zero- or multi-argument
+  `Arrays.asList` as `Collection`; Python `set`/`frozenset`, Rust
+  `std::collections::{HashSet,BTreeSet}::from`, Java `Set.of`, Ruby
+  `Set.new`, and JS-like `new Set` as `Set`; Rust
+  `std::collections::{HashMap,BTreeMap}::from`, Java `Map.of`/`Map.ofEntries`,
+  and JS-like `new Map` as `Map`; and JS-like one-argument `Array.from` as
+  `Array`. `Map.entry`, `Array.isArray`, `Boolean`, regex `.test`,
+  `math.prod`, `Arrays.stream`, map `get`, iterator adapters, promise `.then`,
+  and generic method contracts do not emit `Domain` records because their
+  results are not simple container receiver domains under the current
+  vocabulary;
 - lowered `Seq` surfaces emit `SequenceSurface` evidence, including Go map
   literal and Go map-entry surfaces where those tags carry first-party meaning.
 
@@ -277,8 +301,13 @@ callers:
   value-graph membership/property/map/integer gates, and strict exact receiver
   gates. Consumers ask `nose-semantics` whether a receiver satisfies a
   `DomainRequirement`, so node-anchored receiver evidence, scoped parameter
-  evidence, ambiguity handling, and compatibility fallback are no longer
-  reimplemented separately in each crate;
+  evidence, selected API result-domain evidence, ambiguity handling, and
+  compatibility fallback are no longer reimplemented separately in each crate.
+  Coarse API result-domain evidence is not exact-tree proof: value-graph
+  consumers prefer concrete factory/result-shape canonicalization before using a
+  domain-shaped fallback, and strict exact consumers still require the receiver
+  expression itself to satisfy the relevant factory, literal, binding, or
+  typed-variable safety contract;
 - import proof parsing for compatibility helpers, with value-graph import
   identity and imported literal replacement consuming evidence-only facts;
 - cross-file imported literal replacement copies the provider's closed evidence
@@ -330,7 +359,7 @@ callers:
   or conflicting evidence keeps the exact path closed.
 
 Broader field/place/effect facts, `LibraryApi` occurrence evidence for remaining
-receiver-method APIs and unmodeled stdlib/ecosystem APIs, producer coverage for
+receiver-method APIs and unmodeled stdlib/ecosystem APIs, broader inferred
 receiver-expression domain evidence, immutable local/module binding domain
 evidence, full protocol/demand/effect receiver obligations, full
 scope-resolution and namespace-member evidence, broader guard evidence, general

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -334,6 +334,18 @@ and pack ecosystem.
   `MethodReceiverContract` exposes the subset of receiver obligations that are
   domain-backed, while imported namespace, unshadowed global, map-literal,
   demand, and effect obligations remain separate checks.
+- Selected first-party library/API factory result domains now produce
+  node-anchored `Domain` evidence after the call occurrence has admitted
+  `LibraryApi` evidence. This covers Python builtin/imported collection
+  factories, Rust `Vec::new`/`vec!`/selected `std::collections::*::from`
+  factories, Ruby `Set.new`, Java `List.of`/`Set.of`/zero- or multi-argument
+  `Arrays.asList`/`Map.of`/`Map.ofEntries`, JS-like `new Set`/`new Map`, and
+  JS-like one-argument `Array.from`. The mapping is contract-scoped and
+  deliberately excludes lookalikes, Java single-argument `Arrays.asList(x)`
+  without element-provenance proof, and non-container results such as
+  `Map.entry`, `Array.isArray`, `Boolean`, regex `.test`, `math.prod`,
+  `Arrays.stream`, map `get`, promise `.then`, iterator adapters, and generic
+  method contracts.
 - An experimental `abstraction` scan mode landed as a weak sibling claim over a
   narrow `near` subset. It emits typed literal-hole witnesses and caveats for
   refactoring-template candidates, but does not feed `semantic`, `verify`, or exact
@@ -423,7 +435,9 @@ Remaining in this phase:
   free-name/path factories, Ruby require-backed factories, Java `java.util`
   static factories/adapters, and JS regex literals. Remaining stdlib and
   ecosystem APIs still need dependency-backed occurrence records before they
-  become pack-facing.
+  become pack-facing. Producer-covered factory/API result calls now also emit
+  dependent call-node `Domain` evidence when the current `DomainEvidence`
+  vocabulary can represent the result.
 - Keep value-graph and strict exact gates on the same contract source. Factory,
   constructor, and selected method/view/adapter gates now share
   `LibraryApiContract` identity/result rows, and selected JS-like,
@@ -449,10 +463,12 @@ Remaining in this phase:
   requires per-entry surface evidence.
 - Continue expanding domain evidence beyond parameter annotations. The shared
   receiver-domain consumer contract now accepts exact node-anchored receiver
-  facts, but first-party producers still mostly emit parameter-derived domain
-  evidence. Remaining work is producer coverage for inferred receiver domains,
-  immutable local/module binding domain evidence, mutation exclusion, and
-  protocol-specific receiver facts that include demand/effect obligations.
+  facts, and first-party producers now emit them for selected admitted
+  library/API factory results. Remaining work is broader inferred receiver
+  domains, Java constructor call-domain evidence if that lowering stops
+  collapsing directly to sequence surfaces, immutable local/module binding
+  domain evidence, mutation exclusion, and protocol-specific receiver facts that
+  include demand/effect obligations.
 - Turn named value-graph rule modules into LawPack-facing law ids/contracts while
   retaining formal-obligation metadata as the first-party proof boundary.
 - Add receiver/place facts so field read/write and property contracts are not

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -16,7 +16,9 @@ Library/API identity is consolidated through internal `LibraryApiContract` rows
 for factory, constructor, and selected non-factory method/view surfaces, with
 occurrence evidence covering selected JS-like static/global APIs, Python
 builtin/import-backed APIs, Rust free-name/path APIs, Ruby require-backed APIs,
-Java `java.util` APIs, and JS regex API calls.
+Java `java.util` APIs, and JS regex API calls. Selected producer-covered
+factory/API calls now also emit dependent receiver-expression `Domain` evidence
+for their result container domain.
 
 ## What exists today
 
@@ -97,8 +99,10 @@ migrated.
   fallback. Desugaring, normalize idiom canonicalization, value-graph receiver
   gates, and strict exact receiver gates consume this same helper layer. This
   preserves the current Array/Collection/Set/Map/Option/String/Integer/Number
-  and ByteArray distinctions while opening the internal boundary for future packs
-  or inference passes to attach receiver-expression domain facts directly.
+  and ByteArray distinctions. First-party producers now attach
+  receiver-expression domain facts directly for selected admitted library/API
+  factory results, while future packs or inference passes can use the same
+  node-anchored shape for broader domains.
 - Property builtin contracts are language-constrained; a selector such as
   `length` is not enough without receiver proof. JS/TS `filter(...).length`
   is admitted only after the receiver has already entered a proven collection/HOF
@@ -133,9 +137,17 @@ migrated.
   source. Producer-covered surfaces additionally require admitted `LibraryApi`
   occurrence evidence whose dependencies carry the local import, earlier
   top-level require, unshadowed-global, macro-invocation source,
-  construct-syntax, or regex-literal proof. Receiver/domain, entry-shape,
-  mutation, demand, and exact-safety obligations remain separate contract checks
-  at the consumer.
+  construct-syntax, or regex-literal proof. Selected producer-covered result
+  calls emit dependent `Domain` evidence for the result receiver:
+  collection-like factories as `Collection`, set factories/constructors as
+  `Set`, map factories as `Map`, and JS-like one-argument `Array.from` as
+  `Array`. Java `Arrays.asList(x)` with exactly one argument is excluded because
+  array-spread versus single-element provenance is ambiguous without additional
+  proof. `Map.entry`, `Array.isArray`, `Boolean`, regex `.test`, `math.prod`,
+  `Arrays.stream`, map `get`, iterator adapters, promise `.then`, and generic
+  method contracts do not emit result-domain evidence under the current
+  vocabulary. Entry-shape, mutation, demand, and exact-safety obligations remain
+  separate contract checks at the consumer.
 - Selected non-factory library/API surfaces also consume `LibraryApiContract`
   rows before normalize, value-graph, or strict exact paths assign semantics.
   Current rows cover map-key views and wrappers, Java/Rust/JS-like map `get`,
@@ -175,16 +187,20 @@ migrated.
   evidence; missing, conflicting, or dependency-broken API evidence keeps the
   exact path closed. Older import/symbol/source facts are still required
   dependencies of the occurrence evidence, but they no longer act as fallback
-  API-identity proof for these surfaces. The record proves API identity only;
-  receiver/domain, source, exact-safe argument, result-shape, and mutation
-  obligations remain separate.
+  API-identity proof for these surfaces. Where a producer emits result-domain
+  evidence, that `Domain` record depends on the `LibraryApi` occurrence record,
+  so broken API proof also closes receiver-domain proof. The `LibraryApi` record
+  itself proves API identity only; source, exact-safe argument, result-shape,
+  mutation, and demand/effect obligations remain separate.
 - Java empty collection constructor contracts cover `new ArrayList<>()` and
   `new LinkedList<>()` through `LibraryApiContract` rows only for the Java
   `java.util` list types. Simple names require `java.util` import proof and no
   local type declaration with the same simple name. A `java.util.*` wildcard
   import is not enough when another package explicitly imports the same simple
   type; fully-qualified `java.util.*List` names carry the namespace proof in the
-  selector itself.
+  selector itself. These constructors currently lower directly to a sequence
+  surface rather than remaining as raw call nodes, so they do not emit call-node
+  result-domain evidence yet.
 - Builder append contracts are separate from arbitrary method calls. A selector
   such as `push`, `append`, or `add` is not proof by itself. First-party
   frontend/normalize paths must prove the receiver or active-builder contract and


### PR DESCRIPTION
## Summary

This is the larger semantic-kernel migration slice for selected library/API result-domain producers.

- emit dependent call-node `Domain` evidence after admitted `LibraryApi` occurrence evidence for selected first-party collection/set/map/array-producing contracts
- keep hard negatives explicit, including single-argument Java `Arrays.asList(x)`, `Map.entry`, `Arrays.stream`, `Array.isArray`, `Boolean`, regex `.test`, `math.prod`, map `get`, iterator adapters, promise `.then`, and generic method contracts
- adjust normalize and detect consumers so result-domain evidence can improve coarse receiver recall without becoming strict exact-tree proof
- update snapshot/history/remaining-work docs and evidence-record docs

Updates #109.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo build --release`
- `./scripts/check-duplication.sh`
- `awiki lint --root docs`
- `git diff --check`
- `python3 scripts/check-formal-obligations.py --self-test`
- `python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 라이브러리 API 호출 결과에 대한 도메인 증거 추적 강화
  * 컬렉션 팩토리 결과 도메인 매핑 유틸리티 추가

* **버그 수정**
  * 엄격한 타입 수신자 검증 정확도 개선
  * 멤버십 판정 로직 정확화

* **리팩토링**
  * 라이브러리 API 증거 계획 구조 개선
  * 컬렉션 멤버십 평가 처리 최적화

* **문서**
  * 증거 기록 사양 및 로드맵 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->