### PR TITLE
Define semantic pack extension API v0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
       # awiki lints the docs/ wiki: fails on orphan pages or disconnected islands.
       - name: install awiki
         run: go install github.com/corca-ai/awiki/cmd/awiki@v0.1.4
-      - name: lint docs graph
-        run: awiki lint --root docs
+      - name: lint docs and semantic pack examples
+        run: ./scripts/check-docs.sh
 
   formal:
     name: formal obligations · lean proofs

--- a/docs/examples/semantic-packs/v0/language-pack.json
+++ b/docs/examples/semantic-packs/v0/language-pack.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "../../../schemas/semantic-pack-v0.schema.json",
+  "api_version": "nose.semantic-pack.v0",
+  "pack": {
+    "id": "com.example.javascript-core-mini",
+    "kind": "LanguagePack",
+    "version": "0.1.0",
+    "display_name": "Example JavaScript core surface pack",
+    "description": "Illustrative v0 language pack metadata for source and symbol facts. This is not a loadable pack.",
+    "trust": "external-opt-in",
+    "enabled_by_default": false,
+    "status": "draft-example"
+  },
+  "provenance": {
+    "provider": {
+      "name": "Example Semantic Packs",
+      "contact": "semantics@example.invalid"
+    },
+    "license": "MIT",
+    "repository": "https://example.invalid/semantic-packs/javascript-core-mini",
+    "source_revision": "0000000000000000000000000000000000000000"
+  },
+  "compatibility": {
+    "nose": ">=0.5.0 <0.6.0",
+    "schema": "v0",
+    "notes": "Example only. Future loaders must compare this range before enabling the pack."
+  },
+  "supported_languages": [
+    {
+      "id": "javascript",
+      "language_version": "ES2020+",
+      "runtime": "ecmascript",
+      "runtime_versions": [
+        "ES2020+"
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "id": "nose.protocol.core",
+      "version": ">=0.1.0 <1.0.0",
+      "required": true
+    }
+  ],
+  "declares": {
+    "evidence_producers": [
+      {
+        "id": "js.source.construct",
+        "kind": "Source.Call.Construct",
+        "anchors": [
+          "node",
+          "source-span"
+        ],
+        "channel": "syntax-only",
+        "emits": [
+          "Source.Call.Construct"
+        ],
+        "requires": [],
+        "stable_hash_inputs": [
+          "api_version",
+          "pack.id",
+          "producer.id",
+          "language.id",
+          "source_span",
+          "node_kind"
+        ],
+        "conflict_policy": "fail-closed",
+        "notes": "Preserves new-expression syntax. It does not prove constructor identity by itself."
+      },
+      {
+        "id": "js.source.strict-equality",
+        "kind": "Source.Operator.StrictEquality",
+        "anchors": [
+          "node",
+          "source-span"
+        ],
+        "channel": "syntax-only",
+        "emits": [
+          "Source.Operator.StrictEquality"
+        ],
+        "requires": [],
+        "stable_hash_inputs": [
+          "api_version",
+          "pack.id",
+          "producer.id",
+          "language.id",
+          "source_span"
+        ],
+        "conflict_policy": "fail-closed",
+        "notes": "Distinguishes === from == so equality-sensitive contracts can require the exact source family."
+      },
+      {
+        "id": "js.symbol.unshadowed-global",
+        "kind": "Symbol.UnshadowedGlobal",
+        "anchors": [
+          "node",
+          "source-span"
+        ],
+        "channel": "syntax-only",
+        "emits": [
+          "Symbol.UnshadowedGlobal"
+        ],
+        "requires": [],
+        "stable_hash_inputs": [
+          "api_version",
+          "pack.id",
+          "producer.id",
+          "language.id",
+          "source_span",
+          "global_name"
+        ],
+        "conflict_policy": "fail-closed",
+        "notes": "A selected global is asserted only when local scope analysis proves no binding shadows it."
+      }
+    ],
+    "contracts": [
+      {
+        "id": "js.operator.strict-equality-source-contract",
+        "surface": {
+          "kind": "operator",
+          "language": "javascript",
+          "selector": "===",
+          "arity": {
+            "min": 2,
+            "max": 2
+          }
+        },
+        "requires": [
+          {
+            "ref": "js.source.strict-equality",
+            "subject": "source",
+            "required": true,
+            "same_anchor_as": "operator-node"
+          }
+        ],
+        "semantics": {
+          "operation": "LanguageCore.StrictEqualitySource",
+          "result_domain": "Boolean",
+          "demand": {
+            "arguments": "eager-left-to-right",
+            "callbacks": "none"
+          },
+          "effects": [
+            "argument-effects-in-order"
+          ],
+          "exceptions": "language-default"
+        },
+        "channel": "syntax-only",
+        "proof_status": "covered",
+        "conformance_refs": [
+          "js-strict-equality-positive",
+          "js-loose-equality-hard-negative"
+        ],
+        "known_unsupported": [
+          "This contract preserves source provenance only; it does not claim all JavaScript equality laws are exact-safe."
+        ],
+        "notes": "Library packs can depend on this source fact when loose equality would be unsound."
+      }
+    ],
+    "value_laws": []
+  },
+  "conformance": {
+    "positive_fixtures": [
+      {
+        "id": "js-strict-equality-positive",
+        "description": "A strict equality source surface emits Source.Operator.StrictEquality.",
+        "path": "fixtures/javascript/strict_equality.js",
+        "expectation": "source-fact-present"
+      }
+    ],
+    "hard_negatives": [
+      {
+        "id": "js-loose-equality-hard-negative",
+        "description": "A loose equality source surface must not satisfy contracts requiring strict equality.",
+        "path": "fixtures/javascript/loose_equality.js",
+        "expectation": "exact-contract-closed"
+      },
+      {
+        "id": "js-shadowed-global-hard-negative",
+        "description": "A locally rebound global name must not emit an unshadowed-global fact.",
+        "path": "fixtures/javascript/shadowed_global.js",
+        "expectation": "symbol-proof-closed"
+      }
+    ],
+    "known_unsupported": [
+      "Dynamic eval and with-scope semantics are outside this example.",
+      "This example does not model JavaScript object identity or equality conversion rules."
+    ],
+    "command": "nose-semantic-pack check --manifest language-pack.json"
+  }
+}

