### PR TITLE
[codex] add immutable binding domain evidence

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -715,10 +715,11 @@ impl StrictFacts {
                 continue;
             }
             let safe_literal = immutable_binding_safe(il, &env, &self.immutable_names, kids[1]);
+            let binding_domain =
+                nose_semantics::domain_evidence_for_binding_lhs(il, interner, kids[0]);
             let safe_collection_container =
-                strict_exact_module_collection_binding_safe(il, interner, self, kids[1]);
-            let safe_map_container =
-                strict_exact_module_map_binding_safe(il, interner, self, kids[1]);
+                binding_domain.is_some_and(|domain| domain.is_collection_or_set());
+            let safe_map_container = binding_domain.is_some_and(|domain| domain.is_map());
             if safe_literal || safe_collection_container || safe_map_container {
                 self.immutable_names.insert(name);
                 if safe_collection_container {
@@ -746,7 +747,6 @@ impl StrictFacts {
     }
 
     fn collect_local_container_bindings(&mut self, il: &Il, interner: &Interner) {
-        let mut counts: FxHashMap<u32, usize> = FxHashMap::default();
         for (idx, node) in il.nodes.iter().enumerate() {
             if node.kind != NodeKind::Assign {
                 continue;
@@ -757,72 +757,18 @@ impl StrictFacts {
                 continue;
             }
             if let Payload::Cid(cid) = il.node(kids[0]).payload {
-                *counts.entry(cid).or_insert(0) += 1;
-            }
-        }
-        let candidates: FxHashSet<u32> = counts
-            .iter()
-            .filter_map(|(&cid, &count)| (count == 1).then_some(cid))
-            .collect();
-        let mutated = collect_mutated_cids(il, interner, &candidates);
-        for (idx, node) in il.nodes.iter().enumerate() {
-            if node.kind != NodeKind::Assign {
-                continue;
-            }
-            let id = NodeId(idx as u32);
-            let kids = il.children(id);
-            if kids.len() != 2 || il.kind(kids[0]) != NodeKind::Var {
-                continue;
-            }
-            let Payload::Cid(cid) = il.node(kids[0]).payload else {
-                continue;
-            };
-            if !candidates.contains(&cid) || mutated.contains(&cid) {
-                continue;
-            }
-            if strict_exact_local_collection_binding_safe(il, interner, self, kids[1]) {
-                self.collection_cids.insert(cid);
-            } else if strict_exact_local_map_binding_safe(il, interner, self, kids[1]) {
-                self.map_cids.insert(cid);
+                match nose_semantics::domain_evidence_for_binding_lhs(il, interner, kids[0]) {
+                    Some(domain) if domain.is_collection_or_set() => {
+                        self.collection_cids.insert(cid);
+                    }
+                    Some(domain) if domain.is_map() => {
+                        self.map_cids.insert(cid);
+                    }
+                    _ => {}
+                }
             }
         }
     }
-}
-
-fn collect_mutated_cids(
-    il: &Il,
-    interner: &Interner,
-    candidates: &FxHashSet<u32>,
-) -> FxHashSet<u32> {
-    let mut mutated = FxHashSet::default();
-    for (idx, node) in il.nodes.iter().enumerate() {
-        if node.kind != NodeKind::Call {
-            continue;
-        }
-        let id = NodeId(idx as u32);
-        let kids = il.children(id);
-        let Some(&callee) = kids.first() else {
-            continue;
-        };
-        if il.kind(callee) != NodeKind::Field {
-            continue;
-        }
-        let Payload::Name(method) = il.node(callee).payload else {
-            continue;
-        };
-        if !mutating_method_name(interner.resolve(method)) {
-            continue;
-        }
-        let Some(&receiver) = il.children(callee).first() else {
-            continue;
-        };
-        if let (NodeKind::Var, Payload::Cid(cid)) = (il.kind(receiver), il.node(receiver).payload) {
-            if candidates.contains(&cid) {
-                mutated.insert(cid);
-            }
-        }
-    }
-    mutated
 }
 
 fn top_level_statements(il: &Il) -> Vec<NodeId> {
@@ -849,58 +795,6 @@ fn assignment_name(il: &Il, stmt: NodeId) -> Option<Symbol> {
         return None;
     };
     il.cid_names.get(cid as usize).copied()
-}
-
-fn strict_exact_module_collection_binding_safe(
-    il: &Il,
-    interner: &Interner,
-    facts: &StrictFacts,
-    node: NodeId,
-) -> bool {
-    strict_exact_literal_collection_receiver_safe(il, interner, facts, node)
-        || strict_exact_python_collection_factory_safe(il, interner, facts, node)
-        || strict_exact_ruby_set_factory_safe(il, interner, facts, node)
-        || strict_exact_rust_vec_macro_collection_safe(il, interner, facts, node)
-        || strict_exact_rust_std_collection_factory_safe(il, interner, facts, node)
-        || strict_exact_set_constructor_collection_safe(il, interner, facts, node)
-        || strict_exact_java_collection_factory_safe(il, interner, facts, node)
-}
-
-fn strict_exact_module_map_binding_safe(
-    il: &Il,
-    interner: &Interner,
-    facts: &StrictFacts,
-    node: NodeId,
-) -> bool {
-    strict_exact_map_constructor_entries_safe(il, interner, facts, node)
-        || strict_exact_java_map_factory_safe(il, interner, facts, node)
-        || strict_exact_rust_std_map_factory_safe(il, interner, facts, node)
-}
-
-fn strict_exact_local_collection_binding_safe(
-    il: &Il,
-    interner: &Interner,
-    facts: &StrictFacts,
-    node: NodeId,
-) -> bool {
-    strict_exact_literal_collection_receiver_safe(il, interner, facts, node)
-        || strict_exact_python_collection_factory_safe(il, interner, facts, node)
-        || strict_exact_ruby_set_factory_safe(il, interner, facts, node)
-        || strict_exact_rust_vec_macro_collection_safe(il, interner, facts, node)
-        || strict_exact_rust_std_collection_factory_safe(il, interner, facts, node)
-        || strict_exact_rust_vec_new_safe(il, interner, node)
-        || strict_exact_java_collection_factory_safe(il, interner, facts, node)
-}
-
-fn strict_exact_local_map_binding_safe(
-    il: &Il,
-    interner: &Interner,
-    facts: &StrictFacts,
-    node: NodeId,
-) -> bool {
-    strict_exact_java_map_factory_safe(il, interner, facts, node)
-        || strict_exact_rust_std_map_factory_safe(il, interner, facts, node)
-        || strict_exact_map_constructor_entries_safe(il, interner, facts, node)
 }
 
 fn immutable_binding_safe(
@@ -1023,8 +917,8 @@ fn strict_exact_in_membership_collection_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    if strict_exact_proven_collection_receiver_safe(il, facts, node)
-        || strict_exact_proven_map_receiver_safe(il, facts, node)
+    if strict_exact_proven_collection_receiver_safe(il, interner, facts, node)
+        || strict_exact_proven_map_receiver_safe(il, interner, facts, node)
     {
         return true;
     }
@@ -1484,7 +1378,7 @@ fn strict_exact_collection_contains_call_safe(
                 return false;
             };
             strict_exact_literal_collection_receiver_safe(il, interner, facts, receiver)
-                || strict_exact_proven_collection_receiver_safe(il, facts, receiver)
+                || strict_exact_proven_collection_receiver_safe(il, interner, facts, receiver)
                 || strict_exact_python_collection_factory_safe(il, interner, facts, receiver)
                 || strict_exact_ruby_set_factory_safe(il, interner, facts, receiver)
                 || strict_exact_rust_vec_macro_collection_safe(il, interner, facts, receiver)
@@ -1496,7 +1390,7 @@ fn strict_exact_collection_contains_call_safe(
             let Some(&receiver) = il.children(callee).first() else {
                 return false;
             };
-            strict_exact_typed_set_param_receiver_safe(il, receiver)
+            strict_exact_typed_set_param_receiver_safe(il, interner, receiver)
                 || strict_exact_set_constructor_collection_safe(il, interner, facts, receiver)
         }
         _ => false,
@@ -1534,10 +1428,7 @@ fn strict_exact_map_contains_call_safe(
     let Some(&receiver) = il.children(callee).first() else {
         return false;
     };
-    (strict_exact_proven_map_receiver_safe(il, facts, receiver)
-        || strict_exact_java_map_factory_safe(il, interner, facts, receiver)
-        || strict_exact_rust_std_map_factory_safe(il, interner, facts, receiver)
-        || strict_exact_map_constructor_entries_safe(il, interner, facts, receiver))
+    strict_exact_map_receiver_or_factory_safe(il, interner, facts, receiver, true)
         && strict_exact_call_args_safe(il, interner, facts, node)
 }
 
@@ -1561,9 +1452,7 @@ fn strict_exact_map_get_call_safe(
     let Some(&receiver) = il.children(callee).first() else {
         return false;
     };
-    (strict_exact_proven_map_receiver_safe(il, facts, receiver)
-        || strict_exact_java_map_factory_safe(il, interner, facts, receiver)
-        || strict_exact_map_constructor_entries_safe(il, interner, facts, receiver))
+    strict_exact_map_receiver_or_factory_safe(il, interner, facts, receiver, false)
         && strict_exact_call_args_safe(il, interner, facts, node)
 }
 
@@ -1595,10 +1484,22 @@ fn strict_exact_map_get_default_call_safe(
     let Some(&receiver) = il.children(callee).first() else {
         return false;
     };
-    (strict_exact_proven_map_receiver_safe(il, facts, receiver)
-        || strict_exact_java_map_factory_safe(il, interner, facts, receiver)
-        || strict_exact_map_constructor_entries_safe(il, interner, facts, receiver))
+    strict_exact_map_receiver_or_factory_safe(il, interner, facts, receiver, false)
         && strict_exact_map_get_default_args_safe(il, interner, facts, node, contract.args)
+}
+
+fn strict_exact_map_receiver_or_factory_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    receiver: NodeId,
+    allow_rust_std_factory: bool,
+) -> bool {
+    strict_exact_proven_map_receiver_safe(il, interner, facts, receiver)
+        || strict_exact_java_map_factory_safe(il, interner, facts, receiver)
+        || strict_exact_map_constructor_entries_safe(il, interner, facts, receiver)
+        || (allow_rust_std_factory
+            && strict_exact_rust_std_map_factory_safe(il, interner, facts, receiver))
 }
 
 fn strict_exact_map_get_default_args_safe(
@@ -1685,7 +1586,7 @@ fn strict_exact_iterator_receiver_safe(
     facts: &StrictFacts,
     receiver: NodeId,
 ) -> bool {
-    strict_exact_proven_collection_receiver_safe(il, facts, receiver)
+    strict_exact_proven_collection_receiver_safe(il, interner, facts, receiver)
         || strict_exact_literal_collection_receiver_safe(il, interner, facts, receiver)
         || strict_exact_rust_vec_macro_collection_safe(il, interner, facts, receiver)
         || strict_exact_rust_std_collection_factory_safe(il, interner, facts, receiver)
@@ -1722,31 +1623,46 @@ fn strict_exact_iterator_identity_adapter_node_safe(
     )
 }
 
-fn strict_exact_typed_set_param_receiver_safe(il: &Il, receiver: NodeId) -> bool {
-    strict_exact_typed_receiver_safe(il, receiver, DomainRequirement::Set)
+fn strict_exact_typed_set_param_receiver_safe(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+) -> bool {
+    strict_exact_typed_receiver_safe(il, interner, receiver, DomainRequirement::Set)
 }
 
-fn strict_exact_typed_collection_param_receiver_safe(il: &Il, receiver: NodeId) -> bool {
-    strict_exact_typed_receiver_safe(il, receiver, DomainRequirement::ArrayCollectionOrSet)
+fn strict_exact_typed_collection_param_receiver_safe(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+) -> bool {
+    strict_exact_typed_receiver_safe(
+        il,
+        interner,
+        receiver,
+        DomainRequirement::ArrayCollectionOrSet,
+    )
 }
 
 fn strict_exact_typed_receiver_safe(
     il: &Il,
+    interner: &Interner,
     receiver: NodeId,
     requirement: DomainRequirement,
 ) -> bool {
     if il.kind(receiver) != NodeKind::Var {
         return false;
     }
-    nose_semantics::receiver_satisfies_domain(il, receiver, requirement)
+    nose_semantics::receiver_satisfies_domain(il, interner, receiver, requirement)
 }
 
 fn strict_exact_proven_collection_receiver_safe(
     il: &Il,
+    interner: &Interner,
     facts: &StrictFacts,
     receiver: NodeId,
 ) -> bool {
-    if strict_exact_typed_collection_param_receiver_safe(il, receiver) {
+    if strict_exact_typed_collection_param_receiver_safe(il, interner, receiver) {
         return true;
     }
     matches!(
@@ -1758,12 +1674,21 @@ fn strict_exact_proven_collection_receiver_safe(
     )
 }
 
-fn strict_exact_typed_map_param_receiver_safe(il: &Il, receiver: NodeId) -> bool {
-    strict_exact_typed_receiver_safe(il, receiver, DomainRequirement::Map)
+fn strict_exact_typed_map_param_receiver_safe(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+) -> bool {
+    strict_exact_typed_receiver_safe(il, interner, receiver, DomainRequirement::Map)
 }
 
-fn strict_exact_proven_map_receiver_safe(il: &Il, facts: &StrictFacts, receiver: NodeId) -> bool {
-    if strict_exact_typed_map_param_receiver_safe(il, receiver) {
+fn strict_exact_proven_map_receiver_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    receiver: NodeId,
+) -> bool {
+    if strict_exact_typed_map_param_receiver_safe(il, interner, receiver) {
         return true;
     }
     matches!(
@@ -1814,7 +1739,7 @@ fn strict_exact_map_key_view_safe_matching(
     let Some(&receiver) = il.children(kids[0]).first() else {
         return false;
     };
-    strict_exact_proven_map_receiver_safe(il, facts, receiver)
+    strict_exact_proven_map_receiver_safe(il, interner, facts, receiver)
         || strict_exact_map_constructor_entries_safe(il, interner, facts, receiver)
         || strict_exact_java_map_factory_safe(il, interner, facts, receiver)
         || strict_exact_rust_std_map_factory_safe(il, interner, facts, receiver)
@@ -1878,8 +1803,8 @@ fn strict_exact_membership_collection_safe(
                 || strict_exact_java_collection_factory_safe(il, interner, facts, node)
                 || strict_exact_map_key_view_collection_safe(il, interner, facts, node);
         }
-        if strict_exact_proven_collection_receiver_safe(il, facts, node)
-            || strict_exact_proven_map_receiver_safe(il, facts, node)
+        if strict_exact_proven_collection_receiver_safe(il, interner, facts, node)
+            || strict_exact_proven_map_receiver_safe(il, interner, facts, node)
         {
             return true;
         }
@@ -4113,6 +4038,60 @@ mod tests {
         assert!(
             !strict_exact_safe_tree(&il, &interner, &facts, call),
             "conflicting receiver-domain evidence must close strict exact fallback"
+        );
+    }
+
+    #[test]
+    fn strict_exact_contains_consumes_binding_domain_evidence() {
+        let interner = Interner::new();
+        let xs = interner.intern("xs");
+        let mut b = IlBuilder::new(FileId(0));
+        let lhs = b.add(NodeKind::Var, Payload::Cid(0), sp(30), &[]);
+        let seq = b.add(NodeKind::Seq, Payload::None, sp(31), &[]);
+        let assign = b.add(NodeKind::Assign, Payload::None, sp(30), &[lhs, seq]);
+        let receiver = b.add(NodeKind::Var, Payload::Cid(0), sp(32), &[]);
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("includes")),
+            sp(33),
+            &[receiver],
+        );
+        let item = b.add(NodeKind::Lit, Payload::LitInt(7), sp(34), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(35), &[callee, item]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(29), &[assign, call]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.ts".into(),
+                lang: Lang::TypeScript,
+            },
+            Vec::new(),
+            vec![xs],
+        );
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(sp(30), stable_symbol_hash("xs")),
+            EvidenceKind::Domain(nose_semantics::DomainEvidence::Collection),
+            Vec::new(),
+        ));
+
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(strict_exact_collection_contains_call_safe(
+            &il, &interner, &facts, call, callee, "includes"
+        ));
+
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::binding(sp(30), stable_symbol_hash("xs")),
+            EvidenceKind::Domain(nose_semantics::DomainEvidence::Map),
+            Vec::new(),
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(
+            !strict_exact_collection_contains_call_safe(
+                &il, &interner, &facts, call, callee, "includes"
+            ),
+            "conflicting binding-domain evidence must close strict exact receiver proof"
         );
     }
 

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -1510,29 +1510,13 @@ fn post_lower_find_or_push_evidence(
     rule: &str,
     dependencies: Vec<EvidenceId>,
 ) -> Option<EvidenceId> {
-    if let Some(id) = il.evidence.iter().find_map(|record| {
-        (record.anchor == anchor
-            && record.kind == kind
-            && record.status == EvidenceStatus::Asserted
-            && record.dependencies == dependencies)
-            .then_some(record.id)
-    }) {
-        return Some(id);
-    }
-    let id = EvidenceId(il.evidence.len() as u32);
-    il.evidence.push(EvidenceRecord {
-        id,
+    Some(il.find_or_push_first_party_evidence(
         anchor,
         kind,
-        provenance: EvidenceProvenance {
-            emitter: EvidenceEmitter::FirstParty,
-            pack_hash: Some(stable_symbol_hash(nose_semantics::FIRST_PARTY_PACK_ID)),
-            rule_hash: Some(stable_symbol_hash(rule)),
-        },
+        nose_semantics::FIRST_PARTY_PACK_ID,
+        rule,
         dependencies,
-        status: EvidenceStatus::Asserted,
-    });
-    Some(id)
+    ))
 }
 
 fn post_lower_top_level_statements(il: &Il) -> Vec<NodeId> {

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -97,6 +97,71 @@ impl Il {
         &self.edges[s..s + n.child_len as usize]
     }
 
+    pub fn find_or_push_first_party_evidence(
+        &mut self,
+        anchor: EvidenceAnchor,
+        kind: EvidenceKind,
+        pack_id: &str,
+        rule: &str,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceId {
+        let pack_hash = stable_symbol_hash(pack_id);
+        let rule_hash = stable_symbol_hash(rule);
+        if let Some(id) = self.evidence.iter().find_map(|record| {
+            (record.anchor == anchor
+                && record.kind == kind
+                && record.status == EvidenceStatus::Asserted
+                && record.provenance.emitter == EvidenceEmitter::FirstParty
+                && record.provenance.pack_hash == Some(pack_hash)
+                && record.provenance.rule_hash == Some(rule_hash)
+                && record.dependencies == dependencies)
+                .then_some(record.id)
+        }) {
+            return id;
+        }
+        let id = EvidenceId(self.evidence.len() as u32);
+        self.evidence.push(EvidenceRecord {
+            id,
+            anchor,
+            kind,
+            provenance: EvidenceProvenance {
+                emitter: EvidenceEmitter::FirstParty,
+                pack_hash: Some(pack_hash),
+                rule_hash: Some(rule_hash),
+            },
+            dependencies,
+            status: EvidenceStatus::Asserted,
+        });
+        id
+    }
+
+    #[inline]
+    pub fn evidence_record_by_id(&self, id: EvidenceId) -> Option<&EvidenceRecord> {
+        self.evidence
+            .get(id.0 as usize)
+            .filter(|record| record.id == id)
+            .or_else(|| self.evidence.iter().find(|record| record.id == id))
+    }
+
+    pub fn evidence_dependencies_asserted(&self, record: &EvidenceRecord) -> bool {
+        let mut stack = record.dependencies.clone();
+        let mut seen = Vec::new();
+        while let Some(id) = stack.pop() {
+            if seen.contains(&id) {
+                continue;
+            }
+            seen.push(id);
+            let Some(dep) = self.evidence_record_by_id(id) else {
+                return false;
+            };
+            if dep.status != EvidenceStatus::Asserted {
+                return false;
+            }
+            stack.extend_from_slice(&dep.dependencies);
+        }
+        true
+    }
+
     /// Render a subtree as an s-expression (used by `nose il --format sexpr`).
     pub fn to_sexpr(&self, root: NodeId, interner: &Interner) -> String {
         sexpr::to_sexpr(self, root, interner)
@@ -311,5 +376,50 @@ mod validate_tests {
             il.validate().is_err(),
             "an out-of-range child span must fail"
         );
+    }
+
+    #[test]
+    fn first_party_evidence_dedupe_preserves_provenance_boundary() {
+        let mut il = leaf_il();
+        let anchor = EvidenceAnchor::node(il.node(il.root).span, NodeKind::Module);
+        let kind = EvidenceKind::Domain(DomainEvidence::Collection);
+        il.evidence.push(EvidenceRecord {
+            id: EvidenceId(0),
+            anchor,
+            kind,
+            provenance: EvidenceProvenance {
+                emitter: EvidenceEmitter::External,
+                pack_hash: Some(stable_symbol_hash("external.pack")),
+                rule_hash: Some(stable_symbol_hash("external.rule")),
+            },
+            dependencies: Vec::new(),
+            status: EvidenceStatus::Asserted,
+        });
+
+        let first = il.find_or_push_first_party_evidence(
+            anchor,
+            kind,
+            "nose.first_party",
+            "rule.a",
+            Vec::new(),
+        );
+        let duplicate = il.find_or_push_first_party_evidence(
+            anchor,
+            kind,
+            "nose.first_party",
+            "rule.a",
+            Vec::new(),
+        );
+        let different_rule = il.find_or_push_first_party_evidence(
+            anchor,
+            kind,
+            "nose.first_party",
+            "rule.b",
+            Vec::new(),
+        );
+
+        assert_eq!(first, EvidenceId(1));
+        assert_eq!(duplicate, first);
+        assert_eq!(different_rule, EvidenceId(2));
     }
 }

--- a/crates/nose-normalize/src/binding_evidence.rs
+++ b/crates/nose-normalize/src/binding_evidence.rs
@@ -1,0 +1,577 @@
+use nose_il::{
+    stable_symbol_hash, Builtin, DomainEvidence, EvidenceAnchor, EvidenceId, EvidenceKind,
+    EvidenceRecord, EvidenceStatus, Il, Interner, NodeId, NodeKind, Payload, SequenceSurfaceKind,
+    Symbol,
+};
+use nose_semantics::{module_binding_mutating_method_name, FIRST_PARTY_PACK_ID};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+#[derive(Clone, Copy)]
+struct BindingAssignment {
+    assign: NodeId,
+    lhs: NodeId,
+    rhs: NodeId,
+    name: Symbol,
+    control_gated: bool,
+}
+
+/// Emit first-party domain evidence for immutable local/module bindings.
+///
+/// This runs after desugaring and before alpha-renaming: the IL has canonical
+/// surface shapes and evidence records, but binding names are still available
+/// for stable `EvidenceAnchor::Binding` local hashes.
+pub(crate) fn run(il: &mut Il, interner: &Interner) {
+    let root = il.root;
+    record_scope_bindings(il, interner, root);
+}
+
+fn record_scope_bindings(il: &mut Il, interner: &Interner, scope: NodeId) {
+    let mut assignments = Vec::new();
+    let mut nested_scopes = Vec::new();
+    collect_scope_assignments(
+        il,
+        scope,
+        scope,
+        false,
+        &mut assignments,
+        &mut nested_scopes,
+    );
+    record_assignments_in_scope(il, interner, scope, &assignments);
+    for nested in nested_scopes {
+        record_scope_bindings(il, interner, nested);
+    }
+}
+
+fn collect_scope_assignments(
+    il: &Il,
+    scope: NodeId,
+    node: NodeId,
+    control_gated: bool,
+    assignments: &mut Vec<BindingAssignment>,
+    nested_scopes: &mut Vec<NodeId>,
+) {
+    if node != scope && matches!(il.kind(node), NodeKind::Func | NodeKind::Lambda) {
+        nested_scopes.push(node);
+        return;
+    }
+
+    let now_control_gated =
+        control_gated || matches!(il.kind(node), NodeKind::If | NodeKind::Loop | NodeKind::Try);
+    if il.kind(node) == NodeKind::Assign {
+        let kids = il.children(node);
+        if kids.len() == 2 {
+            if let Some(name) = binding_lhs_name(il, kids[0]) {
+                assignments.push(BindingAssignment {
+                    assign: node,
+                    lhs: kids[0],
+                    rhs: kids[1],
+                    name,
+                    control_gated,
+                });
+            }
+        }
+    }
+
+    for &child in il.children(node) {
+        collect_scope_assignments(
+            il,
+            scope,
+            child,
+            now_control_gated,
+            assignments,
+            nested_scopes,
+        );
+    }
+}
+
+fn record_assignments_in_scope(
+    il: &mut Il,
+    interner: &Interner,
+    scope: NodeId,
+    assignments: &[BindingAssignment],
+) {
+    let mut counts: FxHashMap<Symbol, usize> = FxHashMap::default();
+    for assignment in assignments {
+        *counts.entry(assignment.name).or_insert(0) += 1;
+    }
+
+    let unit_names: FxHashSet<Symbol> = if il.kind(scope) == NodeKind::Module {
+        il.units.iter().filter_map(|unit| unit.name).collect()
+    } else {
+        FxHashSet::default()
+    };
+
+    let mut env: FxHashMap<Symbol, (DomainEvidence, EvidenceId)> = FxHashMap::default();
+    let mut ordered = assignments.to_vec();
+    ordered.sort_by_key(|assignment| {
+        (
+            il.node(assignment.assign).span.start_byte,
+            il.node(assignment.assign).span.end_byte,
+        )
+    });
+
+    for assignment in ordered {
+        if assignment.control_gated {
+            continue;
+        }
+        if counts.get(&assignment.name).copied().unwrap_or(0) != 1 {
+            continue;
+        }
+        if unit_names.contains(&assignment.name) {
+            continue;
+        }
+        if node_contains_name(il, assignment.rhs, assignment.name) {
+            continue;
+        }
+        if binding_mutated_in_scope(il, interner, scope, assignments, assignment) {
+            continue;
+        }
+
+        let Some((domain, dependencies)) = rhs_domain_evidence(il, assignment.rhs, &env) else {
+            continue;
+        };
+        let local_hash = stable_symbol_hash(interner.resolve(assignment.name));
+        let Some(id) = find_or_push_evidence(
+            il,
+            EvidenceAnchor::binding(il.node(assignment.lhs).span, local_hash),
+            EvidenceKind::Domain(domain),
+            "immutable_binding_domain",
+            dependencies,
+        ) else {
+            continue;
+        };
+        env.insert(assignment.name, (domain, id));
+    }
+}
+
+fn binding_lhs_name(il: &Il, lhs: NodeId) -> Option<Symbol> {
+    if il.kind(lhs) != NodeKind::Var {
+        return None;
+    }
+    match il.node(lhs).payload {
+        Payload::Name(name) => Some(name),
+        Payload::Cid(cid) => il.cid_names.get(cid as usize).copied(),
+        _ => None,
+    }
+}
+
+fn rhs_domain_evidence(
+    il: &Il,
+    rhs: NodeId,
+    env: &FxHashMap<Symbol, (DomainEvidence, EvidenceId)>,
+) -> Option<(DomainEvidence, Vec<EvidenceId>)> {
+    if let Some((domain, id)) = domain_evidence_record_for_node(il, rhs) {
+        return Some((domain, vec![id]));
+    }
+    if let Some((domain, id)) = sequence_domain_evidence_record_for_node(il, rhs) {
+        return Some((domain, vec![id]));
+    }
+    if il.kind(rhs) == NodeKind::Var {
+        if let Some(name) = binding_lhs_name(il, rhs) {
+            if let Some(&(domain, id)) = env.get(&name) {
+                return Some((domain, vec![id]));
+            }
+        }
+    }
+    None
+}
+
+fn domain_evidence_record_for_node(il: &Il, node: NodeId) -> Option<(DomainEvidence, EvidenceId)> {
+    let expected = EvidenceAnchor::node(il.node(node).span, il.kind(node));
+    let mut found = None;
+    for record in &il.evidence {
+        if record.anchor != expected {
+            continue;
+        }
+        let EvidenceKind::Domain(domain) = record.kind else {
+            continue;
+        };
+        if !record_is_live(il, record) {
+            return None;
+        }
+        match found {
+            None => found = Some((domain, record.id)),
+            Some((existing, _)) if existing == domain => {}
+            Some(_) => return None,
+        }
+    }
+    found
+}
+
+fn sequence_domain_evidence_record_for_node(
+    il: &Il,
+    node: NodeId,
+) -> Option<(DomainEvidence, EvidenceId)> {
+    if il.kind(node) != NodeKind::Seq {
+        return None;
+    }
+    let span = il.node(node).span;
+    let mut found = None;
+    for record in &il.evidence {
+        if !matches!(record.anchor, EvidenceAnchor::Sequence { span: anchor_span } if anchor_span == span)
+        {
+            continue;
+        }
+        let EvidenceKind::SequenceSurface(surface) = record.kind else {
+            continue;
+        };
+        if !record_is_live(il, record) {
+            return None;
+        }
+        match found {
+            None => found = Some((surface, record.id)),
+            Some((existing, _)) if existing == surface => {}
+            Some(_) => return None,
+        }
+    }
+    let (surface, id) = found?;
+    let domain = match surface {
+        SequenceSurfaceKind::Collection => DomainEvidence::Collection,
+        SequenceSurfaceKind::Map => DomainEvidence::Map,
+        _ => return None,
+    };
+    Some((domain, id))
+}
+
+fn record_is_live(il: &Il, record: &EvidenceRecord) -> bool {
+    record.status == EvidenceStatus::Asserted && il.evidence_dependencies_asserted(record)
+}
+
+fn binding_mutated_in_scope(
+    il: &Il,
+    interner: &Interner,
+    scope: NodeId,
+    assignments: &[BindingAssignment],
+    binding: BindingAssignment,
+) -> bool {
+    for assignment in assignments {
+        if assignment.assign != binding.assign
+            && node_contains_name(il, assignment.lhs, binding.name)
+        {
+            return true;
+        }
+    }
+
+    let mut mutated = false;
+    visit_scope_nodes(il, scope, binding.name, |node| {
+        if mutated {
+            return;
+        }
+        match il.kind(node) {
+            NodeKind::Call
+                if matches!(il.node(node).payload, Payload::Builtin(Builtin::Append)) =>
+            {
+                if let Some(&receiver) = il.children(node).first() {
+                    mutated = node_refers_to_name(il, receiver, binding.name);
+                }
+            }
+            NodeKind::Field => {
+                let Payload::Name(method) = il.node(node).payload else {
+                    return;
+                };
+                if !module_binding_mutating_method_name(interner.resolve(method)) {
+                    return;
+                }
+                if let Some(&receiver) = il.children(node).first() {
+                    mutated = node_refers_to_name(il, receiver, binding.name);
+                }
+            }
+            NodeKind::Assign if node != binding.assign => {
+                if let Some(&lhs) = il.children(node).first() {
+                    mutated = node_contains_name(il, lhs, binding.name);
+                }
+            }
+            _ => {}
+        }
+    });
+    mutated
+}
+
+fn visit_scope_nodes(il: &Il, scope: NodeId, binding_name: Symbol, mut visit: impl FnMut(NodeId)) {
+    fn go(
+        il: &Il,
+        scope: NodeId,
+        binding_name: Symbol,
+        node: NodeId,
+        visit: &mut impl FnMut(NodeId),
+    ) {
+        visit(node);
+        if node != scope
+            && matches!(il.kind(node), NodeKind::Func | NodeKind::Lambda)
+            && scope_binds_name(il, node, binding_name)
+        {
+            return;
+        }
+        for &child in il.children(node) {
+            go(il, scope, binding_name, child, visit);
+        }
+    }
+    go(il, scope, binding_name, scope, &mut visit);
+}
+
+fn scope_binds_name(il: &Il, scope: NodeId, name: Symbol) -> bool {
+    fn go(il: &Il, scope: NodeId, node: NodeId, name: Symbol) -> bool {
+        if node != scope && matches!(il.kind(node), NodeKind::Func | NodeKind::Lambda) {
+            return false;
+        }
+        match il.kind(node) {
+            NodeKind::Param if binding_node_name(il, node) == Some(name) => return true,
+            NodeKind::Assign => {
+                if let Some(&lhs) = il.children(node).first() {
+                    if target_binds_name(il, lhs, name) {
+                        return true;
+                    }
+                }
+            }
+            NodeKind::Loop => {
+                if let Some(&pattern) = il.children(node).first() {
+                    if target_binds_name(il, pattern, name) {
+                        return true;
+                    }
+                }
+            }
+            _ => {}
+        }
+        il.children(node)
+            .iter()
+            .any(|&child| go(il, scope, child, name))
+    }
+    go(il, scope, scope, name)
+}
+
+fn node_refers_to_name(il: &Il, node: NodeId, name: Symbol) -> bool {
+    il.kind(node) == NodeKind::Var && binding_node_name(il, node) == Some(name)
+}
+
+fn node_contains_name(il: &Il, node: NodeId, name: Symbol) -> bool {
+    node_refers_to_name(il, node, name)
+        || il
+            .children(node)
+            .iter()
+            .any(|&child| node_contains_name(il, child, name))
+}
+
+fn target_binds_name(il: &Il, node: NodeId, name: Symbol) -> bool {
+    match il.kind(node) {
+        NodeKind::Var => binding_node_name(il, node) == Some(name),
+        NodeKind::Seq => il
+            .children(node)
+            .iter()
+            .any(|&child| target_binds_name(il, child, name)),
+        _ => false,
+    }
+}
+
+fn find_or_push_evidence(
+    il: &mut Il,
+    anchor: EvidenceAnchor,
+    kind: EvidenceKind,
+    rule: &str,
+    dependencies: Vec<EvidenceId>,
+) -> Option<EvidenceId> {
+    Some(il.find_or_push_first_party_evidence(
+        anchor,
+        kind,
+        FIRST_PARTY_PACK_ID,
+        rule,
+        dependencies,
+    ))
+}
+
+fn binding_node_name(il: &Il, node: NodeId) -> Option<Symbol> {
+    match (il.kind(node), il.node(node).payload) {
+        (NodeKind::Var | NodeKind::Param, Payload::Name(name)) => Some(name),
+        (NodeKind::Var | NodeKind::Param, Payload::Cid(cid)) => {
+            il.cid_names.get(cid as usize).copied()
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nose_il::{
+        EvidenceEmitter, EvidenceProvenance, FileId, FileMeta, IlBuilder, Lang,
+        SequenceSurfaceKind, Span, Unit, UnitKind,
+    };
+
+    fn sp(line: u32) -> Span {
+        Span::new(FileId(0), line, line, line, line)
+    }
+
+    fn finish(builder: IlBuilder, root: NodeId, lang: Lang) -> Il {
+        builder.finish(
+            root,
+            FileMeta {
+                path: "t".into(),
+                lang,
+            },
+            vec![Unit {
+                root,
+                kind: UnitKind::Function,
+                name: None,
+            }],
+            Vec::new(),
+        )
+    }
+
+    fn sequence_evidence(id: u32, span: Span, kind: SequenceSurfaceKind) -> EvidenceRecord {
+        EvidenceRecord {
+            id: EvidenceId(id),
+            anchor: EvidenceAnchor::sequence(span),
+            kind: EvidenceKind::SequenceSurface(kind),
+            provenance: EvidenceProvenance {
+                emitter: EvidenceEmitter::FirstParty,
+                pack_hash: Some(stable_symbol_hash(FIRST_PARTY_PACK_ID)),
+                rule_hash: Some(stable_symbol_hash("test")),
+            },
+            dependencies: Vec::new(),
+            status: EvidenceStatus::Asserted,
+        }
+    }
+
+    fn binding_domain_record<'a>(il: &'a Il, name: &str) -> Option<&'a EvidenceRecord> {
+        let local_hash = stable_symbol_hash(name);
+        il.evidence.iter().find(|record| {
+            matches!(
+                record.anchor,
+                EvidenceAnchor::Binding {
+                    local_hash: anchor_hash,
+                    ..
+                } if anchor_hash == local_hash
+            ) && matches!(record.kind, EvidenceKind::Domain(_))
+        })
+    }
+
+    fn array_assignment(
+        b: &mut IlBuilder,
+        interner: &Interner,
+        name: Symbol,
+        assign_span: Span,
+        seq_span: Span,
+    ) -> (NodeId, NodeId) {
+        let lhs = b.add(NodeKind::Var, Payload::Name(name), assign_span, &[]);
+        let seq = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            seq_span,
+            &[],
+        );
+        let assign = b.add(NodeKind::Assign, Payload::None, assign_span, &[lhs, seq]);
+        (assign, seq)
+    }
+
+    fn append_call(b: &mut IlBuilder, name: Symbol, span: Span) -> NodeId {
+        let receiver = b.add(NodeKind::Var, Payload::Name(name), span, &[]);
+        let item = b.add(NodeKind::Lit, Payload::LitInt(1), span, &[]);
+        b.add(
+            NodeKind::Call,
+            Payload::Builtin(Builtin::Append),
+            span,
+            &[receiver, item],
+        )
+    }
+
+    fn finish_with_sequence_evidence(b: IlBuilder, root: NodeId) -> Il {
+        let mut il = finish(b, root, Lang::TypeScript);
+        il.evidence
+            .push(sequence_evidence(0, sp(2), SequenceSurfaceKind::Collection));
+        il
+    }
+
+    #[derive(Clone, Copy)]
+    enum MutationCase {
+        Direct,
+        NestedModule,
+        NestedLocal,
+    }
+
+    fn mutation_case_il(interner: &Interner, case: MutationCase) -> Il {
+        let xs = interner.intern("xs");
+        let mut b = IlBuilder::new(FileId(0));
+        let (assign, _) = array_assignment(&mut b, interner, xs, sp(1), sp(2));
+        let append_span = match case {
+            MutationCase::Direct => sp(3),
+            MutationCase::NestedModule => sp(4),
+            MutationCase::NestedLocal => sp(5),
+        };
+        let append = append_call(&mut b, xs, append_span);
+        let root = match case {
+            MutationCase::Direct => b.add(NodeKind::Func, Payload::None, sp(1), &[assign, append]),
+            MutationCase::NestedModule => {
+                let body = b.add(NodeKind::Block, Payload::None, sp(4), &[append]);
+                let nested = b.add(NodeKind::Func, Payload::None, sp(3), &[body]);
+                b.add(NodeKind::Module, Payload::None, sp(1), &[assign, nested])
+            }
+            MutationCase::NestedLocal => {
+                let nested_body = b.add(NodeKind::Block, Payload::None, sp(5), &[append]);
+                let nested = b.add(NodeKind::Func, Payload::None, sp(4), &[nested_body]);
+                b.add(NodeKind::Func, Payload::None, sp(1), &[assign, nested])
+            }
+        };
+        finish_with_sequence_evidence(b, root)
+    }
+
+    #[test]
+    fn records_binding_domain_from_sequence_surface_evidence() {
+        let interner = Interner::new();
+        let xs = interner.intern("xs");
+        let mut b = IlBuilder::new(FileId(0));
+        let (assign, _) = array_assignment(&mut b, &interner, xs, sp(1), sp(2));
+        let root = b.add(NodeKind::Func, Payload::None, sp(1), &[assign]);
+        let mut il = finish_with_sequence_evidence(b, root);
+
+        run(&mut il, &interner);
+
+        let record = binding_domain_record(&il, "xs").expect("binding domain evidence");
+        assert!(matches!(
+            record.kind,
+            EvidenceKind::Domain(DomainEvidence::Collection)
+        ));
+        assert_eq!(record.dependencies, vec![EvidenceId(0)]);
+    }
+
+    #[test]
+    fn binding_domain_chains_through_prior_immutable_binding() {
+        let interner = Interner::new();
+        let xs = interner.intern("xs");
+        let ys = interner.intern("ys");
+        let mut b = IlBuilder::new(FileId(0));
+        let (xs_assign, _) = array_assignment(&mut b, &interner, xs, sp(1), sp(2));
+        let ys_lhs = b.add(NodeKind::Var, Payload::Name(ys), sp(3), &[]);
+        let xs_ref = b.add(NodeKind::Var, Payload::Name(xs), sp(4), &[]);
+        let ys_assign = b.add(NodeKind::Assign, Payload::None, sp(3), &[ys_lhs, xs_ref]);
+        let root = b.add(
+            NodeKind::Func,
+            Payload::None,
+            sp(1),
+            &[xs_assign, ys_assign],
+        );
+        let mut il = finish_with_sequence_evidence(b, root);
+
+        run(&mut il, &interner);
+
+        let xs_record = binding_domain_record(&il, "xs").expect("xs binding evidence");
+        let ys_record = binding_domain_record(&il, "ys").expect("ys binding evidence");
+        assert!(matches!(
+            ys_record.kind,
+            EvidenceKind::Domain(DomainEvidence::Collection)
+        ));
+        assert_eq!(ys_record.dependencies, vec![xs_record.id]);
+    }
+
+    #[test]
+    fn mutations_block_binding_domain_evidence() {
+        let interner = Interner::new();
+        for case in [
+            MutationCase::Direct,
+            MutationCase::NestedModule,
+            MutationCase::NestedLocal,
+        ] {
+            let mut il = mutation_case_il(&interner, case);
+            run(&mut il, &interner);
+            assert!(binding_domain_record(&il, "xs").is_none());
+        }
+    }
+}

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -8,8 +8,8 @@
 //! proof-obligation: normalize.value_graph.min_max
 
 use nose_il::{
-    contains_js_identifier, Builtin, DomainEvidence, EvidenceAnchor, EvidenceId, EvidenceKind,
-    EvidenceRecord, EvidenceStatus, HoFKind, Il, Interner, NodeId, NodeKind, Payload, Span, Symbol,
+    contains_js_identifier, Builtin, DomainEvidence, EvidenceAnchor, EvidenceKind, EvidenceStatus,
+    HoFKind, Il, Interner, NodeId, NodeKind, Payload, Span, Symbol,
 };
 use nose_semantics::{
     domain_evidence_for_param, free_function_builtin_contract, imported_namespace_symbol,
@@ -257,7 +257,7 @@ fn node_domain_index(old: &Il) -> FxHashMap<(Span, NodeKind), DomainLookup> {
             continue;
         };
         let entry = domains.entry((span, kind)).or_insert(DomainLookup::Missing);
-        if record.status != EvidenceStatus::Asserted || !evidence_dependencies_asserted(old, record)
+        if record.status != EvidenceStatus::Asserted || !old.evidence_dependencies_asserted(record)
         {
             *entry = DomainLookup::Ambiguous;
         } else {
@@ -265,32 +265,6 @@ fn node_domain_index(old: &Il) -> FxHashMap<(Span, NodeKind), DomainLookup> {
         }
     }
     domains
-}
-
-fn evidence_dependencies_asserted(il: &Il, record: &EvidenceRecord) -> bool {
-    let mut stack = record.dependencies.clone();
-    let mut seen = Vec::new();
-    while let Some(id) = stack.pop() {
-        if seen.contains(&id) {
-            continue;
-        }
-        seen.push(id);
-        let Some(dep) = evidence_record_by_id(il, id) else {
-            return false;
-        };
-        if dep.status != EvidenceStatus::Asserted {
-            return false;
-        }
-        stack.extend_from_slice(&dep.dependencies);
-    }
-    true
-}
-
-fn evidence_record_by_id(il: &Il, id: EvidenceId) -> Option<&EvidenceRecord> {
-    il.evidence
-        .get(id.0 as usize)
-        .filter(|record| record.id == id)
-        .or_else(|| il.evidence.iter().find(|record| record.id == id))
 }
 
 #[cfg(test)]

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -15,6 +15,7 @@
 
 mod algebra;
 mod alpha;
+mod binding_evidence;
 mod cfg_norm;
 mod commutative;
 mod dataflow;
@@ -232,6 +233,8 @@ pub fn normalize(il: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il {
     let mut timer = NormalizeTimer::new(&il.meta.path);
     let mut out = desugar::run(il, interner, opts);
     timer.lap("desugar");
+    binding_evidence::run(&mut out, interner);
+    timer.lap("binding");
     alpha::run(&mut out);
     timer.lap("alpha");
     if opts.oracle {

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -832,23 +832,43 @@ impl<'a> Builder<'a> {
     }
 
     fn domain_evidence_of_expr(&self, expr: NodeId) -> Option<DomainEvidence> {
-        nose_semantics::domain_evidence_for_receiver(self.il, expr)
+        nose_semantics::domain_evidence_for_receiver(self.il, self.interner, expr)
     }
 
     fn is_collection_param_expr(&self, expr: NodeId) -> bool {
-        nose_semantics::receiver_satisfies_domain(self.il, expr, DomainRequirement::CollectionOrSet)
+        nose_semantics::receiver_satisfies_domain(
+            self.il,
+            self.interner,
+            expr,
+            DomainRequirement::CollectionOrSet,
+        )
     }
 
     fn is_set_param_expr(&self, expr: NodeId) -> bool {
-        nose_semantics::receiver_satisfies_domain(self.il, expr, DomainRequirement::Set)
+        nose_semantics::receiver_satisfies_domain(
+            self.il,
+            self.interner,
+            expr,
+            DomainRequirement::Set,
+        )
     }
 
     fn is_map_param_expr(&self, expr: NodeId) -> bool {
-        nose_semantics::receiver_satisfies_domain(self.il, expr, DomainRequirement::Map)
+        nose_semantics::receiver_satisfies_domain(
+            self.il,
+            self.interner,
+            expr,
+            DomainRequirement::Map,
+        )
     }
 
     fn is_integer_param_expr(&self, expr: NodeId) -> bool {
-        nose_semantics::receiver_satisfies_domain(self.il, expr, DomainRequirement::Integer)
+        nose_semantics::receiver_satisfies_domain(
+            self.il,
+            self.interner,
+            expr,
+            DomainRequirement::Integer,
+        )
     }
 
     /// Whether `value` is a parameter (an `Input`) carrying the given proof-gate domain.
@@ -1261,24 +1281,47 @@ impl<'a> Builder<'a> {
         expr: NodeId,
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
+        let value = self.proven_local_binding_initializer_value(expr, env, |domain| {
+            domain.is_collection_or_set()
+        })?;
+        self.proven_collection_value(value)
+    }
+
+    fn proven_local_map_binding_value(
+        &mut self,
+        expr: NodeId,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        let value =
+            self.proven_local_binding_initializer_value(expr, env, |domain| domain.is_map())?;
+        self.proven_map_value(value)
+    }
+
+    fn proven_local_binding_initializer_value(
+        &mut self,
+        expr: NodeId,
+        env: &FxHashMap<u32, ValueId>,
+        accepts_domain: impl FnOnce(DomainEvidence) -> bool,
+    ) -> Option<ValueId> {
         if self.il.kind(expr) != NodeKind::Var {
             return None;
         }
         let Payload::Cid(cid) = self.il.node(expr).payload else {
             return None;
         };
-        if self.local_binding_mutated(cid) {
+        let (lhs, rhs) = self.local_binding_initializer(cid, expr)?;
+        if !nose_semantics::domain_evidence_for_binding_lhs(self.il, self.interner, lhs)
+            .is_some_and(accepts_domain)
+        {
             return None;
         }
-        let rhs = self.local_binding_initializer(cid)?;
         if self.node_contains_cid(rhs, cid) {
             return None;
         }
-        let value = self.eval(rhs, env);
-        self.proven_collection_value(value)
+        Some(self.eval(rhs, env))
     }
 
-    fn local_binding_initializer(&self, cid: u32) -> Option<NodeId> {
+    fn local_binding_initializer(&self, cid: u32, use_node: NodeId) -> Option<(NodeId, NodeId)> {
         let mut rhs = None;
         for (idx, node) in self.il.nodes.iter().enumerate() {
             if node.kind != NodeKind::Assign {
@@ -1290,53 +1333,18 @@ impl<'a> Builder<'a> {
                 continue;
             }
             if self.node_refers_to_cid(kids[0], cid) {
+                if node.span.end_byte > self.il.node(use_node).span.start_byte {
+                    continue;
+                }
                 if rhs.is_some() {
                     return None;
                 }
-                rhs = Some(kids[1]);
+                rhs = Some((kids[0], kids[1]));
             } else if self.node_contains_cid(kids[0], cid) {
                 return None;
             }
         }
         rhs
-    }
-
-    fn local_binding_mutated(&self, cid: u32) -> bool {
-        self.il
-            .nodes
-            .iter()
-            .enumerate()
-            .any(|(idx, node)| match node.kind {
-                NodeKind::Call => self
-                    .call_mutates_cid(NodeId(idx as u32), cid)
-                    .unwrap_or(false),
-                NodeKind::Field => self
-                    .field_mutates_cid(NodeId(idx as u32), cid)
-                    .unwrap_or(false),
-                _ => false,
-            })
-    }
-
-    fn call_mutates_cid(&self, call: NodeId, cid: u32) -> Option<bool> {
-        if !matches!(
-            self.il.node(call).payload,
-            Payload::Builtin(Builtin::Append)
-        ) {
-            return Some(false);
-        }
-        let receiver = self.il.children(call).first().copied()?;
-        Some(self.node_refers_to_cid(receiver, cid))
-    }
-
-    fn field_mutates_cid(&self, field: NodeId, cid: u32) -> Option<bool> {
-        let Payload::Name(method) = self.il.node(field).payload else {
-            return Some(false);
-        };
-        if !mutating_method_name(self.interner.resolve(method)) {
-            return Some(false);
-        }
-        let receiver = self.il.children(field).first().copied()?;
-        Some(self.node_refers_to_cid(receiver, cid))
     }
 
     /// `factory([<entry>, …])` where `factory` is a free name that builds a map from a sequence of
@@ -1456,6 +1464,106 @@ impl<'a> Builder<'a> {
             return Some(self.mk(ValOp::Seq(SEQ_VALUE_MAP), canonical_entries));
         }
         None
+    }
+
+    fn eval_java_map_factory_expr(
+        &mut self,
+        expr: NodeId,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if !semantics(self.il.meta.lang).stdlib().java_map_factories()
+            || kids.is_empty()
+            || self.il.kind(kids[0]) != NodeKind::Field
+        {
+            return None;
+        }
+        let Payload::Name(method) = self.il.node(kids[0]).payload else {
+            return None;
+        };
+        let contract = library_java_map_factory_contract_by_hash(
+            self.il.meta.lang,
+            "Map",
+            self.interner.symbol_hash(method),
+        )?;
+        let LibraryApiCalleeContract::JavaUtilStaticMember { .. } = contract.callee else {
+            return None;
+        };
+        match library_api_contract_evidence_for_call(
+            self.il,
+            self.interner,
+            expr,
+            contract.id,
+            contract.callee,
+            kids.len().saturating_sub(1),
+        ) {
+            LibraryApiEvidenceStatus::Admitted => {}
+            LibraryApiEvidenceStatus::Rejected => return None,
+            LibraryApiEvidenceStatus::Missing => return None,
+        }
+        let LibraryMapFactoryResult::JavaFactory { kind } = contract.result else {
+            return None;
+        };
+        match kind {
+            JavaMapFactoryKind::Of => {
+                let entries = &kids[1..];
+                if entries.len() % 2 != 0 {
+                    return None;
+                }
+                let values: Vec<ValueId> = entries.iter().map(|&kid| self.eval(kid, env)).collect();
+                let mut canonical_entries = Vec::with_capacity(values.len() / 2);
+                for kv in values.chunks(2) {
+                    canonical_entries.push(self.mk(ValOp::Seq(SEQ_VALUE_PAIR), kv.to_vec()));
+                }
+                Some(self.mk(ValOp::Seq(SEQ_VALUE_MAP), canonical_entries))
+            }
+            JavaMapFactoryKind::OfEntries => {
+                let mut canonical_entries = Vec::with_capacity(kids.len().saturating_sub(1));
+                for &entry in &kids[1..] {
+                    let kv = self.eval_java_map_entry_pair_expr(entry, env)?;
+                    canonical_entries.push(self.mk(ValOp::Seq(SEQ_VALUE_PAIR), kv));
+                }
+                Some(self.mk(ValOp::Seq(SEQ_VALUE_MAP), canonical_entries))
+            }
+        }
+    }
+
+    fn eval_java_map_entry_pair_expr(
+        &mut self,
+        expr: NodeId,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<Vec<ValueId>> {
+        if self.il.kind(expr) != NodeKind::Call {
+            return None;
+        }
+        let kids = self.il.children(expr);
+        if kids.len() != 3 || self.il.kind(kids[0]) != NodeKind::Field {
+            return None;
+        }
+        let Payload::Name(method) = self.il.node(kids[0]).payload else {
+            return None;
+        };
+        let contract = library_java_map_entry_contract_by_hash(
+            self.il.meta.lang,
+            "Map",
+            self.interner.symbol_hash(method),
+        )?;
+        let LibraryApiCalleeContract::JavaUtilStaticMember { .. } = contract.callee else {
+            return None;
+        };
+        match library_api_contract_evidence_for_call(
+            self.il,
+            self.interner,
+            expr,
+            contract.id,
+            contract.callee,
+            2,
+        ) {
+            LibraryApiEvidenceStatus::Admitted => {}
+            LibraryApiEvidenceStatus::Rejected => return None,
+            LibraryApiEvidenceStatus::Missing => return None,
+        }
+        Some(vec![self.eval(kids[1], env), self.eval(kids[2], env)])
     }
 
     fn proven_java_map_entry_pair(&self, value: ValueId) -> Option<Vec<ValueId>> {
@@ -1890,7 +1998,8 @@ impl<'a> Builder<'a> {
         let map = if self.is_map_param_expr(receiver) {
             receiver_value
         } else {
-            self.proven_map_value(receiver_value)?
+            self.proven_map_value(receiver_value)
+                .or_else(|| self.proven_local_map_binding_value(receiver, env))?
         };
         Some(self.mk(ValOp::Bin(Op::In as u32), vec![key, map]))
     }
@@ -1930,7 +2039,8 @@ impl<'a> Builder<'a> {
         let map = if self.is_map_param_expr(receiver) {
             receiver_value
         } else {
-            self.proven_map_value(receiver_value)?
+            self.proven_map_value(receiver_value)
+                .or_else(|| self.proven_local_map_binding_value(receiver, env))?
         };
         let key = self.eval(kids[1], env);
         let default = self.eval_map_get_default_arg(contract.args, kids[2], env)?;
@@ -2890,16 +3000,22 @@ impl<'a> Builder<'a> {
                 continue;
             }
             let value = self.eval(kids[1], &env);
+            let binding_domain =
+                nose_semantics::domain_evidence_for_binding_lhs(self.il, self.interner, kids[0]);
             let value = if self.immutable_binding_safe(kids[1], &env) {
                 value
-            } else {
-                let Some(proven) = self
-                    .proven_map_value(value)
-                    .or_else(|| self.proven_collection_value(value))
-                else {
+            } else if binding_domain.is_some_and(|domain| domain.is_map()) {
+                let Some(proven) = self.proven_map_value(value) else {
                     continue;
                 };
                 proven
+            } else if binding_domain.is_some_and(|domain| domain.is_collection_or_set()) {
+                let Some(proven) = self.proven_collection_value(value) else {
+                    continue;
+                };
+                proven
+            } else {
+                continue;
             };
             if let Payload::Cid(cid) = self.il.node(kids[0]).payload {
                 env.insert(cid, value);
@@ -7866,6 +7982,9 @@ impl<'a> Builder<'a> {
                 if let Some(v) = self.eval_js_like_constructed_collection_or_map(expr, &kids, env) {
                     return v;
                 }
+                if let Some(v) = self.eval_java_map_factory_expr(expr, &kids, env) {
+                    return v;
+                }
                 if let Some(v) = self.eval_iterator_identity_adapter(&kids, env) {
                     return v;
                 }
@@ -8804,6 +8923,147 @@ mod tests {
         );
     }
 
+    fn node_with_span(il: &Il, kind: NodeKind, span: Span) -> NodeId {
+        il.nodes
+            .iter()
+            .enumerate()
+            .find_map(|(idx, node)| {
+                (node.kind == kind && node.span == span).then_some(NodeId(idx as u32))
+            })
+            .expect("node with requested span")
+    }
+
+    #[derive(Clone, Copy)]
+    enum BindingMembershipCase {
+        Visible,
+        Late,
+        MutatedVisible,
+    }
+
+    fn binding_assignment(
+        b: &mut IlBuilder,
+        xs: Symbol,
+        array: Symbol,
+        line: u32,
+    ) -> (NodeId, Span) {
+        let lhs = b.add(NodeKind::Var, Payload::Name(xs), sp(line), &[]);
+        let seq_span = sp(line + 1);
+        let seq = b.add(NodeKind::Seq, Payload::Name(array), seq_span, &[]);
+        (
+            b.add(NodeKind::Assign, Payload::None, sp(line), &[lhs, seq]),
+            seq_span,
+        )
+    }
+
+    fn binding_membership_call(
+        b: &mut IlBuilder,
+        xs: Symbol,
+        item_name: Symbol,
+        includes: Symbol,
+        line: u32,
+    ) -> (NodeId, Span) {
+        let receiver = b.add(NodeKind::Var, Payload::Name(xs), sp(line), &[]);
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(includes),
+            sp(line + 1),
+            &[receiver],
+        );
+        let item = b.add(NodeKind::Var, Payload::Name(item_name), sp(line + 2), &[]);
+        let call_span = sp(line + 3);
+        (
+            b.add(NodeKind::Call, Payload::None, call_span, &[callee, item]),
+            call_span,
+        )
+    }
+
+    fn binding_append(b: &mut IlBuilder, xs: Symbol, line: u32) -> NodeId {
+        let append_receiver = b.add(NodeKind::Var, Payload::Name(xs), sp(line), &[]);
+        let appended = b.add(NodeKind::Lit, Payload::LitInt(1), sp(line), &[]);
+        b.add(
+            NodeKind::Call,
+            Payload::Builtin(Builtin::Append),
+            sp(line),
+            &[append_receiver, appended],
+        )
+    }
+
+    fn normalized_binding_membership_op(case: BindingMembershipCase) -> ValOp {
+        let interner = Interner::new();
+        let xs = interner.intern("xs");
+        let item_name = interner.intern("item");
+        let includes = interner.intern("includes");
+        let array = interner.intern("array");
+        let mut b = IlBuilder::new(FileId(0));
+        let ((root_children, seq_span), call_span) = match case {
+            BindingMembershipCase::Visible => {
+                let (assign, seq_span) = binding_assignment(&mut b, xs, array, 10);
+                let (call, call_span) =
+                    binding_membership_call(&mut b, xs, item_name, includes, 12);
+                ((vec![assign, call], seq_span), call_span)
+            }
+            BindingMembershipCase::Late => {
+                let (call, call_span) =
+                    binding_membership_call(&mut b, xs, item_name, includes, 12);
+                let (assign, seq_span) = binding_assignment(&mut b, xs, array, 20);
+                ((vec![call, assign], seq_span), call_span)
+            }
+            BindingMembershipCase::MutatedVisible => {
+                let (assign, seq_span) = binding_assignment(&mut b, xs, array, 20);
+                let append = binding_append(&mut b, xs, 22);
+                let (call, call_span) =
+                    binding_membership_call(&mut b, xs, item_name, includes, 23);
+                ((vec![assign, append, call], seq_span), call_span)
+            }
+        };
+        let body = b.add(NodeKind::Block, Payload::None, sp(9), &root_children);
+        let root = b.add(NodeKind::Func, Payload::None, sp(8), &[body]);
+        let mut il = finish_test_il(b, root, Lang::TypeScript);
+        il.evidence.push(collection_sequence_evidence(0, seq_span));
+        let normalized = crate::normalize(
+            &il,
+            &interner,
+            &crate::NormalizeOptions {
+                cfg_norm: false,
+                dataflow: false,
+                dce: false,
+                oracle: false,
+            },
+        );
+        let normalized_call = node_with_span(&normalized, NodeKind::Call, call_span);
+        eval_op(&normalized, &interner, normalized_call)
+    }
+
+    #[test]
+    fn membership_call_consumes_normalized_binding_domain_evidence() {
+        assert!(matches!(
+            normalized_binding_membership_op(BindingMembershipCase::Visible),
+            ValOp::Bin(op) if op == Op::In as u32
+        ));
+    }
+
+    #[test]
+    fn membership_call_rejects_binding_domain_after_receiver_use() {
+        assert!(
+            !matches!(
+                normalized_binding_membership_op(BindingMembershipCase::Late),
+                ValOp::Bin(op) if op == Op::In as u32
+            ),
+            "binding-domain evidence must not prove use-before-assignment receivers"
+        );
+    }
+
+    #[test]
+    fn mutated_binding_domain_evidence_keeps_membership_rewrite_closed() {
+        assert!(
+            !matches!(
+                normalized_binding_membership_op(BindingMembershipCase::MutatedVisible),
+                ValOp::Bin(op) if op == Op::In as u32
+            ),
+            "mutated binding must not receive binding-domain evidence"
+        );
+    }
+
     #[test]
     fn free_name_collection_factory_value_graph_requires_library_api_evidence() {
         let interner = Interner::new();
@@ -9291,6 +9551,18 @@ mod tests {
             }),
             vec![EvidenceId(3)],
         ));
+        il.evidence.push(evidence_with_dependencies(
+            5,
+            EvidenceAnchor::node(sp(107), NodeKind::Call),
+            EvidenceKind::Domain(DomainEvidence::Map),
+            vec![EvidenceId(3)],
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            6,
+            EvidenceAnchor::binding(sp(108), stable_symbol_hash("LOOKUP")),
+            EvidenceKind::Domain(DomainEvidence::Map),
+            vec![EvidenceId(5)],
+        ));
 
         let mut builder = Builder::new(&il, &interner);
         assert!(!builder.unit_defines_symbol(lookup));
@@ -9299,26 +9571,10 @@ mod tests {
             "read-only getOrDefault use must not mark LOOKUP as mutated"
         );
         builder.seed_module_value_bindings();
-        let raw = builder.eval(call, &FxHashMap::default());
-        let raw_args = builder.nodes[raw as usize].args.clone();
-        let raw_callee = raw_args[0];
-        let raw_receiver = builder.nodes[raw_callee as usize].args.first().copied();
-        assert_eq!(
-            builder.library_api_evidence_for_value_call(
-                raw,
-                raw_callee,
-                raw_receiver,
-                contract.id,
-                contract.callee,
-                4
-            ),
-            LibraryApiEvidenceStatus::Admitted
-        );
+        let map_value = builder.eval(call, &FxHashMap::default());
         assert!(matches!(
-            builder
-                .proven_map_value(raw)
-                .map(|value| builder.nodes[value as usize].op.clone()),
-            Some(ValOp::Seq(SEQ_VALUE_MAP))
+            builder.nodes[map_value as usize].op,
+            ValOp::Seq(SEQ_VALUE_MAP)
         ));
         let proven = builder.eval(lookup_ref, &FxHashMap::default());
         assert!(
@@ -9467,6 +9723,18 @@ mod tests {
                 root_kind: NodeKind::Call,
             }),
             vec![EvidenceId(3)],
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            5,
+            EvidenceAnchor::node(sp(137), NodeKind::Call),
+            EvidenceKind::Domain(DomainEvidence::Map),
+            vec![EvidenceId(3)],
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            6,
+            EvidenceAnchor::binding(sp(138), stable_symbol_hash("LOOKUP")),
+            EvidenceKind::Domain(DomainEvidence::Map),
+            vec![EvidenceId(5)],
         ));
 
         let mut builder = Builder::new(&il, &interner);

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -8,10 +8,10 @@
 
 use nose_il::{
     contains_js_identifier, stable_symbol_hash, Builtin, EffectEvidenceKind, EvidenceAnchor,
-    EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceRecord, EvidenceStatus, GuardEvidenceKind,
-    HoFKind, Il, ImportEvidenceKind, Interner, Lang, LibraryApiEvidenceKind, LitClass, NodeId,
-    NodeKind, Op, ParamSemantic, Payload, PlaceEvidenceKind, SequenceSurfaceKind, SourceCallKind,
-    SourceFactKind, SourceLiteralKind, SourceOperatorKind, Span, Symbol, SymbolEvidenceKind,
+    EvidenceEmitter, EvidenceKind, EvidenceRecord, EvidenceStatus, GuardEvidenceKind, HoFKind, Il,
+    ImportEvidenceKind, Interner, Lang, LibraryApiEvidenceKind, LitClass, NodeId, NodeKind, Op,
+    ParamSemantic, Payload, PlaceEvidenceKind, SequenceSurfaceKind, SourceCallKind, SourceFactKind,
+    SourceLiteralKind, SourceOperatorKind, Span, Symbol, SymbolEvidenceKind,
 };
 
 pub use nose_il::DomainEvidence;
@@ -96,8 +96,7 @@ fn unique_asserted_evidence_at<T: Copy + Eq>(
         let Some(value) = project(record.kind) else {
             continue;
         };
-        if record.status != EvidenceStatus::Asserted || !evidence_dependencies_asserted(il, record)
-        {
+        if record.status != EvidenceStatus::Asserted || !il.evidence_dependencies_asserted(record) {
             return EvidenceResolution::Ambiguous;
         }
         match found {
@@ -268,7 +267,22 @@ pub fn domain_evidence_for_node(il: &Il, node: NodeId) -> Option<DomainEvidence>
     }
 }
 
-pub fn domain_evidence_for_receiver(il: &Il, receiver: NodeId) -> Option<DomainEvidence> {
+pub fn domain_evidence_for_binding_lhs(
+    il: &Il,
+    interner: &Interner,
+    lhs: NodeId,
+) -> Option<DomainEvidence> {
+    match domain_evidence_at_binding_lhs(il, interner, lhs) {
+        EvidenceResolution::Found(domain) => Some(domain),
+        EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
+    }
+}
+
+pub fn domain_evidence_for_receiver(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+) -> Option<DomainEvidence> {
     match domain_evidence_at_exact_anchor(
         il,
         EvidenceAnchor::node(il.node(receiver).span, il.kind(receiver)),
@@ -277,21 +291,32 @@ pub fn domain_evidence_for_receiver(il: &Il, receiver: NodeId) -> Option<DomainE
         EvidenceResolution::Ambiguous => return None,
         EvidenceResolution::Missing => {}
     }
+    match domain_evidence_for_binding_reference(il, interner, receiver) {
+        EvidenceResolution::Found(domain) => return Some(domain),
+        EvidenceResolution::Ambiguous => return None,
+        EvidenceResolution::Missing => {}
+    }
     domain_evidence_for_var_reference(il, receiver)
 }
 
-pub fn domain_evidence_for_var(il: &Il, node: NodeId) -> Option<DomainEvidence> {
+pub fn domain_evidence_for_var(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<DomainEvidence> {
     (il.kind(node) == NodeKind::Var)
-        .then(|| domain_evidence_for_receiver(il, node))
+        .then(|| domain_evidence_for_receiver(il, interner, node))
         .flatten()
 }
 
 pub fn receiver_satisfies_domain(
     il: &Il,
+    interner: &Interner,
     receiver: NodeId,
     requirement: DomainRequirement,
 ) -> bool {
-    domain_evidence_for_receiver(il, receiver).is_some_and(|domain| requirement.accepts(domain))
+    domain_evidence_for_receiver(il, interner, receiver)
+        .is_some_and(|domain| requirement.accepts(domain))
 }
 
 fn domain_evidence_for_var_reference(il: &Il, node: NodeId) -> Option<DomainEvidence> {
@@ -324,6 +349,100 @@ fn domain_evidence_for_var_reference(il: &Il, node: NodeId) -> Option<DomainEvid
             domain_evidence_for_param(il, param)
         }
         _ => None,
+    }
+}
+
+fn domain_evidence_for_binding_reference(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> EvidenceResolution<DomainEvidence> {
+    if il.kind(node) != NodeKind::Var {
+        return EvidenceResolution::Missing;
+    }
+    let lhs = match unique_binding_lhs_for_var_reference(il, node) {
+        EvidenceResolution::Found(lhs) => lhs,
+        EvidenceResolution::Ambiguous => return EvidenceResolution::Ambiguous,
+        EvidenceResolution::Missing => return EvidenceResolution::Missing,
+    };
+    domain_evidence_at_binding_lhs(il, interner, lhs)
+}
+
+fn domain_evidence_at_binding_lhs(
+    il: &Il,
+    interner: &Interner,
+    lhs: NodeId,
+) -> EvidenceResolution<DomainEvidence> {
+    let span = il.node(lhs).span;
+    let Some(local_hash) = node_name_hash(il, interner, lhs) else {
+        return EvidenceResolution::Missing;
+    };
+    unique_asserted_evidence_at(
+        il,
+        |anchor| {
+            matches!(
+                anchor,
+                EvidenceAnchor::Binding {
+                    span: anchor_span,
+                    local_hash: anchor_hash,
+                } if anchor_span == span && anchor_hash == local_hash
+            )
+        },
+        |evidence| match evidence {
+            EvidenceKind::Domain(domain) => Some(domain),
+            _ => None,
+        },
+    )
+}
+
+fn unique_binding_lhs_for_var_reference(il: &Il, node: NodeId) -> EvidenceResolution<NodeId> {
+    let scope = nearest_scope(il, node);
+    let reference_is_free_name = matches!(il.node(node).payload, Payload::Name(_));
+    let mut found = None;
+    for (idx, candidate) in il.nodes.iter().enumerate() {
+        if candidate.kind != NodeKind::Assign {
+            continue;
+        }
+        let assign = NodeId(idx as u32);
+        let assignment_scope = nearest_scope(il, assign);
+        if assignment_scope != scope && !(reference_is_free_name && assignment_scope.is_none()) {
+            continue;
+        }
+        if !assignment_is_visible_at_reference(il, assign, node) {
+            continue;
+        }
+        let Some(&lhs) = il.children(assign).first() else {
+            continue;
+        };
+        if !var_references_same_binding(il, lhs, node) {
+            continue;
+        }
+        match found {
+            None => found = Some(lhs),
+            Some(existing) if existing == lhs => {}
+            Some(_) => return EvidenceResolution::Ambiguous,
+        }
+    }
+    found.map_or(EvidenceResolution::Missing, EvidenceResolution::Found)
+}
+
+fn assignment_is_visible_at_reference(il: &Il, assign: NodeId, reference: NodeId) -> bool {
+    il.node(assign).span.end_byte <= il.node(reference).span.start_byte
+}
+
+fn var_references_same_binding(il: &Il, lhs: NodeId, reference: NodeId) -> bool {
+    if il.kind(lhs) != NodeKind::Var || il.kind(reference) != NodeKind::Var {
+        return false;
+    }
+    match (il.node(lhs).payload, il.node(reference).payload) {
+        (Payload::Cid(lhs_cid), Payload::Cid(reference_cid)) => lhs_cid == reference_cid,
+        (Payload::Name(lhs_name), Payload::Name(reference_name)) => lhs_name == reference_name,
+        (Payload::Cid(lhs_cid), Payload::Name(reference_name))
+        | (Payload::Name(reference_name), Payload::Cid(lhs_cid)) => il
+            .cid_names
+            .get(lhs_cid as usize)
+            .is_some_and(|&lhs_name| lhs_name == reference_name),
+        _ => false,
     }
 }
 
@@ -956,7 +1075,7 @@ pub fn imported_literal_producer_evidence_at_span(il: &Il, span: Span, kind: Nod
                     }
                 ) if root_kind == kind
             )
-            && evidence_dependencies_asserted(il, record)
+            && il.evidence_dependencies_asserted(record)
     })
 }
 
@@ -972,7 +1091,7 @@ pub fn imported_literal_snapshot_evidence_at_span(il: &Il, span: Span, kind: Nod
                     ..
                 }) if root_kind == kind
             )
-            && evidence_dependencies_asserted(il, record)
+            && il.evidence_dependencies_asserted(record)
     })
 }
 
@@ -983,32 +1102,6 @@ pub fn imported_literal_producer_evidence_for_node(il: &Il, node: NodeId) -> boo
 fn first_party_record(record: &EvidenceRecord) -> bool {
     record.provenance.emitter == EvidenceEmitter::FirstParty
         && record.provenance.pack_hash == Some(stable_symbol_hash(FIRST_PARTY_PACK_ID))
-}
-
-fn evidence_dependencies_asserted(il: &Il, record: &EvidenceRecord) -> bool {
-    let mut stack = record.dependencies.clone();
-    let mut seen = Vec::new();
-    while let Some(id) = stack.pop() {
-        if seen.contains(&id) {
-            continue;
-        }
-        seen.push(id);
-        let Some(dep) = evidence_record_by_id(il, id) else {
-            return false;
-        };
-        if dep.status != EvidenceStatus::Asserted {
-            return false;
-        }
-        stack.extend_from_slice(&dep.dependencies);
-    }
-    true
-}
-
-fn evidence_record_by_id(il: &Il, id: EvidenceId) -> Option<&EvidenceRecord> {
-    il.evidence
-        .get(id.0 as usize)
-        .filter(|record| record.id == id)
-        .or_else(|| il.evidence.iter().find(|record| record.id == id))
 }
 
 fn symbol_evidence_at_node(il: &Il, node: NodeId) -> EvidenceResolution<SymbolEvidenceKind> {
@@ -2369,11 +2462,12 @@ pub fn method_receiver_domain_requirement(
 
 pub fn receiver_satisfies_method_domain(
     il: &Il,
+    interner: &Interner,
     receiver: NodeId,
     contract: MethodReceiverContract,
 ) -> bool {
     method_receiver_domain_requirement(contract)
-        .is_some_and(|requirement| receiver_satisfies_domain(il, receiver, requirement))
+        .is_some_and(|requirement| receiver_satisfies_domain(il, interner, receiver, requirement))
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -4153,7 +4247,7 @@ pub fn library_api_contract_evidence_for_call(
         saw_library_api_evidence = true;
         if record.status != EvidenceStatus::Asserted
             || api != expected
-            || !evidence_dependencies_asserted(il, record)
+            || !il.evidence_dependencies_asserted(record)
             || !library_api_callee_shape_matches(il, interner, node, callee)
             || !library_api_dependencies_match_callee(il, interner, node, callee, record)
         {
@@ -4198,7 +4292,7 @@ pub fn library_api_contract_evidence_at_call_span(
         saw_library_api_evidence = true;
         if record.status != EvidenceStatus::Asserted
             || api != expected
-            || !evidence_dependencies_asserted(il, record)
+            || !il.evidence_dependencies_asserted(record)
             || !library_api_dependencies_match_callee_at_span(
                 il,
                 interner,
@@ -4935,7 +5029,7 @@ fn dependency_has_imported_symbol_dependency(
     expected: SymbolEvidenceKind,
 ) -> bool {
     record.dependencies.iter().any(|&id| {
-        let Some(dependency) = evidence_record_by_id(il, id) else {
+        let Some(dependency) = il.evidence_record_by_id(id) else {
             return false;
         };
         dependency.status == EvidenceStatus::Asserted
@@ -4969,7 +5063,7 @@ fn dependency_has_imported_symbol_anchor(
         return false;
     }
     let Some(symbol_record) = record.dependencies.iter().find_map(|&id| {
-        let dependency = evidence_record_by_id(il, id)?;
+        let dependency = il.evidence_record_by_id(id)?;
         (dependency.anchor == EvidenceAnchor::node(span, kind)
             && dependency.status == EvidenceStatus::Asserted
             && dependency.kind == EvidenceKind::Symbol(expected))
@@ -4994,7 +5088,7 @@ fn imported_occurrence_symbol_dependencies_valid(
         return false;
     };
     let Some(binding_record) = symbol_record.dependencies.iter().find_map(|&id| {
-        let dependency = evidence_record_by_id(il, id)?;
+        let dependency = il.evidence_record_by_id(id)?;
         (dependency.status == EvidenceStatus::Asserted
             && dependency.kind == EvidenceKind::Symbol(expected)
             && matches!(dependency.anchor, EvidenceAnchor::Binding { .. }))
@@ -5157,7 +5251,7 @@ fn dependency_has_asserted_record(
     kind: EvidenceKind,
 ) -> bool {
     record.dependencies.iter().any(|&id| {
-        evidence_record_by_id(il, id).is_some_and(|dependency| {
+        il.evidence_record_by_id(id).is_some_and(|dependency| {
             dependency.anchor == anchor
                 && dependency.status == EvidenceStatus::Asserted
                 && dependency.kind == kind
@@ -6188,6 +6282,7 @@ mod tests {
 
     #[test]
     fn receiver_domain_evidence_at_node_is_preferred_over_param_evidence() {
+        let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
         let param = b.add(NodeKind::Param, Payload::Cid(0), span(10, 12, 1), &[]);
         let receiver = b.add(NodeKind::Var, Payload::Cid(0), span(20, 22, 2), &[]);
@@ -6223,16 +6318,18 @@ mod tests {
             Some(DomainEvidence::Set)
         );
         assert_eq!(
-            domain_evidence_for_receiver(&il, receiver),
+            domain_evidence_for_receiver(&il, &interner, receiver),
             Some(DomainEvidence::Map)
         );
         assert!(receiver_satisfies_domain(
             &il,
+            &interner,
             receiver,
             DomainRequirement::Map
         ));
         assert!(!receiver_satisfies_domain(
             &il,
+            &interner,
             receiver,
             DomainRequirement::Set
         ));
@@ -6270,11 +6367,232 @@ mod tests {
             EvidenceStatus::Asserted,
         ));
 
-        assert_eq!(domain_evidence_for_receiver(&il, receiver), None);
+        let interner = Interner::new();
+        assert_eq!(domain_evidence_for_receiver(&il, &interner, receiver), None);
+    }
+
+    fn binding_receiver_fixture(
+        interner: &Interner,
+        module_receiver: bool,
+    ) -> (Il, NodeId, NodeId) {
+        let xs = interner.intern("xs");
+        let mut b = IlBuilder::new(FileId(0));
+        let lhs = b.add(NodeKind::Var, Payload::Cid(0), span(10, 12, 1), &[]);
+        let rhs = b.add(NodeKind::Seq, Payload::None, span(15, 17, 1), &[]);
+        let assign = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            span(10, 17, 1),
+            &[lhs, rhs],
+        );
+        let receiver_payload = if module_receiver {
+            Payload::Name(xs)
+        } else {
+            Payload::Cid(0)
+        };
+        let receiver = b.add(NodeKind::Var, receiver_payload, span(40, 42, 3), &[]);
+        let root = if module_receiver {
+            let stmt = b.add(
+                NodeKind::ExprStmt,
+                Payload::None,
+                span(40, 42, 3),
+                &[receiver],
+            );
+            let body = b.add(NodeKind::Block, Payload::None, span(38, 45, 3), &[stmt]);
+            let func = b.add(NodeKind::Func, Payload::None, span(30, 50, 2), &[body]);
+            b.add(
+                NodeKind::Module,
+                Payload::None,
+                span(0, 60, 1),
+                &[assign, func],
+            )
+        } else {
+            let body = b.add(
+                NodeKind::Block,
+                Payload::None,
+                span(10, 44, 1),
+                &[assign, receiver],
+            );
+            b.add(NodeKind::Func, Payload::None, span(0, 50, 1), &[body])
+        };
+        let mut il = finish_il(b, root, Lang::TypeScript);
+        il.cid_names = vec![xs];
+        (il, lhs, receiver)
+    }
+
+    #[test]
+    fn binding_domain_evidence_drives_receiver_domain_proof() {
+        let interner = Interner::new();
+        let (mut il, lhs, receiver) = binding_receiver_fixture(&interner, false);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(span(10, 12, 1), stable_symbol_hash("xs")),
+            EvidenceKind::Domain(DomainEvidence::Collection),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert_eq!(
+            domain_evidence_for_binding_lhs(&il, &interner, lhs),
+            Some(DomainEvidence::Collection)
+        );
+        assert_eq!(
+            domain_evidence_for_receiver(&il, &interner, receiver),
+            Some(DomainEvidence::Collection)
+        );
+
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::binding(span(10, 12, 1), stable_symbol_hash("xs")),
+            EvidenceKind::Domain(DomainEvidence::Map),
+            EvidenceStatus::Asserted,
+        ));
+        assert_eq!(
+            domain_evidence_for_receiver(&il, &interner, receiver),
+            None,
+            "conflicting binding-domain evidence must close receiver proof"
+        );
+    }
+
+    #[test]
+    fn binding_domain_evidence_validates_dependencies() {
+        let interner = Interner::new();
+        let (mut il, _, receiver) = binding_receiver_fixture(&interner, false);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(span(15, 17, 1)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+            EvidenceStatus::Ambiguous,
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            1,
+            EvidenceAnchor::binding(span(10, 12, 1), stable_symbol_hash("xs")),
+            EvidenceKind::Domain(DomainEvidence::Collection),
+            EvidenceStatus::Asserted,
+            vec![EvidenceId(0)],
+        ));
+
+        assert_eq!(
+            domain_evidence_for_receiver(&il, &interner, receiver),
+            None,
+            "dependency-broken binding-domain evidence must fail closed"
+        );
+    }
+
+    #[test]
+    fn module_binding_domain_evidence_reaches_free_name_receiver() {
+        let interner = Interner::new();
+        let (mut il, _, receiver) = binding_receiver_fixture(&interner, true);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(span(10, 12, 1), stable_symbol_hash("xs")),
+            EvidenceKind::Domain(DomainEvidence::Collection),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert_eq!(
+            domain_evidence_for_receiver(&il, &interner, receiver),
+            Some(DomainEvidence::Collection)
+        );
+    }
+
+    #[test]
+    fn binding_domain_evidence_requires_matching_local_hash() {
+        let interner = Interner::new();
+        let xs = interner.intern("xs");
+        let ys = interner.intern("ys");
+        let mut b = IlBuilder::new(FileId(0));
+        let xs_lhs = b.add(NodeKind::Var, Payload::Cid(0), span(10, 12, 1), &[]);
+        let xs_rhs = b.add(NodeKind::Seq, Payload::None, span(14, 15, 1), &[]);
+        let xs_assign = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            span(10, 15, 1),
+            &[xs_lhs, xs_rhs],
+        );
+        let ys_lhs = b.add(NodeKind::Var, Payload::Cid(1), span(10, 12, 1), &[]);
+        let ys_rhs = b.add(NodeKind::Seq, Payload::None, span(18, 19, 1), &[]);
+        let ys_assign = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            span(16, 19, 1),
+            &[ys_lhs, ys_rhs],
+        );
+        let ys_receiver = b.add(NodeKind::Var, Payload::Cid(1), span(30, 32, 2), &[]);
+        let body = b.add(
+            NodeKind::Block,
+            Payload::None,
+            span(8, 34, 1),
+            &[xs_assign, ys_assign, ys_receiver],
+        );
+        let root = b.add(NodeKind::Func, Payload::None, span(0, 40, 1), &[body]);
+        let mut il = finish_il(b, root, Lang::TypeScript);
+        il.cid_names = vec![xs, ys];
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(span(10, 12, 1), stable_symbol_hash("xs")),
+            EvidenceKind::Domain(DomainEvidence::Collection),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert_eq!(
+            domain_evidence_for_binding_lhs(&il, &interner, xs_lhs),
+            Some(DomainEvidence::Collection)
+        );
+        assert_eq!(
+            domain_evidence_for_binding_lhs(&il, &interner, ys_lhs),
+            None,
+            "same-span binding evidence must not cross local_hash boundaries"
+        );
+        assert_eq!(
+            domain_evidence_for_receiver(&il, &interner, ys_receiver),
+            None
+        );
+    }
+
+    #[test]
+    fn binding_domain_evidence_requires_assignment_before_receiver() {
+        let interner = Interner::new();
+        let xs = interner.intern("xs");
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(NodeKind::Var, Payload::Cid(0), span(10, 12, 1), &[]);
+        let lhs = b.add(NodeKind::Var, Payload::Cid(0), span(20, 22, 2), &[]);
+        let rhs = b.add(NodeKind::Seq, Payload::None, span(24, 25, 2), &[]);
+        let assign = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            span(20, 25, 2),
+            &[lhs, rhs],
+        );
+        let body = b.add(
+            NodeKind::Block,
+            Payload::None,
+            span(8, 28, 1),
+            &[receiver, assign],
+        );
+        let root = b.add(NodeKind::Func, Payload::None, span(0, 30, 1), &[body]);
+        let mut il = finish_il(b, root, Lang::TypeScript);
+        il.cid_names = vec![xs];
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::binding(span(20, 22, 2), stable_symbol_hash("xs")),
+            EvidenceKind::Domain(DomainEvidence::Collection),
+            EvidenceStatus::Asserted,
+        ));
+
+        assert_eq!(
+            domain_evidence_for_binding_lhs(&il, &interner, lhs),
+            Some(DomainEvidence::Collection)
+        );
+        assert_eq!(
+            domain_evidence_for_receiver(&il, &interner, receiver),
+            None,
+            "binding-domain evidence must not prove use-before-assignment receivers"
+        );
     }
 
     #[test]
     fn cid_receiver_domain_uses_nearest_function_scope() {
+        let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
         let first_param = b.add(NodeKind::Param, Payload::Cid(0), span(10, 12, 1), &[]);
         let first_body = b.add(NodeKind::Block, Payload::None, span(14, 20, 1), &[]);
@@ -6320,13 +6638,14 @@ mod tests {
         ));
 
         assert_eq!(
-            domain_evidence_for_receiver(&il, receiver),
+            domain_evidence_for_receiver(&il, &interner, receiver),
             Some(DomainEvidence::Map)
         );
     }
 
     #[test]
     fn dependency_broken_receiver_domain_evidence_blocks_param_fallback() {
+        let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
         let param = b.add(NodeKind::Param, Payload::Cid(0), span(10, 12, 1), &[]);
         let receiver = b.add(NodeKind::Var, Payload::Cid(0), span(20, 22, 2), &[]);
@@ -6352,7 +6671,7 @@ mod tests {
             vec![EvidenceId(99)],
         ));
 
-        assert_eq!(domain_evidence_for_receiver(&il, receiver), None);
+        assert_eq!(domain_evidence_for_receiver(&il, &interner, receiver), None);
     }
 
     #[test]
@@ -6384,7 +6703,7 @@ mod tests {
         ));
 
         assert_eq!(
-            domain_evidence_for_receiver(&il, receiver),
+            domain_evidence_for_receiver(&il, &interner, receiver),
             Some(DomainEvidence::Collection)
         );
 
@@ -6425,7 +6744,7 @@ mod tests {
             EvidenceStatus::Asserted,
         ));
 
-        assert_eq!(domain_evidence_for_receiver(&il, receiver), None);
+        assert_eq!(domain_evidence_for_receiver(&il, &interner, receiver), None);
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,10 +39,11 @@ source ──tree-sitter──▶ raw IL ──normalize──▶ canonical IL �
 1. **Lower** ([languages](languages.md)): tree-sitter parses each file; a per-language pass
    walks the CST and emits raw IL using a small, desugared core node set. Every
    node copies its source span, so every match traces back to exact lines.
-   Frontends also emit source-origin facts when that core IL would otherwise erase
-   exact source distinctions needed by semantic contracts, then tag syntactic unit
-   boundaries (function/method/class/block), which gives detection accurate
-   boundaries for free.
+   Frontends also emit semantic evidence records when that core IL would
+   otherwise erase exact source, domain, import, symbol, guard, place/effect,
+   library API, or sequence-surface distinctions needed by semantic contracts,
+   then tag syntactic unit boundaries (function/method/class/block), which gives
+   detection accurate boundaries for free.
 2. **Normalize** ([normalization](normalization.md)): a fixed sequence of passes canonicalizes
    the IL — desugaring (with idiom canonicalization), alpha-renaming, an oracle cutoff,
    recursion-to-iteration normalization, dataflow propagation, control-flow normalization,
@@ -81,8 +82,8 @@ A Cargo workspace; data flows left-to-right through them.
 |---|---|
 | `nose-il` | arena IL model (`Vec<Node>`, `NodeId(u32)`, out-of-line edges), provenance spans, semantic evidence records, interner, serialization, IR verifier |
 | `nose-semantics` | first-party semantic facade: language profiles, evidence/source-fact helpers, effect/operator/module/stdlib predicates, API contracts, and exact-channel proof obligations |
-| `nose-frontend` | tree-sitter parse + per-language CST→IL lowering and source-fact emission (one module per language; embedded `<script>` extraction) |
-| `nose-normalize` | the normalization passes + the value graph (GVN) |
+| `nose-frontend` | tree-sitter parse + per-language CST→IL lowering and first-party evidence emission (one module per language; embedded `<script>` extraction) |
+| `nose-normalize` | the normalization passes, inferred immutable binding-domain evidence, and the value graph (GVN) |
 | `nose-detect` | unit/feature extraction, MinHash/LSH, scoring, clustering, refactor ranking |
 | `nose-eval` | benchmark scoring (precision/recall, pooled, stratified) — see [benchmark](benchmark.md) |
 | `nose-cli` | the `nose` binary, config loading, baselines, caching |

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -132,13 +132,16 @@ symbol fact or stronger scope-resolution evidence exists.
 
 Domain evidence follows the same fail-closed rule. First-party parameter
 annotations emit `Domain` evidence on `Param` anchors, and `nose-semantics`
-resolves `Domain` evidence on exact receiver-expression node anchors before
-consulting parameter-anchor evidence. A conflicting, ambiguous, or
-dependency-broken receiver-domain record closes that receiver proof and must not
-fall back to side-table mirrors or selector spelling. When a receiver is an
-alpha-renamed parameter reference, lookup is constrained to the nearest
-function/lambda scope so same-numbered parameter ids from other units do not
-prove the current receiver. Method receiver contracts expose their domain-backed
+resolves `Domain` evidence on exact receiver-expression node anchors, then
+binding anchors for immutable local/module variables, then parameter anchors. A
+conflicting, ambiguous, or dependency-broken receiver-domain record closes that
+receiver proof and must not fall back to side-table mirrors or selector
+spelling. Binding-anchor lookup matches both source span and `local_hash`, and a
+binding proof is applied to a receiver only when the assignment is visible before
+that receiver use. When a receiver is an alpha-renamed parameter or local binding
+reference, lookup is constrained to the nearest function/lambda scope where
+appropriate so same-numbered parameter/local ids from other units do not prove
+the current receiver. Method receiver contracts expose their domain-backed
 obligations through `DomainRequirement`; obligations such as imported namespace,
 unshadowed global, exact map literal, and future demand/effect constraints remain
 separate checks.
@@ -215,8 +218,11 @@ First-party frontends now emit these facts as `EvidenceRecord`:
 - parameter semantic annotations become `Domain` evidence. Selected first-party
   library/API factory calls now also emit receiver-expression `Domain` evidence
   at the exact call node after their `LibraryApi` occurrence has been admitted.
-  Future packs and inference producers should use the same node-anchored
-  receiver-domain shape instead of selector spelling;
+  Normalize also emits binding-anchored `Domain` evidence for single-assignment
+  local/module bindings whose initializer has asserted sequence or result-domain
+  evidence and whose binding has no direct mutation under the current
+  first-party mutation scan. Future packs and inference producers should use
+  node or binding anchors for receiver-domain proof instead of selector spelling;
 - source-origin facts become `Source` evidence;
 - import binding and namespace lowering emits `Import` evidence for the proof RHS
   and `Symbol` evidence for the local alias identity;
@@ -296,13 +302,16 @@ The first migrated consumers are the shared semantic helpers and their direct
 callers:
 
 - source-fact lookup for construct syntax, regex literal, and operator provenance;
-- receiver-domain lookup used by desugaring, normalize idiom canonicalization,
-  value-graph membership/property/map/integer gates, and strict exact receiver
-  gates. Consumers ask `nose-semantics` whether a receiver satisfies a
-  `DomainRequirement`, so node-anchored receiver evidence, scoped parameter
-  evidence, selected API result-domain evidence, ambiguity handling, and
-  compatibility fallback are no longer reimplemented separately in each crate.
-  Coarse API result-domain evidence is not exact-tree proof: value-graph
+- receiver-domain lookup used by post-desugar semantic/value-graph
+  membership/property/map/integer gates and strict exact receiver gates.
+  Consumers ask `nose-semantics` whether a receiver satisfies a
+  `DomainRequirement`, so node-anchored receiver evidence, immutable
+  local/module binding evidence, scoped parameter evidence, selected API
+  result-domain evidence, ambiguity handling, and compatibility fallback are no
+  longer reimplemented separately in those paths. Desugaring and early idiom
+  canonicalization still run before immutable binding-domain inference, so they
+  only consume the domain evidence already present at that point. Coarse API
+  result-domain and binding-domain evidence is not exact-tree proof: value-graph
   consumers prefer concrete factory/result-shape canonicalization before using a
   domain-shaped fallback, and strict exact consumers still require the receiver
   expression itself to satisfy the relevant factory, literal, binding, or
@@ -359,8 +368,8 @@ callers:
 
 Broader field/place/effect facts, `LibraryApi` occurrence evidence for remaining
 receiver-method APIs and unmodeled stdlib/ecosystem APIs, broader inferred
-receiver-expression domain evidence, immutable local/module binding domain
-evidence, full protocol/demand/effect receiver obligations, full
-scope-resolution and namespace-member evidence, broader guard evidence, general
-cross-module dependency manifests, report-level provenance, and external
-manifest loading are still open work.
+receiver-expression domain evidence, first-class mutation/effect evidence beyond
+the current first-party binding scan, full protocol/demand/effect receiver
+obligations, full scope-resolution and namespace-member evidence, broader guard
+evidence, general cross-module dependency manifests, report-level provenance,
+and external manifest loading are still open work.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -351,6 +351,14 @@ and pack ecosystem.
   `Map.entry`, `Array.isArray`, `Boolean`, regex `.test`, `math.prod`,
   `Arrays.stream`, map `get`, promise `.then`, iterator adapters, and generic
   method contracts.
+- Immutable local/module binding domains now produce binding-anchored `Domain`
+  evidence during normalization when the initializer has asserted sequence or
+  result-domain evidence, the binding is single-assignment in the current scope,
+  and the first-party mutation scan finds no direct binding/place mutation.
+  `nose-semantics` resolves receiver-domain proof from exact receiver nodes,
+  binding anchors, and scoped parameters through the same `DomainRequirement`
+  helper, so value-graph and strict exact gates no longer maintain separate
+  collection/map binding proof sets.
 - An experimental `abstraction` scan mode landed as a weak sibling claim over a
   narrow `near` subset. It emits typed literal-hole witnesses and caveats for
   refactoring-template candidates, but does not feed `semantic`, `verify`, or exact
@@ -471,12 +479,12 @@ Remaining in this phase:
   requires per-entry surface evidence.
 - Continue expanding domain evidence beyond parameter annotations. The shared
   receiver-domain consumer contract now accepts exact node-anchored receiver
-  facts, and first-party producers now emit them for selected admitted
-  library/API factory results. Remaining work is broader inferred receiver
+  facts, binding-anchored immutable local/module facts, and selected admitted
+  library/API factory result facts. Remaining work is broader inferred receiver
   domains, Java constructor call-domain evidence if that lowering stops
-  collapsing directly to sequence surfaces, immutable local/module binding
-  domain evidence, mutation exclusion, and protocol-specific receiver facts that
-  include demand/effect obligations.
+  collapsing directly to sequence surfaces, first-class mutation/effect evidence
+  beyond the current first-party binding scan, and protocol-specific receiver
+  facts that include demand/effect obligations.
 - Turn named value-graph rule modules into LawPack-facing law ids/contracts while
   retaining formal-obligation metadata as the first-party proof boundary.
 - Add receiver/place facts so field read/write and property contracts are not

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -18,7 +18,9 @@ occurrence evidence covering selected JS-like static/global APIs, Python
 builtin/import-backed APIs, Rust free-name/path APIs, Ruby require-backed APIs,
 Java `java.util` APIs, and JS regex API calls. Selected producer-covered
 factory/API calls now also emit dependent receiver-expression `Domain` evidence
-for their result container domain.
+for their result container domain, and normalize emits binding-anchored `Domain`
+evidence for immutable local/module bindings whose initializer domain and
+non-mutation conditions are proven by first-party evidence/analysis.
 
 ## What exists today
 
@@ -26,17 +28,16 @@ nose now has a first internal semantic-kernel facade, but most of the engine is
 still being migrated toward it.
 
 - `nose-il` defines a compact shared IL, `Lang`, `Builtin`, `HoFKind`, operators,
-  literals, source spans, units, compatibility parameter/source facts, and
-  pack-facing internal `EvidenceRecord` facts.
+  literals, source spans, units, and pack-facing internal `EvidenceRecord` facts.
 - `nose-semantics` defines the first-party semantic profile facade: language,
   source-fact, operator, effect, fragment, module, stdlib, builtin, method-call,
   property, async, iterator-adapter, builder-append, and factory contracts.
 - `nose-frontend` owns tree-sitter parsing, per-language lowering, embedded
-  `<script>` extraction, import facts, source-origin fact emission, and Raw-node
-  coverage.
+  `<script>` extraction, source/domain/import/symbol/guard/place/effect/API/
+  sequence evidence emission, and Raw-node coverage.
 - `nose-normalize` owns desugaring, alpha-renaming, recursion normalization,
-  dataflow, CFG/algebra normalization, type-gated value-graph rules, and the
-  interpreter oracle.
+  immutable binding-domain evidence inference, dataflow, CFG/algebra
+  normalization, type-gated value-graph rules, and the interpreter oracle.
 - proof-sensitive value-graph laws are starting to move into named rule modules
   under `crates/nose-normalize/src/value_graph/rules/`; `clamp` and
   `promise_then` are the current examples.
@@ -95,15 +96,23 @@ migrated.
 - Source-level `ParamSemantic` facts are stored directly as
   `EvidenceRecord::Domain`, and `nose-semantics` resolves receiver-domain
   evidence through a shared `DomainRequirement` contract. Consumers check exact
-  receiver node evidence first, then scoped parameter evidence, and fail closed
-  on ambiguous/conflicting/dependency-broken records without consulting a
-  side-table mirror. Desugaring, normalize idiom canonicalization, value-graph
-  receiver gates, and strict exact receiver gates consume this same helper layer.
-  This preserves the current Array/Collection/Set/Map/Option/String/Integer/Number
-  and ByteArray distinctions. First-party producers now attach
+  receiver node evidence first, then immutable binding evidence for local or
+  module variables, then scoped parameter evidence, and fail closed on
+  ambiguous/conflicting/dependency-broken records without consulting a side-table
+  mirror. Post-desugar value-graph receiver gates and strict exact receiver
+  gates consume this same helper layer; desugaring and early idiom
+  canonicalization still run before immutable binding-domain inference and only
+  see domain evidence already present at that point. This preserves the current
+  Array/Collection/Set/Map/Option/String/Integer/Number and ByteArray
+  distinctions. First-party producers now attach
   receiver-expression domain facts directly for selected admitted library/API
-  factory results, while future packs or inference passes can use the same
-  node-anchored shape for broader domains.
+  factory results, and normalize emits binding-anchored `Domain` evidence for
+  single-assignment local/module bindings whose initializer has asserted
+  sequence or result-domain evidence and whose binding has no direct mutation
+  under the current first-party mutation scan. Binding-domain lookup matches the
+  binding `local_hash` and only applies an assignment to receiver uses that occur
+  after it. That mutation scan is producer policy; general mutation/effect
+  evidence remains separate future work.
 - Property builtin contracts are language-constrained; a selector such as
   `length` is not enough without receiver proof. JS/TS `filter(...).length`
   is admitted only after the receiver has already entered a proven collection/HOF
@@ -374,8 +383,8 @@ migrated.
   contracts.
 - Strict exact collection-membership gates no longer treat any strict-safe
   expression as collection evidence. Non-literal receivers must now be proven by
-  typed parameter facts, local collection/map binding facts, or module-level
-  immutable collection/map binding facts.
+  `Domain` evidence from exact receiver nodes, immutable local/module binding
+  anchors, scoped parameter annotations, or selected admitted API result records.
 
 ## Scattered semantic knowledge
 
@@ -410,13 +419,13 @@ Semantic knowledge still appears in several forms outside the facade:
   instead of versioned `LawPack` records;
 - hard-coded oracle evaluation rules for eager calls, short-circuit operators,
   HOFs, nullish defaulting, recursion, and effect traces;
-- duplicated receiver/domain and library/API proof gates in desugaring,
-  idiom lowering, value-graph, and strict exact paths. `LibraryApi` occurrence
-  evidence now reduces this for selected JS-like static/global APIs,
-  Python builtin/import-backed factories/functions, Rust free-name/path
-  factories, Ruby `require "set"; Set.new(...)`, Java `java.util` static
-  factories/adapters, and JS regex literals, but Java empty constructors and
-  broad receiver-method surfaces still rely on contract rows plus local proof.
+- duplicated library/API proof gates in desugaring, idiom lowering, value-graph,
+  and strict exact paths. `LibraryApi` occurrence evidence now reduces this for
+  selected JS-like static/global APIs, Python builtin/import-backed
+  factories/functions, Rust free-name/path factories, Ruby
+  `require "set"; Set.new(...)`, Java `java.util` static factories/adapters, and
+  JS regex literals, but Java empty constructors and broad receiver-method
+  surfaces still rely on contract rows plus local proof.
 
 These are valuable, but they do not yet share one complete semantic contract
 language.


### PR DESCRIPTION
## Summary

This is the larger semantic-kernel slice for immutable binding-domain evidence. It is based on latest `origin/main` (`e2b02bd`, including #132 scan-performance/cache work) and keeps the change as one PR rather than splitting the migration into small review fragments.

- add a pre-alpha normalize pass that emits first-party `Domain` evidence for single-assignment local/module bindings whose initializer has asserted sequence/result-domain evidence and no direct mutation under the current first-party scan
- centralize first-party evidence insertion, evidence id lookup, and dependency-closure validation on `Il`
- teach `nose-semantics` to resolve receiver domain proof through node, binding, and scoped parameter evidence without raw name guessing
- require binding receiver proof to match both binding span and `local_hash`, and require the assignment to be visible before the receiver use
- move value graph and strict exact collection/map receiver handling to consume binding-domain evidence instead of recomputing raw RHS/mutation facts
- keep Java Map factory/provider canonicalization evidence-backed, including imported/provider-seeded map bindings
- update docs to distinguish current snapshot from roadmap/history and to scope binding-domain consumption to post-desugar consumers

## Review-blocker follow-up included

A read-only subagent review found three blockers before opening the PR. This PR includes fixes and regressions for all three:

- same-span different binding locals no longer share `Domain` proof because binding lookup now checks `local_hash`
- use-before-assignment receivers no longer consume later binding-domain evidence, including value-graph membership rewrites
- docs no longer claim immutable binding-domain evidence is available to desugar/early idiom canonicalization before the binding pass runs

Also included: provenance-aware `Il::find_or_push_first_party_evidence`, so external or different-rule evidence is not reused as first-party evidence.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --release`
- `git diff --check`
- `awiki lint --root docs`
- `./scripts/check-duplication.sh`
- `./scripts/check-lean-proofs.sh`
- `python3 scripts/check-formal-obligations.py --self-test`
- `python3 scripts/check-formal-obligations.py`

Fixes part of #109.
