### PR TITLE
[codex] Move static API semantics onto occurrence evidence

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -28,8 +28,8 @@ use nose_semantics::{
     library_map_key_view_contract, library_map_key_view_wrapper_contract,
     library_method_call_contract, library_regex_test_contract, library_ruby_set_factory_contract,
     library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
-    nullish_global_contract, own_property_guard_for_node, record_shape_guard_for_node, semantics,
-    seq_surface_contract_for_node, source_operator_at_node, static_index_membership_contract,
+    library_static_index_membership_contract, nullish_global_contract, own_property_guard_for_node,
+    record_shape_guard_for_node, semantics, seq_surface_contract_for_node, source_operator_at_node,
     typeof_operator_contract, unshadowed_global_symbol, DomainRequirement,
     IndexMembershipThreshold, JavaMapFactoryKind, LibraryApiCalleeContract,
     LibraryApiEvidenceStatus, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
@@ -1004,8 +1004,20 @@ fn strict_exact_static_index_membership_parts(
     if !strict_exact_static_non_float_collection(il, interner, receiver) {
         return None;
     }
-    let contract = static_index_membership_contract(il.meta.lang, method, kids.len() - 1)?;
-    match contract.kind {
+    let contract = library_static_index_membership_contract(il.meta.lang, method, kids.len() - 1)?;
+    match library_api_contract_evidence_for_call(
+        il,
+        interner,
+        node,
+        contract.id,
+        contract.callee,
+        kids.len().saturating_sub(1),
+    ) {
+        LibraryApiEvidenceStatus::Admitted => {}
+        LibraryApiEvidenceStatus::Rejected => return None,
+        LibraryApiEvidenceStatus::Missing => return None,
+    }
+    match contract.result.kind {
         StaticIndexMembershipKind::IndexOf => Some((kids[1], receiver)),
         StaticIndexMembershipKind::FindIndex => {
             let element = strict_exact_lambda_eq_param_element(il, interner, facts, kids[1])?;

--- a/crates/nose-frontend/src/java.rs
+++ b/crates/nose-frontend/src/java.rs
@@ -8,8 +8,9 @@
 
 use crate::lower::{common_bin_op, Lowering};
 use nose_il::{
-    FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, ParamSemantic, Payload,
-    Span, UnitKind,
+    stable_symbol_hash, EvidenceAnchor, EvidenceKind, FileId, Il, ImportEvidenceKind, Interner,
+    Lang, LitClass, LoopKind, NodeId, NodeKind, Op, ParamSemantic, Payload, SourceCallKind,
+    SourceFactKind, Span, UnitKind,
 };
 use nose_semantics::{
     library_java_collection_constructor_contract, LibraryApiCalleeContract,
@@ -76,6 +77,14 @@ fn lower_import(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     }
     let path = text.strip_prefix("import ")?.trim();
     if path.ends_with(".*") {
+        let module = path.trim_end_matches(".*").trim();
+        lo.record_evidence(
+            EvidenceAnchor::source_span(span),
+            EvidenceKind::Import(ImportEvidenceKind::Wildcard {
+                module_hash: stable_symbol_hash(module),
+            }),
+            "java_wildcard_import",
+        );
         return None;
     }
     let (module, exported) = path.rsplit_once('.')?;
@@ -541,10 +550,10 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                     kids.push(lower_expr(lo, a));
                 }
             }
-            if let Some(list) = lower_empty_java_collection_constructor(lo, node, kids.len(), span)
-            {
+            if let Some(list) = lower_empty_java_collection_constructor(lo, node, &kids, span) {
                 return list;
             }
+            lo.record_source_fact(span, SourceFactKind::Call(SourceCallKind::Construct));
             lo.add(NodeKind::Call, Payload::None, span, &kids)
         }
         "field_access" => {
@@ -729,12 +738,13 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
 fn lower_empty_java_collection_constructor(
     lo: &mut Lowering,
     node: TsNode,
-    arg_count: usize,
+    args: &[NodeId],
     span: Span,
 ) -> Option<NodeId> {
     let ty = node.child_by_field_name("type")?;
+    let type_span = lo.span(ty);
     let type_name = java_constructor_type_name(lo.text(ty));
-    let contract = library_java_collection_constructor_contract(lo.lang, &type_name, arg_count)?;
+    let contract = library_java_collection_constructor_contract(lo.lang, &type_name, args.len())?;
     let LibraryApiCalleeContract::JavaUtilConstructor {
         simple_type,
         module,
@@ -759,8 +769,17 @@ fn lower_empty_java_collection_constructor(
     }
     match contract.result {
         LibraryCollectionFactoryResult::EmptySequence => {
-            let tag = lo.sym("array");
-            Some(lo.add(NodeKind::Seq, Payload::Name(tag), span, &[]))
+            let callee = lo.add(
+                NodeKind::Var,
+                Payload::Name(lo.sym(&type_name)),
+                type_span,
+                &[],
+            );
+            let mut kids = Vec::with_capacity(args.len() + 1);
+            kids.push(callee);
+            kids.extend_from_slice(args);
+            lo.record_source_fact(span, SourceFactKind::Call(SourceCallKind::Construct));
+            Some(lo.add(NodeKind::Call, Payload::None, span, &kids))
         }
         _ => None,
     }

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -6,8 +6,9 @@ use nose_il::{
     stable_symbol_hash, Builtin, DomainEvidence, EffectEvidenceKind, EvidenceAnchor,
     EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance, EvidenceRecord, EvidenceStatus,
     FileId, FileMeta, Il, IlBuilder, ImportEvidenceKind, Interner, Lang, LibraryApiEvidenceKind,
-    LoopKind, NodeId, NodeKind, Op, ParamSemantic, Payload, PlaceEvidenceKind, SourceCallKind,
-    SourceFactKind, Span, Symbol, SymbolEvidenceKind, Unit, UnitKind,
+    LitClass, LoopKind, NodeId, NodeKind, Op, ParamSemantic, Payload, PlaceEvidenceKind,
+    SequenceSurfaceKind, SourceCallKind, SourceFactKind, Span, Symbol, SymbolEvidenceKind, Unit,
+    UnitKind,
 };
 use nose_semantics::{
     library_api_callee_contract_hash, library_api_contract_id_hash,
@@ -15,16 +16,17 @@ use nose_semantics::{
     library_collection_factory_result_domain_for_arity,
     library_free_name_collection_factory_contract, library_free_name_map_factory_contract,
     library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
-    library_java_collection_factory_contract, library_java_map_entry_contract,
-    library_java_map_factory_contract, library_js_array_is_array_contract,
-    library_js_boolean_coercion_contract, library_js_like_map_constructor_contract,
-    library_js_like_set_constructor_contract, library_map_factory_result_domain,
-    library_map_key_view_wrapper_contract, library_map_key_view_wrapper_result_domain,
-    library_receiver_method_api_contract, library_regex_test_contract,
-    library_ruby_set_factory_contract, library_rust_vec_macro_factory_contract,
-    library_rust_vec_new_factory_contract, library_static_collection_adapter_contract,
+    library_java_collection_constructor_contract, library_java_collection_factory_contract,
+    library_java_map_entry_contract, library_java_map_factory_contract,
+    library_js_array_is_array_contract, library_js_boolean_coercion_contract,
+    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
+    library_map_factory_result_domain, library_map_key_view_wrapper_contract,
+    library_map_key_view_wrapper_result_domain, library_receiver_method_api_contract,
+    library_regex_test_contract, library_ruby_set_factory_contract,
+    library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
+    library_static_collection_adapter_contract, library_static_index_membership_contract,
     sequence_surface_kind_for_tag, ImportFactKind, LibraryApiCalleeContract, LibraryApiContractId,
-    LibraryApiDependencyCache, MethodReceiverContract,
+    LibraryApiDependencyCache, MethodReceiverContract, StaticIndexMembershipReceiverContract,
 };
 use tree_sitter::Node as TsNode;
 
@@ -234,6 +236,9 @@ impl<'a> Lowering<'a> {
         if let Some(result) = self.java_util_static_member_api_contract(callee, arg_count) {
             return Some(result);
         }
+        if let Some(result) = self.static_index_membership_api_contract(callee, arg_count) {
+            return Some(result);
+        }
         if let Some(result) = self.regex_literal_method_api_contract(callee, arg_count) {
             return Some(result);
         }
@@ -304,6 +309,19 @@ impl<'a> Lowering<'a> {
         Some((
             receiver_node,
             self.interner.resolve(receiver_name),
+            self.interner.resolve(method),
+        ))
+    }
+
+    fn field_callee_receiver_and_method(&self, callee: NodeId) -> Option<(NodeId, &str)> {
+        if self.b.kind(callee) != NodeKind::Field {
+            return None;
+        }
+        let Payload::Name(method) = self.b.payload(callee) else {
+            return None;
+        };
+        Some((
+            self.b.children(callee).first().copied()?,
             self.interner.resolve(method),
         ))
     }
@@ -403,20 +421,13 @@ impl<'a> Lowering<'a> {
         callee: NodeId,
         arg_count: usize,
     ) -> Option<LibraryApiEvidencePlan> {
-        if self.b.kind(callee) != NodeKind::Field {
-            return None;
-        }
-        let Payload::Name(method) = self.b.payload(callee) else {
-            return None;
-        };
-        let function = self.interner.resolve(method);
+        let (receiver, function) = self.field_callee_receiver_and_method(callee)?;
         let contract =
             library_imported_namespace_function_contract(self.lang, function, arg_count)?;
         let LibraryApiCalleeContract::ImportedNamespaceFunction { module, .. } = contract.callee
         else {
             return None;
         };
-        let receiver = self.b.children(callee).first().copied()?;
         let dependency = self.record_imported_namespace_symbol_for_node(receiver, module)?;
         Some(LibraryApiEvidencePlan {
             id: contract.id,
@@ -517,18 +528,90 @@ impl<'a> Lowering<'a> {
         })
     }
 
+    fn static_index_membership_api_contract(
+        &self,
+        callee: NodeId,
+        arg_count: usize,
+    ) -> Option<LibraryApiEvidencePlan> {
+        let (receiver_node, method) = self.field_callee_receiver_and_method(callee)?;
+        let contract = library_static_index_membership_contract(self.lang, method, arg_count)?;
+        let LibraryApiCalleeContract::StaticIndexMembershipMethod { receiver, .. } =
+            contract.callee
+        else {
+            return None;
+        };
+        let dependency =
+            self.static_index_membership_receiver_dependency(receiver_node, receiver)?;
+        Some(LibraryApiEvidencePlan {
+            id: contract.id,
+            callee: contract.callee,
+            dependencies: vec![dependency],
+            rule: "library_api_static_index_membership",
+            result_domain: None,
+        })
+    }
+
+    fn static_index_membership_receiver_dependency(
+        &self,
+        receiver: NodeId,
+        contract: StaticIndexMembershipReceiverContract,
+    ) -> Option<EvidenceId> {
+        match contract {
+            StaticIndexMembershipReceiverContract::StaticNonFloatLiteralCollection => {
+                if !self.static_non_float_collection_literal(receiver) {
+                    return None;
+                }
+                self.sequence_surface_evidence_id(receiver, SequenceSurfaceKind::Collection)
+            }
+        }
+    }
+
+    fn static_non_float_collection_literal(&self, node: NodeId) -> bool {
+        if self.b.kind(node) != NodeKind::Seq {
+            return false;
+        }
+        let Payload::Name(tag) = self.b.payload(node) else {
+            return false;
+        };
+        if sequence_surface_kind_for_tag(self.lang, Some(self.interner.resolve(tag)))
+            != Some(SequenceSurfaceKind::Collection)
+        {
+            return false;
+        }
+        let kids = self.b.children(node);
+        !kids.is_empty()
+            && kids.iter().all(|&kid| {
+                self.b.kind(kid) == NodeKind::Lit
+                    && matches!(
+                        self.b.payload(kid),
+                        Payload::LitInt(_)
+                            | Payload::LitBool(_)
+                            | Payload::LitStr(_)
+                            | Payload::Lit(LitClass::Null)
+                    )
+            })
+    }
+
+    fn sequence_surface_evidence_id(
+        &self,
+        node: NodeId,
+        surface: SequenceSurfaceKind,
+    ) -> Option<EvidenceId> {
+        let span = self.b.node(node).span;
+        self.evidence.iter().find_map(|record| {
+            (record.anchor == EvidenceAnchor::sequence(span)
+                && record.kind == EvidenceKind::SequenceSurface(surface)
+                && record.status == EvidenceStatus::Asserted)
+                .then_some(record.id)
+        })
+    }
+
     fn regex_literal_method_api_contract(
         &self,
         callee: NodeId,
         arg_count: usize,
     ) -> Option<LibraryApiEvidencePlan> {
-        if self.b.kind(callee) != NodeKind::Field {
-            return None;
-        }
-        let Payload::Name(method) = self.b.payload(callee) else {
-            return None;
-        };
-        let method = self.interner.resolve(method);
+        let (receiver, method) = self.field_callee_receiver_and_method(callee)?;
         let contract = library_regex_test_contract(self.lang, method, arg_count)?;
         let LibraryApiCalleeContract::RegexLiteralMethod {
             required_receiver_fact,
@@ -537,7 +620,6 @@ impl<'a> Lowering<'a> {
         else {
             return None;
         };
-        let receiver = self.b.children(callee).first().copied()?;
         let dependency = self.source_fact_evidence_id(receiver, required_receiver_fact)?;
         Some(LibraryApiEvidencePlan {
             id: contract.id,
@@ -923,12 +1005,9 @@ impl<'a> Lowering<'a> {
             // `2.71` (JS has one `number` kind, so its floats arrive here). Hex/binary/
             // suffixed integers that don't parse stay the abstract `Int` class (unchanged).
             _ if t.contains(['.', 'e', 'E']) && !t.starts_with("0x") => self.float_lit(text, span),
-            _ => self.b.add(
-                NodeKind::Lit,
-                Payload::Lit(nose_il::LitClass::Int),
-                span,
-                &[],
-            ),
+            _ => self
+                .b
+                .add(NodeKind::Lit, Payload::Lit(LitClass::Int), span, &[]),
         }
     }
 
@@ -1184,6 +1263,9 @@ fn record_post_lower_library_api_evidence(il: &mut Il, interner: &Interner) {
         if record_post_lower_ruby_static_member_library_api(il, interner, call) {
             continue;
         }
+        if record_post_lower_java_collection_constructor_library_api(il, interner, call) {
+            continue;
+        }
         record_post_lower_receiver_method_library_api(il, interner, call, &mut dependency_cache);
     }
 }
@@ -1378,6 +1460,89 @@ fn record_post_lower_ruby_static_member_library_api(
     true
 }
 
+fn record_post_lower_java_collection_constructor_library_api(
+    il: &mut Il,
+    interner: &Interner,
+    call: NodeId,
+) -> bool {
+    let kids = il.children(call);
+    let Some((&callee, args)) = kids.split_first() else {
+        return false;
+    };
+    let arg_count = args.len();
+    let Some(type_name) = post_lower_var_name(il, interner, callee) else {
+        return false;
+    };
+    let Some(contract) =
+        library_java_collection_constructor_contract(il.meta.lang, type_name, arg_count)
+    else {
+        return false;
+    };
+    let LibraryApiCalleeContract::JavaUtilConstructor {
+        simple_type,
+        qualified_type,
+        module,
+        requires_import_for_simple_type,
+        requires_no_local_type_shadow,
+    } = contract.callee
+    else {
+        return false;
+    };
+    let Some(source_dependency) =
+        post_lower_source_call_evidence_id(il, call, SourceCallKind::Construct)
+    else {
+        return false;
+    };
+    let mut dependencies = vec![source_dependency];
+    if type_name == simple_type {
+        if requires_no_local_type_shadow
+            && post_lower_unit_defines_name(il, interner, simple_type, il.node(callee).span)
+        {
+            return false;
+        }
+        if requires_import_for_simple_type {
+            if let Some(dependency) = post_lower_imported_binding_symbol_evidence_id(
+                il,
+                interner,
+                callee,
+                module,
+                simple_type,
+            ) {
+                dependencies.push(dependency);
+            } else {
+                let Some(dependency) = post_lower_java_wildcard_import_evidence_id(
+                    il,
+                    interner,
+                    module,
+                    simple_type,
+                    il.node(call).span,
+                ) else {
+                    return false;
+                };
+                dependencies.push(dependency);
+            }
+        }
+    } else if type_name != qualified_type {
+        return false;
+    }
+    let api = post_lower_library_api_evidence_id(
+        il,
+        call,
+        contract.id,
+        contract.callee,
+        arg_count,
+        "library_api_java_collection_constructor",
+        dependencies,
+    );
+    post_lower_record_library_api_result_domain(
+        il,
+        call,
+        library_collection_factory_result_domain_for_arity(contract, arg_count),
+        api,
+    );
+    true
+}
+
 fn record_post_lower_receiver_method_library_api(
     il: &mut Il,
     interner: &Interner,
@@ -1488,6 +1653,27 @@ fn post_lower_unshadowed_symbol_evidence_id(
     )
 }
 
+fn post_lower_imported_binding_symbol_evidence_id(
+    il: &mut Il,
+    interner: &Interner,
+    node: NodeId,
+    module: &str,
+    exported: &str,
+) -> Option<EvidenceId> {
+    let expected = SymbolEvidenceKind::ImportedBinding {
+        module_hash: stable_symbol_hash(module),
+        exported_hash: stable_symbol_hash(exported),
+    };
+    let dependency = post_lower_binding_symbol_evidence_id(il, interner, node, expected)?;
+    post_lower_find_or_push_evidence(
+        il,
+        EvidenceAnchor::node(il.node(node).span, NodeKind::Var),
+        EvidenceKind::Symbol(expected),
+        "symbol_imported_binding_occurrence_post_lower",
+        vec![dependency],
+    )
+}
+
 fn post_lower_imported_namespace_symbol_evidence_id(
     il: &mut Il,
     interner: &Interner,
@@ -1530,6 +1716,54 @@ fn post_lower_binding_symbol_evidence_id(
         ) && record.kind == EvidenceKind::Symbol(expected)
             && record.status == EvidenceStatus::Asserted)
             .then_some(record.id)
+    })
+}
+
+fn post_lower_java_wildcard_import_evidence_id(
+    il: &Il,
+    interner: &Interner,
+    module: &str,
+    simple_type: &str,
+    use_span: Span,
+) -> Option<EvidenceId> {
+    if post_lower_explicit_import_conflicts(il, interner, module, simple_type) {
+        return None;
+    }
+    let kind = EvidenceKind::Import(ImportEvidenceKind::Wildcard {
+        module_hash: stable_symbol_hash(module),
+    });
+    il.evidence.iter().find_map(|record| {
+        (record.kind == kind
+            && record.status == EvidenceStatus::Asserted
+            && matches!(
+                record.anchor,
+                EvidenceAnchor::SourceSpan(span)
+                    if span.file == use_span.file && span.end_byte <= use_span.start_byte
+            ))
+        .then_some(record.id)
+    })
+}
+
+fn post_lower_explicit_import_conflicts(
+    il: &Il,
+    _interner: &Interner,
+    module: &str,
+    simple_type: &str,
+) -> bool {
+    let local_hash = stable_symbol_hash(simple_type);
+    let expected = SymbolEvidenceKind::ImportedBinding {
+        module_hash: stable_symbol_hash(module),
+        exported_hash: stable_symbol_hash(simple_type),
+    };
+    il.evidence.iter().any(|record| {
+        matches!(
+            record.anchor,
+            EvidenceAnchor::Binding {
+                local_hash: anchor_hash,
+                ..
+            } if anchor_hash == local_hash
+        ) && record.status == EvidenceStatus::Asserted
+            && matches!(record.kind, EvidenceKind::Symbol(actual) if actual != expected)
     })
 }
 
@@ -1689,6 +1923,21 @@ fn post_lower_file_defines_name_visible_at(
     occurrence_span: Span,
 ) -> bool {
     nose_semantics::file_defines_name_visible_at(il, interner, name, occurrence_span)
+}
+
+fn post_lower_unit_defines_name(
+    il: &Il,
+    interner: &Interner,
+    name: &str,
+    occurrence_span: Span,
+) -> bool {
+    let name_hash = stable_symbol_hash(name);
+    il.units.iter().any(|unit| {
+        il.node(unit.root).span.file == occurrence_span.file
+            && unit
+                .name
+                .is_some_and(|symbol| stable_symbol_hash(interner.resolve(symbol)) == name_hash)
+    })
 }
 
 fn normalize_type_text(text: &str) -> String {
@@ -3202,6 +3451,148 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             None,
             "receiver-domain proof must close when the LibraryApi dependency is ambiguous"
         );
+    }
+
+    #[test]
+    fn java_empty_collection_constructor_emits_occurrence_evidence() {
+        let interner = Interner::new();
+        let il = crate::lower_source(
+            FileId(0),
+            "C.java",
+            b"import java.util.ArrayList;\nclass C { Object f() { return new ArrayList<>(); } }\n",
+            Lang::Java,
+            &interner,
+        )
+        .expect("java lowering should succeed");
+        let contract =
+            library_java_collection_constructor_contract(Lang::Java, "ArrayList", 0).unwrap();
+        let api = library_api_evidence_ids_in_records(
+            &il.evidence,
+            library_api_contract_id_hash(contract.id),
+            library_api_callee_contract_hash(contract.callee),
+        );
+        assert_eq!(api.len(), 1);
+        assert!(
+            il.evidence.iter().any(|record| {
+                record.kind == EvidenceKind::Domain(DomainEvidence::Collection)
+                    && record.dependencies.len() == 1
+                    && api.contains(&record.dependencies[0])
+            }),
+            "Java constructor result-domain evidence must depend on the LibraryApi occurrence"
+        );
+    }
+
+    #[test]
+    fn java_empty_collection_constructor_wildcard_import_is_dependency_backed() {
+        let interner = Interner::new();
+        let wildcard = crate::lower_source(
+            FileId(0),
+            "C.java",
+            b"import java.util.*;\nclass C { Object f() { return new ArrayList<>(); } }\n",
+            Lang::Java,
+            &interner,
+        )
+        .expect("java lowering should succeed");
+        let contract =
+            library_java_collection_constructor_contract(Lang::Java, "ArrayList", 0).unwrap();
+        let api = wildcard
+            .evidence
+            .iter()
+            .find(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                        contract_hash,
+                        callee_hash,
+                        ..
+                    }) if contract_hash == library_api_contract_id_hash(contract.id)
+                        && callee_hash == library_api_callee_contract_hash(contract.callee)
+                )
+            })
+            .expect("wildcard java.util import should admit supported ArrayList constructor");
+        assert!(api.dependencies.iter().any(|id| {
+            wildcard.evidence_record_by_id(*id).is_some_and(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::Import(ImportEvidenceKind::Wildcard { module_hash })
+                        if module_hash == stable_symbol_hash("java.util")
+                )
+            })
+        }));
+
+        let shadowed = crate::lower_source(
+            FileId(0),
+            "C.java",
+            b"import java.util.*;\nclass ArrayList<T> {}\nclass C { Object f() { return new ArrayList<>(); } }\n",
+            Lang::Java,
+            &interner,
+        )
+        .expect("java lowering should succeed");
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &shadowed.evidence,
+                library_api_contract_id_hash(contract.id),
+                library_api_callee_contract_hash(contract.callee),
+            ),
+            0,
+            "local ArrayList type must close the java.util constructor occurrence"
+        );
+
+        let explicit_conflict = crate::lower_source(
+            FileId(0),
+            "C.java",
+            b"import java.util.*;\nimport other.ArrayList;\nclass C { Object f() { return new ArrayList<>(); } }\n",
+            Lang::Java,
+            &interner,
+        )
+        .expect("java lowering should succeed");
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &explicit_conflict.evidence,
+                library_api_contract_id_hash(contract.id),
+                library_api_callee_contract_hash(contract.callee),
+            ),
+            0,
+            "explicit same-name imports must close java.util wildcard constructor proof"
+        );
+    }
+
+    #[test]
+    fn js_static_index_membership_emits_occurrence_evidence() {
+        let interner = Interner::new();
+        let il = crate::lower_source(
+            FileId(0),
+            "index.js",
+            b"function f(value) { return [\"red\", \"blue\"].indexOf(value) !== -1; }\n",
+            Lang::JavaScript,
+            &interner,
+        )
+        .expect("js lowering should succeed");
+        let contract =
+            library_static_index_membership_contract(Lang::JavaScript, "indexOf", 1).unwrap();
+        let api = il
+            .evidence
+            .iter()
+            .find(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                        contract_hash,
+                        callee_hash,
+                        ..
+                    }) if contract_hash == library_api_contract_id_hash(contract.id)
+                        && callee_hash == library_api_callee_contract_hash(contract.callee)
+                )
+            })
+            .expect("static index membership should emit a LibraryApi occurrence");
+        assert!(api.dependencies.iter().any(|id| {
+            il.evidence_record_by_id(*id).is_some_and(|record| {
+                matches!(
+                    record.kind,
+                    EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection)
+                )
+            })
+        }));
     }
 
     #[test]

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -296,6 +296,9 @@ pub enum ImportEvidenceKind {
     Namespace {
         module_hash: u64,
     },
+    Wildcard {
+        module_hash: u64,
+    },
     Require {
         module_hash: u64,
     },

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -58,26 +58,27 @@ use nose_semantics::{
     library_api_contract_evidence_at_call_span, library_api_contract_evidence_for_call,
     library_free_name_collection_factory_contracts, library_free_name_map_factory_contracts,
     library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
-    library_iterator_identity_adapter_contract, library_java_collection_factory_contract_by_hash,
-    library_java_map_entry_contract_by_hash, library_java_map_factory_contract_by_hash,
-    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
-    library_map_get_contract_by_hash, library_map_key_view_contract_by_hash,
-    library_map_key_view_wrapper_contract_by_hash, library_method_call_contract,
-    library_ruby_set_factory_contract_by_hash, library_rust_vec_macro_factory_contract,
-    library_rust_vec_new_factory_contract, nullish_global_contract,
+    library_iterator_identity_adapter_contract, library_java_collection_constructor_contract,
+    library_java_collection_factory_contract_by_hash, library_java_map_entry_contract_by_hash,
+    library_java_map_factory_contract_by_hash, library_js_like_map_constructor_contract,
+    library_js_like_set_constructor_contract, library_map_get_contract_by_hash,
+    library_map_key_view_contract_by_hash, library_map_key_view_wrapper_contract_by_hash,
+    library_method_call_contract, library_ruby_set_factory_contract_by_hash,
+    library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
+    library_static_index_membership_contract, nullish_global_contract,
     own_property_guard_evidence_at_span, record_shape_guard_for_node, reduction_builtin_contract,
     rust_option_and_then_contract, rust_option_none_sentinel_contract,
     rust_option_some_constructor_contract, scalar_integer_method_contract, semantics,
-    seq_surface_contract_for_node, source_operator_at_node, static_index_membership_contract,
-    unshadowed_global_symbol, BuiltinArgContract, CardinalityPredicate, CardinalityThreshold,
-    ComparisonLaw, DomainEvidence, DomainRequirement, GoZeroMapDefaultKind, ImportFactKind,
-    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
-    JavaMapFactoryKind, LibraryApiCalleeContract, LibraryApiEvidenceStatus,
-    LibraryApiSpanEvidenceQuery, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
-    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
-    ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract, StaticIndexMembershipKind,
-    ValueDomain, ValueLaw, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD,
-    SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
+    seq_surface_contract_for_node, source_operator_at_node, unshadowed_global_symbol,
+    BuiltinArgContract, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
+    DomainRequirement, GoZeroMapDefaultKind, ImportFactKind, ImportedNamespaceFunctionSemantic,
+    IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind,
+    LibraryApiCalleeContract, LibraryApiEvidenceStatus, LibraryApiSpanEvidenceQuery,
+    LibraryCollectionFactoryResult, LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs,
+    MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
+    SeqSurfaceContract, StaticIndexMembershipKind, ValueDomain, ValueLaw, SEQ_VALUE_COLLECTION,
+    SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD,
+    SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
@@ -1094,6 +1095,45 @@ impl<'a> Builder<'a> {
             return None;
         }
         Some(self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), args[1..].to_vec()))
