### PR TITLE
Disable CodeRabbit for this repository

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# CodeRabbit is intentionally disabled for this repository.
+# The GitHub App is installed at the corca-ai organization level; this file
+# prevents repository-level CodeRabbit activity without changing other repos.
+inheritance: false
+early_access: false
+
+reviews:
+  request_changes_workflow: false
+  path_filters:
+    - "!**/*"
+    - "!**/.*"
+    - "!.*"
+  high_level_summary: false
+  high_level_summary_placeholder: ""
+  high_level_summary_in_walkthrough: false
+  review_status: false
+  commit_status: false
+  fail_commit_status: false
+  changed_files_summary: false
+  sequence_diagrams: false
+  assess_linked_issues: false
+  related_issues: false
+  related_prs: false
+  suggested_labels: false
+  auto_apply_labels: false
+  suggested_reviewers: false
+  auto_assign_reviewers: false
+  enable_prompt_for_ai_agents: false
+  slop_detection:
+    enabled: false
+  auto_review:
+    enabled: false
+    auto_incremental_review: false
+    auto_pause_after_reviewed_commits: 0
+    description_keyword: ""
+    labels: []
+    drafts: false
+    base_branches: []
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+    custom: []
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+    title:
+      mode: "off"
+    issue_assessment:
+      mode: "off"
+    custom_checks: []
+
+chat:
+  auto_reply: false
+  art: false
+  allow_non_org_members: false
+
+issue_enrichment:
+  auto_enrich:
+    enabled: false
+  labeling:
+    auto_apply_labels: false
+    labeling_instructions: []
+  planning:
+    enabled: false
+    auto_planning:
+      enabled: false
+      labels: []
+
+knowledge_base:
+  opt_out: true
+  automatic_repository_linking: false
+  code_guidelines:
+    enabled: false
+  web_search:
+    enabled: false

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -71,6 +71,18 @@ release build/tests, the self-hosted duplication gate, MSRV check, supply-chain
 checks, docs wiki connectivity, the formal obligation registry, and Lean soundness proofs
 via [check-lean-proofs.sh](../scripts/check-lean-proofs.sh).
 
+## External review bots
+
+CodeRabbit is disabled for this repository with the root `.coderabbit.yaml`. The
+file opts out of inherited CodeRabbit settings and disables automatic review,
+incremental review, review file scope, chat auto-replies, finishing touches,
+pre-merge checks, issue enrichment, and knowledge-base retention for nose.
+
+The CodeRabbit GitHub App is installed at the `corca-ai` organization level. Fully
+removing repository access requires an organization owner to change the app
+installation from "all repositories" to a selected-repositories installation that
+excludes `corca-ai/nose`, or to uninstall CodeRabbit from the organization.
+
 ## Baselines — incremental adoption
 
 An existing codebase already has dozens of clone families, so a bare `--fail-on any`


### PR DESCRIPTION
## Summary
- add a root .coderabbit.yaml that disables CodeRabbit inheritance and repository-level activity
- turn off automatic and incremental reviews, chat auto-replies, finishing touches, pre-merge checks, issue enrichment, and knowledge-base retention
- document that the GitHub App is still installed at the corca-ai organization level and that removing app access requires an organization owner

## Validation
- ruby YAML parse + JSON conversion
- npx ajv-cli@5 validate --spec=draft2020 --strict=false -s /tmp/coderabbit-schema.v2.json -d /tmp/nose-coderabbit-config.json
- awiki lint --root docs

## Note
I attempted to remove corca-ai/nose from the CodeRabbit GitHub App installation through the API, but GitHub rejected it with: "You do not have permission to modify this app on corca-ai. Please contact an Organization Owner." The app is currently installed for all repositories in the organization, so an organization owner must change the installation scope or uninstall the app to remove GitHub App access completely.


<!-- Disable CodeRabbit for this bootstrap PR. -->
@coderabbitai ignore
