### PR TITLE
[codex] remove source domain evidence mirrors

### DIFF
--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -6,8 +6,8 @@ use nose_il::{
     stable_symbol_hash, Builtin, DomainEvidence, EffectEvidenceKind, EvidenceAnchor,
     EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance, EvidenceRecord, EvidenceStatus,
     FileId, FileMeta, Il, IlBuilder, ImportEvidenceKind, Interner, Lang, LibraryApiEvidenceKind,
-    LoopKind, NodeId, NodeKind, Op, ParamSemantic, ParamTypeFact, Payload, PlaceEvidenceKind,
-    SourceCallKind, SourceFact, SourceFactKind, Span, Symbol, SymbolEvidenceKind, Unit, UnitKind,
+    LoopKind, NodeId, NodeKind, Op, ParamSemantic, Payload, PlaceEvidenceKind, SourceCallKind,
+    SourceFactKind, Span, Symbol, SymbolEvidenceKind, Unit, UnitKind,
 };
 use nose_semantics::{
     library_api_callee_contract_hash, library_api_contract_id_hash,
@@ -41,9 +41,7 @@ pub(crate) struct Lowering<'a> {
     pub lang: Lang,
     pub interner: &'a Interner,
     pub units: Vec<Unit>,
-    pub param_type_facts: Vec<ParamTypeFact>,
     pub evidence: Vec<EvidenceRecord>,
-    pub source_facts: Vec<SourceFact>,
     pub param_semantic_aliases: Vec<(String, ParamSemantic)>,
     pub unsigned_32_aliases: Vec<String>,
 }
@@ -56,9 +54,7 @@ impl<'a> Lowering<'a> {
             lang,
             interner,
             units: Vec::new(),
-            param_type_facts: Vec::new(),
             evidence: Vec::new(),
-            source_facts: Vec::new(),
             param_semantic_aliases: Vec::new(),
             unsigned_32_aliases: Vec::new(),
         }