--- a/docs/examples/semantic-packs/v0/library-pack.json
+++ b/docs/examples/semantic-packs/v0/library-pack.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "../../../schemas/semantic-pack-v0.schema.json",
+  "api_version": "nose.semantic-pack.v0",
+  "pack": {
+    "id": "com.example.python-math-prod",
+    "kind": "LibraryPack",
+    "version": "0.1.0",
+    "display_name": "Example Python math.prod semantic pack",
+    "description": "Illustrative v0 library pack metadata for one imported namespace function. This is not a loadable pack.",
+    "trust": "external-opt-in",
+    "enabled_by_default": false,
+    "status": "draft-example"
+  },
+  "provenance": {
+    "provider": {
+      "name": "Example Semantic Packs",
+      "contact": "semantics@example.invalid"
+    },
+    "license": "MIT",
+    "repository": "https://example.invalid/semantic-packs/python-math-prod",
+    "source_revision": "0000000000000000000000000000000000000000"
+  },
+  "compatibility": {
+    "nose": ">=0.5.0 <0.6.0",
+    "schema": "v0",
+    "notes": "Example only. Future loaders must compare this range before enabling the pack."
+  },
+  "supported_languages": [
+    {
+      "id": "python",
+      "language_version": ">=3.8",
+      "runtime": "cpython",
+      "runtime_versions": [
+        ">=3.8"
+      ]
+    }
+  ],
+  "packages": [
+    {
+      "ecosystem": "python-stdlib",
+      "name": "math",
+      "versions": ">=3.8",
+      "stdlib": true
+    }
+  ],
+  "dependencies": [
+    {
+      "id": "nose.protocol.reduction",
+      "version": ">=0.1.0 <1.0.0",
+      "required": true
+    }
+  ],
+  "declares": {
+    "evidence_producers": [
+      {
+        "id": "python.import.namespace.math",
+        "kind": "Import.Namespace",
+        "anchors": [
+          "binding",
+          "module"
+        ],
+        "channel": "syntax-only",
+        "emits": [
+          "Import.Namespace",
+          "Symbol.ImportedNamespace"
+        ],
+        "requires": [],
+        "stable_hash_inputs": [
+          "api_version",
+          "pack.id",
+          "producer.id",
+          "language.id",
+          "module_name",
+          "binding_hash",
+          "source_span"
+        ],
+        "conflict_policy": "fail-closed",
+        "notes": "Proves that a local namespace binding denotes the Python stdlib math module."
+      },
+      {
+        "id": "python.library-api.math-prod",
+        "kind": "LibraryApi.Contract",
+        "anchors": [
+          "node"
+        ],
+        "channel": "exact-empirical",
+        "emits": [
+          "LibraryApi.Contract"
+        ],
+        "requires": [
+          {
+            "ref": "python.import.namespace.math",
+            "subject": "callee.namespace",
+            "required": true,
+            "within_scope": "call"
+          }
+        ],
+        "stable_hash_inputs": [
+          "api_version",
+          "pack.id",
+          "producer.id",
+          "language.id",
+          "module_name",
+          "exported_name",
+          "arity",
+          "call_span",
+          "dependency_ids"
+        ],
+        "conflict_policy": "fail-closed",
+        "notes": "The occurrence proof is for imported stdlib math.prod, not for any function locally named prod."
+      }
+    ],
+    "contracts": [
+      {
+        "id": "python.math.prod.reduction",
+        "surface": {
+          "kind": "imported-namespace-function",
+          "language": "python",
+          "package": "math",
+          "module": "math",
+          "export": "prod",
+          "arity": {
+            "min": 1,
+            "max": 2
+          },
+          "receiver": "none"
+        },
+        "requires": [
+          {
+            "ref": "python.library-api.math-prod",
+            "subject": "call",
+            "required": true,
+            "same_anchor_as": "call-node"
+          },
+          {
+            "ref": "python.import.namespace.math",
+            "subject": "callee.namespace",
+            "required": true,
+            "within_scope": "call"
+          }
+        ],
+        "semantics": {
+          "operation": "Protocol.ProductReduction",
+          "result_domain": "NumberOrUnknown",
+          "demand": {
+            "arguments": "eager-left-to-right",
+            "iterable": "eager-consumer",
+            "callbacks": "none"
+          },
+          "effects": [
+            "argument-effects-in-order",
+            "iteration-effects-in-order"
+          ],
+          "exceptions": "python-math-prod-default",
+          "mutation": "does-not-mutate-input-by-contract",
+          "identity": "no-allocation-identity-claim"
+        },
+        "channel": "exact-empirical",
+        "proof_status": "covered",
+        "conformance_refs": [
+          "python-math-prod-positive",
+          "python-math-prod-local-shadow-hard-negative",
+          "python-math-prod-wrong-namespace-hard-negative"
+        ],
+        "known_unsupported": [
+          "Exact product laws still require domain and overflow/float semantics from a value-law contract.",
+          "Iterables with externally observable iteration side effects require the demand/effect contract to stay in force."
+        ],
+        "notes": "This contract connects a specific imported namespace function to a reduction protocol only after import and occurrence evidence are present."
+      }
+    ],
+    "value_laws": []
+  },
+  "conformance": {
+    "positive_fixtures": [
+      {
+        "id": "python-math-prod-positive",
+        "description": "import math; math.prod(xs) emits the imported-namespace function occurrence evidence.",
+        "path": "fixtures/python/math_prod_positive.py",
+        "expectation": "library-api-occurrence-present"
+      }
+    ],
+    "hard_negatives": [
+      {
+        "id": "python-math-prod-local-shadow-hard-negative",
+        "description": "A local math binding must close the imported namespace function contract.",
+        "path": "fixtures/python/math_prod_shadowed_math.py",
+        "expectation": "exact-contract-closed"
+      },
+      {
+        "id": "python-math-prod-wrong-namespace-hard-negative",
+        "description": "other.prod(xs) must not satisfy the Python stdlib math.prod contract.",
+        "path": "fixtures/python/math_prod_wrong_namespace.py",
+        "expectation": "exact-contract-closed"
+      }
+    ],
+    "known_unsupported": [
+      "This example does not prove numeric algebraic product laws.",
+      "This example does not certify behavior for monkey-patched module objects."
+    ],
+    "command": "nose-semantic-pack check --manifest library-pack.json",
+    "proofs": [
+      "https://example.invalid/semantic-packs/python-math-prod/conformance"
+    ]
+  }
+}

--- a/docs/home.md
+++ b/docs/home.md
@@ -52,6 +52,7 @@ You want to *change* nose or understand how it works inside.
 - [architecture](architecture.md) — the crates and the lower → normalize → detect → rank pipeline.
 - [normalization](normalization.md) — the passes that make behaviorally-equivalent code converge (the hard part).
 - [semantic-kernel](semantic-kernel.md) — semantic-kernel and pack architecture: language/library semantics, extension boundaries, responsibility model, and exact-channel eligibility.
+- [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) — versioned v0 schema and provider-facing extension API for language/library semantic packs, with examples and a conformance checklist.
 - [evidence-records](evidence-records.md) — the internal pack-facing evidence substrate for source, domain, import, symbol, type, guard, place/effect, library API, and sequence-surface facts.
 - [source-facts](source-facts.md) — source-origin evidence for semantic contracts: construct syntax, async/generator/error boundaries, literal/operator provenance, pack boundaries, and fail-closed exact admission.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.

