### PR TITLE
[codex] Require sequence surface evidence

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -4031,6 +4031,28 @@ mod tests {
         (il, call)
     }
 
+    fn raw_array_seq_il(interner: &Interner) -> (Il, NodeId) {
+        let mut b = IlBuilder::new(FileId(0));
+        let one = b.add(NodeKind::Lit, Payload::LitInt(1), sp(60), &[]);
+        let seq = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(61),
+            &[one],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(59), &[seq]);
+        let il = b.finish(
+            root,
+            FileMeta {
+                path: "t.js".into(),
+                lang: Lang::JavaScript,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        (il, seq)
+    }
+
     fn ts_contains_call_il(interner: &Interner) -> (Il, NodeId, Span) {
         let mut b = IlBuilder::new(FileId(0));
         let receiver_span = sp(50);
@@ -4059,6 +4081,31 @@ mod tests {
             Vec::new(),
         );
         (il, call, receiver_span)
+    }
+
+    #[test]
+    fn strict_exact_sequence_surfaces_require_evidence() {
+        let interner = Interner::new();
+        let (mut il, seq) = raw_array_seq_il(&interner);
+        let facts = StrictFacts::collect(&il, &interner);
+
+        assert!(!strict_exact_safe_tree(&il, &interner, &facts, seq));
+        assert!(!strict_exact_membership_collection_safe(
+            &il, &interner, &facts, seq
+        ));
+
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(sp(61)),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+            Vec::new(),
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+
+        assert!(strict_exact_safe_tree(&il, &interner, &facts, seq));
+        assert!(strict_exact_membership_collection_safe(
+            &il, &interner, &facts, seq
+        ));
     }
 
     #[test]

--- a/crates/nose-normalize/src/desugar.rs
+++ b/crates/nose-normalize/src/desugar.rs
@@ -230,8 +230,8 @@ impl Rebuilder<'_> {
         }
     }
 
-    /// `x.length` → `Len(x)`; async method/type names → their sync counterpart
-    /// (`__aexit__` → `__exit__`, `AsyncIterable` → `Iterable`); others pass through.
+    /// `x.length` → `Len(x)` when the receiver has exact collection proof;
+    /// others pass through.
     fn field(&mut self, old_id: NodeId) -> NodeId {
         let n = *self.old.node(old_id);
         if let Payload::Name(s) = n.payload {
@@ -256,19 +256,6 @@ impl Rebuilder<'_> {
                         &[new_base],
                     );
                 }
-            }
-            if let Some(sync) = crate::idioms::async_to_sync(self.old.meta.lang, name) {
-                let sym = self.interner.intern(sync);
-                let kids: Vec<NodeId> = self
-                    .old
-                    .children(old_id)
-                    .to_vec()
-                    .iter()
-                    .map(|&c| self.go(c))
-                    .collect();
-                return self
-                    .b
-                    .add(NodeKind::Field, Payload::Name(sym), n.span, &kids);
             }
         }
         self.generic(old_id)
@@ -325,8 +312,29 @@ fn property_receiver_exact_hof_call(
         return false;
     };
     let method_text = interner.resolve(method);
