### PR TITLE
Move free builtins onto API occurrence evidence

### DIFF
--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -13,7 +13,7 @@ use nose_il::{
 use nose_semantics::{
     library_api_callee_contract_hash, library_api_contract_id_hash,
     library_api_free_name_shadow_safe, library_api_receiver_dependencies_for_call_with_cache,
-    library_collection_factory_result_domain_for_arity,
+    library_collection_factory_result_domain_for_arity, library_free_function_builtin_contract,
     library_free_name_collection_factory_contract, library_free_name_map_factory_contract,
     library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
     library_java_collection_constructor_contract, library_java_collection_factory_contract,
@@ -1325,6 +1325,18 @@ fn record_post_lower_free_name_library_api(il: &mut Il, interner: &Interner, cal
                         library_collection_factory_result_domain_for_arity(contract, arg_count),
                     )
                 })
+        })
+        .or_else(|| {
+            library_free_function_builtin_contract(il.meta.lang, callee_name, arg_count).map(
+                |contract| {
+                    (
+                        contract.id,
+                        contract.callee,
+                        "library_api_free_function_builtin",
+                        None,
+                    )
+                },
+            )
         });
     let Some((id, callee_contract, rule, result_domain)) = contract else {
         return false;
@@ -3143,6 +3155,87 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
                 library_api_callee_contract_hash(py_contract.callee),
             ),
             0