@@ -760,7 +756,6 @@ impl<'a> Lowering<'a> {
     }
 
     pub(crate) fn record_param_semantic(&mut self, span: Span, semantic: ParamSemantic) {
-        self.param_type_facts.push(ParamTypeFact { span, semantic });
         self.record_evidence(
             EvidenceAnchor::param(span),
             EvidenceKind::Domain(DomainEvidence::from_param_semantic(semantic)),
@@ -769,7 +764,6 @@ impl<'a> Lowering<'a> {
     }
 
     pub(crate) fn record_source_fact(&mut self, span: Span, kind: SourceFactKind) {
-        self.source_facts.push(SourceFact { span, kind });
         self.record_evidence(
             EvidenceAnchor::source_span(span),
             EvidenceKind::Source(kind),
@@ -1162,13 +1156,9 @@ pub(crate) fn lower_file_with_setup(
         lang,
     };
     let units = std::mem::take(&mut lo.units);
-    let param_type_facts = std::mem::take(&mut lo.param_type_facts);
     let evidence = std::mem::take(&mut lo.evidence);
-    let source_facts = std::mem::take(&mut lo.source_facts);
     let mut il = lo.b.finish(module, meta, units, Vec::new());
-    il.param_type_facts = param_type_facts;
     il.evidence = evidence;
-    il.source_facts = source_facts;
     record_post_lower_library_api_evidence(&mut il, interner);
     drop_suppressed_units(&mut il, src);
     Ok(il)

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -24,9 +24,9 @@ pub use node::{
     Builtin, DomainEvidence, EffectEvidenceKind, EvidenceAnchor, EvidenceEmitter, EvidenceId,
     EvidenceKind, EvidenceProvenance, EvidenceRecord, EvidenceStatus, GuardEvidenceKind, HoFKind,
     ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, LibraryApiEvidenceKind,
-    LitClass, LoopKind, Node, NodeId, NodeKind, Op, ParamSemantic, ParamTypeFact, Payload,
-    PlaceEvidenceKind, SequenceSurfaceKind, SourceCallKind, SourceFact, SourceFactKind,
-    SourceLiteralKind, SourceOperatorKind, SymbolEvidenceKind,
+    LitClass, LoopKind, Node, NodeId, NodeKind, Op, ParamSemantic, Payload, PlaceEvidenceKind,
+    SequenceSurfaceKind, SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
+    SymbolEvidenceKind,
 };
 pub use span::{FileId, FileMeta, Lang, Span};
 
@@ -71,21 +71,11 @@ pub struct Il {
     /// carries it, which is what the contiguous channel reads.
     #[serde(default)]
     pub suppressed: Vec<(u32, u32)>,
-    /// Explicit source-level parameter semantic facts, keyed by the original parameter
-    /// node span. Normalization preserves spans; after alpha-renaming the value graph can
-    /// connect these facts to canonical parameter ids for strict proof-gated rewrites.
-    #[serde(default)]
-    pub param_type_facts: Vec<ParamTypeFact>,
     /// Pack-facing semantic evidence records keyed by stable source anchors.
-    /// Existing source/param/import side tables are mirrored here for compatibility
-    /// today; future language/library packs should emit this record shape directly.
+    /// Source-origin and parameter-domain proof is stored here directly; exact
+    /// consumers must not use side-table mirrors as alternate proof channels.
     #[serde(default)]
     pub evidence: Vec<EvidenceRecord>,
-    /// Source-origin evidence facts keyed by source span. These preserve facts that the
-    /// shared IL shape intentionally abstracts away, such as construct syntax, regex
-    /// literal syntax, and the original equality/operator family.
-    #[serde(default)]
-    pub source_facts: Vec<SourceFact>,
 }
 
 impl Il {
@@ -242,9 +232,7 @@ impl IlBuilder {
             units,
             cid_names,
             suppressed: Vec::new(),
-            param_type_facts: Vec::new(),
             evidence: Vec::new(),
-            source_facts: Vec::new(),
         }
     }
 }

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -219,12 +219,6 @@ impl DomainEvidence {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
-pub struct ParamTypeFact {
-    pub span: Span,
-    pub semantic: ParamSemantic,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub struct EvidenceId(pub u32);
 
 /// Stable subject addressed by a semantic evidence record. Node ids are not used
@@ -422,15 +416,6 @@ pub struct EvidenceRecord {
     pub provenance: EvidenceProvenance,
     pub dependencies: Vec<EvidenceId>,
     pub status: EvidenceStatus,
-}
-
-/// Source-origin facts that must survive lowering before a semantic contract can
-/// consume them. These are evidence records, not semantic approval: contracts in
-/// `nose-semantics` decide whether a fact is sufficient for an exact rule.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
-pub struct SourceFact {
-    pub span: Span,
-    pub kind: SourceFactKind,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -822,8 +822,8 @@ mod tests {
     use nose_il::{
         EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
         EvidenceRecord, EvidenceStatus, FileId, FileMeta, IlBuilder, ImportEvidenceKind, Lang,
-        LibraryApiEvidenceKind, ParamSemantic, ParamTypeFact, SequenceSurfaceKind, Span,
-        SymbolEvidenceKind, Unit, UnitKind,
+        LibraryApiEvidenceKind, ParamSemantic, SequenceSurfaceKind, Span, SymbolEvidenceKind, Unit,
+        UnitKind,
     };
 
     fn sp() -> Span {
@@ -1147,15 +1147,23 @@ mod tests {
             Vec::new(),
             Vec::new(),
         );
-        il.param_type_facts.push(ParamTypeFact {
-            span: param_span,
-            semantic,
-        });
-        if duplicate_param_name {
-            il.param_type_facts.push(ParamTypeFact {
-                span: duplicate_span,
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::param(param_span),
+            EvidenceKind::Domain(nose_semantics::DomainEvidence::from_param_semantic(
                 semantic,
-            });
+            )),
+            EvidenceStatus::Asserted,
+        ));
+        if duplicate_param_name {
+            il.evidence.push(evidence(
+                1,
+                EvidenceAnchor::param(duplicate_span),
+                EvidenceKind::Domain(nose_semantics::DomainEvidence::from_param_semantic(
+                    semantic,
+                )),
+                EvidenceStatus::Asserted,
+            ));
         }
         (il, interner, call)
     }

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -153,9 +153,7 @@ pub(crate) fn finalize_rebuild(
         lang: old.meta.lang,
     };
     let mut out = builder.finish(new_root, meta, units, cid_names);
-    out.param_type_facts = old.param_type_facts.clone();
     out.evidence = old.evidence.clone();
-    out.source_facts = old.source_facts.clone();
     out
 }
 

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -8514,8 +8514,8 @@ mod tests {
         EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
         EvidenceRecord, EvidenceStatus, FileId, FileMeta, GuardEvidenceKind, IlBuilder,
         ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, Lang,
-        LibraryApiEvidenceKind, ParamSemantic, ParamTypeFact, SequenceSurfaceKind, SourceCallKind,
-        SourceFactKind, Span, SymbolEvidenceKind, Unit, UnitKind,
+        LibraryApiEvidenceKind, ParamSemantic, SequenceSurfaceKind, SourceCallKind, SourceFactKind,
+        Span, SymbolEvidenceKind, Unit, UnitKind,
     };
     use nose_semantics::{
         library_api_callee_contract_hash, library_api_contract_id_hash,
@@ -8950,10 +8950,11 @@ mod tests {
         );
         for (idx, semantic) in semantics.into_iter().enumerate() {
             if let Some(semantic) = semantic {
-                il.param_type_facts.push(ParamTypeFact {
-                    span: sp(idx as u32 + 1),
-                    semantic,
-                });
+                il.evidence.push(evidence(
+                    idx as u32,
+                    EvidenceAnchor::param(sp(idx as u32 + 1)),
+                    EvidenceKind::Domain(DomainEvidence::from_param_semantic(semantic)),
+                ));
             }
         }
         let mut builder = Builder::new(&il, &interner);
@@ -8989,10 +8990,11 @@ mod tests {
             }],
             Vec::new(),
         );
-        il.param_type_facts.push(ParamTypeFact {
-            span: sp(1),
-            semantic: ParamSemantic::Integer,
-        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::param(sp(1)),
+            EvidenceKind::Domain(DomainEvidence::Integer),
+        ));
         let mut builder = Builder::new(&il, &interner);
         builder.build_unit(func);
         (

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -114,7 +114,7 @@ fn evidence_at_span<T: Copy + Eq>(
     span: Span,
     project: impl Fn(EvidenceKind) -> Option<T>,
 ) -> EvidenceResolution<T> {
-    unique_evidence_at(il, |anchor| anchor.matches_span(span), project)
+    unique_asserted_evidence_at(il, |anchor| anchor.matches_span(span), project)
 }
 
 pub fn source_fact_at_node(il: &Il, node: NodeId, kind: SourceFactKind) -> bool {
@@ -132,17 +132,7 @@ pub fn source_operator_at_node(il: &Il, node: NodeId) -> Option<SourceOperatorKi
         _ => None,
     }) {
         EvidenceResolution::Found(operator) => Some(operator),
-        EvidenceResolution::Ambiguous => None,
-        EvidenceResolution::Missing => {
-            unique_legacy_source_fact(il.source_facts.iter().filter_map(|fact| {
-                (fact.span == span)
-                    .then_some(fact.kind)
-                    .and_then(|kind| match kind {
-                        SourceFactKind::Operator(operator) => Some(operator),
-                        SourceFactKind::Call(_) | SourceFactKind::Literal(_) => None,
-                    })
-            }))
-        }
+        EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
     }
 }
 
@@ -153,17 +143,7 @@ pub fn source_call_at_node(il: &Il, node: NodeId) -> Option<SourceCallKind> {
         _ => None,
     }) {
         EvidenceResolution::Found(call) => Some(call),
-        EvidenceResolution::Ambiguous => None,
-        EvidenceResolution::Missing => {
-            unique_legacy_source_fact(il.source_facts.iter().filter_map(|fact| {
-                (fact.span == span)
-                    .then_some(fact.kind)
-                    .and_then(|kind| match kind {
-                        SourceFactKind::Call(call) => Some(call),
-                        SourceFactKind::Operator(_) | SourceFactKind::Literal(_) => None,
-                    })
-            }))
-        }
+        EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
     }
 }
 
@@ -174,30 +154,8 @@ pub fn source_literal_at_node(il: &Il, node: NodeId) -> Option<SourceLiteralKind
         _ => None,
     }) {
         EvidenceResolution::Found(literal) => Some(literal),
-        EvidenceResolution::Ambiguous => None,
-        EvidenceResolution::Missing => {
-            unique_legacy_source_fact(il.source_facts.iter().filter_map(|fact| {
-                (fact.span == span)
-                    .then_some(fact.kind)
-                    .and_then(|kind| match kind {
-                        SourceFactKind::Literal(literal) => Some(literal),
-                        SourceFactKind::Operator(_) | SourceFactKind::Call(_) => None,
-                    })
-            }))
-        }
+        EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
     }