-    nose_semantics::method_hof_contract(il.meta.lang, method_text).is_some()
-        && property_receiver_exact_safe(il, interner, domains, receiver)
+    let arg_count = kids.len() - 1;
+    let Some(kind) = nose_semantics::method_hof_contract(il.meta.lang, method_text) else {
+        return false;
+    };
+    let Some(contract) =
+        nose_semantics::library_method_call_contract(il.meta.lang, method_text, arg_count)
+    else {
+        return false;
+    };
+    if contract.result.semantic != nose_semantics::MethodSemanticContract::HoF(kind) {
+        return false;
+    }
+    matches!(
+        nose_semantics::library_api_contract_evidence_for_call(
+            il,
+            interner,
+            node,
+            contract.id,
+            contract.callee,
+            arg_count,
+        ),
+        nose_semantics::LibraryApiEvidenceStatus::Admitted
+    ) && property_receiver_exact_safe(il, interner, domains, receiver)
 }
 
 fn property_receiver_exact_hof_node(
@@ -344,4 +352,113 @@ fn property_receiver_exact_hof_node(
     il.children(node)
         .first()
         .is_some_and(|&receiver| property_receiver_exact_safe(il, interner, domains, receiver))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nose_il::{
+        EvidenceAnchor, EvidenceKind, FileId, FileMeta, Lang, SequenceSurfaceKind, Span,
+    };
+    use nose_semantics::FIRST_PARTY_PACK_ID;
+
+    fn sp() -> Span {
+        Span::new(FileId(0), 1, 1, 1, 1)
+    }
+
+    #[test]
+    fn async_like_field_names_are_not_rewritten_without_protocol_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("reader")),
+            sp(),
+            &[],
+        );
+        let field = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("aread")),
+            sp(),
+            &[receiver],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(), &[field]);
+        let il = b.finish(
+            root,
+            FileMeta {
+                path: "t.py".to_string(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let out = run(&il, &interner, &NormalizeOptions::default());
+        let lowered_field = out
+            .nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::Field)
+            .expect("field should remain a field");
+        assert!(matches!(
+            lowered_field.payload,
+            Payload::Name(name) if interner.resolve(name) == "aread"
+        ));
+    }
+
+    #[test]
+    fn hof_length_field_requires_hof_occurrence_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let one = b.add(NodeKind::Lit, Payload::LitInt(1), sp(), &[]);
+        let receiver = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(),
+            &[one],
+        );
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("filter")),
+            sp(),
+            &[receiver],
+        );
+        let lambda = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("predicate")),
+            sp(),
+            &[],
+        );
+        let filter_call = b.add(NodeKind::Call, Payload::None, sp(), &[callee, lambda]);
+        let length = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("length")),
+            sp(),
+            &[filter_call],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(), &[length]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.js".to_string(),
+                lang: Lang::JavaScript,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.find_or_push_first_party_evidence(
+            EvidenceAnchor::sequence(sp()),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+            FIRST_PARTY_PACK_ID,
+            "test_sequence_surface",
+            Vec::new(),
+        );
+
+        let out = run(&il, &interner, &NormalizeOptions::default());
+        assert!(
+            !out.nodes
+                .iter()
+                .any(|node| matches!(node.payload, Payload::Builtin(nose_il::Builtin::Len))),
+            "raw HOF selector plus receiver evidence must not prove length semantics"
+        );
+    }
 }

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -994,14 +994,6 @@ fn map_factory_entries_match_surface(
     })
 }
 
