### PR TITLE
Preserve async and generator protocol boundaries

### DIFF
--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -525,6 +525,122 @@ fn scan_mode_semantic_rejects_reassigned_param_with_stale_collection_domain() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// Soundness (semantic-kernel async protocol boundary): `await x` is not
+/// equivalent to `x` until a language/protocol contract proves that erasure.
+/// The old lowering stripped `await`, which made a sync function and an async
+/// function form an exact semantic family even though Promise/thenable
+/// scheduling and error propagation have different observable semantics.
+#[test]
+fn scan_mode_semantic_rejects_unproven_js_await_sync_convergence() {
+    let dir = std::env::temp_dir().join(format!("nose_js_await_boundary_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("sync.js"),
+        "function id(x) {\n  return x + 1;\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("async.js"),
+        "async function idAsync(x) {\n  return await x + 1;\n}\n",
+    )
+    .unwrap();
+
+    let json = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--format",
+        "json",
+        "--top",
+        "0",
+        "--min-size",
+        "1",
+        "--min-lines",
+        "1",
+    ]));
+    assert!(
+        !family_contains_all(&json, &["sync.js", "async.js"]),
+        "await must not be erased into a sync exact semantic family without protocol evidence: {json}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Same async protocol boundary for Python: `await x` is a coroutine protocol
+/// operation, not a plain value read unless a future contract proves it.
+#[test]
+fn scan_mode_semantic_rejects_unproven_python_await_sync_convergence() {
+    let dir = std::env::temp_dir().join(format!("nose_py_await_boundary_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("sync.py"), "def id(x):\n    return x + 1\n").unwrap();
+    fs::write(
+        dir.join("async.py"),
+        "async def id_async(x):\n    return await x + 1\n",
+    )
+    .unwrap();
+
+    let json = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--format",
+        "json",
+        "--top",
+        "0",
+        "--min-size",
+        "1",
+        "--min-lines",
+        "1",
+    ]));
+    assert!(
+        !family_contains_all(&json, &["sync.py", "async.py"]),
+        "await must not be erased into a sync exact semantic family without protocol evidence: {json}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Rust `.await` and `async {}` are Future protocol operations, not plain
+/// wrappers around the body. Exact sync/async convergence requires future
+/// protocol proof that is not modeled yet.
+#[test]
+fn scan_mode_semantic_rejects_unproven_rust_await_sync_convergence() {
+    let dir = std::env::temp_dir().join(format!("nose_rs_await_boundary_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("sync.rs"), "fn id(x: i32) -> i32 { x + 1 }\n").unwrap();
+    fs::write(
+        dir.join("async.rs"),
+        "async fn id_async(x: i32) -> i32 { async move { x + 1 }.await }\n",
+    )
+    .unwrap();
+
+    let json = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--format",
+        "json",
+        "--top",
+        "0",
+        "--min-size",
+        "1",
+        "--min-lines",
+        "1",
+    ]));
+    assert!(
+        !family_contains_all(&json, &["sync.rs", "async.rs"]),
+        "Rust async/await must not be erased into a sync exact semantic family without future protocol evidence: {json}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn scan_human_hides_generated_header_families() {
     let dir = make_generated_header_project("human");

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -1,8 +1,8 @@
 //! JavaScript / TypeScript → raw IL lowering.
 //!
 //! JS and TS share one walk; TypeScript type syntax is erased (`type_annotation`,
-//! `as`/`satisfies`/`!` are stripped). Convergence-friendly lowering: `await e`
-//! and `a as T` reduce to `e`/`a`; `i++` and `x += 1` desugar to assignments;
+//! `as`/`satisfies`/`!` are stripped). Convergence-friendly lowering:
+//! `a as T` reduces to `a`; `i++` and `x += 1` desugar to assignments;
 //! C-style `for`, `for...of`, `do/while` map to the unified `Loop`; `switch`
 //! becomes an `if`/`else if` chain; ternary lowers to an expression `If`.
 
@@ -907,11 +907,14 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             .named_child(0)
             .map(|c| lower_expr(lo, c))
             .unwrap_or_else(|| lo.empty_block(span)),
-        // Strip await / TS-only wrappers so variants converge.
-        "await_expression" => node
-            .named_child(0)
-            .map(|c| lower_expr(lo, c))
-            .unwrap_or_else(|| lo.empty_block(span)),
+        "await_expression" => {
+            let value = node
+                .named_child(0)
+                .map(|c| lower_expr(lo, c))
+                .unwrap_or_else(|| lo.empty_block(span));
+            lo.await_boundary(span, value)
+        }
+        // TS-only wrappers have no runtime behavior.
         "as_expression" | "satisfies_expression" | "non_null_expression" | "type_assertion" => node
             .named_child(0)
             .map(|c| lower_expr(lo, c))
@@ -981,10 +984,10 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             .named_child(0)
             .map(|c| lower_expr(lo, c))
             .unwrap_or_else(|| lo.empty_block(span)),
-        "yield_expression" => node
-            .named_child(0)
-            .map(|c| lower_expr(lo, c))
-            .unwrap_or_else(|| lo.empty_block(span)),
+        "yield_expression" => {
+            let value = node.named_child(0).map(|c| lower_expr(lo, c));
+            lo.yield_boundary(span, value)
+        }
         "computed_property_name" => node
             .named_child(0)
             .map(|c| lower_expr(lo, c))
@@ -1949,7 +1952,7 @@ mod tests {
     use nose_il::{
         stable_symbol_hash, EvidenceAnchor, EvidenceKind, FileId, GuardEvidenceKind, Interner,
         JsRecordGuardComparison, JsRecordGuardNullCheck, LibraryApiEvidenceKind,
-        SymbolEvidenceKind,
+        SourceProtocolKind, SymbolEvidenceKind,
     };
     use nose_semantics::{
         library_api_callee_contract_hash, library_api_contract_id_hash,
@@ -2070,6 +2073,46 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    #[test]
+    fn await_expression_preserves_source_backed_async_boundary() {
+        let interner = Interner::new();
+        let il = lower(
+            FileId(0),
+            "t.js",
+            b"async function f(x) { return await x + 1; }",
+            Lang::JavaScript,
+            &interner,
+        )
+        .expect("lower js");
+
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "await",
+            SourceProtocolKind::Await,
+        );
+    }
+
+    #[test]
+    fn yield_expression_preserves_source_backed_protocol_boundary() {
+        let interner = Interner::new();
+        let il = lower(
+            FileId(0),
+            "t.js",
+            b"function* f(x) { yield x + 1; }",
+            Lang::JavaScript,
+            &interner,
+        )
+        .expect("lower js");
+
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "yield",
+            SourceProtocolKind::Yield,
+        );
     }
 
     fn js_own_property_guard_evidence(il: &Il) -> Vec<&nose_il::EvidenceRecord> {

--- a/crates/nose-frontend/src/lib.rs
+++ b/crates/nose-frontend/src/lib.rs
@@ -20,6 +20,44 @@ use nose_il::{Corpus, FileId, Il, Interner, Lang};
 use rayon::prelude::*;
 use std::path::Path;
 
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use nose_il::{Il, Interner, NodeId, NodeKind, Payload, SourceProtocolKind};
+    use nose_semantics::source_protocol_at_node;
+
+    pub(crate) fn expect_raw_protocol_boundary(
+        il: &Il,
+        interner: &Interner,
+        tag: &str,
+        protocol: SourceProtocolKind,
+    ) -> NodeId {
+        let nodes: Vec<NodeId> = il
+            .nodes
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, node)| match node.payload {
+                Payload::Name(sym)
+                    if node.kind == NodeKind::Raw && interner.resolve(sym) == tag =>
+                {
+                    Some(NodeId(idx as u32))
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            nodes.len(),
+            1,
+            "{tag} should stay as one raw protocol boundary: {nodes:?}"
+        );
+        assert_eq!(
+            source_protocol_at_node(il, nodes[0]),
+            Some(protocol),
+            "{tag} boundary should carry source protocol evidence"
+        );
+        nodes[0]
+    }
+}
+
 /// Lower a single in-memory source buffer.
 pub fn lower_source(
     file: FileId,

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -7,8 +7,8 @@ use nose_il::{
     EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance, EvidenceRecord, EvidenceStatus,
     FileId, FileMeta, Il, IlBuilder, ImportEvidenceKind, Interner, Lang, LibraryApiEvidenceKind,
     LitClass, LoopKind, NodeId, NodeKind, Op, ParamSemantic, Payload, PlaceEvidenceKind,
-    SequenceSurfaceKind, SourceCallKind, SourceFactKind, Span, Symbol, SymbolEvidenceKind, Unit,
-    UnitKind,
+    SequenceSurfaceKind, SourceCallKind, SourceFactKind, SourceProtocolKind, Span, Symbol,
+    SymbolEvidenceKind, Unit, UnitKind,
 };
 use nose_semantics::{
     library_api_callee_contract_hash, library_api_contract_id_hash,
@@ -1038,6 +1038,32 @@ impl<'a> Lowering<'a> {
         let sym = self.sym(surface_kind);
         self.b
             .add(NodeKind::Raw, Payload::Name(sym), span, children)
+    }
+
+    /// Preserve an async `await` boundary until a protocol/demand contract proves
+    /// it can be erased safely.
+    pub(crate) fn await_boundary(&mut self, span: Span, value: NodeId) -> NodeId {
+        self.protocol_boundary(span, SourceProtocolKind::Await, "await", &[value])
+    }
+
+    /// Preserve a generator `yield` boundary until a protocol/demand contract
+    /// proves it can be interpreted safely.
+    pub(crate) fn yield_boundary(&mut self, span: Span, value: Option<NodeId>) -> NodeId {
+        let children: Vec<NodeId> = value.into_iter().collect();
+        self.protocol_boundary(span, SourceProtocolKind::Yield, "yield", &children)
+    }
+
+    /// Preserve a language protocol boundary until a contract proves it can be
+    /// interpreted as a shared semantic operation.
+    pub(crate) fn protocol_boundary(
+        &mut self,
+        span: Span,
+        protocol: SourceProtocolKind,
+        tag: &str,
+        children: &[NodeId],
+    ) -> NodeId {
+        self.record_source_fact(span, SourceFactKind::Protocol(protocol));
+        self.raw(tag, span, children)
     }
 
     /// Tag a detection unit.

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -3,9 +3,9 @@
 //! Covers the constructs that matter for clone detection (functions, classes,
 //! control flow, calls, operators, literals, comprehensions) and falls back to
 //! `Raw` for the rest. A few convergence-friendly choices are made here because
-//! they are language-specific: `await e` is stripped to `e` (async/sync clones),
-//! compound assignment is desugared (no core node for it), and ternary lowers to
-//! an expression-position `If`.
+//! they are language-specific: compound assignment is desugared (no core node
+//! for it), and ternary lowers to an expression-position `If`. `await e` stays
+//! as a source-backed async boundary until a protocol contract proves erasure.
 
 use crate::lower::Lowering;
 use nose_il::{
@@ -733,11 +733,13 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             .named_child(0)
             .map(|c| lower_expr(lo, c))
             .unwrap_or_else(|| lo.empty_block(span)),
-        // Strip `await` so sync and async variants converge.
-        "await" => node
-            .named_child(0)
-            .map(|c| lower_expr(lo, c))
-            .unwrap_or_else(|| lo.empty_block(span)),
+        "await" => {
+            let value = node
+                .named_child(0)
+                .map(|c| lower_expr(lo, c))
+                .unwrap_or_else(|| lo.empty_block(span));
+            lo.await_boundary(span, value)
+        }
         "named_expression" => {
             // walrus `name := value` → Assign in expression position
             let lhs = node
@@ -766,10 +768,10 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             .named_child(0)
             .map(|c| lower_expr(lo, c))
             .unwrap_or_else(|| lo.empty_block(span)),
-        "yield" => node
-            .named_child(0)
-            .map(|c| lower_expr(lo, c))
-            .unwrap_or_else(|| lo.empty_block(span)),
+        "yield" => {
+            let value = node.named_child(0).map(|c| lower_expr(lo, c));
+            lo.yield_boundary(span, value)
+        }
         _ => {
             let kids: Vec<NodeId> = Lowering::named_children(node)
                 .into_iter()
@@ -1174,6 +1176,7 @@ fn py_cmp_op(text: &str) -> Option<(Op, bool, Option<SourceOperatorKind>)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nose_il::SourceProtocolKind;
 
     #[test]
     fn literal_match_lowers_without_raw_case_nodes() {
@@ -1231,6 +1234,44 @@ mod tests {
                 .iter()
                 .any(|node| node.kind == NodeKind::BinOp && node.payload == Payload::Op(Op::Or)),
             "or-pattern match should lower to an OR condition"
+        );
+    }
+
+    #[test]
+    fn await_expression_preserves_source_backed_async_boundary() {
+        let interner = Interner::new();
+        let il = lower(
+            FileId(0),
+            "t.py",
+            b"async def f(x):\n    return await x + 1\n",
+            &interner,
+        )
+        .expect("lower");
+
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "await",
+            SourceProtocolKind::Await,
+        );
+    }
+
+    #[test]
+    fn yield_expression_preserves_source_backed_protocol_boundary() {
+        let interner = Interner::new();
+        let il = lower(
+            FileId(0),
+            "t.py",
+            b"def f(x):\n    yield x + 1\n",
+            &interner,
+        )
+        .expect("lower");
+
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "yield",
+            SourceProtocolKind::Yield,
         );
     }
 

--- a/crates/nose-frontend/src/rust.rs
+++ b/crates/nose-frontend/src/rust.rs
@@ -1,16 +1,18 @@
 //! Rust → raw IL lowering.
 //!
-//! Convergence-friendly lowering: `?` and `.await` are stripped to their operand;
-//! `&x`/`&mut x`/`*x` references peel to the operand; `x op= y` desugars to an
-//! assignment; `for`/`while`/`loop` map to the unified `Loop`; `match` becomes an
-//! `if`/`else if` chain (arm pattern as the condition); `if let`/`while let`
-//! preserve their pattern tests. `fn` items become function units; `impl`,
+//! Convergence-friendly lowering: `&x`/`&mut x`/`*x` references peel to the
+//! operand; `x op= y` desugars to an assignment; `for`/`while`/`loop` map to the
+//! unified `Loop`; `match` becomes an `if`/`else if` chain (arm pattern as the
+//! condition); `if let`/`while let` preserve their pattern tests. Rust `?`,
+//! `.await`, and `async {}` stay as source-backed protocol boundaries until
+//! contracts prove their error/async semantics.
+//! `fn` items become function units; `impl`,
 //! `trait`, `struct`, `enum` become class-like units so similar types cluster.
 
 use crate::lower::Lowering;
 use nose_il::{
-    FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload, Span, Symbol,
-    UnitKind,
+    FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload,
+    SourceProtocolKind, Span, Symbol, UnitKind,
 };
 use tree_sitter::Node as TsNode;
 
@@ -496,8 +498,21 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         "unary_expression" => lower_unary(lo, node),
         "assignment_expression" => crate::lower::assignment(lo, node, lower_expr),
         "compound_assignment_expr" => lower_compound_assign(lo, node),
-        // peel try / await / paren wrappers to their operand
-        "try_expression" | "await_expression" | "parenthesized_expression" => node
+        "try_expression" => {
+            let value = node
+                .named_child(0)
+                .map(|c| lower_expr(lo, c))
+                .unwrap_or_else(|| lo.empty_block(span));
+            lo.protocol_boundary(span, SourceProtocolKind::TryPropagation, "try", &[value])
+        }
+        "await_expression" => {
+            let value = node
+                .named_child(0)
+                .map(|c| lower_expr(lo, c))
+                .unwrap_or_else(|| lo.empty_block(span));
+            lo.await_boundary(span, value)
+        }
+        "parenthesized_expression" => node
             .named_child(0)
             .map(|c| lower_expr(lo, c))
             .unwrap_or_else(|| lo.empty_block(span)),
@@ -585,12 +600,13 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             .named_child(0)
             .map(|c| lower_expr(lo, c))
             .unwrap_or_else(|| lo.empty_block(span)),
-        // `async { … }` / `async move { … }` is a wrapper around the block; `.await`
-        // is already peeled above.
-        "async_block" => node
-            .named_child(0)
-            .map(|c| lower_expr(lo, c))
-            .unwrap_or_else(|| lo.empty_block(span)),
+        "async_block" => {
+            let body = node
+                .named_child(0)
+                .map(|c| lower_expr(lo, c))
+                .unwrap_or_else(|| lo.empty_block(span));
+            lo.protocol_boundary(span, SourceProtocolKind::AsyncBlock, "async_block", &[body])
+        }
         // Type-level nodes carry no runtime behavior — erase (don't Raw). These reach
         // expression position via turbofish, casts, and closure/fn param subtrees.
         "type_arguments"
@@ -1427,7 +1443,7 @@ mod tests {
     }
 
     #[test]
-    fn async_blocks_lower_to_body_not_raw() {
+    fn async_blocks_preserve_source_backed_protocol_boundaries() {
         let interner = Interner::new();
         let il = lower(
             FileId(0),
@@ -1437,18 +1453,17 @@ mod tests {
         )
         .expect("lower");
 
-        let raw: Vec<_> = il
-            .nodes
-            .iter()
-            .filter(|node| node.kind == NodeKind::Raw)
-            .filter_map(|node| match node.payload {
-                Payload::Name(sym) => Some(interner.resolve(sym)),
-                _ => None,
-            })
-            .collect();
-        assert!(
-            raw.is_empty(),
-            "async block should lower without Raw: {raw:?}"
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "async_block",
+            SourceProtocolKind::AsyncBlock,
+        );
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "await",
+            SourceProtocolKind::Await,
         );
 
         let ops: Vec<_> = il
@@ -1460,5 +1475,24 @@ mod tests {
             })
             .collect();
         assert!(ops.contains(&Op::Add), "async block body was lost: {ops:?}");
+    }
+
+    #[test]
+    fn try_expression_preserves_source_backed_protocol_boundary() {
+        let interner = Interner::new();
+        let il = lower(
+            FileId(0),
+            "t.rs",
+            b"fn f(x: Result<i32, E>) -> Result<i32, E> { Ok(x? + 1) }\n",
+            &interner,
+        )
+        .expect("lower");
+
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "try",
+            SourceProtocolKind::TryPropagation,
+        );
     }
 }

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -26,7 +26,7 @@ pub use node::{
     ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, LibraryApiEvidenceKind,
     LitClass, LoopKind, Node, NodeId, NodeKind, Op, ParamSemantic, Payload, PlaceEvidenceKind,
     SequenceSurfaceKind, SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
-    SymbolEvidenceKind,
+    SourceProtocolKind, SymbolEvidenceKind,
 };
 pub use span::{FileId, FileMeta, Lang, Span};
 

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -425,6 +425,7 @@ pub struct EvidenceRecord {
 pub enum SourceFactKind {
     Operator(SourceOperatorKind),
     Call(SourceCallKind),
+    Protocol(SourceProtocolKind),
     Literal(SourceLiteralKind),
 }
 
@@ -445,6 +446,14 @@ pub enum SourceOperatorKind {
 pub enum SourceCallKind {
     Construct,
     MacroInvocation,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum SourceProtocolKind {
+    Await,
+    AsyncBlock,
+    TryPropagation,
+    Yield,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -11,7 +11,8 @@ use nose_il::{
     EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceRecord, EvidenceStatus, GuardEvidenceKind,
     HoFKind, Il, ImportEvidenceKind, Interner, Lang, LibraryApiEvidenceKind, LitClass, NodeId,
     NodeKind, Op, ParamSemantic, Payload, PlaceEvidenceKind, SequenceSurfaceKind, SourceCallKind,
-    SourceFactKind, SourceLiteralKind, SourceOperatorKind, Span, Symbol, SymbolEvidenceKind,
+    SourceFactKind, SourceLiteralKind, SourceOperatorKind, SourceProtocolKind, Span, Symbol,
+    SymbolEvidenceKind,
 };
 use rustc_hash::FxHashMap;
 
@@ -122,6 +123,7 @@ pub fn source_fact_at_node(il: &Il, node: NodeId, kind: SourceFactKind) -> bool 
     match kind {
         SourceFactKind::Operator(operator) => source_operator_at_node(il, node) == Some(operator),
         SourceFactKind::Call(call) => source_call_at_node(il, node) == Some(call),
+        SourceFactKind::Protocol(protocol) => source_protocol_at_node(il, node) == Some(protocol),
         SourceFactKind::Literal(literal) => source_literal_at_node(il, node) == Some(literal),
     }
 }
@@ -144,6 +146,17 @@ pub fn source_call_at_node(il: &Il, node: NodeId) -> Option<SourceCallKind> {
         _ => None,
     }) {
         EvidenceResolution::Found(call) => Some(call),
+        EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
+    }
+}
+
+pub fn source_protocol_at_node(il: &Il, node: NodeId) -> Option<SourceProtocolKind> {
+    let span = il.node(node).span;
+    match evidence_at_span(il, span, |evidence| match evidence {
+        EvidenceKind::Source(SourceFactKind::Protocol(protocol)) => Some(protocol),
+        _ => None,
+    }) {
+        EvidenceResolution::Found(protocol) => Some(protocol),
         EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
     }
 }
@@ -13013,7 +13026,13 @@ mod tests {
         let mut b = IlBuilder::new(FileId(0));
         let call = b.add(NodeKind::Call, Payload::None, sp(7), &[]);
         let regex = b.add(NodeKind::Lit, Payload::LitStr(42), sp(8), &[]);
-        let root = b.add(NodeKind::Block, Payload::None, sp(7), &[call, regex]);
+        let await_boundary = b.add(NodeKind::Raw, Payload::None, sp(9), &[]);
+        let root = b.add(
+            NodeKind::Block,
+            Payload::None,
+            sp(7),
+            &[call, regex, await_boundary],
+        );
         let mut il = finish_il(b, root, Lang::JavaScript);
         il.evidence.push(evidence(
             0,
@@ -13027,9 +13046,19 @@ mod tests {
             EvidenceKind::Source(SourceFactKind::Literal(SourceLiteralKind::Regex)),
             EvidenceStatus::Asserted,
         ));
+        il.evidence.push(evidence(
+            2,
+            EvidenceAnchor::source_span(sp(9)),
+            EvidenceKind::Source(SourceFactKind::Protocol(SourceProtocolKind::Await)),
+            EvidenceStatus::Asserted,
+        ));
 
         assert!(construct_syntax_proof(&il, call));
         assert!(regex_literal_proof(&il, regex));
+        assert_eq!(
+            source_protocol_at_node(&il, await_boundary),
+            Some(SourceProtocolKind::Await)
+        );
         assert!(!construct_syntax_proof(&il, regex));
         assert_eq!(
             source_fact_contract(SourceFactKind::Call(SourceCallKind::Construct)).channel,

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -54,7 +54,7 @@ The current implemented kinds are:
 
 | kind | purpose |
 |---|---|
-| `Source` | construct syntax, Rust macro invocation syntax, regex literal provenance, and source operator family |
+| `Source` | construct syntax, Rust macro invocation syntax, async/generator/error protocol boundary syntax, regex literal provenance, and source operator family |
 | `Domain` | parameter, receiver-expression, or value/binding domain such as collection, map, option, string, integer, or byte array |
 | `Import` | static import binding/namespace proof, Java wildcard import proof, Ruby `require` module proof, and imported-literal snapshot provenance |
 | `Symbol` | resolved or proven symbol identity, with record kinds for unshadowed globals, static imported binding/namespace aliases, and selected qualified global API paths |
@@ -265,7 +265,13 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   evidence and whose binding has no direct mutation under the current
   first-party mutation scan. Future packs and inference producers should use
   node or binding anchors for receiver-domain proof instead of selector spelling;
-- source-origin facts become `Source` evidence;
+- source-origin facts become `Source` evidence. JS/TS, Python, and Rust `await`
+  expressions preserve a raw async boundary and emit
+  `Source::Protocol(Await)` at that source span. JS/TS and Python `yield`
+  expressions emit `Source::Protocol(Yield)`. Rust `async {}` and `?` emit
+  `Source::Protocol(AsyncBlock)` and `Source::Protocol(TryPropagation)`. These
+  are future protocol/demand proof anchors, not evidence that the source
+  operation is equivalent to its operand or body;
 - import binding and namespace lowering emits `Import` evidence for the proof RHS
   and `Symbol` evidence for the local alias identity;
 - selected top-level Ruby literal `require "module"` calls that occur before a
@@ -365,7 +371,8 @@ validation remain open.
 The first migrated consumers are the shared semantic helpers and their direct
 callers:
 
-- source-fact lookup for construct syntax, regex literal, and operator provenance;
+- source-fact lookup for construct syntax, async/generator/error protocol boundaries,
+  regex literal, and operator provenance;
 - receiver-domain lookup used by post-desugar semantic/value-graph
   membership/property/map/integer gates and strict exact receiver gates.
   Consumers ask `nose-semantics` whether a receiver satisfies a

--- a/docs/home.md
+++ b/docs/home.md
@@ -53,7 +53,7 @@ You want to *change* nose or understand how it works inside.
 - [normalization](normalization.md) — the passes that make behaviorally-equivalent code converge (the hard part).
 - [semantic-kernel](semantic-kernel.md) — semantic-kernel and pack architecture: language/library semantics, extension boundaries, responsibility model, and exact-channel eligibility.
 - [evidence-records](evidence-records.md) — the internal pack-facing evidence substrate for source, domain, import, symbol, guard, place/effect, library API, and sequence-surface facts.
-- [source-facts](source-facts.md) — source-origin evidence for semantic contracts: construct syntax, literal/operator provenance, pack boundaries, and fail-closed exact admission.
+- [source-facts](source-facts.md) — source-origin evidence for semantic contracts: construct syntax, async/generator/error boundaries, literal/operator provenance, pack boundaries, and fail-closed exact admission.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.
 - [fragment-contracts](fragment-contracts.md) — how exact sub-function fragments are modeled: classification, contract, the wrapper-synthesis behavior oracle, the effect algebra, and fail-closed receiver identity.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -429,6 +429,16 @@ and pack ecosystem.
   inner HOF call's admitted `LibraryApi` occurrence instead of a raw method
   selector. Raw Python async-looking field names no longer rewrite to sync names
   until an explicit async/sync protocol evidence path exists.
+- JS/TS, Python, and Rust `await` expressions now preserve a raw async protocol
+  boundary and emit `Source::Protocol(Await)` evidence instead of lowering
+  directly to the operand. JS/TS and Python `yield` expressions preserve raw
+  generator protocol boundaries with `Source::Protocol(Yield)`. Rust `async {}`
+  and `?` also preserve raw protocol boundaries with
+  `Source::Protocol(AsyncBlock)` and
+  `Source::Protocol(TryPropagation)`. This closes the old exact async/sync and
+  error-propagation convergence paths, plus generator/body erasure, until
+  language/runtime-specific protocol contracts can prove receiver, demand,
+  scheduling, suspension, exception, and effect obligations.
 - The protocol/API occurrence closure slice extended `LibraryApi` beyond
   call-only APIs. JS/TS/Java `length` property reads now require a
   `PropertyBuiltin` occurrence anchored to the `Field` node, JS-like `length()`
@@ -503,8 +513,9 @@ Remaining in this phase:
 - Continue moving library API recognition into `LibraryApiContract` rows and
   `LibraryApi` occurrence evidence. The already producer-covered occurrence
   surfaces are now fail-closed on missing evidence; remaining work is promise
-  receiver proof, async/sync protocol convergence, and ecosystem APIs whose
-  receiver/domain/demand obligations are not yet expressible.
+  receiver proof, explicit async/sync protocol convergence contracts, and
+  ecosystem APIs whose receiver/domain/demand obligations are not yet
+  expressible.
   The first internal slice covers collection/map factories, selected
   constructors, Java empty collection constructors, Java `Map.entry`, and the
   shared shadow/import/result
@@ -531,8 +542,8 @@ Remaining in this phase:
   evidence, as do generic Python/Go free-function builtins and selected
   receiver-method families. Lowered sequence-surface consumers are now
   evidence-only where covered. Remaining API work is promise receiver proof,
-  async/sync protocol convergence, and ecosystem APIs only after demand,
-  receiver, and effect obligations are expressible.
+  explicit async/sync protocol convergence contracts, and ecosystem APIs only
+  after demand, receiver, and effect obligations are expressible.
 - Continue import/module proof migration beyond the removed raw import payloads
   and evidence-only import identity path. Value-graph import identity and
   imported-symbol exact proof are now evidence-only, imported literal replacement

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -13,6 +13,12 @@ receiver-domain evidence resolution, and a shared evidence-record substrate for
 source, domain, import, symbol-identity, guard,
 place/effect, selected library API occurrence, value-domain/law contracts, and
 sequence-surface facts.
+JS/TS, Python, and Rust `await` expressions are preserved as raw async protocol
+boundaries with `Source::Protocol(Await)` evidence instead of being erased into
+their operand. JS/TS and Python `yield` expressions are preserved as generator
+protocol boundaries with `Source::Protocol(Yield)`. Rust `async {}` and `?` are
+likewise preserved as protocol boundaries with `Source::Protocol(AsyncBlock)` and
+`Source::Protocol(TryPropagation)`.
 Library/API identity is consolidated through internal `LibraryApiContract` rows
 for factory, constructor, selected property/non-factory method/view surfaces,
 and selected non-call sentinels, with occurrence evidence covering selected
@@ -104,13 +110,18 @@ migrated.
   provenance and independent conformance status are not yet tracked as separate
   value-law evidence records.
 - Source facts are now first-class internal evidence for source distinctions that
-  the shared IL erases. JS/TS frontends emit construct syntax, regex literal,
-  strict/loose equality, strict/loose inequality, and `instanceof` facts. Python
-  emits value equality/inequality and identity equality/inequality facts, and
-  Rust emits macro invocation syntax for selected macro-backed APIs. These are
-  stored directly as `EvidenceRecord::Source`; there is no source-fact side-table
-  fallback. Normalize and detect consume source facts only where a semantic
-  contract requires that exact source surface.
+  the shared IL erases. JS/TS frontends emit construct syntax, async `await`,
+  generator `yield` boundaries, regex literal, strict/loose equality,
+  strict/loose inequality, and `instanceof` facts. Python emits async `await`,
+  generator `yield` boundaries, value equality/inequality, and identity
+  equality/inequality facts, and Rust emits
+  macro invocation syntax for selected macro-backed APIs plus async/error
+  protocol facts for `.await`, `async {}`, and `?`. These are stored directly as
+  `EvidenceRecord::Source`; there is no source-fact side-table fallback.
+  Normalize and detect consume source facts only where a semantic contract
+  requires that exact source surface. Current JS/TS/Python/Rust `await` nodes,
+  JS/TS/Python `yield` nodes, and Rust `async`/`?` nodes remain raw
+  exact-closed protocol anchors until such a contract exists.
 - Free-function builtin contracts are language- and arity-constrained. Supported
   Python/Go free builtins such as `len`, `sum`, `min`, `max`, `any`, `all`, and
   Go `append` require admitted `LibraryApi(FreeFunctionBuiltin)` occurrence
@@ -503,7 +514,11 @@ Semantic knowledge still appears in several forms outside the facade:
   APIs, and broader protocol/API evidence paths still rely on contract rows plus
   local proof or remain exact-closed. Raw Python async-looking field names such
   as `aread` no longer rewrite to sync names without an explicit protocol/API
-  evidence path.
+  evidence path, JS/TS/Python/Rust `await` expressions no longer erase to their
+  operand without async protocol proof, JS/TS/Python `yield` no longer erases to
+  its yielded expression without generator protocol proof, and Rust
+  `async {}`/`?` no longer erase to their body or operand without async/error
+  protocol proof.
 
 These are valuable, but they do not yet share one complete semantic contract
 language.
@@ -546,6 +561,12 @@ this worktree because the required evidence is not yet modeled:
 
 - JS-like `.then(lambda)` does not converge with `await` code until Promise-like
   receiver proof exists.
+- JS/TS, Python, and Rust `await value` does not converge with plain `value`
+  until language/runtime-specific async protocol, demand, scheduling, exception,
+  and effect obligations are modeled. Rust `async {}` and `?` are similarly
+  closed until future/error protocol obligations are modeled. JS/TS and Python
+  `yield value` remains closed against plain `value` until generator demand and
+  suspension semantics are modeled.
 - Plain JS/TS `Map(...)` and `Set(...)` calls do not enter exact matching because
   constructor-only contracts require construct-syntax proof.
 - Ordinary JS/TS string `.test(...)` calls do not enter regex-test exact matching

--- a/docs/source-facts.md
+++ b/docs/source-facts.md
@@ -10,7 +10,9 @@ shape for all semantic evidence is described in
 Source facts are the bridge between source syntax and semantic contracts. They
 preserve source-origin distinctions that the shared IL intentionally abstracts
 away, such as `new Set(...)` versus `Set(...)`, a JavaScript regex literal versus
-an ordinary string, or JavaScript `===` versus `==`.
+an ordinary string, JavaScript `===` versus `==`, `await value` versus a plain
+value expression, `yield value` versus a plain expression, or Rust `expr?`
+versus `expr`.
 
 They are evidence, not semantics. A source fact never approves an exact clone,
 mints a value fingerprint, or bypasses a law. It is admissible only when a
@@ -77,7 +79,7 @@ The pack-facing vocabulary should cover at least these classes.
 | Receiver and domain | array, collection, map, option, string, primitive integer, byte array, promise-like receiver |
 | Operator | strict equality, loose equality, identity equality, value equality, type membership, language membership |
 | Literal and surface | regex literal, string literal, map/object literal, tuple/list/array surface, computed property key |
-| Call shape | constructor call, ordinary function call, method call, property access, macro-like call |
+| Call/protocol shape | constructor call, ordinary function call, method call, property access, macro-like call, async `await` boundary, generator `yield` boundary, Rust `?` error propagation |
 | Sequence and aggregate | collection surface, map-entry surface, iterator surface, exported literal surface |
 | Place and mutation | receiver field, index assignment, builder append, immutable binding, direct write, opaque escape |
 | Module export | exported binding, import dependency, provider mutation proof, importer mutation proof |
@@ -89,11 +91,21 @@ source-fact helpers in `nose-semantics`. Source-origin proof is evidence-only:
 frontends emit `EvidenceKind::Source` records directly, and consumers do not
 fall back to a side-table mirror when source evidence is missing.
 
-- JS/TS lowering emits source facts for construct syntax, regex literals, strict
-  equality, strict inequality, loose equality, loose inequality, and
-  `instanceof`.
-- Python lowering emits source facts for value equality/inequality and identity
+- JS/TS lowering emits source facts for construct syntax, async `await`
+  boundaries, generator `yield` boundaries, regex literals, strict equality,
+  strict inequality, loose equality, loose inequality, and `instanceof`.
+- Python lowering emits source facts for async `await` boundaries, generator
+  `yield` boundaries, value equality/inequality, and identity
   equality/inequality.
+- Rust lowering emits source facts for macro invocation syntax, `.await`, async
+  blocks, and `?` error propagation.
+- JS/TS, Python, and Rust `await` lowering preserves `Raw("await", value)`
+  instead of erasing the source operation. JS/TS and Python `yield` preserves
+  `Raw("yield", value)`. Rust `async {}` and `?` are preserved as
+  `Raw("async_block", body)` and `Raw("try", value)`. Exact async/sync,
+  generator, and error-propagation convergence stays closed until a future
+  protocol contract proves the receiver, demand, scheduling, exception, and
+  effect obligations for that language/runtime.
 - JS-like `new Set(...)` and `new Map(...)` can enter exact matching only when
   construct syntax is proven, the `Set`/`Map` callee has unshadowed-global
   symbol proof, and the collection/map argument remains exact-safe. Plain


### PR DESCRIPTION
## Summary
- add `SourceFactKind::Protocol` with protocol boundary kinds for `await`, `yield`, Rust `async {}`, and Rust `?`
- preserve JS/TS, Python, and Rust async/generator/error protocol surfaces as raw exact-closed IL nodes until future contracts prove their semantics
- add frontend evidence tests and CLI hard negatives for unproven async/sync exact convergence
- update semantic-kernel docs, source-facts, evidence-records, and roadmap snapshot

## Validation
- `cargo test -p nose-frontend --lib`
- `cargo test -p nose-semantics --lib source_fact_contracts_are_span_keyed_evidence -- --nocapture`
- `cargo test -p nose-cli --test cli unproven_ -- --nocapture`
- `awiki lint --root docs`
- `git diff --check`
- `./scripts/check-ci-local.sh --fast`

Refs #109