+    }
+
+    fn eval_java_collection_constructor_expr(
+        &mut self,
+        expr: NodeId,
+        kids: &[NodeId],
+    ) -> Option<ValueId> {
+        if kids.len() != 1 || self.il.kind(kids[0]) != NodeKind::Var {
+            return None;
+        }
+        let Payload::Name(type_name) = self.il.node(kids[0]).payload else {
+            return None;
+        };
+        let contract = library_java_collection_constructor_contract(
+            self.il.meta.lang,
+            self.interner.resolve(type_name),
+            kids.len().saturating_sub(1),
+        )?;
+        let LibraryApiCalleeContract::JavaUtilConstructor { .. } = contract.callee else {
+            return None;
+        };
+        match library_api_contract_evidence_for_call(
+            self.il,
+            self.interner,
+            expr,
+            contract.id,
+            contract.callee,
+            kids.len().saturating_sub(1),
+        ) {
+            LibraryApiEvidenceStatus::Admitted => {}
+            LibraryApiEvidenceStatus::Rejected => return None,
+            LibraryApiEvidenceStatus::Missing => return None,
+        }
+        match contract.result {
+            LibraryCollectionFactoryResult::EmptySequence => {
+                Some(self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), vec![]))
+            }
+            _ => None,
+        }
     }
 
     fn proven_ruby_set_factory_value(&self, value: ValueId) -> Option<ValueId> {
@@ -6687,8 +6727,21 @@ impl<'a> Builder<'a> {
         if !self.is_static_non_float_collection_expr(receiver) {
             return None;
         }
-        let contract = static_index_membership_contract(self.il.meta.lang, method, kids.len() - 1)?;
-        match contract.kind {
+        let contract =
+            library_static_index_membership_contract(self.il.meta.lang, method, kids.len() - 1)?;
+        match library_api_contract_evidence_for_call(
+            self.il,
+            self.interner,
+            node,
+            contract.id,
+            contract.callee,
+            kids.len().saturating_sub(1),
+        ) {
+            LibraryApiEvidenceStatus::Admitted => {}
+            LibraryApiEvidenceStatus::Rejected => return None,
+            LibraryApiEvidenceStatus::Missing => return None,
+        }
+        match contract.result.kind {
             StaticIndexMembershipKind::IndexOf => {
                 let element = self.eval(kids[1], env);
                 let collection = self.eval_membership_collection(receiver, env);
@@ -7889,6 +7942,15 @@ impl<'a> Builder<'a> {
                         return self
                             .mk(ValOp::Call(JS_PROTOTYPE_IN_CODE), vec![element, collection]);
                     }
+                    if semantics(self.il.meta.lang)
+                        .operators()
+                        .membership_operator(Op::In)
+                        .is_none()
+                    {
+                        let collection = self.eval(kids[1], env);
+                        let salt = self.source_salted_hash(expr, 0x494E_4F50);
+                        return self.mk(ValOp::Opaque(salt), vec![element, collection]);
+                    }
                     if let Some(map) = self.proven_map_key_view_expr(kids[1], env) {
                         return self.mk(ValOp::Bin(op), vec![element, map]);
                     }
@@ -8143,6 +8205,9 @@ impl<'a> Builder<'a> {
                 }
                 if kids.len() == 1 && self.is_rust_vec_new_call(expr, kids[0]) {
                     return self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), vec![]);
+                }
+                if let Some(v) = self.eval_java_collection_constructor_expr(expr, &kids) {
+                    return v;
                 }
                 if let Some(v) = self.eval_js_like_constructed_collection_or_map(expr, &kids, env) {
                     return v;
@@ -8813,9 +8878,10 @@ mod tests {
     use nose_semantics::{
         library_api_callee_contract_hash, library_api_contract_id_hash,
         library_free_name_collection_factory_contract,
-        library_imported_collection_factory_contract, library_java_collection_factory_contract,
-        library_java_map_factory_contract, library_js_like_map_constructor_contract,
-        library_js_like_set_constructor_contract, library_method_call_contract,
+        library_imported_collection_factory_contract, library_java_collection_constructor_contract,
+        library_java_collection_factory_contract, library_java_map_factory_contract,
+        library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
+        library_method_call_contract, library_static_index_membership_contract,
         LibraryApiContractId, FIRST_PARTY_PACK_ID,
     };
 
@@ -9643,6 +9709,109 @@ mod tests {
         let admitted = eval_proven_collection_op(&il, &interner, call)
             .expect("admitted LibraryApi evidence should prove the Java factory");
         assert!(matches!(admitted, ValOp::Seq(SEQ_VALUE_COLLECTION)));
+    }
+
+    #[test]
+    fn java_collection_constructor_value_graph_uses_library_api_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let callee = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("ArrayList")),
+            sp(80),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(81), &[callee]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(79), &[call]);
+        let mut il = finish_test_il(b, root, Lang::Java);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::source_span(sp(81)),
+            EvidenceKind::Source(SourceFactKind::Call(SourceCallKind::Construct)),
+        ));
+        push_imported_binding_use(&mut il, 1, sp(70), 2, sp(80), "java.util", "ArrayList");
+        assert!(
+            !matches!(
+                eval_op(&il, &interner, call),
+                ValOp::Seq(SEQ_VALUE_COLLECTION)
+            ),
+            "source/import proof alone must not canonicalize a Java constructor"
+        );
+
+        let contract =
+            library_java_collection_constructor_contract(Lang::Java, "ArrayList", 0).unwrap();
+        il.evidence.push(library_api_contract_evidence(
+            3,
+            sp(81),
+            contract.id,
+            contract.callee,
+            0,
+            vec![EvidenceId(0), EvidenceId(2)],
+        ));
+        assert!(matches!(
+            eval_op(&il, &interner, call),
+            ValOp::Seq(SEQ_VALUE_COLLECTION)
+        ));
+    }
+
+    #[test]
+    fn static_index_membership_value_graph_uses_library_api_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let red = b.add(
+            NodeKind::Lit,
+            Payload::LitStr(stable_symbol_hash("red")),
+            sp(90),
+            &[],
+        );
+        let array = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(91),
+            &[red],
+        );
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("indexOf")),
+            sp(92),
+            &[array],
+        );
+        let value = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("value")),
+            sp(93),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(94), &[callee, value]);
+        let minus_one = b.add(NodeKind::Lit, Payload::LitInt(-1), sp(95), &[]);
+        let comparison = b.add(
+            NodeKind::BinOp,
+            Payload::Op(Op::Ne),
+            sp(96),
+            &[call, minus_one],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(89), &[comparison]);
+        let mut il = finish_test_il(b, root, Lang::JavaScript);
+        il.evidence.push(collection_sequence_evidence(0, sp(91)));
+        assert!(
+            !matches!(eval_op(&il, &interner, comparison), ValOp::Bin(op) if op == Op::In as u32),
+            "static array receiver proof alone must not prove indexOf membership"
+        );
+
+        let contract =
+            library_static_index_membership_contract(Lang::JavaScript, "indexOf", 1).unwrap();
+        il.evidence.push(library_api_contract_evidence(
+            1,
+            sp(94),
+            contract.id,
+            contract.callee,
+            1,
+            vec![EvidenceId(0)],
+        ));
+        assert!(matches!(
+            eval_op(&il, &interner, comparison),
+            ValOp::Bin(op) if op == Op::In as u32
+        ));
     }
 
     #[test]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -4103,6 +4103,7 @@ pub enum LibraryApiContractId {
     JsArrayIsArray,
     JsBooleanCoercion,
     RegexTest,
