### PR TITLE
Preserve protocol and demand boundaries

### DIFF
--- a/crates/nose-cli/tests/cli.rs
+++ b/crates/nose-cli/tests/cli.rs
@@ -641,6 +641,269 @@ fn scan_mode_semantic_rejects_unproven_rust_await_sync_convergence() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// Go concurrency and channel operations have synchronization/scheduling
+/// semantics. They must not be erased into ordinary calls or value reads until
+/// a language protocol contract proves the required demand/effect obligations.
+#[test]
+fn scan_mode_semantic_rejects_unproven_go_concurrency_protocol_convergence() {
+    let dir =
+        std::env::temp_dir().join(format!("nose_go_protocol_boundary_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("direct_call.go"),
+        "package p\nfunc direct(x int) { record(x) }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("goroutine.go"),
+        "package p\nfunc goroutine(x int) { go record(x) }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("deferred.go"),
+        "package p\nfunc deferred(x int) { defer record(x) }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("plain_value.go"),
+        "package p\nfunc plain(ch int) int { return ch }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("channel_receive.go"),
+        "package p\nfunc receive(ch chan int) int { return <-ch }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("channel_status.go"),
+        "package p\nfunc status(ch chan int) bool { _, ok := <-ch; return ok }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("constant_status.go"),
+        "package p\nfunc constant(ch chan int) bool { return false }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("send_a.go"),
+        "package p\nfunc sendA(ch chan int, x int) { ch <- x }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("send_b.go"),
+        "package p\nfunc sendB(ch chan int, x int) { ch <- x }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("select_receive.go"),
+        "package p\nfunc selectReceive(ch chan int) int { select { case v := <-ch: return v; default: return 0 } }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("if_receive.go"),
+        "package p\nfunc ifReceive(ch chan int) int { v := <-ch; if v != 0 { return v }; return 0 }\n",
+    )
+    .unwrap();
+
+    let json = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--format",
+        "json",
+        "--top",
+        "0",
+        "--min-size",
+        "1",
+        "--min-lines",
+        "1",
+    ]));
+    for pair in [
+        ["direct_call.go", "goroutine.go"],
+        ["direct_call.go", "deferred.go"],
+        ["plain_value.go", "channel_receive.go"],
+        ["channel_status.go", "constant_status.go"],
+        ["send_a.go", "send_b.go"],
+        ["select_receive.go", "if_receive.go"],
+    ] {
+        assert!(
+            !family_contains_all(&json, &pair),
+            "Go protocol boundary must not be erased into an ordinary exact semantic family for {pair:?}: {json}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Python comprehension source surfaces are not interchangeable. A list
+/// comprehension is eager and materialized, a generator expression is lazy and
+/// one-shot, and a set comprehension deduplicates and is unordered.
+#[test]
+fn scan_mode_semantic_rejects_unproven_python_comprehension_surface_convergence() {
+    let dir = std::env::temp_dir().join(format!(
+        "nose_py_comprehension_boundary_{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("list_value.py"),
+        "def f(xs):\n    return [x * x for x in xs]\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("generator_value.py"),
+        "def f(xs):\n    return (x * x for x in xs)\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("set_value.py"),
+        "def f(xs):\n    return {x * x for x in xs}\n",
+    )
+    .unwrap();
+
+    let json = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--format",
+        "json",
+        "--top",
+        "0",
+        "--min-size",
+        "1",
+        "--min-lines",
+        "1",
+    ]));
+    for pair in [
+        ["list_value.py", "generator_value.py"],
+        ["list_value.py", "set_value.py"],
+        ["generator_value.py", "set_value.py"],
+    ] {
+        assert!(
+            !family_contains_all(&json, &pair),
+            "Python comprehension surfaces must not merge without materialization/demand proof for {pair:?}: {json}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Terminal consumers may reopen supported list/generator count reductions, but
+/// `len(generator)` is a TypeError and `len(set_comprehension)` observes
+/// deduplication rather than iteration count.
+#[test]
+fn scan_mode_semantic_respects_python_comprehension_cardinality_boundaries() {
+    let dir = std::env::temp_dir().join(format!(
+        "nose_py_comprehension_cardinality_{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("list_len.py"),
+        "def f(xs):\n    return len([x for x in xs if x > 0])\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("sum_count.py"),
+        "def f(xs):\n    return sum(1 for x in xs if x > 0)\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("generator_len.py"),
+        "def f(xs):\n    return len(x for x in xs if x > 0)\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("set_len.py"),
+        "def f(xs):\n    return len({x % 2 for x in xs})\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("list_mod_len.py"),
+        "def f(xs):\n    return len([x % 2 for x in xs])\n",
+    )
+    .unwrap();
+
+    let json = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--format",
+        "json",
+        "--top",
+        "0",
+        "--min-size",
+        "1",
+        "--min-lines",
+        "1",
+    ]));
+    assert!(
+        family_contains_all(&json, &["list_len.py", "sum_count.py"]),
+        "proof-backed list comprehension cardinality should still converge with a count reduction: {json}"
+    );
+    for pair in [
+        ["generator_len.py", "list_len.py"],
+        ["generator_len.py", "sum_count.py"],
+        ["set_len.py", "list_mod_len.py"],
+    ] {
+        assert!(
+            !family_contains_all(&json, &pair),
+            "unsupported Python comprehension cardinality must stay closed for {pair:?}: {json}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Generator expression construction is lazy. Its body must not be treated like
+/// an eager list comprehension body for exception timing.
+#[test]
+fn scan_mode_semantic_respects_python_generator_lazy_exception_timing() {
+    let dir = std::env::temp_dir().join(format!(
+        "nose_py_generator_lazy_exception_{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("eager_list.py"),
+        "def f():\n    try:\n        return [1 / 0 for x in [1]]\n    except ZeroDivisionError:\n        return 7\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("lazy_generator.py"),
+        "def f():\n    try:\n        return (1 / 0 for x in [1])\n    except ZeroDivisionError:\n        return 7\n",
+    )
+    .unwrap();
+
+    let json = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--format",
+        "json",
+        "--top",
+        "0",
+        "--min-size",
+        "1",
+        "--min-lines",
+        "1",
+    ]));
+    assert!(
+        !family_contains_all(&json, &["eager_list.py", "lazy_generator.py"]),
+        "generator construction must not inherit eager list-comprehension exception timing: {json}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn scan_human_hides_generated_header_families() {
     let dir = make_generated_header_project("human");

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -6,36 +6,37 @@
 use crate::abstraction;
 use crate::fragment::{FragmentKind, ProofFacts};
 use nose_il::{
-    Builtin, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload, Symbol,
-    UnitKind,
+    Builtin, HoFKind, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload,
+    SourceComprehensionKind, Symbol, UnitKind,
 };
 use nose_normalize::{
     module_facts::{collect_module_mutations, mutating_method_name},
     node_tag,
 };
 use nose_semantics::{
-    builder_append_call_args, construct_syntax_proof, exact_java_return_this,
-    exact_non_overloadable_index_assignment, exact_non_overloadable_index_assignment_parts,
-    exact_self_field_write_assignment, exact_static_membership_predicate_operator,
-    go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
-    go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract,
-    library_api_contract_evidence_for_call, library_api_contract_evidence_for_node,
-    library_free_name_collection_factory_contract, library_free_name_map_factory_contract,
-    library_imported_collection_factory_contracts, library_iterator_identity_adapter_contract,
-    library_java_collection_constructor_contract, library_java_collection_factory_contract,
-    library_java_map_entry_contract, library_java_map_factory_contract,
-    library_js_array_is_array_contract, library_js_like_map_constructor_contract,
-    library_js_like_set_constructor_contract, library_map_get_contract,
-    library_map_key_view_contract, library_map_key_view_wrapper_contract,
+    admitted_hof_api_at_node, builder_append_call_args, construct_syntax_proof,
+    exact_java_return_this, exact_non_overloadable_index_assignment,
+    exact_non_overloadable_index_assignment_parts, exact_self_field_write_assignment,
+    exact_static_membership_predicate_operator, go_zero_map_default_kind,
+    go_zero_map_entry_contract_for_node, go_zero_map_literal_contract_for_node,
+    go_zero_map_lookup_contract, library_api_contract_evidence_for_call,
+    library_api_contract_evidence_for_node, library_free_name_collection_factory_contract,
+    library_free_name_map_factory_contract, library_imported_collection_factory_contracts,
+    library_iterator_identity_adapter_contract, library_java_collection_constructor_contract,
+    library_java_collection_factory_contract, library_java_map_entry_contract,
+    library_java_map_factory_contract, library_js_array_is_array_contract,
+    library_js_like_map_constructor_contract, library_js_like_set_constructor_contract,
+    library_map_get_contract, library_map_key_view_contract, library_map_key_view_wrapper_contract,
     library_method_call_contract, library_regex_test_contract, library_ruby_set_factory_contract,
     library_rust_option_none_sentinel_contract, library_rust_vec_macro_factory_contract,
     library_rust_vec_new_factory_contract, library_static_index_membership_contract,
     nullish_global_contract, own_property_guard_for_node, record_shape_guard_for_node, semantics,
-    seq_surface_contract_for_node, source_operator_at_node, typeof_operator_contract,
-    unshadowed_global_symbol, DomainRequirement, IndexMembershipThreshold, JavaMapFactoryKind,
-    LibraryApiCalleeContract, LibraryApiEvidenceStatus, LibraryCollectionFactoryResult,
-    LibraryMapFactoryResult, LibraryMapGetContract, LibraryMethodCallContract, MapKeyViewKind,
-    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
+    seq_surface_contract_for_node, source_comprehension_at_node, source_operator_at_node,
+    typeof_operator_contract, unshadowed_global_symbol, DomainRequirement,
+    IndexMembershipThreshold, JavaMapFactoryKind, LibraryApiCalleeContract,
+    LibraryApiEvidenceStatus, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
+    LibraryMapGetContract, LibraryMethodCallContract, MapKeyViewKind, MethodBuiltinArgs,
+    MethodReceiverContract, MethodSemanticContract, StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::time::Instant;
@@ -868,6 +869,7 @@ fn strict_exact_safe_tree(il: &Il, interner: &Interner, facts: &StrictFacts, nod
                     .all(|&c| strict_exact_safe_tree(il, interner, facts, c))
         }
         NodeKind::Call => strict_exact_safe_call(il, interner, facts, node),
+        NodeKind::HoF => strict_exact_safe_hof(il, interner, facts, node),
         NodeKind::Index
             if strict_exact_go_literal_zero_map_index_safe(il, interner, facts, node) =>
         {
@@ -890,6 +892,106 @@ fn strict_exact_safe_tree(il: &Il, interner: &Interner, facts: &StrictFacts, nod
             .iter()
             .all(|&c| strict_exact_safe_tree(il, interner, facts, c)),
     }
+}
+
+fn strict_exact_safe_hof(il: &Il, interner: &Interner, facts: &StrictFacts, node: NodeId) -> bool {
+    match source_comprehension_at_node(il, node) {
+        Some(SourceComprehensionKind::PythonListComprehension)
+        | Some(SourceComprehensionKind::PythonDictComprehension) => {
+            strict_exact_hof_children_safe(il, interner, facts, node)
+        }
+        Some(
+            SourceComprehensionKind::PythonGeneratorExpression
+            | SourceComprehensionKind::PythonSetComprehension,
+        ) => false,
+        None => match il.node(node).payload {
+            Payload::HoF(kind) if admitted_hof_api_at_node(il, node, kind) => {
+                strict_exact_hof_children_safe(il, interner, facts, node)
+            }
+            _ => false,
+        },
+    }
+}
+
+fn strict_exact_terminal_reduction_arg_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+) -> bool {
+    if il.kind(node) != NodeKind::HoF {
+        return strict_exact_safe_tree(il, interner, facts, node);
+    }
+    match source_comprehension_at_node(il, node) {
+        Some(
+            SourceComprehensionKind::PythonGeneratorExpression
+            | SourceComprehensionKind::PythonListComprehension,
+        ) => strict_exact_hof_children_safe(il, interner, facts, node),
+        Some(
+            SourceComprehensionKind::PythonDictComprehension
+            | SourceComprehensionKind::PythonSetComprehension,
+        ) => false,
+        None => match il.node(node).payload {
+            Payload::HoF(kind) if admitted_hof_api_at_node(il, node, kind) => {
+                strict_exact_hof_children_safe(il, interner, facts, node)
+            }
+            _ => false,
+        },
+    }
+}
+
+fn strict_exact_len_arg_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+) -> bool {
+    if il.kind(node) != NodeKind::HoF {
+        return strict_exact_safe_tree(il, interner, facts, node);
+    }
+    match source_comprehension_at_node(il, node) {
+        Some(SourceComprehensionKind::PythonListComprehension) => {
+            strict_exact_hof_children_safe(il, interner, facts, node)
+        }
+        Some(
+            SourceComprehensionKind::PythonDictComprehension
+            | SourceComprehensionKind::PythonGeneratorExpression
+            | SourceComprehensionKind::PythonSetComprehension,
+        ) => false,
+        None => match il.node(node).payload {
+            Payload::HoF(kind) if admitted_hof_api_at_node(il, node, kind) => {
+                strict_exact_hof_children_safe(il, interner, facts, node)
+            }
+            _ => false,
+        },
+    }
+}
+
+fn strict_exact_hof_children_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+) -> bool {
+    il.children(node).iter().all(|&child| {
+        if il.kind(child) == NodeKind::HoF {
+            strict_exact_hof_internal_safe(il, interner, facts, child)
+        } else {
+            strict_exact_safe_tree(il, interner, facts, child)
+        }
+    })
+}
+
+fn strict_exact_hof_internal_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+) -> bool {
+    matches!(
+        il.node(node).payload,
+        Payload::HoF(HoFKind::Map | HoFKind::FlatMap | HoFKind::Filter | HoFKind::FilterMap)
+    ) && strict_exact_hof_children_safe(il, interner, facts, node)
 }
 
 fn strict_exact_in_membership_safe(
@@ -1208,11 +1310,22 @@ fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, nod
             && strict_exact_safe_tree(il, interner, facts, kids[0])
             && strict_exact_membership_collection_safe(il, interner, facts, kids[1]);
     }
-    if matches!(il.node(node).payload, Payload::Builtin(_)) {
-        return il
-            .children(node)
-            .iter()
-            .all(|&c| strict_exact_safe_tree(il, interner, facts, c));
+    if let Payload::Builtin(builtin) = il.node(node).payload {
+        let kids = il.children(node);
+        return match builtin {
+            Builtin::Len if kids.len() == 1 => {
+                strict_exact_len_arg_safe(il, interner, facts, kids[0])
+            }
+            Builtin::Sum | Builtin::Any | Builtin::All if kids.len() == 1 => {
+                strict_exact_terminal_reduction_arg_safe(il, interner, facts, kids[0])
+            }
+            Builtin::Min | Builtin::Max if kids.len() == 1 => {
+                strict_exact_terminal_reduction_arg_safe(il, interner, facts, kids[0])
+            }
+            _ => kids
+                .iter()
+                .all(|&c| strict_exact_safe_tree(il, interner, facts, c)),
+        };
     }
     if strict_exact_set_constructor_collection_safe(il, interner, facts, node) {
         return true;

--- a/crates/nose-frontend/src/go.rs
+++ b/crates/nose-frontend/src/go.rs
@@ -1,13 +1,14 @@
 //! Go → raw IL lowering.
 //!
 //! Convergence-friendly lowering: `x++`/`x op= y` desugar to assignments; the
-//! several `for` forms map to the unified `Loop`; `*p`, `&x`, `<-ch` unary
-//! wrappers and `go`/`defer` are stripped to their operand; `switch` becomes an
+//! several `for` forms map to the unified `Loop`; Go concurrency/channel
+//! constructs stay as source-backed protocol boundaries; `switch` becomes an
 //! `if`/`else if` chain; `true`/`false`/`nil` identifiers become literals.
 
 use crate::lower::Lowering;
 use nose_il::{
-    Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload, Span,
+    Builtin, FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload,
+    SourceProtocolKind, Span,
 };
 use tree_sitter::Node as TsNode;
 
@@ -60,12 +61,19 @@ fn lower_stmt(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
         }
         "break_statement" => Some(lo.add(NodeKind::Break, Payload::None, span, &[])),
         "continue_statement" => Some(lo.add(NodeKind::Continue, Payload::None, span, &[])),
+        "receive_statement" => Some(lower_receive_statement(lo, node)),
         "send_statement" => Some(lower_send_statement(lo, node)),
-        // strip `go` / `defer` to the called expression
-        "go_statement" | "defer_statement" => node.named_child(0).map(|c| {
-            let e = lower_expr(lo, c);
-            lo.add(NodeKind::ExprStmt, Payload::None, span, &[e])
+        "go_statement" => node.named_child(0).map(|c| {
+            let call = lower_expr(lo, c);
+            let boundary = lo.protocol_boundary(span, SourceProtocolKind::GoRoutine, "go", &[call]);
+            lo.add(NodeKind::ExprStmt, Payload::None, span, &[boundary])
         }),
+        "defer_statement" => node.named_child(0).map(|c| {
+            let call = lower_expr(lo, c);
+            let boundary = lo.protocol_boundary(span, SourceProtocolKind::Defer, "defer", &[call]);
+            lo.add(NodeKind::ExprStmt, Payload::None, span, &[boundary])
+        }),
+        "select_statement" => Some(lower_select_statement(lo, node)),
         "labeled_statement" => {
             // lower the inner statement, ignore the label
             Lowering::named_children(node)
@@ -105,9 +113,74 @@ fn lower_send_statement(lo: &mut Lowering, node: TsNode) -> NodeId {
         .into_iter()
         .map(|child| lower_expr(lo, child))
         .collect();
-    let tag = lo.sym("send_statement");
-    let send = lo.add(NodeKind::Seq, Payload::Name(tag), span, &kids);
+    let send = lo.protocol_boundary(span, SourceProtocolKind::ChannelSend, "channel_send", &kids);
     lo.add(NodeKind::ExprStmt, Payload::None, span, &[send])
+}
+
+fn lower_receive_statement(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let receive_node = Lowering::named_children(node)
+        .into_iter()
+        .find(|child| is_channel_receive_expr(lo, *child));
+    let receive = receive_node
+        .map(|receive| lower_channel_receive_expr(lo, receive))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let lefts = Lowering::named_children(node)
+        .into_iter()
+        .find(|child| child.kind() == "expression_list")
+        .map(expr_list_items)
+        .unwrap_or_default();
+    if let Some(lhs_node) = lefts.into_iter().find(|lhs| lo.text(*lhs) != "_") {
+        let lhs = lower_expr(lo, lhs_node);
+        lo.add(
+            NodeKind::Assign,
+            Payload::None,
+            lo.span(lhs_node),
+            &[lhs, receive],
+        )
+    } else {
+        lo.add(NodeKind::ExprStmt, Payload::None, span, &[receive])
+    }
+}
+
+fn lower_select_statement(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let kids: Vec<NodeId> = Lowering::named_children(node)
+        .into_iter()
+        .map(|child| lower_select_child(lo, child))
+        .collect();
+    lo.protocol_boundary(span, SourceProtocolKind::ChannelSelect, "select", &kids)
+}
+
+fn lower_select_child(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    match node.kind() {
+        "communication_case" => {
+            let kids: Vec<NodeId> = Lowering::named_children(node)
+                .into_iter()
+                .filter_map(|child| lower_stmt(lo, child))
+                .collect();
+            lo.protocol_boundary(
+                span,
+                SourceProtocolKind::ChannelSelectCase,
+                "select_case",
+                &kids,
+            )
+        }
+        "default_case" => {
+            let kids: Vec<NodeId> = Lowering::named_children(node)
+                .into_iter()
+                .filter_map(|child| lower_stmt(lo, child))
+                .collect();
+            lo.protocol_boundary(
+                span,
+                SourceProtocolKind::ChannelSelectDefault,
+                "select_default",
+                &kids,
+            )
+        }
+        _ => lower_stmt(lo, node).unwrap_or_else(|| lower_expr(lo, node)),
+    }
 }
 
 fn lower_static_import(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
@@ -247,6 +320,49 @@ fn lower_assign_like(lo: &mut Lowering, node: TsNode) -> NodeId {
                 };
             }
         }
+        if is_channel_receive_expr(lo, rights[0]) {
+            let mut assigns = Vec::new();
+            let receive_span = lo.span(rights[0]);
+            let channel = rights[0]
+                .child_by_field_name("operand")
+                .map(|operand| lower_expr(lo, operand))
+                .unwrap_or_else(|| lo.empty_block(receive_span));
+            if lo.text(lefts[0]) != "_" {
+                let lhs = lower_expr(lo, lefts[0]);
+                let value = lo.protocol_boundary(
+                    receive_span,
+                    SourceProtocolKind::ChannelReceive,
+                    "channel_receive",
+                    &[channel],
+                );
+                assigns.push(lo.add(
+                    NodeKind::Assign,
+                    Payload::None,
+                    lo.span(lefts[0]),
+                    &[lhs, value],
+                ));
+            }
+            if lo.text(lefts[1]) != "_" {
+                let ok_lhs = lower_expr(lo, lefts[1]);
+                let ok = lo.protocol_boundary(
+                    receive_span,
+                    SourceProtocolKind::ChannelReceive,
+                    "channel_receive_status",
+                    &[channel],
+                );
+                assigns.push(lo.add(
+                    NodeKind::Assign,
+                    Payload::None,
+                    lo.span(lefts[1]),
+                    &[ok_lhs, ok],
+                ));
+            }
+            return if assigns.len() == 1 {
+                assigns[0]
+            } else {
+                lo.add(NodeKind::Block, Payload::None, span, &assigns)
+            };
+        }
     }
 
     let mut assigns = Vec::new();
@@ -297,6 +413,27 @@ fn lower_map_lookup_ok(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
         lo.span(node),
         &[key, map],
     ))
+}
+
+fn is_channel_receive_expr(lo: &Lowering, node: TsNode) -> bool {
+    node.kind() == "unary_expression"
+        && node
+            .child_by_field_name("operator")
+            .is_some_and(|op| lo.text(op) == "<-")
+}
+
+fn lower_channel_receive_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let arg = node
+        .child_by_field_name("operand")
+        .map(|a| lower_expr(lo, a))
+        .unwrap_or_else(|| lo.empty_block(span));
+    lo.protocol_boundary(
+        span,
+        SourceProtocolKind::ChannelReceive,
+        "channel_receive",
+        &[arg],
+    )
 }
 
 fn expr_list_items(node: TsNode) -> Vec<TsNode> {
@@ -806,7 +943,10 @@ fn lower_unary(lo: &mut Lowering, node: TsNode) -> NodeId {
                 .unwrap_or_else(|| lo.empty_block(span));
             lo.add(NodeKind::UnOp, Payload::Op(op), span, &[arg])
         }
-        // `*p`, `&x`, `<-ch`: strip to operand.
+        "<-" => lower_channel_receive_expr(lo, node),
+        // `*p`, `&x`: strip to operand. Pointer/place semantics need a separate
+        // place-evidence slice; channel receive is preserved above because it has
+        // observable synchronization behavior.
         _ => operand
             .map(|a| lower_expr(lo, a))
             .unwrap_or_else(|| lo.empty_block(span)),
@@ -891,29 +1031,101 @@ mod tests {
     }
 
     #[test]
-    fn send_statement_lowers_without_raw() {
+    fn go_defer_and_channel_operations_preserve_source_backed_protocol_boundaries() {
         let interner = Interner::new();
         let il = lower(
             FileId(0),
             "t.go",
-            b"package main\nfunc f(ch chan int, x int) { ch <- x }\n",
+            b"package main\nfunc f(ch chan int, x int) int { go record(x); defer record(x); ch <- x; return <-ch }\n",
             &interner,
         )
         .expect("lower");
 
-        let raw: Vec<_> = il
-            .nodes
-            .iter()
-            .filter(|node| node.kind == NodeKind::Raw)
-            .filter_map(|node| match node.payload {
-                Payload::Name(sym) => Some(interner.resolve(sym)),
-                _ => None,
-            })
-            .collect();
-        assert!(raw.is_empty(), "send should lower without Raw: {raw:?}");
-        assert!(il.nodes.iter().any(|node| {
-            matches!(node.kind, NodeKind::Seq)
-                && matches!(node.payload, Payload::Name(sym) if interner.resolve(sym) == "send_statement")
-        }));
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "go",
+            SourceProtocolKind::GoRoutine,
+        );
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "defer",
+            SourceProtocolKind::Defer,
+        );
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "channel_send",
+            SourceProtocolKind::ChannelSend,
+        );
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "channel_receive",
+            SourceProtocolKind::ChannelReceive,
+        );
+    }
+
+    #[test]
+    fn select_statement_preserves_source_backed_protocol_boundary() {
+        let interner = Interner::new();
+        let il = lower(
+            FileId(0),
+            "t.go",
+            b"package main\nfunc f(ch chan int) { select { case v := <-ch: _ = v; default: return } }\n",
+            &interner,
+        )
+        .expect("lower");
+
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "select",
+            SourceProtocolKind::ChannelSelect,
+        );
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "select_case",
+            SourceProtocolKind::ChannelSelectCase,
+        );
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "select_default",
+            SourceProtocolKind::ChannelSelectDefault,
+        );
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "channel_receive",
+            SourceProtocolKind::ChannelReceive,
+        );
+    }
+
+    #[test]
+    fn comma_ok_receive_preserves_value_and_status_protocol_boundaries() {
+        let interner = Interner::new();
+        let il = lower(
+            FileId(0),
+            "t.go",
+            b"package main\nfunc f(ch chan int) bool { v, ok := <-ch; _ = v; return ok }\n",
+            &interner,
+        )
+        .expect("lower");
+
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "channel_receive",
+            SourceProtocolKind::ChannelReceive,
+        );
+        crate::test_helpers::expect_raw_protocol_boundary(
+            &il,
+            &interner,
+            "channel_receive_status",
+            SourceProtocolKind::ChannelReceive,
+        );
     }
 }

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -10,7 +10,7 @@
 use crate::lower::Lowering;
 use nose_il::{
     Builtin, FileId, HoFKind, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op,
-    Payload, SourceFactKind, SourceOperatorKind, Span, UnitKind,
+    Payload, SourceComprehensionKind, SourceFactKind, SourceOperatorKind, Span, UnitKind,
 };
 use tree_sitter::Node as TsNode;
 
