### PR TITLE
Add coverage and complexity quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,25 @@ jobs:
       - name: duplication gate (nose on itself)
         run: ./scripts/check-duplication.sh
 
+  coverage:
+    name: test coverage (llvm-cov)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      # Prebuilt binary — no compile cost.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      # Line-coverage ratchet. The bar starts lenient (current line coverage is
+      # ~87%); raise --fail-under-lines over time as coverage improves. Keep it
+      # in sync with scripts/check-ci-local.sh.
+      - name: coverage gate (>= 85% lines)
+        run: cargo llvm-cov --workspace --summary-only --fail-under-lines 85
+
   msrv:
     name: minimum supported rust version
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ full run here is a green CI. The full gates are:
 | **docs** | `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace` | no broken/private intra-doc links |
 | **build** | `cargo build --release` | the workspace compiles in release |
 | **tests** | `cargo test --release` | the full suite, incl. cross-language convergence |
+| **coverage** | `cargo llvm-cov --workspace --summary-only --fail-under-lines 85` | line coverage stays above the ratchet floor (currently ~87%) |
 | **copy-paste** | `./scripts/check-duplication.sh` | nose run on its own source — substantial duplicate families stay within budget |
 | **MSRV** | `cargo +$MSRV check --workspace --all-targets` | the crates still build on the declared minimum Rust (`rust-version` in `Cargo.toml`) |
 | **unused deps** | `cargo machete` | no dependency declared but unused (à la *knip*) |
@@ -47,16 +48,23 @@ and checked by its own CI job. Bumping the MSRV is a conscious change — update
 `Cargo.toml` and note why.
 
 The lint policy is defined once in the root `Cargo.toml` under `[workspace.lints]`
-and inherited by every crate via `[lints] workspace = true`.
+and inherited by every crate via `[lints] workspace = true`. The tunable
+complexity thresholds (`cognitive-complexity-threshold`, `too-many-arguments`,
+`type-complexity`) live in `clippy.toml`. Both the clippy thresholds and the
+coverage floor start lenient and are **ratchets** — tighten them over time
+(lower the clippy thresholds, raise `--fail-under-lines`) as the code is
+simplified and tests are added; never loosen them to make a red build pass.
 
 ### One-time tool install
 