--- a/docs/schemas/semantic-pack-v0.schema.json
+++ b/docs/schemas/semantic-pack-v0.schema.json
@@ -1,0 +1,532 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/corca-ai/nose/docs/schemas/semantic-pack-v0.schema.json",
+  "title": "nose semantic pack manifest v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "pack",
+    "provenance",
+    "compatibility",
+    "supported_languages",
+    "declares",
+    "conformance"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "api_version": {
+      "const": "nose.semantic-pack.v0"
+    },
+    "pack": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "version",
+        "display_name",
+        "trust",
+        "enabled_by_default"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/stable_id"
+        },
+        "kind": {
+          "enum": [
+            "LanguagePack",
+            "StdlibPack",
+            "LibraryPack",
+            "ProtocolPack",
+            "LawPack"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "display_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        },
+        "trust": {
+          "enum": [
+            "default-first-party",
+            "first-party-optional",
+            "external-opt-in"
+          ]
+        },
+        "enabled_by_default": {
+          "type": "boolean"
+        },
+        "status": {
+          "enum": [
+            "draft-example",
+            "experimental",
+            "stable",
+            "deprecated"
+          ]
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "license",
+        "repository"
+      ],
+      "properties": {
+        "provider": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "contact": {
+              "type": "string"
+            }
+          }
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_revision": {
+          "type": "string"
+        }
+      }
+    },
+    "compatibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "nose"
+      ],
+      "properties": {
+        "nose": {
+          "type": "string",
+          "minLength": 1
+        },
+        "schema": {
+          "const": "v0"
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "supported_languages": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/language"
+      }
+    },
+    "packages": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/package"
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/dependency"
+      }
+    },
+    "declares": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evidence_producers",
+        "contracts"
+      ],
+      "properties": {
+        "evidence_producers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/evidence_producer"
+          }
+        },
+        "contracts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/contract"
+          }
+        },
+        "value_laws": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/value_law"
+          }
+        }
+      }
+    },
+    "conformance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "positive_fixtures",
+        "hard_negatives",
+        "known_unsupported"
+      ],
+      "properties": {
+        "positive_fixtures": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/fixture"
+          }
+        },
+        "hard_negatives": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/fixture"
+          }
+        },
+        "known_unsupported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "command": {
+          "type": "string"
+        },
+        "proofs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "stable_id": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.:-]*$"
+    },
+    "language": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "language_version": {
+          "type": "string"
+        },
+        "runtime": {
+          "type": "string"
+        },
+        "runtime_versions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ecosystem",
+        "name",
+        "versions"
+      ],
+      "properties": {
+        "ecosystem": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "versions": {
+          "type": "string"
+        },
+        "stdlib": {
+          "type": "boolean"
+        }
+      }
+    },
+    "dependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "version",
+        "required"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/stable_id"
+        },
+        "version": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "evidence_producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "anchors",
+        "channel",
+        "stable_hash_inputs",
+        "conflict_policy"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/stable_id"
+        },
+        "kind": {
+          "$ref": "#/$defs/evidence_kind"
+        },
+        "anchors": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/anchor"
+          }
+        },
+        "channel": {
+          "$ref": "#/$defs/channel"
+        },
+        "emits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/evidence_kind"
+          }
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/requirement"
+          }
+        },
+        "stable_hash_inputs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "conflict_policy": {
+          "enum": [
+            "fail-closed",
+            "near-only"
+          ]
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "surface",
+        "requires",
+        "semantics",
+        "channel",
+        "proof_status",
+        "conformance_refs"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/stable_id"
+        },
+        "surface": {
+          "type": "object"
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/requirement"
+          }
+        },
+        "semantics": {
+          "type": "object"
+        },
+        "channel": {
+          "$ref": "#/$defs/channel"
+        },
+        "proof_status": {
+          "$ref": "#/$defs/proof_status"
+        },
+        "conformance_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/stable_id"
+          }
+        },
+        "known_unsupported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "value_law": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "requires",
+        "semantics",
+        "channel",
+        "proof_status",
+        "conformance_refs"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/stable_id"
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/requirement"
+          }
+        },
+        "semantics": {
+          "type": "object"
+        },
+        "channel": {
+          "$ref": "#/$defs/channel"
+        },
+        "proof_status": {
+          "$ref": "#/$defs/proof_status"
+        },
+        "conformance_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/stable_id"
+          }
+        }
+      }
+    },
+    "requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ref",
+        "subject",
+        "required"
+      ],
+      "properties": {
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "subject": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "same_anchor_as": {
+          "type": "string"
+        },
+        "within_scope": {
+          "type": "string"
+        },
+        "before": {
+          "type": "string"
+        },
+        "after": {
+          "type": "string"
+        }
+      }
+    },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "description"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/stable_id"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "type": "string"
+        },
+        "expectation": {
+          "type": "string"
+        }
+      }
+    },
+    "channel": {
+      "enum": [
+        "syntax-only",
+        "near-only",
+        "abstraction-witness",
+        "exact-empirical",
+        "exact-proven"
+      ]
+    },
+    "proof_status": {
+      "enum": [
+        "proven",
+        "covered",
+        "missing",
+        "empirical-only",
+        "rejected-counterexample"
+      ]
+    },
+    "anchor": {
+      "enum": [
+        "source-span",
+        "node",
+        "param",
+        "binding",
+        "sequence",
+        "module",
+        "package"
+      ]
+    },
+    "evidence_kind": {
+      "type": "string",
+      "pattern": "^(Source|Symbol|Import|Domain|Type|Guard|Place|Effect|LibraryApi|CallTarget|SequenceSurface)\\.[A-Za-z0-9_.:-]+$"
+    }
+  }
+}

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -3,7 +3,9 @@
 Back to [semantic-kernel](semantic-kernel.md). Current code shape is recorded in
 [semantic-kernel-snapshot](semantic-kernel-snapshot.md). The post-PR #147 audit
 of remaining raw/local semantic pockets is in
-[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md).
+[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md). The
+provider-facing v0 extension API is in
+[semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md).
 
 This page tracks decisions, history, and remaining work for the semantic kernel
 and pack ecosystem.
@@ -627,6 +629,10 @@ and pack ecosystem.
   admitted-resolver consumers, intentionally opaque call identity policy, or
   future pack surfaces. The detailed classification is in
   [semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md).
+- The v0 pack extension API defined the first provider-facing manifest shape for
+  language/library packs, including evidence producers, contract rows, anchors,
+  dependencies, channel eligibility, trust/default status, provider/user
+  responsibility boundaries, examples, and a lightweight checked example gate.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -637,6 +643,9 @@ and pack ecosystem.
   formal-soundness.
 - The docs distinguish implemented facade behavior from planned external-pack
   capability.
+- The v0 provider-facing pack API is documented separately from the snapshot and
+  roadmap so current implementation status, history, and extension design do not
+  blur together.
 
 ## Phase 1: kernel facade and fail-closed migration (first slice landed)
 
@@ -794,8 +803,10 @@ Remaining in this phase:
 
 ## Phase 4: external pack contract
 