-}
-
-fn unique_legacy_source_fact<T: Copy + Eq>(facts: impl Iterator<Item = T>) -> Option<T> {
-    let mut found = None;
-    for fact in facts {
-        match found {
-            None => found = Some(fact),
-            Some(existing) if existing == fact => {}
-            Some(_) => return None,
-        }
-    }
-    found
 }
 
 pub fn construct_syntax_proof(il: &Il, node: NodeId) -> bool {
@@ -235,19 +193,7 @@ pub fn domain_evidence_at_span(il: &Il, span: Span) -> Option<DomainEvidence> {
         },
     ) {
         EvidenceResolution::Found(domain) => Some(domain),
-        EvidenceResolution::Ambiguous => None,
-        EvidenceResolution::Missing => {
-            let mut found = None;
-            for fact in il.param_type_facts.iter().filter(|fact| fact.span == span) {
-                let domain = domain_evidence_from_param_semantic(fact.semantic);
-                match found {
-                    None => found = Some(domain),
-                    Some(existing) if existing == domain => {}
-                    Some(_) => return None,
-                }
-            }
-            found
-        }
+        EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
     }
 }
 
@@ -6031,8 +5977,8 @@ mod tests {
         EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
         EvidenceRecord, EvidenceStatus, FileId, FileMeta, GuardEvidenceKind, IlBuilder,
         ImportEvidenceKind, Interner, JsRecordGuardComparison, JsRecordGuardNullCheck,
-        LibraryApiEvidenceKind, ParamSemantic, ParamTypeFact, SequenceSurfaceKind, SourceFact,
-        Span, Symbol, SymbolEvidenceKind, Unit, UnitKind,
+        LibraryApiEvidenceKind, ParamSemantic, SequenceSurfaceKind, Span, Symbol,
+        SymbolEvidenceKind, Unit, UnitKind,
     };
 
     const ALL_LANGS: &[Lang] = &[
@@ -6200,15 +6146,11 @@ mod tests {
     }
 
     #[test]
-    fn domain_evidence_records_are_preferred_over_legacy_param_facts() {
+    fn domain_evidence_records_drive_param_domain_proof() {
         let mut b = IlBuilder::new(FileId(0));
         let param = b.add(NodeKind::Param, Payload::None, sp(3), &[]);
         let root = b.add(NodeKind::Func, Payload::None, sp(3), &[param]);
         let mut il = finish_il(b, root, Lang::TypeScript);
-        il.param_type_facts.push(ParamTypeFact {
-            span: sp(3),
-            semantic: ParamSemantic::Set,
-        });
         il.evidence.push(evidence(
             0,
             EvidenceAnchor::param(sp(3)),
@@ -6223,15 +6165,11 @@ mod tests {
     }
 
     #[test]
-    fn ambiguous_domain_evidence_blocks_legacy_fallback() {
+    fn ambiguous_domain_evidence_stays_closed() {
         let mut b = IlBuilder::new(FileId(0));
         let param = b.add(NodeKind::Param, Payload::None, sp(4), &[]);
         let root = b.add(NodeKind::Func, Payload::None, sp(4), &[param]);
         let mut il = finish_il(b, root, Lang::TypeScript);
-        il.param_type_facts.push(ParamTypeFact {
-            span: sp(4),
-            semantic: ParamSemantic::Set,
-        });
         il.evidence.push(evidence(
             0,
             EvidenceAnchor::param(sp(4)),
@@ -6249,7 +6187,7 @@ mod tests {
     }
 
     #[test]
-    fn receiver_domain_evidence_at_node_is_preferred_over_param_mirror() {
+    fn receiver_domain_evidence_at_node_is_preferred_over_param_evidence() {
         let mut b = IlBuilder::new(FileId(0));
         let param = b.add(NodeKind::Param, Payload::Cid(0), span(10, 12, 1), &[]);
         let receiver = b.add(NodeKind::Var, Payload::Cid(0), span(20, 22, 2), &[]);
@@ -6267,12 +6205,14 @@ mod tests {
             &[param, body],
         );
         let mut il = finish_il(b, root, Lang::TypeScript);
-        il.param_type_facts.push(ParamTypeFact {
-            span: span(10, 12, 1),
-            semantic: ParamSemantic::Set,
-        });
         il.evidence.push(evidence(
             0,
+            EvidenceAnchor::param(span(10, 12, 1)),
+            EvidenceKind::Domain(DomainEvidence::Set),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence(
+            1,
             EvidenceAnchor::node(span(20, 22, 2), NodeKind::Var),
             EvidenceKind::Domain(DomainEvidence::Map),
             EvidenceStatus::Asserted,
@@ -6311,18 +6251,20 @@ mod tests {
             &[param, body],
         );
         let mut il = finish_il(b, root, Lang::TypeScript);
-        il.param_type_facts.push(ParamTypeFact {
-            span: span(10, 12, 1),
-            semantic: ParamSemantic::Map,
-        });
         il.evidence.push(evidence(
             0,
+            EvidenceAnchor::param(span(10, 12, 1)),
+            EvidenceKind::Domain(DomainEvidence::Map),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence(
+            1,
             EvidenceAnchor::node(span(20, 22, 2), NodeKind::Var),
             EvidenceKind::Domain(DomainEvidence::Set),
             EvidenceStatus::Asserted,
         ));
         il.evidence.push(evidence(
-            1,
+            2,
             EvidenceAnchor::node(span(20, 22, 2), NodeKind::Var),
             EvidenceKind::Domain(DomainEvidence::Map),
             EvidenceStatus::Asserted,
@@ -6396,12 +6338,14 @@ mod tests {
             &[param, body],
         );
         let mut il = finish_il(b, root, Lang::TypeScript);
-        il.param_type_facts.push(ParamTypeFact {
-            span: span(10, 12, 1),
-            semantic: ParamSemantic::Set,
-        });
-        il.evidence.push(evidence_with_dependencies(
+        il.evidence.push(evidence(
             0,
+            EvidenceAnchor::param(span(10, 12, 1)),
+            EvidenceKind::Domain(DomainEvidence::Set),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            1,
             EvidenceAnchor::node(span(20, 22, 2), NodeKind::Var),
             EvidenceKind::Domain(DomainEvidence::Map),
             EvidenceStatus::Asserted,
@@ -10134,14 +10078,18 @@ mod tests {
         let regex = b.add(NodeKind::Lit, Payload::LitStr(42), sp(8), &[]);
         let root = b.add(NodeKind::Block, Payload::None, sp(7), &[call, regex]);
         let mut il = finish_il(b, root, Lang::JavaScript);
-        il.source_facts.push(SourceFact {
-            span: sp(7),
-            kind: SourceFactKind::Call(SourceCallKind::Construct),
-        });
-        il.source_facts.push(SourceFact {
-            span: sp(8),
-            kind: SourceFactKind::Literal(SourceLiteralKind::Regex),
-        });
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::source_span(sp(7)),
+            EvidenceKind::Source(SourceFactKind::Call(SourceCallKind::Construct)),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::source_span(sp(8)),
+            EvidenceKind::Source(SourceFactKind::Literal(SourceLiteralKind::Regex)),
+            EvidenceStatus::Asserted,
+        ));
 
         assert!(construct_syntax_proof(&il, call));
         assert!(regex_literal_proof(&il, regex));
@@ -10158,10 +10106,6 @@ mod tests {
         let op = b.add(NodeKind::BinOp, Payload::Op(Op::Eq), sp(9), &[]);
         let root = b.add(NodeKind::Block, Payload::None, sp(9), &[op]);
         let mut il = finish_il(b, root, Lang::JavaScript);
-        il.source_facts.push(SourceFact {
-            span: sp(9),
-            kind: SourceFactKind::Operator(SourceOperatorKind::StrictEquality),
-        });
         il.evidence.push(evidence(
             0,
             EvidenceAnchor::source_span(sp(9)),
@@ -10180,6 +10124,28 @@ mod tests {
             EvidenceStatus::Asserted,
         ));
         assert_eq!(source_operator_at_node(&il, op), None);
+    }
+
+    #[test]
+    fn source_fact_evidence_requires_live_dependencies() {
+        let mut b = IlBuilder::new(FileId(0));
+        let call = b.add(NodeKind::Call, Payload::None, sp(10), &[]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(10), &[call]);
+        let mut il = finish_il(b, root, Lang::Rust);
+        il.evidence.push(evidence_with_dependencies(
+            0,
+            EvidenceAnchor::source_span(sp(10)),
+            EvidenceKind::Source(SourceFactKind::Call(SourceCallKind::MacroInvocation)),
+            EvidenceStatus::Asserted,
+            vec![EvidenceId(99)],
+        ));
+
+        assert_eq!(source_call_at_node(&il, call), None);
+        assert!(!source_fact_at_node(
+            &il,
+            call,
+            SourceFactKind::Call(SourceCallKind::MacroInvocation),
+        ));
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,7 +79,7 @@ A Cargo workspace; data flows left-to-right through them.
 
 | crate | role |
 |---|---|
-| `nose-il` | arena IL model (`Vec<Node>`, `NodeId(u32)`, out-of-line edges), provenance spans, semantic evidence records, compatibility source facts, interner, serialization, IR verifier |
+| `nose-il` | arena IL model (`Vec<Node>`, `NodeId(u32)`, out-of-line edges), provenance spans, semantic evidence records, interner, serialization, IR verifier |
 | `nose-semantics` | first-party semantic facade: language profiles, evidence/source-fact helpers, effect/operator/module/stdlib predicates, API contracts, and exact-channel proof obligations |
 | `nose-frontend` | tree-sitter parse + per-language CST→IL lowering and source-fact emission (one module per language; embedded `<script>` extraction) |
 | `nose-normalize` | the normalization passes + the value graph (GVN) |

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -19,8 +19,9 @@ precondition.
 - Make facts carry stable ids, anchors, provenance, dependencies, and status.
 - Keep exact matching fail-closed when evidence is missing, ambiguous, or
   conflicting.
-- Preserve existing behavior while first-party frontends mirror their older
-  side-table facts into the new record shape.
+- Preserve existing behavior while first-party frontends emit source,
+  parameter-domain, import, symbol, guard, place/effect, library API, and
+  sequence-surface facts directly into the record shape.
 - Make the future external pack schema a narrowing of an implemented internal
   boundary, not a speculative document-only API.
 
@@ -30,10 +31,6 @@ precondition.
   pairs exact.
 - Do not expose this internal Rust record as the final external pack manifest or
   scan JSON schema.
-- Do not remove compatibility mirrors in the first slice. `SourceFact`,
-  `ParamTypeFact`, and raw import `Seq` payloads still exist while consumers are
-  migrated, though new proof-bearing consumers should prefer evidence-only
-  helpers.
 - Do not certify external pack claims. nose validates record shape and fails
   closed; providers own their claims, and users own opt-in decisions.
 - Do not model demand evidence or every place/effect family in this slice. The
@@ -109,9 +106,10 @@ side tables.
 - A lookup succeeds only when asserted evidence resolves to exactly one relevant
   fact.
 - Conflicting asserted evidence makes the lookup fail.
+- Dependency-broken evidence makes the lookup fail.
 - `Ambiguous` evidence makes the lookup fail.
-- If any relevant ambiguous/conflicting evidence exists, compatibility fallback
-  must not reopen the exact path.
+- If any relevant ambiguous, conflicting, or dependency-broken evidence exists,
+  compatibility fallback must not reopen the exact path.
 - Compatibility fallback is allowed only when no relevant evidence record exists,
   and only for explicitly legacy compatibility helpers.
 
@@ -133,12 +131,12 @@ alias is rebound or ambiguous, the exact path stays closed until a node-level
 symbol fact or stronger scope-resolution evidence exists.
 
 Domain evidence follows the same fail-closed rule. First-party parameter
-annotations still mirror into `Domain` evidence on `Param` anchors, but
-`nose-semantics` now also resolves `Domain` evidence on exact receiver-expression
-node anchors before consulting parameter compatibility facts. A conflicting,
-ambiguous, or dependency-broken receiver-domain record closes that receiver proof
-and must not fall back to `ParamTypeFact` or selector spelling. When a receiver is
-an alpha-renamed parameter reference, lookup is constrained to the nearest
+annotations emit `Domain` evidence on `Param` anchors, and `nose-semantics`
+resolves `Domain` evidence on exact receiver-expression node anchors before
+consulting parameter-anchor evidence. A conflicting, ambiguous, or
+dependency-broken receiver-domain record closes that receiver proof and must not
+fall back to side-table mirrors or selector spelling. When a receiver is an
+alpha-renamed parameter reference, lookup is constrained to the nearest
 function/lambda scope so same-numbered parameter ids from other units do not
 prove the current receiver. Method receiver contracts expose their domain-backed
 obligations through `DomainRequirement`; obligations such as imported namespace,
@@ -212,7 +210,7 @@ instead of accepting an unrelated imported symbol elsewhere in the file.
 
 ## Current Producers
 
-First-party frontends now mirror these facts into `EvidenceRecord`:
+First-party frontends now emit these facts as `EvidenceRecord`:
 
 - parameter semantic annotations become `Domain` evidence. Selected first-party
   library/API factory calls now also emit receiver-expression `Domain` evidence
@@ -284,12 +282,13 @@ First-party frontends now mirror these facts into `EvidenceRecord`:
 - lowered `Seq` surfaces emit `SequenceSurface` evidence, including Go map
   literal and Go map-entry surfaces where those tags carry first-party meaning.
 
-The older `ParamTypeFact`, `SourceFact`, and raw import `Seq` shapes remain as
-compatibility mirrors. First-party JS/TS record-shape guards now have dedicated
-guard evidence, and exact-fragment append/index/self-field gates now have the
-first place/effect evidence substrate. Broader guard families, richer
+Source-origin and parameter-domain proof no longer has side-table mirror storage:
+frontends emit `Source` and `Domain` records directly, and semantic lookups are
+evidence-only for those facts. First-party JS/TS record-shape guards now have
+dedicated guard evidence, and exact-fragment append/index/self-field gates now
+have the first place/effect evidence substrate. Broader guard families, richer
 source-clause dependencies, richer receiver/place families, and general evidence
-validation remain open. These mirrors are not the desired pack boundary.
+validation remain open.
 
 ## Current Consumers
 

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -245,6 +245,11 @@ and pack ecosystem.
   facts into records with ids, anchors, provenance, dependencies, and status.
   `nose-semantics` lookups fail closed on ambiguous/conflicting evidence before
   falling back to compatibility storage.
+- Source-origin and parameter-domain proof later became evidence-only: the
+  `SourceFact` and `ParamTypeFact` side-table mirrors were removed from IL
+  storage, first-party frontends emit `Source` and `Domain` records directly, and
+  semantic lookups no longer reopen those proof paths from compatibility mirrors
+  when evidence is missing.
 - Symbol-identity evidence now represents static imported binding/namespace
   aliases. Normalize idiom admission, value-graph namespace fallbacks, and strict
   exact gates have started consuming this helper layer instead of each re-scanning
@@ -404,9 +409,12 @@ Remaining in this phase:
   A later source-fact slice preserves selected JS/TS and Python equality-like
   source operators, but broader operator dispatch, overload semantics, and
   pack-facing consumers remain open.
-- Continue migrating compatibility source/domain/import/symbol/sequence storage
-  onto `EvidenceRecord` consumers, then remove the old mirrors once no exact gate
-  depends on them.
+- Continue migrating compatibility storage onto `EvidenceRecord` consumers.
+  Source-origin, parameter-domain, import identity, symbol identity, guard,
+  selected place/effect, selected library API occurrence, and selected
+  sequence-surface consumers now use evidence-only proof paths where covered.
+  Remaining mirror work is concentrated in broader lowered sequence/tag surfaces
+  and unmodeled module/export dependencies rather than source/domain side tables.
 - Add scope, dependency, and ambiguity validation for evidence records before
   they become a stable external extension surface.
 - Expand the exact fragment facade from first-party helper functions into
@@ -447,13 +455,13 @@ Remaining in this phase:
   and broad receiver-method proof dependencies into explicit evidence records,
   then cover broader reduction/HOF and ecosystem APIs only after demand,
   receiver, and effect obligations are expressible.
-- Remove the remaining raw import/module proof IL payload storage after import
-  and symbol evidence records can carry every consumer obligation, including
-  module export dependencies, scope, rebinding, and mutation proof. Value-graph
-  import identity and imported-symbol exact proof are now evidence-only, and
-  imported literal replacement copies provider evidence, and selected JS/TS
-  `QualifiedGlobal` paths are covered, but general qualified-member, namespace
-  export identity, and manifest-level cross-module dependency evidence are not.
+- Continue import/module proof migration beyond the removed raw import payloads
+  and evidence-only import identity path. Value-graph import identity and
+  imported-symbol exact proof are now evidence-only, imported literal replacement
+  copies provider evidence, and selected JS/TS `QualifiedGlobal` paths are
+  covered, but general qualified-member resolution, namespace export identity,
+  provider/export dependency manifests, richer scope/rebinding facts, and
+  manifest-level cross-module dependency evidence are not.
 - Generalize dedicated guard evidence beyond the first JS/TS record-shape and
   own-property contracts, including richer source-clause records, API dependency
   validation, subject/place identity, and truthiness/null semantics.

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -66,9 +66,10 @@ migrated.
   symbol-identity, guard, place/effect, selected library API occurrence, and
   sequence-surface proof facts. Records carry ids, stable source anchors, kind,
   provenance, dependencies, and asserted/ambiguous status. Lookups in
-  `nose-semantics` fail closed on ambiguous or conflicting evidence and use older
-  side tables only as compatibility fallback when no relevant evidence record is
-  present.
+  `nose-semantics` fail closed on ambiguous, conflicting, or dependency-broken
+  evidence. Source-origin and parameter-domain proof is now evidence-only;
+  explicitly legacy helper fallbacks remain only for proof families whose
+  evidence migration is not complete.
 - `OperatorSemantics` now owns the first shared operator contracts:
   comparison-direction transforms, comparison negation, equality operand
   commutativity, comparison-lattice laws, abs/min/max/selection guard laws,
@@ -83,22 +84,22 @@ migrated.
   strict/loose equality, strict/loose inequality, and `instanceof` facts. Python
   emits value equality/inequality and identity equality/inequality facts, and
   Rust emits macro invocation syntax for selected macro-backed APIs. These are
-  mirrored into `EvidenceRecord::Source`; the older `SourceFact` vector remains
-  a compatibility fallback. Normalize and detect consume source facts only where
-  a semantic contract requires that exact source surface.
+  stored directly as `EvidenceRecord::Source`; there is no source-fact side-table
+  fallback. Normalize and detect consume source facts only where a semantic
+  contract requires that exact source surface.
 - Free-function builtin contracts are language- and arity-constrained and require
   unshadowed builtin/global proof before exact lowering.
 - Method contracts carry receiver obligations such as exact collection, exact
   protocol, exact option, exact string, exact primitive integer, exact map literal,
   imported namespace, or unshadowed global.
-- Source-level `ParamSemantic` facts are mirrored into
-  `EvidenceRecord::Domain`, and `nose-semantics` now resolves receiver-domain
+- Source-level `ParamSemantic` facts are stored directly as
+  `EvidenceRecord::Domain`, and `nose-semantics` resolves receiver-domain
   evidence through a shared `DomainRequirement` contract. Consumers check exact
   receiver node evidence first, then scoped parameter evidence, and fail closed
-  on ambiguous/conflicting/dependency-broken records before any compatibility
-  fallback. Desugaring, normalize idiom canonicalization, value-graph receiver
-  gates, and strict exact receiver gates consume this same helper layer. This
-  preserves the current Array/Collection/Set/Map/Option/String/Integer/Number
+  on ambiguous/conflicting/dependency-broken records without consulting a
+  side-table mirror. Desugaring, normalize idiom canonicalization, value-graph
+  receiver gates, and strict exact receiver gates consume this same helper layer.
+  This preserves the current Array/Collection/Set/Map/Option/String/Integer/Number
   and ByteArray distinctions. First-party producers now attach
   receiver-expression domain facts directly for selected admitted library/API
   factory results, while future packs or inference passes can use the same

--- a/docs/source-facts.md
+++ b/docs/source-facts.md
@@ -45,7 +45,7 @@ preconditions.
 
 | term | meaning |
 |---|---|
-| `SourceFact` | Compatibility mirror keyed by source span and fact kind. |
+| Source evidence | `EvidenceKind::Source` records keyed by stable source anchors. |
 | Evidence record | Current internal form of a source or semantic fact, with stable ids, anchors, dependencies, status, and provenance. The external pack manifest is not defined yet. |
 | Contract | Kernel rule that maps a proven source/API surface to a semantic operation or law under explicit preconditions. |
 | Pack provenance | The pack id, provider, trust policy, version range, contract id, and evidence status behind an admitted fact or contract. |
@@ -85,8 +85,9 @@ The pack-facing vocabulary should cover at least these classes.
 ## Current internal slice
 
 The current implementation has `Il::evidence` records in `nose-il` and
-source-fact helpers in `nose-semantics`. `SourceFact` still exists as a
-compatibility mirror while consumers migrate to evidence records.
+source-fact helpers in `nose-semantics`. Source-origin proof is evidence-only:
+frontends emit `EvidenceKind::Source` records directly, and consumers do not
+fall back to a side-table mirror when source evidence is missing.
 
 - JS/TS lowering emits source facts for construct syntax, regex literals, strict
   equality, strict inequality, loose equality, loose inequality, and


### PR DESCRIPTION
## Summary

This is the next semantic-kernel migration slice for evidence-only source/domain proof.

- remove legacy `SourceFact` and `ParamTypeFact` side-table storage from `Il`
- keep `SourceFactKind`, `ParamSemantic`, and `DomainEvidence` as contract vocabulary, but store proof only in `EvidenceRecord`
- make first-party lowering emit source-origin and parameter-domain proof directly as records
- remove source/domain compatibility fallback in `nose-semantics`
- make source evidence dependency-aware, so dependency-broken source facts fail closed
- update manual IL tests and semantic-kernel docs to reflect the evidence-only boundary

Updates #109.

## Behavior Judgment

First-party producer-covered behavior is preserved; full workspace tests pass. Manual or external IL that only populated the removed side tables now fails closed unless it emits `EvidenceRecord` facts, which is the intended pack boundary. `nose il --format json` internal IL output no longer includes the removed mirror fields; source/domain proof should be read from `evidence`.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo build --release`
- `./scripts/check-duplication.sh`
- `awiki lint --root docs`
- `git diff --check`
- `python3 scripts/check-formal-obligations.py --self-test`
- `python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`