+        );
+
+        let py_len = crate::lower_source(
+            FileId(0),
+            "len.py",
+            b"def f(values):\n    return len(values)\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        let py_len_contract =
+            library_free_function_builtin_contract(Lang::Python, "len", 1).unwrap();
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &py_len.evidence,
+                library_api_contract_id_hash(py_len_contract.id),
+                library_api_callee_contract_hash(py_len_contract.callee),
+            ),
+            1
+        );
+
+        let shadowed_py_len = crate::lower_source(
+            FileId(0),
+            "shadowed_len.py",
+            b"def f(len, values):\n    return len(values)\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &shadowed_py_len.evidence,
+                library_api_contract_id_hash(py_len_contract.id),
+                library_api_callee_contract_hash(py_len_contract.callee),
+            ),
+            0
+        );
+
+        let wildcard_py_len = crate::lower_source(
+            FileId(0),
+            "wildcard_len.py",
+            b"from custom import *\n\ndef f(values):\n    return len(values)\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &wildcard_py_len.evidence,
+                library_api_contract_id_hash(py_len_contract.id),
+                library_api_callee_contract_hash(py_len_contract.callee),
+            ),
+            0
+        );
+
+        let go = crate::lower_source(
+            FileId(0),
+            "builtin.go",
+            b"package p\nfunc f(xs []int, x int) int { return len(xs) }\nfunc g(xs []int, x int) []int { return append(xs, x) }\n",
+            Lang::Go,
+            &interner,
+        )
+        .expect("go lowering should succeed");
+        let go_len_contract = library_free_function_builtin_contract(Lang::Go, "len", 1).unwrap();
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &go.evidence,
+                library_api_contract_id_hash(go_len_contract.id),
+                library_api_callee_contract_hash(go_len_contract.callee),
+            ),
+            1
+        );
+        let go_append_contract =
+            library_free_function_builtin_contract(Lang::Go, "append", 2).unwrap();
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &go.evidence,
+                library_api_contract_id_hash(go_append_contract.id),
+                library_api_callee_contract_hash(go_append_contract.callee),
+            ),
+            1
         );
 
         let rust = crate::lower_source(

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -12,8 +12,8 @@ use nose_il::{
     HoFKind, Il, Interner, NodeId, NodeKind, Payload, Span, Symbol,
 };
 use nose_semantics::{
-    domain_evidence_for_param, free_function_builtin_contract, imported_namespace_symbol,
-    library_api_contract_evidence_for_call, library_free_name_map_factory_contract,
+    domain_evidence_for_param, imported_namespace_symbol, library_api_contract_evidence_for_call,
+    library_free_function_builtin_contract, library_free_name_map_factory_contract,
     library_iterator_identity_adapter_contract, library_map_get_contract,
     library_map_key_view_contract, library_method_call_contract,
     library_static_collection_adapter_contract, rust_option_some_constructor_contract,
@@ -306,17 +306,24 @@ pub(crate) fn canon_call_with_domains(
     match cn.kind {
         NodeKind::Var => {
             if let Payload::Name(s) = cn.payload {
-                if let Some(contract) =
-                    free_function_builtin_contract(old.meta.lang, interner.resolve(s), args.len())
-                {
-                    if contract.requires_unshadowed
-                        && file_defines_name(old, interner, interner.resolve(s))
-                    {
+                if let Some(contract) = library_free_function_builtin_contract(
+                    old.meta.lang,
+                    interner.resolve(s),
+                    args.len(),
+                ) {
+                    if !library_api_evidence_admitted(
+                        old,
+                        interner,
+                        call_id,
+                        contract.id,
+                        contract.callee,
+                        args.len(),
+                    ) {
                         return CallCanon::None;
                     }
-                    match contract.args {
-                        BuiltinArgContract::First => builtin!(contract.builtin, first),
-                        BuiltinArgContract::All => builtin!(contract.builtin, all),
+                    match contract.result.args {
+                        BuiltinArgContract::First => builtin!(contract.result.builtin, first),
+                        BuiltinArgContract::All => builtin!(contract.result.builtin, all),
                     }
                 }
             }
@@ -1288,6 +1295,45 @@ mod tests {
         Some(EvidenceId(id))
     }
 
+    fn push_free_function_builtin_library_api_evidence(
+        il: &mut Il,
+        interner: &Interner,
+        call: NodeId,
+    ) -> Option<EvidenceId> {
+        let kids = il.children(call);
+        let (&callee, args) = kids.split_first()?;
+        let arg_count = args.len();
+        let callee_span = il.node(callee).span;
+        let call_span = il.node(call).span;
+        let Payload::Name(symbol) = il.node(callee).payload else {
+            return None;
+        };
+        let name = interner.resolve(symbol);
+        let contract = library_free_function_builtin_contract(il.meta.lang, name, arg_count)?;
+        let symbol_id = next_evidence_id(il);
+        il.evidence.push(evidence(
+            symbol_id,
+            EvidenceAnchor::node(callee_span, NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash(name),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        let id = next_evidence_id(il);
+        il.evidence.push(evidence_with_dependencies(
+            id,
+            EvidenceAnchor::node(call_span, NodeKind::Call),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: nose_semantics::library_api_contract_id_hash(contract.id),
+                callee_hash: nose_semantics::library_api_callee_contract_hash(contract.callee),
+                arity: arg_count as u16,
+            }),
+            EvidenceStatus::Asserted,
+            vec![EvidenceId(symbol_id)],
+        ));
+        Some(EvidenceId(id))
+    }
+
     fn free_call_il(lang: Lang, name: &str, shadow_name: bool) -> (Il, Interner, NodeId) {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
@@ -1874,13 +1920,17 @@ mod tests {
 
     #[test]
     fn free_name_builtin_requires_no_shadowing() {
-        let (il, interner, call) = free_call_il(Lang::Python, "len", true);
+        let (mut il, interner, call) = free_call_il(Lang::Python, "len", true);
+        let _ = push_free_function_builtin_library_api_evidence(&mut il, &interner, call);
         assert!(matches!(canon_call(&il, &interner, call), CallCanon::None));
     }
 
     #[test]
-    fn python_unshadowed_builtin_is_admitted() {
-        let (il, interner, call) = free_call_il(Lang::Python, "len", false);
+    fn python_unshadowed_builtin_requires_library_api_evidence() {
+        let (mut il, interner, call) = free_call_il(Lang::Python, "len", false);
+        assert!(matches!(canon_call(&il, &interner, call), CallCanon::None));
+
+        let _ = push_free_function_builtin_library_api_evidence(&mut il, &interner, call);
         assert!(matches!(
             canon_call(&il, &interner, call),
             CallCanon::Builtin {

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -51,23 +51,23 @@ use nose_il::{
 use nose_semantics::{
     builder_append_method_contract, builtin_tag, construct_syntax_proof,
     domain_evidence_for_param as semantic_domain_evidence_for_param,
-    exact_static_membership_predicate_operator, free_function_builtin_contract,
-    go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
-    go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract, import_fact_evidence_rhs,
+    exact_static_membership_predicate_operator, go_zero_map_default_kind,
+    go_zero_map_entry_contract_for_node, go_zero_map_literal_contract_for_node,
+    go_zero_map_lookup_contract, import_fact_evidence_rhs,
     imported_literal_producer_evidence_for_node, imported_namespace_symbol,
     library_api_contract_evidence_at_call_span, library_api_contract_evidence_for_call,
-    library_free_name_collection_factory_contracts, library_free_name_map_factory_contracts,
-    library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
-    library_iterator_identity_adapter_contract, library_java_collection_constructor_contract,
-    library_java_collection_factory_contract_by_hash, library_java_map_entry_contract_by_hash,
-    library_java_map_factory_contract_by_hash, library_js_like_map_constructor_contract,
-    library_js_like_set_constructor_contract, library_map_get_contract_by_hash,
-    library_map_key_view_contract_by_hash, library_map_key_view_wrapper_contract_by_hash,
-    library_method_call_contract, library_ruby_set_factory_contract_by_hash,
-    library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
-    library_static_index_membership_contract, nullish_global_contract,
-    own_property_guard_evidence_at_span, record_shape_guard_for_node, reduction_builtin_contract,
-    rust_option_and_then_contract, rust_option_none_sentinel_contract,
+    library_free_function_builtin_contract, library_free_name_collection_factory_contracts,
+    library_free_name_map_factory_contracts, library_imported_collection_factory_contracts,
+    library_imported_namespace_function_contract, library_iterator_identity_adapter_contract,
+    library_java_collection_constructor_contract, library_java_collection_factory_contract_by_hash,
+    library_java_map_entry_contract_by_hash, library_java_map_factory_contract_by_hash,
+    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
+    library_map_get_contract_by_hash, library_map_key_view_contract_by_hash,
+    library_map_key_view_wrapper_contract_by_hash, library_method_call_contract,
+    library_ruby_set_factory_contract_by_hash, library_rust_vec_macro_factory_contract,
+    library_rust_vec_new_factory_contract, library_static_index_membership_contract,
+    nullish_global_contract, own_property_guard_evidence_at_span, record_shape_guard_for_node,
+    reduction_builtin_contract, rust_option_and_then_contract, rust_option_none_sentinel_contract,
     rust_option_some_constructor_contract, scalar_integer_method_contract, semantics,
     seq_surface_contract_for_node, source_operator_at_node, unshadowed_global_symbol,
     BuiltinArgContract, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
@@ -2308,6 +2308,7 @@ impl<'a> Builder<'a> {
 
     fn eval_proven_free_minmax_call(
         &mut self,
+        expr: NodeId,
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
@@ -2318,11 +2319,11 @@ impl<'a> Builder<'a> {
             return None;
         };
         let method = self.interner.resolve(name);
-        let contract = free_function_builtin_contract(self.il.meta.lang, method, 2)?;
-        if contract.requires_unshadowed && self.file_defines_name(method) {
+        let contract = library_free_function_builtin_contract(self.il.meta.lang, method, 2)?;
+        if !self.library_api_evidence_admitted(expr, contract.id, contract.callee, 2) {
             return None;
         }
-        let op = match (contract.builtin, contract.args) {
+        let op = match (contract.result.builtin, contract.result.args) {
             (Builtin::Min, BuiltinArgContract::All) => MIN_CODE,
             (Builtin::Max, BuiltinArgContract::All) => MAX_CODE,
             _ => return None,
@@ -8218,7 +8219,7 @@ impl<'a> Builder<'a> {
                 if let Some(v) = self.eval_iterator_identity_adapter(expr, &kids, env) {
                     return v;
                 }
-                if let Some(v) = self.eval_proven_free_minmax_call(&kids, env) {
+                if let Some(v) = self.eval_proven_free_minmax_call(expr, &kids, env) {
                     return v;
                 }
                 if let Some(r) = self.eval_proven_collection_membership_call(expr, &kids, env) {
@@ -8877,7 +8878,7 @@ mod tests {
     };
     use nose_semantics::{
         library_api_callee_contract_hash, library_api_contract_id_hash,
-        library_free_name_collection_factory_contract,
+        library_free_function_builtin_contract, library_free_name_collection_factory_contract,
         library_imported_collection_factory_contract, library_java_collection_constructor_contract,
         library_java_collection_factory_contract, library_java_map_factory_contract,
         library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
@@ -9366,6 +9367,53 @@ mod tests {
         assert!(matches!(
             eval_proven_collection_op(&il, &interner, call),
             Some(ValOp::Seq(SEQ_VALUE_COLLECTION))
+        ));
+    }
+
+    #[test]
+    fn free_name_minmax_value_graph_requires_library_api_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let callee = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("min")),
+            sp(24),
+            &[],
+        );
+        let left = b.add(NodeKind::Lit, Payload::LitInt(1), sp(25), &[]);
+        let right = b.add(NodeKind::Lit, Payload::LitInt(2), sp(26), &[]);
+        let call = b.add(
+            NodeKind::Call,
+            Payload::None,
+            sp(27),
+            &[callee, left, right],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(23), &[call]);
+        let mut il = finish_test_il(b, root, Lang::Python);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(24), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("min"),
+            }),
+        ));
+        assert!(
+            !matches!(eval_op(&il, &interner, call), ValOp::Bin(op) if op == MIN_CODE),
+            "symbol proof alone must not prove the migrated Python min builtin"
+        );
+
+        let contract = library_free_function_builtin_contract(Lang::Python, "min", 2).unwrap();
+        il.evidence.push(library_api_contract_evidence(
+            1,
+            sp(27),
+            contract.id,
+            contract.callee,
+            2,
+            vec![EvidenceId(0)],
+        ));
+        assert!(matches!(
+            eval_op(&il, &interner, call),
+            ValOp::Bin(op) if op == MIN_CODE
         ));
     }
 

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -2722,9 +2722,95 @@ pub enum BuiltinArgContract {
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct FreeFunctionBuiltinContract {
+    pub name: &'static str,
     pub builtin: Builtin,
     pub args: BuiltinArgContract,
     pub requires_unshadowed: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum FreeFunctionBuiltinArity {
+    Exact(usize),
+    AtLeast(usize),
+    OneOf(&'static [usize]),
+}
+
+impl FreeFunctionBuiltinArity {
+    fn accepts(self, arg_count: usize) -> bool {
+        match self {
+            FreeFunctionBuiltinArity::Exact(expected) => arg_count == expected,
+            FreeFunctionBuiltinArity::AtLeast(minimum) => arg_count >= minimum,
+            FreeFunctionBuiltinArity::OneOf(expected) => expected.contains(&arg_count),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct FreeFunctionBuiltinRow {
+    lang: Lang,
+    name: &'static str,
+    builtin: Builtin,
+    args: BuiltinArgContract,
+    arity: FreeFunctionBuiltinArity,
+    requires_unshadowed: bool,
+}
+
+const ONE_OR_TWO_ARGS: &[usize] = &[1, 2];
+const ONE_TO_THREE_ARGS: &[usize] = &[1, 2, 3];
+const PY: Lang = Lang::Python;
+const GO: Lang = Lang::Go;
+const FIRST_ARG: BuiltinArgContract = BuiltinArgContract::First;
+const ALL_ARGS: BuiltinArgContract = BuiltinArgContract::All;
+const ARITY_ANY: FreeFunctionBuiltinArity = FreeFunctionBuiltinArity::AtLeast(0);
+const ARITY_ONE: FreeFunctionBuiltinArity = FreeFunctionBuiltinArity::Exact(1);
+const ARITY_TWO: FreeFunctionBuiltinArity = FreeFunctionBuiltinArity::Exact(2);
+const ARITY_AT_LEAST_TWO: FreeFunctionBuiltinArity = FreeFunctionBuiltinArity::AtLeast(2);
+const ARITY_ONE_OR_TWO: FreeFunctionBuiltinArity = FreeFunctionBuiltinArity::OneOf(ONE_OR_TWO_ARGS);
+const ARITY_ONE_TO_THREE: FreeFunctionBuiltinArity =
+    FreeFunctionBuiltinArity::OneOf(ONE_TO_THREE_ARGS);
+
+const fn free_function_builtin_row(
+    lang: Lang,
+    name: &'static str,
+    builtin: Builtin,
+    args: BuiltinArgContract,
+    arity: FreeFunctionBuiltinArity,
+) -> FreeFunctionBuiltinRow {
+    FreeFunctionBuiltinRow {
+        lang,
+        name,
+        builtin,
+        args,
+        arity,
+        requires_unshadowed: true,
+    }
+}
+
+const FREE_FUNCTION_BUILTINS: &[FreeFunctionBuiltinRow] = &[
+    free_function_builtin_row(PY, "len", Builtin::Len, FIRST_ARG, ARITY_ONE),
+    free_function_builtin_row(GO, "len", Builtin::Len, FIRST_ARG, ARITY_ONE),
+    free_function_builtin_row(GO, "append", Builtin::Append, ALL_ARGS, ARITY_AT_LEAST_TWO),
+    free_function_builtin_row(PY, "print", Builtin::Print, ALL_ARGS, ARITY_ANY),
+    free_function_builtin_row(PY, "range", Builtin::Range, ALL_ARGS, ARITY_ONE_TO_THREE),
+    free_function_builtin_row(PY, "sum", Builtin::Sum, FIRST_ARG, ARITY_ONE),
+    free_function_builtin_row(PY, "min", Builtin::Min, ALL_ARGS, ARITY_ONE_OR_TWO),
+    free_function_builtin_row(PY, "max", Builtin::Max, ALL_ARGS, ARITY_ONE_OR_TWO),
+    free_function_builtin_row(PY, "abs", Builtin::Abs, FIRST_ARG, ARITY_ONE),
+    free_function_builtin_row(PY, "zip", Builtin::Zip, ALL_ARGS, ARITY_TWO),
+    free_function_builtin_row(PY, "enumerate", Builtin::Enumerate, FIRST_ARG, ARITY_ONE),
+    free_function_builtin_row(PY, "any", Builtin::Any, FIRST_ARG, ARITY_ONE),
+    free_function_builtin_row(PY, "all", Builtin::All, FIRST_ARG, ARITY_ONE),
+];
+
+fn free_function_builtin_contract_from_row(
+    row: &FreeFunctionBuiltinRow,
+) -> FreeFunctionBuiltinContract {
+    FreeFunctionBuiltinContract {
+        name: row.name,
+        builtin: row.builtin,
+        args: row.args,
+        requires_unshadowed: row.requires_unshadowed,
+    }
 }
 
 pub fn free_function_builtin_contract(
@@ -2732,44 +2818,10 @@ pub fn free_function_builtin_contract(
     name: &str,
     arg_count: usize,
 ) -> Option<FreeFunctionBuiltinContract> {
-    let contract = match name {
-        "len" if matches!(lang, Lang::Python | Lang::Go) && arg_count == 1 => {
-            (Builtin::Len, BuiltinArgContract::First)
-        }
-        "append" if lang == Lang::Go && arg_count >= 2 => {
-            (Builtin::Append, BuiltinArgContract::All)
-        }
-        "print" if lang == Lang::Python => (Builtin::Print, BuiltinArgContract::All),
-        "range" if lang == Lang::Python => (Builtin::Range, BuiltinArgContract::All),
-        "sum" if lang == Lang::Python && arg_count == 1 => {
-            (Builtin::Sum, BuiltinArgContract::First)
-        }
-        "min" if lang == Lang::Python && (arg_count == 1 || arg_count == 2) => {
-            (Builtin::Min, BuiltinArgContract::All)
-        }
-        "max" if lang == Lang::Python && (arg_count == 1 || arg_count == 2) => {
-            (Builtin::Max, BuiltinArgContract::All)
-        }
-        "abs" if lang == Lang::Python && arg_count == 1 => {
-            (Builtin::Abs, BuiltinArgContract::First)
-        }
-        "zip" if lang == Lang::Python && arg_count == 2 => (Builtin::Zip, BuiltinArgContract::All),
-        "enumerate" if lang == Lang::Python && arg_count == 1 => {
-            (Builtin::Enumerate, BuiltinArgContract::First)
-        }
-        "any" if lang == Lang::Python && arg_count == 1 => {
-            (Builtin::Any, BuiltinArgContract::First)
-        }
-        "all" if lang == Lang::Python && arg_count == 1 => {
-            (Builtin::All, BuiltinArgContract::First)
-        }
-        _ => return None,
-    };
-    Some(FreeFunctionBuiltinContract {
-        builtin: contract.0,
-        args: contract.1,
-        requires_unshadowed: true,
-    })
+    FREE_FUNCTION_BUILTINS
+        .iter()
+        .find(|row| row.lang == lang && row.name == name && row.arity.accepts(arg_count))
+        .map(free_function_builtin_contract_from_row)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -4086,6 +4138,7 @@ const IMPORTED_COLLECTION_FACTORIES: &[ImportedCollectionFactory] = &[ImportedCo
 pub enum LibraryApiContractId {
     PythonBuiltinCollectionFactory,
     PythonImportedCollectionFactory,
+    FreeFunctionBuiltin(Builtin),
     RustStdCollectionFactory,
     RustStdMapFactory,
     RustVecMacroFactory,
@@ -4122,6 +4175,9 @@ fn library_api_contract_id_key(id: LibraryApiContractId) -> String {
         }
         LibraryApiContractId::PythonImportedCollectionFactory => {
             "python.imported.collection_factory".into()
+        }
+        LibraryApiContractId::FreeFunctionBuiltin(builtin) => {
+            format!("free_function_builtin.{}", builtin as u32)
         }
         LibraryApiContractId::RustStdCollectionFactory => "rust.std.collection_factory".into(),
         LibraryApiContractId::RustStdMapFactory => "rust.std.map_factory".into(),
@@ -4601,6 +4657,13 @@ pub struct LibraryMethodCallContract {
     pub id: LibraryApiContractId,
     pub callee: LibraryApiCalleeContract,
     pub result: MethodCallContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryFreeFunctionBuiltinContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: FreeFunctionBuiltinContract,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -6281,6 +6344,18 @@ fn library_api_contract_ids() -> Vec<LibraryApiContractId> {
     let mut ids = vec![
         LibraryApiContractId::PythonBuiltinCollectionFactory,
         LibraryApiContractId::PythonImportedCollectionFactory,
+        LibraryApiContractId::FreeFunctionBuiltin(Builtin::Len),
+        LibraryApiContractId::FreeFunctionBuiltin(Builtin::Append),
+        LibraryApiContractId::FreeFunctionBuiltin(Builtin::Print),
+        LibraryApiContractId::FreeFunctionBuiltin(Builtin::Range),
+        LibraryApiContractId::FreeFunctionBuiltin(Builtin::Sum),
+        LibraryApiContractId::FreeFunctionBuiltin(Builtin::Min),
+        LibraryApiContractId::FreeFunctionBuiltin(Builtin::Max),
+        LibraryApiContractId::FreeFunctionBuiltin(Builtin::Abs),
+        LibraryApiContractId::FreeFunctionBuiltin(Builtin::Zip),
+        LibraryApiContractId::FreeFunctionBuiltin(Builtin::Enumerate),
+        LibraryApiContractId::FreeFunctionBuiltin(Builtin::Any),
+        LibraryApiContractId::FreeFunctionBuiltin(Builtin::All),
         LibraryApiContractId::RustStdCollectionFactory,
         LibraryApiContractId::RustStdMapFactory,
         LibraryApiContractId::RustVecMacroFactory,
@@ -6417,6 +6492,9 @@ fn library_api_callee_contracts_for_id(
                 .map(|contract| contract.callee)
                 .collect()
         }
+        LibraryApiContractId::FreeFunctionBuiltin(builtin) => {
+            library_free_function_builtin_callee_contracts_for_id(lang, builtin)
+        }
         LibraryApiContractId::RustStdMapFactory => library_free_name_map_factory_contracts(lang)
             .filter(|contract| contract.id == id)
             .map(|contract| contract.callee)
@@ -6536,6 +6614,32 @@ fn library_api_callee_contracts_for_id(
         }
         _ => Vec::new(),
     }
+}
+
+fn library_free_function_builtin_callee_contracts_for_id(
+    lang: Lang,
+    builtin: Builtin,
+) -> Vec<LibraryApiCalleeContract> {
+    let candidate = match (lang, builtin) {
+        (Lang::Python, Builtin::Len) => Some(("len", 1)),
+        (Lang::Go, Builtin::Len) => Some(("len", 1)),
+        (Lang::Go, Builtin::Append) => Some(("append", 2)),
+        (Lang::Python, Builtin::Print) => Some(("print", 0)),
+        (Lang::Python, Builtin::Range) => Some(("range", 1)),
+        (Lang::Python, Builtin::Sum) => Some(("sum", 1)),
+        (Lang::Python, Builtin::Min) => Some(("min", 1)),
+        (Lang::Python, Builtin::Max) => Some(("max", 1)),
+        (Lang::Python, Builtin::Abs) => Some(("abs", 1)),
+        (Lang::Python, Builtin::Zip) => Some(("zip", 2)),
+        (Lang::Python, Builtin::Enumerate) => Some(("enumerate", 1)),
+        (Lang::Python, Builtin::Any) => Some(("any", 1)),
+        (Lang::Python, Builtin::All) => Some(("all", 1)),
+        _ => None,
+    };
+    candidate
+        .and_then(|(name, arg_count)| library_free_function_builtin_contract(lang, name, arg_count))
+        .map(|contract| vec![contract.callee])
+        .unwrap_or_default()
 }
 
 fn method_call_contract_callees_for_semantic(
@@ -7257,6 +7361,22 @@ pub fn library_free_name_collection_factory_contracts(
                 .iter()
                 .filter_map(move |name| library_free_name_collection_factory_contract(lang, name))
         })
+}
+
+pub fn library_free_function_builtin_contract(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<LibraryFreeFunctionBuiltinContract> {
+    let result = free_function_builtin_contract(lang, name, arg_count)?;
+    Some(LibraryFreeFunctionBuiltinContract {
+        id: LibraryApiContractId::FreeFunctionBuiltin(result.builtin),
+        callee: LibraryApiCalleeContract::FreeName {
+            name: result.name,
+            shadow: library_free_name_shadow_policy(lang, result.requires_unshadowed),
+        },
+        result,
+    })
 }
 
 pub fn library_imported_collection_factory_contract(
@@ -10435,6 +10555,52 @@ mod tests {
         );
 
         let mut b = IlBuilder::new(FileId(0));
+        let callee = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("len")),
+            sp(45),
+            &[],
+        );
+        let arg = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(46),
+            &[],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(47), &[callee, arg]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(44), &[call]);
+        let mut il = finish_il(b, root, Lang::Python);
+        let contract = library_free_function_builtin_contract(Lang::Python, "len", 1)
+            .expect("Python len contract");
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(45), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("len"),
+            }),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(library_api_record(
+            1,
+            sp(47),
+            contract.id,
+            contract.callee,
+            EvidenceStatus::Asserted,
+            &[0],
+        ));
+        assert_eq!(
+            library_api_contract_evidence_for_call(
+                &il,
+                &interner,
+                call,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        );
+
+        let mut b = IlBuilder::new(FileId(0));
         let require_callee = b.add(
             NodeKind::Var,
             Payload::Name(interner.intern("require")),
@@ -10736,6 +10902,22 @@ mod tests {
                     shadow: LibraryApiShadowPolicy::SameName,
                 },
                 result: LibraryCollectionFactoryResult::SequenceArgument,
+            })
+        );
+        assert_eq!(
+            library_free_function_builtin_contract(Lang::Python, "len", 1),
+            Some(LibraryFreeFunctionBuiltinContract {
+                id: LibraryApiContractId::FreeFunctionBuiltin(Builtin::Len),
+                callee: LibraryApiCalleeContract::FreeName {
+                    name: "len",
+                    shadow: LibraryApiShadowPolicy::SameName,
+                },
+                result: FreeFunctionBuiltinContract {
+                    name: "len",
+                    builtin: Builtin::Len,
+                    args: BuiltinArgContract::First,
+                    requires_unshadowed: true,
+                },
             })
         );
         assert_eq!(
@@ -11264,6 +11446,7 @@ mod tests {
         assert_eq!(
             free_function_builtin_contract(Lang::Python, "len", 1),
             Some(FreeFunctionBuiltinContract {
+                name: "len",
                 builtin: Builtin::Len,
                 args: BuiltinArgContract::First,
                 requires_unshadowed: true,
@@ -11277,6 +11460,7 @@ mod tests {
         assert_eq!(
             free_function_builtin_contract(Lang::Python, "print", 3),
             Some(FreeFunctionBuiltinContract {
+                name: "print",
                 builtin: Builtin::Print,
                 args: BuiltinArgContract::All,
                 requires_unshadowed: true,
@@ -11285,6 +11469,7 @@ mod tests {
         assert_eq!(
             free_function_builtin_contract(Lang::Go, "append", 2),
             Some(FreeFunctionBuiltinContract {
+                name: "append",
                 builtin: Builtin::Append,
                 args: BuiltinArgContract::All,
                 requires_unshadowed: true,
@@ -11297,8 +11482,18 @@ mod tests {
             None
         );
         assert_eq!(
+            free_function_builtin_contract(Lang::Python, "range", 0),
+            None
+        );
+        assert!(free_function_builtin_contract(Lang::Python, "range", 3).is_some());
+        assert_eq!(
+            free_function_builtin_contract(Lang::Python, "range", 4),
+            None
+        );
+        assert_eq!(
             free_function_builtin_contract(Lang::Python, "max", 2),
             Some(FreeFunctionBuiltinContract {
+                name: "max",
                 builtin: Builtin::Max,
                 args: BuiltinArgContract::All,
                 requires_unshadowed: true,

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -61,7 +61,7 @@ The current implemented kinds are:
 | `Guard` | multi-obligation guard proof facts such as JS/TS record-shape and own-property guard contracts |
 | `Place` | fixed receiver/place facts currently covering `SelfReceiver` and `SelfField` |
 | `Effect` | observable effect facts currently covering canonical builder append calls, non-overloadable index writes, and fixed self-field writes |
-| `LibraryApi` | proof that a specific call occurrence matches a language/API contract coordinate, currently for selected JS-like static/global/static-index APIs, selected Python/Rust/Ruby/Java/regex APIs, and selected receiver-method families |
+| `LibraryApi` | proof that a specific call occurrence matches a language/API contract coordinate, currently for selected JS-like static/global/static-index APIs, selected Python/Rust/Ruby/Java/regex APIs, generic Python/Go free-function builtins, and selected receiver-method families |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, guard surfaces, Go composite map literals, or Go map entries |
 
 `LibraryApi` evidence is an occurrence fact, not the whole contract. It records
@@ -81,9 +81,10 @@ Current first-party `LibraryApi` callee coordinates are intentionally specific:
 - `ImportedBinding` and `ImportedNamespaceFunction` name a module/export or
   namespace/function identity and depend on import-backed call-site symbol
   evidence. They do not infer semantics from the local alias spelling.
-- `FreeName` names a language-scoped free identifier, such as Python `list` or
-  Rust `Vec`, and depends on `Symbol(UnshadowedGlobal)` evidence at the callee
-  anchor plus the contract's shadow policy.
+- `FreeName` names a language-scoped free identifier, such as Python `list`,
+  Python `len`, Go `append`, or Rust `Vec`, and depends on
+  `Symbol(UnshadowedGlobal)` evidence at the callee anchor plus the contract's
+  shadow policy.
 - `JavaUtilStaticMember` names selected Java `java.util` static factory/adaptor
   calls and depends on matching Java import-binding evidence plus source-origin
   local type shadow checks.
@@ -420,12 +421,10 @@ callers:
   language-gated helper only when no relevant evidence record exists. Ambiguous
   or conflicting evidence keeps the exact path closed.
 
-Broader field/place/effect facts, `LibraryApi` occurrence evidence for
-free-name builtin calls outside the current factory/function rows, promise
-receiver proof, async/sync protocol convergence, and unmodeled
-stdlib/ecosystem APIs, broader inferred receiver-expression domain evidence,
-first-class mutation/effect evidence beyond the current first-party binding
-scan, full protocol/demand/effect receiver obligations, full scope-resolution
-and namespace-member evidence, broader guard evidence, general cross-module
-dependency manifests, report-level provenance, and external manifest loading are
-still open work.
+Broader field/place/effect facts, promise receiver proof, async/sync protocol
+convergence, unmodeled stdlib/ecosystem APIs, broader inferred
+receiver-expression domain evidence, first-class mutation/effect evidence beyond
+the current first-party binding scan, full protocol/demand/effect receiver
+obligations, full scope-resolution and namespace-member evidence, broader guard
+evidence, general cross-module dependency manifests, report-level provenance,
+and external manifest loading are still open work.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -167,9 +167,11 @@ and pack ecosystem.
   unshadowed `Math` receiver, and JS record-shape guards using `Boolean(...)`
   consume a static-global function contract with an unshadowed `Boolean`
   requirement.
-- Value-graph two-argument free `min(...)`/`max(...)` now consumes the Python
-  free-function builtin contract instead of the raw callee name, closing
-  unqualified JS `min(...)` and local-shadowing false positives.
+- Generic Python/Go free-function builtins now have `LibraryApi` occurrence
+  rows. Early idiom canonicalization and value-graph two-argument
+  `min(...)`/`max(...)` require admitted occurrence evidence instead of raw
+  callee spelling, closing unqualified JS `min(...)`, local-shadowing, and
+  missing-producer bypasses.
 - Ruby `fetch(key) { fallback }` map-default handling now consumes an explicit
   zero-arg-lambda fallback argument contract, and Go `slices.Contains` value-graph
   membership proof consumes the imported namespace carried by the method contract
@@ -474,10 +476,9 @@ Remaining in this phase:
   place facts and receiver-sensitive mutation/effect proofs.
 - Continue moving library API recognition into `LibraryApiContract` rows and
   `LibraryApi` occurrence evidence. The already producer-covered occurrence
-  surfaces are now fail-closed on missing evidence; remaining work is producer
-  coverage for free-name builtin calls outside the current factory/function
-  rows, promise receiver proof, async/sync protocol convergence, and ecosystem
-  APIs whose receiver/domain/demand obligations are not yet expressible.
+  surfaces are now fail-closed on missing evidence; remaining work is promise
+  receiver proof, async/sync protocol convergence, and ecosystem APIs whose
+  receiver/domain/demand obligations are not yet expressible.
   The first internal slice covers collection/map factories, selected
   constructors, Java empty collection constructors, Java `Map.entry`, and the
   shared shadow/import/result
@@ -500,10 +501,11 @@ Remaining in this phase:
   `LibraryApiContract` identity/result rows, and selected JS-like,
   Python builtin/import-backed, Rust free-name/path, Ruby require-backed, Java
   `java.util`, and regex calls now additionally share `LibraryApi` occurrence
-  evidence, as do selected receiver-method families. Remaining API work is to
-  move the remaining raw sequence/tag and free-builtin proof dependencies into
-  explicit evidence records, then cover ecosystem APIs only after demand,
-  receiver, and effect obligations are expressible.
+  evidence, as do generic Python/Go free-function builtins and selected
+  receiver-method families. Remaining API work is to move the remaining raw
+  sequence/tag proof dependencies into explicit evidence records, then cover
+  ecosystem APIs only after demand, receiver, and effect obligations are
+  expressible.
 - Continue import/module proof migration beyond the removed raw import payloads
   and evidence-only import identity path. Value-graph import identity and
   imported-symbol exact proof are now evidence-only, imported literal replacement

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -109,8 +109,11 @@ migrated.
   stored directly as `EvidenceRecord::Source`; there is no source-fact side-table
   fallback. Normalize and detect consume source facts only where a semantic
   contract requires that exact source surface.
-- Free-function builtin contracts are language- and arity-constrained and require
-  unshadowed builtin/global proof before exact lowering.
+- Free-function builtin contracts are language- and arity-constrained. Supported
+  Python/Go free builtins such as `len`, `sum`, `min`, `max`, `any`, `all`, and
+  Go `append` require admitted `LibraryApi(FreeFunctionBuiltin)` occurrence
+  evidence whose dependencies prove the unshadowed builtin/global callee before
+  exact lowering.
 - Method contracts carry receiver obligations such as exact collection, exact
   protocol, exact option, exact string, exact primitive integer, exact map literal,
   imported namespace, or unshadowed global.
@@ -356,8 +359,10 @@ migrated.
   contracts with an unshadowed `Math` receiver requirement instead of frontend
   text-only builtin lowering.
 - Two-argument free `min(...)`/`max(...)` normalization consumes the Python
-  free-function builtin contract. Same-named functions from other languages,
-  including JS `min(...)`, and locally shadowed Python names stay exact-closed.
+  free-function builtin `LibraryApi` occurrence contract. Same-named functions
+  from other languages, including JS `min(...)`, locally shadowed Python names,
+  and manually constructed calls without admitted occurrence evidence stay
+  exact-closed.
 - JS-like `typeof` exact-safety now consumes a language- and arity-constrained
   operator contract. A same-named function from another language or unresolved
   provider is not treated as the JS operator.
@@ -478,10 +483,10 @@ Semantic knowledge still appears in several forms outside the facade:
   APIs and static-index membership, Python builtin/import-backed
   factories/functions, Rust free-name/path factories, Ruby
   `require "set"; Set.new(...)`, Java `java.util` static factories/adapters and
-  selected empty constructors, JS regex literals, and selected receiver-method
-  families. Free-name builtin calls outside the current factory/function rows,
-  promise receiver proof, async/sync protocol convergence, and ecosystem APIs
-  still rely on contract rows plus local proof or remain exact-closed.
+  selected empty constructors, JS regex literals, generic Python/Go
+  free-function builtins, and selected receiver-method families. Promise
+  receiver proof, async/sync protocol convergence, and ecosystem APIs still rely
+  on contract rows plus local proof or remain exact-closed.
 
 These are valuable, but they do not yet share one complete semantic contract
 language.


### PR DESCRIPTION
## Summary

- add `LibraryApiContractId::FreeFunctionBuiltin` rows for supported Python/Go free builtins and derive them from the existing builtin contract table
- emit dependency-backed first-party `LibraryApi` occurrence evidence for supported free builtins during lowering, with Python wildcard import and local shadowing keeping occurrences closed
- require admitted occurrence evidence in early idiom canonicalization and the value-graph Python `min`/`max` path instead of raw callee spelling
- tighten Python `range` to the supported 1-3 arity contract and update semantic-kernel docs

## Validation

- `cargo test -p nose-semantics -p nose-frontend -p nose-normalize --lib free`
- `cargo test -p nose-semantics -p nose-frontend -p nose-normalize --lib`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --release`
- `./scripts/check-duplication.sh`
- `python3 scripts/check-formal-obligations.py`
- `./scripts/check-lean-proofs.sh`
- `cargo fmt --check`
- `git diff --check`
- `awiki lint --root docs`

Closes part of #109.