### PR TITLE
Move receiver method APIs onto occurrence evidence

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -33,8 +33,8 @@ use nose_semantics::{
     typeof_operator_contract, unshadowed_global_symbol, DomainRequirement,
     IndexMembershipThreshold, JavaMapFactoryKind, LibraryApiCalleeContract,
     LibraryApiEvidenceStatus, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
-    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
-    StaticIndexMembershipKind,
+    LibraryMapGetContract, LibraryMethodCallContract, MapKeyViewKind, MethodBuiltinArgs,
+    MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -1292,6 +1292,38 @@ fn library_api_evidence_required(
     )
 }
 
+fn call_arg_count(il: &Il, node: NodeId) -> usize {
+    il.children(node).len().saturating_sub(1)
+}
+
+fn admitted_method_call_contract(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    method: &str,
+) -> Option<(LibraryMethodCallContract, usize)> {
+    let arg_count = call_arg_count(il, node);
+    let contract = library_method_call_contract(il.meta.lang, method, arg_count)?;
+    library_api_evidence_required(il, interner, node, contract.id, contract.callee, arg_count)
+        .then_some((contract, arg_count))
+}
+
+fn admitted_map_get_contract(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    method: &str,
+) -> Option<(LibraryMapGetContract, usize)> {
+    let arg_count = call_arg_count(il, node);
+    let contract = library_map_get_contract(il.meta.lang, method, arg_count)?;
+    library_api_evidence_required(il, interner, node, contract.id, contract.callee, arg_count)
+        .then_some((contract, arg_count))
+}
+
+fn field_receiver(il: &Il, callee: NodeId) -> Option<NodeId> {
+    il.children(callee).first().copied()
+}
+
 fn strict_exact_regex_test_safe(
     il: &Il,
     interner: &Interner,
@@ -1326,7 +1358,7 @@ fn strict_exact_js_array_is_array_safe(
     callee: NodeId,
     method: &str,
 ) -> bool {
-    let Some(&receiver) = il.children(callee).first() else {
+    let Some(receiver) = field_receiver(il, callee) else {
         return false;
     };
     let (NodeKind::Var, Payload::Name(receiver_name)) =
@@ -1334,7 +1366,7 @@ fn strict_exact_js_array_is_array_safe(
     else {
         return false;
     };
-    let arg_count = il.children(node).len().saturating_sub(1);
+    let arg_count = call_arg_count(il, node);
     let Some(contract) = library_js_array_is_array_contract(
         il.meta.lang,
         interner.resolve(receiver_name),
@@ -1357,24 +1389,21 @@ fn strict_exact_collection_contains_call_safe(
     callee: NodeId,
     method: &str,
 ) -> bool {
-    let Some(contract) = library_method_call_contract(
-        il.meta.lang,
-        method,
-        il.children(node).len().saturating_sub(1),
-    ) else {
+    let Some((contract, _arg_count)) = admitted_method_call_contract(il, interner, node, method)
+    else {
         return false;
     };
-    let contract = contract.result;
-    if contract.semantic != MethodSemanticContract::Builtin(Builtin::Contains)
-        || contract.args != MethodBuiltinArgs::FirstThenReceiver
+    let result = contract.result;
+    if result.semantic != MethodSemanticContract::Builtin(Builtin::Contains)
+        || result.args != MethodBuiltinArgs::FirstThenReceiver
     {
         return false;
     }
-    let receiver_safe = match contract.receiver {
+    let receiver_safe = match result.receiver {
         MethodReceiverContract::ExactCollection
         | MethodReceiverContract::ExactCollectionOrMap
         | MethodReceiverContract::ExactCollectionOrJavaKeySet => {
-            let Some(&receiver) = il.children(callee).first() else {
+            let Some(receiver) = field_receiver(il, callee) else {
                 return false;
             };
             strict_exact_literal_collection_receiver_safe(il, interner, facts, receiver)
@@ -1387,7 +1416,7 @@ fn strict_exact_collection_contains_call_safe(
                 || strict_exact_map_key_view_collection_safe(il, interner, facts, receiver)
         }
         MethodReceiverContract::ExactSetOrMap => {
-            let Some(&receiver) = il.children(callee).first() else {
+            let Some(receiver) = field_receiver(il, callee) else {
                 return false;
             };
             strict_exact_typed_set_param_receiver_safe(il, interner, receiver)
@@ -1406,18 +1435,15 @@ fn strict_exact_map_contains_call_safe(
     callee: NodeId,
     method: &str,
 ) -> bool {
-    let Some(contract) = library_method_call_contract(
-        il.meta.lang,
-        method,
-        il.children(node).len().saturating_sub(1),
-    ) else {
+    let Some((contract, _arg_count)) = admitted_method_call_contract(il, interner, node, method)
+    else {
         return false;
     };
-    let contract = contract.result;
-    if contract.semantic != MethodSemanticContract::Builtin(Builtin::Contains)
-        || contract.args != MethodBuiltinArgs::FirstThenReceiver
+    let result = contract.result;
+    if result.semantic != MethodSemanticContract::Builtin(Builtin::Contains)
+        || result.args != MethodBuiltinArgs::FirstThenReceiver
         || !matches!(
-            contract.receiver,
+            result.receiver,
             MethodReceiverContract::ExactMap
                 | MethodReceiverContract::ExactCollectionOrMap
                 | MethodReceiverContract::ExactSetOrMap
@@ -1425,7 +1451,7 @@ fn strict_exact_map_contains_call_safe(
     {
         return false;
     }
-    let Some(&receiver) = il.children(callee).first() else {
+    let Some(receiver) = field_receiver(il, callee) else {
         return false;
     };
     strict_exact_map_receiver_or_factory_safe(il, interner, facts, receiver, true)
@@ -1440,16 +1466,11 @@ fn strict_exact_map_get_call_safe(
     callee: NodeId,
     method: &str,
 ) -> bool {
-    if library_map_get_contract(
-        il.meta.lang,
-        method,
-        il.children(node).len().saturating_sub(1),
-    )
-    .is_none()
-    {
+    let Some((_contract, _arg_count)) = admitted_map_get_contract(il, interner, node, method)
+    else {
         return false;
-    }
-    let Some(&receiver) = il.children(callee).first() else {
+    };
+    let Some(receiver) = field_receiver(il, callee) else {
         return false;
     };
     strict_exact_map_receiver_or_factory_safe(il, interner, facts, receiver, false)
@@ -1464,28 +1485,25 @@ fn strict_exact_map_get_default_call_safe(
     callee: NodeId,
     method: &str,
 ) -> bool {
-    let Some(contract) = library_method_call_contract(
-        il.meta.lang,
-        method,
-        il.children(node).len().saturating_sub(1),
-    ) else {
+    let Some((contract, _arg_count)) = admitted_method_call_contract(il, interner, node, method)
+    else {
         return false;
     };
-    let contract = contract.result;
-    if contract.semantic != MethodSemanticContract::Builtin(Builtin::GetOrDefault)
-        || contract.receiver != MethodReceiverContract::ExactMap
+    let result = contract.result;
+    if result.semantic != MethodSemanticContract::Builtin(Builtin::GetOrDefault)
+        || result.receiver != MethodReceiverContract::ExactMap
         || !matches!(
-            contract.args,
+            result.args,
             MethodBuiltinArgs::MapGetDefault | MethodBuiltinArgs::MapGetDefaultOrZeroArgLambda
         )
     {
         return false;
     }
-    let Some(&receiver) = il.children(callee).first() else {
+    let Some(receiver) = field_receiver(il, callee) else {
         return false;
     };
     strict_exact_map_receiver_or_factory_safe(il, interner, facts, receiver, false)
-        && strict_exact_map_get_default_args_safe(il, interner, facts, node, contract.args)
+        && strict_exact_map_get_default_args_safe(il, interner, facts, node, result.args)
 }
 
 fn strict_exact_map_receiver_or_factory_safe(
@@ -1567,7 +1585,12 @@ fn strict_exact_iterator_identity_adapter_call_safe(
     let Some(arg_count) = kids.len().checked_sub(1) else {
         return false;
     };
-    if library_iterator_identity_adapter_contract(il.meta.lang, method, arg_count).is_none() {
+    let Some(contract) =
+        library_iterator_identity_adapter_contract(il.meta.lang, method, arg_count)
+    else {
+        return false;
+    };
+    if !library_api_evidence_required(il, interner, node, contract.id, contract.callee, arg_count) {
         return false;
     }
     if il.kind(callee) != NodeKind::Field {
@@ -1732,8 +1755,11 @@ fn strict_exact_map_key_view_safe_matching(
     else {
         return false;
     };
-    let contract = contract.result;
-    if !accepts(contract.kind) {
+    if !library_api_evidence_required(il, interner, node, contract.id, contract.callee, 0) {
+        return false;
+    }
+    let result = contract.result;
+    if !accepts(result.kind) {
         return false;
     }
     let Some(&receiver) = il.children(kids[0]).first() else {
@@ -3886,7 +3912,8 @@ mod tests {
     use nose_semantics::{
         library_api_callee_contract_hash, library_api_contract_id_hash,
         library_java_collection_factory_contract, library_js_like_map_constructor_contract,
-        library_js_like_set_constructor_contract, FIRST_PARTY_PACK_ID,
+        library_js_like_set_constructor_contract, library_method_call_contract,
+        FIRST_PARTY_PACK_ID,
     };
 
     fn sp(line: u32) -> Span {
@@ -3929,6 +3956,26 @@ mod tests {
                 callee_hash: library_api_callee_contract_hash(callee),
                 arity,
             }),
+            dependencies,
+        )
+    }
+
+    fn method_call_library_api_evidence(
+        id: u32,
+        lang: Lang,
+        method: &str,
+        call_span: Span,
+        arity: usize,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceRecord {
+        let contract =
+            library_method_call_contract(lang, method, arity).expect("method call contract");
+        library_api_contract_evidence(
+            id,
+            call_span,
+            contract.id,
+            contract.callee,
+            arity as u16,
             dependencies,
         )
     }
@@ -4025,11 +4072,19 @@ mod tests {
             EvidenceKind::Domain(nose_semantics::DomainEvidence::Collection),
             Vec::new(),
         ));
+        il.evidence.push(method_call_library_api_evidence(
+            1,
+            Lang::TypeScript,
+            "includes",
+            sp(53),
+            1,
+            vec![EvidenceId(0)],
+        ));
         let facts = StrictFacts::collect(&il, &interner);
         assert!(strict_exact_safe_tree(&il, &interner, &facts, call));
 
         il.evidence.push(evidence(
-            1,
+            2,
             EvidenceAnchor::node(receiver_span, NodeKind::Var),
             EvidenceKind::Domain(nose_semantics::DomainEvidence::Map),
             Vec::new(),
@@ -4074,6 +4129,14 @@ mod tests {
             EvidenceKind::Domain(nose_semantics::DomainEvidence::Collection),
             Vec::new(),
         ));
+        il.evidence.push(method_call_library_api_evidence(
+            1,
+            Lang::TypeScript,
+            "includes",
+            sp(35),
+            1,
+            vec![EvidenceId(0)],
+        ));
 
         let facts = StrictFacts::collect(&il, &interner);
         assert!(strict_exact_collection_contains_call_safe(
@@ -4081,7 +4144,7 @@ mod tests {
         ));
 
         il.evidence.push(evidence(
-            1,
+            2,
             EvidenceAnchor::binding(sp(30), stable_symbol_hash("xs")),
             EvidenceKind::Domain(nose_semantics::DomainEvidence::Map),
             Vec::new(),
@@ -4359,6 +4422,14 @@ mod tests {
             2,
             vec![EvidenceId(1)],
         ));
+        il.evidence.push(method_call_library_api_evidence(
+            3,
+            Lang::Java,
+            "contains",
+            sp(28),
+            1,
+            vec![EvidenceId(2)],
+        ));
         let facts = StrictFacts::collect(&il, &interner);
         assert!(strict_exact_java_collection_factory_safe(
             &il, &interner, &facts, factory
@@ -4367,6 +4438,7 @@ mod tests {
 
         let wrong = library_js_like_set_constructor_contract(Lang::JavaScript, "Set").unwrap();
         il.evidence.pop();
+        il.evidence.pop();
         il.evidence.push(library_api_contract_evidence(
             2,
             sp(25),
@@ -4374,6 +4446,14 @@ mod tests {
             wrong.callee,
             2,
             vec![EvidenceId(1)],
+        ));
+        il.evidence.push(method_call_library_api_evidence(
+            3,
+            Lang::Java,
+            "contains",
+            sp(28),
+            1,
+            vec![EvidenceId(2)],
         ));
         let facts = StrictFacts::collect(&il, &interner);
         assert!(!strict_exact_java_collection_factory_safe(

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -2036,6 +2036,30 @@ mod tests {
             .collect()
     }
 
+    fn library_api_dependency_counts_for(
+        il: &Il,
+        contract_hash: u64,
+        callee_hash: u64,
+        arity: u16,
+    ) -> Vec<usize> {
+        il.evidence
+            .iter()
+            .filter_map(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                        contract_hash: actual_contract,
+                        callee_hash: actual_callee,
+                        arity: actual_arity,
+                    }) if actual_contract == contract_hash
+                        && actual_callee == callee_hash
+                        && actual_arity == arity
+                )
+                .then_some(record.dependencies.len())
+            })
+            .collect()
+    }
+
     fn js_record_shape_guard_evidence(il: &Il) -> Vec<&nose_il::EvidenceRecord> {
         il.evidence
             .iter()
@@ -2169,9 +2193,26 @@ mod tests {
         assert!(
             library_api_dependency_counts(&il)
                 .into_iter()
-                .all(|count| count >= 2),
-            "selected JS API evidence should depend on source/symbol proof"
+                .all(|count| count >= 1),
+            "selected JS API evidence should depend on explicit proof"
         );
+        for (id, callee, arity) in [
+            (map.id, map.callee, 1),
+            (set.id, set.callee, 1),
+            (is_array.id, is_array.callee, 1),
+        ] {
+            assert!(
+                library_api_dependency_counts_for(
+                    &il,
+                    library_api_contract_id_hash(id),
+                    library_api_callee_contract_hash(callee),
+                    arity,
+                )
+                .into_iter()
+                .all(|count| count >= 2),
+                "selected JS static/global API evidence should depend on source/symbol proof"
+            );
+        }
         assert!(
             !il.nodes
                 .iter()

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -11,7 +11,8 @@ use nose_il::{
 };
 use nose_semantics::{
     library_api_callee_contract_hash, library_api_contract_id_hash,
-    library_api_free_name_shadow_safe, library_collection_factory_result_domain_for_arity,
+    library_api_free_name_shadow_safe, library_api_receiver_dependencies_for_call_with_cache,
+    library_collection_factory_result_domain_for_arity,
     library_free_name_collection_factory_contract, library_free_name_map_factory_contract,
     library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
     library_java_collection_factory_contract, library_java_map_entry_contract,
@@ -19,10 +20,11 @@ use nose_semantics::{
     library_js_boolean_coercion_contract, library_js_like_map_constructor_contract,
     library_js_like_set_constructor_contract, library_map_factory_result_domain,
     library_map_key_view_wrapper_contract, library_map_key_view_wrapper_result_domain,
-    library_regex_test_contract, library_ruby_set_factory_contract,
-    library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
-    library_static_collection_adapter_contract, sequence_surface_kind_for_tag, ImportFactKind,
-    LibraryApiCalleeContract, LibraryApiContractId,
+    library_receiver_method_api_contract, library_regex_test_contract,
+    library_ruby_set_factory_contract, library_rust_vec_macro_factory_contract,
+    library_rust_vec_new_factory_contract, library_static_collection_adapter_contract,
+    sequence_surface_kind_for_tag, ImportFactKind, LibraryApiCalleeContract, LibraryApiContractId,
+    LibraryApiDependencyCache, MethodReceiverContract,
 };
 use tree_sitter::Node as TsNode;
 
@@ -1174,11 +1176,15 @@ fn record_post_lower_library_api_evidence(il: &mut Il, interner: &Interner) {
                 .then_some(NodeId(idx as u32))
         })
         .collect();
+    let mut dependency_cache = LibraryApiDependencyCache::default();
     for call in calls {
         if record_post_lower_free_name_library_api(il, interner, call) {
             continue;
         }
-        record_post_lower_ruby_static_member_library_api(il, interner, call);
+        if record_post_lower_ruby_static_member_library_api(il, interner, call) {
+            continue;
+        }
+        record_post_lower_receiver_method_library_api(il, interner, call, &mut dependency_cache);
     }
 }
 
@@ -1372,6 +1378,87 @@ fn record_post_lower_ruby_static_member_library_api(
     true
 }
 
+fn record_post_lower_receiver_method_library_api(
+    il: &mut Il,
+    interner: &Interner,
+    call: NodeId,
+    dependency_cache: &mut LibraryApiDependencyCache,
+) -> bool {
+    let kids = il.children(call);
+    let Some((&callee, args)) = kids.split_first() else {
+        return false;
+    };
+    if il.kind(callee) != NodeKind::Field {
+        return false;
+    }
+    let Payload::Name(method) = il.node(callee).payload else {
+        return false;
+    };
+    let method = interner.resolve(method);
+    let arg_count = args.len();
+    let Some(contract) = library_receiver_method_api_contract(il.meta.lang, method, arg_count)
+    else {
+        return false;
+    };
+    seed_post_lower_receiver_method_dependencies(il, interner, callee, contract.callee);
+    let Some(dependencies) = library_api_receiver_dependencies_for_call_with_cache(
+        il,
+        interner,
+        call,
+        contract.callee,
+        dependency_cache,
+    ) else {
+        return false;
+    };
+    post_lower_library_api_evidence_id(
+        il,
+        call,
+        contract.id,
+        contract.callee,
+        arg_count,
+        contract.rule,
+        dependencies,
+    );
+    true
+}
+
+fn seed_post_lower_receiver_method_dependencies(
+    il: &mut Il,
+    interner: &Interner,
+    callee: NodeId,
+    callee_contract: LibraryApiCalleeContract,
+) {
+    let LibraryApiCalleeContract::Method { receiver, .. } = callee_contract else {
+        return;
+    };
+    let Some(&receiver_node) = il.children(callee).first() else {
+        return;
+    };
+    match receiver {
+        MethodReceiverContract::UnshadowedGlobal(name) => {
+            if post_lower_var_name(il, interner, receiver_node) == Some(name)
+                && !post_lower_file_defines_name_visible_at(
+                    il,
+                    interner,
+                    name,
+                    il.node(receiver_node).span,
+                )
+            {
+                let _ = post_lower_unshadowed_symbol_evidence_id(il, receiver_node, name);
+            }
+        }
+        MethodReceiverContract::ImportedNamespace(module) => {
+            let _ = post_lower_imported_namespace_symbol_evidence_id(
+                il,
+                interner,
+                receiver_node,
+                module,
+            );
+        }
+        _ => {}
+    }
+}
+
 fn post_lower_var_name<'a>(il: &Il, interner: &'a Interner, node: NodeId) -> Option<&'a str> {
     if il.kind(node) != NodeKind::Var {
         return None;
@@ -1399,6 +1486,51 @@ fn post_lower_unshadowed_symbol_evidence_id(
         "symbol_unshadowed_global_post_lower",
         vec![],
     )
+}
+
+fn post_lower_imported_namespace_symbol_evidence_id(
+    il: &mut Il,
+    interner: &Interner,
+    node: NodeId,
+    module: &str,
+) -> Option<EvidenceId> {
+    let expected = SymbolEvidenceKind::ImportedNamespace {
+        module_hash: stable_symbol_hash(module),
+    };
+    let dependency = post_lower_binding_symbol_evidence_id(il, interner, node, expected)?;
+    post_lower_find_or_push_evidence(
+        il,
+        EvidenceAnchor::node(il.node(node).span, NodeKind::Var),
+        EvidenceKind::Symbol(expected),
+        "symbol_imported_namespace_occurrence_post_lower",
+        vec![dependency],
+    )
+}
+
+fn post_lower_binding_symbol_evidence_id(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    expected: SymbolEvidenceKind,
+) -> Option<EvidenceId> {
+    if il.kind(node) != NodeKind::Var {
+        return None;
+    }
+    let Payload::Name(local) = il.node(node).payload else {
+        return None;
+    };
+    let local_hash = stable_symbol_hash(interner.resolve(local));
+    il.evidence.iter().find_map(|record| {
+        (matches!(
+            record.anchor,
+            EvidenceAnchor::Binding {
+                local_hash: anchor_hash,
+                ..
+            } if anchor_hash == local_hash
+        ) && record.kind == EvidenceKind::Symbol(expected)
+            && record.status == EvidenceStatus::Asserted)
+            .then_some(record.id)
+    })
 }
 
 fn post_lower_required_module_evidence_id(
@@ -1556,38 +1688,7 @@ fn post_lower_file_defines_name_visible_at(
     name: &str,
     occurrence_span: Span,
 ) -> bool {
-    let name_hash = stable_symbol_hash(name);
-    il.units.iter().any(|unit| {
-        il.node(unit.root).span.file == occurrence_span.file
-            && unit
-                .name
-                .is_some_and(|symbol| stable_symbol_hash(interner.resolve(symbol)) == name_hash)
-    }) || il.nodes.iter().enumerate().any(|(idx, node)| {
-        node.span.file == occurrence_span.file
-            && match node.kind {
-                NodeKind::Module | NodeKind::Block | NodeKind::Param => {
-                    post_lower_node_defines_name(il, interner, NodeId(idx as u32), name_hash)
-                }
-                NodeKind::Assign => il
-                    .children(NodeId(idx as u32))
-                    .first()
-                    .copied()
-                    .is_some_and(|lhs| post_lower_node_defines_name(il, interner, lhs, name_hash)),
-                _ => false,
-            }
-    })
-}
-
-fn post_lower_node_defines_name(
-    il: &Il,
-    interner: &Interner,
-    node: NodeId,
-    name_hash: u64,
-) -> bool {
-    matches!(
-        il.node(node).payload,
-        Payload::Name(symbol) if stable_symbol_hash(interner.resolve(symbol)) == name_hash
-    )
+    nose_semantics::file_defines_name_visible_at(il, interner, name, occurrence_span)
 }
 
 fn normalize_type_text(text: &str) -> String {

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -16,11 +16,11 @@ use nose_semantics::{
     library_api_contract_evidence_for_call, library_free_name_map_factory_contract,
     library_iterator_identity_adapter_contract, library_map_get_contract,
     library_map_key_view_contract, library_method_call_contract,
-    library_static_collection_adapter_contract, method_hof_contract,
-    rust_option_some_constructor_contract, seq_surface_contract_for_node, unshadowed_global_symbol,
-    BuiltinArgContract, DomainRequirement, LibraryApiCalleeContract, LibraryApiEvidenceStatus,
-    LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs, MethodCallContract,
-    MethodReceiverContract, MethodSemanticContract, SEQ_VALUE_MAP,
+    library_static_collection_adapter_contract, rust_option_some_constructor_contract,
+    seq_surface_contract_for_node, unshadowed_global_symbol, BuiltinArgContract, DomainRequirement,
+    LibraryApiCalleeContract, LibraryApiEvidenceStatus, LibraryMapFactoryResult, MapKeyViewKind,
+    MethodBuiltinArgs, MethodCallContract, MethodReceiverContract, MethodSemanticContract,
+    SEQ_VALUE_MAP,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -328,6 +328,16 @@ pub(crate) fn canon_call_with_domains(
                 if let Some(contract) =
                     library_method_call_contract(old.meta.lang, fname, args.len())
                 {
+                    if !library_api_evidence_admitted(
+                        old,
+                        interner,
+                        call_id,
+                        contract.id,
+                        contract.callee,
+                        args.len(),
+                    ) {
+                        return CallCanon::None;
+                    }
                     let Some(base) = base else {
                         return CallCanon::None;
                     };
@@ -675,8 +685,16 @@ fn unwrap_iter(old: &Il, interner: &Interner, node: NodeId) -> NodeId {
                         method,
                         call_kids.len() - 1,
                     )
-                    .is_some()
-                    {
+                    .is_some_and(|contract| {
+                        library_api_evidence_admitted(
+                            old,
+                            interner,
+                            node,
+                            contract.id,
+                            contract.callee,
+                            call_kids.len() - 1,
+                        )
+                    }) {
                         if let Some(&base) = old.children(callee).first() {
                             return unwrap_iter(old, interner, base);
                         }
@@ -727,20 +745,50 @@ fn exact_protocol_receiver(
         return exact_collection_receiver(old, interner, domains, arg);
     }
     if let Some(contract) = library_method_call_contract(old.meta.lang, method, kids.len() - 1) {
-        let contract = contract.result;
-        if contract.semantic == MethodSemanticContract::Builtin(Builtin::Zip)
-            && contract.receiver == MethodReceiverContract::ExactProtocolPairArgument
-            && contract.args == MethodBuiltinArgs::RustZip
+        if contract.result.semantic == MethodSemanticContract::Builtin(Builtin::Zip)
+            && contract.result.receiver == MethodReceiverContract::ExactProtocolPairArgument
+            && contract.result.args == MethodBuiltinArgs::RustZip
+            && library_api_evidence_admitted(
+                old,
+                interner,
+                node,
+                contract.id,
+                contract.callee,
+                kids.len() - 1,
+            )
         {
             return exact_protocol_receiver(old, interner, domains, receiver)
                 && exact_protocol_receiver(old, interner, domains, kids[1]);
         }
     }
-    if library_iterator_identity_adapter_contract(old.meta.lang, method, kids.len() - 1).is_some() {
+    if library_iterator_identity_adapter_contract(old.meta.lang, method, kids.len() - 1)
+        .is_some_and(|contract| {
+            library_api_evidence_admitted(
+                old,
+                interner,
+                node,
+                contract.id,
+                contract.callee,
+                kids.len() - 1,
+            )
+        })
+    {
         return exact_protocol_receiver(old, interner, domains, receiver);
     }
-    if method_hof_contract(old.meta.lang, method).is_some() && kids.len() >= 2 {
-        return exact_protocol_receiver(old, interner, domains, receiver);
+    if let Some(contract) = library_method_call_contract(old.meta.lang, method, kids.len() - 1) {
+        if matches!(contract.result.semantic, MethodSemanticContract::HoF(_))
+            && kids.len() >= 2
+            && library_api_evidence_admitted(
+                old,
+                interner,
+                node,
+                contract.id,
+                contract.callee,
+                kids.len() - 1,
+            )
+        {
+            return exact_protocol_receiver(old, interner, domains, receiver);
+        }
     }
     false
 }
@@ -777,6 +825,20 @@ fn static_collection_adapter_arg(
         LibraryApiEvidenceStatus::Missing => return None,
     }
     call_kids.get(1).copied()
+}
+
+fn library_api_evidence_admitted(
+    old: &Il,
+    interner: &Interner,
+    call: NodeId,
+    id: nose_semantics::LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+    arg_count: usize,
+) -> bool {
+    matches!(
+        library_api_contract_evidence_for_call(old, interner, call, id, callee, arg_count),
+        LibraryApiEvidenceStatus::Admitted
+    )
 }
 
 fn exact_set_param(old: &Il, domains: &ParamDomainIndex, node: NodeId) -> bool {
@@ -1012,7 +1074,10 @@ fn map_get_call_parts(old: &Il, interner: &Interner, id: NodeId) -> Option<(Node
     let Payload::Name(method) = old.node(kids[0]).payload else {
         return None;
     };
-    library_map_get_contract(old.meta.lang, interner.resolve(method), 1)?;
+    let contract = library_map_get_contract(old.meta.lang, interner.resolve(method), 1)?;
+    if !library_api_evidence_admitted(old, interner, id, contract.id, contract.callee, 1) {
+        return None;
+    }
     let receiver = *old.children(kids[0]).first()?;
     Some((receiver, kids[1]))
 }
@@ -1028,8 +1093,11 @@ fn key_set_receiver(old: &Il, interner: &Interner, id: NodeId) -> Option<NodeId>
     let Payload::Name(method) = old.node(kids[0]).payload else {
         return None;
     };
-    let contract =
-        library_map_key_view_contract(old.meta.lang, interner.resolve(method), 0)?.result;
+    let contract = library_map_key_view_contract(old.meta.lang, interner.resolve(method), 0)?;
+    if !library_api_evidence_admitted(old, interner, id, contract.id, contract.callee, 0) {
+        return None;
+    }
+    let contract = contract.result;
     if contract.kind != MapKeyViewKind::Collection {
         return None;
     }
@@ -1138,6 +1206,88 @@ mod tests {
         }
     }
 
+    fn next_evidence_id(il: &Il) -> u32 {
+        il.evidence.len() as u32
+    }
+
+    fn method_call_receiver(il: &Il, call: NodeId) -> Option<NodeId> {
+        let callee = *il.children(call).first()?;
+        (il.kind(callee) == NodeKind::Field)
+            .then(|| il.children(callee).first().copied())
+            .flatten()
+    }
+
+    fn push_sequence_surface_evidence(
+        il: &mut Il,
+        node: NodeId,
+        surface: SequenceSurfaceKind,
+    ) -> EvidenceId {
+        let id = next_evidence_id(il);
+        il.evidence.push(evidence(
+            id,
+            EvidenceAnchor::sequence(il.node(node).span),
+            EvidenceKind::SequenceSurface(surface),
+            EvidenceStatus::Asserted,
+        ));
+        EvidenceId(id)
+    }
+
+    fn push_receiver_sequence_surface_evidence(
+        il: &mut Il,
+        call: NodeId,
+        surface: SequenceSurfaceKind,
+    ) -> EvidenceId {
+        let receiver = method_call_receiver(il, call).expect("method receiver");
+        push_sequence_surface_evidence(il, receiver, surface)
+    }
+
+    fn push_receiver_method_library_api_evidence(
+        il: &mut Il,
+        interner: &Interner,
+        call: NodeId,
+    ) -> Option<EvidenceId> {
+        let kids = il.children(call);
+        let (&callee, args) = kids.split_first()?;
+        if il.kind(callee) != NodeKind::Field {
+            return None;
+        }
+        let Payload::Name(method) = il.node(callee).payload else {
+            return None;
+        };
+        let method = interner.resolve(method);
+        let arg_count = args.len();
+        let contract = library_map_get_contract(il.meta.lang, method, arg_count)
+            .map(|contract| (contract.id, contract.callee))
+            .or_else(|| {
+                library_map_key_view_contract(il.meta.lang, method, arg_count)
+                    .map(|contract| (contract.id, contract.callee))
+            })
+            .or_else(|| {
+                library_iterator_identity_adapter_contract(il.meta.lang, method, arg_count)
+                    .map(|contract| (contract.id, contract.callee))
+            })
+            .or_else(|| {
+                library_method_call_contract(il.meta.lang, method, arg_count)
+                    .map(|contract| (contract.id, contract.callee))
+            })?;
+        let dependencies = nose_semantics::library_api_receiver_dependencies_for_call(
+            il, interner, call, contract.1,
+        )?;
+        let id = next_evidence_id(il);
+        il.evidence.push(evidence_with_dependencies(
+            id,
+            EvidenceAnchor::node(il.node(call).span, NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: nose_semantics::library_api_contract_id_hash(contract.0),
+                callee_hash: nose_semantics::library_api_callee_contract_hash(contract.1),
+                arity: arg_count as u16,
+            }),
+            EvidenceStatus::Asserted,
+            dependencies,
+        ));
+        Some(EvidenceId(id))
+    }
+
     fn free_call_il(lang: Lang, name: &str, shadow_name: bool) -> (Il, Interner, NodeId) {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
@@ -1207,7 +1357,7 @@ mod tests {
         );
         let call = b.add(NodeKind::Call, Payload::None, sp(), &[field, func]);
         let root = b.add(NodeKind::Module, Payload::None, sp(), &[call]);
-        let il = b.finish(
+        let mut il = b.finish(
             root,
             FileMeta {
                 path: "t".to_string(),
@@ -1216,6 +1366,10 @@ mod tests {
             Vec::new(),
             Vec::new(),
         );
+        if literal_receiver {
+            push_receiver_sequence_surface_evidence(&mut il, call, SequenceSurfaceKind::Collection);
+            let _ = push_receiver_method_library_api_evidence(&mut il, &interner, call);
+        }
         (il, interner, call)
     }
 
@@ -1249,7 +1403,7 @@ mod tests {
         );
         let call = b.add(NodeKind::Call, Payload::None, sp(), &[field]);
         let root = b.add(NodeKind::Module, Payload::None, sp(), &[call]);
-        let il = b.finish(
+        let mut il = b.finish(
             root,
             FileMeta {
                 path: "t".to_string(),
@@ -1258,6 +1412,10 @@ mod tests {
             Vec::new(),
             Vec::new(),
         );
+        if literal_receiver {
+            push_receiver_sequence_surface_evidence(&mut il, call, SequenceSurfaceKind::Collection);
+            let _ = push_receiver_method_library_api_evidence(&mut il, &interner, call);
+        }
         (il, interner, call)
     }
 
@@ -1307,7 +1465,7 @@ mod tests {
         };
         let call = b.add(NodeKind::Call, Payload::None, sp(), &[field, arg]);
         let root = b.add(NodeKind::Module, Payload::None, sp(), &[call]);
-        let il = b.finish(
+        let mut il = b.finish(
             root,
             FileMeta {
                 path: "t".to_string(),
@@ -1316,6 +1474,13 @@ mod tests {
             Vec::new(),
             Vec::new(),
         );
+        if literal_receiver {
+            push_receiver_sequence_surface_evidence(&mut il, call, SequenceSurfaceKind::Collection);
+        }
+        if literal_arg {
+            push_sequence_surface_evidence(&mut il, arg, SequenceSurfaceKind::Collection);
+        }
+        let _ = push_receiver_method_library_api_evidence(&mut il, &interner, call);
         (il, interner, call)
     }
 
@@ -1358,7 +1523,7 @@ mod tests {
         };
         let call = b.add(NodeKind::Call, Payload::None, sp(), &[field, key, fallback]);
         let root = b.add(NodeKind::Module, Payload::None, sp(), &[call]);
-        let il = b.finish(
+        let mut il = b.finish(
             root,
             FileMeta {
                 path: "t".to_string(),
@@ -1367,6 +1532,8 @@ mod tests {
             Vec::new(),
             Vec::new(),
         );
+        push_receiver_sequence_surface_evidence(&mut il, call, SequenceSurfaceKind::Map);
+        let _ = push_receiver_method_library_api_evidence(&mut il, &interner, call);
         (il, interner, call, fallback_value)
     }
 
@@ -1435,6 +1602,7 @@ mod tests {
                 EvidenceStatus::Asserted,
             ));
         }
+        let _ = push_receiver_method_library_api_evidence(&mut il, &interner, call);
         (il, interner, call)
     }
 
@@ -1482,6 +1650,7 @@ mod tests {
             EvidenceKind::Domain(domain),
             EvidenceStatus::Asserted,
         ));
+        let _ = push_receiver_method_library_api_evidence(&mut il, &interner, call);
         (il, interner, call, receiver_span)
     }
 
@@ -1593,7 +1762,7 @@ mod tests {
         let call = b.add(NodeKind::Call, Payload::None, sp(), &[field, arg]);
         module_kids.push(call);
         let root = b.add(NodeKind::Module, Payload::None, sp(), &module_kids);
-        let il = b.finish(
+        let mut il = b.finish(
             root,
             FileMeta {
                 path: "t".to_string(),
@@ -1602,6 +1771,17 @@ mod tests {
             Vec::new(),
             cid_names,
         );
+        if !shadow_console {
+            il.evidence.push(evidence(
+                0,
+                EvidenceAnchor::node(il.node(receiver).span, NodeKind::Var),
+                EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                    name_hash: stable_symbol_hash("console"),
+                }),
+                EvidenceStatus::Asserted,
+            ));
+            let _ = push_receiver_method_library_api_evidence(&mut il, &interner, call);
+        }
         (il, interner, call)
     }
 
@@ -1672,6 +1852,16 @@ mod tests {
                 }),
                 EvidenceStatus::Asserted,
             ));
+            il.evidence.push(evidence_with_dependencies(
+                2,
+                EvidenceAnchor::node(sp(), NodeKind::Var),
+                EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace {
+                    module_hash: stable_symbol_hash("math"),
+                }),
+                EvidenceStatus::Asserted,
+                vec![EvidenceId(1)],
+            ));
+            let _ = push_receiver_method_library_api_evidence(&mut il, &interner, call);
         }
         (il, interner, call)
     }
@@ -1826,7 +2016,7 @@ mod tests {
         let (mut il, interner, call, receiver_span) =
             receiver_domain_method_call_il(DomainEvidence::Collection);
         il.evidence.push(evidence(
-            1,
+            next_evidence_id(&il),
             EvidenceAnchor::node(receiver_span, NodeKind::Var),
             EvidenceKind::Domain(DomainEvidence::Map),
             EvidenceStatus::Asserted,

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -23,6 +23,7 @@ mod dce;
 mod desugar;
 mod idioms;
 mod interp;
+mod library_api_evidence;
 mod literals;
 pub mod module_facts;
 mod recursion;
@@ -234,6 +235,8 @@ pub fn normalize(il: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il {
     timer.lap("desugar");
     binding_evidence::run(&mut out, interner);
     timer.lap("binding");
+    library_api_evidence::run(&mut out, interner);
+    timer.lap("api-evidence");
     alpha::run(&mut out);
     timer.lap("alpha");
     if opts.oracle {
@@ -266,6 +269,8 @@ pub fn normalize(il: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il {
         cfg_norm::run(&mut out, interner);
         timer.lap("cfg-orient");
     }
+    library_api_evidence::run(&mut out, interner);
+    timer.lap("api-evidence-final");
     // IR-verifier discipline: in debug/test builds, assert the rewrite pipeline
     // produced a structurally well-formed arena. Free in release.
     debug_assert!(

--- a/crates/nose-normalize/src/library_api_evidence.rs
+++ b/crates/nose-normalize/src/library_api_evidence.rs
@@ -1,0 +1,207 @@
+use nose_il::{
+    stable_symbol_hash, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceStatus,
+    Il, Interner, LibraryApiEvidenceKind, NodeId, NodeKind, Payload, SymbolEvidenceKind,
+};
+use nose_semantics::{
+    library_api_callee_contract_hash, library_api_contract_id_hash,
+    library_api_receiver_dependencies_for_call_with_cache, library_receiver_method_api_contract,
+    LibraryApiCalleeContract, LibraryApiDependencyCache, MethodReceiverContract,
+    FIRST_PARTY_PACK_ID,
+};
+
+pub(crate) fn run(il: &mut Il, interner: &Interner) {
+    let calls: Vec<NodeId> = il
+        .nodes
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, node)| (node.kind == NodeKind::Call).then_some(NodeId(idx as u32)))
+        .collect();
+    let mut dependency_cache = LibraryApiDependencyCache::default();
+    for call in calls {
+        record_receiver_method_library_api(il, interner, call, &mut dependency_cache);
+    }
+}
+
+fn record_receiver_method_library_api(
+    il: &mut Il,
+    interner: &Interner,
+    call: NodeId,
+    dependency_cache: &mut LibraryApiDependencyCache,
+) -> bool {
+    let kids = il.children(call);
+    let Some((&callee, args)) = kids.split_first() else {
+        return false;
+    };
+    if il.kind(callee) != NodeKind::Field {
+        return false;
+    }
+    let Payload::Name(method) = il.node(callee).payload else {
+        return false;
+    };
+    let method = interner.resolve(method);
+    let arg_count = args.len();
+    let Some(contract) = library_receiver_method_api_contract(il.meta.lang, method, arg_count)
+    else {
+        return false;
+    };
+    seed_receiver_method_dependencies(il, interner, callee, contract.callee);
+    let Some(dependencies) = library_api_receiver_dependencies_for_call_with_cache(
+        il,
+        interner,
+        call,
+        contract.callee,
+        dependency_cache,
+    ) else {
+        return false;
+    };
+    upsert_first_party_evidence(
+        il,
+        EvidenceAnchor::node(il.node(call).span, NodeKind::Call),
+        EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+            contract_hash: library_api_contract_id_hash(contract.id),
+            callee_hash: library_api_callee_contract_hash(contract.callee),
+            arity: arg_count as u16,
+        }),
+        contract.rule,
+        dependencies,
+    );
+    true
+}
+
+fn seed_receiver_method_dependencies(
+    il: &mut Il,
+    interner: &Interner,
+    callee: NodeId,
+    callee_contract: LibraryApiCalleeContract,
+) {
+    let LibraryApiCalleeContract::Method { receiver, .. } = callee_contract else {
+        return;
+    };
+    let Some(&receiver_node) = il.children(callee).first() else {
+        return;
+    };
+    match receiver {
+        MethodReceiverContract::UnshadowedGlobal(name) => {
+            if node_name(il, interner, receiver_node) == Some(name)
+                && !file_defines_name_visible_at(il, interner, name, il.node(receiver_node).span)
+            {
+                let _ = unshadowed_symbol_evidence_id(il, receiver_node, name);
+            }
+        }
+        MethodReceiverContract::ImportedNamespace(module) => {
+            let _ = imported_namespace_symbol_evidence_id(il, interner, receiver_node, module);
+        }
+        _ => {}
+    }
+}
+
+fn unshadowed_symbol_evidence_id(il: &mut Il, node: NodeId, expected: &str) -> Option<EvidenceId> {
+    (il.kind(node) == NodeKind::Var).then_some(())?;
+    Some(upsert_first_party_evidence(
+        il,
+        EvidenceAnchor::node(il.node(node).span, NodeKind::Var),
+        EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+            name_hash: stable_symbol_hash(expected),
+        }),
+        "symbol_unshadowed_global_normalize",
+        Vec::new(),
+    ))
+}
+
+fn imported_namespace_symbol_evidence_id(
+    il: &mut Il,
+    interner: &Interner,
+    node: NodeId,
+    module: &str,
+) -> Option<EvidenceId> {
+    let expected = SymbolEvidenceKind::ImportedNamespace {
+        module_hash: stable_symbol_hash(module),
+    };
+    let dependency = binding_symbol_evidence_id(il, interner, node, expected)?;
+    Some(upsert_first_party_evidence(
+        il,
+        EvidenceAnchor::node(il.node(node).span, NodeKind::Var),
+        EvidenceKind::Symbol(expected),
+        "symbol_imported_namespace_occurrence_normalize",
+        vec![dependency],
+    ))
+}
+
+fn binding_symbol_evidence_id(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    expected: SymbolEvidenceKind,
+) -> Option<EvidenceId> {
+    if il.kind(node) != NodeKind::Var {
+        return None;
+    }
+    let local_hash = node_name_hash(il, interner, node)?;
+    il.evidence.iter().find_map(|record| {
+        (matches!(
+            record.anchor,
+            EvidenceAnchor::Binding {
+                local_hash: anchor_hash,
+                ..
+            } if anchor_hash == local_hash
+        ) && record.kind == EvidenceKind::Symbol(expected)
+            && record.status == EvidenceStatus::Asserted)
+            .then_some(record.id)
+    })
+}
+
+fn node_name<'a>(il: &Il, interner: &'a Interner, node: NodeId) -> Option<&'a str> {
+    if il.kind(node) != NodeKind::Var {
+        return None;
+    }
+    match il.node(node).payload {
+        Payload::Name(symbol) => Some(interner.resolve(symbol)),
+        Payload::Cid(cid) => il
+            .cid_names
+            .get(cid as usize)
+            .map(|&symbol| interner.resolve(symbol)),
+        _ => None,
+    }
+}
+
+fn node_name_hash(il: &Il, interner: &Interner, node: NodeId) -> Option<u64> {
+    node_name(il, interner, node).map(stable_symbol_hash)
+}
+
+fn file_defines_name_visible_at(
+    il: &Il,
+    interner: &Interner,
+    name: &str,
+    occurrence_span: nose_il::Span,
+) -> bool {
+    nose_semantics::file_defines_name_visible_at(il, interner, name, occurrence_span)
+}
+
+fn upsert_first_party_evidence(
+    il: &mut Il,
+    anchor: EvidenceAnchor,
+    kind: EvidenceKind,
+    rule: &str,
+    dependencies: Vec<EvidenceId>,
+) -> EvidenceId {
+    let pack_hash = stable_symbol_hash(FIRST_PARTY_PACK_ID);
+    let rule_hash = stable_symbol_hash(rule);
+    let mut found = None;
+    for record in &mut il.evidence {
+        if record.anchor == anchor
+            && record.kind == kind
+            && record.status == EvidenceStatus::Asserted
+            && record.provenance.emitter == EvidenceEmitter::FirstParty
+            && record.provenance.pack_hash == Some(pack_hash)
+        {
+            if found.is_none() {
+                found = Some(record.id);
+            }
+            record.provenance.rule_hash = Some(rule_hash);
+            record.dependencies = dependencies.clone();
+        }
+    }
+    found.unwrap_or_else(|| {
+        il.find_or_push_first_party_evidence(anchor, kind, FIRST_PARTY_PACK_ID, rule, dependencies)
+    })
+}

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -1633,11 +1633,31 @@ impl<'a> Builder<'a> {
             LibraryApiSpanEvidenceQuery {
                 call_span: self.node_span[value as usize],
                 callee_span: self.library_api_value_span(callee),
-                receiver_span: receiver.and_then(|receiver| self.library_api_value_span(receiver)),
+                receiver_span: self.library_api_receiver_query_span(value, callee, receiver),
                 id,
                 callee: callee_contract,
                 arg_count,
             },
+        )
+    }
+
+    fn library_api_evidence_admitted(
+        &self,
+        call: NodeId,
+        id: nose_semantics::LibraryApiContractId,
+        callee: LibraryApiCalleeContract,
+        arg_count: usize,
+    ) -> bool {
+        matches!(
+            library_api_contract_evidence_for_call(
+                self.il,
+                self.interner,
+                call,
+                id,
+                callee,
+                arg_count,
+            ),
+            LibraryApiEvidenceStatus::Admitted
         )
     }
 
@@ -1646,6 +1666,46 @@ impl<'a> Builder<'a> {
             ValOp::ImportBinding { .. } | ValOp::ImportNamespace { .. } => None,
             _ => self.node_span[value as usize],
         }
+    }
+
+    fn library_api_receiver_query_span(
+        &self,
+        value: ValueId,
+        callee: ValueId,
+        receiver: Option<ValueId>,
+    ) -> Option<Span> {
+        let receiver_span = receiver.and_then(|receiver| self.library_api_value_span(receiver))?;
+        let Some(call_span) = self.node_span[value as usize] else {
+            return Some(receiver_span);
+        };
+        let Some(callee_span) = self.library_api_value_span(callee) else {
+            return Some(receiver_span);
+        };
+        if self
+            .source_call_receiver_span(call_span, callee_span)
+            .is_some_and(|source_receiver_span| source_receiver_span != receiver_span)
+        {
+            None
+        } else {
+            Some(receiver_span)
+        }
+    }
+
+    fn source_call_receiver_span(&self, call_span: Span, callee_span: Span) -> Option<Span> {
+        self.il.nodes.iter().enumerate().find_map(|(idx, node)| {
+            if node.kind != NodeKind::Call || node.span != call_span {
+                return None;
+            }
+            let call = NodeId(idx as u32);
+            let callee = self.il.children(call).first().copied()?;
+            if self.il.node(callee).span != callee_span {
+                return None;
+            }
+            self.il
+                .children(callee)
+                .first()
+                .map(|&receiver| self.il.node(receiver).span)
+        })
     }
 
     fn eval_js_like_constructed_collection_or_map(
@@ -1808,9 +1868,25 @@ impl<'a> Builder<'a> {
         let ValOp::Field(method) = callee.op else {
             return None;
         };
-        library_map_get_contract_by_hash(self.il.meta.lang, method, args.len().saturating_sub(1))?;
+        let contract = library_map_get_contract_by_hash(
+            self.il.meta.lang,
+            method,
+            args.len().saturating_sub(1),
+        )?;
         if callee.args.len() != 1 {
             return None;
+        }
+        match self.library_api_evidence_for_value_call(
+            value,
+            args[0],
+            Some(callee.args[0]),
+            contract.id,
+            contract.callee,
+            args.len().saturating_sub(1),
+        ) {
+            LibraryApiEvidenceStatus::Admitted => {}
+            LibraryApiEvidenceStatus::Rejected => return None,
+            LibraryApiEvidenceStatus::Missing => return None,
         }
         let map = callee.args[0];
         let map = if self.is_param_value(map, DomainEvidence::Map) {
@@ -1840,10 +1916,21 @@ impl<'a> Builder<'a> {
             let ValOp::Field(method) = callee.op else {
                 return None;
             };
-            let contract =
-                library_map_key_view_contract_by_hash(self.il.meta.lang, method, 0)?.result;
-            if contract.kind != accepted || callee.args.len() != 1 {
+            let contract = library_map_key_view_contract_by_hash(self.il.meta.lang, method, 0)?;
+            if contract.result.kind != accepted || callee.args.len() != 1 {
                 return None;
+            }
+            match self.library_api_evidence_for_value_call(
+                value,
+                args[0],
+                Some(callee.args[0]),
+                contract.id,
+                contract.callee,
+                0,
+            ) {
+                LibraryApiEvidenceStatus::Admitted => {}
+                LibraryApiEvidenceStatus::Rejected => return None,
+                LibraryApiEvidenceStatus::Missing => return None,
             }
             let map = callee.args[0];
             return if self.is_param_value(map, DomainEvidence::Map) {
@@ -1902,6 +1989,7 @@ impl<'a> Builder<'a> {
 
     fn eval_proven_collection_membership_call(
         &mut self,
+        expr: NodeId,
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
@@ -1917,15 +2005,23 @@ impl<'a> Builder<'a> {
         let receiver = callee_kids.first().copied();
 
         let contract =
-            library_method_call_contract(self.il.meta.lang, method, kids.len().saturating_sub(1))?
-                .result;
-        if contract.semantic != MethodSemanticContract::Builtin(Builtin::Contains) {
+            library_method_call_contract(self.il.meta.lang, method, kids.len().saturating_sub(1))?;
+        if !self.library_api_evidence_admitted(
+            expr,
+            contract.id,
+            contract.callee,
+            kids.len().saturating_sub(1),
+        ) {
+            return None;
+        }
+        let result = contract.result;
+        if result.semantic != MethodSemanticContract::Builtin(Builtin::Contains) {
             return None;
         }
 
-        if contract.args == MethodBuiltinArgs::FirstThenReceiver
+        if result.args == MethodBuiltinArgs::FirstThenReceiver
             && matches!(
-                contract.receiver,
+                result.receiver,
                 MethodReceiverContract::ExactCollection
                     | MethodReceiverContract::ExactCollectionOrMap
                     | MethodReceiverContract::ExactCollectionOrJavaKeySet
@@ -1936,7 +2032,7 @@ impl<'a> Builder<'a> {
             let receiver = receiver?;
             let element = self.eval(kids[1], env);
             if matches!(
-                contract.receiver,
+                result.receiver,
                 MethodReceiverContract::ExactCollectionOrMap
                     | MethodReceiverContract::ExactCollectionOrJavaKeySet
             ) {
@@ -1952,7 +2048,7 @@ impl<'a> Builder<'a> {
                 let collection = self.canonical_membership_collection_value(collection);
                 return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
             }
-            let receiver_param_safe = match contract.receiver {
+            let receiver_param_safe = match result.receiver {
                 MethodReceiverContract::ExactSetOrMap => self.is_set_param_expr(receiver),
                 _ => self.is_collection_param_expr(receiver),
             };
@@ -1961,9 +2057,9 @@ impl<'a> Builder<'a> {
                 return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
             }
             None
-        } else if contract.args == MethodBuiltinArgs::GoSliceContains && kids.len() == 3 {
+        } else if result.args == MethodBuiltinArgs::GoSliceContains && kids.len() == 3 {
             let receiver = receiver?;
-            let MethodReceiverContract::ImportedNamespace(module) = contract.receiver else {
+            let MethodReceiverContract::ImportedNamespace(module) = result.receiver else {
                 return None;
             };
             if !self.is_import_namespace_expr(receiver, module, env)
@@ -1986,6 +2082,7 @@ impl<'a> Builder<'a> {
 
     fn eval_proven_map_key_membership_call(
         &mut self,
+        expr: NodeId,
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
@@ -2000,11 +2097,15 @@ impl<'a> Builder<'a> {
             return None;
         };
         let method = self.interner.resolve(name);
-        let contract = library_method_call_contract(self.il.meta.lang, method, 1)?.result;
-        if contract.semantic != MethodSemanticContract::Builtin(Builtin::Contains)
-            || contract.args != MethodBuiltinArgs::FirstThenReceiver
+        let contract = library_method_call_contract(self.il.meta.lang, method, 1)?;
+        if !self.library_api_evidence_admitted(expr, contract.id, contract.callee, 1) {
+            return None;
+        }
+        let result = contract.result;
+        if result.semantic != MethodSemanticContract::Builtin(Builtin::Contains)
+            || result.args != MethodBuiltinArgs::FirstThenReceiver
             || !matches!(
-                contract.receiver,
+                result.receiver,
                 MethodReceiverContract::ExactMap
                     | MethodReceiverContract::ExactCollectionOrMap
                     | MethodReceiverContract::ExactSetOrMap
@@ -2026,6 +2127,7 @@ impl<'a> Builder<'a> {
 
     fn eval_proven_map_get_default_call(
         &mut self,
+        expr: NodeId,
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
@@ -2043,12 +2145,20 @@ impl<'a> Builder<'a> {
             self.il.meta.lang,
             self.interner.resolve(name),
             kids.len().saturating_sub(1),
-        )?
-        .result;
-        if contract.semantic != MethodSemanticContract::Builtin(Builtin::GetOrDefault)
-            || contract.receiver != MethodReceiverContract::ExactMap
+        )?;
+        if !self.library_api_evidence_admitted(
+            expr,
+            contract.id,
+            contract.callee,
+            kids.len().saturating_sub(1),
+        ) {
+            return None;
+        }
+        let result = contract.result;
+        if result.semantic != MethodSemanticContract::Builtin(Builtin::GetOrDefault)
+            || result.receiver != MethodReceiverContract::ExactMap
             || !matches!(
-                contract.args,
+                result.args,
                 MethodBuiltinArgs::MapGetDefault | MethodBuiltinArgs::MapGetDefaultOrZeroArgLambda
             )
         {
@@ -2063,7 +2173,7 @@ impl<'a> Builder<'a> {
                 .or_else(|| self.proven_local_map_binding_value(receiver, env))?
         };
         let key = self.eval(kids[1], env);
-        let default = self.eval_map_get_default_arg(contract.args, kids[2], env)?;
+        let default = self.eval_map_get_default_arg(result.args, kids[2], env)?;
         Some(self.mk(
             ValOp::Call(builtin_tag(Builtin::GetOrDefault)),
             vec![map, key, default],
@@ -3531,13 +3641,7 @@ impl<'a> Builder<'a> {
             }
             (value_a, ret_a)
         };
-        if let Some((map, key)) = self.proven_map_get_value(value) {
-            return Some(self.mk(
-                ValOp::Call(builtin_tag(Builtin::GetOrDefault)),
-                vec![map, key, default],
-            ));
-        }
-        Some(self.mk_value_default(value, default))
+        Some(self.mk_value_or_map_default(value, default))
     }
 
     fn value_default_from_guarded_fallthrough(
@@ -3558,7 +3662,7 @@ impl<'a> Builder<'a> {
             }
             guarded_ret
         };
-        Some(self.mk_value_default(value, default))
+        Some(self.mk_value_or_map_default(value, default))
     }
 
     fn guarded_return_parts(&self, value: ValueId) -> Option<(ValueId, ValueId)> {
@@ -6700,13 +6804,7 @@ impl<'a> Builder<'a> {
             }
             then_v
         };
-        if let Some((map, key)) = self.proven_map_get_value(value) {
-            return Some(self.mk(
-                ValOp::Call(builtin_tag(Builtin::GetOrDefault)),
-                vec![map, key, default],
-            ));
-        }
-        Some(self.mk_value_default(value, default))
+        Some(self.mk_value_or_map_default(value, default))
     }
 
     fn value_default_call(&self, value: ValueId) -> Option<(ValueId, ValueId)> {
@@ -6738,6 +6836,16 @@ impl<'a> Builder<'a> {
             ValOp::Call(builtin_tag(Builtin::ValueOrDefault)),
             vec![value, default],
         )
+    }
+
+    fn mk_value_or_map_default(&mut self, value: ValueId, default: ValueId) -> ValueId {
+        if let Some((map, key)) = self.proven_map_get_value(value) {
+            return self.mk(
+                ValOp::Call(builtin_tag(Builtin::GetOrDefault)),
+                vec![map, key, default],
+            );
+        }
+        self.mk_value_default(value, default)
     }
 
     fn null_condition(&self, cond: ValueId) -> Option<(ValueId, bool)> {
@@ -6883,9 +6991,26 @@ impl<'a> Builder<'a> {
         let ValOp::Field(method) = callee.op else {
             return false;
         };
-        if library_map_get_contract_by_hash(self.il.meta.lang, method, 1).is_none()
-            || callee.args.len() != 1
-        {
+        let Some(contract) = library_map_get_contract_by_hash(self.il.meta.lang, method, 1) else {
+            return false;
+        };
+        if callee.args.len() != 1 {
+            return false;
+        }
+        match self.library_api_evidence_for_value_call(
+            value,
+            args[0],
+            Some(callee.args[0]),
+            contract.id,
+            contract.callee,
+            1,
+        ) {
+            LibraryApiEvidenceStatus::Admitted => {}
+            LibraryApiEvidenceStatus::Rejected | LibraryApiEvidenceStatus::Missing => {
+                return false;
+            }
+        }
+        if callee.args.len() != 1 {
             return false;
         }
         let receiver = callee.args[0];
@@ -7027,6 +7152,7 @@ impl<'a> Builder<'a> {
 
     fn eval_count_call(
         &mut self,
+        expr: NodeId,
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
@@ -7041,11 +7167,19 @@ impl<'a> Builder<'a> {
             self.il.meta.lang,
             self.interner.resolve(name),
             kids.len().saturating_sub(1),
-        )?
-        .result;
-        if contract.semantic != MethodSemanticContract::Builtin(Builtin::Len)
-            || contract.receiver != MethodReceiverContract::ExactProtocol
-            || contract.args != MethodBuiltinArgs::CollectionReduction
+        )?;
+        if !self.library_api_evidence_admitted(
+            expr,
+            contract.id,
+            contract.callee,
+            kids.len().saturating_sub(1),
+        ) {
+            return None;
+        }
+        let result = contract.result;
+        if result.semantic != MethodSemanticContract::Builtin(Builtin::Len)
+            || result.receiver != MethodReceiverContract::ExactProtocol
+            || result.args != MethodBuiltinArgs::CollectionReduction
         {
             return None;
         }
@@ -7118,6 +7252,7 @@ impl<'a> Builder<'a> {
 
     fn eval_iterator_identity_adapter(
         &mut self,
+        expr: NodeId,
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
@@ -7131,12 +7266,15 @@ impl<'a> Builder<'a> {
             self.il.meta.lang,
             self.interner.resolve(method),
             0,
-        )?
-        .result;
+        )?;
+        if !self.library_api_evidence_admitted(expr, contract.id, contract.callee, 0) {
+            return None;
+        }
+        let result = contract.result;
         let base = *self.il.children(kids[0]).first()?;
         let value = self.eval(base, env);
         let value = self.param_domain_value(value);
-        self.iterator_adapter_receiver_proven(contract.receiver, value)
+        self.iterator_adapter_receiver_proven(result.receiver, value)
             .then_some(value)
     }
 
@@ -7155,6 +7293,7 @@ impl<'a> Builder<'a> {
 
     fn eval_rust_map_get_unwrap_or_call(
         &mut self,
+        expr: NodeId,
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
@@ -7165,10 +7304,13 @@ impl<'a> Builder<'a> {
             return None;
         };
         let contract =
-            library_method_call_contract(self.il.meta.lang, self.interner.resolve(method), 1)?
-                .result;
-        if contract.receiver != MethodReceiverContract::RustMapGetOrExactOption
-            || contract.args != MethodBuiltinArgs::RustMapGetOrOptionDefault
+            library_method_call_contract(self.il.meta.lang, self.interner.resolve(method), 1)?;
+        if !self.library_api_evidence_admitted(expr, contract.id, contract.callee, 1) {
+            return None;
+        }
+        let result = contract.result;
+        if result.receiver != MethodReceiverContract::RustMapGetOrExactOption
+            || result.args != MethodBuiltinArgs::RustMapGetOrOptionDefault
         {
             return None;
         }
@@ -7184,6 +7326,7 @@ impl<'a> Builder<'a> {
 
     fn eval_rust_map_get_is_some_call(
         &mut self,
+        expr: NodeId,
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
@@ -7194,11 +7337,14 @@ impl<'a> Builder<'a> {
             return None;
         };
         let contract =
-            library_method_call_contract(self.il.meta.lang, self.interner.resolve(method), 0)?
-                .result;
-        if contract.receiver != MethodReceiverContract::RustMapGetOrExactOption
-            || contract.args != MethodBuiltinArgs::ReceiverOnly
-            || contract.semantic != MethodSemanticContract::Builtin(Builtin::IsNotNull)
+            library_method_call_contract(self.il.meta.lang, self.interner.resolve(method), 0)?;
+        if !self.library_api_evidence_admitted(expr, contract.id, contract.callee, 0) {
+            return None;
+        }
+        let result = contract.result;
+        if result.receiver != MethodReceiverContract::RustMapGetOrExactOption
+            || result.args != MethodBuiltinArgs::ReceiverOnly
+            || result.semantic != MethodSemanticContract::Builtin(Builtin::IsNotNull)
         {
             return None;
         }
@@ -7972,7 +8118,7 @@ impl<'a> Builder<'a> {
                     if let [value, default] = kids.as_slice() {
                         let value = self.eval(*value, env);
                         let default = self.eval(*default, env);
-                        return self.mk_value_default(value, default);
+                        return self.mk_value_or_map_default(value, default);
                     }
                 }
                 if let Payload::Builtin(b) = node.payload {
@@ -7980,7 +8126,7 @@ impl<'a> Builder<'a> {
                         return r;
                     }
                 }
-                if let Some(r) = self.eval_count_call(&kids, env) {
+                if let Some(r) = self.eval_count_call(expr, &kids, env) {
                     return r;
                 }
                 if let Some(r) = self.eval_product_call(expr, &kids, env) {
@@ -7989,10 +8135,10 @@ impl<'a> Builder<'a> {
                 if let Some(r) = self.eval_proven_integer_method_call(&kids, env) {
                     return r;
                 }
-                if let Some(r) = self.eval_rust_map_get_unwrap_or_call(&kids, env) {
+                if let Some(r) = self.eval_rust_map_get_unwrap_or_call(expr, &kids, env) {
                     return r;
                 }
-                if let Some(r) = self.eval_rust_map_get_is_some_call(&kids, env) {
+                if let Some(r) = self.eval_rust_map_get_is_some_call(expr, &kids, env) {
                     return r;
                 }
                 if kids.len() == 1 && self.is_rust_vec_new_call(expr, kids[0]) {
@@ -8004,19 +8150,19 @@ impl<'a> Builder<'a> {
                 if let Some(v) = self.eval_java_map_factory_expr(expr, &kids, env) {
                     return v;
                 }
-                if let Some(v) = self.eval_iterator_identity_adapter(&kids, env) {
+                if let Some(v) = self.eval_iterator_identity_adapter(expr, &kids, env) {
                     return v;
                 }
                 if let Some(v) = self.eval_proven_free_minmax_call(&kids, env) {
                     return v;
                 }
-                if let Some(r) = self.eval_proven_collection_membership_call(&kids, env) {
+                if let Some(r) = self.eval_proven_collection_membership_call(expr, &kids, env) {
                     return r;
                 }
-                if let Some(r) = self.eval_proven_map_key_membership_call(&kids, env) {
+                if let Some(r) = self.eval_proven_map_key_membership_call(expr, &kids, env) {
                     return r;
                 }
-                if let Some(r) = self.eval_proven_map_get_default_call(&kids, env) {
+                if let Some(r) = self.eval_proven_map_get_default_call(expr, &kids, env) {
                     return r;
                 }
                 if self.is_unproven_membership_like_call(expr, &kids) {
@@ -8669,7 +8815,8 @@ mod tests {
         library_free_name_collection_factory_contract,
         library_imported_collection_factory_contract, library_java_collection_factory_contract,
         library_java_map_factory_contract, library_js_like_map_constructor_contract,
-        library_js_like_set_constructor_contract, LibraryApiContractId, FIRST_PARTY_PACK_ID,
+        library_js_like_set_constructor_contract, library_method_call_contract,
+        LibraryApiContractId, FIRST_PARTY_PACK_ID,
     };
 
     fn sp(line: u32) -> Span {
@@ -8798,6 +8945,33 @@ mod tests {
         )
     }
 
+    fn push_method_call_library_api_evidence(
+        il: &mut Il,
+        interner: &Interner,
+        id: u32,
+        call: NodeId,
+        method: &str,
+        arity: usize,
+    ) {
+        let contract =
+            library_method_call_contract(il.meta.lang, method, arity).expect("method contract");
+        let dependencies = nose_semantics::library_api_receiver_dependencies_for_call(
+            il,
+            interner,
+            call,
+            contract.callee,
+        )
+        .expect("method receiver dependencies");
+        il.evidence.push(library_api_contract_evidence(
+            id,
+            il.node(call).span,
+            contract.id,
+            contract.callee,
+            arity as u16,
+            dependencies,
+        ));
+    }
+
     fn eval_proven_collection_op(il: &Il, interner: &Interner, call: NodeId) -> Option<ValOp> {
         let mut builder = Builder::new(il, interner);
         let raw = builder.eval(call, &FxHashMap::default());
@@ -8853,13 +9027,14 @@ mod tests {
             EvidenceAnchor::node(receiver_span, NodeKind::Var),
             EvidenceKind::Domain(DomainEvidence::Collection),
         ));
+        push_method_call_library_api_evidence(&mut il, &interner, 1, call, "includes", 1);
         assert!(matches!(
             eval_op(&il, &interner, call),
             ValOp::Bin(op) if op == Op::In as u32
         ));
 
         il.evidence.push(evidence(
-            1,
+            2,
             EvidenceAnchor::node(receiver_span, NodeKind::Var),
             EvidenceKind::Domain(DomainEvidence::Map),
         ));
@@ -8926,6 +9101,7 @@ mod tests {
             EvidenceKind::Domain(DomainEvidence::Set),
             vec![EvidenceId(0)],
         ));
+        push_method_call_library_api_evidence(&mut il, &interner, 2, call, "includes", 1);
         assert!(matches!(
             eval_op(&il, &interner, call),
             ValOp::Bin(op) if op == Op::In as u32
@@ -9751,6 +9927,7 @@ mod tests {
             EvidenceKind::Domain(DomainEvidence::Map),
             vec![EvidenceId(5)],
         ));
+        push_method_call_library_api_evidence(&mut il, &interner, 7, get_call, "getOrDefault", 2);
 
         let mut builder = Builder::new(&il, &interner);
         builder.seed_module_value_bindings();

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -8,10 +8,10 @@
 
 use nose_il::{
     contains_js_identifier, stable_symbol_hash, Builtin, EffectEvidenceKind, EvidenceAnchor,
-    EvidenceEmitter, EvidenceKind, EvidenceRecord, EvidenceStatus, GuardEvidenceKind, HoFKind, Il,
-    ImportEvidenceKind, Interner, Lang, LibraryApiEvidenceKind, LitClass, NodeId, NodeKind, Op,
-    ParamSemantic, Payload, PlaceEvidenceKind, SequenceSurfaceKind, SourceCallKind, SourceFactKind,
-    SourceLiteralKind, SourceOperatorKind, Span, Symbol, SymbolEvidenceKind,
+    EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceRecord, EvidenceStatus, GuardEvidenceKind,
+    HoFKind, Il, ImportEvidenceKind, Interner, Lang, LibraryApiEvidenceKind, LitClass, NodeId,
+    NodeKind, Op, ParamSemantic, Payload, PlaceEvidenceKind, SequenceSurfaceKind, SourceCallKind,
+    SourceFactKind, SourceLiteralKind, SourceOperatorKind, Span, Symbol, SymbolEvidenceKind,
 };
 use rustc_hash::FxHashMap;
 
@@ -53,6 +53,7 @@ pub fn source_fact_contract(kind: SourceFactKind) -> SourceFactContract {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum EvidenceResolution<T> {
     Missing,
     Found(T),
@@ -1570,7 +1571,7 @@ fn file_defines_name(il: &Il, interner: &Interner, name: &str) -> bool {
         })
 }
 
-fn file_defines_name_visible_at(
+pub fn file_defines_name_visible_at(
     il: &Il,
     interner: &Interner,
     name: &str,
@@ -4562,6 +4563,13 @@ pub struct LibraryMethodCallContract {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryReceiverMethodApiContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub rule: &'static str,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum LibraryApiEvidenceStatus {
     Missing,
     Admitted,
@@ -4640,6 +4648,7 @@ pub fn library_api_contract_evidence_at_call_span(
         callee_hash: library_api_callee_contract_hash(query.callee),
         arity: query.arg_count as u16,
     };
+    let source_call = node_at_span_with_kind(il, span, NodeKind::Call);
     let mut saw_library_api_evidence = false;
     let mut admitted = false;
     for record in &il.evidence {
@@ -4650,18 +4659,28 @@ pub fn library_api_contract_evidence_at_call_span(
             continue;
         };
         saw_library_api_evidence = true;
+        let source_call_matches = source_call.is_some_and(|node| {
+            library_api_source_call_spans_match_query(
+                il,
+                node,
+                query.callee_span,
+                query.receiver_span,
+            ) && library_api_callee_shape_matches(il, interner, node, query.callee)
+                && library_api_dependencies_match_callee(il, interner, node, query.callee, record)
+        });
+        let span_query_matches = library_api_dependencies_match_callee_at_span(
+            il,
+            interner,
+            span,
+            query.callee_span,
+            query.receiver_span,
+            query.callee,
+            record,
+        );
         if record.status != EvidenceStatus::Asserted
             || api != expected
             || !il.evidence_dependencies_asserted(record)
-            || !library_api_dependencies_match_callee_at_span(
-                il,
-                interner,
-                span,
-                query.callee_span,
-                query.receiver_span,
-                query.callee,
-                record,
-            )
+            || (!source_call_matches && !span_query_matches)
         {
             return LibraryApiEvidenceStatus::Rejected;
         }
@@ -4673,6 +4692,69 @@ pub fn library_api_contract_evidence_at_call_span(
         LibraryApiEvidenceStatus::Rejected
     } else {
         LibraryApiEvidenceStatus::Missing
+    }
+}
+
+fn library_api_source_call_spans_match_query(
+    il: &Il,
+    source_call: NodeId,
+    callee_span: Option<Span>,
+    receiver_span: Option<Span>,
+) -> bool {
+    let Some(&callee) = il.children(source_call).first() else {
+        return false;
+    };
+    if callee_span.is_some_and(|span| il.node(callee).span != span) {
+        return false;
+    }
+    if let Some(span) = receiver_span {
+        let Some(&receiver) = il.children(callee).first() else {
+            return false;
+        };
+        if il.node(receiver).span != span {
+            return false;
+        }
+    }
+    true
+}
+
+pub fn library_api_receiver_dependencies_for_call(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    callee: LibraryApiCalleeContract,
+) -> Option<Vec<EvidenceId>> {
+    let mut cache = LibraryApiDependencyCache::default();
+    library_api_receiver_dependencies_for_call_with_cache(il, interner, call, callee, &mut cache)
+}
+
+#[derive(Default)]
+pub struct LibraryApiDependencyCache {
+    nearest_scope_by_node: FxHashMap<NodeId, Option<NodeId>>,
+    binding_lhs_by_reference: FxHashMap<NodeId, EvidenceResolution<NodeId>>,
+    receiver_param_span_by_reference: FxHashMap<NodeId, Option<Span>>,
+    name_assigned_in_scope: FxHashMap<(NodeId, Symbol), bool>,
+}
+
+pub fn library_api_receiver_dependencies_for_call_with_cache(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    callee: LibraryApiCalleeContract,
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<Vec<EvidenceId>> {
+    let (&callee_node, args) = il.children(call).split_first()?;
+    match callee {
+        LibraryApiCalleeContract::Method { method, receiver } => {
+            let receiver_node = method_callee_receiver(il, interner, callee_node, method)?;
+            method_receiver_dependency_ids(il, interner, receiver_node, receiver, args, cache)
+        }
+        LibraryApiCalleeContract::IteratorAdapterMethod { method, receiver } => {
+            let receiver_node = method_callee_receiver(il, interner, callee_node, method)?;
+            iterator_adapter_receiver_dependency_ids(il, interner, receiver_node, receiver, cache)
+        }
+        LibraryApiCalleeContract::AsyncMethod { .. } => None,
+        _ => Some(Vec::new()),
     }
 }
 
@@ -4731,6 +4813,11 @@ fn library_api_callee_shape_matches(
         }
         LibraryApiCalleeContract::StaticGlobalFunction { function, .. } => {
             var_name_matches(il, interner, callee_node, function)
+        }
+        LibraryApiCalleeContract::Method { method, .. }
+        | LibraryApiCalleeContract::AsyncMethod { method, .. }
+        | LibraryApiCalleeContract::IteratorAdapterMethod { method, .. } => {
+            method_callee_receiver(il, interner, callee_node, method).is_some()
         }
         _ => false,
     }
@@ -4852,6 +4939,12 @@ fn library_api_dependencies_match_callee(
             !requires_unshadowed_function
                 || dependency_has_unshadowed_global_node(il, record, callee_node, function)
         }
+        LibraryApiCalleeContract::Method { .. }
+        | LibraryApiCalleeContract::IteratorAdapterMethod { .. } => {
+            library_api_receiver_dependencies_for_call(il, interner, node, callee)
+                .is_some_and(|dependencies| dependency_ids_are_present(record, &dependencies))
+        }
+        LibraryApiCalleeContract::AsyncMethod { .. } => false,
         _ => false,
     }
 }
@@ -5030,8 +5123,1156 @@ fn library_api_dependencies_match_callee_at_span(
                     )
                 })
         }
+        LibraryApiCalleeContract::Method { method, receiver } => {
+            callee_span.is_some_and(|span| field_method_at_span(il, interner, span, method))
+                && receiver_span.is_some_and(|span| {
+                    method_receiver_dependencies_at_span(il, interner, span, receiver).is_some_and(
+                        |dependencies| dependency_ids_are_present(record, &dependencies),
+                    )
+                })
+        }
+        LibraryApiCalleeContract::IteratorAdapterMethod { method, receiver } => {
+            callee_span.is_some_and(|span| field_method_at_span(il, interner, span, method))
+                && receiver_span.is_some_and(|span| {
+                    iterator_adapter_receiver_dependencies_at_span(il, interner, span, receiver)
+                        .is_some_and(|dependencies| {
+                            dependency_ids_are_present(record, &dependencies)
+                        })
+                })
+        }
+        LibraryApiCalleeContract::AsyncMethod { .. } => false,
         _ => false,
     }
+}
+
+fn method_callee_receiver(
+    il: &Il,
+    interner: &Interner,
+    callee: NodeId,
+    expected_method: &str,
+) -> Option<NodeId> {
+    if !field_method_matches(il, interner, callee, expected_method) {
+        return None;
+    }
+    il.children(callee).first().copied()
+}
+
+fn field_method_at_span(il: &Il, interner: &Interner, span: Span, expected: &str) -> bool {
+    il.nodes.iter().any(|node| {
+        node.span == span
+            && node.kind == NodeKind::Field
+            && matches!(node.payload, Payload::Name(method) if interner.resolve(method) == expected)
+    })
+}
+
+fn method_receiver_dependency_ids(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+    contract: MethodReceiverContract,
+    args: &[NodeId],
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<Vec<EvidenceId>> {
+    let mut dependencies = receiver_dependency_ids(il, interner, receiver, contract, cache)?;
+    if contract == MethodReceiverContract::ExactProtocolPairArgument {
+        let pair = *args.first()?;
+        dependencies.extend(receiver_dependency_ids(
+            il,
+            interner,
+            pair,
+            MethodReceiverContract::ExactProtocol,
+            cache,
+        )?);
+    }
+    Some(dependencies)
+}
+
+fn iterator_adapter_receiver_dependency_ids(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+    contract: IteratorAdapterReceiverContract,
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<Vec<EvidenceId>> {
+    match contract {
+        IteratorAdapterReceiverContract::ExactIterableValue => receiver_dependency_ids(
+            il,
+            interner,
+            receiver,
+            MethodReceiverContract::ExactProtocol,
+            cache,
+        ),
+    }
+}
+
+fn method_receiver_dependencies_at_span(
+    il: &Il,
+    interner: &Interner,
+    receiver_span: Span,
+    contract: MethodReceiverContract,
+) -> Option<Vec<EvidenceId>> {
+    let receiver = node_at_span(il, receiver_span)?;
+    let mut cache = LibraryApiDependencyCache::default();
+    receiver_dependency_ids(il, interner, receiver, contract, &mut cache)
+}
+
+fn iterator_adapter_receiver_dependencies_at_span(
+    il: &Il,
+    interner: &Interner,
+    receiver_span: Span,
+    contract: IteratorAdapterReceiverContract,
+) -> Option<Vec<EvidenceId>> {
+    let receiver = node_at_span(il, receiver_span)?;
+    let mut cache = LibraryApiDependencyCache::default();
+    iterator_adapter_receiver_dependency_ids(il, interner, receiver, contract, &mut cache)
+}
+
+fn node_at_span(il: &Il, span: Span) -> Option<NodeId> {
+    let mut found = None;
+    for (idx, node) in il.nodes.iter().enumerate() {
+        if node.span != span {
+            continue;
+        }
+        let id = NodeId(idx as u32);
+        match found {
+            None => found = Some(id),
+            Some(existing)
+                if il.kind(existing) == node.kind && il.node(existing).payload == node.payload => {}
+            Some(_) => return None,
+        }
+    }
+    found
+}
+
+fn node_at_span_with_kind(il: &Il, span: Span, kind: NodeKind) -> Option<NodeId> {
+    let mut found = None;
+    for (idx, node) in il.nodes.iter().enumerate() {
+        if node.span != span || node.kind != kind {
+            continue;
+        }
+        let id = NodeId(idx as u32);
+        match found {
+            None => found = Some(id),
+            Some(existing) if il.node(existing).payload == node.payload => {}
+            Some(_) => return None,
+        }
+    }
+    found
+}
+
+fn receiver_dependency_ids(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+    contract: MethodReceiverContract,
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<Vec<EvidenceId>> {
+    match contract {
+        MethodReceiverContract::LiteralString => {
+            matches!(il.node(receiver).payload, Payload::LitStr(_)).then_some(Vec::new())
+        }
+        MethodReceiverContract::UnshadowedGlobal(global) => {
+            Some(vec![symbol_dependency_id_for_node(
+                il,
+                receiver,
+                SymbolEvidenceKind::UnshadowedGlobal {
+                    name_hash: stable_symbol_hash(global),
+                },
+            )?])
+        }
+        MethodReceiverContract::ImportedNamespace(module) => {
+            Some(vec![imported_symbol_dependency_id_for_node(
+                il,
+                interner,
+                receiver,
+                SymbolEvidenceKind::ImportedNamespace {
+                    module_hash: stable_symbol_hash(module),
+                },
+            )?])
+        }
+        MethodReceiverContract::ExactMapLiteral => {
+            Some(vec![sequence_surface_dependency_id_for_receiver(
+                il, interner, receiver, contract,
+            )?])
+        }
+        MethodReceiverContract::ExactCollectionOrMapLiteral => {
+            domain_or_sequence_dependency_ids(il, interner, receiver, contract, cache)
+        }
+        MethodReceiverContract::ExactCollection | MethodReceiverContract::ExactCollectionOrMap => {
+            if let Some(ids) =
+                domain_or_sequence_dependency_ids(il, interner, receiver, contract, cache)
+            {
+                return Some(ids);
+            }
+            library_api_dependency_id_for_map_key_view_call(
+                il,
+                interner,
+                receiver,
+                &[MapKeyViewKind::Collection],
+            )
+            .map(|id| vec![id])
+        }
+        MethodReceiverContract::RustMapGetOrExactOption => {
+            if let Some(ids) =
+                domain_or_sequence_dependency_ids(il, interner, receiver, contract, cache)
+            {
+                return Some(ids);
+            }
+            library_api_dependency_id_for_call(il, interner, receiver, LibraryApiContractId::MapGet)
+                .map(|id| vec![id])
+        }
+        MethodReceiverContract::ExactCollectionOrJavaKeySet => {
+            if let Some(ids) =
+                domain_or_sequence_dependency_ids(il, interner, receiver, contract, cache)
+            {
+                return Some(ids);
+            }
+            if let Some(id) = library_api_dependency_id_for_call(
+                il,
+                interner,
+                receiver,
+                LibraryApiContractId::MapKeyView(MapKeyViewKind::Collection),
+            ) {
+                return Some(vec![id]);
+            }
+            library_api_dependency_id_for_receiver_domain_call(il, interner, receiver, contract)
+                .map(|id| vec![id])
+        }
+        MethodReceiverContract::ExactProtocol => {
+            if let Some(ids) =
+                domain_or_sequence_dependency_ids(il, interner, receiver, contract, cache)
+            {
+                return Some(ids);
+            }
+            if let Some(id) = library_api_dependency_id_for_map_key_view_call(
+                il,
+                interner,
+                receiver,
+                &[MapKeyViewKind::Collection, MapKeyViewKind::Iterator],
+            ) {
+                return Some(vec![id]);
+            }
+            if let Some(id) =
+                library_api_dependency_id_for_receiver_domain_call(il, interner, receiver, contract)
+            {
+                return Some(vec![id]);
+            }
+            if let Some(id) = library_api_dependency_id_for_normalized_hof(il, receiver) {
+                return Some(vec![id]);
+            }
+            library_api_dependency_id_for_protocol_call(il, interner, receiver).map(|id| vec![id])
+        }
+        MethodReceiverContract::ExactProtocolPairArgument => domain_or_sequence_dependency_ids(
+            il,
+            interner,
+            receiver,
+            MethodReceiverContract::ExactProtocol,
+            cache,
+        )
+        .or_else(|| {
+            library_api_dependency_id_for_map_key_view_call(
+                il,
+                interner,
+                receiver,
+                &[MapKeyViewKind::Collection, MapKeyViewKind::Iterator],
+            )
+            .map(|id| vec![id])
+        })
+        .or_else(|| {
+            library_api_dependency_id_for_receiver_domain_call(
+                il,
+                interner,
+                receiver,
+                MethodReceiverContract::ExactProtocol,
+            )
+            .map(|id| vec![id])
+        })
+        .or_else(|| library_api_dependency_id_for_normalized_hof(il, receiver).map(|id| vec![id]))
+        .or_else(|| {
+            library_api_dependency_id_for_protocol_call(il, interner, receiver).map(|id| vec![id])
+        }),
+        _ => domain_or_sequence_dependency_ids(il, interner, receiver, contract, cache).or_else(
+            || {
+                library_api_dependency_id_for_receiver_domain_call(il, interner, receiver, contract)
+                    .map(|id| vec![id])
+            },
+        ),
+    }
+}
+
+fn domain_or_sequence_dependency_ids(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+    contract: MethodReceiverContract,
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<Vec<EvidenceId>> {
+    if let Some(id) = domain_dependency_id_for_receiver(il, interner, receiver, contract, cache) {
+        return Some(vec![id]);
+    }
+    sequence_surface_dependency_id_for_receiver(il, interner, receiver, contract).map(|id| vec![id])
+}
+
+fn domain_dependency_id_for_receiver(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+    contract: MethodReceiverContract,
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<EvidenceId> {
+    let requirement = method_receiver_domain_requirement(contract)?;
+    let mut found = None;
+    for record in &il.evidence {
+        let EvidenceKind::Domain(domain) = record.kind else {
+            continue;
+        };
+        if record.status != EvidenceStatus::Asserted
+            || !il.evidence_dependencies_asserted(record)
+            || !requirement.accepts(domain)
+            || !domain_dependency_anchor_matches_receiver(
+                il,
+                interner,
+                receiver,
+                record.anchor,
+                cache,
+            )
+        {
+            continue;
+        }
+        match found {
+            None => found = Some((domain, record.id)),
+            Some((existing, _)) if existing == domain => {}
+            Some(_) => return None,
+        }
+    }
+    found.map(|(_, id)| id)
+}
+
+fn domain_dependency_anchor_matches_receiver(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+    anchor: EvidenceAnchor,
+    cache: &mut LibraryApiDependencyCache,
+) -> bool {
+    match anchor {
+        EvidenceAnchor::Node { span, kind } => {
+            span == il.node(receiver).span && kind == il.kind(receiver)
+        }
+        EvidenceAnchor::Binding { span, local_hash } => {
+            matches!(
+                unique_binding_lhs_for_var_reference_cached(il, receiver, cache),
+                EvidenceResolution::Found(lhs)
+                    if il.node(lhs).span == span
+                        && node_name_hash(il, interner, lhs) == Some(local_hash)
+            )
+        }
+        EvidenceAnchor::Param { span } => {
+            receiver_param_span_cached(il, receiver, cache) == Some(span)
+        }
+        _ => false,
+    }
+}
+
+fn unique_binding_lhs_for_var_reference_cached(
+    il: &Il,
+    node: NodeId,
+    cache: &mut LibraryApiDependencyCache,
+) -> EvidenceResolution<NodeId> {
+    if let Some(&cached) = cache.binding_lhs_by_reference.get(&node) {
+        return cached;
+    }
+    let resolution = unique_binding_lhs_for_var_reference_with_cache(il, node, cache);
+    cache.binding_lhs_by_reference.insert(node, resolution);
+    resolution
+}
+
+fn unique_binding_lhs_for_var_reference_with_cache(
+    il: &Il,
+    node: NodeId,
+    cache: &mut LibraryApiDependencyCache,
+) -> EvidenceResolution<NodeId> {
+    let scope = nearest_scope_cached(il, node, cache);
+    let reference_is_free_name = matches!(il.node(node).payload, Payload::Name(_));
+    let mut found = None;
+    for (idx, candidate) in il.nodes.iter().enumerate() {
+        if candidate.kind != NodeKind::Assign {
+            continue;
+        }
+        let assign = NodeId(idx as u32);
+        let assignment_scope = nearest_scope_cached(il, assign, cache);
+        if assignment_scope != scope && !(reference_is_free_name && assignment_scope.is_none()) {
+            continue;
+        }
+        if !assignment_is_visible_at_reference(il, assign, node) {
+            continue;
+        }
+        let Some(&lhs) = il.children(assign).first() else {
+            continue;
+        };
+        if !var_references_same_binding(il, lhs, node) {
+            continue;
+        }
+        match found {
+            None => found = Some(lhs),
+            Some(existing) if existing == lhs => {}
+            Some(_) => return EvidenceResolution::Ambiguous,
+        }
+    }
+    found.map_or(EvidenceResolution::Missing, EvidenceResolution::Found)
+}
+
+fn nearest_scope_cached(
+    il: &Il,
+    node: NodeId,
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<NodeId> {
+    if let Some(cached) = cache.nearest_scope_by_node.get(&node).copied() {
+        return cached;
+    }
+    let scope = nearest_scope(il, node);
+    cache.nearest_scope_by_node.insert(node, scope);
+    scope
+}
+
+fn receiver_param_span_cached(
+    il: &Il,
+    receiver: NodeId,
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<Span> {
+    if let Some(cached) = cache
+        .receiver_param_span_by_reference
+        .get(&receiver)
+        .copied()
+    {
+        return cached;
+    }
+    let span = receiver_var_payload(il, receiver).and_then(|payload| match payload {
+        Payload::Cid(cid) => receiver_cid_param_span_with_cache(il, receiver, cid, cache),
+        Payload::Name(name) => receiver_named_param_span_with_cache(il, receiver, name, cache),
+        _ => None,
+    });
+    cache
+        .receiver_param_span_by_reference
+        .insert(receiver, span);
+    span
+}
+
+fn receiver_var_payload(il: &Il, receiver: NodeId) -> Option<Payload> {
+    (il.kind(receiver) == NodeKind::Var).then_some(il.node(receiver).payload)
+}
+
+fn receiver_cid_param_span_with_cache(
+    il: &Il,
+    receiver: NodeId,
+    cid: u32,
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<Span> {
+    let scope = nearest_scope_cached(il, receiver, cache);
+    let mut found = None;
+    for (idx, candidate) in il.nodes.iter().enumerate() {
+        if candidate.kind != NodeKind::Param {
+            continue;
+        }
+        let id = NodeId(idx as u32);
+        if nearest_scope_cached(il, id, cache) != scope {
+            continue;
+        }
+        if !matches!(candidate.payload, Payload::Cid(param_cid) if param_cid == cid) {
+            continue;
+        }
+        match found {
+            None => found = Some(candidate.span),
+            Some(existing) if existing == candidate.span => {}
+            Some(_) => return None,
+        }
+    }
+    found
+}
+
+fn receiver_named_param_span_with_cache(
+    il: &Il,
+    receiver: NodeId,
+    name: Symbol,
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<Span> {
+    let (scope, param) = nearest_named_param_scope(il, receiver, name)?;
+    (!name_is_assigned_in_scope_cached(il, name, scope, cache)).then_some(il.node(param).span)
+}
+
+fn name_is_assigned_in_scope_cached(
+    il: &Il,
+    name: Symbol,
+    scope: NodeId,
+    cache: &mut LibraryApiDependencyCache,
+) -> bool {
+    if let Some(&assigned) = cache.name_assigned_in_scope.get(&(scope, name)) {
+        return assigned;
+    }
+    let assigned = il.nodes.iter().enumerate().any(|(idx, node)| {
+        if node.kind != NodeKind::Assign {
+            return false;
+        }
+        let id = NodeId(idx as u32);
+        if nearest_scope_cached(il, id, cache) != Some(scope) {
+            return false;
+        }
+        let Some(&lhs) = il.children(id).first() else {
+            return false;
+        };
+        il.kind(lhs) == NodeKind::Var && il.node(lhs).payload == Payload::Name(name)
+    });
+    cache.name_assigned_in_scope.insert((scope, name), assigned);
+    assigned
+}
+
+fn sequence_surface_dependency_id_for_receiver(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+    contract: MethodReceiverContract,
+) -> Option<EvidenceId> {
+    if il.kind(receiver) != NodeKind::Seq {
+        return None;
+    }
+    let surface = seq_surface_contract_for_node(il, interner, receiver)?;
+    if !sequence_surface_satisfies_method_receiver(surface, contract) {
+        return None;
+    }
+    let anchor = EvidenceAnchor::sequence(il.node(receiver).span);
+    let mut found = None;
+    for record in &il.evidence {
+        let EvidenceKind::SequenceSurface(kind) = record.kind else {
+            continue;
+        };
+        if record.anchor != anchor
+            || record.status != EvidenceStatus::Asserted
+            || !il.evidence_dependencies_asserted(record)
+        {
+            continue;
+        }
+        match found {
+            None => found = Some((kind, record.id)),
+            Some((existing, _)) if existing == kind => {}
+            Some(_) => return None,
+        }
+    }
+    found.map(|(_, id)| id)
+}
+
+fn sequence_surface_satisfies_method_receiver(
+    surface: SeqSurfaceContract,
+    contract: MethodReceiverContract,
+) -> bool {
+    match contract {
+        MethodReceiverContract::ExactCollection
+        | MethodReceiverContract::ExactProtocol
+        | MethodReceiverContract::ExactProtocolPairArgument
+        | MethodReceiverContract::ExactCollectionOrJavaKeySet => surface.membership_collection,
+        MethodReceiverContract::ExactMap | MethodReceiverContract::ExactMapLiteral => {
+            surface.value_tag == SEQ_VALUE_MAP
+        }
+        MethodReceiverContract::ExactCollectionOrMap
+        | MethodReceiverContract::ExactCollectionOrMapLiteral => {
+            surface.membership_collection || surface.value_tag == SEQ_VALUE_MAP
+        }
+        MethodReceiverContract::ExactSetOrMap => surface.value_tag == SEQ_VALUE_MAP,
+        _ => false,
+    }
+}
+
+fn symbol_dependency_id_for_node(
+    il: &Il,
+    node: NodeId,
+    expected: SymbolEvidenceKind,
+) -> Option<EvidenceId> {
+    let anchor = EvidenceAnchor::node(il.node(node).span, il.kind(node));
+    il.evidence.iter().find_map(|record| {
+        (record.anchor == anchor
+            && record.status == EvidenceStatus::Asserted
+            && record.kind == EvidenceKind::Symbol(expected)
+            && il.evidence_dependencies_asserted(record))
+        .then_some(record.id)
+    })
+}
+
+fn imported_symbol_dependency_id_for_node(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    expected: SymbolEvidenceKind,
+) -> Option<EvidenceId> {
+    let anchor = EvidenceAnchor::node(il.node(node).span, il.kind(node));
+    il.evidence.iter().find_map(|record| {
+        (record.anchor == anchor
+            && record.status == EvidenceStatus::Asserted
+            && record.kind == EvidenceKind::Symbol(expected)
+            && imported_occurrence_symbol_dependencies_valid(il, interner, record, expected))
+        .then_some(record.id)
+    })
+}
+
+fn library_api_dependency_id_for_normalized_hof(il: &Il, receiver: NodeId) -> Option<EvidenceId> {
+    let Payload::HoF(kind) = il.node(receiver).payload else {
+        return None;
+    };
+    let expected_id = LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(kind));
+    let expected_contract_hash = library_api_contract_id_hash(expected_id);
+    let anchor = EvidenceAnchor::node(il.node(receiver).span, NodeKind::Call);
+    let mut found = None;
+    for record in &il.evidence {
+        if record.anchor != anchor
+            || record.status != EvidenceStatus::Asserted
+            || !il.evidence_dependencies_asserted(record)
+        {
+            continue;
+        }
+        let EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+            contract_hash,
+            callee_hash,
+            ..
+        }) = record.kind
+        else {
+            continue;
+        };
+        if contract_hash != expected_contract_hash {
+            continue;
+        }
+        if library_api_callee_contract_for_hash(il.meta.lang, expected_id, callee_hash).is_none() {
+            continue;
+        }
+        match found {
+            None => found = Some(record.id),
+            Some(existing) if existing == record.id => {}
+            Some(_) => return None,
+        }
+    }
+    found
+}
+
+fn library_api_dependency_id_for_protocol_call(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+) -> Option<EvidenceId> {
+    if let Some(id) = library_api_dependency_id_for_call(
+        il,
+        interner,
+        call,
+        LibraryApiContractId::IteratorIdentityAdapter,
+    ) {
+        return Some(id);
+    }
+    if let Some(id) = library_api_dependency_id_for_call(
+        il,
+        interner,
+        call,
+        LibraryApiContractId::StaticCollectionAdapter,
+    ) {
+        return Some(id);
+    }
+    library_api_dependency_id_for_call_predicate(il, interner, call, |id| {
+        matches!(
+            id,
+            LibraryApiContractId::MethodCall(
+                MethodSemanticContract::HoF(_) | MethodSemanticContract::Builtin(Builtin::Zip)
+            )
+        )
+    })
+}
+
+fn library_api_dependency_id_for_receiver_domain_call(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    contract: MethodReceiverContract,
+) -> Option<EvidenceId> {
+    let requirement = method_receiver_domain_requirement(contract)?;
+    library_api_dependency_id_for_call_contract(il, interner, call, |id, callee, arity| {
+        library_api_contract_result_domain_for_arity(id, callee, arity)
+            .is_some_and(|domain| requirement.accepts(domain))
+    })
+}
+
+fn library_api_dependency_id_for_call(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    id: LibraryApiContractId,
+) -> Option<EvidenceId> {
+    library_api_dependency_id_for_call_predicate(il, interner, call, |actual| actual == id)
+}
+
+fn library_api_dependency_id_for_map_key_view_call(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    allowed: &[MapKeyViewKind],
+) -> Option<EvidenceId> {
+    library_api_dependency_id_for_call_predicate(
+        il,
+        interner,
+        call,
+        |id| matches!(id, LibraryApiContractId::MapKeyView(kind) if allowed.contains(&kind)),
+    )
+}
+
+fn library_api_dependency_id_for_call_predicate(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    accepts: impl Fn(LibraryApiContractId) -> bool,
+) -> Option<EvidenceId> {
+    library_api_dependency_id_for_call_contract(il, interner, call, |id, _, _| accepts(id))
+}
+
+fn library_api_dependency_id_for_call_contract(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    accepts: impl Fn(LibraryApiContractId, LibraryApiCalleeContract, u16) -> bool,
+) -> Option<EvidenceId> {
+    if il.kind(call) != NodeKind::Call {
+        return None;
+    }
+    let anchor = EvidenceAnchor::node(il.node(call).span, NodeKind::Call);
+    let mut found = None;
+    for record in &il.evidence {
+        if record.anchor != anchor
+            || record.status != EvidenceStatus::Asserted
+            || !il.evidence_dependencies_asserted(record)
+        {
+            continue;
+        }
+        let EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+            contract_hash,
+            callee_hash,
+            arity,
+        }) = record.kind
+        else {
+            continue;
+        };
+        let Some(id) = library_api_contract_id_from_hash(contract_hash) else {
+            continue;
+        };
+        let Some(callee) = library_api_callee_contract_for_hash(il.meta.lang, id, callee_hash)
+        else {
+            continue;
+        };
+        if !accepts(id, callee, arity) {
+            continue;
+        }
+        if !library_api_record_admitted_for_current_shape(il, interner, call, record) {
+            continue;
+        }
+        match found {
+            None => found = Some(record.id),
+            Some(existing) if existing == record.id => {}
+            Some(_) => return None,
+        }
+    }
+    found
+}
+
+fn library_api_contract_result_domain_for_arity(
+    id: LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+    arity: u16,
+) -> Option<DomainEvidence> {
+    match id {
+        LibraryApiContractId::PythonBuiltinCollectionFactory
+        | LibraryApiContractId::PythonImportedCollectionFactory
+        | LibraryApiContractId::RustStdCollectionFactory
+        | LibraryApiContractId::RustVecMacroFactory
+        | LibraryApiContractId::RustVecNewFactory
+        | LibraryApiContractId::JavaCollectionFactory(_)
+        | LibraryApiContractId::JavaCollectionConstructor(_)
+        | LibraryApiContractId::RubySetFactory
+        | LibraryApiContractId::JsLikeSetConstructor => {
+            library_collection_factory_result_domain_for_arity(
+                LibraryCollectionFactoryContract {
+                    id,
+                    callee,
+                    result: LibraryCollectionFactoryResult::SequenceArgument,
+                },
+                arity as usize,
+            )
+        }
+        LibraryApiContractId::RustStdMapFactory
+        | LibraryApiContractId::JavaMapFactory(_)
+        | LibraryApiContractId::JsLikeMapConstructor => Some(library_map_factory_result_domain(
+            LibraryMapFactoryContract {
+                id,
+                callee,
+                result: LibraryMapFactoryResult::EntrySequence {
+                    entry_seq_tag: SEQ_VALUE_COLLECTION,
+                },
+            },
+        )),
+        LibraryApiContractId::MapKeyViewWrapper => Some(
+            library_map_key_view_wrapper_result_domain(LibraryMapKeyViewWrapperContract {
+                id,
+                callee,
+                result: MapKeyViewWrapperContract {
+                    receiver: "Array",
+                    method: "from",
+                    qualified_path: "Array.from",
+                },
+            }),
+        ),
+        _ => None,
+    }
+}
+
+fn library_api_contract_id_from_hash(hash: u64) -> Option<LibraryApiContractId> {
+    library_api_contract_ids()
+        .into_iter()
+        .find(|id| library_api_contract_id_hash(*id) == hash)
+}
+
+fn library_api_contract_ids() -> Vec<LibraryApiContractId> {
+    let mut ids = vec![
+        LibraryApiContractId::PythonBuiltinCollectionFactory,
+        LibraryApiContractId::PythonImportedCollectionFactory,
+        LibraryApiContractId::RustStdCollectionFactory,
+        LibraryApiContractId::RustStdMapFactory,
+        LibraryApiContractId::RustVecMacroFactory,
+        LibraryApiContractId::RustVecNewFactory,
+        LibraryApiContractId::JavaMapEntryFactory,
+        LibraryApiContractId::RubySetFactory,
+        LibraryApiContractId::JsLikeSetConstructor,
+        LibraryApiContractId::JsLikeMapConstructor,
+        LibraryApiContractId::MapKeyViewWrapper,
+        LibraryApiContractId::MapGet,
+        LibraryApiContractId::JsArrayIsArray,
+        LibraryApiContractId::JsBooleanCoercion,
+        LibraryApiContractId::RegexTest,
+        LibraryApiContractId::PromiseThen,
+        LibraryApiContractId::IteratorIdentityAdapter,
+        LibraryApiContractId::StaticCollectionAdapter,
+    ];
+    ids.extend(
+        [
+            JavaCollectionFactoryKind::ListOf,
+            JavaCollectionFactoryKind::SetOf,
+            JavaCollectionFactoryKind::ArraysAsList,
+        ]
+        .into_iter()
+        .map(LibraryApiContractId::JavaCollectionFactory),
+    );
+    ids.push(LibraryApiContractId::JavaCollectionConstructor(
+        JavaCollectionConstructorKind::EmptyList,
+    ));
+    ids.extend(
+        [JavaMapFactoryKind::Of, JavaMapFactoryKind::OfEntries]
+            .into_iter()
+            .map(LibraryApiContractId::JavaMapFactory),
+    );
+    ids.extend(
+        [MapKeyViewKind::Collection, MapKeyViewKind::Iterator]
+            .into_iter()
+            .map(LibraryApiContractId::MapKeyView),
+    );
+    ids.extend(
+        [ImportedNamespaceFunctionSemantic::ProductReduction {
+            op: Op::Mul,
+            identity: 1,
+        }]
+        .into_iter()
+        .map(LibraryApiContractId::ImportedNamespaceFunction),
+    );
+    ids.extend(
+        [
+            MethodSemanticContract::Builtin(Builtin::Append),
+            MethodSemanticContract::Builtin(Builtin::Print),
+            MethodSemanticContract::Builtin(Builtin::Len),
+            MethodSemanticContract::Builtin(Builtin::IsEmpty),
+            MethodSemanticContract::Builtin(Builtin::IsNull),
+            MethodSemanticContract::Builtin(Builtin::IsNotNull),
+            MethodSemanticContract::Builtin(Builtin::StartsWith),
+            MethodSemanticContract::Builtin(Builtin::EndsWith),
+            MethodSemanticContract::Builtin(Builtin::Contains),
+            MethodSemanticContract::Builtin(Builtin::Join),
+            MethodSemanticContract::Builtin(Builtin::GetOrDefault),
+            MethodSemanticContract::Builtin(Builtin::ValueOrDefault),
+            MethodSemanticContract::Builtin(Builtin::Reduce),
+            MethodSemanticContract::Builtin(Builtin::Sum),
+            MethodSemanticContract::Builtin(Builtin::Abs),
+            MethodSemanticContract::Builtin(Builtin::Min),
+            MethodSemanticContract::Builtin(Builtin::Max),
+            MethodSemanticContract::Builtin(Builtin::Zip),
+            MethodSemanticContract::Builtin(Builtin::Any),
+            MethodSemanticContract::Builtin(Builtin::All),
+            MethodSemanticContract::HoF(HoFKind::Map),
+            MethodSemanticContract::HoF(HoFKind::Filter),
+            MethodSemanticContract::HoF(HoFKind::FlatMap),
+            MethodSemanticContract::HoF(HoFKind::FilterMap),
+        ]
+        .into_iter()
+        .map(LibraryApiContractId::MethodCall),
+    );
+    ids
+}
+
+fn library_api_record_admitted_for_current_shape(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    record: &EvidenceRecord,
+) -> bool {
+    let EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+        contract_hash,
+        callee_hash,
+        arity,
+    }) = record.kind
+    else {
+        return false;
+    };
+    let Some(id) = library_api_contract_id_from_hash(contract_hash) else {
+        return false;
+    };
+    let Some(callee) = library_api_callee_contract_for_hash(il.meta.lang, id, callee_hash) else {
+        return false;
+    };
+    matches!(
+        library_api_contract_evidence_for_call(il, interner, call, id, callee, arity as usize),
+        LibraryApiEvidenceStatus::Admitted
+    )
+}
+
+fn library_api_callee_contract_for_hash(
+    lang: Lang,
+    id: LibraryApiContractId,
+    hash: u64,
+) -> Option<LibraryApiCalleeContract> {
+    library_api_callee_contracts_for_id(lang, id)
+        .into_iter()
+        .find(|callee| library_api_callee_contract_hash(*callee) == hash)
+}
+
+fn library_api_callee_contracts_for_id(
+    lang: Lang,
+    id: LibraryApiContractId,
+) -> Vec<LibraryApiCalleeContract> {
+    match id {
+        LibraryApiContractId::PythonBuiltinCollectionFactory
+        | LibraryApiContractId::RustStdCollectionFactory => {
+            library_free_name_collection_factory_contracts(lang)
+                .filter(|contract| contract.id == id)
+                .map(|contract| contract.callee)
+                .collect()
+        }
+        LibraryApiContractId::PythonImportedCollectionFactory => {
+            library_imported_collection_factory_contracts(lang)
+                .filter(|contract| contract.id == id)
+                .map(|contract| contract.callee)
+                .collect()
+        }
+        LibraryApiContractId::RustStdMapFactory => library_free_name_map_factory_contracts(lang)
+            .filter(|contract| contract.id == id)
+            .map(|contract| contract.callee)
+            .collect(),
+        LibraryApiContractId::RustVecMacroFactory => {
+            library_rust_vec_macro_factory_contract(lang, "vec")
+                .filter(|contract| contract.id == id)
+                .map(|contract| vec![contract.callee])
+                .unwrap_or_default()
+        }
+        LibraryApiContractId::RustVecNewFactory => {
+            ["Vec::new", "std::vec::Vec::new", "alloc::vec::Vec::new"]
+                .into_iter()
+                .filter_map(|name| library_rust_vec_new_factory_contract(lang, name))
+                .filter(|contract| contract.id == id)
+                .map(|contract| contract.callee)
+                .collect()
+        }
+        LibraryApiContractId::JavaCollectionFactory(kind) => {
+            [("List", "of"), ("Set", "of"), ("Arrays", "asList")]
+                .into_iter()
+                .filter_map(|(receiver, method)| {
+                    library_java_collection_factory_contract(lang, receiver, method)
+                })
+                .filter(|contract| contract.id == LibraryApiContractId::JavaCollectionFactory(kind))
+                .map(|contract| contract.callee)
+                .collect()
+        }
+        LibraryApiContractId::JavaCollectionConstructor(kind) => [
+            "ArrayList",
+            "java.util.ArrayList",
+            "LinkedList",
+            "java.util.LinkedList",
+        ]
+        .into_iter()
+        .filter_map(|type_name| library_java_collection_constructor_contract(lang, type_name, 0))
+        .filter(|contract| contract.id == LibraryApiContractId::JavaCollectionConstructor(kind))
+        .map(|contract| contract.callee)
+        .collect(),
+        LibraryApiContractId::JavaMapFactory(kind) => ["of", "ofEntries"]
+            .into_iter()
+            .filter_map(|method| library_java_map_factory_contract(lang, "Map", method))
+            .filter(|contract| contract.id == LibraryApiContractId::JavaMapFactory(kind))
+            .map(|contract| contract.callee)
+            .collect(),
+        LibraryApiContractId::JavaMapEntryFactory => {
+            library_java_map_entry_contract(lang, "Map", "entry")
+                .map(|contract| vec![contract.callee])
+                .unwrap_or_default()
+        }
+        LibraryApiContractId::RubySetFactory => {
+            library_ruby_set_factory_contract(lang, "Set", "new", 1)
+                .map(|contract| vec![contract.callee])
+                .unwrap_or_default()
+        }
+        LibraryApiContractId::JsLikeSetConstructor => {
+            library_js_like_set_constructor_contract(lang, "Set")
+                .map(|contract| vec![contract.callee])
+                .unwrap_or_default()
+        }
+        LibraryApiContractId::JsLikeMapConstructor => {
+            library_js_like_map_constructor_contract(lang, "Map")
+                .map(|contract| vec![contract.callee])
+                .unwrap_or_default()
+        }
+        LibraryApiContractId::MapKeyViewWrapper => {
+            library_map_key_view_wrapper_contract(lang, "Array", "from", 1)
+                .map(|contract| vec![contract.callee])
+                .unwrap_or_default()
+        }
+        LibraryApiContractId::MapGet => ["get"]
+            .into_iter()
+            .filter_map(|method| {
+                library_map_get_contract(lang, method, 1).map(|contract| contract.callee)
+            })
+            .collect(),
+        LibraryApiContractId::MapKeyView(kind) => ["keys", "keySet"]
+            .into_iter()
+            .filter_map(|method| library_map_key_view_contract(lang, method, 0))
+            .filter(|contract| contract.result.kind == kind)
+            .map(|contract| contract.callee)
+            .collect(),
+        LibraryApiContractId::IteratorIdentityAdapter => {
+            let methods = [
+                "iter",
+                "into_iter",
+                "iter_mut",
+                "collect",
+                "to_vec",
+                "copied",
+                "cloned",
+                "stream",
+            ];
+            methods
+                .into_iter()
+                .filter_map(|method| {
+                    library_iterator_identity_adapter_contract(lang, method, 0)
+                        .map(|contract| contract.callee)
+                })
+                .collect()
+        }
+        LibraryApiContractId::StaticCollectionAdapter => {
+            library_static_collection_adapter_contract(lang, "Arrays", "stream", 1)
+                .map(|contract| vec![contract.callee])
+                .unwrap_or_default()
+        }
+        LibraryApiContractId::MethodCall(semantic) => {
+            method_call_contract_callees_for_semantic(lang, semantic)
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn method_call_contract_callees_for_semantic(
+    lang: Lang,
+    semantic: MethodSemanticContract,
+) -> Vec<LibraryApiCalleeContract> {
+    let methods = [
+        "append",
+        "push",
+        "log",
+        "info",
+        "debug",
+        "Println",
+        "Printf",
+        "Print",
+        "Abs",
+        "HasPrefix",
+        "HasSuffix",
+        "Contains",
+        "len",
+        "size",
+        "length",
+        "is_empty",
+        "isEmpty",
+        "empty?",
+        "nil?",
+        "is_none",
+        "is_some",
+        "startsWith",
+        "startswith",
+        "starts_with",
+        "start_with?",
+        "endsWith",
+        "endswith",
+        "ends_with",
+        "end_with?",
+        "containsKey",
+        "contains_key",
+        "key?",
+        "has_key?",
+        "__contains__",
+        "includes",
+        "include?",
+        "member?",
+        "contains",
+        "has",
+        "join",
+        "get",
+        "fetch",
+        "getOrDefault",
+        "unwrap_or",
+        "unwrap_or_else",
+        "map_or",
+        "reduce",
+        "Min",
+        "Max",
+        "abs",
+        "min",
+        "max",
+        "zip",
+        "fold",
+        "inject",
+        "map",
+        "collect",
+        "filter",
+        "select",
+        "flatMap",
+        "flat_map",
+        "filter_map",
+        "some",
+        "every",
+        "all",
+        "any",
+        "all?",
+        "any?",
+        "allMatch",
+        "anyMatch",
+        "sum",
+        "count",
+    ];
+    methods
+        .into_iter()
+        .flat_map(|method| {
+            (0..=3).filter_map(move |arity| library_method_call_contract(lang, method, arity))
+        })
+        .filter(|contract| contract.result.semantic == semantic)
+        .map(|contract| contract.callee)
+        .collect()
+}
+
+fn dependency_ids_are_present(record: &EvidenceRecord, dependencies: &[EvidenceId]) -> bool {
+    dependencies
+        .iter()
+        .all(|dependency| record.dependencies.contains(dependency))
 }
 
 fn var_name_matches(il: &Il, interner: &Interner, node: NodeId, expected: &str) -> bool {
@@ -6256,6 +7497,46 @@ pub fn library_method_call_contract(
         },
         result,
     })
+}
+
+pub fn library_receiver_method_api_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<LibraryReceiverMethodApiContract> {
+    library_map_get_contract(lang, method, arg_count)
+        .map(|contract| LibraryReceiverMethodApiContract {
+            id: contract.id,
+            callee: contract.callee,
+            rule: "library_api_map_get",
+        })
+        .or_else(|| {
+            library_map_key_view_contract(lang, method, arg_count).map(|contract| {
+                LibraryReceiverMethodApiContract {
+                    id: contract.id,
+                    callee: contract.callee,
+                    rule: "library_api_map_key_view",
+                }
+            })
+        })
+        .or_else(|| {
+            library_iterator_identity_adapter_contract(lang, method, arg_count).map(|contract| {
+                LibraryReceiverMethodApiContract {
+                    id: contract.id,
+                    callee: contract.callee,
+                    rule: "library_api_iterator_identity_adapter",
+                }
+            })
+        })
+        .or_else(|| {
+            library_method_call_contract(lang, method, arg_count).map(|contract| {
+                LibraryReceiverMethodApiContract {
+                    id: contract.id,
+                    callee: contract.callee,
+                    rule: "library_api_method_call",
+                }
+            })
+        })
 }
 
 fn library_method_selector_name(name: &str) -> Option<&'static str> {

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -113,3 +113,17 @@ shares a heavy sub-DAG, each site in the report carries `locations[].shared_subd
 — its OWN source range for the shared computation — and `nose scan`'s text output appends
 `(shared computation: lines X-Y)` to each site. So a partial / sub-DAG clone points at *where* the
 shared logic lives in every copy, not just that one exists.
+
+## Budget 21 → 22 and receiver-method LibraryApi occurrence evidence
+
+Moving receiver-method APIs onto admitted `LibraryApi` occurrence evidence briefly raised the
+dogfooding count to 25. The new occurrence-producer and strict-exact gate duplication was real and
+was deduped: receiver-method contract selection now lives in the semantic kernel, shadow checks use
+one semantic helper, bulk dependency lookup reuses a cache, and strict-exact call evidence gates
+share admitted-contract helpers.
+
+The remaining 22nd family is pre-existing domain/binding helper similarity (`ParamDomainIndex`,
+`domain_evidence_for_var_reference`, and `binding_lhs_name`). It crosses the substantial threshold
+because receiver-method occurrence evidence lets the near channel recognize more of the existing
+semantic proof plumbing, not because this PR added another copy. The gate budget is therefore
+re-baselined to 22 while continuing to ratchet against new avoidable duplication.

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -61,7 +61,7 @@ The current implemented kinds are:
 | `Guard` | multi-obligation guard proof facts such as JS/TS record-shape and own-property guard contracts |
 | `Place` | fixed receiver/place facts currently covering `SelfReceiver` and `SelfField` |
 | `Effect` | observable effect facts currently covering canonical builder append calls, non-overloadable index writes, and fixed self-field writes |
-| `LibraryApi` | proof that a specific call occurrence matches a language/API contract coordinate, currently for selected JS-like static/global APIs plus selected Python, Rust, Ruby, Java, and regex APIs |
+| `LibraryApi` | proof that a specific call occurrence matches a language/API contract coordinate, currently for selected JS-like static/global APIs, selected Python/Rust/Ruby/Java/regex APIs, and selected receiver-method families |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, guard surfaces, Go composite map literals, or Go map entries |
 
 `LibraryApi` evidence is an occurrence fact, not the whole contract. It records
@@ -97,6 +97,11 @@ Current first-party `LibraryApi` callee coordinates are intentionally specific:
 - `JsGlobalConstructor` and `RegexLiteralMethod` name APIs whose identity
   includes source provenance, such as construct syntax or regex-literal receiver
   proof.
+- `Method` and `IteratorAdapterMethod` name language-scoped receiver methods by
+  exact method string and arity. They depend on receiver proof such as
+  `Domain`, `SequenceSurface`, imported-namespace or unshadowed-global `Symbol`,
+  or nested admitted `LibraryApi` evidence for factory/result calls. They do not
+  infer semantics from a selector spelling alone.
 
 ## Consumption Rules
 
@@ -283,6 +288,19 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   arities, unsupported static paths, unresolved free-name/path factories, and
   Ruby require-backed APIs without require evidence do not emit API occurrence
   evidence;
+- first-party lowering plus post-binding and final-normalization refresh passes
+  emit `LibraryApi`
+  occurrence evidence for selected receiver methods that remain as raw call
+  nodes: map `get`, map-key views, iterator identity adapters, and the
+  language-scoped method-call contracts currently used for collection/map
+  membership, map defaulting, count/length, predicates, Rust `zip`, HOF, and
+  reduction methods. The post-binding refresh exists because immutable
+  binding-domain evidence is inferred after lowering; the final refresh exists
+  because CFG/dataflow/algebra rewrites can replace receiver expressions with
+  equivalent sequence or result values. Refreshing upserts first-party occurrence
+  records so `VALUES = List.of(...); VALUES.contains(x)` depends on the current
+  binding or sequence-domain proof rather than falling back to selector
+  matching;
 - selected `LibraryApi` producer-covered result calls emit dependent
   receiver-expression `Domain` evidence: Python `list`/`tuple` and
   `collections.deque`, Rust `Vec::new`, `vec!`, and
@@ -351,14 +369,25 @@ callers:
   evidence for `Array.from`;
 - selected `LibraryApiContract` consumers now consult `LibraryApi` occurrence
   evidence first for the migrated JS-like, Python builtin/imported, Rust
-  free-name/path, Ruby require-backed, Java static, and regex-literal surfaces;
+  free-name/path, Ruby require-backed, Java static, regex-literal, and
+  receiver-method surfaces;
   conflicting or dependency-broken API evidence keeps
   the value-graph, idiom, and strict exact paths closed. Missing API evidence is
   now also closed for those producer-covered surfaces; older symbol/source proof
   helpers remain dependency inputs to `LibraryApi` evidence, not fallback API
-  proofs. Other factory and method/view contract rows still name API
+  proofs. Other factory and constructor contract rows still name API
   identity/result semantics while local consumers prove their current `Symbol`,
   `Import`, `Source`, `Domain`, and `SequenceSurface` obligations;
+- value-graph consumers that query by source span re-check the original source
+  `Call` node shape and its evidence dependencies when that call can be
+  recovered. This preserves receiver-method precision when value-graph CSE has
+  collapsed a parameter receiver into a spanless input, and it still fails closed
+  if the source span does not identify a matching call occurrence;
+- normalized `HoF` nodes produced from admitted receiver-method calls preserve
+  the same-span `LibraryApi(MethodCall(HoF(...)))` occurrence record as protocol
+  receiver evidence. Downstream calls such as Rust `.collect()` can therefore
+  depend on the admitted `filter_map`/`map`/`filter` occurrence after IL
+  canonicalization, without reopening selector-only proof;
 - JS/TS record-shape guard exact admission and value-graph tagging require both
   `SequenceSurface(RecordGuard)` and `Guard::JsRecordShape`; raw
   `Seq("record_guard")` cannot enter the proof-bearing exact/value-graph path by
@@ -378,8 +407,9 @@ callers:
   language-gated helper only when no relevant evidence record exists. Ambiguous
   or conflicting evidence keeps the exact path closed.
 
-Broader field/place/effect facts, `LibraryApi` occurrence evidence for remaining
-receiver-method APIs and unmodeled stdlib/ecosystem APIs, broader inferred
+Broader field/place/effect facts, `LibraryApi` occurrence evidence for Java
+constructors, JS/TS static-index membership, free-name builtin calls, promise
+receiver proof, and unmodeled stdlib/ecosystem APIs, broader inferred
 receiver-expression domain evidence, first-class mutation/effect evidence beyond
 the current first-party binding scan, full protocol/demand/effect receiver
 obligations, full scope-resolution and namespace-member evidence, broader guard

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -358,7 +358,26 @@ and pack ecosystem.
   `nose-semantics` resolves receiver-domain proof from exact receiver nodes,
   binding anchors, and scoped parameters through the same `DomainRequirement`
   helper, so value-graph and strict exact gates no longer maintain separate
-  collection/map binding proof sets.
+  receiver-domain scanners.
+- The receiver-method `LibraryApi` occurrence slice moved broad method-family
+  consumers behind dependency-backed call occurrence records. First-party
+  lowering now emits occurrence evidence for map `get`, map-key views, iterator
+  identity adapters, and language-scoped method-call contracts only when the
+  exact language/method/arity row and receiver proof are present. Normalize runs
+  receiver-method refresh passes after immutable binding-domain inference and
+  after final CFG/dataflow/algebra rewrites, so binding receivers such as
+  `VALUES.contains(x)` can depend on the current binding or sequence-domain
+  proof produced from `VALUES = List.of(...)`. Source-span evidence lookup
+  re-checks the recovered source `Call` node when value-graph CSE has collapsed
+  parameter receivers into spanless values, which keeps Java/TS/Python map
+  defaulting aligned without accepting selector-only proof. Normalize idioms,
+  value-graph rewrites, and strict exact gates for collection/map membership,
+  map defaulting, map-key views, iterator adapters, Rust `zip`, and
+  HOF/reduction methods now require admitted occurrence evidence instead of raw
+  selector plus receiver-domain scans. Normalized `HoF` nodes produced from
+  admitted method calls also remain admissible protocol receivers through their
+  same-span `MethodCall(HoF(...))` occurrence record, so downstream adapters can
+  consume canonicalized HOFs without trusting selector spelling alone.
 - Value-graph and structural-recursion domain gates moved from normalize-local
   `types.rs` / `Ty` inference to `nose-semantics` `ValueDomain` and `ValueLaw`
   contracts. The first contract set covers add non-concat ordering,
@@ -444,9 +463,9 @@ Remaining in this phase:
 - Continue moving library API recognition into `LibraryApiContract` rows and
   `LibraryApi` occurrence evidence. The already producer-covered occurrence
   surfaces are now fail-closed on missing evidence; remaining work is producer
-  coverage for Java constructors, broad receiver-method families, and
-  ecosystem APIs whose receiver/domain/demand obligations are not yet
-  expressible.
+  coverage for Java constructors, JS/TS static-index membership, free-name
+  builtin calls, promise receiver proof, and ecosystem APIs whose
+  receiver/domain/demand obligations are not yet expressible.
   The first internal slice covers collection/map factories, selected
   constructors, Java empty collection constructors, Java `Map.entry`, and the
   shared shadow/import/result
@@ -458,20 +477,20 @@ Remaining in this phase:
   call contracts. Occurrence-evidence slices now cover selected JS-like
   static/global APIs, Python builtin/import-backed factories/functions, Rust
   free-name/path factories, Ruby require-backed factories, Java `java.util`
-  static factories/adapters, and JS regex literals. Remaining stdlib and
-  ecosystem APIs still need dependency-backed occurrence records before they
-  become pack-facing. Producer-covered factory/API result calls now also emit
-  dependent call-node `Domain` evidence when the current `DomainEvidence`
-  vocabulary can represent the result.
+  static factories/adapters, JS regex literals, and selected receiver-method
+  families. Remaining stdlib and ecosystem APIs still need dependency-backed
+  occurrence records before they become pack-facing. Producer-covered
+  factory/API result calls now also emit dependent call-node `Domain` evidence
+  when the current `DomainEvidence` vocabulary can represent the result.
 - Keep value-graph and strict exact gates on the same contract source. Factory,
   constructor, and selected method/view/adapter gates now share
   `LibraryApiContract` identity/result rows, and selected JS-like,
   Python builtin/import-backed, Rust free-name/path, Ruby require-backed, Java
   `java.util`, and regex calls now additionally share `LibraryApi` occurrence
-  evidence. Remaining API work is to move raw sequence/tag, Java constructor,
-  and broad receiver-method proof dependencies into explicit evidence records,
-  then cover broader reduction/HOF and ecosystem APIs only after demand,
-  receiver, and effect obligations are expressible.
+  evidence, as do selected receiver-method families. Remaining API work is to
+  move raw sequence/tag, Java constructor, JS/TS static-index, and free-builtin
+  proof dependencies into explicit evidence records, then cover ecosystem APIs
+  only after demand, receiver, and effect obligations are expressible.
 - Continue import/module proof migration beyond the removed raw import payloads
   and evidence-only import identity path. Value-graph import identity and
   imported-symbol exact proof are now evidence-only, imported literal replacement

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -17,8 +17,11 @@ Library/API identity is consolidated through internal `LibraryApiContract` rows
 for factory, constructor, and selected non-factory method/view surfaces, with
 occurrence evidence covering selected JS-like static/global APIs, Python
 builtin/import-backed APIs, Rust free-name/path APIs, Ruby require-backed APIs,
-Java `java.util` APIs, and JS regex API calls. Selected producer-covered
-factory/API calls now also emit dependent receiver-expression `Domain` evidence
+Java `java.util` APIs, JS regex API calls, and selected language-scoped
+receiver-method APIs such as collection membership, map lookup/defaulting,
+map-key views, iterator identity adapters, Rust `zip`, and HOF/reduction
+methods. Selected producer-covered factory/API calls now also emit dependent
+receiver-expression `Domain` evidence
 for their result container domain, and normalize emits binding-anchored `Domain`
 evidence for immutable local/module bindings whose initializer domain and
 non-mutation conditions are proven by first-party evidence/analysis.
@@ -138,11 +141,12 @@ migrated.
   is closed until a pack/frontend can prove a Promise-like receiver.
 - Rust iterator identity adapters (`iter`, `into_iter`, `collect`, `to_vec`,
   `copied`, `cloned`) are language-, arity-, and receiver-proof constrained
-  through `LibraryApiContract`. Normalize's exact protocol receiver admission
-  consumes this same contract instead of accepting same-named methods from other
-  languages.
+  through `LibraryApiContract` and admitted `LibraryApi` occurrence evidence.
+  Normalize's exact protocol receiver admission consumes this same contract
+  instead of accepting same-named methods from other languages.
 - Rust method `zip(...)` is admitted as a protocol-pair operation only through
-  the Rust library method-call contract and exact protocol proof for both sides.
+  the Rust library method-call occurrence contract and exact protocol proof for
+  both sides.
 - Rust stdlib path contracts for `Some`/`Option::Some`,
   `None`/`Option::None`, `Option::and_then`, and `Vec::new` carry the exact
   selector and shadow-root requirement through `nose-semantics`;
@@ -219,6 +223,26 @@ migrated.
   so broken API proof also closes receiver-domain proof. The `LibraryApi` record
   itself proves API identity only; source, exact-safe argument, result-shape,
   mutation, and demand/effect obligations remain separate.
+- Receiver-method calls that remain as raw `Field`/`Call` nodes now emit
+  `LibraryApi` occurrence evidence for the first-party method families currently
+  backed by `LibraryApiContract`: map `get`, map-key views, iterator identity
+  adapters, and generic language-scoped method-call contracts such as
+  collection/map membership, map defaulting, count/length methods,
+  string/collection predicates, Rust `zip`, and HOF/reduction methods. The
+  occurrence record is admitted only for the exact language/method/arity row and
+  depends on receiver proof: node/binding/parameter `Domain`, `SequenceSurface`,
+  imported namespace or unshadowed-global `Symbol`, or a nested admitted
+  `LibraryApi` result such as a collection/map factory, map-key view, iterator
+  adapter, HOF, or map `get`. First-party lowering seeds these records when the
+  receiver proof already exists; normalize refreshes and upserts first-party
+  records after immutable binding-domain inference and again after final
+  CFG/dataflow/algebra rewrites, so bindings such as
+  `VALUES = List.of(...); VALUES.contains(x)` keep the same semantic fingerprint
+  as direct factory receivers without reopening selector-only fallbacks.
+  Normalized HOF receivers keep their same-span admitted `MethodCall(HoF(...))`
+  occurrence as protocol evidence, so downstream adapters such as Rust
+  `.collect()` can consume a canonicalized `filter_map` receiver without trusting
+  the `collect` selector alone.
 - Java empty collection constructor contracts cover `new ArrayList<>()` and
   `new LinkedList<>()` through `LibraryApiContract` rows only for the Java
   `java.util` list types. Simple names require `java.util` import proof and no
@@ -438,13 +462,14 @@ Semantic knowledge still appears in several forms outside the facade:
   instead of versioned `LawPack` records;
 - hard-coded oracle evaluation rules for eager calls, short-circuit operators,
   HOFs, nullish defaulting, recursion, and effect traces;
-- duplicated library/API proof gates in desugaring, idiom lowering, value-graph,
-  and strict exact paths. `LibraryApi` occurrence evidence now reduces this for
-  selected JS-like static/global APIs, Python builtin/import-backed
-  factories/functions, Rust free-name/path factories, Ruby
-  `require "set"; Set.new(...)`, Java `java.util` static factories/adapters, and
-  JS regex literals, but Java empty constructors and broad receiver-method
-  surfaces still rely on contract rows plus local proof.
+- remaining library/API proof gates that do not yet have occurrence records.
+  `LibraryApi` occurrence evidence now covers selected JS-like static/global
+  APIs, Python builtin/import-backed factories/functions, Rust free-name/path
+  factories, Ruby `require "set"; Set.new(...)`, Java `java.util` static
+  factories/adapters, JS regex literals, and selected receiver-method families.
+  Java empty constructors, JS/TS static-index membership, free-name builtin
+  calls, promise receiver proof, and ecosystem APIs still rely on contract rows
+  plus local proof or remain exact-closed.
 
 These are valuable, but they do not yet share one complete semantic contract
 language.

--- a/scripts/check-duplication.sh
+++ b/scripts/check-duplication.sh
@@ -29,7 +29,9 @@ MIN_VALUE=40   # ignore small/incidental similarity; gate only on substantial fa
 # 20 → 21: weight-grading the sub-DAG score (a larger shared computation now scores higher, up to
 # 0.90) lifts one PRE-EXISTING partial-clone family in nose's own source past the substantial
 # (value ≥ 40) line — finer ranking surfacing real debt, not new code. Still a dedup candidate.
-BUDGET=21      # accepted substantial families today (see docs/dogfooding.md)
+# 21 → 22: receiver-method LibraryApi occurrence evidence makes the near channel admit one
+# PRE-EXISTING param-domain/binding helper family; new occurrence-producer duplication was deduped.
+BUDGET=22      # accepted substantial families today (see docs/dogfooding.md)
 BIN="${NOSE_BIN:-./target/release/nose}"
 GATE_ARGS=(scan crates --exclude tests --mode near --min-value "$MIN_VALUE")
 


### PR DESCRIPTION
## Summary

Moves the currently covered receiver-method API surfaces onto dependency-backed `LibraryApi` occurrence evidence instead of selector-only or local receiver-domain gates. This is the next large slice of #109.

Key changes:
- produce receiver-method `LibraryApi` records for map `get`, map-key views, iterator identity adapters, collection/map membership, map defaulting, predicates, Rust `zip`, and HOF/reduction method contracts;
- refresh/upsert first-party receiver-method evidence after immutable binding-domain inference and after final normalization rewrites;
- require admitted occurrence evidence in normalize idioms, value-graph rewrites, and strict exact gates for producer-covered receiver methods;
- preserve precision through source-call recovery, explicit span consistency, value-receiver substitution handling, and normalized HoF occurrence evidence for downstream adapters like Rust `.collect()`;
- update semantic-kernel snapshot/history docs and remaining-work tracking.

## Validation

- `cargo fmt && cargo check --workspace && cargo test --workspace && awiki lint --root docs`

## Follow-up

Still remaining under #109: Java constructor occurrence evidence, JS/TS static-index membership evidence, free-name builtin calls, promise receiver proof, and broader stdlib/ecosystem API pack surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **개선사항**
  * 라이브러리 API 호출 감지 정확도 향상으로 더 정확한 코드 분석
  * 증거 검증 캐싱 적용으로 분석 성능 개선
  * 의존성 추적 로직 강화로 신뢰성 증대

* **문서**
  * 라이브러리 API 증거 기록 메커니즘에 대한 설명 확대
  * 시맨틱 커널 로드맵 및 스냅샷 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->