### PR TITLE
Close protocol API occurrences over evidence

### DIFF
--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -19,22 +19,23 @@ use nose_semantics::{
     exact_self_field_write_assignment, exact_static_membership_predicate_operator,
     go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
     go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract,
-    library_api_contract_evidence_for_call, library_free_name_collection_factory_contract,
-    library_free_name_map_factory_contract, library_imported_collection_factory_contracts,
-    library_iterator_identity_adapter_contract, library_java_collection_constructor_contract,
-    library_java_collection_factory_contract, library_java_map_entry_contract,
-    library_java_map_factory_contract, library_js_array_is_array_contract,
-    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
-    library_map_get_contract, library_map_key_view_contract, library_map_key_view_wrapper_contract,
+    library_api_contract_evidence_for_call, library_api_contract_evidence_for_node,
+    library_free_name_collection_factory_contract, library_free_name_map_factory_contract,
+    library_imported_collection_factory_contracts, library_iterator_identity_adapter_contract,
+    library_java_collection_constructor_contract, library_java_collection_factory_contract,
+    library_java_map_entry_contract, library_java_map_factory_contract,
+    library_js_array_is_array_contract, library_js_like_map_constructor_contract,
+    library_js_like_set_constructor_contract, library_map_get_contract,
+    library_map_key_view_contract, library_map_key_view_wrapper_contract,
     library_method_call_contract, library_regex_test_contract, library_ruby_set_factory_contract,
-    library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
-    library_static_index_membership_contract, nullish_global_contract, own_property_guard_for_node,
-    record_shape_guard_for_node, semantics, seq_surface_contract_for_node, source_operator_at_node,
-    typeof_operator_contract, unshadowed_global_symbol, DomainRequirement,
-    IndexMembershipThreshold, JavaMapFactoryKind, LibraryApiCalleeContract,
-    LibraryApiEvidenceStatus, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
-    LibraryMapGetContract, LibraryMethodCallContract, MapKeyViewKind, MethodBuiltinArgs,
-    MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
+    library_rust_option_none_sentinel_contract, library_rust_vec_macro_factory_contract,
+    library_rust_vec_new_factory_contract, library_static_index_membership_contract,
+    nullish_global_contract, own_property_guard_for_node, record_shape_guard_for_node, semantics,
+    seq_surface_contract_for_node, source_operator_at_node, typeof_operator_contract,
+    unshadowed_global_symbol, DomainRequirement, IndexMembershipThreshold, JavaMapFactoryKind,
+    LibraryApiCalleeContract, LibraryApiEvidenceStatus, LibraryCollectionFactoryResult,
+    LibraryMapFactoryResult, LibraryMapGetContract, LibraryMethodCallContract, MapKeyViewKind,
+    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -847,6 +848,7 @@ fn function_binding_safe(
         NodeKind::Var => {
             strict_exact_safe_var(il, facts, node)
                 || strict_exact_nullish_global_safe(il, interner, node)
+                || strict_exact_rust_option_none_safe(il, interner, node)
         }
         _ => il
             .children(node)
@@ -881,6 +883,7 @@ fn strict_exact_safe_tree(il: &Il, interner: &Interner, facts: &StrictFacts, nod
         NodeKind::Var => {
             strict_exact_safe_var(il, facts, node)
                 || strict_exact_nullish_global_safe(il, interner, node)
+                || strict_exact_rust_option_none_safe(il, interner, node)
         }
         _ => il
             .children(node)
@@ -1164,6 +1167,20 @@ fn strict_exact_nullish_global_safe(il: &Il, interner: &Interner, node: NodeId) 
         return false;
     };
     !contract.requires_unshadowed || unshadowed_global_symbol(il, interner, node, contract.name)
+}
+
+fn strict_exact_rust_option_none_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    let (NodeKind::Var, Payload::Name(name)) = (il.kind(node), il.node(node).payload) else {
+        return false;
+    };
+    let name = interner.resolve(name);
+    let Some(contract) = library_rust_option_none_sentinel_contract(il.meta.lang, name) else {
+        return false;
+    };
+    matches!(
+        library_api_contract_evidence_for_node(il, interner, node, contract.id, contract.callee, 0,),
+        LibraryApiEvidenceStatus::Admitted
+    )
 }
 
 fn strict_exact_safe_seq(il: &Il, interner: &Interner, node: NodeId) -> bool {

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -1287,6 +1287,7 @@ fn record_post_lower_library_api_evidence(il: &mut Il, interner: &Interner) {
         record_post_lower_property_library_api(il, interner, field, &mut dependency_cache);
     }
     for var in vars {
+        record_post_lower_rust_option_some_pattern_library_api(il, interner, var);
         record_post_lower_rust_option_none_library_api(il, interner, var);
     }
 }
@@ -1507,6 +1508,41 @@ fn record_post_lower_rust_option_none_library_api(
         vec![symbol_dependency],
     );
     post_lower_record_library_api_node_result_domain(il, var, contract.result_domain, api);
+    true
+}
+
+fn record_post_lower_rust_option_some_pattern_library_api(
+    il: &mut Il,
+    interner: &Interner,
+    var: NodeId,
+) -> bool {
+    let Some(name) = post_lower_var_name(il, interner, var) else {
+        return false;
+    };
+    let Some(contract) = library_rust_option_some_constructor_contract(il.meta.lang, name, 1)
+    else {
+        return false;
+    };
+    let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+        return false;
+    };
+    if !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+        post_lower_file_defines_name_visible_at(il, interner, candidate, il.node(var).span)
+    }) {
+        return false;
+    }
+    let Some(symbol_dependency) = post_lower_unshadowed_symbol_evidence_id(il, var, name) else {
+        return false;
+    };
+    post_lower_library_api_node_evidence_id(
+        il,
+        var,
+        contract.id,
+        contract.callee,
+        1,
+        "library_api_rust_option_some_pattern",
+        vec![symbol_dependency],
+    );
     true
 }
 
@@ -3875,6 +3911,40 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             1,
             "typed exact-collection property access should carry LibraryApi occurrence evidence"
         );
+        let ts_filter_length = crate::lower_source(
+            FileId(0),
+            "t.ts",
+            b"function f(value: string) { return [\"red\", \"blue\"].filter((item: string) => item === value).length >= 1; }\n",
+            Lang::TypeScript,
+            &interner,
+        )
+        .expect("typescript lowering should succeed");
+        let filter_length_field = ts_filter_length
+            .nodes
+            .iter()
+            .enumerate()
+            .find_map(|(idx, node)| {
+                (node.kind == NodeKind::Field
+                    && matches!(
+                        node.payload,
+                        Payload::Name(symbol) if interner.resolve(symbol) == "length"
+                    ))
+                .then_some((NodeId(idx as u32), node.span))
+            })
+            .expect("filter length field should be lowered");
+        let filter_length_api = library_api_evidence_ids_at_node(
+            &ts_filter_length.evidence,
+            filter_length_field.1,
+            NodeKind::Field,
+            library_api_contract_id_hash(property_contract.id),
+            library_api_callee_contract_hash(property_contract.callee),
+            0,
+        );
+        assert_eq!(
+            filter_length_api.len(),
+            1,
+            "HOF result property access should carry LibraryApi occurrence evidence"
+        );
 
         let rust_some = crate::lower_source(
             FileId(0),
@@ -3918,6 +3988,46 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             DomainEvidence::Option,
             &some_api,
         ));
+
+        let rust_some_pattern = crate::lower_source(
+            FileId(0),
+            "t.rs",
+            b"pub fn f(value: Option<i32>) -> bool { if let Some(_) = value { true } else { false } }\n",
+            Lang::Rust,
+            &interner,
+        )
+        .expect("rust lowering should succeed");
+        let some_pattern_var = rust_some_pattern
+            .nodes
+            .iter()
+            .find_map(|node| {
+                (node.kind == NodeKind::Var
+                    && matches!(
+                        node.payload,
+                        Payload::Name(symbol) if interner.resolve(symbol) == "Some"
+                    ))
+                .then_some(node.span)
+            })
+            .expect("Some pattern var should be preserved");
+        let some_pattern_api = library_api_evidence_ids_at_node(
+            &rust_some_pattern.evidence,
+            some_pattern_var,
+            NodeKind::Var,
+            library_api_contract_id_hash(some_contract.id),
+            library_api_callee_contract_hash(some_contract.callee),
+            1,
+        );
+        assert_eq!(some_pattern_api.len(), 1);
+        assert!(
+            !result_domain_depends_on_api_at_node(
+                &rust_some_pattern.evidence,
+                some_pattern_var,
+                NodeKind::Var,
+                DomainEvidence::Option,
+                &some_pattern_api,
+            ),
+            "pattern occurrence identity must not become a constructor result domain"
+        );
 
         let rust_none = crate::lower_source(
             FileId(0),

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -12,7 +12,8 @@ use nose_il::{
 };
 use nose_semantics::{
     library_api_callee_contract_hash, library_api_contract_id_hash,
-    library_api_free_name_shadow_safe, library_api_receiver_dependencies_for_call_with_cache,
+    library_api_free_name_shadow_safe, library_api_property_dependencies_for_field_with_cache,
+    library_api_receiver_dependencies_for_call_with_cache,
     library_collection_factory_result_domain_for_arity, library_free_function_builtin_contract,
     library_free_name_collection_factory_contract, library_free_name_map_factory_contract,
     library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
@@ -21,12 +22,14 @@ use nose_semantics::{
     library_js_array_is_array_contract, library_js_boolean_coercion_contract,
     library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
     library_map_factory_result_domain, library_map_key_view_wrapper_contract,
-    library_map_key_view_wrapper_result_domain, library_receiver_method_api_contract,
-    library_regex_test_contract, library_ruby_set_factory_contract,
-    library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
-    library_static_collection_adapter_contract, library_static_index_membership_contract,
-    sequence_surface_kind_for_tag, ImportFactKind, LibraryApiCalleeContract, LibraryApiContractId,
-    LibraryApiDependencyCache, MethodReceiverContract, StaticIndexMembershipReceiverContract,
+    library_map_key_view_wrapper_result_domain, library_property_builtin_contract,
+    library_receiver_method_api_contract, library_regex_test_contract,
+    library_ruby_set_factory_contract, library_rust_option_none_sentinel_contract,
+    library_rust_option_some_constructor_contract, library_rust_vec_macro_factory_contract,
+    library_rust_vec_new_factory_contract, library_static_collection_adapter_contract,
+    library_static_index_membership_contract, sequence_surface_kind_for_tag, ImportFactKind,
+    LibraryApiCalleeContract, LibraryApiContractId, LibraryApiDependencyCache,
+    MethodReceiverContract, StaticIndexMembershipReceiverContract,
 };
 use tree_sitter::Node as TsNode;
 
@@ -1255,6 +1258,18 @@ fn record_post_lower_library_api_evidence(il: &mut Il, interner: &Interner) {
                 .then_some(NodeId(idx as u32))
         })
         .collect();
+    let fields: Vec<NodeId> = il
+        .nodes
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, node)| (node.kind == NodeKind::Field).then_some(NodeId(idx as u32)))
+        .collect();
+    let vars: Vec<NodeId> = il
+        .nodes
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, node)| (node.kind == NodeKind::Var).then_some(NodeId(idx as u32)))
+        .collect();
     let mut dependency_cache = LibraryApiDependencyCache::default();
     for call in calls {
         if record_post_lower_free_name_library_api(il, interner, call) {
@@ -1267,6 +1282,12 @@ fn record_post_lower_library_api_evidence(il: &mut Il, interner: &Interner) {
             continue;
         }
         record_post_lower_receiver_method_library_api(il, interner, call, &mut dependency_cache);
+    }
+    for field in fields {
+        record_post_lower_property_library_api(il, interner, field, &mut dependency_cache);
+    }
+    for var in vars {
+        record_post_lower_rust_option_none_library_api(il, interner, var);
     }
 }
 
@@ -1325,6 +1346,18 @@ fn record_post_lower_free_name_library_api(il: &mut Il, interner: &Interner, cal
                         library_collection_factory_result_domain_for_arity(contract, arg_count),
                     )
                 })
+        })
+        .or_else(|| {
+            library_rust_option_some_constructor_contract(il.meta.lang, callee_name, arg_count).map(
+                |contract| {
+                    (
+                        contract.id,
+                        contract.callee,
+                        "library_api_rust_option_some_constructor",
+                        Some(contract.result_domain),
+                    )
+                },
+            )
         })
         .or_else(|| {
             library_free_function_builtin_contract(il.meta.lang, callee_name, arg_count).map(
@@ -1401,6 +1434,79 @@ fn record_post_lower_free_name_library_api(il: &mut Il, interner: &Interner, cal
         dependencies,
     );
     post_lower_record_library_api_result_domain(il, call, result_domain, api);
+    true
+}
+
+fn record_post_lower_property_library_api(
+    il: &mut Il,
+    interner: &Interner,
+    field: NodeId,
+    dependency_cache: &mut LibraryApiDependencyCache,
+) -> bool {
+    if il.kind(field) != NodeKind::Field {
+        return false;
+    }
+    let Payload::Name(property) = il.node(field).payload else {
+        return false;
+    };
+    let Some(contract) =
+        library_property_builtin_contract(il.meta.lang, interner.resolve(property))
+    else {
+        return false;
+    };
+    let Some(dependencies) = library_api_property_dependencies_for_field_with_cache(
+        il,
+        interner,
+        field,
+        contract.callee,
+        dependency_cache,
+    ) else {
+        return false;
+    };
+    post_lower_library_api_node_evidence_id(
+        il,
+        field,
+        contract.id,
+        contract.callee,
+        0,
+        "library_api_property_builtin",
+        dependencies,
+    );
+    true
+}
+
+fn record_post_lower_rust_option_none_library_api(
+    il: &mut Il,
+    interner: &Interner,
+    var: NodeId,
+) -> bool {
+    let Some(name) = post_lower_var_name(il, interner, var) else {
+        return false;
+    };
+    let Some(contract) = library_rust_option_none_sentinel_contract(il.meta.lang, name) else {
+        return false;
+    };
+    let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+        return false;
+    };
+    if !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+        post_lower_file_defines_name_visible_at(il, interner, candidate, il.node(var).span)
+    }) {
+        return false;
+    }
+    let Some(symbol_dependency) = post_lower_unshadowed_symbol_evidence_id(il, var, name) else {
+        return false;
+    };
+    let api = post_lower_library_api_node_evidence_id(
+        il,
+        var,
+        contract.id,
+        contract.callee,
+        0,
+        "library_api_rust_option_none_sentinel",
+        vec![symbol_dependency],
+    );
+    post_lower_record_library_api_node_result_domain(il, var, contract.result_domain, api);
     true
 }
 
