### PR TITLE
[codex] Require effect evidence for exact fragments

### DIFF
--- a/crates/nose-detect/src/fragment/conditional_guard.rs
+++ b/crates/nose-detect/src/fragment/conditional_guard.rs
@@ -12,7 +12,7 @@ use super::{Exit, FragmentKind};
 use nose_il::{Il, Interner, NodeId, NodeKind, Payload};
 use nose_semantics::{
     builder_append_call_args, exact_non_overloadable_index_assignment,
-    exact_non_overloadable_index_assignment_parts, exact_self_field_write_assignment, semantics,
+    exact_non_overloadable_index_assignment_parts, exact_self_field_write_assignment,
 };
 use rustc_hash::FxHashSet;
 
@@ -370,12 +370,6 @@ fn ordered_append_effect_sequence(
 }
 
 fn ordered_index_assignment_effect_sequence(il: &Il, node: NodeId) -> Option<Vec<EffectSite>> {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .non_overloadable_index_assignment()
-    {
-        return None;
-    }
     let kids = il.children(node);
     if il.kind(node) != NodeKind::Block || !(2..=5).contains(&kids.len()) {
         return None;
@@ -424,12 +418,6 @@ fn ordered_self_field_assignment_sequence(
     interner: &Interner,
     node: NodeId,
 ) -> Option<Vec<EffectSite>> {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-    {
-        return None;
-    }
     let kids = il.children(node);
     if il.kind(node) != NodeKind::Block || !(2..=3).contains(&kids.len()) {
         return None;

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -2918,12 +2918,6 @@ fn exact_temp_chain_consumed_by_append_effect(
 }
 
 fn exact_ordered_index_assignment_effect_sequence_block(il: &Il, node: NodeId) -> bool {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .non_overloadable_index_assignment()
-    {
-        return false;
-    }
     if il.kind(node) != NodeKind::Block {
         return false;
     }
@@ -2984,11 +2978,7 @@ fn exact_ordered_self_field_assignment_sequence_block(
     interner: &Interner,
     node: NodeId,
 ) -> bool {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        || il.kind(node) != NodeKind::Block
-    {
+    if il.kind(node) != NodeKind::Block {
         return false;
     }
     let kids = il.children(node);

--- a/crates/nose-normalize/src/effect_evidence.rs
+++ b/crates/nose-normalize/src/effect_evidence.rs
@@ -1,0 +1,160 @@
+use nose_il::{
+    stable_symbol_hash, Builtin, EffectEvidenceKind, EvidenceAnchor, EvidenceEmitter, EvidenceId,
+    EvidenceKind, EvidenceStatus, Il, Interner, Lang, NodeId, NodeKind, Payload, PlaceEvidenceKind,
+};
+use nose_semantics::FIRST_PARTY_PACK_ID;
+
+pub(crate) fn run(il: &mut Il, interner: &Interner) {
+    let nodes: Vec<NodeId> = il
+        .nodes
+        .iter()
+        .enumerate()
+        .map(|(idx, _)| NodeId(idx as u32))
+        .collect();
+    for node in nodes {
+        match il.kind(node) {
+            NodeKind::Var => {
+                let _ = record_self_receiver(il, interner, node);
+            }
+            NodeKind::Field => {
+                let _ = record_self_field(il, interner, node);
+            }
+            NodeKind::Call => {
+                record_builder_append(il, node);
+            }
+            NodeKind::Assign => {
+                record_assignment_effect(il, interner, node);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn record_self_receiver(il: &mut Il, interner: &Interner, node: NodeId) -> Option<EvidenceId> {
+    if il.meta.lang != Lang::Java || il.kind(node) != NodeKind::Var {
+        return None;
+    }
+    let Payload::Name(name) = il.node(node).payload else {
+        return None;
+    };
+    if interner.resolve(name) != "this" {
+        return None;
+    }
+    Some(upsert(
+        il,
+        node,
+        EvidenceKind::Place(PlaceEvidenceKind::SelfReceiver),
+        "place_self_receiver_normalize",
+        Vec::new(),
+    ))
+}
+
+fn record_self_field(il: &mut Il, interner: &Interner, node: NodeId) -> Option<EvidenceId> {
+    if il.meta.lang != Lang::Java || il.kind(node) != NodeKind::Field {
+        return None;
+    }
+    let Payload::Name(field) = il.node(node).payload else {
+        return None;
+    };
+    let receiver = il.children(node).first().copied()?;
+    let receiver_evidence = record_self_receiver(il, interner, receiver)?;
+    let field_hash = stable_symbol_hash(interner.resolve(field));
+    Some(upsert(
+        il,
+        node,
+        EvidenceKind::Place(PlaceEvidenceKind::SelfField { field_hash }),
+        "place_self_field_normalize",
+        vec![receiver_evidence],
+    ))
+}
+
+fn record_builder_append(il: &mut Il, node: NodeId) {
+    if il.kind(node) != NodeKind::Call
+        || !matches!(il.node(node).payload, Payload::Builtin(Builtin::Append))
+        || il.children(node).len() != 2
+    {
+        return;
+    }
+    upsert(
+        il,
+        node,
+        EvidenceKind::Effect(EffectEvidenceKind::BuilderAppendCall),
+        "effect_builder_append_normalize",
+        Vec::new(),
+    );
+}
+
+fn record_assignment_effect(il: &mut Il, interner: &Interner, node: NodeId) {
+    if il.kind(node) != NodeKind::Assign {
+        return;
+    }
+    let Some(&target) = il.children(node).first() else {
+        return;
+    };
+    if matches!(il.meta.lang, Lang::C | Lang::Go | Lang::Java) && il.kind(target) == NodeKind::Index
+    {
+        upsert(
+            il,
+            node,
+            EvidenceKind::Effect(EffectEvidenceKind::NonOverloadableIndexWrite),
+            "effect_non_overloadable_index_write_normalize",
+            Vec::new(),
+        );
+        return;
+    }
+    if let Some((field_hash, place_evidence)) = self_field_target(il, interner, target) {
+        upsert(
+            il,
+            node,
+            EvidenceKind::Effect(EffectEvidenceKind::SelfFieldWrite { field_hash }),
+            "effect_self_field_write_normalize",
+            vec![place_evidence],
+        );
+    }
+}
+
+fn self_field_target(
+    il: &mut Il,
+    interner: &Interner,
+    target: NodeId,
+) -> Option<(u64, EvidenceId)> {
+    if il.meta.lang != Lang::Java || il.kind(target) != NodeKind::Field {
+        return None;
+    }
+    let Payload::Name(field) = il.node(target).payload else {
+        return None;
+    };
+    let field_hash = stable_symbol_hash(interner.resolve(field));
+    let place_evidence = record_self_field(il, interner, target)?;
+    Some((field_hash, place_evidence))
+}
+
+fn upsert(
+    il: &mut Il,
+    node: NodeId,
+    kind: EvidenceKind,
+    rule: &'static str,
+    dependencies: Vec<EvidenceId>,
+) -> EvidenceId {
+    let anchor = EvidenceAnchor::node(il.node(node).span, il.kind(node));
+    let pack_hash = stable_symbol_hash(FIRST_PARTY_PACK_ID);
+    let rule_hash = stable_symbol_hash(rule);
+    let mut found = None;
+    for record in &mut il.evidence {
+        if record.anchor == anchor
+            && record.kind == kind
+            && record.status == EvidenceStatus::Asserted
+            && record.provenance.emitter == EvidenceEmitter::FirstParty
+            && record.provenance.pack_hash == Some(pack_hash)
+        {
+            if found.is_none() {
+                found = Some(record.id);
+            }
+            record.provenance.rule_hash = Some(rule_hash);
+            record.dependencies = dependencies.clone();
+        }
+    }
+    found.unwrap_or_else(|| {
+        il.find_or_push_first_party_evidence(anchor, kind, FIRST_PARTY_PACK_ID, rule, dependencies)
+    })
+}

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -21,6 +21,7 @@ mod commutative;
 mod dataflow;
 mod dce;
 mod desugar;
+mod effect_evidence;
 mod idioms;
 mod interp;
 mod library_api_evidence;
@@ -233,6 +234,8 @@ pub fn normalize(il: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il {
     let mut timer = NormalizeTimer::new(&il.meta.path);
     let mut out = desugar::run(il, interner, opts);
     timer.lap("desugar");
+    effect_evidence::run(&mut out, interner);
+    timer.lap("effect-evidence");
     binding_evidence::run(&mut out, interner);
     timer.lap("binding");
     library_api_evidence::run(&mut out, interner);
@@ -269,6 +272,8 @@ pub fn normalize(il: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il {
         cfg_norm::run(&mut out, interner);
         timer.lap("cfg-orient");
     }
+    effect_evidence::run(&mut out, interner);
+    timer.lap("effect-evidence-final");
     library_api_evidence::run(&mut out, interner);
     timer.lap("api-evidence-final");
     // IR-verifier discipline: in debug/test builds, assert the rewrite pipeline

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -2287,27 +2287,18 @@ fn place_evidence_for_node(il: &Il, node: NodeId) -> EvidenceResolution<PlaceEvi
     )
 }
 
-/// Exact Java `this` receiver proof for first-party self-field fragments.
-pub fn exact_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
+/// Exact self receiver proof for first-party self-field fragments.
+pub fn exact_java_this_var(il: &Il, _interner: &Interner, node: NodeId) -> bool {
     match place_evidence_for_node(il, node) {
         EvidenceResolution::Found(PlaceEvidenceKind::SelfReceiver) => {
-            return il.kind(node) == NodeKind::Var;
+            il.kind(node) == NodeKind::Var
         }
-        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => return false,
-        EvidenceResolution::Missing => {}
+        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => false,
+        EvidenceResolution::Missing => false,
     }
-    legacy_exact_java_this_var(il, interner, node)
 }
 
-fn legacy_exact_java_this_var(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        && il.kind(node) == NodeKind::Var
-        && matches!(il.node(node).payload, Payload::Name(name) if interner.resolve(name) == "this")
-}
-
-/// Exact Java `this.field` place proof for receiver-aware field-write fingerprints.
+/// Exact self-field place proof for receiver-aware field-write fingerprints.
 pub fn exact_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
     match place_evidence_for_node(il, node) {
         EvidenceResolution::Found(PlaceEvidenceKind::SelfField { field_hash }) => {
@@ -2320,40 +2311,18 @@ pub fn exact_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool
             if stable_symbol_hash(interner.resolve(field)) != field_hash {
                 return false;
             }
-            return il
-                .children(node)
+            il.children(node)
                 .first()
-                .is_some_and(|&receiver| exact_java_this_var(il, interner, receiver));
+                .is_some_and(|&receiver| exact_java_this_var(il, interner, receiver))
         }
-        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => return false,
-        EvidenceResolution::Missing => {}
+        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => false,
+        EvidenceResolution::Missing => false,
     }
-    legacy_exact_java_this_field(il, interner, node)
 }
 
-fn legacy_exact_java_this_field(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        || il.kind(node) != NodeKind::Field
-    {
-        return false;
-    }
-    if !matches!(il.node(node).payload, Payload::Name(_)) {
-        return false;
-    }
-    il.children(node)
-        .first()
-        .is_some_and(|&receiver| exact_java_this_var(il, interner, receiver))
-}
-
-/// Exact Java `return this` proof used by self-field body fragments.
+/// Exact self-return proof used by self-field body fragments.
 pub fn exact_java_return_this(il: &Il, interner: &Interner, node: NodeId) -> bool {
-    if !semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        || il.kind(node) != NodeKind::Return
-    {
+    if il.kind(node) != NodeKind::Return {
         return false;
     }
     let kids = il.children(node);
@@ -2362,24 +2331,19 @@ pub fn exact_java_return_this(il: &Il, interner: &Interner, node: NodeId) -> boo
 
 /// `(receiver, key, value)` of a first-party exact-safe index assignment.
 ///
-/// This is intentionally language-gated: languages with overloadable/user-dispatched index
-/// assignment remain fail-closed until a pack supplies a stronger receiver proof.
+/// This is intentionally evidence-gated: languages with overloadable/user-dispatched index
+/// assignment remain fail-closed unless a frontend or pack supplies effect proof.
 pub fn exact_non_overloadable_index_assignment_parts(
     il: &Il,
     node: NodeId,
 ) -> Option<(NodeId, Option<NodeId>, NodeId)> {
     match effect_evidence_for_node(il, node) {
         EvidenceResolution::Found(EffectEvidenceKind::NonOverloadableIndexWrite) => {
-            return syntactic_index_assignment_parts(il, node);
+            syntactic_index_assignment_parts(il, node)
         }
-        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => return None,
-        EvidenceResolution::Missing => {}
+        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => None,
+        EvidenceResolution::Missing => None,
     }
-    semantics(il.meta.lang)
-        .exact_fragments()
-        .non_overloadable_index_assignment()
-        .then_some(())
-        .and_then(|()| syntactic_index_assignment_parts(il, node))
 }
 
 fn syntactic_index_assignment_parts(
@@ -2404,15 +2368,11 @@ pub fn exact_non_overloadable_index_assignment(il: &Il, node: NodeId) -> bool {
 pub fn exact_self_field_write_assignment(il: &Il, interner: &Interner, node: NodeId) -> bool {
     match effect_evidence_for_node(il, node) {
         EvidenceResolution::Found(EffectEvidenceKind::SelfFieldWrite { field_hash }) => {
-            return syntactic_self_field_write_assignment(il, interner, node, Some(field_hash));
+            syntactic_self_field_write_assignment(il, interner, node, Some(field_hash))
         }
-        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => return false,
-        EvidenceResolution::Missing => {}
+        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => false,
+        EvidenceResolution::Missing => false,
     }
-    semantics(il.meta.lang)
-        .exact_fragments()
-        .java_this_field_place()
-        && syntactic_self_field_write_assignment(il, interner, node, None)
 }
 
 fn syntactic_self_field_write_assignment(
@@ -3926,10 +3886,9 @@ pub fn builder_append_method_contract(lang: Lang, method: &str, arg_count: usize
 /// `(receiver, value)` of a single-item append-like builder call admitted by first-party
 /// language/library contracts.
 ///
-/// This intentionally reads only the canonical `Builtin::Append` surface. Raw method
-/// selectors such as `push`, `append`, or `add` are not proof by themselves; callers that
-/// see those selectors must first prove the receiver/builder contract and lower the call to
-/// the canonical builtin.
+/// Raw method selectors such as `push`, `append`, or `add` are not proof by themselves;
+/// callers that see those selectors must first prove the receiver/builder contract, lower
+/// the call to the canonical builtin, and attach append-effect evidence.
 pub fn builder_append_call_args(
     il: &Il,
     _interner: &Interner,
@@ -3937,12 +3896,11 @@ pub fn builder_append_call_args(
 ) -> Option<(NodeId, NodeId)> {
     match effect_evidence_for_node(il, node) {
         EvidenceResolution::Found(EffectEvidenceKind::BuilderAppendCall) => {
-            return syntactic_append_call_args(il, node);
+            syntactic_append_call_args(il, node)
         }
-        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => return None,
-        EvidenceResolution::Missing => {}
+        EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => None,
+        EvidenceResolution::Missing => None,
     }
-    canonical_append_call_args(il, node)
 }
 
 fn canonical_append_call_args(il: &Il, node: NodeId) -> Option<(NodeId, NodeId)> {
@@ -8340,6 +8298,55 @@ mod tests {
         }
     }
 
+    fn push_node_effect(
+        il: &mut Il,
+        id: u32,
+        node: NodeId,
+        effect: EffectEvidenceKind,
+    ) -> EvidenceId {
+        push_node_effect_with_dependencies(il, id, node, effect, Vec::new())
+    }
+
+    fn push_node_effect_with_dependencies(
+        il: &mut Il,
+        id: u32,
+        node: NodeId,
+        effect: EffectEvidenceKind,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceId {
+        let evidence_id = EvidenceId(id);
+        il.evidence.push(evidence_with_dependencies(
+            id,
+            EvidenceAnchor::node(il.node(node).span, il.kind(node)),
+            EvidenceKind::Effect(effect),
+            EvidenceStatus::Asserted,
+            dependencies,
+        ));
+        evidence_id
+    }
+
+    fn push_node_place(il: &mut Il, id: u32, node: NodeId, place: PlaceEvidenceKind) -> EvidenceId {
+        push_node_place_with_dependencies(il, id, node, place, Vec::new())
+    }
+
+    fn push_node_place_with_dependencies(
+        il: &mut Il,
+        id: u32,
+        node: NodeId,
+        place: PlaceEvidenceKind,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceId {
+        let evidence_id = EvidenceId(id);
+        il.evidence.push(evidence_with_dependencies(
+            id,
+            EvidenceAnchor::node(il.node(node).span, il.kind(node)),
+            EvidenceKind::Place(place),
+            EvidenceStatus::Asserted,
+            dependencies,
+        ));
+        evidence_id
+    }
+
     #[test]
     fn first_party_profile_wraps_each_language() {
         for &lang in ALL_LANGS {
@@ -12371,42 +12378,27 @@ mod tests {
     }
 
     #[test]
-    fn exact_java_this_helpers_are_language_and_shape_constrained() {
-        let interner = Interner::default();
-        let this = interner.intern("this");
-        let field_name = interner.intern("value");
-        let mut b = IlBuilder::new(FileId(0));
-        let receiver = b.add(NodeKind::Var, Payload::Name(this), sp(1), &[]);
-        let field = b.add(
-            NodeKind::Field,
-            Payload::Name(field_name),
-            sp(1),
-            &[receiver],
-        );
-        let ret = b.add(NodeKind::Return, Payload::None, sp(2), &[receiver]);
-        let root = b.add(NodeKind::Block, Payload::None, sp(1), &[field, ret]);
-        let il = finish_il(b, root, Lang::Java);
-
-        assert!(exact_java_this_var(&il, &interner, receiver));
-        assert!(exact_java_this_field(&il, &interner, field));
-        assert!(exact_java_return_this(&il, &interner, ret));
-
-        let mut js_il = il.clone();
-        js_il.meta.lang = Lang::JavaScript;
-        assert!(!exact_java_this_var(&js_il, &interner, receiver));
-        assert!(!exact_java_this_field(&js_il, &interner, field));
-        assert!(!exact_java_return_this(&js_il, &interner, ret));
-    }
-
-    #[test]
-    fn exact_index_assignment_parts_are_language_constrained() {
+    fn exact_index_assignment_parts_require_effect_evidence() {
         let mut b = IlBuilder::new(FileId(0));
         let receiver = b.add(NodeKind::Var, Payload::Cid(1), sp(1), &[]);
         let key = b.add(NodeKind::Var, Payload::Cid(2), sp(1), &[]);
         let target = b.add(NodeKind::Index, Payload::None, sp(1), &[receiver, key]);
         let value = b.add(NodeKind::Var, Payload::Cid(3), sp(1), &[]);
         let assign = b.add(NodeKind::Assign, Payload::None, sp(1), &[target, value]);
-        let il = finish_il(b, assign, Lang::Go);
+        let mut il = finish_il(b, assign, Lang::Go);
+
+        assert_eq!(
+            exact_non_overloadable_index_assignment_parts(&il, assign),
+            None
+        );
+        assert!(!exact_non_overloadable_index_assignment(&il, assign));
+
+        push_node_effect(
+            &mut il,
+            0,
+            assign,
+            EffectEvidenceKind::NonOverloadableIndexWrite,
+        );
 
         assert_eq!(
             exact_non_overloadable_index_assignment_parts(&il, assign),
@@ -12414,17 +12406,16 @@ mod tests {
         );
         assert!(exact_non_overloadable_index_assignment(&il, assign));
 
-        let mut ruby_il = il.clone();
-        ruby_il.meta.lang = Lang::Ruby;
+        push_node_effect(&mut il, 1, assign, EffectEvidenceKind::BuilderAppendCall);
         assert_eq!(
-            exact_non_overloadable_index_assignment_parts(&ruby_il, assign),
+            exact_non_overloadable_index_assignment_parts(&il, assign),
             None
         );
-        assert!(!exact_non_overloadable_index_assignment(&ruby_il, assign));
+        assert!(!exact_non_overloadable_index_assignment(&il, assign));
     }
 
     #[test]
-    fn builder_append_call_args_require_canonical_append_proof() {
+    fn builder_append_call_args_require_effect_evidence() {
         let interner = Interner::default();
         let append = interner.intern("append");
         let push = interner.intern("push");
@@ -12449,6 +12440,9 @@ mod tests {
         );
         let il = finish_il(b, root, Lang::Python);
 
+        assert_eq!(builder_append_call_args(&il, &interner, builtin), None);
+        let mut il = il;
+        push_node_effect(&mut il, 0, builtin, EffectEvidenceKind::BuilderAppendCall);
         assert_eq!(
             builder_append_call_args(&il, &interner, builtin),
             Some((receiver, value))
@@ -12479,23 +12473,23 @@ mod tests {
             None
         );
 
-        il.evidence.push(evidence(
+        push_node_effect(
+            &mut il,
             0,
-            EvidenceAnchor::node(sp(9), NodeKind::Assign),
-            EvidenceKind::Effect(EffectEvidenceKind::NonOverloadableIndexWrite),
-            EvidenceStatus::Asserted,
-        ));
+            assign,
+            EffectEvidenceKind::NonOverloadableIndexWrite,
+        );
         assert_eq!(
             exact_non_overloadable_index_assignment_parts(&il, assign),
             Some((receiver, Some(key), value))
         );
 
-        il.evidence.push(evidence(
+        push_node_effect(
+            &mut il,
             1,
-            EvidenceAnchor::node(sp(9), NodeKind::Assign),
-            EvidenceKind::Effect(EffectEvidenceKind::SelfFieldWrite { field_hash: 1 }),
-            EvidenceStatus::Asserted,
-        ));
+            assign,
+            EffectEvidenceKind::SelfFieldWrite { field_hash: 1 },
+        );
         assert_eq!(
             exact_non_overloadable_index_assignment_parts(&il, assign),
             None
@@ -12508,12 +12502,12 @@ mod tests {
         let value = b.add(NodeKind::Var, Payload::Cid(3), sp(1), &[]);
         let call = b.add(NodeKind::Call, Payload::None, sp(10), &[target, value]);
         let mut non_assign = finish_il(b, call, Lang::Ruby);
-        non_assign.evidence.push(evidence(
+        push_node_effect(
+            &mut non_assign,
             0,
-            EvidenceAnchor::node(sp(10), NodeKind::Call),
-            EvidenceKind::Effect(EffectEvidenceKind::NonOverloadableIndexWrite),
-            EvidenceStatus::Asserted,
-        ));
+            call,
+            EffectEvidenceKind::NonOverloadableIndexWrite,
+        );
         assert_eq!(
             exact_non_overloadable_index_assignment_parts(&non_assign, call),
             None
@@ -12533,23 +12527,18 @@ mod tests {
 
         assert_eq!(builder_append_call_args(&il, &interner, call), None);
 
-        il.evidence.push(evidence(
-            0,
-            EvidenceAnchor::node(sp(3), NodeKind::Call),
-            EvidenceKind::Effect(EffectEvidenceKind::BuilderAppendCall),
-            EvidenceStatus::Asserted,
-        ));
+        push_node_effect(&mut il, 0, call, EffectEvidenceKind::BuilderAppendCall);
         assert_eq!(
             builder_append_call_args(&il, &interner, call),
             Some((receiver, value))
         );
 
-        il.evidence.push(evidence(
+        push_node_effect(
+            &mut il,
             1,
-            EvidenceAnchor::node(sp(3), NodeKind::Call),
-            EvidenceKind::Effect(EffectEvidenceKind::NonOverloadableIndexWrite),
-            EvidenceStatus::Asserted,
-        ));
+            call,
+            EffectEvidenceKind::NonOverloadableIndexWrite,
+        );
         assert_eq!(builder_append_call_args(&il, &interner, call), None);
     }
 
@@ -12569,42 +12558,48 @@ mod tests {
         );
         let value = b.add(NodeKind::Var, Payload::Cid(1), sp(3), &[]);
         let assign = b.add(NodeKind::Assign, Payload::None, sp(4), &[field, value]);
-        let mut il = finish_il(b, assign, Lang::Ruby);
+        let ret = b.add(NodeKind::Return, Payload::None, sp(5), &[receiver]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(1), &[assign, ret]);
+        let mut il = finish_il(b, root, Lang::Ruby);
 
+        assert!(!exact_java_this_var(&il, &interner, receiver));
         assert!(!exact_java_this_field(&il, &interner, field));
+        assert!(!exact_java_return_this(&il, &interner, ret));
         assert!(!exact_self_field_write_assignment(&il, &interner, assign));
 
-        il.evidence.push(evidence(
-            0,
-            EvidenceAnchor::node(sp(1), NodeKind::Var),
-            EvidenceKind::Place(PlaceEvidenceKind::SelfReceiver),
-            EvidenceStatus::Asserted,
-        ));
-        il.evidence.push(evidence_with_dependencies(
+        let receiver_evidence =
+            push_node_place(&mut il, 0, receiver, PlaceEvidenceKind::SelfReceiver);
+        let field_evidence = push_node_place_with_dependencies(
+            &mut il,
             1,
-            EvidenceAnchor::node(sp(2), NodeKind::Field),
-            EvidenceKind::Place(PlaceEvidenceKind::SelfField { field_hash }),
-            EvidenceStatus::Asserted,
-            vec![EvidenceId(0)],
-        ));
-        il.evidence.push(evidence_with_dependencies(
+            field,
+            PlaceEvidenceKind::SelfField { field_hash },
+            vec![receiver_evidence],
+        );
+        push_node_effect_with_dependencies(
+            &mut il,
             2,
-            EvidenceAnchor::node(sp(4), NodeKind::Assign),
-            EvidenceKind::Effect(EffectEvidenceKind::SelfFieldWrite { field_hash }),
-            EvidenceStatus::Asserted,
-            vec![EvidenceId(1)],
-        ));
+            assign,
+            EffectEvidenceKind::SelfFieldWrite { field_hash },
+            vec![field_evidence],
+        );
+        assert!(exact_java_this_var(&il, &interner, receiver));
         assert!(exact_java_this_field(&il, &interner, field));
+        assert!(exact_java_return_this(&il, &interner, ret));
         assert!(exact_self_field_write_assignment(&il, &interner, assign));
 
-        il.evidence.push(evidence(
-            3,
-            EvidenceAnchor::node(sp(2), NodeKind::Field),
-            EvidenceKind::Place(PlaceEvidenceKind::SelfReceiver),
-            EvidenceStatus::Asserted,
-        ));
+        push_node_place(&mut il, 3, field, PlaceEvidenceKind::SelfReceiver);
         assert!(!exact_java_this_field(&il, &interner, field));
         assert!(!exact_self_field_write_assignment(&il, &interner, assign));
+
+        push_node_place(
+            &mut il,
+            4,
+            receiver,
+            PlaceEvidenceKind::SelfField { field_hash },
+        );
+        assert!(!exact_java_this_var(&il, &interner, receiver));
+        assert!(!exact_java_return_this(&il, &interner, ret));
 
         let other = interner.intern("other");
         let mut b = IlBuilder::new(FileId(0));
@@ -12618,18 +12613,18 @@ mod tests {
         let value = b.add(NodeKind::Var, Payload::Cid(1), sp(7), &[]);
         let assign = b.add(NodeKind::Assign, Payload::None, sp(8), &[field, value]);
         let mut il = finish_il(b, assign, Lang::Ruby);
-        il.evidence.push(evidence(
+        push_node_place(
+            &mut il,
             0,
-            EvidenceAnchor::node(sp(6), NodeKind::Field),
-            EvidenceKind::Place(PlaceEvidenceKind::SelfField { field_hash }),
-            EvidenceStatus::Asserted,
-        ));
-        il.evidence.push(evidence(
+            field,
+            PlaceEvidenceKind::SelfField { field_hash },
+        );
+        push_node_effect(
+            &mut il,
             1,
-            EvidenceAnchor::node(sp(8), NodeKind::Assign),
-            EvidenceKind::Effect(EffectEvidenceKind::SelfFieldWrite { field_hash }),
-            EvidenceStatus::Asserted,
-        ));
+            assign,
+            EffectEvidenceKind::SelfFieldWrite { field_hash },
+        );
         assert!(!exact_java_this_field(&il, &interner, field));
         assert!(!exact_self_field_write_assignment(&il, &interner, assign));
     }

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -204,16 +204,17 @@ on one supported qualified-global API path, currently `Object.hasOwn` or
 `value.hasOwnProperty(...)`, shadowed `Object` roots, missing dependencies, or
 ambiguous guard evidence remain closed.
 
-Place and effect evidence are also authoritative where present. For example,
-raw method selectors such as `push`, `append`, or `add` do not prove an append
-effect; a consumer needs `Effect(BuilderAppendCall)` or the legacy canonical
-`Builtin::Append` compatibility path when no effect evidence exists. Likewise,
-non-overloadable index writes and fixed self-field writes are admitted through
-`Effect` records, with `Place(SelfReceiver)` and `Place(SelfField)` proving the
+Place and effect evidence are authoritative for the exact-fragment substrate.
+Raw method selectors such as `push`, `append`, or `add` do not prove an append
+effect; exact consumers need `Effect(BuilderAppendCall)`, even when the call has
+already been lowered to canonical `Builtin::Append`. Likewise, non-overloadable
+index writes and fixed self-field writes are admitted only through `Effect`
+records, with `Place(SelfReceiver)` and `Place(SelfField)` proving the
 receiver/place side. First-party `Place(SelfField)` depends on the matching
 `Place(SelfReceiver)`, and `Effect(SelfFieldWrite)` depends on the matching
-`Place(SelfField)`. Conflicting or ambiguous place/effect evidence blocks the
-legacy language-gated fallback.
+`Place(SelfField)`. Missing, conflicting, ambiguous, or dependency-broken
+place/effect evidence closes exact fragments instead of reopening a legacy
+language/shape fallback.
 
 Library API evidence follows the same fail-closed rule. If a call carries
 `LibraryApi` evidence for a selected API occurrence, consumers must validate the
@@ -271,12 +272,13 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   null/truthiness clause kind, whether JS loose equality was admitted, and
   asserted dependencies for the required `Array.isArray` API proof plus optional
   `Boolean` proof;
-- first-party lowering emits `Place(SelfReceiver)` for Java `this`,
-  `Place(SelfField)` for Java `this.field`, `Effect(SelfFieldWrite)` for Java
-  `this.field = ...`, `Effect(NonOverloadableIndexWrite)` for C/Go/Java index
-  writes, and `Effect(BuilderAppendCall)` for canonical `Builtin::Append`.
-  Self-field place/write evidence records include dependencies that link the
-  write proof back to the receiver proof;
+- first-party lowering and normalize refreshes emit `Place(SelfReceiver)` for
+  Java `this`, `Place(SelfField)` for Java `this.field`,
+  `Effect(SelfFieldWrite)` for Java `this.field = ...`,
+  `Effect(NonOverloadableIndexWrite)` for C/Go/Java index writes, and
+  `Effect(BuilderAppendCall)` for canonical `Builtin::Append`. Self-field
+  place/write evidence records include dependencies that link the write proof
+  back to the receiver proof;
 - first-party lowering emits `LibraryApi` evidence for selected API calls that
   remain as raw call nodes: JS-like `Array.from(...)`, `Array.isArray(...)`,
   `Boolean(...)`, `new Map(...)`, `new Set(...)`, and static
@@ -417,9 +419,8 @@ callers:
   so `composite_literal`/`keyed_element` tag spelling alone no longer admits the
   exact map-default path;
 - exact-fragment append, non-overloadable index-write, and self-field-write
-  gates now consult `Effect`/`Place` evidence first, falling back to the legacy
-  language-gated helper only when no relevant evidence record exists. Ambiguous
-  or conflicting evidence keeps the exact path closed.
+  gates now require `Effect`/`Place` evidence. Missing, ambiguous, conflicting,
+  or dependency-broken evidence keeps the exact path closed.
 
 Broader field/place/effect facts, promise receiver proof, async/sync protocol
 convergence, unmodeled stdlib/ecosystem APIs, broader inferred

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -414,6 +414,13 @@ and pack ecosystem.
   family member must fit the same normalized IL template with the same literal-leaf
   hole position. Mixed connected components are not given a weak witness merely
   because one representative pair looked actionable.
+- Exact-fragment place/effect gates became evidence-authoritative for the
+  producer-covered substrate. First-party normalize refreshes now upsert
+  `Effect(BuilderAppendCall)` for canonical append calls,
+  `Effect(NonOverloadableIndexWrite)` for C/Go/Java index assignments, and Java
+  self receiver/field/write `Place`/`Effect` records after canonical rewrites.
+  Exact fragment consumers no longer reopen append/index/self-field admission
+  through language/shape fallback when `Effect`/`Place` evidence is missing.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -470,10 +477,12 @@ Remaining in this phase:
 - Expand the exact fragment facade from first-party helper functions into
   versioned pack-facing effect/place evidence records. The first substrate now
   covers canonical append calls, C/Go/Java non-overloadable index writes, and
-  Java self-receiver/self-field writes through `Effect`/`Place` evidence.
+  Java self-receiver/self-field writes through required `Effect`/`Place`
+  evidence, including normalize refreshes after canonical rewrites.
 - Continue replacing remaining local exact-fragment proof helpers with
   versioned pack-facing evidence records, especially broader field/read/write
-  place facts and receiver-sensitive mutation/effect proofs.
+  place facts, receiver-sensitive mutation/effect proofs, and mutation
+  invalidation evidence shared with binding/import safety.
 - Continue moving library API recognition into `LibraryApiContract` rows and
   `LibraryApi` occurrence evidence. The already producer-covered occurrence
   surfaces are now fail-closed on missing evidence; remaining work is promise

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -264,10 +264,11 @@ migrated.
   path.
 - Builder append contracts are separate from arbitrary method calls. A selector
   such as `push`, `append`, or `add` is not proof by itself. First-party
-  frontend/normalize paths must prove the receiver or active-builder contract and
-  lower the call to canonical `Builtin::Append` before exact fragments can treat
-  it as an append effect. Value-graph active list-builder paths still consume the
-  method selector only after a local builder seed is active.
+  frontend/normalize paths must prove the receiver or active-builder contract,
+  lower the call to canonical `Builtin::Append`, and emit
+  `Effect(BuilderAppendCall)` before exact fragments can treat it as an append
+  effect. Value-graph active list-builder paths still consume the method
+  selector only after a local builder seed is active.
 - Exact fragment surface proofs for Java `this.field`, Java `return this`,
   non-overloadable C/Go/Java index assignment, and single-item builder append
   calls are now shared through `nose-semantics`; predicate and contract paths
@@ -280,13 +281,14 @@ migrated.
   Same-unit value-graph readback uses syntactic receiver/place evidence only; it
   does not assume aliasing or computed call-result receivers.
 - Exact-fragment place/effect gates now have the first pack-facing evidence
-  substrate. First-party lowering emits `Place(SelfReceiver)` and
-  `Place(SelfField)` for Java `this`/`this.field`, plus `Effect` evidence for
-  canonical builder append calls, C/Go/Java non-overloadable index writes, and
-  Java self-field writes. Fragment recognizers consume these records first and
-  use legacy language gates only when no relevant place/effect evidence exists.
-  Self-field place/write records depend on the matching receiver/place records,
-  and conflicting or ambiguous place/effect evidence closes the exact path.
+  substrate. First-party lowering and normalize refreshes emit
+  `Place(SelfReceiver)` and `Place(SelfField)` for Java `this`/`this.field`,
+  plus `Effect` evidence for canonical builder append calls, C/Go/Java
+  non-overloadable index writes, and Java self-field writes. Fragment
+  recognizers require these records; missing, conflicting, ambiguous, or
+  dependency-broken place/effect evidence closes the exact path instead of
+  reopening a language/shape fallback. Self-field place/write records depend on
+  the matching receiver/place records.
 - `SeqSurfaceContract` now centralizes first-party lowered sequence tags and
   keeps separate axes for exact-tree safety, membership-collection admission,
   map-entry-list admission, imported-literal eligibility, and value-graph


### PR DESCRIPTION
## Summary
- add a normalize refresh pass that emits first-party `Place`/`Effect` evidence for currently supported exact fragment semantics
- make exact self receiver/field, self-field write, non-overloadable index write, and builder append gates fail closed unless that evidence is present and live
- remove raw language/shape pre-gates from detect exact sequence paths so shared evidence-backed helpers are authoritative
- update the semantic kernel snapshot, evidence records, and roadmap to describe the new contract

Part of #109.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check-duplication.sh`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `awiki lint --root docs`
- `cargo test --release`