-/// Canonical sync name for a known async counterpart, so behaviorally-equivalent
-/// sync/async twins (a frequent real Type-4 pattern, e.g. `__exit__`/`__aexit__`,
-/// `read`/`aread`) converge. Curated to high-confidence pairs only — generic
-/// `a`-prefixed names (`add`, `append`, `get`) are deliberately excluded.
-pub(crate) fn async_to_sync(lang: nose_il::Lang, name: &str) -> Option<&'static str> {
-    nose_semantics::async_to_sync_name(lang, name)
-}
-
 fn file_defines_name(old: &Il, interner: &Interner, name: &str) -> bool {
     old.units
         .iter()
@@ -2098,10 +2090,21 @@ mod tests {
             Vec::new(),
         );
 
-        assert!(map_like_literal(&il, &interner, map));
+        assert!(
+            !map_like_literal(&il, &interner, map),
+            "raw map tag alone must not prove a semantic map surface"
+        );
 
         il.evidence.push(evidence(
             0,
+            EvidenceAnchor::sequence(sp()),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Map),
+            EvidenceStatus::Asserted,
+        ));
+        assert!(map_like_literal(&il, &interner, map));
+
+        il.evidence.push(evidence(
+            1,
             EvidenceAnchor::sequence(sp()),
             EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
             EvidenceStatus::Asserted,
@@ -2115,18 +2118,20 @@ mod tests {
     fn rust_hash_map_from_call(entry_surface: &str, shadow_std: bool) -> (Il, Interner, NodeId) {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
+        let entry_span = sp_at(10, 20, 1);
+        let entries_span = sp_at(30, 40, 1);
         let key = b.add(NodeKind::Lit, Payload::LitStr(1), sp(), &[]);
         let value = b.add(NodeKind::Lit, Payload::LitInt(1), sp(), &[]);
         let entry = b.add(
             NodeKind::Seq,
             Payload::Name(interner.intern(entry_surface)),
-            sp(),
+            entry_span,
             &[key, value],
         );
         let entries = b.add(
             NodeKind::Seq,
             Payload::Name(interner.intern("array")),
-            sp(),
+            entries_span,
             &[entry],
         );
         let callee = b.add(
@@ -2146,7 +2151,7 @@ mod tests {
         } else {
             Vec::new()
         };
-        let il = b.finish(
+        let mut il = b.finish(
             root,
             FileMeta {
                 path: "t".to_string(),
@@ -2155,6 +2160,23 @@ mod tests {
             units,
             Vec::new(),
         );
+        let entry_kind = match entry_surface {
+            "tuple" => SequenceSurfaceKind::Tuple,
+            "array" => SequenceSurfaceKind::Collection,
+            other => panic!("unexpected test entry surface: {other}"),
+        };
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::sequence(entry_span),
+            EvidenceKind::SequenceSurface(entry_kind),
+            EvidenceStatus::Asserted,
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::sequence(entries_span),
+            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+            EvidenceStatus::Asserted,
+        ));
         (il, interner, call)
     }
 
@@ -2162,16 +2184,18 @@ mod tests {
         let contract =
             library_free_name_map_factory_contract(Lang::Rust, "std::collections::HashMap::from")
                 .expect("Rust HashMap::from contract");
+        let symbol_id = next_evidence_id(il);
         il.evidence.push(evidence(
-            0,
+            symbol_id,
             EvidenceAnchor::node(sp(), NodeKind::Var),
             EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
                 name_hash: stable_symbol_hash("std::collections::HashMap::from"),
             }),
             EvidenceStatus::Asserted,
         ));
+        let api_id = next_evidence_id(il);
         il.evidence.push(evidence_with_dependencies(
-            1,
+            api_id,
             EvidenceAnchor::node(sp(), NodeKind::Call),
             EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
                 contract_hash: nose_semantics::library_api_contract_id_hash(contract.id),
@@ -2179,7 +2203,7 @@ mod tests {
                 arity: 1,
             }),
             EvidenceStatus::Asserted,
-            vec![EvidenceId(0)],
+            vec![EvidenceId(symbol_id)],
         ));
     }
 

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -8992,6 +8992,36 @@ mod tests {
         )
     }
 
+    #[test]
+    fn raw_sequence_tags_do_not_prove_value_graph_surfaces() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let one = b.add(NodeKind::Lit, Payload::LitInt(1), sp(20), &[]);
+        let seq = b.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp(21),
+            &[one],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(19), &[seq]);
+        let mut il = finish_test_il(b, root, Lang::JavaScript);
+
+        let mut builder = Builder::new(&il, &interner);
+        let raw = builder.eval(seq, &FxHashMap::default());
+        assert!(!matches!(
+            builder.nodes[raw as usize].op,
+            ValOp::Seq(SEQ_VALUE_COLLECTION)
+        ));
+
+        il.evidence.push(collection_sequence_evidence(0, sp(21)));
+        let mut builder = Builder::new(&il, &interner);
+        let proven = builder.eval(seq, &FxHashMap::default());
+        assert!(matches!(
+            builder.nodes[proven as usize].op,
+            ValOp::Seq(SEQ_VALUE_COLLECTION)
+        ));
+    }
+
     fn library_api_contract_evidence(
         id: u32,
         call_span: Span,

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -777,32 +777,6 @@ pub fn seq_surface_contract_for_node(
         Payload::Name(name) => Some(interner.resolve(name)),
         _ => return None,
     };
-    let span = il.node(node).span;
-    match sequence_surface_evidence_at_sequence_span(il, span) {
-        EvidenceResolution::Found(kind) => {
-            let (raw_kind, raw_contract) = seq_surface_contract_for_tag(il.meta.lang, raw_tag)?;
-            (kind == raw_kind).then_some(raw_contract)
-        }
-        EvidenceResolution::Ambiguous => None,
-        EvidenceResolution::Missing => seq_surface_contract(il.meta.lang, raw_tag),
-    }
-}
-
-/// Evidence-only `Seq` surface resolution for consumers that must not infer a
-/// semantic surface from tag spelling alone.
-pub fn seq_surface_contract_evidence_for_node(
-    il: &Il,
-    interner: &Interner,
-    node: NodeId,
-) -> Option<SeqSurfaceContract> {
-    if il.kind(node) != NodeKind::Seq {
-        return None;
-    }
-    let raw_tag = match il.node(node).payload {
-        Payload::None => None,
-        Payload::Name(name) => Some(interner.resolve(name)),
-        _ => return None,
-    };
     let (raw_kind, raw_contract) = seq_surface_contract_for_tag(il.meta.lang, raw_tag)?;
     match sequence_surface_evidence_at_sequence_span(il, il.node(node).span) {
         EvidenceResolution::Found(kind) if kind == raw_kind => Some(raw_contract),
@@ -810,6 +784,15 @@ pub fn seq_surface_contract_evidence_for_node(
         | EvidenceResolution::Ambiguous
         | EvidenceResolution::Missing => None,
     }
+}
+
+/// Backward-compatible name for the evidence-only `Seq` surface resolver.
+pub fn seq_surface_contract_evidence_for_node(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<SeqSurfaceContract> {
+    seq_surface_contract_for_node(il, interner, node)
 }
 
 fn sequence_surface_evidence_at_sequence_span(
@@ -8129,33 +8112,6 @@ pub fn module_binding_mutating_method_name(method: &str) -> bool {
     )
 }
 
-pub fn async_to_sync_name(lang: Lang, name: &str) -> Option<&'static str> {
-    if lang != Lang::Python {
-        return None;
-    }
-    Some(match name {
-        "__aenter__" => "__enter__",
-        "__aexit__" => "__exit__",
-        "__anext__" => "__next__",
-        "__aiter__" => "__iter__",
-        "aread" => "read",
-        "areadline" => "readline",
-        "areadlines" => "readlines",
-        "awrite" => "write",
-        "aclose" => "close",
-        "asend" => "send",
-        "areceive" => "receive",
-        "aconnect" => "connect",
-        "adrain" => "drain",
-        "aflush" => "flush",
-        "AsyncIterable" => "Iterable",
-        "AsyncIterator" => "Iterator",
-        "AsyncGenerator" => "Generator",
-        "AsyncContextManager" => "ContextManager",
-        _ => return None,
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -8969,6 +8925,13 @@ mod tests {
         let seq = b.add(NodeKind::Seq, Payload::Name(array), sp(5), &[]);
         let root = b.add(NodeKind::Block, Payload::None, sp(5), &[seq]);
         let mut il = finish_il(b, root, Lang::JavaScript);
+
+        assert_eq!(
+            seq_surface_contract_for_node(&il, &interner, seq),
+            None,
+            "raw sequence tags do not prove semantic surfaces without evidence"
+        );
+
         il.evidence.push(evidence(
             0,
             EvidenceAnchor::sequence(sp(5)),
@@ -11693,21 +11656,6 @@ mod tests {
             scalar_integer_method_contract(Lang::JavaScript, "abs", 0),
             None
         );
-    }
-
-    #[test]
-    fn async_to_sync_contracts_are_python_constrained() {
-        assert_eq!(
-            async_to_sync_name(Lang::Python, "__aenter__"),
-            Some("__enter__")
-        );
-        assert_eq!(async_to_sync_name(Lang::Python, "aread"), Some("read"));
-        assert_eq!(
-            async_to_sync_name(Lang::Python, "AsyncIterator"),
-            Some("Iterator")
-        );
-        assert_eq!(async_to_sync_name(Lang::JavaScript, "aread"), None);
-        assert_eq!(async_to_sync_name(Lang::Python, "append"), None);
     }
 
     #[test]

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -182,6 +182,15 @@ claim as well. The result-domain record proves only the container/protocol shape
 of the call result; exact consumers still prove argument safety, entry shape,
 mutation, receiver requirements, and demand/effect obligations separately.
 
+Sequence-surface evidence is also authoritative for exact/value-graph aggregate
+semantics. A lowered `Seq("array")`, `Seq("object")`, `Seq("tuple")`, or
+language-specific tag does not by itself prove exact-tree safety, collection
+membership, map-entry-list shape, imported-literal eligibility, or a canonical
+value-graph tag. Consumers resolve the tag only when a matching
+`SequenceSurface` record exists at the same sequence anchor and its dependencies
+remain asserted. Missing, conflicting, ambiguous, or wrong-kind surface evidence
+keeps the exact/value-graph path closed.
+
 Qualified global identity is also evidence, not a selector guess. The current
 first-party JS/TS producer emits `QualifiedGlobal` only for selected static paths
 whose root is proven unshadowed, such as `Object.hasOwn`,

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -421,6 +421,14 @@ and pack ecosystem.
   self receiver/field/write `Place`/`Effect` records after canonical rewrites.
   Exact fragment consumers no longer reopen append/index/self-field admission
   through language/shape fallback when `Effect`/`Place` evidence is missing.
+- Sequence-surface exact/value consumers became evidence-only. Raw
+  `Seq("array")`, `Seq("object")`, `Seq("tuple")`, Go `composite_literal`, and
+  similar lowered tags no longer prove exact-tree safety, membership collection
+  admission, map-entry-list shape, or value-graph sequence tags without matching
+  `SequenceSurface` evidence. JS/TS `filter(...).length` also now requires the
+  inner HOF call's admitted `LibraryApi` occurrence instead of a raw method
+  selector. Raw Python async-looking field names no longer rewrite to sync names
+  until an explicit async/sync protocol evidence path exists.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -511,10 +519,11 @@ Remaining in this phase:
   Python builtin/import-backed, Rust free-name/path, Ruby require-backed, Java
   `java.util`, and regex calls now additionally share `LibraryApi` occurrence
   evidence, as do generic Python/Go free-function builtins and selected
-  receiver-method families. Remaining API work is to move the remaining raw
-  sequence/tag proof dependencies into explicit evidence records, then cover
-  ecosystem APIs only after demand, receiver, and effect obligations are
-  expressible.
+  receiver-method families. Lowered sequence-surface consumers are now
+  evidence-only where covered. Remaining API work is property occurrence
+  evidence, Rust Option constructor/sentinel/`and_then` occurrence evidence,
+  Rust scalar method occurrence evidence, promise receiver proof, and ecosystem
+  APIs only after demand, receiver, and effect obligations are expressible.
 - Continue import/module proof migration beyond the removed raw import payloads
   and evidence-only import identity path. Value-graph import identity and
   imported-symbol exact proof are now evidence-only, imported literal replacement
@@ -525,10 +534,11 @@ Remaining in this phase:
 - Generalize dedicated guard evidence beyond the first JS/TS record-shape and
   own-property contracts, including richer source-clause records, API dependency
   validation, subject/place identity, and truthiness/null semantics.
-- Expand the first `SequenceSurface` evidence into sequence/aggregate records for
-  factories, more nested entries, iterator views, and exported-literal
-  eligibility. Go map literal entries are the first exact consumer that now
-  requires per-entry surface evidence.
+- Expand the first `SequenceSurface` evidence into richer sequence/aggregate
+  records for factories, more nested entries, iterator views, and
+  exported-literal eligibility. Current exact/value-graph consumers are
+  evidence-only for covered lowered surfaces, but richer aggregate semantics
+  still need versioned records beyond the first tag-kind vocabulary.
 - Continue expanding domain evidence beyond parameter annotations. The shared
   receiver-domain consumer contract now accepts exact node-anchored receiver
   facts, binding-anchored immutable local/module facts, and selected admitted

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -140,7 +140,8 @@ migrated.
 - Property builtin contracts are language-constrained; a selector such as
   `length` is not enough without receiver proof. JS/TS `filter(...).length`
   is admitted only after the receiver has already entered a proven collection/HOF
-  value. JS object `.length` remains a property read, not collection cardinality.
+  value and raw HOF calls carry admitted `LibraryApi` occurrence evidence. JS
+  object `.length` remains a property read, not collection cardinality.
 - Promise `.then` has a JS-like library API contract, but exact beta-reduction
   is closed until a pack/frontend can prove a Promise-like receiver.
 - Rust iterator identity adapters (`iter`, `into_iter`, `collect`, `to_vec`,
@@ -293,7 +294,8 @@ migrated.
   keeps separate axes for exact-tree safety, membership-collection admission,
   map-entry-list admission, imported-literal eligibility, and value-graph
   canonical tags. Strict exact gates, value-graph sequence lowering, and
-  sibling-module literal export checks consume this contract instead of local
+  sibling-module literal export checks consume this contract only through
+  matching `SequenceSurface` evidence rather than raw tag spelling or local
   string allowlists. Untagged `Seq` remains an internal grouping surface and
   does not itself prove exact collection semantics; the older Python empty
   sequence collection case is handled only by the explicit collection profile
@@ -487,8 +489,11 @@ Semantic knowledge still appears in several forms outside the facade:
   `require "set"; Set.new(...)`, Java `java.util` static factories/adapters and
   selected empty constructors, JS regex literals, generic Python/Go
   free-function builtins, and selected receiver-method families. Promise
-  receiver proof, async/sync protocol convergence, and ecosystem APIs still rely
-  on contract rows plus local proof or remain exact-closed.
+  receiver proof, async/sync protocol convergence, property occurrence evidence,
+  Rust Option/scalar occurrence evidence, and ecosystem APIs still rely on
+  contract rows plus local proof or remain exact-closed. Raw Python async-looking
+  field names such as `aread` no longer rewrite to sync names without an
+  explicit protocol/API evidence path.
 
 These are valuable, but they do not yet share one complete semantic contract
 language.


### PR DESCRIPTION
Part of #109.

## Summary
- Make covered SequenceSurface exact/value consumers evidence-only: raw lowered Seq tags no longer prove strict exact safety, membership collection, map entry-list shape, or value-graph aggregate tags without matching SequenceSurface evidence.
- Require admitted LibraryApi occurrence evidence before a JS/TS HOF call result can make `.length` exact.
- Stop raw Python async-looking field-name rewrites until an explicit async/sync protocol evidence path exists.
- Update the semantic-kernel snapshot, roadmap, and evidence-record docs with the new boundary and remaining work.

## Validation
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --release
- cargo test --release
- ./scripts/check-duplication.sh
- awiki lint --root docs
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 시퀀스 표면 판단 시 명시적 증거 없이 원시 태그만으로는 안전성을 인정하지 않도록 강화했습니다.
  * 필드 이름 패턴 기반의 비동기/동기 자동 변환 로직을 제거하여 명확한 프로토콜 증거 필요 조건을 적용했습니다.

* **테스트**
  * 시퀀스 표면, 맵 리터럴, 값 그래프 증거 요구 조건을 검증하는 테스트를 강화했습니다.

* **문서**
  * 증거 기반 의미론 규칙과 시퀀스 표면 증거 필수 조건을 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->