@@ -1864,6 +1970,29 @@ fn post_lower_library_api_evidence_id(
     .expect("post-lower LibraryApi evidence insertion should always produce an id")
 }
 
+fn post_lower_library_api_node_evidence_id(
+    il: &mut Il,
+    node: NodeId,
+    id: LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+    arg_count: usize,
+    rule: &str,
+    dependencies: Vec<EvidenceId>,
+) -> EvidenceId {
+    post_lower_find_or_push_evidence(
+        il,
+        EvidenceAnchor::node(il.node(node).span, il.kind(node)),
+        EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+            contract_hash: library_api_contract_id_hash(id),
+            callee_hash: library_api_callee_contract_hash(callee),
+            arity: arg_count as u16,
+        }),
+        rule,
+        dependencies,
+    )
+    .expect("post-lower node LibraryApi evidence insertion should always produce an id")
+}
+
 fn post_lower_record_library_api_result_domain(
     il: &mut Il,
     call: NodeId,
@@ -1879,6 +2008,21 @@ fn post_lower_record_library_api_result_domain(
             vec![api],
         );
     }
+}
+
+fn post_lower_record_library_api_node_result_domain(
+    il: &mut Il,
+    node: NodeId,
+    domain: DomainEvidence,
+    api: EvidenceId,
+) {
+    let _ = post_lower_find_or_push_evidence(
+        il,
+        EvidenceAnchor::node(il.node(node).span, il.kind(node)),
+        EvidenceKind::Domain(domain),
+        "library_api_result_domain",
+        vec![api],
+    );
 }
 
 fn post_lower_find_or_push_evidence(
@@ -2618,6 +2762,33 @@ mod tests {
             .collect()
     }
 
+    fn library_api_evidence_ids_at_node(
+        evidence: &[EvidenceRecord],
+        span: Span,
+        kind: NodeKind,
+        contract_hash: u64,
+        callee_hash: u64,
+        arity: u16,
+    ) -> Vec<EvidenceId> {
+        evidence
+            .iter()
+            .filter_map(|record| {
+                (record.anchor == EvidenceAnchor::node(span, kind)
+                    && matches!(
+                        record.kind,
+                        EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                            contract_hash: actual_contract,
+                            callee_hash: actual_callee,
+                            arity: actual_arity,
+                        }) if actual_contract == contract_hash
+                            && actual_callee == callee_hash
+                            && actual_arity == arity
+                    ))
+                .then_some(record.id)
+            })
+            .collect()
+    }
+
     fn result_domain_depends_on_api(
         evidence: &[EvidenceRecord],
         span: Span,
@@ -2626,6 +2797,21 @@ mod tests {
     ) -> bool {
         evidence.iter().any(|record| {
             record.anchor == EvidenceAnchor::node(span, NodeKind::Call)
+                && record.kind == EvidenceKind::Domain(domain)
+                && record.dependencies.len() == 1
+                && api_ids.contains(&record.dependencies[0])
+        })
+    }
+
+    fn result_domain_depends_on_api_at_node(
+        evidence: &[EvidenceRecord],
+        span: Span,
+        kind: NodeKind,
+        domain: DomainEvidence,
+        api_ids: &[EvidenceId],
+    ) -> bool {
+        evidence.iter().any(|record| {
+            record.anchor == EvidenceAnchor::node(span, kind)
                 && record.kind == EvidenceKind::Domain(domain)
                 && record.dependencies.len() == 1
                 && api_ids.contains(&record.dependencies[0])
@@ -3647,6 +3833,146 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             ),
             0,
             "explicit same-name imports must close java.util wildcard constructor proof"
+        );
+    }
+
+    #[test]
+    fn post_lowering_emits_property_and_rust_option_occurrences() {
+        let interner = Interner::new();
+        let ts = crate::lower_source(
+            FileId(0),
+            "t.ts",
+            b"function f(xs: number[]) { return xs.length; }\n",
+            Lang::TypeScript,
+            &interner,
+        )
+        .expect("typescript lowering should succeed");
+        let property_contract =
+            library_property_builtin_contract(Lang::TypeScript, "length").unwrap();
+        let length_field = ts
+            .nodes
+            .iter()
+            .enumerate()
+            .find_map(|(idx, node)| {
+                (node.kind == NodeKind::Field
+                    && matches!(
+                        node.payload,
+                        Payload::Name(symbol) if interner.resolve(symbol) == "length"
+                    ))
+                .then_some((NodeId(idx as u32), node.span))
+            })
+            .expect("length field should be lowered");
+        let property_api = library_api_evidence_ids_at_node(
+            &ts.evidence,
+            length_field.1,
+            NodeKind::Field,
+            library_api_contract_id_hash(property_contract.id),
+            library_api_callee_contract_hash(property_contract.callee),
+            0,
+        );
+        assert_eq!(
+            property_api.len(),
+            1,
+            "typed exact-collection property access should carry LibraryApi occurrence evidence"
+        );
+
+        let rust_some = crate::lower_source(
+            FileId(0),
+            "t.rs",
+            b"fn f(x: i32) -> Option<i32> { Some(x) }\n",
+            Lang::Rust,
+            &interner,
+        )
+        .expect("rust lowering should succeed");
+        let some_contract =
+            library_rust_option_some_constructor_contract(Lang::Rust, "Some", 1).unwrap();
+        let some_call = rust_some
+            .nodes
+            .iter()
+            .enumerate()
+            .find_map(|(idx, node)| {
+                (node.kind == NodeKind::Call
+                    && rust_some
+                        .children(NodeId(idx as u32))
+                        .first()
+                        .is_some_and(|&callee| {
+                            matches!(
+                                rust_some.node(callee).payload,
+                                Payload::Name(symbol) if interner.resolve(symbol) == "Some"
+                            )
+                        }))
+                .then_some(node.span)
+            })
+            .expect("Some call should be lowered");
+        let some_api = library_api_evidence_ids_at(
+            &rust_some.evidence,
+            some_call,
+            library_api_contract_id_hash(some_contract.id),
+            library_api_callee_contract_hash(some_contract.callee),
+            1,
+        );
+        assert_eq!(some_api.len(), 1);
+        assert!(result_domain_depends_on_api(
+            &rust_some.evidence,
+            some_call,
+            DomainEvidence::Option,
+            &some_api,
+        ));
+
+        let rust_none = crate::lower_source(
+            FileId(0),
+            "t.rs",
+            b"fn f() -> Option<i32> { None }\n",
+            Lang::Rust,
+            &interner,
+        )
+        .expect("rust lowering should succeed");
+        let none_contract = library_rust_option_none_sentinel_contract(Lang::Rust, "None").unwrap();
+        let none_var = rust_none
+            .nodes
+            .iter()
+            .find_map(|node| {
+                (node.kind == NodeKind::Var
+                    && matches!(
+                        node.payload,
+                        Payload::Name(symbol) if interner.resolve(symbol) == "None"
+                    ))
+                .then_some(node.span)
+            })
+            .expect("None var should be lowered");
+        let none_api = library_api_evidence_ids_at_node(
+            &rust_none.evidence,
+            none_var,
+            NodeKind::Var,
+            library_api_contract_id_hash(none_contract.id),
+            library_api_callee_contract_hash(none_contract.callee),
+            0,
+        );
+        assert_eq!(none_api.len(), 1);
+        assert!(result_domain_depends_on_api_at_node(
+            &rust_none.evidence,
+            none_var,
+            NodeKind::Var,
+            DomainEvidence::Option,
+            &none_api,
+        ));
+
+        let shadowed_some = crate::lower_source(
+            FileId(0),
+            "t.rs",
+            b"fn Some(x: i32) -> Option<i32> { None }\nfn f(x: i32) -> Option<i32> { Some(x) }\n",
+            Lang::Rust,
+            &interner,
+        )
+        .expect("rust lowering should succeed");
+        assert_eq!(
+            library_api_evidence_count_in_records(
+                &shadowed_some.evidence,
+                library_api_contract_id_hash(some_contract.id),
+                library_api_callee_contract_hash(some_contract.callee),
+            ),
+            0,
+            "local Rust Some item must close the std Option constructor occurrence"
         );
     }
 

--- a/crates/nose-frontend/src/rust.rs
+++ b/crates/nose-frontend/src/rust.rs
@@ -3,8 +3,8 @@
 //! Convergence-friendly lowering: `?` and `.await` are stripped to their operand;
 //! `&x`/`&mut x`/`*x` references peel to the operand; `x op= y` desugars to an
 //! assignment; `for`/`while`/`loop` map to the unified `Loop`; `match` becomes an
-//! `if`/`else if` chain (arm pattern as the condition); `if let`/`while let` keep
-//! their scrutinee as the condition. `fn` items become function units; `impl`,
+//! `if`/`else if` chain (arm pattern as the condition); `if let`/`while let`
+//! preserve their pattern tests. `fn` items become function units; `impl`,
 //! `trait`, `struct`, `enum` become class-like units so similar types cluster.
 
 use crate::lower::Lowering;
@@ -898,8 +898,9 @@ fn lower_if(lo: &mut Lowering, node: TsNode) -> NodeId {
     lo.add(NodeKind::If, Payload::None, span, &kids)
 }
 
-/// `if let PAT = expr` / `let PAT = expr` condition → use the scrutinee expression
-/// as the condition (the pattern binding is irrelevant to behavioral shape).
+/// `if let PAT = expr` / `let PAT = expr` condition → preserve the pattern test
+/// as `expr == PAT`. Rust enum-variant/const pattern resolution is still carried
+/// by post-lower occurrence evidence on the lowered pattern nodes.
 fn lower_cond(lo: &mut Lowering, node: TsNode) -> NodeId {
     match node.kind() {
         "let_condition" => lower_let_condition(lo, node),
@@ -913,13 +914,17 @@ fn lower_cond(lo: &mut Lowering, node: TsNode) -> NodeId {
 }
 
 fn lower_let_condition(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
     let Some(value_node) = node
         .child_by_field_name("value")
         .or_else(|| node.named_child(node.named_child_count().saturating_sub(1)))
     else {
         return lower_expr(lo, node);
     };
-    lower_expr(lo, value_node)
+    let value = lower_expr(lo, value_node);
+    node.child_by_field_name("pattern")
+        .and_then(|pattern| lower_match_pattern_condition(lo, value, pattern, span))
+        .unwrap_or(value)
 }
 
 #[cfg(test)]
@@ -1320,6 +1325,30 @@ mod tests {
             "if let Some(_) = value { true } else { false }",
             "Some"
         ));
+    }
+
+    #[test]
+    fn if_let_option_patterns_preserve_pattern_surface() {
+        let (interner, il) = lower_rust(
+            "pub fn f(value: Option<i32>) -> bool { if let None = value { true } else { false } }",
+        );
+
+        assert!(il.nodes.iter().any(|node| {
+            node.kind == NodeKind::Var
+                && matches!(node.payload, Payload::Name(sym) if interner.resolve(sym) == "None")
+        }));
+        assert!(il
+            .nodes
+            .iter()
+            .any(|node| node.kind == NodeKind::BinOp && node.payload == Payload::Op(Op::Eq)));
+
+        let (shadowed_interner, shadowed) = lower_rust(
+            "pub const None: Option<i32> = Some(0);\npub fn f(value: Option<i32>) -> bool { if let None = value { true } else { false } }",
+        );
+        assert!(shadowed.nodes.iter().any(|node| {
+            node.kind == NodeKind::Var
+                && matches!(node.payload, Payload::Name(sym) if shadowed_interner.resolve(sym) == "None")
+        }));
     }
 
     #[test]

--- a/crates/nose-frontend/src/rust.rs
+++ b/crates/nose-frontend/src/rust.rs
@@ -9,8 +9,8 @@
 
 use crate::lower::Lowering;
 use nose_il::{
-    Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload, Span,
-    Symbol, UnitKind,
+    FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload, Span, Symbol,
+    UnitKind,
 };
 use tree_sitter::Node as TsNode;
 
@@ -913,35 +913,16 @@ fn lower_cond(lo: &mut Lowering, node: TsNode) -> NodeId {
 }
 
 fn lower_let_condition(lo: &mut Lowering, node: TsNode) -> NodeId {
-    let span = lo.span(node);
     let Some(value_node) = node
         .child_by_field_name("value")
         .or_else(|| node.named_child(node.named_child_count().saturating_sub(1)))
     else {
         return lower_expr(lo, node);
     };
-    let text = lo.text(node).trim();
-    let op = if text.starts_with("let Some") && !rust_file_defines_name(lo, "Some") {
-        Some(Builtin::IsNotNull)
-    } else if text.starts_with("let None") && !rust_file_defines_name(lo, "None") {
-        Some(Builtin::IsNull)
-    } else {
-        None
-    };
-    if let Some(op) = op {
-        let value = lower_expr(lo, value_node);
-        return lo.add(NodeKind::Call, Payload::Builtin(op), span, &[value]);
-    }
     lower_expr(lo, value_node)
 }
 
-fn rust_file_defines_name(lo: &Lowering, name: &str) -> bool {
-    let Ok(src) = std::str::from_utf8(lo.src) else {
-        return false;
-    };
-    rust_item_declares_name(src, name)
-}
-
+#[cfg(test)]
 fn rust_item_declares_name(src: &str, name: &str) -> bool {
     const ITEM_PREFIXES: &[&str] = &[
         "const", "static", "fn", "struct", "enum", "union", "type", "mod", "trait",
@@ -952,16 +933,19 @@ fn rust_item_declares_name(src: &str, name: &str) -> bool {
         .any(|tokens| rust_tokens_declare_name(&tokens, ITEM_PREFIXES, name))
 }
 
+#[cfg(test)]
 fn strip_rust_line_comment(line: &str) -> &str {
     line.split_once("//").map(|(code, _)| code).unwrap_or(line)
 }
 
+#[cfg(test)]
 fn rust_identifier_tokens(line: &str) -> Vec<&str> {
     line.split(|ch: char| !(ch == '_' || ch.is_ascii_alphanumeric()))
         .filter(|token| !token.is_empty())
         .collect()
 }
 
+#[cfg(test)]
 fn rust_tokens_declare_name(tokens: &[&str], item_prefixes: &[&str], name: &str) -> bool {
     tokens.iter().enumerate().any(|(idx, token)| {
         if !item_prefixes.contains(token) {
@@ -973,6 +957,7 @@ fn rust_tokens_declare_name(tokens: &[&str], item_prefixes: &[&str], name: &str)
     })
 }
 
+#[cfg(test)]
 fn rust_item_qualifier_token(token: &str) -> bool {
     matches!(
         token,

--- a/crates/nose-normalize/src/desugar.rs
+++ b/crates/nose-normalize/src/desugar.rs
@@ -14,7 +14,10 @@
 use crate::idioms::{canon_call_with_domains, CallCanon, ParamDomainIndex};
 use crate::NormalizeOptions;
 use nose_il::{Il, IlBuilder, Interner, LoopKind, NodeId, NodeKind, Payload};
-use nose_semantics::{seq_surface_contract_for_node, DomainRequirement};
+use nose_semantics::{
+    library_api_contract_evidence_for_node, library_property_builtin_contract,
+    seq_surface_contract_for_node, DomainRequirement, LibraryApiEvidenceStatus,
+};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 pub(crate) fn run(old: &Il, interner: &Interner, opts: &NormalizeOptions) -> Il {
@@ -236,9 +239,20 @@ impl Rebuilder<'_> {
         let n = *self.old.node(old_id);
         if let Payload::Name(s) = n.payload {
             let name = self.interner.resolve(s);
-            if let Some(builtin) =
-                nose_semantics::property_builtin_contract(self.old.meta.lang, name)
-            {
+            if let Some(contract) = library_property_builtin_contract(self.old.meta.lang, name) {
+                if !matches!(
+                    library_api_contract_evidence_for_node(
+                        self.old,
+                        self.interner,
+                        old_id,
+                        contract.id,
+                        contract.callee,
+                        0,
+                    ),
+                    LibraryApiEvidenceStatus::Admitted
+                ) {
+                    return self.generic(old_id);
+                }
                 if let Some(&base) = self.old.children(old_id).first() {
                     if !property_receiver_exact_safe(
                         self.old,
@@ -251,7 +265,7 @@ impl Rebuilder<'_> {
                     let new_base = self.go(base);
                     return self.b.add(
                         NodeKind::Call,
-                        Payload::Builtin(builtin),
+                        Payload::Builtin(contract.result),
                         n.span,
                         &[new_base],
                     );
@@ -333,7 +347,7 @@ fn property_receiver_exact_hof_call(
             contract.callee,
             arg_count,
         ),
-        nose_semantics::LibraryApiEvidenceStatus::Admitted
+        LibraryApiEvidenceStatus::Admitted
     ) && property_receiver_exact_safe(il, interner, domains, receiver)
 }
 

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -8,15 +8,15 @@
 //! proof-obligation: normalize.value_graph.min_max
 
 use nose_il::{
-    contains_js_identifier, Builtin, DomainEvidence, EvidenceAnchor, EvidenceKind, EvidenceStatus,
-    HoFKind, Il, Interner, NodeId, NodeKind, Payload, Span, Symbol,
+    Builtin, DomainEvidence, EvidenceAnchor, EvidenceKind, EvidenceStatus, HoFKind, Il, Interner,
+    NodeId, NodeKind, Payload, Span, Symbol,
 };
 use nose_semantics::{
     domain_evidence_for_param, imported_namespace_symbol, library_api_contract_evidence_for_call,
     library_free_function_builtin_contract, library_free_name_map_factory_contract,
     library_iterator_identity_adapter_contract, library_map_get_contract,
     library_map_key_view_contract, library_method_call_contract,
-    library_static_collection_adapter_contract, rust_option_some_constructor_contract,
+    library_rust_option_some_constructor_contract, library_static_collection_adapter_contract,
     seq_surface_contract_for_node, unshadowed_global_symbol, BuiltinArgContract, DomainRequirement,
     LibraryApiCalleeContract, LibraryApiEvidenceStatus, LibraryMapFactoryResult, MapKeyViewKind,
     MethodBuiltinArgs, MethodCallContract, MethodReceiverContract, MethodSemanticContract,
@@ -905,10 +905,15 @@ fn exact_option_receiver(
     if kids.len() != 2 || old.kind(kids[0]) != NodeKind::Var {
         return false;
     }
-    matches!(
-        old.node(kids[0]).payload,
-        Payload::Name(name) if rust_option_some_name(old, interner, interner.resolve(name))
-    )
+    let Payload::Name(name) = old.node(kids[0]).payload else {
+        return false;
+    };
+    let Some(contract) =
+        library_rust_option_some_constructor_contract(old.meta.lang, interner.resolve(name), 1)
+    else {
+        return false;
+    };
+    library_api_evidence_admitted(old, interner, node, contract.id, contract.callee, 1)
 }
 
 fn exact_string_receiver(old: &Il, domains: &ParamDomainIndex, node: NodeId) -> bool {
@@ -927,11 +932,6 @@ fn exact_integer_receiver(old: &Il, domains: &ParamDomainIndex, node: NodeId) ->
         old.node(node).payload,
         Payload::LitInt(_) | Payload::Lit(nose_il::LitClass::Int)
     ) || domains.receiver_satisfies_domain(old, node, DomainRequirement::Integer)
-}
-
-fn rust_option_some_name(old: &Il, interner: &Interner, text: &str) -> bool {
-    rust_option_some_constructor_contract(old.meta.lang, text)
-        .is_some_and(|contract| !file_defines_name(old, interner, contract.shadow_root))
 }
 
 fn proven_map_get_call_parts(
@@ -992,56 +992,6 @@ fn map_factory_entries_match_surface(
             && seq_surface_contract_for_node(old, interner, entry)
                 .is_some_and(|contract| contract.value_tag == entry_seq_tag)
     })
-}
-
-fn file_defines_name(old: &Il, interner: &Interner, name: &str) -> bool {
-    old.units
-        .iter()
-        .filter_map(|unit| unit.name)
-        .any(|symbol| interner.resolve(symbol) == name)
-        || old
-            .nodes
-            .iter()
-            .enumerate()
-            .any(|(idx, node)| match node.payload {
-                Payload::Cid(cid) => old
-                    .cid_names
-                    .get(cid as usize)
-                    .is_some_and(|symbol| symbol_defines_name(old, interner, *symbol, name)),
-                Payload::Name(symbol)
-                    if matches!(
-                        node.kind,
-                        NodeKind::Module | NodeKind::Block | NodeKind::Param
-                    ) =>
-                {
-                    symbol_defines_name(old, interner, symbol, name)
-                }
-                _ if node.kind == NodeKind::Assign => old
-                    .children(NodeId(idx as u32))
-                    .first()
-                    .is_some_and(|&lhs| node_defines_name(old, interner, lhs, name)),
-                _ => false,
-            })
-}
-
-fn node_defines_name(old: &Il, interner: &Interner, node: NodeId, name: &str) -> bool {
-    match old.node(node).payload {
-        Payload::Name(symbol) => symbol_defines_name(old, interner, symbol, name),
-        Payload::Cid(cid) => old
-            .cid_names
-            .get(cid as usize)
-            .is_some_and(|symbol| symbol_defines_name(old, interner, *symbol, name)),
-        _ => false,
-    }
-}
-
-fn symbol_defines_name(old: &Il, interner: &Interner, symbol: Symbol, name: &str) -> bool {
-    let text = interner.resolve(symbol);
-    text == name
-        || (nose_semantics::semantics(old.meta.lang)
-            .modules()
-            .js_like_shadowed_module_bindings()
-            && contains_js_identifier(text, name))
 }
 
 fn name_of<'a>(old: &Il, interner: &'a Interner, id: NodeId) -> Option<&'a str> {

--- a/crates/nose-normalize/src/library_api_evidence.rs
+++ b/crates/nose-normalize/src/library_api_evidence.rs
@@ -1,12 +1,15 @@
 use nose_il::{
-    stable_symbol_hash, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceStatus,
-    Il, Interner, LibraryApiEvidenceKind, NodeId, NodeKind, Payload, SymbolEvidenceKind,
+    stable_symbol_hash, DomainEvidence, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
+    EvidenceStatus, Il, Interner, LibraryApiEvidenceKind, NodeId, NodeKind, Payload,
+    SymbolEvidenceKind,
 };
 use nose_semantics::{
     library_api_callee_contract_hash, library_api_contract_id_hash,
-    library_api_receiver_dependencies_for_call_with_cache, library_receiver_method_api_contract,
-    LibraryApiCalleeContract, LibraryApiDependencyCache, MethodReceiverContract,
-    FIRST_PARTY_PACK_ID,
+    library_api_free_name_shadow_safe, library_api_property_dependencies_for_field_with_cache,
+    library_api_receiver_dependencies_for_call_with_cache, library_property_builtin_contract,
+    library_receiver_method_api_contract, library_rust_option_none_sentinel_contract,
+    library_rust_option_some_constructor_contract, LibraryApiCalleeContract,
+    LibraryApiDependencyCache, MethodReceiverContract, FIRST_PARTY_PACK_ID,
 };
 
 pub(crate) fn run(il: &mut Il, interner: &Interner) {
@@ -16,10 +19,144 @@ pub(crate) fn run(il: &mut Il, interner: &Interner) {
         .enumerate()
         .filter_map(|(idx, node)| (node.kind == NodeKind::Call).then_some(NodeId(idx as u32)))
         .collect();
+    let fields: Vec<NodeId> = il
+        .nodes
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, node)| (node.kind == NodeKind::Field).then_some(NodeId(idx as u32)))
+        .collect();
+    let vars: Vec<NodeId> = il
+        .nodes
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, node)| (node.kind == NodeKind::Var).then_some(NodeId(idx as u32)))
+        .collect();
     let mut dependency_cache = LibraryApiDependencyCache::default();
     for call in calls {
+        if record_rust_option_some_library_api(il, interner, call) {
+            continue;
+        }
         record_receiver_method_library_api(il, interner, call, &mut dependency_cache);
     }
+    for field in fields {
+        record_property_library_api(il, interner, field, &mut dependency_cache);
+    }
+    for var in vars {
+        record_rust_option_none_library_api(il, interner, var);
+    }
+}
+
+fn record_rust_option_some_library_api(il: &mut Il, interner: &Interner, call: NodeId) -> bool {
+    let kids = il.children(call);
+    let Some((&callee, args)) = kids.split_first() else {
+        return false;
+    };
+    let Some(name) = node_name(il, interner, callee) else {
+        return false;
+    };
+    let arg_count = args.len();
+    let Some(contract) =
+        library_rust_option_some_constructor_contract(il.meta.lang, name, arg_count)
+    else {
+        return false;
+    };
+    let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+        return false;
+    };
+    if !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+        file_defines_name_visible_at(il, interner, candidate, il.node(callee).span)
+    }) {
+        return false;
+    }
+    let Some(symbol_dependency) = unshadowed_symbol_evidence_id(il, callee, name) else {
+        return false;
+    };
+    let api = upsert_first_party_evidence(
+        il,
+        EvidenceAnchor::node(il.node(call).span, NodeKind::Call),
+        EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+            contract_hash: library_api_contract_id_hash(contract.id),
+            callee_hash: library_api_callee_contract_hash(contract.callee),
+            arity: arg_count as u16,
+        }),
+        "library_api_rust_option_some_constructor",
+        vec![symbol_dependency],
+    );
+    record_library_api_result_domain(il, call, contract.result_domain, api);
+    true
+}
+
+fn record_property_library_api(
+    il: &mut Il,
+    interner: &Interner,
+    field: NodeId,
+    dependency_cache: &mut LibraryApiDependencyCache,
+) -> bool {
+    if il.kind(field) != NodeKind::Field {
+        return false;
+    }
+    let Payload::Name(property) = il.node(field).payload else {
+        return false;
+    };
+    let Some(contract) =
+        library_property_builtin_contract(il.meta.lang, interner.resolve(property))
+    else {
+        return false;
+    };
+    let Some(dependencies) = library_api_property_dependencies_for_field_with_cache(
+        il,
+        interner,
+        field,
+        contract.callee,
+        dependency_cache,
+    ) else {
+        return false;
+    };
+    upsert_first_party_evidence(
+        il,
+        EvidenceAnchor::node(il.node(field).span, NodeKind::Field),
+        EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+            contract_hash: library_api_contract_id_hash(contract.id),
+            callee_hash: library_api_callee_contract_hash(contract.callee),
+            arity: 0,
+        }),
+        "library_api_property_builtin",
+        dependencies,
+    );
+    true
+}
+
+fn record_rust_option_none_library_api(il: &mut Il, interner: &Interner, var: NodeId) -> bool {
+    let Some(name) = node_name(il, interner, var) else {
+        return false;
+    };
+    let Some(contract) = library_rust_option_none_sentinel_contract(il.meta.lang, name) else {
+        return false;
+    };
+    let LibraryApiCalleeContract::FreeName { name, shadow } = contract.callee else {
+        return false;
+    };
+    if !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+        file_defines_name_visible_at(il, interner, candidate, il.node(var).span)
+    }) {
+        return false;
+    }
+    let Some(symbol_dependency) = unshadowed_symbol_evidence_id(il, var, name) else {
+        return false;
+    };
+    let api = upsert_first_party_evidence(
+        il,
+        EvidenceAnchor::node(il.node(var).span, NodeKind::Var),
+        EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+            contract_hash: library_api_contract_id_hash(contract.id),
+            callee_hash: library_api_callee_contract_hash(contract.callee),
+            arity: 0,
+        }),
+        "library_api_rust_option_none_sentinel",
+        vec![symbol_dependency],
+    );
+    record_library_api_node_result_domain(il, var, contract.result_domain, api);
+    true
 }
 
 fn record_receiver_method_library_api(
@@ -66,6 +203,36 @@ fn record_receiver_method_library_api(
         dependencies,
     );
     true
+}
+
+fn record_library_api_result_domain(
+    il: &mut Il,
+    call: NodeId,
+    domain: DomainEvidence,
+    api: EvidenceId,
+) {
+    upsert_first_party_evidence(
+        il,
+        EvidenceAnchor::node(il.node(call).span, NodeKind::Call),
+        EvidenceKind::Domain(domain),
+        "library_api_result_domain",
+        vec![api],
+    );
+}
+
+fn record_library_api_node_result_domain(
+    il: &mut Il,
+    node: NodeId,
+    domain: DomainEvidence,
+    api: EvidenceId,
+) {
+    upsert_first_party_evidence(
+        il,
+        EvidenceAnchor::node(il.node(node).span, il.kind(node)),
+        EvidenceKind::Domain(domain),
+        "library_api_result_domain",
+        vec![api],
+    );
 }
 
 fn seed_receiver_method_dependencies(

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -7724,10 +7724,7 @@ impl<'a> Builder<'a> {
             return None;
         };
         let method = self.interner.resolve(method);
-        let Some(contract) = library_rust_option_and_then_contract(self.il.meta.lang, method, 1)
-        else {
-            return None;
-        };
+        let contract = library_rust_option_and_then_contract(self.il.meta.lang, method, 1)?;
         if !matches!(
             library_api_contract_evidence_for_call(
                 self.il,
@@ -7790,6 +7787,66 @@ impl<'a> Builder<'a> {
             ),
             LibraryApiEvidenceStatus::Admitted
         )
+    }
+
+    fn rust_option_some_wildcard_pattern(&self, node: NodeId) -> Option<NodeId> {
+        let (NodeKind::Raw, Payload::Name(tag)) = (self.il.kind(node), self.il.node(node).payload)
+        else {
+            return None;
+        };
+        if self.interner.resolve(tag) != "tuple_struct_pattern" {
+            return None;
+        }
+        let kids = self.il.children(node);
+        let [callee] = kids else {
+            return None;
+        };
+        if !self.is_rust_option_some_node(*callee) {
+            return None;
+        }
+        Some(*callee)
+    }
+
+    fn is_rust_option_some_node(&self, node: NodeId) -> bool {
+        let (NodeKind::Var, Payload::Name(name)) = (self.il.kind(node), self.il.node(node).payload)
+        else {
+            return false;
+        };
+        let name = self.interner.resolve(name);
+        let Some(contract) =
+            library_rust_option_some_constructor_contract(self.il.meta.lang, name, 1)
+        else {
+            return false;
+        };
+        matches!(
+            library_api_contract_evidence_for_node(
+                self.il,
+                self.interner,
+                node,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        )
+    }
+
+    fn eval_rust_option_some_pattern_comparison(
+        &mut self,
+        op: u32,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if op != Op::Eq as u32 || kids.len() != 2 {
+            return None;
+        }
+        self.rust_option_some_wildcard_pattern(kids[1])?;
+        if self.domain_evidence_of_expr(kids[0]) != Some(DomainEvidence::Option) {
+            return None;
+        }
+        let value = self.eval(kids[0], env);
+        let nil = self.null_const();
+        Some(self.mk(ValOp::Bin(Op::Ne as u32), vec![value, nil]))
     }
 
     fn is_null_literal(&self, node: NodeId) -> bool {
@@ -7962,6 +8019,9 @@ impl<'a> Builder<'a> {
                     }
                     let collection = self.eval_membership_collection(kids[1], env);
                     return self.mk(ValOp::Bin(op), vec![element, collection]);
+                }
+                if let Some(v) = self.eval_rust_option_some_pattern_comparison(op, &kids, env) {
+                    return v;
                 }
                 if let Some(v) = self.eval_static_filter_membership_comparison(op, &kids, env) {
                     return v;
@@ -8891,8 +8951,8 @@ mod tests {
         EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance,
         EvidenceRecord, EvidenceStatus, FileId, FileMeta, GuardEvidenceKind, IlBuilder,
         ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, Lang,
-        LibraryApiEvidenceKind, ParamSemantic, SequenceSurfaceKind, SourceCallKind, SourceFactKind,
-        Span, SymbolEvidenceKind, Unit, UnitKind,
+        LibraryApiEvidenceKind, LitClass, ParamSemantic, SequenceSurfaceKind, SourceCallKind,
+        SourceFactKind, Span, SymbolEvidenceKind, Unit, UnitKind,
     };
     use nose_semantics::{
         library_api_callee_contract_hash, library_api_contract_id_hash,
@@ -8900,7 +8960,8 @@ mod tests {
         library_imported_collection_factory_contract, library_java_collection_constructor_contract,
         library_java_collection_factory_contract, library_java_map_factory_contract,
         library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
-        library_method_call_contract, library_scalar_integer_method_contract,
+        library_method_call_contract, library_rust_option_none_sentinel_contract,
+        library_rust_option_some_constructor_contract, library_scalar_integer_method_contract,
         library_static_index_membership_contract, LibraryApiContractId, FIRST_PARTY_PACK_ID,
     };
 
@@ -9553,6 +9614,148 @@ mod tests {
         builder.build_unit(func);
         let admitted = builder.eval(call, &FxHashMap::default());
         assert!(matches!(builder.nodes[admitted as usize].op, ValOp::Clamp));
+    }
+
+    #[test]
+    fn rust_some_wildcard_pattern_value_graph_requires_library_api_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let value = b.add(NodeKind::Var, Payload::Cid(0), sp(167), &[]);
+        let some = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("Some")),
+            sp(168),
+            &[],
+        );
+        let pattern = b.add(
+            NodeKind::Raw,
+            Payload::Name(interner.intern("tuple_struct_pattern")),
+            sp(170),
+            &[some],
+        );
+        let cond = b.add(
+            NodeKind::BinOp,
+            Payload::Op(Op::Eq),
+            sp(171),
+            &[value, pattern],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(166), &[cond]);
+        let mut il = finish_test_il(b, root, Lang::Rust);
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(167), NodeKind::Var),
+            EvidenceKind::Domain(DomainEvidence::Option),
+        ));
+
+        let mut builder = Builder::new(&il, &interner);
+        let raw = builder.eval(cond, &FxHashMap::default());
+        assert!(
+            !matches!(builder.nodes[raw as usize].op, ValOp::Bin(op) if op == Op::Ne as u32),
+            "raw Some pattern selector must not become an Option presence predicate"
+        );
+
+        let contract = library_rust_option_some_constructor_contract(Lang::Rust, "Some", 1)
+            .expect("Rust Some contract");
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(sp(168), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("Some"),
+            }),
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            2,
+            EvidenceAnchor::node(sp(168), NodeKind::Var),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(contract.id),
+                callee_hash: library_api_callee_contract_hash(contract.callee),
+                arity: 1,
+            }),
+            vec![EvidenceId(1)],
+        ));
+
+        let mut builder = Builder::new(&il, &interner);
+        let proven = builder.eval(cond, &FxHashMap::default());
+        let node = &builder.nodes[proven as usize];
+        assert!(matches!(node.op, ValOp::Bin(op) if op == Op::Ne as u32));
+        assert!(
+            node.args
+                .iter()
+                .any(|&arg| matches!(builder.nodes[arg as usize].op, ValOp::Const(k) if k == LitClass::Null as u32)),
+            "admitted Rust Some wildcard pattern should evaluate as non-null Option presence"
+        );
+    }
+
+    #[test]
+    fn rust_option_none_pattern_value_graph_requires_library_api_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let value = b.add(NodeKind::Var, Payload::Cid(0), sp(171), &[]);
+        let none = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("None")),
+            sp(172),
+            &[],
+        );
+        let cond = b.add(
+            NodeKind::BinOp,
+            Payload::Op(Op::Eq),
+            sp(173),
+            &[value, none],
+        );
+        let then_value = b.add(NodeKind::Lit, Payload::LitBool(true), sp(174), &[]);
+        let else_value = b.add(NodeKind::Lit, Payload::LitBool(false), sp(175), &[]);
+        let then_block = b.add(NodeKind::Block, Payload::None, sp(174), &[then_value]);
+        let else_block = b.add(NodeKind::Block, Payload::None, sp(175), &[else_value]);
+        let if_expr = b.add(
+            NodeKind::If,
+            Payload::None,
+            sp(176),
+            &[cond, then_block, else_block],
+        );
+        let root = b.add(NodeKind::Block, Payload::None, sp(170), &[if_expr]);
+        let mut il = finish_test_il(b, root, Lang::Rust);
+
+        let mut builder = Builder::new(&il, &interner);
+        let raw = builder.eval(if_expr, &FxHashMap::default());
+        let raw_node = &builder.nodes[raw as usize];
+        assert!(
+            !raw_node
+                .args
+                .iter()
+                .any(|&arg| matches!(builder.nodes[arg as usize].op, ValOp::Const(k) if k == LitClass::Null as u32)),
+            "raw None selector must not become a null predicate"
+        );
+
+        let contract = library_rust_option_none_sentinel_contract(Lang::Rust, "None").unwrap();
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::node(sp(172), NodeKind::Var),
+            EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+                name_hash: stable_symbol_hash("None"),
+            }),
+        ));
+        il.evidence.push(evidence_with_dependencies(
+            1,
+            EvidenceAnchor::node(sp(172), NodeKind::Var),
+            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract {
+                contract_hash: library_api_contract_id_hash(contract.id),
+                callee_hash: library_api_callee_contract_hash(contract.callee),
+                arity: 0,
+            }),
+            vec![EvidenceId(0)],
+        ));
+
+        let mut builder = Builder::new(&il, &interner);
+        let proven = builder.eval(if_expr, &FxHashMap::default());
+        let node = &builder.nodes[proven as usize];
+        assert!(matches!(node.op, ValOp::Bin(op) if op == Op::Eq as u32));
+        assert!(
+            node.args
+                .iter()
+                .any(|&arg| matches!(builder.nodes[arg as usize].op, ValOp::Const(k) if k == LitClass::Null as u32)),
+            "admitted Rust None occurrence should evaluate as the null sentinel"
+        );
     }
 
     #[derive(Clone, Copy)]

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -45,8 +45,8 @@ use crate::module_facts::{
     shadowed_js_like_module_binding_nodes_for_symbol_in_scope, top_level_statements_for,
 };
 use nose_il::{
-    contains_js_identifier, stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LoopKind,
-    NodeId, NodeKind, Op, Payload, Span, Symbol, UnitKind,
+    stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LoopKind, NodeId, NodeKind, Op,
+    Payload, Span, Symbol, UnitKind,
 };
 use nose_semantics::{
     builder_append_method_contract, builtin_tag, construct_syntax_proof,
@@ -56,29 +56,30 @@ use nose_semantics::{
     go_zero_map_lookup_contract, import_fact_evidence_rhs,
     imported_literal_producer_evidence_for_node, imported_namespace_symbol,
     library_api_contract_evidence_at_call_span, library_api_contract_evidence_for_call,
-    library_free_function_builtin_contract, library_free_name_collection_factory_contracts,
-    library_free_name_map_factory_contracts, library_imported_collection_factory_contracts,
-    library_imported_namespace_function_contract, library_iterator_identity_adapter_contract,
-    library_java_collection_constructor_contract, library_java_collection_factory_contract_by_hash,
-    library_java_map_entry_contract_by_hash, library_java_map_factory_contract_by_hash,
-    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
-    library_map_get_contract_by_hash, library_map_key_view_contract_by_hash,
-    library_map_key_view_wrapper_contract_by_hash, library_method_call_contract,
-    library_ruby_set_factory_contract_by_hash, library_rust_vec_macro_factory_contract,
-    library_rust_vec_new_factory_contract, library_static_index_membership_contract,
+    library_api_contract_evidence_for_node, library_free_function_builtin_contract,
+    library_free_name_collection_factory_contracts, library_free_name_map_factory_contracts,
+    library_imported_collection_factory_contracts, library_imported_namespace_function_contract,
+    library_iterator_identity_adapter_contract, library_java_collection_constructor_contract,
+    library_java_collection_factory_contract_by_hash, library_java_map_entry_contract_by_hash,
+    library_java_map_factory_contract_by_hash, library_js_like_map_constructor_contract,
+    library_js_like_set_constructor_contract, library_map_get_contract_by_hash,
+    library_map_key_view_contract_by_hash, library_map_key_view_wrapper_contract_by_hash,
+    library_method_call_contract, library_property_builtin_contract,
+    library_ruby_set_factory_contract_by_hash, library_rust_option_and_then_contract,
+    library_rust_option_none_sentinel_contract, library_rust_option_some_constructor_contract,
+    library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
+    library_scalar_integer_method_contract, library_static_index_membership_contract,
     nullish_global_contract, own_property_guard_evidence_at_span, record_shape_guard_for_node,
-    reduction_builtin_contract, rust_option_and_then_contract, rust_option_none_sentinel_contract,
-    rust_option_some_constructor_contract, scalar_integer_method_contract, semantics,
-    seq_surface_contract_for_node, source_operator_at_node, unshadowed_global_symbol,
-    BuiltinArgContract, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
-    DomainRequirement, GoZeroMapDefaultKind, ImportFactKind, ImportedNamespaceFunctionSemantic,
-    IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind,
-    LibraryApiCalleeContract, LibraryApiEvidenceStatus, LibraryApiSpanEvidenceQuery,
-    LibraryCollectionFactoryResult, LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs,
-    MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
-    SeqSurfaceContract, StaticIndexMembershipKind, ValueDomain, ValueLaw, SEQ_VALUE_COLLECTION,
-    SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD,
-    SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
+    reduction_builtin_contract, semantics, seq_surface_contract_for_node, source_operator_at_node,
+    unshadowed_global_symbol, BuiltinArgContract, CardinalityPredicate, CardinalityThreshold,
+    ComparisonLaw, DomainEvidence, DomainRequirement, GoZeroMapDefaultKind, ImportFactKind,
+    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
+    JavaMapFactoryKind, LibraryApiCalleeContract, LibraryApiEvidenceStatus,
+    LibraryApiSpanEvidenceQuery, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
+    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
+    ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract, StaticIndexMembershipKind,
+    ValueDomain, ValueLaw, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD,
+    SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
@@ -1260,46 +1261,6 @@ impl<'a> Builder<'a> {
             && imported_namespace_symbol(self.il, self.interner, expr, module)
     }
 
-    fn file_defines_name(&self, name: &str) -> bool {
-        self.top_level_statements().iter().any(|&stmt| {
-            self.assignment_name(stmt)
-                .is_some_and(|symbol| self.interner.resolve(symbol) == name)
-        }) || self.il.units.iter().any(|unit| {
-            unit.name
-                .is_some_and(|symbol| self.interner.resolve(symbol) == name)
-        }) || self.il.nodes.iter().enumerate().any(|(idx, node)| {
-            let id = NodeId(idx as u32);
-            match node.kind {
-                NodeKind::Module | NodeKind::Block | NodeKind::Param => {
-                    self.node_has_name(id, name)
-                }
-                NodeKind::Assign => self
-                    .il
-                    .children(id)
-                    .first()
-                    .is_some_and(|&lhs| self.node_has_name(lhs, name)),
-                _ => false,
-            }
-        })
-    }
-
-    fn node_has_name(&self, node: NodeId, name: &str) -> bool {
-        match self.il.node(node).payload {
-            Payload::Name(symbol) => self.symbol_defines_name(symbol, name),
-            Payload::Cid(cid) => self
-                .il
-                .cid_names
-                .get(cid as usize)
-                .is_some_and(|symbol| self.symbol_defines_name(*symbol, name)),
-            _ => false,
-        }
-    }
-
-    fn symbol_defines_name(&self, symbol: Symbol, name: &str) -> bool {
-        let text = self.interner.resolve(symbol);
-        text == name || (self.is_js_like_lang() && contains_js_identifier(text, name))
-    }
-
     fn proven_collection_value(&mut self, value: ValueId) -> Option<ValueId> {
         if matches!(
             self.nodes[value as usize].op,
@@ -2255,6 +2216,7 @@ impl<'a> Builder<'a> {
 
     fn eval_proven_integer_method_call(
         &mut self,
+        call: NodeId,
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
@@ -2266,17 +2228,28 @@ impl<'a> Builder<'a> {
             return None;
         };
         let method = self.interner.resolve(name);
-        let contract = scalar_integer_method_contract(
-            self.il.meta.lang,
-            method,
-            kids.len().saturating_sub(1),
-        )?;
-        if contract.receiver != MethodReceiverContract::ExactInteger {
+        let arg_count = kids.len().saturating_sub(1);
+        let contract =
+            library_scalar_integer_method_contract(self.il.meta.lang, method, arg_count)?;
+        if !matches!(
+            library_api_contract_evidence_for_call(
+                self.il,
+                self.interner,
+                call,
+                contract.id,
+                contract.callee,
+                arg_count,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        ) {
+            return None;
+        }
+        if contract.result.receiver != MethodReceiverContract::ExactInteger {
             return None;
         }
         let receiver = self.il.children(callee).first().copied()?;
         let receiver_value = self.eval_proven_integer_expr(receiver, env)?;
-        match contract.semantic {
+        match contract.result.semantic {
             ScalarIntegerMethod::Abs => Some(self.mk(ValOp::Un(ABS_CODE), vec![receiver_value])),
             ScalarIntegerMethod::Min => {
                 let rhs = self.eval(*kids.get(1)?, env);
@@ -7719,8 +7692,20 @@ impl<'a> Builder<'a> {
         else {
             return None;
         };
-        self.rust_option_some_name(self.interner.resolve(name))
-            .then_some(kids[1])
+        let name = self.interner.resolve(name);
+        let contract = library_rust_option_some_constructor_contract(self.il.meta.lang, name, 1)?;
+        matches!(
+            library_api_contract_evidence_for_call(
+                self.il,
+                self.interner,
+                node,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        )
+        .then_some(kids[1])
     }
 
     fn rust_option_and_then_call_parts(&self, node: NodeId) -> Option<(NodeId, NodeId)> {
@@ -7738,7 +7723,22 @@ impl<'a> Builder<'a> {
         let Payload::Name(method) = self.il.node(kids[0]).payload else {
             return None;
         };
-        if !rust_option_and_then_contract(self.il.meta.lang, self.interner.resolve(method), 1) {
+        let method = self.interner.resolve(method);
+        let Some(contract) = library_rust_option_and_then_contract(self.il.meta.lang, method, 1)
+        else {
+            return None;
+        };
+        if !matches!(
+            library_api_contract_evidence_for_call(
+                self.il,
+                self.interner,
+                node,
+                contract.id,
+                contract.callee,
+                1,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        ) {
             return None;
         }
         let receiver = *self.il.children(kids[0]).first()?;
@@ -7769,22 +7769,27 @@ impl<'a> Builder<'a> {
         )
     }
 
-    fn rust_option_some_name(&self, text: &str) -> bool {
-        rust_option_some_constructor_contract(self.il.meta.lang, text)
-            .is_some_and(|contract| !self.file_defines_name(contract.shadow_root))
-    }
-
-    fn rust_option_none_name(&self, text: &str) -> bool {
-        rust_option_none_sentinel_contract(self.il.meta.lang, text)
-            .is_some_and(|contract| !self.file_defines_name(contract.shadow_root))
-    }
-
     fn is_rust_option_none_node(&self, node: NodeId) -> bool {
         let (NodeKind::Var, Payload::Name(name)) = (self.il.kind(node), self.il.node(node).payload)
         else {
             return false;
         };
-        self.rust_option_none_name(self.interner.resolve(name))
+        let name = self.interner.resolve(name);
+        let Some(contract) = library_rust_option_none_sentinel_contract(self.il.meta.lang, name)
+        else {
+            return false;
+        };
+        matches!(
+            library_api_contract_evidence_for_node(
+                self.il,
+                self.interner,
+                node,
+                contract.id,
+                contract.callee,
+                0,
+            ),
+            LibraryApiEvidenceStatus::Admitted
+        )
     }
 
     fn is_null_literal(&self, node: NodeId) -> bool {
@@ -7902,7 +7907,7 @@ impl<'a> Builder<'a> {
                         return v;
                     }
                     let name = self.interner.resolve(s);
-                    if self.rust_option_none_name(name) {
+                    if self.is_rust_option_none_node(expr) {
                         return self.null_const();
                     }
                     if let Some(contract) = nullish_global_contract(self.il.meta.lang, name) {
@@ -8070,11 +8075,24 @@ impl<'a> Builder<'a> {
                 };
                 if a.len() == 1 {
                     if let Payload::Name(s) = node.payload {
-                        if nose_semantics::property_builtin_contract(
+                        let property_contract = library_property_builtin_contract(
                             self.il.meta.lang,
                             self.interner.resolve(s),
-                        ) == Some(Builtin::Len)
-                        {
+                        );
+                        if let Some(contract) = property_contract.filter(|contract| {
+                            contract.result == Builtin::Len
+                                && matches!(
+                                    library_api_contract_evidence_for_node(
+                                        self.il,
+                                        self.interner,
+                                        expr,
+                                        contract.id,
+                                        contract.callee,
+                                        0,
+                                    ),
+                                    LibraryApiEvidenceStatus::Admitted
+                                )
+                        }) {
                             if let Some(len) = self.eval_len_value(a[0]) {
                                 return len;
                             }
@@ -8082,7 +8100,7 @@ impl<'a> Builder<'a> {
                                 .domain_evidence_of_expr(kids[0])
                                 .is_some_and(DomainEvidence::is_array_or_collection)
                             {
-                                return self.mk(ValOp::Call(builtin_tag(Builtin::Len)), a);
+                                return self.mk(ValOp::Call(builtin_tag(contract.result)), a);
                             }
                         }
                         let receiver = &self.nodes[a[0] as usize];
@@ -8195,7 +8213,7 @@ impl<'a> Builder<'a> {
                 if let Some(r) = self.eval_product_call(expr, &kids, env) {
                     return r;
                 }
-                if let Some(r) = self.eval_proven_integer_method_call(&kids, env) {
+                if let Some(r) = self.eval_proven_integer_method_call(expr, &kids, env) {
                     return r;
                 }
                 if let Some(r) = self.eval_rust_map_get_unwrap_or_call(expr, &kids, env) {
@@ -8882,8 +8900,8 @@ mod tests {
         library_imported_collection_factory_contract, library_java_collection_constructor_contract,
         library_java_collection_factory_contract, library_java_map_factory_contract,
         library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
-        library_method_call_contract, library_static_index_membership_contract,
-        LibraryApiContractId, FIRST_PARTY_PACK_ID,
+        library_method_call_contract, library_scalar_integer_method_contract,
+        library_static_index_membership_contract, LibraryApiContractId, FIRST_PARTY_PACK_ID,
     };
 
     fn sp(line: u32) -> Span {
@@ -9065,6 +9083,28 @@ mod tests {
             contract.id,
             contract.callee,
             arity as u16,
+            dependencies,
+        ));
+    }
+
+    fn push_library_api_evidence_for_callee(
+        il: &mut Il,
+        interner: &Interner,
+        id: u32,
+        call: NodeId,
+        contract_id: LibraryApiContractId,
+        callee: LibraryApiCalleeContract,
+        arity: u16,
+    ) {
+        let dependencies =
+            nose_semantics::library_api_receiver_dependencies_for_call(il, interner, call, callee)
+                .expect("library api receiver dependencies");
+        il.evidence.push(library_api_contract_evidence(
+            id,
+            il.node(call).span,
+            contract_id,
+            callee,
+            arity,
             dependencies,
         ));
     }
@@ -9445,6 +9485,74 @@ mod tests {
             eval_op(&il, &interner, call),
             ValOp::Bin(op) if op == MIN_CODE
         ));
+    }
+
+    #[test]
+    fn scalar_integer_method_value_graph_requires_library_api_evidence() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let x = interner.intern("x");
+        let param = b.add(NodeKind::Param, Payload::Cid(0), sp(160), &[]);
+        let receiver = b.add(NodeKind::Var, Payload::Cid(0), sp(161), &[]);
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("clamp")),
+            sp(162),
+            &[receiver],
+        );
+        let lo = b.add(NodeKind::Lit, Payload::LitInt(0), sp(163), &[]);
+        let hi = b.add(NodeKind::Lit, Payload::LitInt(10), sp(164), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(165), &[callee, lo, hi]);
+        let ret = b.add(NodeKind::Return, Payload::None, sp(166), &[call]);
+        let body = b.add(NodeKind::Block, Payload::None, sp(166), &[ret]);
+        let func = b.add(NodeKind::Func, Payload::None, sp(160), &[param, body]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(159), &[func]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.rs".into(),
+                lang: Lang::Rust,
+            },
+            vec![Unit {
+                root: func,
+                kind: UnitKind::Function,
+                name: Some(interner.intern("f")),
+            }],
+            vec![x],
+        );
+        il.evidence.push(evidence(
+            0,
+            EvidenceAnchor::param(sp(160)),
+            EvidenceKind::Domain(DomainEvidence::Integer),
+        ));
+        il.evidence.push(evidence(
+            1,
+            EvidenceAnchor::node(sp(161), NodeKind::Var),
+            EvidenceKind::Domain(DomainEvidence::Integer),
+        ));
+
+        let mut builder = Builder::new(&il, &interner);
+        builder.build_unit(func);
+        let raw = builder.eval(call, &FxHashMap::default());
+        assert!(
+            !matches!(builder.nodes[raw as usize].op, ValOp::Clamp),
+            "raw Rust clamp selector plus integer receiver is not enough"
+        );
+
+        let contract = library_scalar_integer_method_contract(Lang::Rust, "clamp", 2).unwrap();
+        push_library_api_evidence_for_callee(
+            &mut il,
+            &interner,
+            2,
+            call,
+            contract.id,
+            contract.callee,
+            2,
+        );
+        let mut builder = Builder::new(&il, &interner);
+        builder.build_unit(func);
+        let admitted = builder.eval(call, &FxHashMap::default());
+        assert!(matches!(builder.nodes[admitted as usize].op, ValOp::Clamp));
     }
 
     #[derive(Clone, Copy)]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -5917,6 +5917,11 @@ fn receiver_dependency_ids(
             {
                 return Some(ids);
             }
+            if let Some(id) =
+                library_api_dependency_id_for_receiver_domain_call(il, interner, receiver, contract)
+            {
+                return Some(vec![id]);
+            }
             library_api_dependency_id_for_map_key_view_call(
                 il,
                 interner,
@@ -6612,6 +6617,10 @@ fn library_api_contract_result_domain_for_arity(
             }),
         ),
         LibraryApiContractId::RustOptionSomeConstructor => Some(DomainEvidence::Option),
+        LibraryApiContractId::ScalarIntegerMethod(_) => Some(DomainEvidence::Integer),
+        LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(_)) => {
+            Some(DomainEvidence::Collection)
+        }
         _ => None,
     }
 }

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -2901,7 +2901,7 @@ pub struct ScalarIntegerMethodContract {
     pub receiver: MethodReceiverContract,
 }
 
-pub fn scalar_integer_method_contract(
+fn scalar_integer_method_contract_shape(
     lang: Lang,
     name: &str,
     arg_count: usize,
@@ -2919,6 +2919,14 @@ pub fn scalar_integer_method_contract(
         semantic,
         receiver: MethodReceiverContract::ExactInteger,
     })
+}
+
+pub fn scalar_integer_method_contract(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<ScalarIntegerMethodContract> {
+    library_scalar_integer_method_contract(lang, name, arg_count).map(|contract| contract.result)
 }
 
 pub fn method_call_contract(
@@ -2992,11 +3000,6 @@ fn method_call_contract_shape(
         (Lang::Rust, "len", 0) | (Lang::Java, "size", 0) => {
             (Builtin::Len, Receiver::ExactCollection, Args::ReceiverOnly)
         }
-        (
-            Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html,
-            "length",
-            0,
-        ) => (Builtin::Len, Receiver::ExactCollection, Args::ReceiverOnly),
         (Lang::Rust, "is_empty", 0) | (Lang::Java, "isEmpty", 0) | (Lang::Ruby, "empty?", 0) => (
             Builtin::IsEmpty,
             Receiver::ExactCollection,
@@ -3235,6 +3238,32 @@ pub struct ShadowedPathContract {
     pub shadow_root: &'static str,
 }
 
+fn rust_option_some_selector_name(lang: Lang, name: &str) -> Option<&'static str> {
+    if lang != Lang::Rust {
+        return None;
+    }
+    Some(match name {
+        "Some" => "Some",
+        "Option::Some" => "Option::Some",
+        "std::option::Option::Some" => "std::option::Option::Some",
+        "core::option::Option::Some" => "core::option::Option::Some",
+        _ => return None,
+    })
+}
+
+fn rust_option_none_selector_name(lang: Lang, name: &str) -> Option<&'static str> {
+    if lang != Lang::Rust {
+        return None;
+    }
+    Some(match name {
+        "None" => "None",
+        "Option::None" => "Option::None",
+        "std::option::Option::None" => "std::option::Option::None",
+        "core::option::Option::None" => "core::option::Option::None",
+        _ => return None,
+    })
+}
+
 pub fn rust_option_some_constructor_contract(
     lang: Lang,
     name: &str,
@@ -3280,7 +3309,7 @@ pub fn rust_vec_new_factory_contract(lang: Lang, name: &str) -> Option<ShadowedP
 }
 
 pub fn rust_option_and_then_contract(lang: Lang, method: &str, arg_count: usize) -> bool {
-    lang == Lang::Rust && method == "and_then" && arg_count == 1
+    library_rust_option_and_then_contract(lang, method, arg_count).is_some()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -4002,12 +4031,112 @@ pub fn method_collection_reduction_builtin(lang: Lang, name: &str) -> Option<Bui
 }
 
 pub fn property_builtin_contract(lang: Lang, name: &str) -> Option<Builtin> {
+    library_property_builtin_contract(lang, name).map(|contract| contract.result)
+}
+
+fn property_builtin_contract_shape(
+    lang: Lang,
+    name: &str,
+) -> Option<(Builtin, MethodReceiverContract)> {
     Some(match (lang, name) {
         (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "length") => {
-            Builtin::Len
+            (Builtin::Len, MethodReceiverContract::ExactCollection)
         }
-        (Lang::Java, "length") => Builtin::Len,
+        (Lang::Java, "length") => (Builtin::Len, MethodReceiverContract::ExactCollection),
         _ => return None,
+    })
+}
+
+pub fn library_property_builtin_contract(
+    lang: Lang,
+    name: &str,
+) -> Option<LibraryPropertyBuiltinContract> {
+    let (result, receiver) = property_builtin_contract_shape(lang, name)?;
+    let property = library_property_selector_name(name)?;
+    Some(LibraryPropertyBuiltinContract {
+        id: LibraryApiContractId::PropertyBuiltin(result),
+        callee: LibraryApiCalleeContract::Property { property, receiver },
+        result,
+    })
+}
+
+fn library_property_selector_name(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "length" => "length",
+        _ => return None,
+    })
+}
+
+pub fn library_scalar_integer_method_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<LibraryScalarIntegerMethodContract> {
+    let result = scalar_integer_method_contract_shape(lang, method, arg_count)?;
+    let method = library_method_selector_name(method)?;
+    Some(LibraryScalarIntegerMethodContract {
+        id: LibraryApiContractId::ScalarIntegerMethod(result.semantic),
+        callee: LibraryApiCalleeContract::Method {
+            method,
+            receiver: result.receiver,
+        },
+        result,
+    })
+}
+
+pub fn library_rust_option_some_constructor_contract(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<LibraryRustOptionConstructorContract> {
+    if arg_count != 1 {
+        return None;
+    }
+    let name = rust_option_some_selector_name(lang, name)?;
+    let shadow = rust_option_some_constructor_contract(lang, name)?;
+    Some(LibraryRustOptionConstructorContract {
+        id: LibraryApiContractId::RustOptionSomeConstructor,
+        callee: LibraryApiCalleeContract::FreeName {
+            name,
+            shadow: LibraryApiShadowPolicy::ExplicitRoot(shadow.shadow_root),
+        },
+        result_domain: DomainEvidence::Option,
+    })
+}
+
+pub fn library_rust_option_none_sentinel_contract(
+    lang: Lang,
+    name: &str,
+) -> Option<LibraryRustOptionSentinelContract> {
+    let name = rust_option_none_selector_name(lang, name)?;
+    let shadow = rust_option_none_sentinel_contract(lang, name)?;
+    Some(LibraryRustOptionSentinelContract {
+        id: LibraryApiContractId::RustOptionNoneSentinel,
+        callee: LibraryApiCalleeContract::FreeName {
+            name,
+            shadow: LibraryApiShadowPolicy::ExplicitRoot(shadow.shadow_root),
+        },
+        result_domain: DomainEvidence::Option,
+    })
+}
+
+pub fn library_rust_option_and_then_contract(
+    lang: Lang,
+    method: &str,
+    arg_count: usize,
+) -> Option<LibraryRustOptionAndThenContract> {
+    if lang != Lang::Rust || method != "and_then" || arg_count != 1 {
+        return None;
+    }
+    Some(LibraryRustOptionAndThenContract {
+        id: LibraryApiContractId::RustOptionAndThen,
+        callee: LibraryApiCalleeContract::Method {
+            method: "and_then",
+            receiver: MethodReceiverContract::RustMapGetOrExactOption,
+        },
+        result: RustOptionAndThenContract {
+            receiver: MethodReceiverContract::RustMapGetOrExactOption,
+        },
     })
 }
 
@@ -4104,9 +4233,14 @@ const IMPORTED_COLLECTION_FACTORIES: &[ImportedCollectionFactory] = &[ImportedCo
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum LibraryApiContractId {
+    PropertyBuiltin(Builtin),
     PythonBuiltinCollectionFactory,
     PythonImportedCollectionFactory,
     FreeFunctionBuiltin(Builtin),
+    RustOptionSomeConstructor,
+    RustOptionNoneSentinel,
+    RustOptionAndThen,
+    ScalarIntegerMethod(ScalarIntegerMethod),
     RustStdCollectionFactory,
     RustStdMapFactory,
     RustVecMacroFactory,
@@ -4138,6 +4272,9 @@ pub fn library_api_contract_id_hash(id: LibraryApiContractId) -> u64 {
 
 fn library_api_contract_id_key(id: LibraryApiContractId) -> String {
     match id {
+        LibraryApiContractId::PropertyBuiltin(builtin) => {
+            format!("property_builtin.{}", builtin as u32)
+        }
         LibraryApiContractId::PythonBuiltinCollectionFactory => {
             "python.builtin.collection_factory".into()
         }
@@ -4146,6 +4283,15 @@ fn library_api_contract_id_key(id: LibraryApiContractId) -> String {
         }
         LibraryApiContractId::FreeFunctionBuiltin(builtin) => {
             format!("free_function_builtin.{}", builtin as u32)
+        }
+        LibraryApiContractId::RustOptionSomeConstructor => "rust.option.some.constructor".into(),
+        LibraryApiContractId::RustOptionNoneSentinel => "rust.option.none.sentinel".into(),
+        LibraryApiContractId::RustOptionAndThen => "rust.option.and_then".into(),
+        LibraryApiContractId::ScalarIntegerMethod(method) => {
+            format!(
+                "scalar_integer_method.{}",
+                scalar_integer_method_key(method)
+            )
         }
         LibraryApiContractId::RustStdCollectionFactory => "rust.std.collection_factory".into(),
         LibraryApiContractId::RustStdMapFactory => "rust.std.map_factory".into(),
@@ -4196,6 +4342,15 @@ fn library_api_contract_id_key(id: LibraryApiContractId) -> String {
         LibraryApiContractId::MethodCall(semantic) => {
             format!("method_call.{}", method_semantic_contract_key(semantic))
         }
+    }
+}
+
+fn scalar_integer_method_key(method: ScalarIntegerMethod) -> &'static str {
+    match method {
+        ScalarIntegerMethod::Abs => "abs",
+        ScalarIntegerMethod::Min => "min",
+        ScalarIntegerMethod::Max => "max",
+        ScalarIntegerMethod::Clamp => "clamp",
     }
 }
 
@@ -4326,6 +4481,10 @@ pub enum LibraryApiCalleeContract {
         method: &'static str,
         required_receiver_fact: SourceFactKind,
     },
+    Property {
+        property: &'static str,
+        receiver: MethodReceiverContract,
+    },
     StaticIndexMembershipMethod {
         method: &'static str,
         receiver: StaticIndexMembershipReceiverContract,
@@ -4384,6 +4543,12 @@ fn library_api_callee_contract_key(callee: LibraryApiCalleeContract) -> String {
         }
         LibraryApiCalleeContract::RegexLiteralMethod { method, .. } => {
             format!("regex_literal_method:{method}")
+        }
+        LibraryApiCalleeContract::Property { property, receiver } => {
+            format!(
+                "property:{property}:{}",
+                method_receiver_contract_key(receiver)
+            )
         }
         LibraryApiCalleeContract::StaticIndexMembershipMethod { method, receiver } => {
             format!(
@@ -4628,6 +4793,46 @@ pub struct LibraryMethodCallContract {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryPropertyBuiltinContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: Builtin,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryScalarIntegerMethodContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: ScalarIntegerMethodContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryRustOptionConstructorContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result_domain: DomainEvidence,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryRustOptionSentinelContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result_domain: DomainEvidence,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct RustOptionAndThenContract {
+    pub receiver: MethodReceiverContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LibraryRustOptionAndThenContract {
+    pub id: LibraryApiContractId,
+    pub callee: LibraryApiCalleeContract,
+    pub result: RustOptionAndThenContract,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct LibraryFreeFunctionBuiltinContract {
     pub id: LibraryApiContractId,
     pub callee: LibraryApiCalleeContract,
@@ -4690,6 +4895,52 @@ pub fn library_api_contract_evidence_for_call(
             || !il.evidence_dependencies_asserted(record)
             || !library_api_callee_shape_matches(il, interner, node, callee)
             || !library_api_dependencies_match_callee(il, interner, node, callee, record)
+        {
+            return LibraryApiEvidenceStatus::Rejected;
+        }
+        admitted = true;
+    }
+    if admitted {
+        LibraryApiEvidenceStatus::Admitted
+    } else if saw_library_api_evidence {
+        LibraryApiEvidenceStatus::Rejected
+    } else {
+        LibraryApiEvidenceStatus::Missing
+    }
+}
+
+pub fn library_api_contract_evidence_for_node(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    id: LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+    arg_count: usize,
+) -> LibraryApiEvidenceStatus {
+    if arg_count > u16::MAX as usize {
+        return LibraryApiEvidenceStatus::Rejected;
+    }
+    let expected = LibraryApiEvidenceKind::Contract {
+        contract_hash: library_api_contract_id_hash(id),
+        callee_hash: library_api_callee_contract_hash(callee),
+        arity: arg_count as u16,
+    };
+    let anchor = EvidenceAnchor::node(il.node(node).span, il.kind(node));
+    let mut saw_library_api_evidence = false;
+    let mut admitted = false;
+    for record in &il.evidence {
+        if record.anchor != anchor {
+            continue;
+        }
+        let EvidenceKind::LibraryApi(api) = record.kind else {
+            continue;
+        };
+        saw_library_api_evidence = true;
+        if record.status != EvidenceStatus::Asserted
+            || api != expected
+            || !il.evidence_dependencies_asserted(record)
+            || !library_api_node_callee_shape_matches(il, interner, node, callee)
+            || !library_api_dependencies_match_callee_node(il, interner, node, callee, record)
         {
             return LibraryApiEvidenceStatus::Rejected;
         }
@@ -4835,6 +5086,23 @@ pub fn library_api_receiver_dependencies_for_call_with_cache(
     }
 }
 
+pub fn library_api_property_dependencies_for_field_with_cache(
+    il: &Il,
+    interner: &Interner,
+    field: NodeId,
+    callee: LibraryApiCalleeContract,
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<Vec<EvidenceId>> {
+    let LibraryApiCalleeContract::Property { property, receiver } = callee else {
+        return None;
+    };
+    if !field_method_matches(il, interner, field, property) {
+        return None;
+    }
+    let receiver_node = il.children(field).first().copied()?;
+    method_receiver_dependency_ids(il, interner, receiver_node, receiver, &[], cache)
+}
+
 fn library_api_callee_shape_matches(
     il: &Il,
     interner: &Interner,
@@ -4883,6 +5151,7 @@ fn library_api_callee_shape_matches(
         LibraryApiCalleeContract::RegexLiteralMethod { method, .. } => {
             field_method_matches(il, interner, callee_node, method)
         }
+        LibraryApiCalleeContract::Property { .. } => false,
         LibraryApiCalleeContract::StaticIndexMembershipMethod { method, .. } => {
             method_callee_receiver(il, interner, callee_node, method).is_some()
         }
@@ -5021,6 +5290,7 @@ fn library_api_dependencies_match_callee(
             };
             dependency_has_source_fact_node(il, record, receiver_node, required_receiver_fact)
         }
+        LibraryApiCalleeContract::Property { .. } => false,
         LibraryApiCalleeContract::StaticIndexMembershipMethod { method, receiver } => {
             let Some(receiver_node) = method_callee_receiver(il, interner, callee_node, method)
             else {
@@ -5061,6 +5331,48 @@ fn library_api_dependencies_match_callee(
                 .is_some_and(|dependencies| dependency_ids_are_present(record, &dependencies))
         }
         LibraryApiCalleeContract::AsyncMethod { .. } => false,
+    }
+}
+
+fn library_api_node_callee_shape_matches(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    callee: LibraryApiCalleeContract,
+) -> bool {
+    match callee {
+        LibraryApiCalleeContract::FreeName { name, .. } => {
+            var_name_matches(il, interner, node, name)
+        }
+        LibraryApiCalleeContract::Property { property, .. } => {
+            field_method_matches(il, interner, node, property)
+        }
+        _ => false,
+    }
+}
+
+fn library_api_dependencies_match_callee_node(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    callee: LibraryApiCalleeContract,
+    record: &EvidenceRecord,
+) -> bool {
+    match callee {
+        LibraryApiCalleeContract::FreeName { name, shadow } => {
+            dependency_has_unshadowed_global_node(il, record, node, name)
+                && library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+                    file_defines_name_visible_at(il, interner, candidate, il.node(node).span)
+                })
+        }
+        LibraryApiCalleeContract::Property { .. } => {
+            let mut cache = LibraryApiDependencyCache::default();
+            library_api_property_dependencies_for_field_with_cache(
+                il, interner, node, callee, &mut cache,
+            )
+            .is_some_and(|dependencies| dependency_ids_are_present(record, &dependencies))
+        }
+        _ => false,
     }
 }
 
@@ -5361,6 +5673,7 @@ fn library_api_dependencies_match_callee_at_span(
         } => receiver_span.is_some_and(|span| {
             dependency_has_source_fact_anchor(il, record, span, required_receiver_fact)
         }),
+        LibraryApiCalleeContract::Property { .. } => false,
         LibraryApiCalleeContract::StaticIndexMembershipMethod { method, receiver } => {
             callee_span.is_some_and(|span| field_method_at_span(il, interner, span, method))
                 && receiver_span.is_some_and(|span| {
@@ -6298,6 +6611,7 @@ fn library_api_contract_result_domain_for_arity(
                 },
             }),
         ),
+        LibraryApiContractId::RustOptionSomeConstructor => Some(DomainEvidence::Option),
         _ => None,
     }
 }
@@ -6310,6 +6624,7 @@ fn library_api_contract_id_from_hash(hash: u64) -> Option<LibraryApiContractId> 
 
 fn library_api_contract_ids() -> Vec<LibraryApiContractId> {
     let mut ids = vec![
+        LibraryApiContractId::PropertyBuiltin(Builtin::Len),
         LibraryApiContractId::PythonBuiltinCollectionFactory,
         LibraryApiContractId::PythonImportedCollectionFactory,
         LibraryApiContractId::FreeFunctionBuiltin(Builtin::Len),
@@ -6324,6 +6639,9 @@ fn library_api_contract_ids() -> Vec<LibraryApiContractId> {
         LibraryApiContractId::FreeFunctionBuiltin(Builtin::Enumerate),
         LibraryApiContractId::FreeFunctionBuiltin(Builtin::Any),
         LibraryApiContractId::FreeFunctionBuiltin(Builtin::All),
+        LibraryApiContractId::RustOptionSomeConstructor,
+        LibraryApiContractId::RustOptionNoneSentinel,
+        LibraryApiContractId::RustOptionAndThen,
         LibraryApiContractId::RustStdCollectionFactory,
         LibraryApiContractId::RustStdMapFactory,
         LibraryApiContractId::RustVecMacroFactory,
@@ -6343,6 +6661,16 @@ fn library_api_contract_ids() -> Vec<LibraryApiContractId> {
         LibraryApiContractId::IteratorIdentityAdapter,
         LibraryApiContractId::StaticCollectionAdapter,
     ];
+    ids.extend(
+        [
+            ScalarIntegerMethod::Abs,
+            ScalarIntegerMethod::Min,
+            ScalarIntegerMethod::Max,
+            ScalarIntegerMethod::Clamp,
+        ]
+        .into_iter()
+        .map(LibraryApiContractId::ScalarIntegerMethod),
+    );
     ids.extend(
         [
             JavaCollectionFactoryKind::ListOf,
@@ -6447,6 +6775,12 @@ fn library_api_callee_contracts_for_id(
     id: LibraryApiContractId,
 ) -> Vec<LibraryApiCalleeContract> {
     match id {
+        LibraryApiContractId::PropertyBuiltin(builtin) => ["length"]
+            .into_iter()
+            .filter_map(|property| library_property_builtin_contract(lang, property))
+            .filter(|contract| contract.id == LibraryApiContractId::PropertyBuiltin(builtin))
+            .map(|contract| contract.callee)
+            .collect(),
         LibraryApiContractId::PythonBuiltinCollectionFactory
         | LibraryApiContractId::RustStdCollectionFactory => {
             library_free_name_collection_factory_contracts(lang)
@@ -6463,6 +6797,47 @@ fn library_api_callee_contracts_for_id(
         LibraryApiContractId::FreeFunctionBuiltin(builtin) => {
             library_free_function_builtin_callee_contracts_for_id(lang, builtin)
         }
+        LibraryApiContractId::RustOptionSomeConstructor => [
+            "Some",
+            "Option::Some",
+            "std::option::Option::Some",
+            "core::option::Option::Some",
+        ]
+        .into_iter()
+        .filter_map(|name| library_rust_option_some_constructor_contract(lang, name, 1))
+        .map(|contract| contract.callee)
+        .collect(),
+        LibraryApiContractId::RustOptionNoneSentinel => [
+            "None",
+            "Option::None",
+            "std::option::Option::None",
+            "core::option::Option::None",
+        ]
+        .into_iter()
+        .filter_map(|name| library_rust_option_none_sentinel_contract(lang, name))
+        .map(|contract| contract.callee)
+        .collect(),
+        LibraryApiContractId::RustOptionAndThen => {
+            library_rust_option_and_then_contract(lang, "and_then", 1)
+                .map(|contract| vec![contract.callee])
+                .unwrap_or_default()
+        }
+        LibraryApiContractId::ScalarIntegerMethod(method) => ["abs", "min", "max", "clamp"]
+            .into_iter()
+            .filter_map(|name| library_scalar_integer_method_contract(lang, name, 0))
+            .chain(
+                ["abs", "min", "max", "clamp"]
+                    .into_iter()
+                    .filter_map(|name| library_scalar_integer_method_contract(lang, name, 1)),
+            )
+            .chain(
+                ["abs", "min", "max", "clamp"]
+                    .into_iter()
+                    .filter_map(|name| library_scalar_integer_method_contract(lang, name, 2)),
+            )
+            .filter(|contract| contract.id == LibraryApiContractId::ScalarIntegerMethod(method))
+            .map(|contract| contract.callee)
+            .collect(),
         LibraryApiContractId::RustStdMapFactory => library_free_name_map_factory_contracts(lang)
             .filter(|contract| contract.id == id)
             .map(|contract| contract.callee)
@@ -7990,6 +8365,24 @@ pub fn library_receiver_method_api_contract(
             })
         })
         .or_else(|| {
+            library_scalar_integer_method_contract(lang, method, arg_count).map(|contract| {
+                LibraryReceiverMethodApiContract {
+                    id: contract.id,
+                    callee: contract.callee,
+                    rule: "library_api_scalar_integer_method",
+                }
+            })
+        })
+        .or_else(|| {
+            library_rust_option_and_then_contract(lang, method, arg_count).map(|contract| {
+                LibraryReceiverMethodApiContract {
+                    id: contract.id,
+                    callee: contract.callee,
+                    rule: "library_api_rust_option_and_then",
+                }
+            })
+        })
+        .or_else(|| {
             library_method_call_contract(lang, method, arg_count).map(|contract| {
                 LibraryReceiverMethodApiContract {
                     id: contract.id,
@@ -8019,7 +8412,9 @@ fn library_method_selector_name(name: &str) -> Option<&'static str> {
         "any" => "any",
         "any?" => "any?",
         "anyMatch" => "anyMatch",
+        "and_then" => "and_then",
         "append" => "append",
+        "clamp" => "clamp",
         "collect" => "collect",
         "contains" => "contains",
         "containsKey" => "containsKey",

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -61,13 +61,14 @@ The current implemented kinds are:
 | `Guard` | multi-obligation guard proof facts such as JS/TS record-shape and own-property guard contracts |
 | `Place` | fixed receiver/place facts currently covering `SelfReceiver` and `SelfField` |
 | `Effect` | observable effect facts currently covering canonical builder append calls, non-overloadable index writes, and fixed self-field writes |
-| `LibraryApi` | proof that a specific call occurrence matches a language/API contract coordinate, currently for selected JS-like static/global/static-index APIs, selected Python/Rust/Ruby/Java/regex APIs, generic Python/Go free-function builtins, and selected receiver-method families |
+| `LibraryApi` | proof that a specific API occurrence matches a language/API contract coordinate, currently for selected call, property, and sentinel occurrences across JS-like static/global/static-index APIs, selected Python/Rust/Ruby/Java/regex APIs, generic Python/Go free-function builtins, and selected receiver-method families |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, guard surfaces, Go composite map literals, or Go map entries |
 
 `LibraryApi` evidence is an occurrence fact, not the whole contract. It records
-the contract id, callee coordinate, arity, and dependencies for a specific call
-node. `LibraryApiContract` rows in `nose-semantics` still name result semantics
-and the remaining obligations. Existing evidence kinds such as `Symbol`,
+the contract id, callee coordinate, arity, and dependencies for a specific
+`Call`, `Field`, or `Var` node, depending on the contract surface.
+`LibraryApiContract` rows in `nose-semantics` still name result semantics and
+the remaining obligations. Existing evidence kinds such as `Symbol`,
 `Import`, `Source`, `Domain`, and `SequenceSurface` prove those obligations; the
 contract decides whether the facts are enough to admit an exact or value-graph
 path. A future external pack schema may expose library API contracts, but
@@ -107,6 +108,10 @@ Current first-party `LibraryApi` callee coordinates are intentionally specific:
   calls and depends on `SequenceSurface(Collection)` evidence for the exact
   receiver plus the static non-float literal receiver shape required by the
   contract.
+- `Property` names a language-scoped property surface such as JS/TS/Java
+  `length`. It is anchored to the `Field` node and depends on receiver proof
+  such as `Domain`, `SequenceSurface`, or nested admitted `LibraryApi`
+  evidence. It does not infer semantics from a property spelling alone.
 - `Method` and `IteratorAdapterMethod` name language-scoped receiver methods by
   exact method string and arity. They depend on receiver proof such as
   `Domain`, `SequenceSurface`, imported-namespace or unshadowed-global `Symbol`,
@@ -288,8 +293,8 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   `Effect(BuilderAppendCall)` for canonical `Builtin::Append`. Self-field
   place/write evidence records include dependencies that link the write proof
   back to the receiver proof;
-- first-party lowering emits `LibraryApi` evidence for selected API calls that
-  remain as raw call nodes: JS-like `Array.from(...)`, `Array.isArray(...)`,
+- first-party lowering emits `LibraryApi` evidence for selected API occurrences
+  that remain as raw nodes: JS-like `Array.from(...)`, `Array.isArray(...)`,
   `Boolean(...)`, `new Map(...)`, `new Set(...)`, and static
   `indexOf`/`findIndex` membership calls whose receiver has collection
   sequence-surface proof; Python builtin collection factories such as
@@ -297,8 +302,10 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   `collections.deque(...)` through imported binding/namespace proof; Python
   `math.prod(...)` through imported namespace proof; Rust
   `vec!(...)` when macro-invocation source syntax and macro-name shadow policy
-  are proven, `Vec::new()`, and selected `std::collections::*::from(...)`
-  factory paths when their root-shadow policy is proven; Ruby
+  are proven, `Vec::new()`, `Some(...)`, bare `None`, and selected
+  `std::collections::*::from(...)` factory paths when their root-shadow policy
+  is proven; JS/TS/Java `length` property reads whose receiver proof is
+  satisfied; Ruby
   earlier top-level `require "set"; Set.new(...)` through `Import::Require`
   plus unshadowed `require` and `Set` proof; Java `java.util` static
   factories/adapters including `List.of`, `Set.of`, `Arrays.asList`, `Map.of`,
@@ -317,8 +324,10 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   occurrence evidence for selected receiver methods that remain as raw call
   nodes: map `get`, map-key views, iterator identity adapters, and the
   language-scoped method-call contracts currently used for collection/map
-  membership, map defaulting, count/length, predicates, Rust `zip`, HOF, and
-  reduction methods. The post-binding refresh exists because immutable
+  membership, map defaulting, count, predicates, Rust scalar integer methods,
+  Rust `Option::and_then`, Rust `zip`, HOF, and reduction methods. Property
+  cardinality such as JS/TS `length` is modeled as `Property`, not as a method
+  call. The post-binding refresh exists because immutable
   binding-domain evidence is inferred after lowering; the final refresh exists
   because CFG/dataflow/algebra rewrites can replace receiver expressions with
   equivalent sequence or result values. Refreshing upserts first-party occurrence
@@ -394,8 +403,8 @@ callers:
   evidence for `Array.from`;
 - selected `LibraryApiContract` consumers now consult `LibraryApi` occurrence
   evidence first for the migrated JS-like, Python builtin/imported, Rust
-  free-name/path, Ruby require-backed, Java static, regex-literal, and
-  receiver-method surfaces;
+  free-name/path/Option/scalar, Ruby require-backed, Java static/property,
+  regex-literal, property, and receiver-method surfaces;
   conflicting or dependency-broken API evidence keeps
   the value-graph, idiom, and strict exact paths closed. Missing API evidence is
   now also closed for those producer-covered surfaces; older symbol/source proof

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -302,10 +302,10 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   `collections.deque(...)` through imported binding/namespace proof; Python
   `math.prod(...)` through imported namespace proof; Rust
   `vec!(...)` when macro-invocation source syntax and macro-name shadow policy
-  are proven, `Vec::new()`, `Some(...)`, bare `None`, and selected
-  `std::collections::*::from(...)` factory paths when their root-shadow policy
-  is proven; JS/TS/Java `length` property reads whose receiver proof is
-  satisfied; Ruby
+  are proven, `Vec::new()`, `Some(...)`, `Some(_)` pattern selectors, bare
+  `None`, and selected `std::collections::*::from(...)` factory paths when
+  their root-shadow policy is proven; JS/TS/Java `length` property reads whose
+  receiver proof is satisfied; Ruby
   earlier top-level `require "set"; Set.new(...)` through `Import::Require`
   plus unshadowed `require` and `Set` proof; Java `java.util` static
   factories/adapters including `List.of`, `Set.of`, `Arrays.asList`, `Map.of`,

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -429,6 +429,14 @@ and pack ecosystem.
   inner HOF call's admitted `LibraryApi` occurrence instead of a raw method
   selector. Raw Python async-looking field names no longer rewrite to sync names
   until an explicit async/sync protocol evidence path exists.
+- The protocol/API occurrence closure slice extended `LibraryApi` beyond
+  call-only APIs. JS/TS/Java `length` property reads now require a
+  `PropertyBuiltin` occurrence anchored to the `Field` node, JS-like `length()`
+  is no longer a cardinality method contract, Rust `Some(...)` and bare `None`
+  now emit contract-backed Option occurrence evidence, Rust `Option::and_then`
+  and scalar integer methods require admitted receiver-method occurrences, and
+  value-graph/desugar/idiom consumers fail closed when those occurrence records
+  are missing, rejected, or dependency-broken.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -508,7 +516,8 @@ Remaining in this phase:
   static/global APIs, Python builtin/import-backed factories/functions, Rust
   free-name/path factories, Ruby require-backed factories, Java `java.util`
   static factories/adapters and selected empty constructors, JS regex literals,
-  JS/TS static-index membership, and selected receiver-method families.
+  JS/TS static-index membership, JS/TS/Java property builtins, Rust
+  Option/scalar APIs, and selected receiver-method families.
   Remaining stdlib and ecosystem APIs still need dependency-backed occurrence
   records before they become pack-facing. Producer-covered
   factory/API result calls now also emit dependent call-node `Domain` evidence
@@ -520,10 +529,9 @@ Remaining in this phase:
   `java.util`, and regex calls now additionally share `LibraryApi` occurrence
   evidence, as do generic Python/Go free-function builtins and selected
   receiver-method families. Lowered sequence-surface consumers are now
-  evidence-only where covered. Remaining API work is property occurrence
-  evidence, Rust Option constructor/sentinel/`and_then` occurrence evidence,
-  Rust scalar method occurrence evidence, promise receiver proof, and ecosystem
-  APIs only after demand, receiver, and effect obligations are expressible.
+  evidence-only where covered. Remaining API work is promise receiver proof,
+  async/sync protocol convergence, and ecosystem APIs only after demand,
+  receiver, and effect obligations are expressible.
 - Continue import/module proof migration beyond the removed raw import payloads
   and evidence-only import identity path. Value-graph import identity and
   imported-symbol exact proof are now evidence-only, imported literal replacement

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -96,8 +96,8 @@ and pack ecosystem.
 - Rust stdlib path contracts for `Some`/`Option::Some`,
   `None`/`Option::None`, `Option::and_then`, and `Vec::new` moved into the
   kernel facade with explicit shadow-root obligations. The caller still proves
-  local shadow safety, and the Rust frontend no longer lowers bare `None`
-  directly to null before that proof.
+  local shadow safety, and the Rust frontend preserves `if let` pattern tests
+  instead of lowering `Some`/`None` directly to null/not-null before that proof.
 - Java collection/map factory selectors, Python free-name/imported collection
   factories, Rust std collection/map factory paths, Ruby `Set.new`, and JS-like
   `new Map`/`new Set` moved behind internal `LibraryApiContract` rows in
@@ -432,11 +432,12 @@ and pack ecosystem.
 - The protocol/API occurrence closure slice extended `LibraryApi` beyond
   call-only APIs. JS/TS/Java `length` property reads now require a
   `PropertyBuiltin` occurrence anchored to the `Field` node, JS-like `length()`
-  is no longer a cardinality method contract, Rust `Some(...)` and bare `None`
-  now emit contract-backed Option occurrence evidence, Rust `Option::and_then`
-  and scalar integer methods require admitted receiver-method occurrences, and
-  value-graph/desugar/idiom consumers fail closed when those occurrence records
-  are missing, rejected, or dependency-broken.
+  is no longer a cardinality method contract, Rust `Some(...)`, `Some(_)`
+  pattern selectors, and bare `None` now emit contract-backed Option occurrence
+  evidence, Rust `Option::and_then` and scalar integer methods require admitted
+  receiver-method occurrences, and value-graph/desugar/idiom consumers fail
+  closed when those occurrence records are missing, rejected, or
+  dependency-broken.
 
 ## Phase 0: documentation and vocabulary (landed)
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -162,11 +162,11 @@ migrated.
   `None`/`Option::None`, `Option::and_then`, and `Vec::new` carry the exact
   selector and shadow-root requirement through `nose-semantics`. First-party
   lowering/normalization now emits admitted `LibraryApi` occurrence evidence for
-  `Some(...)` calls, bare `None` `Var` occurrences, and `and_then(...)` calls
-  only when the shadow and receiver obligations are satisfied. The Rust
-  frontend preserves bare `None` and `if let` scrutinees instead of lowering
-  them directly to null/not-null builtins, so Option absence/presence is
-  admitted only through the contract-backed occurrence path.
+  `Some(...)` calls, `Some(_)` pattern selectors, bare `None` `Var`
+  occurrences, and `and_then(...)` calls only when the shadow and receiver
+  obligations are satisfied. The Rust frontend preserves `if let` pattern tests
+  instead of lowering them directly to null/not-null builtins, so Option
+  absence/presence is admitted only through the contract-backed occurrence path.
 - Collection factory, map factory, and selected constructor identity now have an
   internal `LibraryApiContract`
   shape in `nose-semantics`. It separates API identity from result eligibility,

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -14,14 +14,16 @@ source, domain, import, symbol-identity, guard,
 place/effect, selected library API occurrence, value-domain/law contracts, and
 sequence-surface facts.
 Library/API identity is consolidated through internal `LibraryApiContract` rows
-for factory, constructor, and selected non-factory method/view surfaces, with
-occurrence evidence covering selected JS-like static/global APIs and static
-index-membership calls, Python builtin/import-backed APIs, Rust free-name/path
-APIs, Ruby require-backed APIs, Java `java.util` APIs including selected empty
-constructors, JS regex API calls, and selected language-scoped receiver-method
-APIs such as collection membership, map lookup/defaulting, map-key views,
-iterator identity adapters, Rust `zip`, and HOF/reduction methods. Selected
-producer-covered factory/API calls now also emit dependent receiver-expression
+for factory, constructor, selected property/non-factory method/view surfaces,
+and selected non-call sentinels, with occurrence evidence covering selected
+JS-like static/global APIs and static index-membership calls, JS/TS/Java
+`length` property reads, Python builtin/import-backed APIs, Rust free-name/path
+APIs including `Option::Some`/`Option::None`, Ruby require-backed APIs, Java
+`java.util` APIs including selected empty constructors, JS regex API calls, and
+selected language-scoped receiver-method APIs such as collection membership,
+map lookup/defaulting, map-key views, iterator identity adapters, Rust scalar
+integer methods, Rust `Option::and_then`, Rust `zip`, and HOF/reduction methods.
+Selected producer-covered factory/API calls now also emit dependent receiver-expression
 `Domain` evidence
 for their result container domain, and normalize emits binding-anchored `Domain`
 evidence for immutable local/module bindings whose initializer domain and
@@ -137,11 +139,15 @@ migrated.
   binding `local_hash` and only applies an assignment to receiver uses that occur
   after it. That mutation scan is producer policy; general mutation/effect
   evidence remains separate future work.
-- Property builtin contracts are language-constrained; a selector such as
-  `length` is not enough without receiver proof. JS/TS `filter(...).length`
-  is admitted only after the receiver has already entered a proven collection/HOF
-  value and raw HOF calls carry admitted `LibraryApi` occurrence evidence. JS
-  object `.length` remains a property read, not collection cardinality.
+- Property builtin contracts are language-constrained occurrence contracts, not
+  selector guesses. JS/TS/Vue/Svelte/HTML and Java `length` reads are admitted
+  only when a `LibraryApi(PropertyBuiltin(Len))` record is anchored to the
+  `Field` node and its dependencies prove the receiver contract. JS-like
+  `length()` is not a method-call cardinality contract. JS/TS
+  `filter(...).length` is admitted only after the receiver has already entered
+  a proven collection/HOF value and raw HOF calls carry admitted `LibraryApi`
+  occurrence evidence. JS object `.length` remains a property read, not
+  collection cardinality.
 - Promise `.then` has a JS-like library API contract, but exact beta-reduction
   is closed until a pack/frontend can prove a Promise-like receiver.
 - Rust iterator identity adapters (`iter`, `into_iter`, `collect`, `to_vec`,
@@ -154,10 +160,13 @@ migrated.
   both sides.
 - Rust stdlib path contracts for `Some`/`Option::Some`,
   `None`/`Option::None`, `Option::and_then`, and `Vec::new` carry the exact
-  selector and shadow-root requirement through `nose-semantics`;
-  normalize/detect still perform the local scope shadow check. The Rust
-  frontend preserves bare `None` as a name rather than lowering it directly to
-  null, so Option absence is admitted only through the contract.
+  selector and shadow-root requirement through `nose-semantics`. First-party
+  lowering/normalization now emits admitted `LibraryApi` occurrence evidence for
+  `Some(...)` calls, bare `None` `Var` occurrences, and `and_then(...)` calls
+  only when the shadow and receiver obligations are satisfied. The Rust
+  frontend preserves bare `None` and `if let` scrutinees instead of lowering
+  them directly to null/not-null builtins, so Option absence/presence is
+  admitted only through the contract-backed occurrence path.
 - Collection factory, map factory, and selected constructor identity now have an
   internal `LibraryApiContract`
   shape in `nose-semantics`. It separates API identity from result eligibility,
@@ -235,8 +244,9 @@ migrated.
   `LibraryApi` occurrence evidence for the first-party method families currently
   backed by `LibraryApiContract`: map `get`, map-key views, iterator identity
   adapters, and generic language-scoped method-call contracts such as
-  collection/map membership, map defaulting, count/length methods,
-  string/collection predicates, Rust `zip`, and HOF/reduction methods. The
+  collection/map membership, map defaulting, count methods,
+  string/collection predicates, Rust scalar integer methods, Rust
+  `Option::and_then`, Rust `zip`, and HOF/reduction methods. The
   occurrence record is admitted only for the exact language/method/arity row and
   depends on receiver proof: node/binding/parameter `Domain`, `SequenceSurface`,
   imported namespace or unshadowed-global `Symbol`, or a nested admitted
@@ -484,16 +494,16 @@ Semantic knowledge still appears in several forms outside the facade:
   HOFs, nullish defaulting, recursion, and effect traces;
 - remaining library/API proof gates that do not yet have occurrence records.
   `LibraryApi` occurrence evidence now covers selected JS-like static/global
-  APIs and static-index membership, Python builtin/import-backed
-  factories/functions, Rust free-name/path factories, Ruby
-  `require "set"; Set.new(...)`, Java `java.util` static factories/adapters and
-  selected empty constructors, JS regex literals, generic Python/Go
-  free-function builtins, and selected receiver-method families. Promise
-  receiver proof, async/sync protocol convergence, property occurrence evidence,
-  Rust Option/scalar occurrence evidence, and ecosystem APIs still rely on
-  contract rows plus local proof or remain exact-closed. Raw Python async-looking
-  field names such as `aread` no longer rewrite to sync names without an
-  explicit protocol/API evidence path.
+  APIs and static-index membership, JS/TS/Java property builtins, Python
+  builtin/import-backed factories/functions, Rust free-name/path factories,
+  Rust Option/scalar APIs, Ruby `require "set"; Set.new(...)`, Java `java.util`
+  static factories/adapters and selected empty constructors, JS regex literals,
+  generic Python/Go free-function builtins, and selected receiver-method
+  families. Promise receiver proof, async/sync protocol convergence, ecosystem
+  APIs, and broader protocol/API evidence paths still rely on contract rows plus
+  local proof or remain exact-closed. Raw Python async-looking field names such
+  as `aread` no longer rewrite to sync names without an explicit protocol/API
+  evidence path.
 
 These are valuable, but they do not yet share one complete semantic contract
 language.


### PR DESCRIPTION
## Summary

This is the next large semantic-kernel migration slice for #109, rebased on `origin/main` after #141.

- Extends `LibraryApiContract` / `LibraryApi` beyond call-only APIs with property, Rust Option, Rust `Option::and_then`, and Rust scalar integer method occurrence contracts.
- Emits dependency-backed first-party occurrence evidence for JS/TS/Java `length` fields, Rust `Some(...)`, Rust `Some(_)` pattern selectors, bare `None`, Rust `and_then(...)`, and Rust scalar methods.
- Keeps Option pattern semantics evidence-backed: `if let` pattern tests are preserved in IL, `Some(_)` only becomes Option presence when the `Some` occurrence and Option receiver domain are admitted, and pattern identity does not become constructor result-domain evidence.
- Makes desugar, idiom, value-graph, and strict-exact consumers fail closed when producer-covered occurrence records are missing, rejected, ambiguous, or dependency-broken.
- Removes JS-like `length()` as a cardinality method contract; length cardinality is now Field-anchored property evidence only.
- Adds API result-domain closure for HOF and Rust scalar integer method results so chained proof-backed calls such as `filter(...).length` and `x.max(lo).min(hi)` remain precise.
- Preserves #141's Java collection-constructor exact-safe recognizer and reassigned-Cid domain soundness fix while adding this PR's Rust Option strict-exact gate.
- Updates semantic-kernel snapshot, roadmap, and evidence-record docs.

## Validation

- `scripts/check-ci-local.sh --full` after rebasing on `origin/main` (`c0df348`): passed.

This includes rustfmt, clippy `-D warnings`, rustdoc warnings, release build, release tests, duplication gate, MSRV, cargo-machete, cargo-deny, awiki connectivity, formal obligation lint, and Lean proofs.

## Notes

This intentionally closes old recall paths that were not evidence-backed, especially JS-like `length()` and direct Rust `if let Some/None` builtin lowering. Reopened Rust `Some(_)` support now goes through explicit Option occurrence evidence plus receiver-domain proof rather than selector or pattern-text inference.

Progress on #109 is now estimated at about 86%. Remaining major slices are promise/async protocol evidence, mutation/generic effect evidence closure, and final integration/pack-boundary audit.