+    JsLikeStaticIndexMembership(StaticIndexMembershipKind),
     ImportedNamespaceFunction(ImportedNamespaceFunctionSemantic),
     PromiseThen,
     IteratorIdentityAdapter,
@@ -4153,6 +4154,12 @@ fn library_api_contract_id_key(id: LibraryApiContractId) -> String {
         LibraryApiContractId::JsArrayIsArray => "js_like.array.is_array".into(),
         LibraryApiContractId::JsBooleanCoercion => "js_like.boolean.coercion".into(),
         LibraryApiContractId::RegexTest => "js_like.regex.test".into(),
+        LibraryApiContractId::JsLikeStaticIndexMembership(kind) => {
+            format!(
+                "js_like.static_index_membership.{}",
+                static_index_membership_kind_key(kind)
+            )
+        }
         LibraryApiContractId::ImportedNamespaceFunction(semantic) => {
             format!(
                 "imported_namespace_function.{}",
@@ -4193,6 +4200,13 @@ fn map_key_view_kind_key(kind: MapKeyViewKind) -> &'static str {
     match kind {
         MapKeyViewKind::Collection => "collection",
         MapKeyViewKind::Iterator => "iterator",
+    }
+}
+
+fn static_index_membership_kind_key(kind: StaticIndexMembershipKind) -> &'static str {
+    match kind {
+        StaticIndexMembershipKind::IndexOf => "index_of",
+        StaticIndexMembershipKind::FindIndex => "find_index",
     }
 }
 
@@ -4288,6 +4302,10 @@ pub enum LibraryApiCalleeContract {
         method: &'static str,
         required_receiver_fact: SourceFactKind,
     },
+    StaticIndexMembershipMethod {
+        method: &'static str,
+        receiver: StaticIndexMembershipReceiverContract,
+    },
     ImportedNamespaceFunction {
         module: &'static str,
         function: &'static str,
@@ -4342,6 +4360,12 @@ fn library_api_callee_contract_key(callee: LibraryApiCalleeContract) -> String {
         }
         LibraryApiCalleeContract::RegexLiteralMethod { method, .. } => {
             format!("regex_literal_method:{method}")
+        }
+        LibraryApiCalleeContract::StaticIndexMembershipMethod { method, receiver } => {
+            format!(
+                "static_index_membership_method:{method}:{}",
+                static_index_membership_receiver_contract_key(receiver)
+            )
         }
         LibraryApiCalleeContract::ImportedNamespaceFunction { module, function } => {
             format!("imported_namespace_function:{module}:{function}")
@@ -4399,6 +4423,16 @@ fn iterator_adapter_receiver_contract_key(
 ) -> &'static str {
     match receiver {
         IteratorAdapterReceiverContract::ExactIterableValue => "exact_iterable_value",
+    }
+}
+
+fn static_index_membership_receiver_contract_key(
+    receiver: StaticIndexMembershipReceiverContract,
+) -> &'static str {
+    match receiver {
+        StaticIndexMembershipReceiverContract::StaticNonFloatLiteralCollection => {
+            "static_non_float_literal_collection"
+        }
     }
 }
 
@@ -4525,6 +4559,13 @@ pub struct LibraryRegexTestContract {
     pub id: LibraryApiContractId,
     pub callee: LibraryApiCalleeContract,
     pub result: RegexTestContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryStaticIndexMembershipContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: StaticIndexMembershipContract,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -4754,6 +4795,11 @@ pub fn library_api_receiver_dependencies_for_call_with_cache(
             iterator_adapter_receiver_dependency_ids(il, interner, receiver_node, receiver, cache)
         }
         LibraryApiCalleeContract::AsyncMethod { .. } => None,
+        LibraryApiCalleeContract::StaticIndexMembershipMethod { method, receiver } => {
+            let receiver_node = method_callee_receiver(il, interner, callee_node, method)?;
+            static_index_membership_receiver_dependency_id(il, interner, receiver_node, receiver)
+                .map(|dependency| vec![dependency])
+        }
         _ => Some(Vec::new()),
     }
 }