-- Define a versioned pack manifest schema.
-- Start with data-only external packs for simple APIs.
+- The first versioned pack manifest schema is defined in
+  [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md). It is a
+  design/API artifact, not a loader.
+- Start with data-only external packs for simple APIs once pack loading exists.
 - Add restricted recognizer hooks only after the manifest path is stable.
 - Require pack metadata: provider, license, version range, supported analysis
   channels, evidence status, conformance commands, and semantic provenance ids.

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -5,7 +5,9 @@ implementation shape; planned work and decision history live in
 [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The internal evidence
 record substrate is described in [evidence-records](evidence-records.md). The
 post-PR #147 raw/local pocket audit is recorded in
-[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md).
+[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md). The
+v0 provider-facing extension API is defined in
+[semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md).
 
 Snapshot date: 2026-06-09. The current implementation has an internal
 semantic-kernel facade, evidence-gated field state, sequence-surface contracts,
@@ -62,6 +64,9 @@ still being migrated toward it.
   library API contract identities, library API row constructors, library API
   evidence-hash registry helpers, negative API guard rows, and library API
   occurrence/admission logic are split into focused modules.
+- The external pack API is documented as a v0 manifest/schema with examples, but
+  there is still no filesystem/network pack loader. First-party producers remain
+  compiled Rust and are expected to map onto the same vocabulary.
 - `nose-frontend` owns tree-sitter parsing, per-language lowering, embedded
   `<script>` extraction, source/domain/import/symbol/type/guard/place/effect/API/
   sequence evidence emission, and Raw-node coverage.

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -4,7 +4,9 @@ Back to [home](home.md). Current implementation status is in
 [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and remaining
 work are tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The
 post-PR #147 raw/local pocket audit is recorded in
-[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md). Source
+[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md). The
+versioned provider-facing extension surface is defined in
+[semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md). Source
 origin evidence is detailed in [source-facts](source-facts.md); the shared
 internal evidence substrate is described in
 [evidence-records](evidence-records.md).
@@ -26,6 +28,10 @@ makes soundness depend on scattered `Lang` checks.
 The semantic kernel is the boundary that all exact semantic reasoning must cross.
 The first internal facade now lives in `nose-semantics`; it is still a compiled
 first-party implementation, not a loadable external pack runtime.
+The external API design starts at
+[semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md): it narrows
+the current internal evidence and contract vocabulary into a manifest shape for
+future language/library packs.
 
 Evidence records are one kernel input at that boundary. They preserve facts that
 the IL deliberately abstracts away, but they do not approve semantic equivalence

--- a/docs/semantic-pack-extension-api-v0.md
+++ b/docs/semantic-pack-extension-api-v0.md
@@ -1,0 +1,471 @@
+# Semantic pack extension API v0
+
+Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
+in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and remaining
+work are tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The
+internal evidence substrate is described in
+[evidence-records](evidence-records.md), and source-origin evidence is described
+in [source-facts](source-facts.md).
+
+Schema artifacts:
+
+- [semantic-pack-v0 schema](schemas/semantic-pack-v0.schema.json)
+- [language-pack example](examples/semantic-packs/v0/language-pack.json)
+- [library-pack example](examples/semantic-packs/v0/library-pack.json)
+
+Status: design v0. nose does not load external packs yet. This page defines the
+extension surface that first-party compiled packs and future external packs must
+use.
+
+## Context
+
+nose is moving toward a DefinitelyTyped-style semantic-pack ecosystem: providers
+publish language, standard-library, library, protocol, and law packs; users opt
+into the packs they trust; nose validates the extension shape and fails closed
+when required facts are absent. nose certifies only the first-party default packs
+that it ships and gates in CI.
+
+The current implementation already has the internal pieces that this API narrows
+into a public boundary: `EvidenceRecord` facts in `nose-il`, contract rows and
+admission helpers in `nose-semantics`, and evidence-only consumers in normalize,
+detect, value-graph, fragment, and oracle paths. v0 is intentionally a schema and
+contract vocabulary, not a loader.
+
+## Goal
+
+- Define a narrow external API for adding language and library semantics without
+  reaching into private normalization or detection internals.
+- Make every semantic claim name the exact language/API surface it covers, the
+  evidence required to admit that surface, and the channel where the claim may
+  be used.
+- Preserve exact-channel precision by making missing, ambiguous, conflicting, or
+  dependency-broken evidence fail closed.
+- Let first-party built-in semantics use the same vocabulary as future external
+  packs, even while first-party packs remain compiled into nose.
+- Give pack authors a conformance checklist that is clear enough for users to
+  judge external packs without implying nose approval.
+
+## Non-goals
+
+- Do not implement filesystem, network, or registry pack loading in this issue.
+- Do not add a user configuration path for enabling packs.
+- Do not expand language or library coverage.
+- Do not let packs mint fingerprints, rewrite value graphs directly, approve
+  exact clone pairs, or bypass the law registry.
+- Do not model lazy, async, stream, channel, observable, or call-by-need behavior
+  beyond naming the demand/effect fields those later contracts must fill.
+- Do not make nose responsible for approving, certifying, or auditing external
+  pack correctness. Providers own claims; users own opt-in decisions.
+
+## Versioning
+
+Every manifest must declare:
+
+- `api_version`: currently `nose.semantic-pack.v0`;
+- `compatibility.nose`: the nose versions the pack claims to support;
+- `pack.version`: the provider's pack version;
+- stable ids for packs, evidence producers, contracts, laws, fixtures, and
+  dependencies.
+
+v0 is allowed to evolve only by adding optional fields or new enum values that
+old consumers can ignore. Removing fields, changing the meaning of an existing
+field, or changing exact-channel admission rules requires a new API version.
+
+## Manifest Shape
+
+The schema is in [schemas/semantic-pack-v0.schema.json](schemas/semantic-pack-v0.schema.json).
+A v0 manifest has these top-level sections:
+
+| section | purpose |
+|---|---|
+| `api_version` | schema family, fixed to `nose.semantic-pack.v0` |
+| `pack` | stable id, kind, version, trust policy, default-enable status, and human label |
+| `provenance` | provider, license, repository, source revision, and contact metadata |
+| `compatibility` | supported nose version range and optional schema notes |
+| `supported_languages` | language/runtime/version claims the pack covers |
+| `packages` | stdlib or ecosystem package coordinates for non-core library packs |
+| `dependencies` | other packs or protocols that must be present |
+| `declares.evidence_producers` | facts the pack may emit |
+| `declares.contracts` | semantic contracts the pack may claim |
+| `declares.value_laws` | optional law contracts, where ready |
+| `conformance` | positive fixtures, hard negatives, commands, proof links, and unsupported edges |
+
+The manifest is declarative. It is not a hook API. A data-only external pack can
+declare rows that a future loader can validate and feed into kernel helpers.
+First-party compiled packs can generate the same manifest metadata for reports
+and conformance gates while still emitting facts from Rust.
+
+## Pack Kinds
+
+| kind | responsibility |
+|---|---|
+| `LanguagePack` | file/language identity, parser/lowering binding, source facts, core evaluation facts, language-level operator/domain/source contracts |
+| `StdlibPack` | standard library APIs tied to a language/runtime version |
+| `LibraryPack` | ecosystem package APIs tied to package/version coordinates |
+| `ProtocolPack` | shared protocol vocabulary such as `Iterable`, `Iterator`, `Map`, `Option`, `Result`, `Promise`, `Observable`, or `Tensor` |
+| `LawPack` | reusable laws with explicit preconditions, proof status, and conformance fixtures |
+
+Language core and library semantics are intentionally separate. JavaScript
+call-by-value order, `Array.prototype.map`, Rust `Iterator::map`, RxJS
+`Observable.map`, and NumPy vector operations must be distinct contracts even if
+some of them map onto a shared protocol operation.
+
+## Trust And Enablement
+
+Trust policy is separate from channel eligibility.
+
+| trust | meaning |
+|---|---|
+| `default-first-party` | maintained, tested, and enabled by nose by default |
+| `first-party-optional` | maintained and tested by nose, but not enabled by default |
+| `external-opt-in` | provider/user responsibility; must be enabled explicitly by the user |
+
+External packs must set `enabled_by_default: false`. A manifest may declare that
+a contract is intended for `exact-empirical` or `exact-proven`, but nose does not
+certify that claim for external packs. A user may still opt into such a pack, and
+nose should surface provenance so the user can see which external pack affected a
+match.
+
+## Channel Eligibility
+
+Each evidence producer, contract, and law declares where it may be used.
+
+| channel | use |
+|---|---|
+| `syntax-only` | source/lowering/report provenance only |
+| `near-only` | candidate generation or review scoring only |
+| `abstraction-witness` | weak refactoring-template witnesses over `near`; never exact equivalence |
+| `exact-empirical` | exact channel only when required fixtures, hard negatives, and oracle-style checks are provided |
+| `exact-proven` | exact channel with proof obligations for the core law or contract |
+
+An exact-capable channel still requires the kernel to find all declared evidence
+and dependencies for the specific occurrence. A contract row is not an admission
+by itself.
+
+## Evidence Producers
+
+Packs declare the evidence kinds they may emit. The current v0 vocabulary mirrors
+the implemented internal substrate without exposing Rust layout as the public
+schema:
+
+| family | examples |
+|---|---|
+| `Source` | construct syntax, macro invocation, regex literal, equality/operator family, ranges, patterns, async/generator/error and Go channel/concurrency protocol boundaries, Python comprehension surfaces |
+| `Symbol` | unshadowed language global, imported binding, imported namespace, qualified global path |
+| `Import` | binding import, namespace import, wildcard import, Ruby require, C quote include, imported literal snapshot |
+| `Domain` | array, collection, set, map, option, string, integer, number, byte array |
+| `Type` | currently C type-alias proofs for exact byte-pack surfaces |
+| `Guard` | JS/TS record-shape and own-property guard facts |
+| `Place` | fixed receiver/place facts such as self receiver and self field |
+| `Effect` | builder append, non-overloadable index write, self-field write, binding write, receiver mutation, opaque argument escape |
+| `LibraryApi` | occurrence proof that a call, field, property, constructor, macro, or sentinel matches one contract coordinate |
+| `CallTarget` | direct user-defined call target proof |
+| `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, record guard, own-property guard, Go map literal, or Go map entry |
+
+The producer declaration must include:
+
+- a stable `id`;
+- the `kind` it may emit;
+- allowed `anchors`;
+- the dependencies it requires;
+- the channel it can influence;
+- stable hash inputs used to derive record ids or occurrence ids;
+- a conflict policy, normally `fail-closed`.
+
+Packs may inspect selectors and syntax while producing evidence, but they must
+emit a specific fact such as `Symbol.UnshadowedGlobal` or
+`LibraryApi.Contract`. A selector string alone is never a semantic fact.
+
+## Anchors
+
+Evidence must attach to one of the kernel-defined subjects:
+
+| anchor | subject |
+|---|---|
+| `source-span` | a source surface that is not tied to a normalized node |
+| `node` | a specific IL node and its span |
+| `param` | a function parameter span |
+| `binding` | a binding span plus stable local-name hash |
+| `sequence` | a lowered aggregate sequence span |
+| `module` | a module or file-level fact, used only when the contract also names how occurrence uses are linked |
+| `package` | a package/version coordinate, used for manifest dependency claims, not as occurrence proof by itself |
+
+Exact consumers should prefer occurrence anchors (`node`, `param`, `binding`, or
+`sequence`) over broad module/package anchors. A module-level dependency can help
+prove an imported namespace, but it must be linked to the queried occurrence by a
+symbol/import dependency before it admits a call or property.
+
+## Dependencies
+
+Dependencies are local references to other evidence records or manifest
+contracts. They are how v0 prevents name-only semantics.
+
+For example, a Python `math.prod(xs)` contract should depend on a call-site
+`Symbol.ImportedNamespace` proof for `math`, which itself depends on import
+evidence for the namespace binding and on shadow/rebinding checks. The local
+name `math` is only a selector inspected by the producer; the admitted contract
+is the dependency-backed occurrence.
+
+A dependency reference has:
+
+- `ref`: the producer, contract, law, or protocol id being required;
+- `subject`: the occurrence role, such as `callee`, `receiver`, `argument[0]`,
+  `callback`, `binding`, or `source`;
+- `required`: whether missing evidence closes the contract;
+- optional `same_anchor_as`, `before`, `after`, or `within_scope` constraints.
+
+If a required dependency is missing, ambiguous, conflicting, dependency-broken,
+wrong-anchor, wrong-arity, wrong-version, or outside scope, exact admission must
+fail closed.
+
+## Contract Rows
+
+Contracts describe what a proven surface means. They do not emit fingerprints.
+
+Every contract must declare:
+
+- stable `id`;
+- `surface`: language/runtime/package coordinate, API kind, selector/path, arity,
+  receiver role, overload identity, and source call shape;
+- `requires`: evidence obligations for source, symbol, import, receiver, domain,
+  type, guard, place, effect, call-target, version, shadowing, and scope;
+- `semantics`: the protocol operation, result domain, evaluation/demand profile,
+  callback demand, effect summary, exception behavior, mutation behavior, and
+  allocation/identity caveats;
+- `channel`: the strongest channel the contract may influence;
+- `proof_status`: `proven`, `covered`, `missing`, `empirical-only`, or
+  `rejected-counterexample`;
+- conformance references and known unsupported boundaries.
+
+### Source-Fact Contracts
+
+Source facts preserve distinctions the IL erases. Examples include `new Map`
+versus `Map`, regex literal versus string, strict versus loose equality, Python
+generator expression versus list comprehension, Rust half-open versus inclusive
+range, and Go channel receive versus ordinary call.
+
+A source fact is syntax provenance. It admits an exact path only when a contract
+also proves the API, receiver, symbol, arity, demand, and effect obligations that
+make the surface meaningful.
+
+### Symbol And Import Contracts
+
+Symbol/import contracts must name the exact coordinate they prove:
+
+- unshadowed language global;
+- imported binding or namespace;
+- qualified global path;
+- Java `java.util` import or wildcard import with local-shadow checks;
+- Ruby `require` module proof;
+- C quote include proof.
+
+Local spelling is not enough. Rebinding, wildcard import ambiguity, local type
+shadowing, missing require/import evidence, or unresolved namespace exports must
+close exact admission.
+
+### Domain And Type Contracts
+
+Domain/type contracts state what is proven about a value or receiver:
+
+- `Array`, `Collection`, `Set`, `Map`, `Option`, `String`, `Integer`, `Number`,
+  `ByteArray`, or future protocol-specific domains;
+- binding-domain proof for immutable local/module values;
+- result-domain proof for admitted factories;
+- type-alias proof for current C byte-pack surfaces.
+
+Domain evidence can satisfy receiver-domain preconditions. It is not a proof
+that an opaque binding value is exact-tree safe, immutable, or mutation-free
+unless separate effect/place/import facts prove those obligations.
+
+### Library API Occurrence Contracts
+
+`LibraryApi` is occurrence evidence: it says this specific call, field, macro,
+constructor, property, or sentinel matches a contract coordinate. The occurrence
+must name:
+
+- contract id;
+- callee coordinate;
+- language/package/version coordinate;
+- arity and receiver position;
+- dependencies that prove callee, receiver, import, source shape, shadowing, and
+  overload obligations.
+
+Examples of valid coordinates include `Python math.prod`, Rust
+`std::collections::HashMap::from`, Java `java.util.Map.of`, JS-like
+`Array.isArray`, JS regex-literal `.test`, or a language-scoped receiver method
+whose receiver domain is proven. `method named map` is not a valid coordinate.
+
+### Demand, Effect, And Place Contracts
+
+Demand and effect fields are mandatory for exact-capable contracts, even when v0
+uses a conservative placeholder.
+
+Demand fields should state:
+
+- argument order and whether arguments are eager, conditional, repeated,
+  per-element pull, delayed, memoized, or never demanded;
+- callback demand, including how often callbacks may run and under which
+  consumer;
+- observation boundary for iterators, generators, promises, futures, channels,
+  streams, and observables.
+
+Effect/place fields should state:
+
+- pure, read-only, local mutation, receiver mutation, builder append, index
+  write, self-field write, opaque escape, allocation, async scheduling,
+  exception, yield, channel send/receive, or stream emission;
+- which place is affected and whether final state or ordered effects are the
+  observable;
+- which effects are skipped, delayed, repeated, or memoized under demand.
+
+If the contract cannot express the demand/effect behavior precisely enough,
+`channel` must be `near-only` or `syntax-only`.
+
+### Call-Target Contracts
+
+Call-target facts prove that a user call resolves to a direct in-file callable.
+They are separate from library APIs. A raw callee spelling such as `f(...)` is
+not enough because local shadowing, duplicate definitions, nested functions,
+method dispatch, imports, or computed callees can change the target.
+
+v0 supports direct target evidence only where the producer can prove a unique
+target span and no shadowing along the relevant lexical path.
+
+### Value Laws
+
+Value laws declare reusable semantic rewrites or equivalence laws. They are the
+future pack-facing shape for current first-party value-graph rule modules.
+
+A law must declare:
+
+- stable `id`;
+- required domains;
+- required demand/effect conditions;
+- protocol operation or operator family;
+- proof status and proof-obligation references;
+- positive fixtures and hard negatives;
+- whether the law is first-party certified or external provider/user trust.
+
+External law declarations do not let a pack bypass the first-party law registry
+or emit private value-graph nodes. Until the law registry is pack-facing, external
+law packs should stay `near-only` unless nose adopts them as first-party.
+
+## Conflict And Ambiguity Policy
+
+The default policy is fail closed:
+
+- more than one asserted fact for the same subject and incompatible kind closes
+  the queried contract;
+- any relevant `ambiguous` fact closes exact admission;
+- a broken dependency closes the dependent fact;
+- overlapping contracts must remain distinct unless a higher-level protocol
+  contract explicitly describes how they compose;
+- external pack conflicts do not get resolved by "newest wins" or provider
+  priority for exact matching;
+- user configuration may disable or select packs, but selection does not make
+  missing proof appear.
+
+Near-mode scoring may retain conflict provenance as a review signal. Exact
+semantic fingerprints must not.
+
+## Stable Hashes And IDs
+
+Stable ids are report and cache coordinates. They must not depend on process
+memory, interner order, local filesystem paths, or non-reproducible timestamps.
+
+v0 hash inputs should include:
+
+- `api_version`;
+- `pack.id` and `pack.version`;
+- producer/contract/law id;
+- language/package coordinate;
+- source span or node anchor, when the hash identifies an occurrence;
+- callee coordinate, arity, receiver role, and version range for API
+  occurrences;
+- dependency ids for records whose meaning depends on other proof facts.
+
+Providers may publish human-readable ids; nose may derive internal numeric hashes
+from those ids. The human ids remain the public contract.
+
+## Structural Validation Versus Trust
+
+nose should validate:
+
+- manifest JSON parses and matches the v0 schema;
+- required sections and ids exist;
+- ids are unique and stable-looking;
+- enum values are known;
+- dependency references resolve;
+- exact-capable contracts declare required evidence, demand, effect, channel,
+  proof status, positive fixtures, and hard negatives;
+- external packs are opt-in and not enabled by default;
+- declared compatibility ranges are syntactically valid enough to compare;
+- examples and fixtures are present at declared paths when a loader or harness
+  supports them.
+
+nose does not validate or certify for external packs:
+
+- whether the provider's semantic claim is true for all versions claimed;
+- whether fixtures and hard negatives are complete;
+- whether an `exact-proven` proof is mathematically sufficient;
+- whether package version metadata, license metadata, repository metadata, or
+  provider identity is trustworthy;
+- whether an external pack is safe to enable in a user's risk model.
+
+First-party default packs are different: nose owns their tests, hard negatives,
+proof obligations, release gating, and documentation.
+
+## First-Party Mapping
+
+The current `nose.first_party` compiled facade should be understood as a set of
+implicit v0 packs:
+
+- language packs for JS/TS, Python, Go, Rust, C, Java, Ruby, and embedded JS/TS
+  containers emit source, symbol, import, domain, guard, place/effect,
+  call-target, and sequence-surface evidence;
+- stdlib packs declare library API occurrence contracts such as Python builtins,
+  Python `math.prod`, Rust `Vec::new`, Rust `Option` constructors, Java
+  `java.util` factories, JS-like globals, regex literal methods, selected
+  property builtins, receiver-method APIs, and builder append APIs;
+- protocol/law packs correspond to current first-party protocol operations,
+  demand profiles, operator laws, value-domain laws, and named value-graph rule
+  modules.
+
+Those packs may remain compiled Rust for now. The important rule is that new
+first-party work should add or consume the same pack-shaped evidence and contract
+vocabulary that an external pack would use later.
+
+## Conformance Checklist
+
+A pack provider should publish:
+
+- manifest with stable ids, provenance, license, repository, support contact,
+  compatibility, dependencies, trust policy, and default status;
+- one or more evidence producer declarations for every fact the pack emits;
+- contract rows that identify exact language/API/package/version coordinates,
+  not broad function or method names;
+- explicit source, symbol, import, receiver, domain, type, guard, place, effect,
+  demand, version, shadowing, overload, and arity obligations for exact-capable
+  contracts;
+- positive fixtures that should converge;
+- hard negatives that must not converge, especially same-named APIs, shadowing,
+  missing imports, wrong receiver domains, wrong arity, unsupported versions,
+  dynamic dispatch, mutation, lazy effects, and ambiguous dependencies;
+- known unsupported boundaries and counterexamples;
+- proof links for `exact-proven` laws;
+- a reproducible conformance command.
+
+First-party packs must run this checklist in nose CI before becoming default.
+External packs should ship it so users can evaluate the pack, but passing the
+checklist is not nose certification.
+
+## v0 Acceptance
+
+This issue is complete when:
+
+- the v0 schema and design document are linked from home, snapshot, and roadmap;
+- the schema has at least one language-pack and one library-pack example;
+- examples are checked by a lightweight harness;
+- the docs state that external pack correctness is provider/user responsibility;
+- the docs state that first-party built-in semantics use the same extension
+  vocabulary even if they remain compiled in initially.

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -47,7 +47,8 @@ need_cmd() {
 
 run_docs_wiki_lint() {
     need_cmd awiki "install it with: brew install corca-ai/tap/awiki"
-    awiki lint --root docs
+    need_cmd python3
+    ./scripts/check-docs.sh
 }
 
 run_formal_obligations_lint() {

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Docs quality gate. awiki checks the docs/ wiki is a single connected graph —
-# no orphan pages, no disconnected islands — so every doc stays reachable and the
-# wiki navigable. Mirrors the `docs` job in .github/workflows/ci.yml.
+# Docs quality gate. The semantic-pack example check keeps checked-in v0
+# manifests structurally honest; awiki checks the docs/ wiki is a single
+# connected graph with no orphan pages or disconnected islands. Mirrors the
+# `docs` job in .github/workflows/ci.yml.
 #
 #   ./scripts/check-docs.sh
 #
@@ -11,6 +12,12 @@
 #   # or: go install github.com/corca-ai/awiki/cmd/awiki@latest
 set -euo pipefail
 cd "$(dirname "$0")/.."
+
+if command -v python3 >/dev/null 2>&1; then
+    python3 scripts/check-semantic-pack-examples.py
+else
+    echo "skipped semantic-pack example check — python3 not installed"
+fi
 
 if ! command -v awiki >/dev/null 2>&1; then
     echo "skipped — awiki not installed (brew install corca-ai/tap/awiki)"

--- a/scripts/check-semantic-pack-examples.py
+++ b/scripts/check-semantic-pack-examples.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Validate checked-in semantic-pack v0 schema examples.
+
+This is intentionally a lightweight structural check, not a full JSON Schema
+implementation. It keeps the design examples honest until nose has a real pack
+loader and conformance harness.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "docs" / "schemas" / "semantic-pack-v0.schema.json"
+EXAMPLES = sorted(
+    (ROOT / "docs" / "examples" / "semantic-packs" / "v0").glob("*.json")
+)
+
+API_VERSION = "nose.semantic-pack.v0"
+PACK_KINDS = {
+    "LanguagePack",
+    "StdlibPack",
+    "LibraryPack",
+    "ProtocolPack",
+    "LawPack",
+}
+TRUST = {
+    "default-first-party",
+    "first-party-optional",
+    "external-opt-in",
+}
+CHANNELS = {
+    "syntax-only",
+    "near-only",
+    "abstraction-witness",
+    "exact-empirical",
+    "exact-proven",
+}
+PROOF_STATUSES = {
+    "proven",
+    "covered",
+    "missing",
+    "empirical-only",
+    "rejected-counterexample",
+}
+ANCHORS = {
+    "source-span",
+    "node",
+    "param",
+    "binding",
+    "sequence",
+    "module",
+    "package",
+}
+EVIDENCE_PREFIXES = (
+    "Source.",
+    "Symbol.",
+    "Import.",
+    "Domain.",
+    "Type.",
+    "Guard.",
+    "Place.",
+    "Effect.",
+    "LibraryApi.",
+    "CallTarget.",
+    "SequenceSurface.",
+)
+ALLOWED_REQUIREMENT_PREFIXES = EVIDENCE_PREFIXES + ("nose.",)
+
+
+def fail(path: Path, message: str) -> None:
+    rel = path.relative_to(ROOT)
+    raise SystemExit(f"{rel}: {message}")
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(path, f"invalid JSON: {exc}")
+    if not isinstance(value, dict):
+        fail(path, "top-level JSON value must be an object")
+    return value
+
+
+def require_object(path: Path, parent: dict[str, Any], key: str) -> dict[str, Any]:
+    value = parent.get(key)
+    if not isinstance(value, dict):
+        fail(path, f"`{key}` must be an object")
+    return value
+
+
+def require_array(path: Path, parent: dict[str, Any], key: str, *, min_items: int = 0) -> list[Any]:
+    value = parent.get(key)
+    if not isinstance(value, list):
+        fail(path, f"`{key}` must be an array")
+    if len(value) < min_items:
+        fail(path, f"`{key}` must contain at least {min_items} item(s)")
+    return value
+
+
+def require_string(path: Path, parent: dict[str, Any], key: str) -> str:
+    value = parent.get(key)
+    if not isinstance(value, str) or not value:
+        fail(path, f"`{key}` must be a non-empty string")
+    return value
+
+
+def require_bool(path: Path, parent: dict[str, Any], key: str) -> bool:
+    value = parent.get(key)
+    if not isinstance(value, bool):
+        fail(path, f"`{key}` must be a boolean")
+    return value
+
+
+def require_enum(path: Path, value: Any, allowed: set[str], label: str) -> str:
+    if not isinstance(value, str) or value not in allowed:
+        fail(path, f"`{label}` must be one of {sorted(allowed)}")
+    return value
+
+
+def require_unique_ids(path: Path, items: list[Any], label: str) -> set[str]:
+    ids: set[str] = set()
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            fail(path, f"`{label}[{index}]` must be an object")
+        item_id = require_string(path, item, "id")
+        if item_id in ids:
+            fail(path, f"duplicate id `{item_id}` in `{label}`")
+        ids.add(item_id)
+    return ids
+
+
+def validate_requirement(path: Path, requirement: Any, known_refs: set[str], context: str) -> None:
+    if not isinstance(requirement, dict):
+        fail(path, f"{context} requirement must be an object")
+    ref = require_string(path, requirement, "ref")
+    if ref not in known_refs and not ref.startswith(ALLOWED_REQUIREMENT_PREFIXES):
+        fail(path, f"{context} requirement references unknown id `{ref}`")
+    require_string(path, requirement, "subject")
+    require_bool(path, requirement, "required")
+
+
+def validate_evidence_producer(path: Path, producer: dict[str, Any], known_refs: set[str]) -> None:
+    kind = require_string(path, producer, "kind")
+    if not kind.startswith(EVIDENCE_PREFIXES):
+        fail(path, f"evidence producer `{producer['id']}` has unknown kind `{kind}`")
+    channel = require_enum(
+        path,
+        producer.get("channel"),
+        CHANNELS,
+        f"producer {producer['id']}.channel",
+    )
+    anchors = require_array(path, producer, "anchors", min_items=1)
+    for anchor in anchors:
+        require_enum(path, anchor, ANCHORS, f"producer {producer['id']}.anchors")
+    stable_inputs = require_array(path, producer, "stable_hash_inputs", min_items=1)
+    if "pack.id" not in stable_inputs or "producer.id" not in stable_inputs:
+        fail(path, f"producer `{producer['id']}` stable_hash_inputs must include pack.id and producer.id")
+    conflict_policy = producer.get("conflict_policy")
+    if conflict_policy not in {"fail-closed", "near-only"}:
+        fail(path, f"producer `{producer['id']}` conflict_policy must be fail-closed or near-only")
+    if channel.startswith("exact") and conflict_policy != "fail-closed":
+        fail(path, f"exact-capable producer `{producer['id']}` must fail closed on conflicts")
+    for emitted in producer.get("emits", []):
+        if not isinstance(emitted, str) or not emitted.startswith(EVIDENCE_PREFIXES):
+            fail(path, f"producer `{producer['id']}` emits unknown evidence kind `{emitted}`")
+    for requirement in producer.get("requires", []):
+        validate_requirement(path, requirement, known_refs, f"producer {producer['id']}")
+
+
+def validate_contract(
+    path: Path,
+    contract: dict[str, Any],
+    known_refs: set[str],
+    conformance_ids: set[str],
+    *,
+    require_surface: bool,
+) -> None:
+    contract_id = require_string(path, contract, "id")
+    if require_surface:
+        require_object(path, contract, "surface")
+    requires = require_array(path, contract, "requires")
+    semantics = require_object(path, contract, "semantics")
+    channel = require_enum(
+        path,
+        contract.get("channel"),
+        CHANNELS,
+        f"contract {contract_id}.channel",
+    )
+    require_enum(
+        path,
+        contract.get("proof_status"),
+        PROOF_STATUSES,
+        f"contract {contract_id}.proof_status",
+    )
+    refs = require_array(path, contract, "conformance_refs", min_items=1)
+    for ref in refs:
+        if ref not in conformance_ids:
+            fail(path, f"contract `{contract_id}` references missing conformance fixture `{ref}`")
+    if channel.startswith("exact"):
+        if not requires:
+            fail(path, f"exact-capable contract `{contract_id}` must declare evidence requirements")
+        if not any(ref in conformance_ids for ref in refs):
+            fail(path, f"exact-capable contract `{contract_id}` must reference conformance fixtures")
+        if "demand" not in semantics or "effects" not in semantics:
+            fail(path, f"exact-capable contract `{contract_id}` must declare demand and effects")
+    for requirement in requires:
+        validate_requirement(path, requirement, known_refs, f"contract {contract_id}")
+
+
+def validate_pack(path: Path, doc: dict[str, Any]) -> None:
+    if doc.get("api_version") != API_VERSION:
+        fail(path, f"`api_version` must be {API_VERSION}")
+    forbidden = {"verdicts", "fingerprints", "exact_pairs", "value_graph_rewrites"}
+    present_forbidden = forbidden.intersection(doc)
+    if present_forbidden:
+        fail(path, f"manifest must not contain verdict/fingerprint fields: {sorted(present_forbidden)}")
+
+    pack = require_object(path, doc, "pack")
+    require_string(path, pack, "id")
+    require_string(path, pack, "version")
+    require_string(path, pack, "display_name")
+    require_enum(path, pack.get("kind"), PACK_KINDS, "pack.kind")
+    trust = require_enum(path, pack.get("trust"), TRUST, "pack.trust")
+    enabled_by_default = require_bool(path, pack, "enabled_by_default")
+    if trust == "external-opt-in" and enabled_by_default:
+        fail(path, "external-opt-in packs must not be enabled by default")
+
+    provenance = require_object(path, doc, "provenance")
+    require_object(path, provenance, "provider")
+    require_string(path, provenance, "license")
+    require_string(path, provenance, "repository")
+
+    compatibility = require_object(path, doc, "compatibility")
+    require_string(path, compatibility, "nose")
+
+    languages = require_array(path, doc, "supported_languages", min_items=1)
+    for language in languages:
+        if not isinstance(language, dict):
+            fail(path, "`supported_languages` entries must be objects")
+        require_string(path, language, "id")
+
+    dependencies = doc.get("dependencies", [])
+    if dependencies is None:
+        dependencies = []
+    if not isinstance(dependencies, list):
+        fail(path, "`dependencies` must be an array when present")
+    dependency_ids = require_unique_ids(path, dependencies, "dependencies")
+
+    declares = require_object(path, doc, "declares")
+    producers = require_array(path, declares, "evidence_producers")
+    contracts = require_array(path, declares, "contracts")
+    laws = declares.get("value_laws", [])
+    if laws is None:
+        laws = []
+    if not isinstance(laws, list):
+        fail(path, "`declares.value_laws` must be an array when present")
+
+    producer_ids = require_unique_ids(path, producers, "declares.evidence_producers")
+    contract_ids = require_unique_ids(path, contracts, "declares.contracts")
+    law_ids = require_unique_ids(path, laws, "declares.value_laws")
+    known_refs = dependency_ids | producer_ids | contract_ids | law_ids
+
+    conformance = require_object(path, doc, "conformance")
+    positives = require_array(path, conformance, "positive_fixtures", min_items=1)
+    negatives = require_array(path, conformance, "hard_negatives", min_items=1)
+    conformance_ids = require_unique_ids(path, positives + negatives, "conformance fixtures")
+    require_array(path, conformance, "known_unsupported")
+
+    for producer in producers:
+        validate_evidence_producer(path, producer, known_refs)
+    for contract in contracts:
+        validate_contract(path, contract, known_refs, conformance_ids, require_surface=True)
+    for law in laws:
+        validate_contract(path, law, known_refs, conformance_ids, require_surface=False)
+
+
+def main() -> int:
+    schema = read_json(SCHEMA)
+    if schema.get("$id") is None or schema.get("title") is None:
+        fail(SCHEMA, "schema must declare $id and title")
+    if not EXAMPLES:
+        fail(ROOT / "docs" / "examples" / "semantic-packs" / "v0", "no examples found")
+    for example in EXAMPLES:
+        validate_pack(example, read_json(example))
+    print(f"validated {len(EXAMPLES)} semantic-pack v0 example(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #151.

## Summary

- Add `docs/semantic-pack-extension-api-v0.md` as the provider-facing v0 extension API for language/library semantic packs.
- Add a versioned JSON schema plus one language-pack and one library-pack example.
- Add a lightweight semantic-pack example checker and wire it into `scripts/check-docs.sh` and the docs CI job.
- Link the v0 API from `docs/home.md`, `docs/semantic-kernel.md`, `docs/semantic-kernel-snapshot.md`, and `docs/semantic-kernel-roadmap.md`.

## Notes

- This is a design/API artifact, not an external pack loader.
- The docs keep external pack correctness as provider/user responsibility and reserve nose certification for first-party default packs.
- The v0 vocabulary maps first-party compiled semantics onto the same evidence/contract boundary expected for future external packs.

## Validation

- `./scripts/check-docs.sh`
- `python3 -m py_compile scripts/check-semantic-pack-examples.py`
- `python3 -m json.tool docs/schemas/semantic-pack-v0.schema.json`
- `python3 -m json.tool docs/examples/semantic-packs/v0/language-pack.json`
- `python3 -m json.tool docs/examples/semantic-packs/v0/library-pack.json`
- `cargo fmt --all --check`
- `cargo test -p nose-semantics`
- `git diff --check`
