### PR TITLE
[codex] Harden CodeRabbit disablement

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,27 +5,38 @@
 # prevents repository-level CodeRabbit activity without changing other repos.
 inheritance: false
 early_access: false
+enable_free_tier: false
 
 reviews:
   request_changes_workflow: false
+  abort_on_close: true
   path_filters:
     - "!**/*"
     - "!**/.*"
     - "!.*"
+  path_instructions: []
   high_level_summary: false
   high_level_summary_placeholder: ""
   high_level_summary_in_walkthrough: false
+  collapse_walkthrough: false
+  review_details: false
   review_status: false
   commit_status: false
   fail_commit_status: false
+  disable_cache: true
   changed_files_summary: false
   sequence_diagrams: false
+  estimate_code_review_effort: false
+  in_progress_fortune: false
+  poem: false
   assess_linked_issues: false
   related_issues: false
   related_prs: false
   suggested_labels: false
   auto_apply_labels: false
+  labeling_instructions: []
   suggested_reviewers: false
+  suggested_reviewers_instructions: []
   auto_assign_reviewers: false
   enable_prompt_for_ai_agents: false
   slop_detection:
@@ -54,11 +65,126 @@ reviews:
     issue_assessment:
       mode: "off"
     custom_checks: []
+  tools:
+    actionlint:
+      enabled: false
+    ast-grep:
+      essential_rules: false
+      packages: []
+      rule_dirs: []
+      util_dirs: []
+    biome:
+      enabled: false
+    blinter:
+      enabled: false
+    brakeman:
+      enabled: false
+    buf:
+      enabled: false
+    checkmake:
+      enabled: false
+    checkov:
+      enabled: false
+    circleci:
+      enabled: false
+    clang:
+      enabled: false
+    clippy:
+      enabled: false
+    cppcheck:
+      enabled: false
+    detekt:
+      enabled: false
+    dotenvLint:
+      enabled: false
+    emberTemplateLint:
+      enabled: false
+    eslint:
+      enabled: false
+    fbinfer:
+      enabled: false
+    flake8:
+      enabled: false
+    fortitudeLint:
+      enabled: false
+    github-checks:
+      enabled: false
+    gitleaks:
+      enabled: false
+    golangci-lint:
+      enabled: false
+    hadolint:
+      enabled: false
+    htmlhint:
+      enabled: false
+    languagetool:
+      enabled: false
+    luacheck:
+      enabled: false
+    markdownlint:
+      enabled: false
+    opengrep:
+      enabled: false
+    osvScanner:
+      enabled: false
+    oxc:
+      enabled: false
+    phpcs:
+      enabled: false
+    phpmd:
+      enabled: false
+    phpstan:
+      enabled: false
+    pmd:
+      enabled: false
+    presidio:
+      enabled: false
+    prismaLint:
+      enabled: false
+    psscriptanalyzer:
+      enabled: false
+    pylint:
+      enabled: false
+    regal:
+      enabled: false
+    rubocop:
+      enabled: false
+    ruff:
+      enabled: false
+    semgrep:
+      enabled: false
+    shellcheck:
+      enabled: false
+    shopifyThemeCheck:
+      enabled: false
+    smartyLint:
+      enabled: false
+    sqlfluff:
+      enabled: false
+    stylelint:
+      enabled: false
+    swiftlint:
+      enabled: false
+    tflint:
+      enabled: false
+    trivy:
+      enabled: false
+    trufflehog:
+      enabled: false
+    yamllint:
+      enabled: false
+    zizmor:
+      enabled: false
 
 chat:
   auto_reply: false
   art: false
   allow_non_org_members: false
+  integrations:
+    jira:
+      usage: "disabled"
+    linear:
+      usage: "disabled"
 
 issue_enrichment:
   auto_enrich:
@@ -75,7 +201,25 @@ issue_enrichment:
 knowledge_base:
   opt_out: true
   automatic_repository_linking: false
+  linked_repositories: []
   code_guidelines:
     enabled: false
+    filePatterns: []
   web_search:
     enabled: false
+  learnings:
+    scope: "local"
+    approval_delay: 30
+  issues:
+    scope: "local"
+  jira:
+    usage: "disabled"
+    project_keys: []
+  linear:
+    usage: "disabled"
+    team_keys: []
+  pull_requests:
+    scope: "local"
+  mcp:
+    usage: "disabled"
+    disabled_servers: []

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -73,15 +73,18 @@ via [check-lean-proofs.sh](../scripts/check-lean-proofs.sh).
 
 ## External review bots
 
-CodeRabbit is disabled for this repository with the root `.coderabbit.yaml`. The
-file opts out of inherited CodeRabbit settings and disables automatic review,
-incremental review, review file scope, chat auto-replies, finishing touches,
-pre-merge checks, issue enrichment, and knowledge-base retention for nose.
+CodeRabbit repository activity is disabled with the root `.coderabbit.yaml`. The
+file opts out of inherited CodeRabbit settings, turns off automatic and
+incremental review, leaves no keyword/label trigger for review opt-in, excludes
+all paths from review scope, disables review statuses, summaries, chat
+auto-replies, finishing touches, pre-merge checks, issue enrichment, knowledge
+base retention, external knowledge sources, and built-in review tools.
 
-The CodeRabbit GitHub App is installed at the `corca-ai` organization level. Fully
-removing repository access requires an organization owner to change the app
-installation from "all repositories" to a selected-repositories installation that
-excludes `corca-ai/nose`, or to uninstall CodeRabbit from the organization.
+That YAML is the repository-owned control. The CodeRabbit GitHub App is installed
+at the `corca-ai` organization level, so fully removing app access still requires
+an organization owner to change the app installation from "all repositories" to a
+selected-repositories installation that excludes `corca-ai/nose`, or to uninstall
+CodeRabbit from the organization.
 
 ## Baselines — incremental adoption
 


### PR DESCRIPTION
## Summary

- harden the repository CodeRabbit disablement in `.coderabbit.yaml`
- explicitly turn off inherited settings, automatic review triggers, review metadata, chat integrations, issue enrichment, knowledge sources, and built-in tools
- clarify in CI docs that YAML disables repository-owned behavior while org-level GitHub App access must be removed by an org owner

## Validation

- `ruby` YAML parse
- strict declared-key/type/enum check against `https://coderabbit.ai/integrations/schema.v2.json`
- `awiki lint --root docs`
- `git diff --check`