-`cargo-machete`, `cargo-deny`, [`awiki`](https://github.com/corca-ai/awiki),
-`elan`, and the MSRV Rust toolchain are required for `--full`. `--fast` requires
-the Rust toolchain plus `awiki`. Install the local CI tools with:
+`cargo-machete`, `cargo-deny`, `cargo-llvm-cov`,
+[`awiki`](https://github.com/corca-ai/awiki), `elan`, and the MSRV Rust
+toolchain are required for `--full`. `--fast` requires the Rust toolchain plus
+`awiki`. Install the local CI tools with:
 
 ```sh
-cargo install cargo-machete cargo-deny
+cargo install cargo-machete cargo-deny cargo-llvm-cov
+rustup component add llvm-tools-preview   # cargo-llvm-cov needs this
 brew install corca-ai/tap/awiki   # or: go install github.com/corca-ai/awiki/cmd/awiki@latest
 curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh
 rustup toolchain install 1.85

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,16 @@ unused_qualifications = "warn"
 dbg_macro = "warn"                # no stray `dbg!` in committed code
 todo = "warn"                     # no `todo!()` left in shipped paths
 uninlined_format_args = "warn"    # prefer `format!("{x}")` to `format!("{}", x)`
+# Complexity / readability ratchets. Tunable thresholds live in `clippy.toml`
+# and start lenient so today's code passes; tighten them over time (see that
+# file). These are `warn` here, which CI's `clippy -D warnings` promotes to a
+# hard gate.
+cognitive_complexity = "warn"     # cap per-function branching complexity (tunable)
+# Exhaustiveness: a `_ =>` arm that only stands in for a single remaining enum
+# variant silently swallows the next variant added. Spell it out instead.
+# (The blunter `wildcard_enum_match_arm` is intentionally NOT used — the IL-kind
+# dispatch matches legitimately fold dozens of variants into `_`.)
+match_wildcard_for_single_variants = "warn"
 
 [profile.release]
 opt-level = 3

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,18 @@
+# Clippy configuration — complexity / readability ratchets.
+#
+# These thresholds are the tunable half of the lints enabled in
+# `[workspace.lints.clippy]` (Cargo.toml). They start at deliberately lenient
+# values so today's code passes `clippy -D warnings`; the plan is to ratchet them
+# DOWN (stricter) over time as the code is simplified. Lower = stricter.
+#
+# Run locally with: cargo clippy --all-targets --all-features -- -D warnings
+
+# Per-function cognitive complexity (branch/nesting weighted). Clippy's default
+# is 25; nose's current production ceiling is 68, so this lenient baseline sits
+# just above it. Ratchet downward as complex functions are simplified.
+cognitive-complexity-threshold = 80
+
+# Already enforced by clippy's default `complexity` group; pinned here so the
+# thresholds are visible and ratchetable alongside the others.
+too-many-arguments-threshold = 7
+type-complexity-threshold = 250

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -3668,6 +3668,10 @@ export const replaceRootDirInPath = (rootDir: string, filePath: string): string 
     );
 }
 
+// A long, flat sequence of independent convergence assertions — its cognitive
+// complexity (133) is breadth, not deep branching, so it sits above the gate's
+// production-oriented threshold. Splitting it would not aid readability.
+#[allow(clippy::cognitive_complexity)]
 #[test]
 fn collection_membership_set_construction_converges_with_boundaries() {
     let i = Interner::new();

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -1403,7 +1403,7 @@ impl<'a> Builder<'a> {
                 }
                 match contract.result {
                     LibraryMapFactoryResult::EntrySequence { entry_seq_tag } => Some(entry_seq_tag),
-                    _ => None,
+                    LibraryMapFactoryResult::JavaFactory { .. } => None,
                 }
             })?;
         self.map_factory_from_seq(seq, entry_tag)
@@ -8455,7 +8455,7 @@ impl<'a> Builder<'a> {
                             None => self.mk(ValOp::Hof(HoFKind::Map as u32), vec![elem]),
                         }
                     }
-                    _ => {
+                    HoFKind::Reduce => {
                         let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
                         self.mk(ValOp::Hof(kind as u32), a)
                     }

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -67,9 +67,16 @@ Before merge or release-sensitive work, run the full local CI mirror:
 ```
 
 The full gate mirrors the GitHub Actions jobs: format, clippy, rustdoc warnings,
-release build/tests, the self-hosted duplication gate, MSRV check, supply-chain
-checks, docs wiki connectivity, the formal obligation registry, and Lean soundness proofs
-via [check-lean-proofs.sh](../scripts/check-lean-proofs.sh).
+release build/tests, the `cargo-llvm-cov` coverage floor, the self-hosted
+duplication gate, MSRV check, supply-chain checks, docs wiki connectivity, the
+formal obligation registry, and Lean soundness proofs via
+[check-lean-proofs.sh](../scripts/check-lean-proofs.sh).
+
+The clippy complexity thresholds (`clippy.toml`) and the coverage floor
+(`--fail-under-lines`) are deliberately **ratchets**: they start lenient so
+today's code is green and are tightened over time, never loosened to pass a red
+build. See [CONTRIBUTING](../CONTRIBUTING.md) for the gate table and the current
+values.
 
 ## External review bots
 

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -100,6 +100,10 @@ cargo build --release
 step "test (release)"
 cargo test --release
 
+step "coverage gate (cargo-llvm-cov, >= 85% lines)"
+need_cmd cargo-llvm-cov "install it with: cargo install cargo-llvm-cov"
+cargo llvm-cov --workspace --summary-only --fail-under-lines 85
+
 step "duplication gate (nose on itself)"
 ./scripts/check-duplication.sh
 


### PR DESCRIPTION
## What

Adds two **ratchet-style** quality gates inspired by [Enforcing the quality of AI-generated code](https://wiki.g15e.com/pages/Enforcing%20the%20quality%20of%20AI-generated%20code), mapped to Rust tooling. Both start at a deliberately lenient "basic" setting so today's tree is green; the plan is to tighten them gradually.

### 1. Test coverage — `cargo-llvm-cov`
- New `coverage` CI job: `cargo llvm-cov --workspace --summary-only --fail-under-lines 85`.
- Current line coverage is **87.25%**, so 85% is the lenient floor — raise it over time.
- Wired into `scripts/check-ci-local.sh --full`; documented in `CONTRIBUTING.md` + `docs/continuous-integration.md`.

### 2. Complexity & exhaustiveness — clippy
- `cognitive_complexity` enabled, threshold **80** in `clippy.toml` (production ceiling today is 68 → lenient headroom; ratchet down later).
- `match_wildcard_for_single_variants` enabled — the two single-variant `_` arms in `value_graph.rs` are now spelled out, so a future added enum variant becomes a *compile error*.
- `too-many-arguments` (7) and `type-complexity` (250) thresholds pinned in `clippy.toml` so they're visible and ratchetable (already enforced by clippy's default `complexity` group).
- One long, flat assertion-sequence test carries a documented `#[allow(clippy::cognitive_complexity)]`.

## Deliberately excluded
- **`too_many_lines`** — 79 functions exceed 100 lines (large test functions + inherently-big IL-lowering / value-graph dispatch), and the lint is a fixed 100-line cliff with **no tunable threshold**. There's no lenient baseline short of 79 scattered `#[allow]`s, which contradicts "start lenient." Deferred to a dedicated refactor pass.
- **`wildcard_enum_match_arm`** (blunter exhaustiveness lint) — the IL-kind dispatch matches legitimately fold dozens of variants into `_`; using it would force enumerating dozens of kinds everywhere.
- Per the user's request, this PR does **not** include test:production ratio, magic-number prohibition, or mutation testing.

## Verification (local)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo fmt --all --check`
- ✅ coverage gate: 87.25% lines ≥ 85%
- ✅ full test suite (ran inside llvm-cov)
- ✅ duplication gate: 23/23 (unchanged)
- ✅ `awiki lint --root docs` (graph still fully connected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)