@@ -4785,6 +4831,14 @@ fn library_api_callee_shape_matches(
             };
             actual_receiver == receiver && actual_method == method
         }
+        LibraryApiCalleeContract::JavaUtilConstructor {
+            simple_type,
+            qualified_type,
+            ..
+        } => {
+            var_name_matches(il, interner, callee_node, simple_type)
+                || var_name_matches(il, interner, callee_node, qualified_type)
+        }
         LibraryApiCalleeContract::RubyRequireStaticMember { method, .. } => {
             if il.kind(callee_node) != NodeKind::Field {
                 return false;
@@ -4797,6 +4851,9 @@ fn library_api_callee_shape_matches(
         }
         LibraryApiCalleeContract::RegexLiteralMethod { method, .. } => {
             field_method_matches(il, interner, callee_node, method)
+        }
+        LibraryApiCalleeContract::StaticIndexMembershipMethod { method, .. } => {
+            method_callee_receiver(il, interner, callee_node, method).is_some()
         }
         LibraryApiCalleeContract::ImportedNamespaceFunction { function, .. } => {
             field_method_matches(il, interner, callee_node, function)
@@ -4819,7 +4876,6 @@ fn library_api_callee_shape_matches(
         | LibraryApiCalleeContract::IteratorAdapterMethod { method, .. } => {
             method_callee_receiver(il, interner, callee_node, method).is_some()
         }
-        _ => false,
     }
 }
 
@@ -4880,6 +4936,27 @@ fn library_api_dependencies_match_callee(
                 il.node(receiver_node).span,
             )
         }
+        LibraryApiCalleeContract::JavaUtilConstructor {
+            simple_type,
+            qualified_type,
+            module,
+            requires_import_for_simple_type,
+            requires_no_local_type_shadow,
+        } => {
+            dependency_has_source_call(il, record, il.node(node).span, SourceCallKind::Construct)
+                && java_constructor_dependencies_match(
+                    il,
+                    interner,
+                    record,
+                    callee_node,
+                    il.node(node).span,
+                    simple_type,
+                    qualified_type,
+                    module,
+                    requires_import_for_simple_type,
+                    requires_no_local_type_shadow,
+                )
+        }
         LibraryApiCalleeContract::RubyRequireStaticMember {
             receiver,
             required_module,
@@ -4913,6 +4990,14 @@ fn library_api_dependencies_match_callee(
             };
             dependency_has_source_fact_node(il, record, receiver_node, required_receiver_fact)
         }
+        LibraryApiCalleeContract::StaticIndexMembershipMethod { method, receiver } => {
+            let Some(receiver_node) = method_callee_receiver(il, interner, callee_node, method)
+            else {
+                return false;
+            };
+            static_index_membership_receiver_dependency_id(il, interner, receiver_node, receiver)
+                .is_some_and(|dependency| dependency_ids_are_present(record, &[dependency]))
+        }
         LibraryApiCalleeContract::ImportedNamespaceFunction { module, .. } => {
             let Some(receiver_node) = il.children(callee_node).first().copied() else {
                 return false;
@@ -4945,8 +5030,161 @@ fn library_api_dependencies_match_callee(
                 .is_some_and(|dependencies| dependency_ids_are_present(record, &dependencies))
         }
         LibraryApiCalleeContract::AsyncMethod { .. } => false,
-        _ => false,
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn java_constructor_dependencies_match(
+    il: &Il,
+    interner: &Interner,
+    record: &EvidenceRecord,
+    callee_node: NodeId,
+    call_span: Span,
+    simple_type: &str,
+    qualified_type: &str,
+    module: &str,
+    requires_import_for_simple_type: bool,
+    requires_no_local_type_shadow: bool,
+) -> bool {
+    let Some(actual) = node_name(il, interner, callee_node) else {
+        return false;
+    };
+    java_constructor_dependencies_match_for_name(
+        il,
+        interner,
+        record,
+        actual,
+        Some(callee_node),
+        il.node(callee_node).span,
+        call_span,
+        simple_type,
+        qualified_type,
+        module,
+        requires_import_for_simple_type,
+        requires_no_local_type_shadow,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn java_constructor_dependencies_match_at_span(
+    il: &Il,
+    interner: &Interner,
+    record: &EvidenceRecord,
+    callee_span: Span,
+    call_span: Span,
+    simple_type: &str,
+    qualified_type: &str,
+    module: &str,
+    requires_import_for_simple_type: bool,
+    requires_no_local_type_shadow: bool,
+) -> bool {
+    let Some(callee_node) = node_at_span_with_kind(il, callee_span, NodeKind::Var) else {
+        return false;
+    };
+    java_constructor_dependencies_match(
+        il,
+        interner,
+        record,
+        callee_node,
+        call_span,
+        simple_type,
+        qualified_type,
+        module,
+        requires_import_for_simple_type,
+        requires_no_local_type_shadow,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn java_constructor_dependencies_match_for_name(
+    il: &Il,
+    interner: &Interner,
+    record: &EvidenceRecord,
+    actual: &str,
+    callee_node: Option<NodeId>,
+    callee_span: Span,
+    call_span: Span,
+    simple_type: &str,
+    qualified_type: &str,
+    module: &str,
+    requires_import_for_simple_type: bool,
+    requires_no_local_type_shadow: bool,
+) -> bool {
+    if actual == qualified_type {
+        return true;
+    }
+    if actual != simple_type {
+        return false;
+    }
+    if requires_no_local_type_shadow
+        && unit_defines_hash_visible_at(il, interner, stable_symbol_hash(simple_type), callee_span)
+    {
+        return false;
+    }
+    if !requires_import_for_simple_type {
+        return true;
+    }
+    let explicit_import = callee_node.is_some_and(|node| {
+        dependency_has_imported_binding_node(il, interner, record, node, module, simple_type)
+    });
+    explicit_import
+        || dependency_has_java_wildcard_import_before(
+            il,
+            interner,
+            record,
+            module,
+            simple_type,
+            call_span,
+        )
+}
+
+fn dependency_has_java_wildcard_import_before(
+    il: &Il,
+    interner: &Interner,
+    record: &EvidenceRecord,
+    module: &str,
+    simple_type: &str,
+    call_span: Span,
+) -> bool {
+    let expected = EvidenceKind::Import(ImportEvidenceKind::Wildcard {
+        module_hash: stable_symbol_hash(module),
+    });
+    record.dependencies.iter().any(|&id| {
+        let Some(dependency) = il.evidence_record_by_id(id) else {
+            return false;
+        };
+        dependency.status == EvidenceStatus::Asserted
+            && dependency.kind == expected
+            && matches!(
+                dependency.anchor,
+                EvidenceAnchor::SourceSpan(span)
+                    if span.file == call_span.file && span.end_byte <= call_span.start_byte
+            )
+            && !java_explicit_import_conflicts(il, interner, module, simple_type)
+    })
+}
+
+fn java_explicit_import_conflicts(
+    il: &Il,
+    _interner: &Interner,
+    module: &str,
+    simple_type: &str,
+) -> bool {
+    let local_hash = stable_symbol_hash(simple_type);
+    let expected = SymbolEvidenceKind::ImportedBinding {
+        module_hash: stable_symbol_hash(module),
+        exported_hash: stable_symbol_hash(simple_type),
+    };
+    il.evidence.iter().any(|record| {
+        matches!(
+            record.anchor,
+            EvidenceAnchor::Binding {
+                local_hash: anchor_hash,
+                ..
+            } if anchor_hash == local_hash
+        ) && matches!(record.kind, EvidenceKind::Symbol(actual) if actual != expected)
+            && record.status == EvidenceStatus::Asserted
+    })
 }
 
 fn library_api_dependencies_match_callee_at_span(
@@ -5046,6 +5284,29 @@ fn library_api_dependencies_match_callee_at_span(
                     !unit_defines_hash(il, interner, stable_symbol_hash(receiver))
                 }
         }
+        LibraryApiCalleeContract::JavaUtilConstructor {
+            simple_type,
+            qualified_type,
+            module,
+            requires_import_for_simple_type,
+            requires_no_local_type_shadow,
+        } => {
+            dependency_has_source_call(il, record, call_span, SourceCallKind::Construct)
+                && callee_span.is_some_and(|span| {
+                    java_constructor_dependencies_match_at_span(
+                        il,
+                        interner,
+                        record,
+                        span,
+                        call_span,
+                        simple_type,
+                        qualified_type,
+                        module,
+                        requires_import_for_simple_type,
+                        requires_no_local_type_shadow,
+                    )
+                })
+        }
         LibraryApiCalleeContract::RubyRequireStaticMember {
             receiver,
             required_module,
@@ -5069,6 +5330,15 @@ fn library_api_dependencies_match_callee_at_span(
         } => receiver_span.is_some_and(|span| {
             dependency_has_source_fact_anchor(il, record, span, required_receiver_fact)
         }),
+        LibraryApiCalleeContract::StaticIndexMembershipMethod { method, receiver } => {
+            callee_span.is_some_and(|span| field_method_at_span(il, interner, span, method))
+                && receiver_span.is_some_and(|span| {
+                    static_index_membership_receiver_dependency_id_at_span(
+                        il, interner, span, receiver,
+                    )
+                    .is_some_and(|dependency| dependency_ids_are_present(record, &[dependency]))
+                })
+        }
         LibraryApiCalleeContract::ImportedNamespaceFunction { module, .. } => {
             if let Some(span) = receiver_span {
                 dependency_has_imported_namespace_anchor(
@@ -5141,7 +5411,6 @@ fn library_api_dependencies_match_callee_at_span(
                 })
         }
         LibraryApiCalleeContract::AsyncMethod { .. } => false,
-        _ => false,
     }
 }
 
@@ -5660,6 +5929,84 @@ fn sequence_surface_dependency_id_for_receiver(
     found.map(|(_, id)| id)
 }
 
+fn static_index_membership_receiver_dependency_id(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+    contract: StaticIndexMembershipReceiverContract,
+) -> Option<EvidenceId> {
+    static_index_membership_receiver_dependency_id_at_span(
+        il,
+        interner,
+        il.node(receiver).span,
+        contract,
+    )
+    .filter(|_| static_index_membership_receiver_shape_matches(il, interner, receiver, contract))
+}
+
+fn static_index_membership_receiver_dependency_id_at_span(
+    il: &Il,
+    interner: &Interner,
+    span: Span,
+    contract: StaticIndexMembershipReceiverContract,
+) -> Option<EvidenceId> {
+    let receiver = node_at_span_with_kind(il, span, NodeKind::Seq)?;
+    if !static_index_membership_receiver_shape_matches(il, interner, receiver, contract) {
+        return None;
+    }
+    let anchor = EvidenceAnchor::sequence(span);
+    let mut found = None;
+    for record in &il.evidence {
+        let EvidenceKind::SequenceSurface(kind) = record.kind else {
+            continue;
+        };
+        if record.anchor != anchor
+            || record.status != EvidenceStatus::Asserted
+            || !il.evidence_dependencies_asserted(record)
+        {
+            continue;
+        }
+        match found {
+            None => found = Some((kind, record.id)),
+            Some((existing, _)) if existing == kind => {}
+            Some(_) => return None,
+        }
+    }
+    found.and_then(|(kind, id)| (kind == SequenceSurfaceKind::Collection).then_some(id))
+}
+
+fn static_index_membership_receiver_shape_matches(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+    contract: StaticIndexMembershipReceiverContract,
+) -> bool {
+    match contract {
+        StaticIndexMembershipReceiverContract::StaticNonFloatLiteralCollection => {
+            if il.kind(receiver) != NodeKind::Seq {
+                return false;
+            }
+            if !seq_surface_contract_for_node(il, interner, receiver)
+                .is_some_and(|surface| surface.membership_collection)
+            {
+                return false;
+            }
+            let kids = il.children(receiver);
+            !kids.is_empty()
+                && kids.iter().all(|&kid| {
+                    il.kind(kid) == NodeKind::Lit
+                        && matches!(
+                            il.node(kid).payload,
+                            Payload::LitInt(_)
+                                | Payload::LitBool(_)
+                                | Payload::LitStr(_)
+                                | Payload::Lit(LitClass::Null)
+                        )
+                })
+        }
+    }
+}
+
 fn sequence_surface_satisfies_method_receiver(
     surface: SeqSurfaceContract,
     contract: MethodReceiverContract,
@@ -5947,6 +6294,8 @@ fn library_api_contract_ids() -> Vec<LibraryApiContractId> {
         LibraryApiContractId::JsArrayIsArray,
         LibraryApiContractId::JsBooleanCoercion,
         LibraryApiContractId::RegexTest,
+        LibraryApiContractId::JsLikeStaticIndexMembership(StaticIndexMembershipKind::IndexOf),
+        LibraryApiContractId::JsLikeStaticIndexMembership(StaticIndexMembershipKind::FindIndex),
         LibraryApiContractId::PromiseThen,
         LibraryApiContractId::IteratorIdentityAdapter,
         LibraryApiContractId::StaticCollectionAdapter,
@@ -6138,6 +6487,14 @@ fn library_api_callee_contracts_for_id(
                 .map(|contract| vec![contract.callee])
                 .unwrap_or_default()
         }
+        LibraryApiContractId::JsLikeStaticIndexMembership(kind) => ["indexOf", "findIndex"]
+            .into_iter()
+            .filter_map(|method| library_static_index_membership_contract(lang, method, 1))
+            .filter(|contract| {
+                contract.id == LibraryApiContractId::JsLikeStaticIndexMembership(kind)
+            })
+            .map(|contract| contract.callee)
+            .collect(),
         LibraryApiContractId::MapGet => ["get"]
             .into_iter()
             .filter_map(|method| {
@@ -7372,6 +7729,22 @@ pub fn library_regex_test_contract(
         callee: LibraryApiCalleeContract::RegexLiteralMethod {
             method: result.method,
             required_receiver_fact: result.required_receiver_fact,
+        },
+        result,
+    })
+}
+
+pub fn library_static_index_membership_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<LibraryStaticIndexMembershipContract> {
+    let result = static_index_membership_contract(lang, method, arg_count)?;
+    Some(LibraryStaticIndexMembershipContract {
+        id: LibraryApiContractId::JsLikeStaticIndexMembership(result.kind),
+        callee: LibraryApiCalleeContract::StaticIndexMembershipMethod {
+            method: result.method,
+            receiver: result.receiver,
         },
         result,
     })

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -56,12 +56,12 @@ The current implemented kinds are:
 |---|---|
 | `Source` | construct syntax, Rust macro invocation syntax, regex literal provenance, and source operator family |
 | `Domain` | parameter, receiver-expression, or value/binding domain such as collection, map, option, string, integer, or byte array |
-| `Import` | static import binding/namespace proof, Ruby `require` module proof, and imported-literal snapshot provenance |
+| `Import` | static import binding/namespace proof, Java wildcard import proof, Ruby `require` module proof, and imported-literal snapshot provenance |
 | `Symbol` | resolved or proven symbol identity, with record kinds for unshadowed globals, static imported binding/namespace aliases, and selected qualified global API paths |
 | `Guard` | multi-obligation guard proof facts such as JS/TS record-shape and own-property guard contracts |
 | `Place` | fixed receiver/place facts currently covering `SelfReceiver` and `SelfField` |
 | `Effect` | observable effect facts currently covering canonical builder append calls, non-overloadable index writes, and fixed self-field writes |
-| `LibraryApi` | proof that a specific call occurrence matches a language/API contract coordinate, currently for selected JS-like static/global APIs, selected Python/Rust/Ruby/Java/regex APIs, and selected receiver-method families |
+| `LibraryApi` | proof that a specific call occurrence matches a language/API contract coordinate, currently for selected JS-like static/global/static-index APIs, selected Python/Rust/Ruby/Java/regex APIs, and selected receiver-method families |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, guard surfaces, Go composite map literals, or Go map entries |
 
 `LibraryApi` evidence is an occurrence fact, not the whole contract. It records
@@ -87,6 +87,11 @@ Current first-party `LibraryApi` callee coordinates are intentionally specific:
 - `JavaUtilStaticMember` names selected Java `java.util` static factory/adaptor
   calls and depends on matching Java import-binding evidence plus source-origin
   local type shadow checks.
+- `JavaUtilConstructor` names selected Java `java.util` constructors and depends
+  on construct-syntax evidence plus exact import-binding evidence or earlier
+  Java wildcard import evidence. Wildcard proof is constrained by Java name
+  resolution: a local same-name type or explicit same-name import from another
+  package keeps the occurrence closed.
 - `RustMacro` names a Rust macro invocation, currently `vec!`, and depends on
   both `Source::Call(MacroInvocation)` at the call span and
   `Symbol(UnshadowedGlobal)` evidence at the macro callee anchor.
@@ -97,6 +102,10 @@ Current first-party `LibraryApi` callee coordinates are intentionally specific:
 - `JsGlobalConstructor` and `RegexLiteralMethod` name APIs whose identity
   includes source provenance, such as construct syntax or regex-literal receiver
   proof.
+- `StaticIndexMembershipMethod` names JS-like `indexOf`/`findIndex` membership
+  calls and depends on `SequenceSurface(Collection)` evidence for the exact
+  receiver plus the static non-float literal receiver shape required by the
+  contract.
 - `Method` and `IteratorAdapterMethod` name language-scoped receiver methods by
   exact method string and arity. They depend on receiver proof such as
   `Domain`, `SequenceSurface`, imported-namespace or unshadowed-global `Symbol`,
@@ -269,25 +278,28 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   write proof back to the receiver proof;
 - first-party lowering emits `LibraryApi` evidence for selected API calls that
   remain as raw call nodes: JS-like `Array.from(...)`, `Array.isArray(...)`,
-  `Boolean(...)`, `new Map(...)`, and `new Set(...)`; Python builtin collection
-  factories such as `list(...)` when the callee has an unshadowed free-name
-  proof; Python `collections.deque(...)` through imported binding/namespace
-  proof; Python `math.prod(...)` through imported namespace proof; Rust
+  `Boolean(...)`, `new Map(...)`, `new Set(...)`, and static
+  `indexOf`/`findIndex` membership calls whose receiver has collection
+  sequence-surface proof; Python builtin collection factories such as
+  `list(...)` when the callee has an unshadowed free-name proof; Python
+  `collections.deque(...)` through imported binding/namespace proof; Python
+  `math.prod(...)` through imported namespace proof; Rust
   `vec!(...)` when macro-invocation source syntax and macro-name shadow policy
   are proven, `Vec::new()`, and selected `std::collections::*::from(...)`
   factory paths when their root-shadow policy is proven; Ruby
   earlier top-level `require "set"; Set.new(...)` through `Import::Require`
   plus unshadowed `require` and `Set` proof; Java `java.util` static
-  factories/adapters including
-  `List.of`, `Set.of`, `Arrays.asList`, `Map.of`, `Map.ofEntries`, `Map.entry`,
-  and `Arrays.stream`; and JS-like regex-literal `.test(...)`. These records
+  factories/adapters including `List.of`, `Set.of`, `Arrays.asList`, `Map.of`,
+  `Map.ofEntries`, `Map.entry`, and `Arrays.stream`, plus selected empty
+  `new ArrayList<>()`/`new LinkedList<>()` constructors through exact or
+  wildcard import proof; and JS-like regex-literal `.test(...)`. These records
   depend on the relevant `QualifiedGlobal`, `UnshadowedGlobal`,
   import-backed call-site `Symbol`, `Import::Require`, construct-syntax
-  `Source`, or regex-literal `Source` evidence. Calls collapsed into specialized
-  guard surfaces emit their guard evidence instead. Shadowed roots, unsupported
-  arities, unsupported static paths, unresolved free-name/path factories, and
-  Ruby require-backed APIs without require evidence do not emit API occurrence
-  evidence;
+  `Source`, `SequenceSurface`, or regex-literal `Source` evidence. Calls
+  collapsed into specialized guard surfaces emit their guard evidence instead.
+  Shadowed roots, unsupported arities, unsupported static paths, unresolved
+  free-name/path factories, and Ruby require-backed APIs without require
+  evidence do not emit API occurrence evidence;
 - first-party lowering plus post-binding and final-normalization refresh passes
   emit `LibraryApi`
   occurrence evidence for selected receiver methods that remain as raw call
@@ -305,9 +317,10 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   receiver-expression `Domain` evidence: Python `list`/`tuple` and
   `collections.deque`, Rust `Vec::new`, `vec!`, and
   `std::collections::VecDeque::from`, Java `List.of` and zero- or multi-argument
-  `Arrays.asList` as `Collection`; Python `set`/`frozenset`, Rust
-  `std::collections::{HashSet,BTreeSet}::from`, Java `Set.of`, Ruby
-  `Set.new`, and JS-like `new Set` as `Set`; Rust
+  `Arrays.asList`, and selected empty `new ArrayList<>()`/`new LinkedList<>()`
+  as `Collection`; Python `set`/`frozenset`, Rust
+  `std::collections::{HashSet,BTreeSet}::from`, Java `Set.of`, Ruby `Set.new`,
+  and JS-like `new Set` as `Set`; Rust
   `std::collections::{HashMap,BTreeMap}::from`, Java `Map.of`/`Map.ofEntries`,
   and JS-like `new Map` as `Map`; and JS-like one-argument `Array.from` as
   `Array`. `Map.entry`, `Array.isArray`, `Boolean`, regex `.test`,
@@ -407,11 +420,12 @@ callers:
   language-gated helper only when no relevant evidence record exists. Ambiguous
   or conflicting evidence keeps the exact path closed.
 
-Broader field/place/effect facts, `LibraryApi` occurrence evidence for Java
-constructors, JS/TS static-index membership, free-name builtin calls, promise
-receiver proof, and unmodeled stdlib/ecosystem APIs, broader inferred
-receiver-expression domain evidence, first-class mutation/effect evidence beyond
-the current first-party binding scan, full protocol/demand/effect receiver
-obligations, full scope-resolution and namespace-member evidence, broader guard
-evidence, general cross-module dependency manifests, report-level provenance,
-and external manifest loading are still open work.
+Broader field/place/effect facts, `LibraryApi` occurrence evidence for
+free-name builtin calls outside the current factory/function rows, promise
+receiver proof, async/sync protocol convergence, and unmodeled
+stdlib/ecosystem APIs, broader inferred receiver-expression domain evidence,
+first-class mutation/effect evidence beyond the current first-party binding
+scan, full protocol/demand/effect receiver obligations, full scope-resolution
+and namespace-member evidence, broader guard evidence, general cross-module
+dependency manifests, report-level provenance, and external manifest loading are
+still open work.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -378,6 +378,18 @@ and pack ecosystem.
   admitted method calls also remain admissible protocol receivers through their
   same-span `MethodCall(HoF(...))` occurrence record, so downstream adapters can
   consume canonicalized HOFs without trusting selector spelling alone.
+- The static API occurrence slice moved Java empty collection constructors and
+  JS-like static `indexOf`/`findIndex` membership behind the same
+  dependency-backed occurrence boundary. `new ArrayList<>()`/
+  `new LinkedList<>()` now stay as construct `Call` nodes until exact or
+  wildcard `java.util` import proof admits the `LibraryApi` record; explicit
+  same-name imports and local type declarations close wildcard proof. Static
+  index membership now emits `LibraryApi` evidence that depends on the exact
+  receiver `SequenceSurface(Collection)` fact, and value-graph/strict exact
+  consumers require the admitted occurrence instead of trusting method spelling
+  plus literal children. Raw `Op::In` value-graph canonicalization now also
+  checks the language membership-operator contract before treating the operator
+  as collection membership.
 - Value-graph and structural-recursion domain gates moved from normalize-local
   `types.rs` / `Ty` inference to `nose-semantics` `ValueDomain` and `ValueLaw`
   contracts. The first contract set covers add non-concat ordering,
@@ -463,9 +475,9 @@ Remaining in this phase:
 - Continue moving library API recognition into `LibraryApiContract` rows and
   `LibraryApi` occurrence evidence. The already producer-covered occurrence
   surfaces are now fail-closed on missing evidence; remaining work is producer
-  coverage for Java constructors, JS/TS static-index membership, free-name
-  builtin calls, promise receiver proof, and ecosystem APIs whose
-  receiver/domain/demand obligations are not yet expressible.
+  coverage for free-name builtin calls outside the current factory/function
+  rows, promise receiver proof, async/sync protocol convergence, and ecosystem
+  APIs whose receiver/domain/demand obligations are not yet expressible.
   The first internal slice covers collection/map factories, selected
   constructors, Java empty collection constructors, Java `Map.entry`, and the
   shared shadow/import/result
@@ -477,9 +489,10 @@ Remaining in this phase:
   call contracts. Occurrence-evidence slices now cover selected JS-like
   static/global APIs, Python builtin/import-backed factories/functions, Rust
   free-name/path factories, Ruby require-backed factories, Java `java.util`
-  static factories/adapters, JS regex literals, and selected receiver-method
-  families. Remaining stdlib and ecosystem APIs still need dependency-backed
-  occurrence records before they become pack-facing. Producer-covered
+  static factories/adapters and selected empty constructors, JS regex literals,
+  JS/TS static-index membership, and selected receiver-method families.
+  Remaining stdlib and ecosystem APIs still need dependency-backed occurrence
+  records before they become pack-facing. Producer-covered
   factory/API result calls now also emit dependent call-node `Domain` evidence
   when the current `DomainEvidence` vocabulary can represent the result.
 - Keep value-graph and strict exact gates on the same contract source. Factory,
@@ -488,9 +501,9 @@ Remaining in this phase:
   Python builtin/import-backed, Rust free-name/path, Ruby require-backed, Java
   `java.util`, and regex calls now additionally share `LibraryApi` occurrence
   evidence, as do selected receiver-method families. Remaining API work is to
-  move raw sequence/tag, Java constructor, JS/TS static-index, and free-builtin
-  proof dependencies into explicit evidence records, then cover ecosystem APIs
-  only after demand, receiver, and effect obligations are expressible.
+  move the remaining raw sequence/tag and free-builtin proof dependencies into
+  explicit evidence records, then cover ecosystem APIs only after demand,
+  receiver, and effect obligations are expressible.
 - Continue import/module proof migration beyond the removed raw import payloads
   and evidence-only import identity path. Value-graph import identity and
   imported-symbol exact proof are now evidence-only, imported literal replacement

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -15,13 +15,14 @@ place/effect, selected library API occurrence, value-domain/law contracts, and
 sequence-surface facts.
 Library/API identity is consolidated through internal `LibraryApiContract` rows
 for factory, constructor, and selected non-factory method/view surfaces, with
-occurrence evidence covering selected JS-like static/global APIs, Python
-builtin/import-backed APIs, Rust free-name/path APIs, Ruby require-backed APIs,
-Java `java.util` APIs, JS regex API calls, and selected language-scoped
-receiver-method APIs such as collection membership, map lookup/defaulting,
-map-key views, iterator identity adapters, Rust `zip`, and HOF/reduction
-methods. Selected producer-covered factory/API calls now also emit dependent
-receiver-expression `Domain` evidence
+occurrence evidence covering selected JS-like static/global APIs and static
+index-membership calls, Python builtin/import-backed APIs, Rust free-name/path
+APIs, Ruby require-backed APIs, Java `java.util` APIs including selected empty
+constructors, JS regex API calls, and selected language-scoped receiver-method
+APIs such as collection membership, map lookup/defaulting, map-key views,
+iterator identity adapters, Rust `zip`, and HOF/reduction methods. Selected
+producer-covered factory/API calls now also emit dependent receiver-expression
+`Domain` evidence
 for their result container domain, and normalize emits binding-anchored `Domain`
 evidence for immutable local/module bindings whose initializer domain and
 non-mutation conditions are proven by first-party evidence/analysis.
@@ -193,8 +194,10 @@ migrated.
 - Selected API call occurrences now also have `LibraryApi` evidence records when
   they remain as raw call nodes. First-party lowering emits occurrence evidence
   for JS-like `Array.from(...)`, `Array.isArray(...)`, `Boolean(...)`,
-  `new Map(...)`, and `new Set(...)`; Python builtin collection factories such
-  as `list(...)` when the callee is proven as an unshadowed free name; Python
+  `new Map(...)`, `new Set(...)`, and static `indexOf`/`findIndex` membership
+  calls whose receiver is a proven static non-float collection literal; Python
+  builtin collection factories such as `list(...)` when the callee is proven as
+  an unshadowed free name; Python
   `collections.deque(...)` when the callee is proven through
   `from collections import deque`, an alias such as
   `from collections import deque as Values`, or `import collections;
@@ -204,13 +207,14 @@ migrated.
   factory paths when their root-shadow policy is proven; Ruby
   `require "set"; Set.new(...)` when an earlier top-level `Import::Require("set")`
   depends on unshadowed `require` proof and unshadowed `Set` receiver proof
-  exists; Java `java.util` static
-  factories/adapters such as `List.of`, `Set.of`, `Arrays.asList`, `Map.of`,
-  `Map.ofEntries`, `Map.entry`, and `Arrays.stream`; and JS-like regex-literal
-  `.test(...)`. These records depend on the relevant `QualifiedGlobal`,
+  exists; Java `java.util` static factories/adapters such as `List.of`,
+  `Set.of`, `Arrays.asList`, `Map.of`, `Map.ofEntries`, `Map.entry`, and
+  `Arrays.stream`, plus selected empty `new ArrayList<>()`/`new LinkedList<>()`
+  constructors; and JS-like regex-literal `.test(...)`. These records depend on
+  the relevant `QualifiedGlobal`,
   `UnshadowedGlobal`, import-backed call-site `Symbol`, `Import::Require`,
-  macro-invocation `Source`, construct-syntax `Source`, or regex-literal
-  `Source` evidence. Calls
+  macro-invocation `Source`, construct-syntax `Source`, `SequenceSurface`, or
+  regex-literal `Source` evidence. Calls
   collapsed into specialized guard surfaces emit guard evidence instead.
   `nose-semantics` resolves these records with a three-state result: admitted,
   missing, or rejected. Value-graph, idiom, strict exact, and provider snapshot
@@ -245,13 +249,16 @@ migrated.
   the `collect` selector alone.
 - Java empty collection constructor contracts cover `new ArrayList<>()` and
   `new LinkedList<>()` through `LibraryApiContract` rows only for the Java
-  `java.util` list types. Simple names require `java.util` import proof and no
-  local type declaration with the same simple name. A `java.util.*` wildcard
-  import is not enough when another package explicitly imports the same simple
-  type; fully-qualified `java.util.*List` names carry the namespace proof in the
-  selector itself. These constructors currently lower directly to a sequence
-  surface rather than remaining as raw call nodes, so they do not emit call-node
-  result-domain evidence yet.
+  `java.util` list types. Simple names require exact `java.util` import proof or
+  earlier `java.util.*` wildcard import proof, plus no local type declaration
+  with the same simple name. A `java.util.*` wildcard import is not enough when
+  another package explicitly imports the same simple type; fully-qualified
+  `java.util.*List` names carry the namespace proof in the selector itself.
+  First-party Java lowering preserves these supported constructors as construct
+  `Call` nodes and emits admitted `LibraryApi` occurrence evidence. Value-graph
+  collection canonicalization and result `Domain(Collection)` evidence require
+  that occurrence proof, so source/import facts alone do not reopen the exact
+  path.
 - Builder append contracts are separate from arbitrary method calls. A selector
   such as `push`, `append`, or `add` is not proof by itself. First-party
   frontend/normalize paths must prove the receiver or active-builder contract and
@@ -327,13 +334,16 @@ migrated.
   separate zero-arg-lambda fallback argument contract, so block fallback demand
   is not inferred from the selector name in normalize/detect.
 - JS-like static array `indexOf`/`findIndex` membership surfaces are explicit
-  contracts, including the static non-float literal collection requirement and
-  accepted `-1`/`0` threshold comparisons through `OperatorSemantics`. Callback
-  membership variants also require source operator facts: JS-like strict
-  equality/inequality can enter exact matching, while loose equality,
-  `instanceof`, and non-JS equality surfaces stay closed for these contracts.
-  Callers still prove the receiver and lambda equality shape before exact
-  normalization/detection accepts them.
+  `LibraryApi` occurrence contracts, including the static non-float literal
+  collection requirement and accepted `-1`/`0` threshold comparisons through
+  `OperatorSemantics`. The occurrence record depends on
+  `SequenceSurface(Collection)` evidence for the exact receiver, and value-graph
+  and strict exact consumers require that admitted call occurrence before
+  treating a threshold comparison as membership. Callback membership variants
+  also require source operator facts: JS-like strict equality/inequality can
+  enter exact matching, while loose equality, `instanceof`, and non-JS equality
+  surfaces stay closed for these contracts. Callers still prove the receiver and
+  lambda equality shape before exact normalization/detection accepts them.
 - Source `Op::In` is not proof by itself. Strict exact collection/map
   membership currently admits Python `in` only through a language-scoped
   membership-operator contract plus receiver evidence. JS `in` remains
@@ -382,10 +392,11 @@ migrated.
   enough. Go `composite_literal` no longer falls back to a generic collection
   sequence tag; it is consumed only by the Go map contract or left as a distinct
   surface.
-- Static JS-like `indexOf`/`findIndex` membership requires a receiver whose
-  sequence surface has membership-collection admission. Untagged sequence
-  expressions, destructuring surfaces, and other positional groupings do not
-  become static array membership merely because their children are literals.
+- Static JS-like `indexOf`/`findIndex` membership requires a call occurrence
+  whose receiver sequence surface has membership-collection admission. Untagged
+  sequence expressions, destructuring surfaces, and other positional groupings
+  do not become static array membership merely because their children are
+  literals.
 - JS/TS object literals preserve static property keys in exact map/object
   semantics, but computed property names are exact-closed until a future
   contract can prove key evaluation, coercion, order, and side-effect behavior.
@@ -464,12 +475,13 @@ Semantic knowledge still appears in several forms outside the facade:
   HOFs, nullish defaulting, recursion, and effect traces;
 - remaining library/API proof gates that do not yet have occurrence records.
   `LibraryApi` occurrence evidence now covers selected JS-like static/global
-  APIs, Python builtin/import-backed factories/functions, Rust free-name/path
-  factories, Ruby `require "set"; Set.new(...)`, Java `java.util` static
-  factories/adapters, JS regex literals, and selected receiver-method families.
-  Java empty constructors, JS/TS static-index membership, free-name builtin
-  calls, promise receiver proof, and ecosystem APIs still rely on contract rows
-  plus local proof or remain exact-closed.
+  APIs and static-index membership, Python builtin/import-backed
+  factories/functions, Rust free-name/path factories, Ruby
+  `require "set"; Set.new(...)`, Java `java.util` static factories/adapters and
+  selected empty constructors, JS regex literals, and selected receiver-method
+  families. Free-name builtin calls outside the current factory/function rows,
+  promise receiver proof, async/sync protocol convergence, and ecosystem APIs
+  still rely on contract rows plus local proof or remain exact-closed.
 
 These are valuable, but they do not yet share one complete semantic contract
 language.


### PR DESCRIPTION
## Summary

Moves two remaining first-party static API surfaces onto dependency-backed `LibraryApi` occurrence evidence:

- Java empty `new ArrayList<>()` / `new LinkedList<>()` constructors now stay as construct `Call` nodes and require admitted Java `java.util` constructor occurrence evidence before result-domain or value-graph collection semantics apply.
- JS/TS static `indexOf` / `findIndex` membership now emits and consumes `LibraryApi` evidence tied to the exact receiver `SequenceSurface(Collection)` fact.
- Raw value-graph `Op::In` now requires a language membership-operator contract before canonicalizing to collection membership, preserving JS `in` as property/prototype semantics.

## Why

This continues the semantic-kernel migration tracked in #109: selectors and source facts remain dependencies, not semantic proof by themselves. The new paths make Java constructor and JS/TS static-index semantics pack-shaped without opening name-only fallbacks.

## Notes

- Java wildcard import proof is represented as `ImportEvidenceKind::Wildcard`, but it is constrained by Java name resolution: explicit same-name imports from other packages and local same-name types close the occurrence.
- Producer-covered constructor calls now emit dependent `Domain(Collection)` evidence only after the `LibraryApi` occurrence is admitted.
- Docs were updated in the snapshot, roadmap, and evidence-record pages.

## Validation

- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo doc --no-deps --workspace`
- `awiki lint --root docs`
- `cargo build --release`
- `./scripts/check-duplication.sh`

Refs #109