@@ -975,6 +975,9 @@ fn comp_lambda(lo: &mut Lowering, pattern: Option<TsNode>, body: NodeId, bspan: 
 /// first-class flat-map nesting — see [`lower_multi_clause_comprehension`].
 fn lower_comprehension(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
+    if let Some(kind) = python_comprehension_kind(node.kind()) {
+        lo.record_source_fact(span, SourceFactKind::Comprehension(kind));
+    }
     let body_node = node.named_child(0);
 
     let for_clauses = Lowering::named_children(node)
@@ -1022,6 +1025,16 @@ fn lower_comprehension(lo: &mut Lowering, node: TsNode) -> NodeId {
         span,
         &[collection, map_lam],
     )
+}
+
+fn python_comprehension_kind(kind: &str) -> Option<SourceComprehensionKind> {
+    Some(match kind {
+        "list_comprehension" => SourceComprehensionKind::PythonListComprehension,
+        "set_comprehension" => SourceComprehensionKind::PythonSetComprehension,
+        "dictionary_comprehension" => SourceComprehensionKind::PythonDictComprehension,
+        "generator_expression" => SourceComprehensionKind::PythonGeneratorExpression,
+        _ => return None,
+    })
 }
 
 /// Lower a comprehension with more than one `for` clause. `[body for a in A for
@@ -1176,7 +1189,8 @@ fn py_cmp_op(text: &str) -> Option<(Op, bool, Option<SourceOperatorKind>)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_il::SourceProtocolKind;
+    use nose_il::{SourceComprehensionKind, SourceProtocolKind};
+    use nose_semantics::source_comprehension_at_node;
 
     #[test]
     fn literal_match_lowers_without_raw_case_nodes() {
@@ -1203,6 +1217,36 @@ mod tests {
             il.nodes.iter().any(|node| node.kind == NodeKind::If),
             "match should lower to an if-chain"
         );
+    }
+
+    #[test]
+    fn comprehension_surfaces_emit_source_evidence() {
+        let interner = Interner::new();
+        let il = lower(
+            FileId(0),
+            "t.py",
+            b"def a(xs):\n    return [x for x in xs]\ndef b(xs):\n    return {x for x in xs}\ndef c(xs):\n    return {x: x for x in xs}\ndef d(xs):\n    return (x for x in xs)\n",
+            &interner,
+        )
+        .expect("lower");
+
+        for kind in [
+            SourceComprehensionKind::PythonListComprehension,
+            SourceComprehensionKind::PythonSetComprehension,
+            SourceComprehensionKind::PythonDictComprehension,
+            SourceComprehensionKind::PythonGeneratorExpression,
+        ] {
+            let count = il
+                .nodes
+                .iter()
+                .enumerate()
+                .filter(|(_, node)| node.kind == NodeKind::HoF)
+                .filter(|(idx, _)| {
+                    source_comprehension_at_node(&il, NodeId(*idx as u32)) == Some(kind)
+                })
+                .count();
+            assert_eq!(count, 1, "{kind:?} should have one source-backed HoF");
+        }
     }
 
     #[test]

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -25,8 +25,8 @@ pub use node::{
     EvidenceKind, EvidenceProvenance, EvidenceRecord, EvidenceStatus, GuardEvidenceKind, HoFKind,
     ImportEvidenceKind, JsRecordGuardComparison, JsRecordGuardNullCheck, LibraryApiEvidenceKind,
     LitClass, LoopKind, Node, NodeId, NodeKind, Op, ParamSemantic, Payload, PlaceEvidenceKind,
-    SequenceSurfaceKind, SourceCallKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
-    SourceProtocolKind, SymbolEvidenceKind,
+    SequenceSurfaceKind, SourceCallKind, SourceComprehensionKind, SourceFactKind,
+    SourceLiteralKind, SourceOperatorKind, SourceProtocolKind, SymbolEvidenceKind,
 };
 pub use span::{FileId, FileMeta, Lang, Span};
 

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -427,6 +427,7 @@ pub enum SourceFactKind {
     Call(SourceCallKind),
     Protocol(SourceProtocolKind),
     Literal(SourceLiteralKind),
+    Comprehension(SourceComprehensionKind),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
@@ -452,6 +453,13 @@ pub enum SourceCallKind {
 pub enum SourceProtocolKind {
     Await,
     AsyncBlock,
+    ChannelReceive,
+    ChannelSelect,
+    ChannelSelectCase,
+    ChannelSelectDefault,
+    ChannelSend,
+    Defer,
+    GoRoutine,
     TryPropagation,
     Yield,
 }
@@ -459,6 +467,14 @@ pub enum SourceProtocolKind {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub enum SourceLiteralKind {
     Regex,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum SourceComprehensionKind {
+    PythonDictComprehension,
+    PythonGeneratorExpression,
+    PythonListComprehension,
+    PythonSetComprehension,
 }
 
 /// Loop flavor; see [`NodeKind::Loop`] for the child layout each implies.

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -46,7 +46,7 @@ use crate::module_facts::{
 };
 use nose_il::{
     stable_symbol_hash, Builtin, HoFKind, Il, Interner, Lang, LoopKind, NodeId, NodeKind, Op,
-    Payload, Span, Symbol, UnitKind,
+    Payload, SourceComprehensionKind, Span, Symbol, UnitKind,
 };
 use nose_semantics::{
     builder_append_method_contract, builtin_tag, construct_syntax_proof,
@@ -70,16 +70,17 @@ use nose_semantics::{
     library_rust_vec_macro_factory_contract, library_rust_vec_new_factory_contract,
     library_scalar_integer_method_contract, library_static_index_membership_contract,
     nullish_global_contract, own_property_guard_evidence_at_span, record_shape_guard_for_node,
-    reduction_builtin_contract, semantics, seq_surface_contract_for_node, source_operator_at_node,
-    unshadowed_global_symbol, BuiltinArgContract, CardinalityPredicate, CardinalityThreshold,
-    ComparisonLaw, DomainEvidence, DomainRequirement, GoZeroMapDefaultKind, ImportFactKind,
-    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IteratorAdapterReceiverContract,
-    JavaMapFactoryKind, LibraryApiCalleeContract, LibraryApiEvidenceStatus,
-    LibraryApiSpanEvidenceQuery, LibraryCollectionFactoryResult, LibraryMapFactoryResult,
-    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
-    ReductionBuiltinContract, ScalarIntegerMethod, SeqSurfaceContract, StaticIndexMembershipKind,
-    ValueDomain, ValueLaw, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD,
-    SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
+    reduction_builtin_contract, semantics, seq_surface_contract_for_node,
+    source_comprehension_at_node, source_operator_at_node, unshadowed_global_symbol,
+    BuiltinArgContract, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
+    DomainRequirement, GoZeroMapDefaultKind, ImportFactKind, ImportedNamespaceFunctionSemantic,
+    IndexMembershipThreshold, IteratorAdapterReceiverContract, JavaMapFactoryKind,
+    LibraryApiCalleeContract, LibraryApiEvidenceStatus, LibraryApiSpanEvidenceQuery,
+    LibraryCollectionFactoryResult, LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs,
+    MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
+    SeqSurfaceContract, StaticIndexMembershipKind, ValueDomain, ValueLaw, SEQ_VALUE_COLLECTION,
+    SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD,
+    SEQ_VALUE_TUPLE, SEQ_VALUE_UNTAGGED,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
@@ -4303,6 +4304,11 @@ impl<'a> Builder<'a> {
                     | Payload::HoF(HoFKind::FilterMap)
             )
         {
+            if source_comprehension_at_node(self.il, expr)
+                == Some(SourceComprehensionKind::PythonGeneratorExpression)
+            {
+                return false;
+            }
             let kids = self.il.children(expr).to_vec();
             return kids
                 .first()
@@ -6348,6 +6354,12 @@ impl<'a> Builder<'a> {
                 }
             }
             ReductionBuiltinContract::Sum => {
+                if kids
+                    .first()
+                    .is_some_and(|&arg| !self.terminal_reduction_arg_admitted(arg))
+                {
+                    return None;
+                }
                 let av = self.eval(*kids.first()?, env);
                 // `sum(map)` → the mapped stream's per-element contribution; a filtered
                 // map/flat-map carries a predicate and becomes `pred ? contrib : 0`,
@@ -6400,6 +6412,9 @@ impl<'a> Builder<'a> {
                 Some(self.mk(ValOp::Reduce(op), args))
             }
             ReductionBuiltinContract::Selection { max } => {
+                if kids.len() == 1 && !self.terminal_reduction_arg_admitted(kids[0]) {
+                    return None;
+                }
                 let (reduce_code, choice_code) = if max {
                     (REDUCE_MAX, MAX_CODE)
                 } else {
@@ -6467,6 +6482,12 @@ impl<'a> Builder<'a> {
                         pred
                     }
                 } else {
+                    if kids
+                        .first()
+                        .is_some_and(|&arg| !self.terminal_reduction_arg_admitted(arg))
+                    {
+                        return None;
+                    }
                     let av = self.eval(*kids.first()?, env);
                     let (contrib, predicate) = self.collection_elem_with_pred(av);
                     if let Some(predicate) = predicate {
@@ -6491,12 +6512,45 @@ impl<'a> Builder<'a> {
     }
 
     fn eval_len_builtin(&mut self, arg: NodeId, env: &FxHashMap<u32, ValueId>) -> Option<ValueId> {
+        if !self.len_arg_admitted(arg) {
+            return None;
+        }
         if let Some(count) = self.eval_filter_count(arg, env) {
             return Some(count);
         }
 
         let av = self.eval(arg, env);
         self.eval_len_value(av)
+    }
+
+    fn len_arg_admitted(&self, arg: NodeId) -> bool {
+        if self.il.kind(arg) != NodeKind::HoF {
+            return true;
+        }
+        matches!(
+            source_comprehension_at_node(self.il, arg),
+            Some(SourceComprehensionKind::PythonListComprehension)
+        ) || self.admitted_hof_api_at_node(arg)
+    }
+
+    fn terminal_reduction_arg_admitted(&self, arg: NodeId) -> bool {
+        if self.il.kind(arg) != NodeKind::HoF {
+            return true;
+        }
+        matches!(
+            source_comprehension_at_node(self.il, arg),
+            Some(
+                SourceComprehensionKind::PythonGeneratorExpression
+                    | SourceComprehensionKind::PythonListComprehension
+            )
+        ) || self.admitted_hof_api_at_node(arg)
+    }
+
+    fn admitted_hof_api_at_node(&self, node: NodeId) -> bool {
+        match self.il.node(node).payload {
+            Payload::HoF(kind) => nose_semantics::admitted_hof_api_at_node(self.il, node, kind),
+            _ => false,
+        }
     }
 
     fn eval_len_value(&mut self, value: ValueId) -> Option<ValueId> {

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -11,8 +11,8 @@ use nose_il::{
     EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceRecord, EvidenceStatus, GuardEvidenceKind,
     HoFKind, Il, ImportEvidenceKind, Interner, Lang, LibraryApiEvidenceKind, LitClass, NodeId,
     NodeKind, Op, ParamSemantic, Payload, PlaceEvidenceKind, SequenceSurfaceKind, SourceCallKind,
-    SourceFactKind, SourceLiteralKind, SourceOperatorKind, SourceProtocolKind, Span, Symbol,
-    SymbolEvidenceKind,
+    SourceComprehensionKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
+    SourceProtocolKind, Span, Symbol, SymbolEvidenceKind,
 };
 use rustc_hash::FxHashMap;
 
@@ -125,6 +125,9 @@ pub fn source_fact_at_node(il: &Il, node: NodeId, kind: SourceFactKind) -> bool 
         SourceFactKind::Call(call) => source_call_at_node(il, node) == Some(call),
         SourceFactKind::Protocol(protocol) => source_protocol_at_node(il, node) == Some(protocol),
         SourceFactKind::Literal(literal) => source_literal_at_node(il, node) == Some(literal),
+        SourceFactKind::Comprehension(comprehension) => {
+            source_comprehension_at_node(il, node) == Some(comprehension)
+        }
     }
 }
 
@@ -170,6 +173,24 @@ pub fn source_literal_at_node(il: &Il, node: NodeId) -> Option<SourceLiteralKind
         EvidenceResolution::Found(literal) => Some(literal),
         EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
     }
+}
+
+pub fn source_comprehension_at_node(il: &Il, node: NodeId) -> Option<SourceComprehensionKind> {
+    let span = il.node(node).span;
+    match evidence_at_span(il, span, |evidence| match evidence {
+        EvidenceKind::Source(SourceFactKind::Comprehension(comprehension)) => Some(comprehension),
+        _ => None,
+    }) {
+        EvidenceResolution::Found(comprehension) => Some(comprehension),
+        EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
+    }
+}
+
+pub fn admitted_hof_api_at_node(il: &Il, node: NodeId, kind: HoFKind) -> bool {
+    if il.kind(node) != NodeKind::HoF || il.node(node).payload != Payload::HoF(kind) {
+        return false;
+    }
+    library_api_dependency_id_for_normalized_hof(il, node).is_some()
 }
 
 pub fn construct_syntax_proof(il: &Il, node: NodeId) -> bool {

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -54,7 +54,7 @@ The current implemented kinds are:
 
 | kind | purpose |
 |---|---|
-| `Source` | construct syntax, Rust macro invocation syntax, async/generator/error protocol boundary syntax, regex literal provenance, and source operator family |
+| `Source` | construct syntax, Rust macro invocation syntax, async/generator/error and Go concurrency/channel protocol boundary syntax, Python comprehension surface provenance, regex literal provenance, and source operator family |
 | `Domain` | parameter, receiver-expression, or value/binding domain such as collection, map, option, string, integer, or byte array |
 | `Import` | static import binding/namespace proof, Java wildcard import proof, Ruby `require` module proof, and imported-literal snapshot provenance |
 | `Symbol` | resolved or proven symbol identity, with record kinds for unshadowed globals, static imported binding/namespace aliases, and selected qualified global API paths |
@@ -271,7 +271,13 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   expressions emit `Source::Protocol(Yield)`. Rust `async {}` and `?` emit
   `Source::Protocol(AsyncBlock)` and `Source::Protocol(TryPropagation)`. These
   are future protocol/demand proof anchors, not evidence that the source
-  operation is equivalent to its operand or body;
+  operation is equivalent to its operand or body. Go `go`, `defer`, channel
+  send/receive, receive-status projection, `select`, and select cases/defaults
+  likewise preserve source-backed protocol anchors instead of ordinary calls,
+  values, or generic sequences. Python list/set/dict comprehensions and generator
+  expressions emit source-comprehension facts so exact consumers can distinguish
+  eager materialized lists, lazy generators, set deduplication, and dict
+  materialization even when the lowered HOF body shape is similar;
 - import binding and namespace lowering emits `Import` evidence for the proof RHS
   and `Symbol` evidence for the local alias identity;
 - selected top-level Ruby literal `require "module"` calls that occur before a
@@ -371,8 +377,9 @@ validation remain open.
 The first migrated consumers are the shared semantic helpers and their direct
 callers:
 
-- source-fact lookup for construct syntax, async/generator/error protocol boundaries,
-  regex literal, and operator provenance;
+- source-fact lookup for construct syntax, async/generator/error and Go
+  concurrency/channel protocol boundaries, Python comprehension surfaces, regex
+  literal, and operator provenance;
 - receiver-domain lookup used by post-desugar semantic/value-graph
   membership/property/map/integer gates and strict exact receiver gates.
   Consumers ask `nose-semantics` whether a receiver satisfies a
@@ -447,10 +454,11 @@ callers:
   gates now require `Effect`/`Place` evidence. Missing, ambiguous, conflicting,
   or dependency-broken evidence keeps the exact path closed.
 
-Broader field/place/effect facts, promise receiver proof, async/sync protocol
-convergence, unmodeled stdlib/ecosystem APIs, broader inferred
+Broader field/place/effect facts, promise receiver proof, async/sync and
+Go-channel protocol convergence, unmodeled stdlib/ecosystem APIs, broader inferred
 receiver-expression domain evidence, first-class mutation/effect evidence beyond
 the current first-party binding scan, full protocol/demand/effect receiver
-obligations, full scope-resolution and namespace-member evidence, broader guard
+obligations for lazy generators, set/dict materialization, channels, and async,
+full scope-resolution and namespace-member evidence, broader guard
 evidence, general cross-module dependency manifests, report-level provenance,
 and external manifest loading are still open work.

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -60,7 +60,7 @@ blocks lowering to their body instead of a `Raw` wrapper, or Rust
 literal/negative-literal/typed-integer/wildcard/range/tuple/slice/reference/OR/guarded
 `match` arms lowering to an if-chain, or Python
 literal/wildcard/capture/qualified/sequence/OR/as/guarded `match` cases lowering to an if-chain, or Go
-channel send statements lowering to a tagged effect shape, or Go multi-label `switch` cases lowering to
+channel operations lowering to source-backed protocol boundaries, or Go multi-label `switch` cases lowering to
 ORed scrutinee comparisons, or JS/TS stacked `switch` case labels sharing the following
 body, or C/Java `switch` labels lowering to real scrutinee comparisons instead of
 placeholder branches, or Java `switch` expression rules, including block `yield` bodies,

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -439,6 +439,18 @@ and pack ecosystem.
   error-propagation convergence paths, plus generator/body erasure, until
   language/runtime-specific protocol contracts can prove receiver, demand,
   scheduling, suspension, exception, and effect obligations.
+- Go concurrency/channel surfaces now preserve source-backed protocol
+  boundaries. `go`, `defer`, channel send, channel receive, receive-status
+  projection, `select`, and select cases/defaults no longer erase to ordinary
+  calls, operands, or ad hoc sequence tags. Exact/value consumers stay closed
+  until channel/goroutine/defer/select contracts can prove scheduling, blocking,
+  close/zero-value, case-selection, demand, and effect obligations.
+- Python comprehension lowering now emits source facts for list/set/dict
+  comprehensions and generator expressions. Exact HOF admission consumes those
+  facts: list/dict materialized surfaces preserve existing positive recall where
+  modeled, returned generator/set surfaces stay closed, `len(generator)` and
+  set-comprehension cardinality stay closed, and supported terminal reductions
+  reopen generator/list streams only under immediate consumer demand.
 - The protocol/API occurrence closure slice extended `LibraryApi` beyond
   call-only APIs. JS/TS/Java `length` property reads now require a
   `PropertyBuiltin` occurrence anchored to the `Field` node, JS-like `length()`
@@ -513,9 +525,10 @@ Remaining in this phase:
 - Continue moving library API recognition into `LibraryApiContract` rows and
   `LibraryApi` occurrence evidence. The already producer-covered occurrence
   surfaces are now fail-closed on missing evidence; remaining work is promise
-  receiver proof, explicit async/sync protocol convergence contracts, and
-  ecosystem APIs whose receiver/domain/demand obligations are not yet
-  expressible.
+  receiver proof, explicit async/sync and Go channel protocol convergence
+  contracts, richer Python/Ruby/Java/Rust iterator materialization/demand
+  contracts, and ecosystem APIs whose receiver/domain/demand obligations are not
+  yet expressible.
   The first internal slice covers collection/map factories, selected
   constructors, Java empty collection constructors, Java `Map.entry`, and the
   shared shadow/import/result
@@ -613,7 +626,10 @@ different APIs.
   per-element callback effects, async scheduling, yields, and stream emissions.
 - Refactor oracle and value graph to consume demand rules instead of local
   hard-coded evaluation behavior.
-- Add lazy iterator/generator hard negatives before enabling new exact laws.
+- Keep expanding lazy iterator/generator/channel hard negatives before enabling
+  new exact laws. The first Python generator/list/set and Go channel/goroutine
+  hard negatives are now in place, but the shared demand/effect abstraction is
+  still future work.
 
 ## Phase 6: ecosystem packs
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -18,7 +18,13 @@ boundaries with `Source::Protocol(Await)` evidence instead of being erased into
 their operand. JS/TS and Python `yield` expressions are preserved as generator
 protocol boundaries with `Source::Protocol(Yield)`. Rust `async {}` and `?` are
 likewise preserved as protocol boundaries with `Source::Protocol(AsyncBlock)` and
-`Source::Protocol(TryPropagation)`.
+`Source::Protocol(TryPropagation)`. Go goroutine spawn, deferred calls, channel
+send/receive, receive-status projections, and `select` boundaries are also
+preserved as raw source-backed protocol anchors rather than ordinary calls,
+values, or sequence tags. Python comprehension lowering now records whether a
+HOF came from a list comprehension, set comprehension, dict comprehension, or
+generator expression, and exact/value consumers use that surface evidence before
+applying materialization or demand-sensitive laws.
 Library/API identity is consolidated through internal `LibraryApiContract` rows
 for factory, constructor, selected property/non-factory method/view surfaces,
 and selected non-call sentinels, with occurrence evidence covering selected
@@ -113,15 +119,20 @@ migrated.
   the shared IL erases. JS/TS frontends emit construct syntax, async `await`,
   generator `yield` boundaries, regex literal, strict/loose equality,
   strict/loose inequality, and `instanceof` facts. Python emits async `await`,
-  generator `yield` boundaries, value equality/inequality, and identity
-  equality/inequality facts, and Rust emits
-  macro invocation syntax for selected macro-backed APIs plus async/error
-  protocol facts for `.await`, `async {}`, and `?`. These are stored directly as
+  generator `yield` boundaries, list/set/dict/generator comprehension surfaces,
+  value equality/inequality, and identity equality/inequality facts. Go emits
+  protocol facts for `go`, `defer`, channel send/receive, receive-status
+  projection, `select`, and select cases/defaults. Rust emits macro invocation
+  syntax for selected macro-backed APIs plus async/error protocol facts for
+  `.await`, `async {}`, and `?`. These are stored directly as
   `EvidenceRecord::Source`; there is no source-fact side-table fallback.
   Normalize and detect consume source facts only where a semantic contract
   requires that exact source surface. Current JS/TS/Python/Rust `await` nodes,
-  JS/TS/Python `yield` nodes, and Rust `async`/`?` nodes remain raw
-  exact-closed protocol anchors until such a contract exists.
+  JS/TS/Python `yield` nodes, Rust `async`/`?` nodes, and Go concurrency/channel
+  nodes remain raw exact-closed protocol anchors until such a contract exists.
+  Python returned generator/set comprehensions and unsupported cardinality
+  surfaces stay exact-closed; supported list/generator terminal reductions can
+  still reopen only through consumer-specific demand checks.
 - Free-function builtin contracts are language- and arity-constrained. Supported
   Python/Go free builtins such as `len`, `sum`, `min`, `max`, `any`, `all`, and
   Go `append` require admitted `LibraryApi(FreeFunctionBuiltin)` occurrence
@@ -518,7 +529,11 @@ Semantic knowledge still appears in several forms outside the facade:
   operand without async protocol proof, JS/TS/Python `yield` no longer erases to
   its yielded expression without generator protocol proof, and Rust
   `async {}`/`?` no longer erase to their body or operand without async/error
-  protocol proof.
+  protocol proof. Go `go`/`defer`/channel receive no longer erase to ordinary
+  calls or operands, Go channel send no longer relies on an untyped
+  `send_statement` sequence tag, and Python list/set/dict/generator
+  comprehension surfaces no longer share exact semantics merely because they
+  lower to HOF-shaped IL.
 
 These are valuable, but they do not yet share one complete semantic contract
 language.
@@ -567,6 +582,15 @@ this worktree because the required evidence is not yet modeled:
   closed until future/error protocol obligations are modeled. JS/TS and Python
   `yield value` remains closed against plain `value` until generator demand and
   suspension semantics are modeled.
+- Go `go f(x)`, `defer f(x)`, `<-ch`, `ch <- x`, and `select` do not converge
+  with ordinary calls, values, sends, or sequential control-flow variants until
+  channel/goroutine/defer/select contracts can prove scheduling, blocking,
+  close/zero-value, case-selection, and effect obligations.
+- Python returned generator and set comprehensions do not converge with returned
+  list comprehensions. `len(generator)` and `len(set_comprehension)` stay closed
+  against list cardinality/count reductions until generator demand and set
+  deduplication obligations are modeled. Supported list/generator terminal
+  reductions remain open only where the consumer immediately demands the stream.
 - Plain JS/TS `Map(...)` and `Set(...)` calls do not enter exact matching because
   constructor-only contracts require construct-syntax proof.
 - Ordinary JS/TS string `.test(...)` calls do not enter regex-test exact matching

--- a/docs/source-facts.md
+++ b/docs/source-facts.md
@@ -11,8 +11,9 @@ Source facts are the bridge between source syntax and semantic contracts. They
 preserve source-origin distinctions that the shared IL intentionally abstracts
 away, such as `new Set(...)` versus `Set(...)`, a JavaScript regex literal versus
 an ordinary string, JavaScript `===` versus `==`, `await value` versus a plain
-value expression, `yield value` versus a plain expression, or Rust `expr?`
-versus `expr`.
+value expression, `yield value` versus a plain expression, Rust `expr?` versus
+`expr`, Go `go f()` versus `f()`, or Python list/set/dict/generator
+comprehension surfaces that otherwise lower to similar HOF shapes.
 
 They are evidence, not semantics. A source fact never approves an exact clone,
 mints a value fingerprint, or bypasses a law. It is admissible only when a
@@ -79,7 +80,8 @@ The pack-facing vocabulary should cover at least these classes.
 | Receiver and domain | array, collection, map, option, string, primitive integer, byte array, promise-like receiver |
 | Operator | strict equality, loose equality, identity equality, value equality, type membership, language membership |
 | Literal and surface | regex literal, string literal, map/object literal, tuple/list/array surface, computed property key |
-| Call/protocol shape | constructor call, ordinary function call, method call, property access, macro-like call, async `await` boundary, generator `yield` boundary, Rust `?` error propagation |
+| Call/protocol shape | constructor call, ordinary function call, method call, property access, macro-like call, async `await` boundary, generator `yield` boundary, Rust `?` error propagation, Go goroutine/defer/channel/select boundaries |
+| Comprehension surface | Python list comprehension, set comprehension, dict comprehension, generator expression |
 | Sequence and aggregate | collection surface, map-entry surface, iterator surface, exported literal surface |
 | Place and mutation | receiver field, index assignment, builder append, immutable binding, direct write, opaque escape |
 | Module export | exported binding, import dependency, provider mutation proof, importer mutation proof |
@@ -95,8 +97,13 @@ fall back to a side-table mirror when source evidence is missing.
   boundaries, generator `yield` boundaries, regex literals, strict equality,
   strict inequality, loose equality, loose inequality, and `instanceof`.
 - Python lowering emits source facts for async `await` boundaries, generator
-  `yield` boundaries, value equality/inequality, and identity
-  equality/inequality.
+  `yield` boundaries, list/set/dict/generator comprehension surfaces, value
+  equality/inequality, and identity equality/inequality.
+- Go lowering emits source facts for goroutine spawn, deferred calls, channel
+  send/receive, select, and select case/default protocol boundaries. These
+  surfaces remain raw protocol anchors; `v, ok := <-ch` preserves both the
+  receive value and the status projection without modeling them as ordinary
+  values.
 - Rust lowering emits source facts for macro invocation syntax, `.await`, async
   blocks, and `?` error propagation.
 - JS/TS, Python, and Rust `await` lowering preserves `Raw("await", value)`
@@ -106,6 +113,11 @@ fall back to a side-table mirror when source evidence is missing.
   generator, and error-propagation convergence stays closed until a future
   protocol contract proves the receiver, demand, scheduling, exception, and
   effect obligations for that language/runtime.
+- Python comprehension HOFs consume source surface facts before entering exact
+  consumers. Returned generator and set comprehensions stay distinct from
+  returned list comprehensions; `len(generator)` and set cardinality stay closed.
+  Terminal reductions can still consume supported list/generator comprehension
+  surfaces where the consumer demand is immediate and the body remains exact-safe.
 - JS-like `new Set(...)` and `new Map(...)` can enter exact matching only when
   construct syntax is proven, the `Set`/`Map` callee has unshadowed-global
   symbol proof, and the collection/map argument remains exact-safe. Plain


### PR DESCRIPTION
## Summary

- Preserve Go concurrency/channel constructs as source-backed protocol boundaries: `go`, `defer`, channel send/receive, comma-ok receive status, `select`, and select cases/defaults no longer erase to ordinary calls/values or ad hoc sequence tags.
- Add Python comprehension source evidence for list/set/dict/generator surfaces and require source/API evidence before exact HOF admission.
- Close unsupported Python demand/materialization paths such as returned generator/set convergence, `len(generator)`, set-comprehension cardinality, and lazy generator exception timing while preserving supported list/dict comprehension and terminal reduction positives.

## Behavior Judgment

- Old Go `go`/`defer`/`<-ch` erasure and comma-ok receive collapse were unsound.
- Old Python list/set/generator returned-value convergence and `len(generator)` / `len(set_comprehension)` count convergence were unsound.
- Existing supported recall for list/dict comprehension, JS map, Java stream, Go/Java builder-loop, and count-reduction positives is preserved where current evidence proves the consumer/materialization obligations.

## Validation

- `./scripts/check-ci-local.sh --fast`
- `cargo build --release -p nose-cli`
- `./scripts/check-duplication.sh`
- `python3 scripts/check-formal-obligations.py`
- targeted frontend/CLI/equivalence tests for Go protocol and Python comprehension boundaries

Tracks #109.