### PR TITLE
[codex] normalize: cache parameter domain proofs

### DIFF
--- a/crates/nose-frontend/src/lib.rs
+++ b/crates/nose-frontend/src/lib.rs
@@ -134,12 +134,21 @@ pub fn lower_corpus_filtered(roots: &[&Path], exclude: &[String]) -> Corpus {
             lower_source(FileId(i as u32), path, &src, *lang, &interner).ok()
         })
         .collect();
-    module_imports::resolve_imported_immutable_bindings(&mut files, &interner);
     if timing {
         eprintln!(
             "  [time] {:<12} {:>7.1}ms  (read+parse+lower, parallel)",
             "parse+lower",
             t1.elapsed().as_secs_f64() * 1e3
+        );
+    }
+
+    let t2 = std::time::Instant::now();
+    module_imports::resolve_imported_immutable_bindings(&mut files, &interner);
+    if timing {
+        eprintln!(
+            "  [time] {:<12} {:>7.1}ms  (corpus import facts)",
+            "import-resolve",
+            t2.elapsed().as_secs_f64() * 1e3
         );
     }
     Corpus::new(interner, files)

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -77,7 +77,11 @@ struct AppendedSnapshot {
 }
 
 pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &Interner) {
-    let exports = collect_literal_exports(files, interner);
+    let contexts: Vec<FileImportContext> = files
+        .iter()
+        .map(|il| FileImportContext::new(il, interner))
+        .collect();
+    let exports = collect_literal_exports(files, interner, &contexts);
     if exports.is_empty() {
         return;
     }
@@ -95,8 +99,16 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
         .iter()
         .enumerate()
         .map(|(file_idx, il)| {
-            collect_top_level_statements(il)
-                .into_iter()
+            let context = &contexts[file_idx];
+            let Some(top_level) = context.top_level.as_deref() else {
+                return Vec::new();
+            };
+            let Some(binding_uses) = context.binding_uses.as_ref() else {
+                return Vec::new();
+            };
+            top_level
+                .iter()
+                .copied()
                 .filter_map(|stmt| {
                     let local = assignment_name(il, stmt)?;
                     let proof = import_binding_proof(il, stmt)?;
@@ -105,7 +117,7 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
                     if export.file_idx == file_idx {
                         return None;
                     }
-                    if binding_mutated(il, interner, local, stmt) {
+                    if binding_uses.binding_mutated(il, local, stmt) {
                         return None;
                     }
                     Some(ImportReplacement {
@@ -144,24 +156,55 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
     }
 }
 
+struct FileImportContext {
+    top_level: Option<Vec<NodeId>>,
+    module_hashes: Vec<u64>,
+    binding_uses: Option<BindingUseIndex>,
+}
+
+impl FileImportContext {
+    fn new(il: &Il, interner: &Interner) -> Self {
+        let module_semantics = semantics(il.meta.lang).modules();
+        let participates = module_semantics.sibling_literal_exports()
+            || module_semantics.java_class_literal_exports();
+        Self {
+            top_level: participates.then(|| collect_top_level_statements(il)),
+            module_hashes: file_module_hashes(il),
+            binding_uses: participates.then(|| BindingUseIndex::new(il, interner)),
+        }
+    }
+}
+
 fn collect_literal_exports(
     files: &[Il],
     interner: &Interner,
+    contexts: &[FileImportContext],
 ) -> FxHashMap<(u64, u64), ExportedBinding> {
     let mut exports = FxHashMap::default();
     let mut ambiguous = FxHashSet::default();
     for (file_idx, il) in files.iter().enumerate() {
-        let module_hashes = file_module_hashes(il);
-        if !module_hashes.is_empty() {
-            let top_level = collect_top_level_statements(il);
+        let context = &contexts[file_idx];
+        if !context.module_hashes.is_empty() {
+            let Some(top_level) = context.top_level.as_deref() else {
+                continue;
+            };
+            let Some(binding_uses) = context.binding_uses.as_ref() else {
+                continue;
+            };
             collect_statement_exports(
                 il,
                 interner,
-                file_idx,
-                &top_level,
-                &module_hashes,
-                &mut exports,
-                &mut ambiguous,
+                StatementExportScope {
+                    file_idx,
+                    statements: top_level,
+                    top_level,
+                    module_hashes: &context.module_hashes,
+                    binding_uses,
+                },
+                ExportCollections {
+                    exports: &mut exports,
+                    ambiguous: &mut ambiguous,
+                },
             );
         }
 
@@ -182,15 +225,27 @@ fn collect_literal_exports(
             if class_module_hashes.is_empty() {
                 continue;
             }
+            let Some(top_level) = context.top_level.as_deref() else {
+                continue;
+            };
+            let Some(binding_uses) = context.binding_uses.as_ref() else {
+                continue;
+            };
             let statements = collect_statements_for_root(il, unit.root);
             collect_statement_exports(
                 il,
                 interner,
-                file_idx,
-                &statements,
-                &class_module_hashes,
-                &mut exports,
-                &mut ambiguous,
+                StatementExportScope {
+                    file_idx,
+                    statements: &statements,
+                    top_level,
+                    module_hashes: &class_module_hashes,
+                    binding_uses,
+                },
+                ExportCollections {
+                    exports: &mut exports,
+                    ambiguous: &mut ambiguous,
+                },
             );
         }
     }
@@ -200,29 +255,39 @@ fn collect_literal_exports(
     exports
 }
 
+struct StatementExportScope<'a> {
+    file_idx: usize,
+    statements: &'a [NodeId],
+    top_level: &'a [NodeId],
+    module_hashes: &'a [u64],
+    binding_uses: &'a BindingUseIndex,
+}
+
+struct ExportCollections<'a> {
+    exports: &'a mut FxHashMap<(u64, u64), ExportedBinding>,
+    ambiguous: &'a mut FxHashSet<(u64, u64)>,
+}
+
 fn collect_statement_exports(
     il: &Il,
     interner: &Interner,
-    file_idx: usize,
-    statements: &[NodeId],
-    module_hashes: &[u64],
-    exports: &mut FxHashMap<(u64, u64), ExportedBinding>,
-    ambiguous: &mut FxHashSet<(u64, u64)>,
+    scope: StatementExportScope<'_>,
+    out: ExportCollections<'_>,
 ) {
     let mut counts: FxHashMap<Symbol, usize> = FxHashMap::default();
-    for &stmt in statements {
+    for &stmt in scope.statements {
         if let Some(name) = assignment_name(il, stmt) {
             *counts.entry(name).or_insert(0) += 1;
         }
     }
-    for &stmt in statements {
+    for &stmt in scope.statements {
         let Some(name) = assignment_name(il, stmt) else {
             continue;
         };
         if counts.get(&name).copied().unwrap_or(0) != 1 {
             continue;
         }
-        if exported_binding_unsafe(il, interner, name, stmt) {
+        if scope.binding_uses.exported_binding_unsafe(il, name, stmt) {
             continue;
         }
         let Some(rhs) = assignment_rhs(il, stmt) else {
@@ -232,29 +297,31 @@ fn collect_statement_exports(
             continue;
         }
         let exported = stable_symbol_hash(interner.resolve(name));
-        let deps = import_dependency_snapshots(il, rhs);
-        for &module in module_hashes {
+        let deps = import_dependency_snapshots(il, rhs, scope.top_level);
+        for &module in scope.module_hashes {
             let key = (module, exported);
-            if exports
+            if out
+                .exports
                 .insert(
                     key,
                     ExportedBinding {
-                        file_idx,
+                        file_idx: scope.file_idx,
                         deps: deps.clone(),
                         rhs,
                     },
                 )
                 .is_some()
             {
-                ambiguous.insert(key);
+                out.ambiguous.insert(key);
             }
         }
     }
 }
 
-fn import_dependency_snapshots(il: &Il, rhs: NodeId) -> Vec<SubtreeSnapshot> {
-    collect_top_level_statements(il)
-        .into_iter()
+fn import_dependency_snapshots(il: &Il, rhs: NodeId, top_level: &[NodeId]) -> Vec<SubtreeSnapshot> {
+    top_level
+        .iter()
+        .copied()
         .filter(|&stmt| {
             assignment_rhs(il, stmt).is_some_and(|dep_rhs| {
                 import_binding_key(il, stmt).is_some() && il.kind(dep_rhs) == NodeKind::Seq
@@ -536,55 +603,74 @@ fn var_text<'a>(il: &Il, interner: &'a Interner, node: NodeId) -> Option<&'a str
     Some(interner.resolve(name))
 }
 
-fn binding_mutated(il: &Il, interner: &Interner, name: Symbol, defining_stmt: NodeId) -> bool {
-    il.nodes.iter().enumerate().any(|(idx, node)| {
-        let node_id = NodeId(idx as u32);
-        if node_id == defining_stmt {
-            return false;
-        }
-        match node.kind {
-            NodeKind::Assign => il
-                .children(node_id)
-                .first()
-                .is_some_and(|&lhs| node_contains_symbol(il, lhs, name)),
-            NodeKind::Field => field_mutates_binding(il, interner, node_id, name),
-            _ => false,
-        }
-    })
+struct BindingUseIndex {
+    assignment_lhs_counts: FxHashMap<Symbol, usize>,
+    mutating_field_receivers: FxHashSet<Symbol>,
+    escaping_call_arg_symbols: FxHashSet<Symbol>,
 }
 
-fn exported_binding_unsafe(
-    il: &Il,
-    interner: &Interner,
-    name: Symbol,
-    defining_stmt: NodeId,
-) -> bool {
-    binding_mutated(il, interner, name, defining_stmt)
-        || il.nodes.iter().enumerate().any(|(idx, node)| {
+impl BindingUseIndex {
+    fn new(il: &Il, interner: &Interner) -> Self {
+        let mut out = Self {
+            assignment_lhs_counts: FxHashMap::default(),
+            mutating_field_receivers: FxHashSet::default(),
+            escaping_call_arg_symbols: FxHashSet::default(),
+        };
+        for (idx, node) in il.nodes.iter().enumerate() {
             let node_id = NodeId(idx as u32);
-            node_id != defining_stmt
-                && node.kind == NodeKind::Call
-                && call_argument_escapes_binding(il, node_id, name)
-        })
-}
-
-fn call_argument_escapes_binding(il: &Il, call: NodeId, name: Symbol) -> bool {
-    il.children(call)
-        .iter()
-        .skip(1)
-        .any(|&arg| node_contains_symbol(il, arg, name))
-}
-
-fn field_mutates_binding(il: &Il, interner: &Interner, field: NodeId, name: Symbol) -> bool {
-    let Payload::Name(method) = il.node(field).payload else {
-        return false;
-    };
-    if !nose_semantics::module_binding_mutating_method_name(interner.resolve(method)) {
-        return false;
+            match node.kind {
+                NodeKind::Assign => {
+                    if let Some(&lhs) = il.children(node_id).first() {
+                        let mut lhs_symbols = FxHashSet::default();
+                        collect_symbols_into_set(il, lhs, &mut lhs_symbols);
+                        for symbol in lhs_symbols {
+                            *out.assignment_lhs_counts.entry(symbol).or_insert(0) += 1;
+                        }
+                    }
+                }
+                NodeKind::Field => out.collect_mutating_field_receiver(il, interner, node_id),
+                NodeKind::Call => out.collect_call_argument_escapes(il, node_id),
+                _ => {}
+            }
+        }
+        out
     }
-    il.children(field)
-        .first()
-        .is_some_and(|&receiver| node_refers_to_symbol(il, receiver, name))
+
+    fn binding_mutated(&self, il: &Il, name: Symbol, defining_stmt: NodeId) -> bool {
+        let defining_lhs_refs_name = il
+            .children(defining_stmt)
+            .first()
+            .is_some_and(|&lhs| node_contains_symbol(il, lhs, name));
+        let own_assignment = usize::from(defining_lhs_refs_name);
+        self.assignment_lhs_counts.get(&name).copied().unwrap_or(0) > own_assignment
+            || self.mutating_field_receivers.contains(&name)
+    }
+
+    fn exported_binding_unsafe(&self, il: &Il, name: Symbol, defining_stmt: NodeId) -> bool {
+        self.binding_mutated(il, name, defining_stmt)
+            || self.escaping_call_arg_symbols.contains(&name)
+    }
+
+    fn collect_mutating_field_receiver(&mut self, il: &Il, interner: &Interner, field: NodeId) {
+        let Payload::Name(method) = il.node(field).payload else {
+            return;
+        };
+        if !nose_semantics::module_binding_mutating_method_name(interner.resolve(method)) {
+            return;
+        }
+        let Some(&receiver) = il.children(field).first() else {
+            return;
+        };
+        if let Payload::Name(name) = il.node(receiver).payload {
+            self.mutating_field_receivers.insert(name);
+        }
+    }
+
+    fn collect_call_argument_escapes(&mut self, il: &Il, call: NodeId) {
+        for &arg in il.children(call).iter().skip(1) {
+            collect_symbols_into_set(il, arg, &mut self.escaping_call_arg_symbols);
+        }
+    }
 }
 
 fn node_refers_to_symbol(il: &Il, node: NodeId, name: Symbol) -> bool {
@@ -600,6 +686,15 @@ fn node_contains_symbol(il: &Il, node: NodeId, name: Symbol) -> bool {
             .children(node)
             .iter()
             .any(|&child| node_contains_symbol(il, child, name))
+}
+
+fn collect_symbols_into_set(il: &Il, node: NodeId, out: &mut FxHashSet<Symbol>) {
+    if let Payload::Name(symbol) = il.node(node).payload {
+        out.insert(symbol);
+    }
+    for &child in il.children(node) {
+        collect_symbols_into_set(il, child, out);
+    }
 }
 
 fn file_module_hashes(il: &Il) -> Vec<u64> {
@@ -1110,8 +1205,9 @@ mod tests {
     #[test]
     fn module_binding_push_marks_export_unsafe() {
         let (il, interner, lookup, assign) = module_with_binding_method("push");
+        let binding_uses = BindingUseIndex::new(&il, &interner);
         assert!(
-            exported_binding_unsafe(&il, &interner, lookup, assign),
+            binding_uses.exported_binding_unsafe(&il, lookup, assign),
             "exported literal bindings mutated through push must not be imported as immutable"
         );
     }
@@ -1119,8 +1215,9 @@ mod tests {
     #[test]
     fn module_binding_get_is_not_a_mutation() {
         let (il, interner, lookup, assign) = module_with_binding_method("get");
+        let binding_uses = BindingUseIndex::new(&il, &interner);
         assert!(
-            !binding_mutated(&il, &interner, lookup, assign),
+            !binding_uses.binding_mutated(&il, lookup, assign),
             "read-only lookup methods should not block immutable import replacement"
         );
     }

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -159,6 +159,14 @@ impl IlBuilder {
         }
     }
 
+    pub fn with_capacity(file: FileId, nodes: usize, edges: usize) -> Self {
+        IlBuilder {
+            nodes: Vec::with_capacity(nodes),
+            edges: Vec::with_capacity(edges),
+            file,
+        }
+    }
+
     pub fn file(&self) -> FileId {
         self.file
     }

--- a/crates/nose-normalize/src/algebra.rs
+++ b/crates/nose-normalize/src/algebra.rs
@@ -26,11 +26,18 @@ use nose_semantics::{semantics, ComparisonLaw};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 pub(crate) fn run(old: &Il, interner: &Interner) -> Il {
+    if !old
+        .nodes
+        .iter()
+        .any(|node| matches!(node.kind, NodeKind::BinOp | NodeKind::UnOp))
+    {
+        return old.clone();
+    }
     let unit_root_set: FxHashSet<u32> = old.units.iter().map(|u| u.root.0).collect();
     let mut rw = Rewriter {
         old,
-        b: IlBuilder::new(old.file),
-        hashes: Vec::new(),
+        b: IlBuilder::with_capacity(old.file, old.nodes.len(), old.edges.len()),
+        hashes: Vec::with_capacity(old.nodes.len()),
         remap: FxHashMap::default(),
         unit_root_set,
         interner,
@@ -109,10 +116,12 @@ impl Rewriter<'_> {
 
     fn generic(&mut self, old_id: NodeId, span: Span) -> (NodeId, u64) {
         let n = *self.old.node(old_id);
-        let mut kids = Vec::new();
-        let mut khashes = Vec::new();
-        for &c in self.old.children(old_id).to_vec().iter() {
-            let (id, h) = self.rewrite(c);
+        let child_count = self.old.children(old_id).len();
+        let mut kids = Vec::with_capacity(child_count);
+        let mut khashes = Vec::with_capacity(child_count);
+        for idx in 0..child_count {
+            let child = self.old.children(old_id)[idx];
+            let (id, h) = self.rewrite(child);
             kids.push(id);
             khashes.push(h);
         }

--- a/crates/nose-normalize/src/alpha.rs
+++ b/crates/nose-normalize/src/alpha.rs
@@ -126,16 +126,18 @@ fn rename(
         }
     }
 
-    let children: Vec<NodeId> = il.children(id).to_vec();
+    let child_count = il.children(id).len();
     if kind == NodeKind::Func {
         // Fresh scope: params (first children) seed v0.., then the body.
         let mut inner = Scope::default();
         let inner_bound = compute_bound(il, id);
-        for c in children {
+        for idx in 0..child_count {
+            let c = il.children(id)[idx];
             rename(il, c, &mut inner, &inner_bound, names);
         }
     } else {
-        for c in children {
+        for idx in 0..child_count {
+            let c = il.children(id)[idx];
             rename(il, c, scope, bound, names);
         }
     }

--- a/crates/nose-normalize/src/cfg_norm.rs
+++ b/crates/nose-normalize/src/cfg_norm.rs
@@ -24,7 +24,7 @@ pub(crate) fn structure(old: &Il) -> Il {
     let unit_root_set = old.units.iter().map(|u| u.root.0).collect();
     let mut rb = SRebuilder {
         old,
-        b: IlBuilder::new(old.file),
+        b: IlBuilder::with_capacity(old.file, old.nodes.len(), old.edges.len()),
         remap: FxHashMap::default(),
         unit_root_set,
     };
@@ -113,10 +113,11 @@ impl SRebuilder<'_> {
 
     fn rewrite_loop(&mut self, old_id: NodeId) -> NodeId {
         let n = *self.old.node(old_id);
-        let kids = self.old.children(old_id).to_vec();
-        let mut new_kids = Vec::with_capacity(kids.len());
-        for (i, &k) in kids.iter().enumerate() {
-            if i + 1 == kids.len() && self.old.kind(k) == NodeKind::Block {
+        let child_count = self.old.children(old_id).len();
+        let mut new_kids = Vec::with_capacity(child_count);
+        for idx in 0..child_count {
+            let k = self.old.children(old_id)[idx];
+            if idx + 1 == child_count && self.old.kind(k) == NodeKind::Block {
                 new_kids.push(self.wrap_body(k));
             } else {
                 new_kids.push(self.go(k));
@@ -180,6 +181,13 @@ impl SRebuilder<'_> {
 // ----------------------------------------------------------------------------
 
 pub(crate) fn run(il: &mut Il, interner: &Interner) {
+    if !il
+        .nodes
+        .iter()
+        .any(|node| node.kind == NodeKind::If && node.child_len == 3)
+    {
+        return;
+    }
     let hashes = subtree_hashes(il, interner);
     for i in 0..il.nodes.len() {
         let node = il.nodes[i];

--- a/crates/nose-normalize/src/dataflow.rs
+++ b/crates/nose-normalize/src/dataflow.rs
@@ -22,11 +22,14 @@ use rustc_hash::{FxHashMap, FxHashSet};
 pub(crate) fn run(old: &Il) -> Il {
     let mut analysis = Analysis::default();
     analyze_scope(old, old.root, true, &mut analysis);
+    if analysis.inline_at.is_empty() && analysis.drop_defs.is_empty() {
+        return old.clone();
+    }
 
     let unit_root_set: FxHashSet<u32> = old.units.iter().map(|u| u.root.0).collect();
     let mut rb = Rebuilder {
         old,
-        b: IlBuilder::new(old.file),
+        b: IlBuilder::with_capacity(old.file, old.nodes.len(), old.edges.len()),
         inline_at: analysis.inline_at,
         drop_defs: analysis.drop_defs,
         remap: FxHashMap::default(),
@@ -258,9 +261,10 @@ impl Rebuilder<'_> {
 
     fn block(&mut self, old_id: NodeId) -> NodeId {
         let span = self.old.node(old_id).span;
-        let children = self.old.children(old_id).to_vec();
-        let mut kids = Vec::with_capacity(children.len());
-        for s in children {
+        let child_count = self.old.children(old_id).len();
+        let mut kids = Vec::with_capacity(child_count);
+        for idx in 0..child_count {
+            let s = self.old.children(old_id)[idx];
             if self.drop_defs.contains(&s.0) {
                 continue;
             }

--- a/crates/nose-normalize/src/dce.rs
+++ b/crates/nose-normalize/src/dce.rs
@@ -21,7 +21,7 @@ pub(crate) fn run(old: &Il) -> Il {
     let unit_root_set: FxHashSet<u32> = old.units.iter().map(|u| u.root.0).collect();
     let mut rb = Rebuilder {
         old,
-        b: IlBuilder::new(old.file),
+        b: IlBuilder::with_capacity(old.file, old.nodes.len(), old.edges.len()),
         drop,
         remap: FxHashMap::default(),
         unit_root_set,
@@ -116,9 +116,10 @@ impl Rebuilder<'_> {
 
     fn block(&mut self, old_id: NodeId) -> NodeId {
         let span = self.old.node(old_id).span;
-        let children = self.old.children(old_id).to_vec();
-        let mut out = Vec::with_capacity(children.len());
-        for s in children {
+        let child_count = self.old.children(old_id).len();
+        let mut out = Vec::with_capacity(child_count);
+        for idx in 0..child_count {
+            let s = self.old.children(old_id)[idx];
             // dead assignment → drop, or keep only its effectful RHS
             if let Some(&pure) = self.drop.get(&s.0) {
                 if !pure {

--- a/crates/nose-normalize/src/desugar.rs
+++ b/crates/nose-normalize/src/desugar.rs
@@ -11,7 +11,7 @@
 //! Unit roots (`Func`/`Method`/class `Block`) are stable node kinds across this
 //! pass, so we remap their ids as we go.
 
-use crate::idioms::{canon_call, CallCanon};
+use crate::idioms::{canon_call_with_domains, CallCanon, ParamDomainIndex};
 use crate::NormalizeOptions;
 use nose_il::{Il, IlBuilder, Interner, LoopKind, NodeId, NodeKind, Payload};
 use nose_semantics::{seq_surface_contract_for_node, DomainRequirement};
@@ -21,11 +21,12 @@ pub(crate) fn run(old: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il 
     let unit_root_set: FxHashSet<u32> = old.units.iter().map(|u| u.root.0).collect();
     let mut rb = Rebuilder {
         old,
-        b: IlBuilder::new(old.file),
+        b: IlBuilder::with_capacity(old.file, old.nodes.len(), old.edges.len()),
         interner,
         opts,
         remap: FxHashMap::default(),
         unit_root_set,
+        param_domains: ParamDomainIndex::new(old),
     };
     let new_root = rb.go(old.root);
 
@@ -40,6 +41,7 @@ struct Rebuilder<'a> {
     opts: &'a NormalizeOptions,
     remap: FxHashMap<u32, NodeId>,
     unit_root_set: FxHashSet<u32>,
+    param_domains: ParamDomainIndex,
 }
 
 impl Rebuilder<'_> {
@@ -64,9 +66,10 @@ impl Rebuilder<'_> {
 
     fn block(&mut self, old_id: NodeId) -> NodeId {
         let span = self.old.node(old_id).span;
-        let children = self.old.children(old_id).to_vec();
-        let mut out = Vec::with_capacity(children.len());
-        for c in children {
+        let child_count = self.old.children(old_id).len();
+        let mut out = Vec::with_capacity(child_count);
+        for idx in 0..child_count {
+            let c = self.old.children(old_id)[idx];
             self.emit_stmt(c, &mut out);
         }
         self.b.add(NodeKind::Block, Payload::None, span, &out)
@@ -79,7 +82,9 @@ impl Rebuilder<'_> {
         match kind {
             // Flatten statement-position blocks; drop empties.
             NodeKind::Block => {
-                for c in self.old.children(old_id).to_vec() {
+                let child_count = self.old.children(old_id).len();
+                for idx in 0..child_count {
+                    let c = self.old.children(old_id)[idx];
                     self.emit_stmt(c, out);
                 }
             }
@@ -205,7 +210,7 @@ impl Rebuilder<'_> {
 
     fn call(&mut self, old_id: NodeId) -> NodeId {
         let span = self.old.node(old_id).span;
-        match canon_call(self.old, self.interner, old_id) {
+        match canon_call_with_domains(self.old, self.interner, &self.param_domains, old_id) {
             CallCanon::Builtin { op, arg_olds } => {
                 let kids: Vec<NodeId> = arg_olds.iter().map(|&a| self.go(a)).collect();
                 self.b
@@ -235,7 +240,12 @@ impl Rebuilder<'_> {
                 nose_semantics::property_builtin_contract(self.old.meta.lang, name)
             {
                 if let Some(&base) = self.old.children(old_id).first() {
-                    if !property_receiver_exact_safe(self.old, self.interner, base) {
+                    if !property_receiver_exact_safe(
+                        self.old,
+                        self.interner,
+                        &self.param_domains,
+                        base,
+                    ) {
                         return self.generic(old_id);
                     }
                     let new_base = self.go(base);
@@ -265,11 +275,20 @@ impl Rebuilder<'_> {
     }
 }
 
-fn property_receiver_exact_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
+fn property_receiver_exact_safe(
+    il: &Il,
+    interner: &Interner,
+    domains: &ParamDomainIndex,
+    node: NodeId,
+) -> bool {
     seq_receiver_exact_collection_safe(il, interner, node)
-        || nose_semantics::receiver_satisfies_domain(il, node, DomainRequirement::ArrayOrCollection)
-        || property_receiver_exact_hof_node(il, interner, node)
-        || property_receiver_exact_hof_call(il, interner, node)
+        || domains.property_receiver_satisfies_domain(
+            il,
+            node,
+            DomainRequirement::ArrayOrCollection,
+        )
+        || property_receiver_exact_hof_node(il, interner, domains, node)
+        || property_receiver_exact_hof_call(il, interner, domains, node)
 }
 
 fn seq_receiver_exact_collection_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
@@ -280,7 +299,12 @@ fn seq_receiver_exact_collection_safe(il: &Il, interner: &Interner, node: NodeId
         .is_some_and(|contract| contract.membership_collection)
 }
 
-fn property_receiver_exact_hof_call(il: &Il, interner: &Interner, node: NodeId) -> bool {
+fn property_receiver_exact_hof_call(
+    il: &Il,
+    interner: &Interner,
+    domains: &ParamDomainIndex,
+    node: NodeId,
+) -> bool {
     if il.kind(node) != NodeKind::Call {
         return false;
     }
@@ -302,10 +326,15 @@ fn property_receiver_exact_hof_call(il: &Il, interner: &Interner, node: NodeId) 
     };
     let method_text = interner.resolve(method);
     nose_semantics::method_hof_contract(il.meta.lang, method_text).is_some()
-        && property_receiver_exact_safe(il, interner, receiver)
+        && property_receiver_exact_safe(il, interner, domains, receiver)
 }
 
-fn property_receiver_exact_hof_node(il: &Il, interner: &Interner, node: NodeId) -> bool {
+fn property_receiver_exact_hof_node(
+    il: &Il,
+    interner: &Interner,
+    domains: &ParamDomainIndex,
+    node: NodeId,
+) -> bool {
     if il.kind(node) != NodeKind::HoF {
         return false;
     }
@@ -314,5 +343,5 @@ fn property_receiver_exact_hof_node(il: &Il, interner: &Interner, node: NodeId) 
     }
     il.children(node)
         .first()
-        .is_some_and(|&receiver| property_receiver_exact_safe(il, interner, receiver))
+        .is_some_and(|&receiver| property_receiver_exact_safe(il, interner, domains, receiver))
 }

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -7,9 +7,12 @@
 //! proof-obligation: normalize.value_graph.functor
 //! proof-obligation: normalize.value_graph.min_max
 
-use nose_il::{contains_js_identifier, Builtin, HoFKind, Il, Interner, NodeId, NodeKind, Payload};
+use nose_il::{
+    contains_js_identifier, Builtin, DomainEvidence, EvidenceAnchor, EvidenceId, EvidenceKind,
+    EvidenceRecord, EvidenceStatus, HoFKind, Il, Interner, NodeId, NodeKind, Payload, Span, Symbol,
+};
 use nose_semantics::{
-    free_function_builtin_contract, imported_namespace_symbol,
+    domain_evidence_for_param, free_function_builtin_contract, imported_namespace_symbol,
     library_api_contract_evidence_for_call, library_free_name_map_factory_contract,
     library_iterator_identity_adapter_contract, library_map_get_contract,
     library_map_key_view_contract, library_method_call_contract,
@@ -19,6 +22,7 @@ use nose_semantics::{
     LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs, MethodCallContract,
     MethodReceiverContract, MethodSemanticContract, SEQ_VALUE_MAP,
 };
+use rustc_hash::{FxHashMap, FxHashSet};
 
 /// The result of inspecting a `Call`: it canonicalizes to a builtin, to a
 /// higher-order op (`HoF`), or stays an ordinary call. The carried `NodeId`s are
@@ -38,7 +42,269 @@ pub(crate) enum CallCanon {
     None,
 }
 
-pub(crate) fn canon_call(old: &Il, interner: &Interner, call_id: NodeId) -> CallCanon {
+pub(crate) struct ParamDomainIndex {
+    global_cid_domains: FxHashMap<u32, DomainLookup>,
+    node_domains: FxHashMap<(Span, NodeKind), DomainLookup>,
+    scopes: Vec<ParamScope>,
+}
+
+struct ParamScope {
+    span: Span,
+    cid_domains: FxHashMap<u32, DomainLookup>,
+    params: FxHashMap<Symbol, Option<DomainEvidence>>,
+    assigned_names: FxHashSet<Symbol>,
+}
+
+#[derive(Clone, Copy)]
+enum DomainLookup {
+    Missing,
+    Found(DomainEvidence),
+    Ambiguous,
+}
+
+impl DomainLookup {
+    fn option(self) -> Option<DomainEvidence> {
+        match self {
+            DomainLookup::Found(domain) => Some(domain),
+            DomainLookup::Missing | DomainLookup::Ambiguous => None,
+        }
+    }
+
+    fn insert(&mut self, domain: DomainEvidence) {
+        match *self {
+            DomainLookup::Missing => *self = DomainLookup::Found(domain),
+            DomainLookup::Found(existing) if existing == domain => {}
+            DomainLookup::Found(_) | DomainLookup::Ambiguous => *self = DomainLookup::Ambiguous,
+        }
+    }
+}
+
+impl ParamDomainIndex {
+    pub(crate) fn new(old: &Il) -> Self {
+        let mut global_cid_domains = FxHashMap::default();
+        let node_domains = node_domain_index(old);
+        let mut scopes = Vec::new();
+        for (idx, node) in old.nodes.iter().enumerate() {
+            if !matches!(node.kind, NodeKind::Func | NodeKind::Lambda) {
+                continue;
+            }
+            let scope = NodeId(idx as u32);
+            let mut cid_domains = FxHashMap::default();
+            let mut params = FxHashMap::default();
+            for &child in old.children(scope) {
+                if old.kind(child) != NodeKind::Param {
+                    continue;
+                }
+                let domain = domain_evidence_for_param(old, child);
+                match old.node(child).payload {
+                    Payload::Cid(cid) => {
+                        merge_domain(&mut cid_domains, cid, domain);
+                    }
+                    Payload::Name(name) => {
+                        params.entry(name).or_insert(domain);
+                    }
+                    _ => {}
+                }
+            }
+            scopes.push(ParamScope {
+                span: node.span,
+                cid_domains,
+                params,
+                assigned_names: FxHashSet::default(),
+            });
+        }
+        for (idx, node) in old.nodes.iter().enumerate() {
+            if node.kind != NodeKind::Param {
+                continue;
+            }
+            let Payload::Cid(cid) = node.payload else {
+                continue;
+            };
+            merge_domain(
+                &mut global_cid_domains,
+                cid,
+                domain_evidence_for_param(old, NodeId(idx as u32)),
+            );
+        }
+
+        scopes.sort_by_key(|scope| scope.span.end_byte.saturating_sub(scope.span.start_byte));
+        for (idx, node) in old.nodes.iter().enumerate() {
+            if node.kind != NodeKind::Assign {
+                continue;
+            }
+            let id = NodeId(idx as u32);
+            let Some(&lhs) = old.children(id).first() else {
+                continue;
+            };
+            if old.kind(lhs) != NodeKind::Var {
+                continue;
+            }
+            let Payload::Name(name) = old.node(lhs).payload else {
+                continue;
+            };
+            if let Some(scope) = scopes
+                .iter_mut()
+                .find(|scope| span_contains(scope.span, node.span))
+            {
+                scope.assigned_names.insert(name);
+            }
+        }
+
+        Self {
+            global_cid_domains,
+            node_domains,
+            scopes,
+        }
+    }
+
+    fn domain_evidence_for_receiver(&self, old: &Il, node: NodeId) -> Option<DomainEvidence> {
+        match self
+            .node_domains
+            .get(&(old.node(node).span, old.kind(node)))
+            .copied()
+            .unwrap_or(DomainLookup::Missing)
+        {
+            DomainLookup::Found(domain) => return Some(domain),
+            DomainLookup::Ambiguous => return None,
+            DomainLookup::Missing => {}
+        }
+        self.domain_evidence_for_var_reference(old, node)
+    }
+
+    fn receiver_satisfies_domain(
+        &self,
+        old: &Il,
+        node: NodeId,
+        requirement: DomainRequirement,
+    ) -> bool {
+        self.domain_evidence_for_receiver(old, node)
+            .is_some_and(|domain| requirement.accepts(domain))
+    }
+
+    fn domain_evidence_for_var_reference(&self, old: &Il, node: NodeId) -> Option<DomainEvidence> {
+        if old.kind(node) != NodeKind::Var {
+            return None;
+        }
+        match old.node(node).payload {
+            Payload::Cid(cid) => {
+                for scope in &self.scopes {
+                    if span_contains(scope.span, old.node(node).span) {
+                        return scope
+                            .cid_domains
+                            .get(&cid)
+                            .copied()
+                            .unwrap_or(DomainLookup::Missing)
+                            .option();
+                    }
+                }
+                self.global_cid_domains
+                    .get(&cid)
+                    .copied()
+                    .unwrap_or(DomainLookup::Missing)
+                    .option()
+            }
+            Payload::Name(name) => {
+                let span = old.node(node).span;
+                for scope in &self.scopes {
+                    if !span_contains(scope.span, span) {
+                        continue;
+                    }
+                    let Some(&domain) = scope.params.get(&name) else {
+                        continue;
+                    };
+                    if scope.assigned_names.contains(&name) {
+                        return None;
+                    }
+                    return domain;
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn property_receiver_satisfies_domain(
+        &self,
+        old: &Il,
+        node: NodeId,
+        requirement: DomainRequirement,
+    ) -> bool {
+        self.receiver_satisfies_domain(old, node, requirement)
+    }
+}
+
+fn merge_domain(
+    domains: &mut FxHashMap<u32, DomainLookup>,
+    key: u32,
+    domain: Option<DomainEvidence>,
+) {
+    let Some(domain) = domain else {
+        return;
+    };
+    domains
+        .entry(key)
+        .or_insert(DomainLookup::Missing)
+        .insert(domain);
+}
+
+fn node_domain_index(old: &Il) -> FxHashMap<(Span, NodeKind), DomainLookup> {
+    let mut domains = FxHashMap::default();
+    for record in &old.evidence {
+        let EvidenceAnchor::Node { span, kind } = record.anchor else {
+            continue;
+        };
+        let EvidenceKind::Domain(domain) = record.kind else {
+            continue;
+        };
+        let entry = domains.entry((span, kind)).or_insert(DomainLookup::Missing);
+        if record.status != EvidenceStatus::Asserted || !evidence_dependencies_asserted(old, record)
+        {
+            *entry = DomainLookup::Ambiguous;
+        } else {
+            entry.insert(domain);
+        }
+    }
+    domains
+}
+
+fn evidence_dependencies_asserted(il: &Il, record: &EvidenceRecord) -> bool {
+    let mut stack = record.dependencies.clone();
+    let mut seen = Vec::new();
+    while let Some(id) = stack.pop() {
+        if seen.contains(&id) {
+            continue;
+        }
+        seen.push(id);
+        let Some(dep) = evidence_record_by_id(il, id) else {
+            return false;
+        };
+        if dep.status != EvidenceStatus::Asserted {
+            return false;
+        }
+        stack.extend_from_slice(&dep.dependencies);
+    }
+    true
+}
+
+fn evidence_record_by_id(il: &Il, id: EvidenceId) -> Option<&EvidenceRecord> {
+    il.evidence
+        .get(id.0 as usize)
+        .filter(|record| record.id == id)
+        .or_else(|| il.evidence.iter().find(|record| record.id == id))
+}
+
+#[cfg(test)]
+fn canon_call(old: &Il, interner: &Interner, call_id: NodeId) -> CallCanon {
+    let domains = ParamDomainIndex::new(old);
+    canon_call_with_domains(old, interner, &domains, call_id)
+}
+
+pub(crate) fn canon_call_with_domains(
+    old: &Il,
+    interner: &Interner,
+    domains: &ParamDomainIndex,
+    call_id: NodeId,
+) -> CallCanon {
     let kids = old.children(call_id);
     if kids.is_empty() {
         return CallCanon::None;
@@ -91,9 +357,14 @@ pub(crate) fn canon_call(old: &Il, interner: &Interner, call_id: NodeId) -> Call
                     let Some(base) = base else {
                         return CallCanon::None;
                     };
-                    let Some(proven) =
-                        prove_method_receiver(old, interner, contract.result.receiver, base, args)
-                    else {
+                    let Some(proven) = prove_method_receiver(
+                        old,
+                        interner,
+                        domains,
+                        contract.result.receiver,
+                        base,
+                        args,
+                    ) else {
                         return CallCanon::None;
                     };
                     return apply_method_contract(old, interner, contract.result, proven, args);
@@ -114,51 +385,53 @@ enum ProvenReceiver {
 fn prove_method_receiver(
     old: &Il,
     interner: &Interner,
+    domains: &ParamDomainIndex,
     contract: MethodReceiverContract,
     base: NodeId,
     args: &[NodeId],
 ) -> Option<ProvenReceiver> {
     match contract {
         MethodReceiverContract::ExactCollection => {
-            exact_collection_receiver(old, interner, base).then_some(ProvenReceiver::Direct(base))
+            exact_collection_receiver(old, interner, domains, base)
+                .then_some(ProvenReceiver::Direct(base))
         }
         MethodReceiverContract::ExactProtocol => {
-            exact_protocol_receiver(old, interner, base).then_some(ProvenReceiver::Direct(base))
+            exact_protocol_receiver(old, interner, domains, base)
+                .then_some(ProvenReceiver::Direct(base))
         }
         MethodReceiverContract::ExactProtocolPairArgument => {
-            (exact_protocol_receiver(old, interner, base)
+            (exact_protocol_receiver(old, interner, domains, base)
                 && args
                     .first()
-                    .is_some_and(|&arg| exact_protocol_receiver(old, interner, arg)))
+                    .is_some_and(|&arg| exact_protocol_receiver(old, interner, domains, arg)))
             .then_some(ProvenReceiver::Direct(base))
         }
-        MethodReceiverContract::ExactOption => {
-            exact_option_receiver(old, interner, base).then_some(ProvenReceiver::Direct(base))
-        }
+        MethodReceiverContract::ExactOption => exact_option_receiver(old, interner, domains, base)
+            .then_some(ProvenReceiver::Direct(base)),
         MethodReceiverContract::ExactString => {
-            exact_string_receiver(old, base).then_some(ProvenReceiver::Direct(base))
+            exact_string_receiver(old, domains, base).then_some(ProvenReceiver::Direct(base))
         }
         MethodReceiverContract::ExactInteger => {
-            exact_integer_receiver(old, base).then_some(ProvenReceiver::Direct(base))
+            exact_integer_receiver(old, domains, base).then_some(ProvenReceiver::Direct(base))
         }
         MethodReceiverContract::ExactMap => {
-            exact_map_receiver(old, interner, base).then_some(ProvenReceiver::Direct(base))
+            exact_map_receiver(old, interner, domains, base).then_some(ProvenReceiver::Direct(base))
         }
         MethodReceiverContract::ExactMapLiteral => {
             map_like_literal(old, interner, base).then_some(ProvenReceiver::Direct(base))
         }
         MethodReceiverContract::ExactCollectionOrMap => {
-            (exact_collection_receiver(old, interner, base)
-                || exact_map_receiver(old, interner, base))
+            (exact_collection_receiver(old, interner, domains, base)
+                || exact_map_receiver(old, interner, domains, base))
             .then_some(ProvenReceiver::Direct(base))
         }
         MethodReceiverContract::ExactCollectionOrMapLiteral => {
-            (exact_collection_receiver(old, interner, base)
+            (exact_collection_receiver(old, interner, domains, base)
                 || map_like_literal(old, interner, base))
             .then_some(ProvenReceiver::Direct(base))
         }
         MethodReceiverContract::ExactCollectionOrJavaKeySet => {
-            if exact_collection_receiver(old, interner, base) {
+            if exact_collection_receiver(old, interner, domains, base) {
                 return Some(ProvenReceiver::Direct(base));
             }
             if old.meta.lang == nose_il::Lang::Java {
@@ -167,11 +440,11 @@ fn prove_method_receiver(
             }
             None
         }
-        MethodReceiverContract::ExactSetOrMap => (exact_set_param(old, base)
-            || exact_map_param(old, base))
+        MethodReceiverContract::ExactSetOrMap => (exact_set_param(old, domains, base)
+            || exact_map_param(old, domains, base))
         .then_some(ProvenReceiver::Direct(base)),
         MethodReceiverContract::LiteralString => {
-            literal_string_receiver(old, base).then_some(ProvenReceiver::Direct(base))
+            literal_string_receiver(old, domains, base).then_some(ProvenReceiver::Direct(base))
         }
         MethodReceiverContract::UnshadowedGlobal(global) => {
             unshadowed_global_symbol(old, interner, base, global)
@@ -185,7 +458,8 @@ fn prove_method_receiver(
             if let Some((map, key)) = proven_map_get_call_parts(old, interner, base) {
                 Some(ProvenReceiver::MapGet { map, key })
             } else {
-                exact_option_receiver(old, interner, base).then_some(ProvenReceiver::Direct(base))
+                exact_option_receiver(old, interner, domains, base)
+                    .then_some(ProvenReceiver::Direct(base))
             }
         }
     }
@@ -440,12 +714,22 @@ fn unwrap_iter(old: &Il, interner: &Interner, node: NodeId) -> NodeId {
     node
 }
 
-fn exact_collection_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
-    exact_protocol_receiver(old, interner, node)
+fn exact_collection_receiver(
+    old: &Il,
+    interner: &Interner,
+    domains: &ParamDomainIndex,
+    node: NodeId,
+) -> bool {
+    exact_protocol_receiver(old, interner, domains, node)
 }
 
-fn exact_protocol_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
-    if exact_collection_literal(old, interner, node) || exact_collection_param(old, node) {
+fn exact_protocol_receiver(
+    old: &Il,
+    interner: &Interner,
+    domains: &ParamDomainIndex,
+    node: NodeId,
+) -> bool {
+    if exact_collection_literal(old, interner, node) || exact_collection_param(old, domains, node) {
         return true;
     }
     if old.kind(node) != NodeKind::Call {
@@ -466,7 +750,7 @@ fn exact_protocol_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool 
         return false;
     };
     if let Some(arg) = static_collection_adapter_arg(old, interner, node, receiver, method, kids) {
-        return exact_collection_receiver(old, interner, arg);
+        return exact_collection_receiver(old, interner, domains, arg);
     }
     if let Some(contract) = library_method_call_contract(old.meta.lang, method, kids.len() - 1) {
         let contract = contract.result;
@@ -474,21 +758,21 @@ fn exact_protocol_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool 
             && contract.receiver == MethodReceiverContract::ExactProtocolPairArgument
             && contract.args == MethodBuiltinArgs::RustZip
         {
-            return exact_protocol_receiver(old, interner, receiver)
-                && exact_protocol_receiver(old, interner, kids[1]);
+            return exact_protocol_receiver(old, interner, domains, receiver)
+                && exact_protocol_receiver(old, interner, domains, kids[1]);
         }
     }
     if library_iterator_identity_adapter_contract(old.meta.lang, method, kids.len() - 1).is_some() {
-        return exact_protocol_receiver(old, interner, receiver);
+        return exact_protocol_receiver(old, interner, domains, receiver);
     }
     if method_hof_contract(old.meta.lang, method).is_some() && kids.len() >= 2 {
-        return exact_protocol_receiver(old, interner, receiver);
+        return exact_protocol_receiver(old, interner, domains, receiver);
     }
     false
 }
 
-fn exact_collection_param(old: &Il, node: NodeId) -> bool {
-    nose_semantics::receiver_satisfies_domain(old, node, DomainRequirement::ArrayCollectionOrSet)
+fn exact_collection_param(old: &Il, domains: &ParamDomainIndex, node: NodeId) -> bool {
+    domains.receiver_satisfies_domain(old, node, DomainRequirement::ArrayCollectionOrSet)
 }
 
 fn static_collection_adapter_arg(
@@ -521,20 +805,31 @@ fn static_collection_adapter_arg(
     call_kids.get(1).copied()
 }
 
-fn exact_set_param(old: &Il, node: NodeId) -> bool {
-    nose_semantics::receiver_satisfies_domain(old, node, DomainRequirement::Set)
+fn exact_set_param(old: &Il, domains: &ParamDomainIndex, node: NodeId) -> bool {
+    domains.receiver_satisfies_domain(old, node, DomainRequirement::Set)
 }
 
-fn exact_map_param(old: &Il, node: NodeId) -> bool {
-    nose_semantics::receiver_satisfies_domain(old, node, DomainRequirement::Map)
+fn exact_map_param(old: &Il, domains: &ParamDomainIndex, node: NodeId) -> bool {
+    domains.receiver_satisfies_domain(old, node, DomainRequirement::Map)
 }
 
-fn exact_map_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
-    exact_map_param(old, node) || map_like_literal(old, interner, node)
+fn exact_map_receiver(
+    old: &Il,
+    interner: &Interner,
+    domains: &ParamDomainIndex,
+    node: NodeId,
+) -> bool {
+    exact_map_param(old, domains, node) || map_like_literal(old, interner, node)
 }
 
-fn exact_option_param(old: &Il, node: NodeId) -> bool {
-    nose_semantics::receiver_satisfies_domain(old, node, DomainRequirement::Option)
+fn exact_option_param(old: &Il, domains: &ParamDomainIndex, node: NodeId) -> bool {
+    domains.receiver_satisfies_domain(old, node, DomainRequirement::Option)
+}
+
+fn span_contains(outer: Span, inner: Span) -> bool {
+    outer.file == inner.file
+        && outer.start_byte <= inner.start_byte
+        && outer.end_byte >= inner.end_byte
 }
 
 fn exact_collection_literal(old: &Il, interner: &Interner, node: NodeId) -> bool {
@@ -545,8 +840,13 @@ fn exact_collection_literal(old: &Il, interner: &Interner, node: NodeId) -> bool
         .is_some_and(|contract| contract.membership_collection)
 }
 
-fn exact_option_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
-    if exact_option_param(old, node) {
+fn exact_option_receiver(
+    old: &Il,
+    interner: &Interner,
+    domains: &ParamDomainIndex,
+    node: NodeId,
+) -> bool {
+    if exact_option_param(old, domains, node) {
         return true;
     }
     if matches!(
@@ -568,22 +868,22 @@ fn exact_option_receiver(old: &Il, interner: &Interner, node: NodeId) -> bool {
     )
 }
 
-fn exact_string_receiver(old: &Il, node: NodeId) -> bool {
+fn exact_string_receiver(old: &Il, domains: &ParamDomainIndex, node: NodeId) -> bool {
     matches!(
         old.node(node).payload,
         Payload::LitStr(_) | Payload::Lit(nose_il::LitClass::Str)
-    ) || nose_semantics::receiver_satisfies_domain(old, node, DomainRequirement::String)
+    ) || domains.receiver_satisfies_domain(old, node, DomainRequirement::String)
 }
 
-fn literal_string_receiver(old: &Il, node: NodeId) -> bool {
-    exact_string_receiver(old, node)
+fn literal_string_receiver(old: &Il, domains: &ParamDomainIndex, node: NodeId) -> bool {
+    exact_string_receiver(old, domains, node)
 }
 
-fn exact_integer_receiver(old: &Il, node: NodeId) -> bool {
+fn exact_integer_receiver(old: &Il, domains: &ParamDomainIndex, node: NodeId) -> bool {
     matches!(
         old.node(node).payload,
         Payload::LitInt(_) | Payload::Lit(nose_il::LitClass::Int)
-    ) || nose_semantics::receiver_satisfies_domain(old, node, DomainRequirement::Integer)
+    ) || domains.receiver_satisfies_domain(old, node, DomainRequirement::Integer)
 }
 
 fn rust_option_some_name(old: &Il, interner: &Interner, text: &str) -> bool {
@@ -700,7 +1000,7 @@ fn node_defines_name(old: &Il, interner: &Interner, node: NodeId, name: &str) ->
     }
 }
 
-fn symbol_defines_name(old: &Il, interner: &Interner, symbol: nose_il::Symbol, name: &str) -> bool {
+fn symbol_defines_name(old: &Il, interner: &Interner, symbol: Symbol, name: &str) -> bool {
     let text = interner.resolve(symbol);
     text == name
         || (nose_semantics::semantics(old.meta.lang)
@@ -1150,27 +1450,21 @@ mod tests {
         il.evidence.push(evidence(
             0,
             EvidenceAnchor::param(param_span),
-            EvidenceKind::Domain(nose_semantics::DomainEvidence::from_param_semantic(
-                semantic,
-            )),
+            EvidenceKind::Domain(DomainEvidence::from_param_semantic(semantic)),
             EvidenceStatus::Asserted,
         ));
         if duplicate_param_name {
             il.evidence.push(evidence(
                 1,
                 EvidenceAnchor::param(duplicate_span),
-                EvidenceKind::Domain(nose_semantics::DomainEvidence::from_param_semantic(
-                    semantic,
-                )),
+                EvidenceKind::Domain(DomainEvidence::from_param_semantic(semantic)),
                 EvidenceStatus::Asserted,
             ));
         }
         (il, interner, call)
     }
 
-    fn receiver_domain_method_call_il(
-        domain: nose_semantics::DomainEvidence,
-    ) -> (Il, Interner, NodeId, Span) {
+    fn receiver_domain_method_call_il(domain: DomainEvidence) -> (Il, Interner, NodeId, Span) {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
         let receiver_span = sp_at(20, 22, 2);
@@ -1215,6 +1509,84 @@ mod tests {
             EvidenceStatus::Asserted,
         ));
         (il, interner, call, receiver_span)
+    }
+
+    fn typed_method_shadowed_by_untyped_inner_param_il() -> (Il, Interner, NodeId) {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let xs = interner.intern("xs");
+        let outer_param_span = Span::new(FileId(0), 2, 4, 1, 1);
+        let inner_param_span = Span::new(FileId(0), 22, 24, 2, 2);
+        let receiver_span = Span::new(FileId(0), 30, 32, 3, 3);
+        let outer_param = b.add(NodeKind::Param, Payload::Name(xs), outer_param_span, &[]);
+        let inner_param = b.add(NodeKind::Param, Payload::Name(xs), inner_param_span, &[]);
+        let receiver = b.add(NodeKind::Var, Payload::Name(xs), receiver_span, &[]);
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("some")),
+            Span::new(FileId(0), 30, 37, 3, 3),
+            &[receiver],
+        );
+        let func = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("f")),
+            Span::new(FileId(0), 38, 39, 3, 3),
+            &[],
+        );
+        let call = b.add(
+            NodeKind::Call,
+            Payload::None,
+            Span::new(FileId(0), 30, 42, 3, 3),
+            &[field, func],
+        );
+        let inner_body = b.add(
+            NodeKind::Block,
+            Payload::None,
+            Span::new(FileId(0), 25, 70, 2, 4),
+            &[call],
+        );
+        let lambda = b.add(
+            NodeKind::Lambda,
+            Payload::None,
+            Span::new(FileId(0), 20, 80, 2, 5),
+            &[inner_param, inner_body],
+        );
+        let outer_body = b.add(
+            NodeKind::Block,
+            Payload::None,
+            Span::new(FileId(0), 10, 90, 1, 6),
+            &[lambda],
+        );
+        let function = b.add(
+            NodeKind::Func,
+            Payload::None,
+            Span::new(FileId(0), 1, 100, 1, 7),
+            &[outer_param, outer_body],
+        );
+        let root = b.add(
+            NodeKind::Module,
+            Payload::None,
+            Span::new(FileId(0), 0, 101, 1, 7),
+            &[function],
+        );
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t".to_string(),
+                lang: Lang::TypeScript,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::param(outer_param_span),
+            EvidenceKind::Domain(DomainEvidence::from_param_semantic(
+                ParamSemantic::Collection,
+            )),
+            EvidenceStatus::Asserted,
+        ));
+        (il, interner, call)
     }
 
     fn console_log_il(shadow_console: bool) -> (Il, Interner, NodeId) {
@@ -1408,20 +1780,28 @@ mod tests {
     #[test]
     fn iterator_identity_adapter_requires_kernel_contract() {
         let (js, js_interner, js_iter) = method_call_no_arg_il(Lang::JavaScript, "iter", true);
+        let js_domains = ParamDomainIndex::new(&js);
         assert!(
-            !exact_protocol_receiver(&js, &js_interner, js_iter),
+            !exact_protocol_receiver(&js, &js_interner, &js_domains, js_iter),
             "a JS method named iter is not a Rust iterator adapter"
         );
 
         let (rust_bad, rust_bad_interner, rust_bad_iter) = method_call_il(Lang::Rust, "iter", true);
+        let rust_bad_domains = ParamDomainIndex::new(&rust_bad);
         assert!(
-            !exact_protocol_receiver(&rust_bad, &rust_bad_interner, rust_bad_iter),
+            !exact_protocol_receiver(
+                &rust_bad,
+                &rust_bad_interner,
+                &rust_bad_domains,
+                rust_bad_iter
+            ),
             "Rust iter with unexpected arguments must not bypass the arity contract"
         );
 
         let (rust, rust_interner, rust_iter) = method_call_no_arg_il(Lang::Rust, "iter", true);
+        let rust_domains = ParamDomainIndex::new(&rust);
         assert!(
-            exact_protocol_receiver(&rust, &rust_interner, rust_iter),
+            exact_protocol_receiver(&rust, &rust_interner, &rust_domains, rust_iter),
             "Rust iter stays admitted through iterator_identity_adapter_contract"
         );
     }
@@ -1430,15 +1810,17 @@ mod tests {
     fn zip_protocol_pair_requires_kernel_contract() {
         let (js, js_interner, js_zip) =
             method_call_with_arg_il(Lang::JavaScript, "zip", true, true);
+        let js_domains = ParamDomainIndex::new(&js);
         assert!(
-            !exact_protocol_receiver(&js, &js_interner, js_zip),
+            !exact_protocol_receiver(&js, &js_interner, &js_domains, js_zip),
             "a JS method named zip is not a Rust zip protocol contract"
         );
 
         let (rust, rust_interner, rust_zip) =
             method_call_with_arg_il(Lang::Rust, "zip", true, true);
+        let rust_domains = ParamDomainIndex::new(&rust);
         assert!(
-            exact_protocol_receiver(&rust, &rust_interner, rust_zip),
+            exact_protocol_receiver(&rust, &rust_interner, &rust_domains, rust_zip),
             "Rust zip stays admitted through method_call_contract"
         );
     }
@@ -1458,8 +1840,7 @@ mod tests {
 
     #[test]
     fn method_bool_reduction_consumes_receiver_domain_evidence() {
-        let (il, interner, call, _) =
-            receiver_domain_method_call_il(nose_semantics::DomainEvidence::Collection);
+        let (il, interner, call, _) = receiver_domain_method_call_il(DomainEvidence::Collection);
         assert!(matches!(
             canon_call(&il, &interner, call),
             CallCanon::Builtin {
@@ -1469,11 +1850,11 @@ mod tests {
         ));
 
         let (mut il, interner, call, receiver_span) =
-            receiver_domain_method_call_il(nose_semantics::DomainEvidence::Collection);
+            receiver_domain_method_call_il(DomainEvidence::Collection);
         il.evidence.push(evidence(
             1,
             EvidenceAnchor::node(receiver_span, NodeKind::Var),
-            EvidenceKind::Domain(nose_semantics::DomainEvidence::Map),
+            EvidenceKind::Domain(DomainEvidence::Map),
             EvidenceStatus::Asserted,
         ));
         assert!(
@@ -1624,6 +2005,15 @@ mod tests {
                 arg_olds
             } if arg_olds.len() == 2
         ));
+    }
+
+    #[test]
+    fn method_bool_reduction_stops_at_untyped_inner_param_shadow() {
+        let (il, interner, call) = typed_method_shadowed_by_untyped_inner_param_il();
+        assert!(
+            matches!(canon_call(&il, &interner, call), CallCanon::None),
+            "an untyped inner parameter must shadow an outer typed parameter"
+        );
     }
 
     #[test]

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -39,6 +39,7 @@ pub use value_graph::{
 
 use nose_il::{FileMeta, Il, IlBuilder, Interner, NodeId, NodeKind, Payload, Symbol, Unit};
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::time::Instant;
 
 /// Mixing constant for [`combine`] (the golden-ratio odd constant, as in fxhash).
 const SEED: u64 = 0x9E37_79B9_7F4A_7C15;
@@ -69,13 +70,12 @@ pub(crate) fn rebuild_like(b: &mut IlBuilder, old: &Il, old_id: NodeId, kids: &[
 macro_rules! rebuild_generic {
     () => {
         fn generic(&mut self, old_id: NodeId) -> NodeId {
-            let kids: Vec<NodeId> = self
-                .old
-                .children(old_id)
-                .to_vec()
-                .iter()
-                .map(|&c| self.go(c))
-                .collect();
+            let child_count = self.old.children(old_id).len();
+            let mut kids = Vec::with_capacity(child_count);
+            for idx in 0..child_count {
+                let child = self.old.children(old_id)[idx];
+                kids.push(self.go(child));
+            }
             crate::rebuild_like(&mut self.b, self.old, old_id, &kids)
         }
     };
@@ -197,11 +197,43 @@ impl Default for NormalizeOptions {
     }
 }
 
+struct NormalizeTimer<'a> {
+    enabled: bool,
+    path: &'a str,
+    last: Instant,
+}
+
+impl<'a> NormalizeTimer<'a> {
+    fn new(path: &'a str) -> Self {
+        Self {
+            enabled: std::env::var_os("NOSE_TIME_NORMALIZE").is_some(),
+            path,
+            last: Instant::now(),
+        }
+    }
+
+    fn lap(&mut self, pass: &str) {
+        if self.enabled {
+            let now = Instant::now();
+            eprintln!(
+                "  [normalize] {:<12} {:>7.1}ms  {}",
+                pass,
+                now.duration_since(self.last).as_secs_f64() * 1e3,
+                self.path,
+            );
+            self.last = now;
+        }
+    }
+}
+
 /// Normalize one lowered file, returning a fresh canonical [`Il`] (the input is
 /// left untouched). Unit roots are remapped onto the new arena.
 pub fn normalize(il: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il {
+    let mut timer = NormalizeTimer::new(&il.meta.path);
     let mut out = desugar::run(il, interner, opts);
+    timer.lap("desugar");
     alpha::run(&mut out);
+    timer.lap("alpha");
     if opts.oracle {
         // Behavior-preserving structural core only — the soundness oracle reads this so it
         // is independent of every semantic canonicalization below.
@@ -213,18 +245,24 @@ pub fn normalize(il: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il {
     // phase, so the loops it emits flow through dataflow / cfg-norm / the value graph and
     // converge with hand-written iteration.
     out = recursion::run(&out);
+    timer.lap("recursion");
     if opts.dataflow {
         out = dataflow::run(&out);
+        timer.lap("dataflow");
     }
     if opts.dce {
         out = dce::run(&out);
+        timer.lap("dce");
     }
     if opts.cfg_norm {
         out = cfg_norm::structure(&out);
+        timer.lap("cfg-structure");
     }
     out = algebra::run(&out, interner);
+    timer.lap("algebra");
     if opts.cfg_norm {
         cfg_norm::run(&mut out, interner);
+        timer.lap("cfg-orient");
     }
     // IR-verifier discipline: in debug/test builds, assert the rewrite pipeline
     // produced a structurally well-formed arena. Free in release.

--- a/crates/nose-normalize/src/recursion.rs
+++ b/crates/nose-normalize/src/recursion.rs
@@ -61,10 +61,13 @@ pub(crate) fn run(old: &Il) -> Il {
             admit.then_some((u.root.0, name))
         })
         .collect();
+    if func_name.is_empty() || !has_possible_self_call(old, &func_name) {
+        return old.clone();
+    }
     let unit_root_set: FxHashSet<u32> = old.units.iter().map(|u| u.root.0).collect();
     let mut rb = Rebuilder {
         old,
-        b: IlBuilder::new(old.file),
+        b: IlBuilder::with_capacity(old.file, old.nodes.len(), old.edges.len()),
         func_name,
         unit_root_set,
         remap: FxHashMap::default(),
@@ -72,6 +75,20 @@ pub(crate) fn run(old: &Il) -> Il {
     let new_root = rb.go(old.root);
 
     crate::finalize_rebuild(old, &rb.remap, rb.b, new_root, old.cid_names.clone())
+}
+
+fn has_possible_self_call(old: &Il, func_name: &FxHashMap<u32, Symbol>) -> bool {
+    let names: FxHashSet<Symbol> = func_name.values().copied().collect();
+    old.nodes.iter().enumerate().any(|(idx, node)| {
+        if node.kind != NodeKind::Call || !matches!(node.payload, Payload::None) {
+            return false;
+        }
+        let id = NodeId(idx as u32);
+        let Some(&callee) = old.children(id).first() else {
+            return false;
+        };
+        matches!(old.node(callee).payload, Payload::Name(name) if names.contains(&name))
+    })
 }
 
 /// A method is safe to admit to the recursion canon only if its body touches no receiver/field

--- a/crates/nose-normalize/src/types.rs
+++ b/crates/nose-normalize/src/types.rs
@@ -62,6 +62,9 @@ fn is_strict_numeric(op: Op) -> bool {
 /// Sound by construction: a type is recorded only when an operator *requires* it (the
 /// code would error otherwise), exactly the assumption the single-op evidence already made.
 pub(crate) fn infer_param_types(il: &Il, root: NodeId) -> Vec<Ty> {
+    if il.kind(root) != NodeKind::Func {
+        return Vec::new();
+    }
     let mut params: Vec<u32> = Vec::new();
     for &k in il.children(root) {
         if il.kind(k) == NodeKind::Param {

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -81,6 +81,7 @@ use nose_semantics::{
     SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::borrow::Cow;
 use std::sync::OnceLock;
 
 const LARGE_AC_EXPR_OPERANDS: usize = 64;
@@ -157,7 +158,7 @@ pub fn value_fingerprint_lits_anchors_with_context(
     interner: &Interner,
     context: &ValueFingerprintContext,
 ) -> FingerprintBundle {
-    let mut b = Builder::new(il, interner).with_shared_subtree_hashes(&context.subtree_hashes);
+    let mut b = Builder::new(il, interner).with_context(context);
     b.build_unit_with_context(root, Some(context));
     let (v, l, r) = b.fingerprint_lits();
     let a = b.anchors(ANCHOR_MIN_WEIGHT);
@@ -185,7 +186,9 @@ impl ValueFingerprintContext {
         let module = ModuleSeedContext::new(il, interner);
         let subtree_hashes = OnceLock::new();
         let function_bindings = {
-            let mut b = Builder::new(il, interner).with_shared_subtree_hashes(&subtree_hashes);
+            let mut b = Builder::new(il, interner)
+                .with_shared_subtree_hashes(&subtree_hashes)
+                .with_local_scope_nodes(&module.local_scope);
             b.seed_module_value_bindings_from_context(&module, None);
             b.collect_function_binding_hashes()
         };
@@ -317,7 +320,7 @@ pub fn value_fingerprint_lits_with_context(
     interner: &Interner,
     context: &ValueFingerprintContext,
 ) -> (Vec<u64>, Vec<u64>, Vec<u64>) {
-    let mut b = Builder::new(il, interner).with_shared_subtree_hashes(&context.subtree_hashes);
+    let mut b = Builder::new(il, interner).with_context(context);
     b.build_unit_with_context(root, Some(context));
     b.fingerprint_lits()
 }
@@ -505,7 +508,7 @@ struct Builder<'a> {
     inline_fns: FxHashMap<Symbol, (Vec<u32>, NodeId)>,
     /// Nodes under function/lambda scopes use local cid numbering. Their `Cid(0)` is not
     /// the module `cid_names[0]`, so module-symbol resolution fails closed there.
-    local_scope_nodes: Vec<bool>,
+    local_scope_nodes: Cow<'a, [bool]>,
     /// Current loop-carried placeholders while evaluating a loop body. Used only to
     /// compact coupled recurrences such as `s1 += f(s2); s2 += g(s1)`, which otherwise
     /// expand into a large raw expression DAG even though they are not clean reductions.
@@ -579,7 +582,7 @@ impl<'a> Builder<'a> {
             building: FxHashMap::default(),
             global_env: FxHashMap::default(),
             inline_fns: FxHashMap::default(),
-            local_scope_nodes: local_scope_nodes(il),
+            local_scope_nodes: Cow::Owned(local_scope_nodes(il)),
             loop_recurrence: None,
             next_loop_key_base: 0,
             contracts: Vec::new(),
@@ -591,6 +594,16 @@ impl<'a> Builder<'a> {
     fn with_shared_subtree_hashes(mut self, hashes: &'a OnceLock<Vec<u64>>) -> Self {
         self.shared_subtree_hashes = Some(hashes);
         self
+    }
+
+    fn with_local_scope_nodes(mut self, local_scope_nodes: &'a [bool]) -> Self {
+        self.local_scope_nodes = Cow::Borrowed(local_scope_nodes);
+        self
+    }
+
+    fn with_context(self, context: &'a ValueFingerprintContext) -> Self {
+        self.with_shared_subtree_hashes(&context.subtree_hashes)
+            .with_local_scope_nodes(&context.module.local_scope)
     }
 
     fn vty(&self, v: ValueId) -> Ty {

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -795,3 +795,15 @@ Representative output JSON was byte-equivalent to `origin/main` after canonical 
 12ms→9ms (1.3x). Whole-pipeline speedups are lower where parse/lower now
 dominates; this moves the next performance frontier toward lower/parse and remaining
 multi-pass normalization overhead rather than file selection policy.
+
+Follow-up profiling split frontend timing into `parse+lower` and `import-resolve`
+inside `NOSE_TIME`. The import pass is corpus-level, not JS-specific: sibling literal
+exports are modeled through language semantics for Python, JavaScript/TypeScript, Java,
+and Rust, while unsupported languages such as Go/C/Ruby do not build the added indexes.
+Caching file top-level statements, path-derived module hashes, and binding-use facts
+reduced representative `import-resolve` costs without changing output JSON: `tex`
+~31–34ms→~4ms, `moonlight-server` ~21–25ms→~6ms, `nose-normalize` ~7–8ms→<1ms,
+and `episteme2` ~6–7ms→~2ms; Go corpora stayed at 0ms. Two tempting follow-ups were
+rejected after output checks: skipping import resolution for `syntax`-only scans changed
+`moonlight-server` syntax families, and caching pure-inline registries changed one
+Python near-family. Both are behavior changes, not safe speedups.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -768,3 +768,30 @@ not the weights, so we mined ground truth before implementing.
   ranking changes (this work) do not. Refresh = `run_corpus.sh` + `tune.py` (minutes,
   cached clones); per-release steps in [hazard-release-checklist](hazard-release-checklist.md).
   Full numbers in [eval/hazard/RESULTS.md](../eval/hazard/RESULTS.md).
+
+## BH. Scan performance — normalize proof lookup, not path exclusions
+
+Profiling real corpora across Rust (`nose-normalize`, `nose-detect`), TypeScript
+(`moonlight-server`, `moonlight-web`, `tex`), Python (`episteme2-app`), and Go
+(`sah-cli`) showed that semantic/near scans were bottlenecked in the shared
+`normalize+extract` path, not in JS-specific parsing or candidate scoring. Large generated
+JS bundles can dominate an unscoped scan, but the product fix is not a built-in generated-path
+exclusion; benchmark scoping used only the existing `--exclude`/config mechanism.
+
+The hot path was `desugar` repeatedly re-scanning the whole IL to prove parameter-domain
+facts for method/property idiom recognition. Replacing that with a per-file
+`ParamDomainIndex` kept the exact same proof policy while removing repeated O(nodes)
+lookups. Additional behavior-preserving cleanup reserved rebuild arena capacity, avoided
+per-node child `Vec` copies in common rebuild loops, reused file-local scope facts in value
+fingerprinting, and skipped no-op recursion/dataflow/algebra/cfg-orientation rebuilds.
+
+Representative output JSON was byte-equivalent to `origin/main` after canonical sorting
+(`nose-normalize`, `nose-detect`, `moonlight-server`, `tex`, `sah-cli`, and
+`craken-cli`; earlier matrix runs also covered `episteme2-app` and scoped
+`moonlight-web`). After rebasing onto `origin/main@42545f2`, representative
+`NOSE_TIME` deltas for `normalize+extract` were: `nose-normalize` semantic
+1452ms→228ms (6.4x), near 1457ms→236ms (6.2x); `tex` semantic 445ms→64ms
+(7.0x); `moonlight-server` semantic 48ms→27ms (1.8x); `sah-cli` semantic
+12ms→9ms (1.3x). Whole-pipeline speedups are lower where parse/lower now
+dominates; this moves the next performance frontier toward lower/parse and remaining
+multi-pass normalization overhead rather than file selection policy.


### PR DESCRIPTION
## Summary

- cache parameter-domain and receiver-domain proof lookup in normalize instead of repeatedly scanning each file IL
- reserve rebuild arena capacity, avoid common child Vec copies, reuse file-local value-fingerprint context, and skip no-op normalize rebuild passes where safe
- cache corpus import-resolution context in the frontend: top-level statements, path-derived module hashes, and binding-use facts are now computed once per participating language file
- split `NOSE_TIME` frontend timing into `parse+lower` and `import-resolve` so the next frontier is visible
- document the multi-language profiling results and explicitly keep generated-path handling out of product defaults

## Validation

- cargo fmt --all --check
- git diff --check
- awiki lint --root docs
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- release JSON equivalence vs main across modes: Rust (`nose-normalize`, `nose-detect`), TypeScript (`tex`, `moonlight-server`), Go (`sah-cli`, `craken-cli`), Python (`episteme2`), and multi-language fixtures including Java/C/Ruby coverage
- import-resolution delta vs previous candidate: `tex` ~31-34ms -> ~4ms, `moonlight-server` ~21-25ms -> ~6ms, `nose-normalize` ~7-8ms -> <1ms, `episteme2` ~6-7ms -> ~2ms; Go/C/Ruby stayed effectively 0ms
- final repeated candidate medians: `nose-normalize` semantic ~443ms, near ~493ms; `tex` semantic ~129ms, near ~137ms; `moonlight-server` semantic ~126ms; `episteme2` semantic ~77ms

## Notes

- No built-in file or folder exclusion criteria were added.
- Benchmark scoping used only existing `.gitignore`, `--exclude`, and config behavior where applicable.
- Rejected during validation: skipping import resolution for syntax-only scans and caching pure-inline registries, because both changed output on real corpora.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 정규화 파이프라인의 처리 속도 향상
  * 불필요한 재할당 제거로 메모리 효율성 개선

* **디버깅 지원**
  * 환경변수를 통해 단계별 성능 측정 시간 출력 기능 추가

* **문서**
  * 성능 최적화 결과 및 분석 내용 추가 기록

<!-- end of auto-generated comment: release notes by coderabbit.ai -->