### PR TITLE
[codex] Add semantic pack loading provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,7 @@ dependencies = [
  "nose-frontend",
  "nose-il",
  "nose-normalize",
+ "nose-semantics",
  "rayon",
  "serde",
  "serde_json",
@@ -542,6 +543,8 @@ version = "0.5.0"
 dependencies = [
  "nose-il",
  "rustc-hash",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/nose-cli/Cargo.toml
+++ b/crates/nose-cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 nose-il = { workspace = true }
+nose-semantics = { workspace = true }
 nose-frontend = { workspace = true }
 nose-normalize = { workspace = true }
 nose-detect = { workspace = true }

--- a/crates/nose-cli/src/config.rs
+++ b/crates/nose-cli/src/config.rs
@@ -11,6 +11,7 @@
 //! min-members = 3
 //! min-size = 30                             # minimum unit size in IL tokens
 //! ignore-file = "nose.ignore.json"
+//! semantic-packs = ["semantic-packs/python-math-prod.json"]
 //! ```
 
 use serde::Deserialize;
@@ -32,6 +33,8 @@ pub(crate) struct ScanConfig {
     pub min_size: Option<usize>,
     pub top: Option<usize>,
     pub ignore_file: Option<PathBuf>,
+    /// Local semantic-pack v0 manifest files or directories. These are explicit opt-ins.
+    pub semantic_packs: Vec<PathBuf>,
 }
 
 #[derive(Deserialize, Default)]
@@ -99,9 +102,13 @@ mod tests {
 
     #[test]
     fn valid_config_still_loads() {
-        let p = write_cfg("ok", "[scan]\nmin-value = 200\nmin-size = 30\n");
+        let p = write_cfg(
+            "ok",
+            "[scan]\nmin-value = 200\nmin-size = 30\nsemantic-packs = [\"packs\"]\n",
+        );
         let cfg = load_scan(Some(&p)).expect("valid config must load");
         assert_eq!(cfg.min_value, Some(200.0));
         assert_eq!(cfg.min_size, Some(30));
+        assert_eq!(cfg.semantic_packs, vec![PathBuf::from("packs")]);
     }
 }

--- a/crates/nose-cli/src/config.rs
+++ b/crates/nose-cli/src/config.rs
@@ -59,7 +59,7 @@ pub(crate) fn load_scan(explicit: Option<&Path>) -> anyhow::Result<ScanConfig> {
         .map_err(|e| anyhow::anyhow!("reading config {}: {e}", path.display()))?;
     let file: File =
         toml::from_str(&text).map_err(|e| anyhow::anyhow!("parsing {}: {e}", path.display()))?;
-    Ok(file.scan)
+    Ok(resolve_config_relative_paths(file.scan, &path))
 }
 
 fn discover() -> Option<PathBuf> {
@@ -67,6 +67,16 @@ fn discover() -> Option<PathBuf> {
         .iter()
         .map(PathBuf::from)
         .find(|p| p.is_file())
+}
+
+fn resolve_config_relative_paths(mut cfg: ScanConfig, path: &Path) -> ScanConfig {
+    let base = path.parent().unwrap_or_else(|| Path::new(""));
+    for pack in &mut cfg.semantic_packs {
+        if pack.is_relative() {
+            *pack = base.join(&pack);
+        }
+    }
+    cfg
 }
 
 #[cfg(test)]
@@ -109,6 +119,6 @@ mod tests {
         let cfg = load_scan(Some(&p)).expect("valid config must load");
         assert_eq!(cfg.min_value, Some(200.0));
         assert_eq!(cfg.min_size, Some(30));
-        assert_eq!(cfg.semantic_packs, vec![PathBuf::from("packs")]);
+        assert_eq!(cfg.semantic_packs, vec![p.parent().unwrap().join("packs")]);
     }
 }

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -168,6 +168,10 @@ enum Cmd {
         /// to `nose.ignore.json` when that file exists.
         #[arg(long, value_name = "FILE")]
         ignore_file: Option<PathBuf>,
+        /// Local semantic-pack v0 manifest file or directory to load. Repeatable;
+        /// each path is an explicit opt-in and currently contributes provenance metadata only.
+        #[arg(long = "semantic-pack", value_name = "FILE_OR_DIR")]
+        semantic_pack: Vec<PathBuf>,
         /// Write the current families to the `--baseline` file (accept today's state)
         /// and exit, instead of reporting.
         #[arg(long, requires = "baseline")]
@@ -693,6 +697,7 @@ struct CapabilitiesReport {
     commands: CapabilitiesCommands,
     schemas: CapabilitiesSchemas,
     scan: CapabilitiesScan,
+    semantic_packs: CapabilitiesSemanticPacks,
     il: CapabilitiesIl,
     stats: CapabilitiesStats,
 }
@@ -726,6 +731,7 @@ struct CapabilitiesCommands {
 struct CapabilitiesSchemas {
     capabilities: Vec<u32>,
     scan_json: Vec<u32>,
+    semantic_packs: Vec<&'static str>,
 }
 
 #[derive(serde::Serialize)]
@@ -736,6 +742,15 @@ struct CapabilitiesScan {
     sort_keys: Vec<&'static str>,
     config_keys: Vec<&'static str>,
     capabilities: std::collections::BTreeMap<&'static str, bool>,
+}
+
+#[derive(serde::Serialize)]
+struct CapabilitiesSemanticPacks {
+    api_versions: Vec<&'static str>,
+    loading: Vec<&'static str>,
+    trust: Vec<&'static str>,
+    external_packs_enabled_by_default: bool,
+    external_pack_influence: &'static str,
 }
 
 #[derive(serde::Serialize)]
@@ -774,6 +789,7 @@ impl CapabilitiesReport {
             schemas: CapabilitiesSchemas {
                 capabilities: vec![CAPABILITIES_SCHEMA_VERSION],
                 scan_json: vec![SCAN_JSON_SCHEMA_VERSION],
+                semantic_packs: vec![nose_semantics::SEMANTIC_PACK_API_VERSION],
             },
             scan: CapabilitiesScan {
                 modes: vec!["syntax", "semantic", "near"],
@@ -788,10 +804,26 @@ impl CapabilitiesReport {
                     "min-size",
                     "min-value",
                     "mode",
+                    "semantic-packs",
                     "sort",
                     "top",
                 ],
                 capabilities: scan_capability_flags(),
+            },
+            semantic_packs: CapabilitiesSemanticPacks {
+                api_versions: vec![nose_semantics::SEMANTIC_PACK_API_VERSION],
+                loading: vec![
+                    "compiled-first-party",
+                    "local-manifest-file",
+                    "local-manifest-directory",
+                ],
+                trust: vec![
+                    "default-first-party",
+                    "first-party-optional",
+                    "external-opt-in",
+                ],
+                external_packs_enabled_by_default: false,
+                external_pack_influence: "metadata-only",
             },
             il: CapabilitiesIl {
                 output_formats: vec!["sexpr", "json"],
@@ -815,6 +847,7 @@ fn scan_capability_flags() -> std::collections::BTreeMap<&'static str, bool> {
         ("hotspots", true),
         ("inline_suppression", true),
         ("proposal", true),
+        ("semantic_pack_loading", true),
         ("structured_ignores", true),
     ]
     .into_iter()
@@ -826,6 +859,7 @@ struct ScanJsonReport<'a> {
     schema_version: u32,
     tool_version: &'static str,
     scope: ScanJsonScope<'a>,
+    semantic_packs: Vec<ScanJsonSemanticPack<'a>>,
     ranking: ScanJsonRanking,
     #[serde(skip_serializing_if = "Option::is_none")]
     baseline: Option<&'a BaselineSummary>,
@@ -846,6 +880,35 @@ struct ScanJsonScope<'a> {
 struct ScanJsonLanguage<'a> {
     language: &'a str,
     files: usize,
+}
+
+#[derive(serde::Serialize)]
+struct ScanJsonSemanticPack<'a> {
+    id: &'a str,
+    hash: String,
+    kind: &'static str,
+    version: &'a str,
+    display_name: &'a str,
+    trust: &'static str,
+    enabled_by_default: bool,
+    source: &'static str,
+    influence: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+    provider: &'a str,
+    repository: &'a str,
+    license: &'a str,
+    supported_languages: &'a [String],
+    counts: ScanJsonSemanticPackCounts,
+}
+
+#[derive(serde::Serialize)]
+struct ScanJsonSemanticPackCounts {
+    evidence_producers: usize,
+    contracts: usize,
+    value_laws: usize,
+    positive_fixtures: usize,
+    hard_negatives: usize,
 }
 
 #[derive(serde::Serialize)]
@@ -886,6 +949,7 @@ struct ScanJsonInput<'a> {
     baseline: Option<&'a BaselineComparison>,
     ignore_set: Option<&'a ignores::IgnoreSet>,
     ignored_families: &'a [IgnoredFamily],
+    semantic_packs: &'a nose_semantics::SemanticPackSet,
 }
 
 impl<'a> ScanJsonReport<'a> {
@@ -906,6 +970,37 @@ impl<'a> ScanJsonReport<'a> {
                     })
                     .collect(),
             },
+            semantic_packs: input
+                .semantic_packs
+                .packs()
+                .iter()
+                .map(|pack| ScanJsonSemanticPack {
+                    id: &pack.id,
+                    hash: pack.hash_hex(),
+                    kind: pack.kind.as_str(),
+                    version: &pack.version,
+                    display_name: &pack.display_name,
+                    trust: pack.trust.as_manifest_str(),
+                    enabled_by_default: pack.enabled_by_default,
+                    source: pack.source.as_str(),
+                    influence: pack.influence.as_str(),
+                    path: pack
+                        .manifest_path
+                        .as_ref()
+                        .map(|path| path.display().to_string()),
+                    provider: &pack.provider,
+                    repository: &pack.repository,
+                    license: &pack.license,
+                    supported_languages: &pack.supported_languages,
+                    counts: ScanJsonSemanticPackCounts {
+                        evidence_producers: pack.counts.evidence_producers,
+                        contracts: pack.counts.contracts,
+                        value_laws: pack.counts.value_laws,
+                        positive_fixtures: pack.counts.positive_fixtures,
+                        hard_negatives: pack.counts.hard_negatives,
+                    },
+                })
+                .collect(),
             ranking: ScanJsonRanking {
                 sort: input.sort.json_name(),
                 total_families: input.families.len(),
@@ -1279,6 +1374,7 @@ fn run() -> Result<()> {
             fail_on,
             baseline,
             ignore_file,
+            semantic_pack,
             write_baseline,
             format,
             exclude,
@@ -1297,6 +1393,7 @@ fn run() -> Result<()> {
             fail_on,
             baseline,
             ignore_file,
+            semantic_pack,
             write_baseline,
             format,
             exclude,
@@ -2400,6 +2497,7 @@ struct ScanArgs {
     fail_on: Option<FailOn>,
     baseline: Option<PathBuf>,
     ignore_file: Option<PathBuf>,
+    semantic_pack: Vec<PathBuf>,
     write_baseline: bool,
     format: ReportFormat,
     exclude: Vec<String>,
@@ -2541,6 +2639,23 @@ fn warn_no_files(paths: &[PathBuf]) {
     );
 }
 
+fn semantic_pack_summary_line(packs: &nose_semantics::SemanticPackSet) -> Option<String> {
+    let local = packs
+        .packs()
+        .iter()
+        .filter(|pack| pack.source == nose_semantics::SemanticPackSource::LocalManifest)
+        .map(|pack| format!("{}@{} ({})", pack.id, pack.version, pack.influence.as_str()))
+        .collect::<Vec<_>>();
+    (!local.is_empty()).then(|| {
+        format!(
+            "semantic packs: {} first-party default · {} local opt-in: {}",
+            nose_semantics::FIRST_PARTY_PACK_ID,
+            local.len(),
+            local.join(", ")
+        )
+    })
+}
+
 fn cmd_scan(args: ScanArgs) -> Result<()> {
     // `--fail-on new` gates on families that are new/changed vs a baseline, so without
     // `--baseline` the gate could never fire — reject the combination instead of silently
@@ -2564,6 +2679,9 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
     let min_lines = args.min_lines.or(cfg.min_lines).unwrap_or(5);
     let min_tokens = args.min_size.or(cfg.min_size).unwrap_or(24);
     let ignore_file = args.ignore_file.or(cfg.ignore_file);
+    let mut semantic_pack_paths = cfg.semantic_packs;
+    semantic_pack_paths.extend(args.semantic_pack.iter().cloned());
+    let semantic_packs = nose_semantics::SemanticPackSet::new_local(&semantic_pack_paths)?;
     // Excludes are additive: config patterns plus any given on the command line.
     let mut exclude = cfg.exclude;
     exclude.extend(args.exclude.iter().cloned());
@@ -2743,6 +2861,7 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
                 baseline: baseline_comparison.as_ref(),
                 ignore_set: ignore_set.as_ref(),
                 ignored_families: &ignored_families,
+                semantic_packs: &semantic_packs,
             });
             println!("{}", serde_json::to_string_pretty(&json)?);
         }
@@ -2750,6 +2869,9 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
             // Scope line first — tells the reader what was actually scanned (so a small
             // count from `.gitignore`/`--exclude` pruning is visible, not a silent gap).
             println!("{}\n", scope.summary());
+            if let Some(line) = semantic_pack_summary_line(&semantic_packs) {
+                println!("{line}\n");
+            }
             print_refactor_markdown(
                 &reportable_families,
                 &shown_reportable,
@@ -2762,6 +2884,9 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
         }
         ReportFormat::Human => {
             println!("{}", scope.summary());
+            if let Some(line) = semantic_pack_summary_line(&semantic_packs) {
+                println!("{line}");
+            }
             if let Some(comparison) = &baseline_comparison {
                 println!("{}", comparison.summary.line());
             }

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -475,6 +475,155 @@ fn config_file_supplies_defaults() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+fn semantic_pack_manifest(id: &str) -> String {
+    format!(
+        r#"{{
+  "api_version": "nose.semantic-pack.v0",
+  "pack": {{
+    "id": "{id}",
+    "kind": "LibraryPack",
+    "version": "0.1.0",
+    "display_name": "Example semantic pack",
+    "trust": "external-opt-in",
+    "enabled_by_default": false
+  }},
+  "provenance": {{
+    "provider": {{ "name": "Example Packs" }},
+    "license": "MIT",
+    "repository": "https://example.invalid/semantic-pack"
+  }},
+  "compatibility": {{ "nose": ">=0.5.0 <0.6.0" }},
+  "supported_languages": [{{ "id": "python" }}],
+  "declares": {{
+    "evidence_producers": [{{
+      "id": "python.library-api.example",
+      "kind": "LibraryApi.Contract",
+      "anchors": ["node"],
+      "channel": "exact-empirical",
+      "stable_hash_inputs": ["pack.id", "producer.id", "call_span"],
+      "conflict_policy": "fail-closed"
+    }}],
+    "contracts": [{{
+      "id": "python.example.contract",
+      "surface": {{ "kind": "function" }},
+      "requires": [{{
+        "ref": "python.library-api.example",
+        "subject": "call",
+        "required": true
+      }}],
+      "semantics": {{
+        "operation": "Example",
+        "demand": {{ "arguments": "eager-left-to-right" }},
+        "effects": ["argument-effects-in-order"]
+      }},
+      "channel": "exact-empirical",
+      "proof_status": "covered",
+      "conformance_refs": ["positive", "negative"]
+    }}],
+    "value_laws": []
+  }},
+  "conformance": {{
+    "positive_fixtures": [{{ "id": "positive", "description": "positive" }}],
+    "hard_negatives": [{{ "id": "negative", "description": "negative" }}],
+    "known_unsupported": []
+  }}
+}}"#
+    )
+}
+
+#[test]
+fn scan_json_reports_first_party_and_local_semantic_pack_provenance() {
+    let dir = make_project("semantic_pack_cli");
+    let pack = dir.join("pack.json");
+    fs::write(&pack, semantic_pack_manifest("com.example.semantic-pack")).unwrap();
+
+    let out = run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--format",
+        "json",
+        "--min-size",
+        "12",
+        "--semantic-pack",
+        pack.to_str().unwrap(),
+    ]);
+    let json = scan_json(&out);
+    let packs = json["semantic_packs"]
+        .as_array()
+        .expect("semantic_packs array");
+    assert_eq!(packs.len(), 2, "first-party + local opt-in pack: {json}");
+    assert_eq!(packs[0]["id"], "nose.first_party");
+    assert_eq!(packs[0]["source"], "compiled-first-party");
+    assert_eq!(packs[0]["influence"], "evidence-and-contracts");
+    assert_eq!(packs[1]["id"], "com.example.semantic-pack");
+    assert_eq!(packs[1]["trust"], "external-opt-in");
+    assert_eq!(packs[1]["source"], "local-manifest");
+    assert_eq!(packs[1]["influence"], "metadata-only");
+    assert_eq!(packs[1]["counts"]["contracts"], 1);
+    assert!(packs[1]["hash"]
+        .as_str()
+        .is_some_and(|hash| hash.len() == 16));
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn scan_human_reports_local_semantic_pack_opt_in() {
+    let dir = make_project("semantic_pack_human");
+    let pack = dir.join("pack.json");
+    fs::write(&pack, semantic_pack_manifest("com.example.semantic-pack")).unwrap();
+
+    let out = run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--min-size",
+        "12",
+        "--semantic-pack",
+        pack.to_str().unwrap(),
+    ]);
+    assert!(
+        out.contains(
+            "semantic packs: nose.first_party first-party default · 1 local opt-in: \
+             com.example.semantic-pack@0.1.0 (metadata-only)"
+        ),
+        "human scan output should disclose local semantic pack opt-ins: {out}"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn config_semantic_packs_are_explicit_opt_ins() {
+    let dir = make_project("semantic_pack_cfg");
+    fs::write(
+        dir.join("pack.json"),
+        semantic_pack_manifest("com.example.config-pack"),
+    )
+    .unwrap();
+    fs::write(
+        dir.join("nose.toml"),
+        "[scan]\nmin-size = 12\nsemantic-packs = [\"pack.json\"]\n",
+    )
+    .unwrap();
+    let out = Command::new(bin())
+        .args(["scan", ".", "--format", "json"])
+        .current_dir(&dir)
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "scan should load config semantic pack: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let json = scan_json(&stdout);
+    let packs = json["semantic_packs"]
+        .as_array()
+        .expect("semantic_packs array");
+    assert!(packs.iter().any(
+        |pack| pack["id"] == "com.example.config-pack" && pack["influence"] == "metadata-only"
+    ));
+    let _ = fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn inline_nose_ignore_suppresses_a_site() {
     // A `nose-ignore` marker above a function drops that site; with only one copy
@@ -875,6 +1024,10 @@ fn capabilities_command_emits_machine_readable_contract() {
     assert_eq!(json["schemas"]["capabilities"][0], 1);
     assert_eq!(json["schemas"]["scan_json"][0], 1);
     assert_eq!(
+        json["schemas"]["semantic_packs"][0],
+        "nose.semantic-pack.v0"
+    );
+    assert_eq!(
         json_array_strings(&json["scan"], "modes"),
         vec!["syntax", "semantic", "near"]
     );
@@ -891,7 +1044,20 @@ fn capabilities_command_emits_machine_readable_contract() {
         vec!["extractability", "value", "sites", "hazard"]
     );
     assert_eq!(json["scan"]["capabilities"]["baseline"], true);
+    assert_eq!(json["scan"]["capabilities"]["semantic_pack_loading"], true);
     assert_eq!(json["scan"]["capabilities"]["structured_ignores"], true);
+    assert_eq!(
+        json["semantic_packs"]["api_versions"][0],
+        "nose.semantic-pack.v0"
+    );
+    assert_eq!(
+        json["semantic_packs"]["external_pack_influence"],
+        "metadata-only"
+    );
+    assert_eq!(
+        json["semantic_packs"]["external_packs_enabled_by_default"],
+        false
+    );
     assert_eq!(
         json_array_strings(&json["il"], "output_formats"),
         vec!["sexpr", "json"]

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -625,6 +625,49 @@ fn config_semantic_packs_are_explicit_opt_ins() {
 }
 
 #[test]
+fn explicit_config_semantic_pack_paths_resolve_from_config_directory() {
+    let dir = make_project("semantic_pack_explicit_cfg");
+    fs::write(
+        dir.join("pack.json"),
+        semantic_pack_manifest("com.example.explicit-config-pack"),
+    )
+    .unwrap();
+    let config = dir.join("nose.toml");
+    fs::write(
+        &config,
+        "[scan]\nmin-size = 12\nsemantic-packs = [\"pack.json\"]\n",
+    )
+    .unwrap();
+
+    let out = Command::new(bin())
+        .args([
+            "scan",
+            dir.to_str().unwrap(),
+            "--config",
+            config.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .current_dir(dir.parent().expect("test project has a parent"))
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "scan should load config-relative semantic pack: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let json = scan_json(&stdout);
+    let packs = json["semantic_packs"]
+        .as_array()
+        .expect("semantic_packs array");
+    assert!(packs
+        .iter()
+        .any(|pack| pack["id"] == "com.example.explicit-config-pack"));
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn inline_nose_ignore_suppresses_a_site() {
     // A `nose-ignore` marker above a function drops that site; with only one copy
     // left there's no family.

--- a/crates/nose-cli/tests/cli/support.rs
+++ b/crates/nose-cli/tests/cli/support.rs
@@ -187,6 +187,34 @@ pub(crate) fn assert_scan_json_v1_contract(json: &serde_json::Value) {
         json["scope"]["languages"].as_array().is_some(),
         "scope.languages should be an array: {json}"
     );
+    let packs = json["semantic_packs"]
+        .as_array()
+        .expect("semantic_packs should be an array");
+    let first_party = packs
+        .first()
+        .and_then(|pack| pack.as_object())
+        .expect("semantic_packs should include first-party provenance");
+    for key in [
+        "id",
+        "hash",
+        "kind",
+        "version",
+        "display_name",
+        "trust",
+        "enabled_by_default",
+        "source",
+        "influence",
+        "provider",
+        "repository",
+        "license",
+        "supported_languages",
+        "counts",
+    ] {
+        assert!(
+            first_party.contains_key(key),
+            "semantic_packs[0].{key} missing: {json}"
+        );
+    }
 
     let ranking = json["ranking"].as_object().expect("ranking object");
     for key in ["sort", "total_families", "shown_families", "limit"] {

--- a/crates/nose-cli/tests/fixtures/scan-json-v1.json
+++ b/crates/nose-cli/tests/fixtures/scan-json-v1.json
@@ -10,6 +10,30 @@
       }
     ]
   },
+  "semantic_packs": [
+    {
+      "id": "nose.first_party",
+      "hash": "87b19e582546aed9",
+      "kind": "LanguagePack",
+      "version": "<version>",
+      "display_name": "nose first-party semantic kernel",
+      "trust": "default-first-party",
+      "enabled_by_default": true,
+      "source": "compiled-first-party",
+      "influence": "evidence-and-contracts",
+      "provider": "Corca, Inc.",
+      "repository": "https://github.com/corca-ai/nose",
+      "license": "MIT",
+      "supported_languages": [],
+      "counts": {
+        "evidence_producers": 0,
+        "contracts": 0,
+        "value_laws": 0,
+        "positive_fixtures": 0,
+        "hard_negatives": 0
+      }
+    }
+  ],
   "ranking": {
     "sort": "extractability",
     "total_families": 1,

--- a/crates/nose-semantics/Cargo.toml
+++ b/crates/nose-semantics/Cargo.toml
@@ -8,6 +8,8 @@ rust-version.workspace = true
 [dependencies]
 nose-il = { workspace = true }
 rustc-hash = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -23,6 +23,7 @@ mod effects;
 mod evidence;
 mod library_api;
 mod module_exports;
+mod packs;
 mod type_domain;
 
 pub use api_guards::*;
@@ -42,6 +43,7 @@ use library_api::{
 };
 pub use module_exports::*;
 pub use nose_il::DomainEvidence;
+pub use packs::*;
 pub use type_domain::{python_stdlib_type_domain, type_domain_from_source_text};
 
 /// Stable pack id for the first-party language/stdlib contracts compiled into nose.

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -679,8 +679,11 @@ fn validate_manifest(manifest: &SemanticPackManifest) -> Result<(), String> {
         "compatibility.notes",
         manifest.compatibility.notes.as_deref(),
     )?;
-    if manifest.pack.trust == PackTrust::ExternalOptIn && manifest.pack.enabled_by_default {
-        return Err("external-opt-in packs must not be enabled by default".to_string());
+    if manifest.pack.trust != PackTrust::ExternalOptIn || manifest.pack.enabled_by_default {
+        return Err(
+            "local semantic pack manifests must be external-opt-in and disabled by default"
+                .to_string(),
+        );
     }
     if manifest.supported_languages.is_empty() {
         return Err("`supported_languages` must contain at least one language".to_string());
@@ -1117,7 +1120,27 @@ mod tests {
         let err = load_local_manifest(&path).expect_err("must reject implicit external default");
         assert!(err
             .to_string()
-            .contains("external-opt-in packs must not be enabled"));
+            .contains("must be external-opt-in and disabled by default"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn local_manifest_claiming_first_party_trust_is_rejected() {
+        let dir = unique_dir("first_party_trust");
+        let path = dir.join("pack.json");
+        fs::write(
+            &path,
+            manifest("com.example.pack").replace(
+                r#""trust": "external-opt-in""#,
+                r#""trust": "default-first-party""#,
+            ),
+        )
+        .unwrap();
+        let err =
+            load_local_manifest(&path).expect_err("local manifest must not claim first-party");
+        assert!(err
+            .to_string()
+            .contains("must be external-opt-in and disabled by default"));
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -1,0 +1,1184 @@
+//! Semantic pack manifest loading and provenance summaries.
+//!
+//! Loading a manifest is an explicit opt-in metadata path. External packs do not
+//! emit evidence or approve exact results from this module; consumers must still
+//! require occurrence evidence and kernel-owned admission checks.
+
+use crate::{PackTrust, FIRST_PARTY_PACK_ID};
+use nose_il::stable_symbol_hash;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+pub const SEMANTIC_PACK_API_VERSION: &str = "nose.semantic-pack.v0";
+
+const ALLOWED_REQUIREMENT_PREFIXES: &[&str] = &[
+    "Source.",
+    "Symbol.",
+    "Import.",
+    "Domain.",
+    "Type.",
+    "Guard.",
+    "Place.",
+    "Effect.",
+    "LibraryApi.",
+    "CallTarget.",
+    "SequenceSurface.",
+    "nose.",
+];
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SemanticPackSource {
+    CompiledFirstParty,
+    LocalManifest,
+}
+
+impl SemanticPackSource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            SemanticPackSource::CompiledFirstParty => "compiled-first-party",
+            SemanticPackSource::LocalManifest => "local-manifest",
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SemanticPackInfluence {
+    EvidenceAndContracts,
+    MetadataOnly,
+}
+
+impl SemanticPackInfluence {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            SemanticPackInfluence::EvidenceAndContracts => "evidence-and-contracts",
+            SemanticPackInfluence::MetadataOnly => "metadata-only",
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Deserialize)]
+pub enum SemanticPackKind {
+    LanguagePack,
+    StdlibPack,
+    LibraryPack,
+    ProtocolPack,
+    LawPack,
+}
+
+impl SemanticPackKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            SemanticPackKind::LanguagePack => "LanguagePack",
+            SemanticPackKind::StdlibPack => "StdlibPack",
+            SemanticPackKind::LibraryPack => "LibraryPack",
+            SemanticPackKind::ProtocolPack => "ProtocolPack",
+            SemanticPackKind::LawPack => "LawPack",
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum SemanticPackAnchor {
+    SourceSpan,
+    Node,
+    Param,
+    Binding,
+    Sequence,
+    Module,
+    Package,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackChannel {
+    SyntaxOnly,
+    NearOnly,
+    AbstractionWitness,
+    ExactEmpirical,
+    ExactProven,
+}
+
+impl SemanticPackChannel {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            SemanticPackChannel::SyntaxOnly => "syntax-only",
+            SemanticPackChannel::NearOnly => "near-only",
+            SemanticPackChannel::AbstractionWitness => "abstraction-witness",
+            SemanticPackChannel::ExactEmpirical => "exact-empirical",
+            SemanticPackChannel::ExactProven => "exact-proven",
+        }
+    }
+
+    pub const fn exact_capable(self) -> bool {
+        matches!(
+            self,
+            SemanticPackChannel::ExactEmpirical | SemanticPackChannel::ExactProven
+        )
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackProofStatus {
+    Proven,
+    Covered,
+    Missing,
+    EmpiricalOnly,
+    RejectedCounterexample,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum SemanticPackStatus {
+    DraftExample,
+    Experimental,
+    Stable,
+    Deprecated,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum SemanticPackSchemaVersion {
+    V0,
+}
+
+impl PackTrust {
+    pub const fn as_manifest_str(self) -> &'static str {
+        match self {
+            PackTrust::DefaultFirstParty => "default-first-party",
+            PackTrust::FirstPartyOptional => "first-party-optional",
+            PackTrust::ExternalOptIn => "external-opt-in",
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PackTrust {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match String::deserialize(deserializer)?.as_str() {
+            "default-first-party" => Ok(PackTrust::DefaultFirstParty),
+            "first-party-optional" => Ok(PackTrust::FirstPartyOptional),
+            "external-opt-in" => Ok(PackTrust::ExternalOptIn),
+            other => Err(serde::de::Error::custom(format!(
+                "unknown pack trust `{other}`"
+            ))),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SemanticPackCounts {
+    pub evidence_producers: usize,
+    pub contracts: usize,
+    pub value_laws: usize,
+    pub positive_fixtures: usize,
+    pub hard_negatives: usize,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SemanticPackSummary {
+    pub id: String,
+    pub hash: u64,
+    pub kind: SemanticPackKind,
+    pub version: String,
+    pub display_name: String,
+    pub trust: PackTrust,
+    pub enabled_by_default: bool,
+    pub source: SemanticPackSource,
+    pub influence: SemanticPackInfluence,
+    pub manifest_path: Option<PathBuf>,
+    pub provider: String,
+    pub repository: String,
+    pub license: String,
+    pub supported_languages: Vec<String>,
+    pub counts: SemanticPackCounts,
+}
+
+impl SemanticPackSummary {
+    pub fn hash_hex(&self) -> String {
+        format!("{:016x}", self.hash)
+    }
+
+    fn from_manifest(path: PathBuf, manifest: SemanticPackManifest) -> Result<Self, String> {
+        validate_manifest(&manifest)?;
+        let id = manifest.pack.id;
+        let supported_languages = manifest
+            .supported_languages
+            .into_iter()
+            .map(|language| language.id)
+            .collect();
+        let counts = SemanticPackCounts {
+            evidence_producers: manifest.declares.evidence_producers.len(),
+            contracts: manifest.declares.contracts.len(),
+            value_laws: manifest.declares.value_laws.len(),
+            positive_fixtures: manifest.conformance.positive_fixtures.len(),
+            hard_negatives: manifest.conformance.hard_negatives.len(),
+        };
+        Ok(Self {
+            hash: semantic_pack_hash(&id),
+            id,
+            kind: manifest.pack.kind,
+            version: manifest.pack.version,
+            display_name: manifest.pack.display_name,
+            trust: manifest.pack.trust,
+            enabled_by_default: manifest.pack.enabled_by_default,
+            source: SemanticPackSource::LocalManifest,
+            influence: SemanticPackInfluence::MetadataOnly,
+            manifest_path: Some(path),
+            provider: manifest.provenance.provider.name,
+            repository: manifest.provenance.repository,
+            license: manifest.provenance.license,
+            supported_languages,
+            counts,
+        })
+    }
+}
+
+pub fn semantic_pack_hash(pack_id: &str) -> u64 {
+    stable_symbol_hash(pack_id)
+}
+
+pub fn first_party_semantic_pack() -> SemanticPackSummary {
+    SemanticPackSummary {
+        id: FIRST_PARTY_PACK_ID.to_string(),
+        hash: semantic_pack_hash(FIRST_PARTY_PACK_ID),
+        kind: SemanticPackKind::LanguagePack,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        display_name: "nose first-party semantic kernel".to_string(),
+        trust: PackTrust::DefaultFirstParty,
+        enabled_by_default: true,
+        source: SemanticPackSource::CompiledFirstParty,
+        influence: SemanticPackInfluence::EvidenceAndContracts,
+        manifest_path: None,
+        provider: "Corca, Inc.".to_string(),
+        repository: "https://github.com/corca-ai/nose".to_string(),
+        license: "MIT".to_string(),
+        supported_languages: Vec::new(),
+        counts: SemanticPackCounts {
+            evidence_producers: 0,
+            contracts: 0,
+            value_laws: 0,
+            positive_fixtures: 0,
+            hard_negatives: 0,
+        },
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SemanticPackSet {
+    packs: Vec<SemanticPackSummary>,
+}
+
+impl SemanticPackSet {
+    pub fn new_local(paths: &[PathBuf]) -> Result<Self, SemanticPackLoadError> {
+        let manifest_paths = discover_manifest_paths(paths)?;
+        let mut packs = vec![first_party_semantic_pack()];
+        for path in manifest_paths {
+            let pack = load_local_manifest(&path)?;
+            if let Some(existing) = packs.iter().find(|existing| existing.id == pack.id) {
+                return Err(SemanticPackLoadError::DuplicatePackId {
+                    id: pack.id,
+                    first_path: existing.manifest_path.clone(),
+                    second_path: Some(path),
+                });
+            }
+            packs.push(pack);
+        }
+        Ok(Self { packs })
+    }
+
+    pub fn first_party_only() -> Self {
+        Self {
+            packs: vec![first_party_semantic_pack()],
+        }
+    }
+
+    pub fn packs(&self) -> &[SemanticPackSummary] {
+        &self.packs
+    }
+}
+
+pub fn discover_manifest_paths(paths: &[PathBuf]) -> Result<Vec<PathBuf>, SemanticPackLoadError> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for path in paths {
+        if path.is_file() {
+            push_unique_manifest(path, &mut seen, &mut out)?;
+        } else if path.is_dir() {
+            discover_manifest_directory(path, &mut seen, &mut out)?;
+        } else {
+            return Err(SemanticPackLoadError::NotFound { path: path.clone() });
+        }
+    }
+    Ok(out)
+}
+
+fn discover_manifest_directory(
+    path: &Path,
+    seen: &mut HashSet<PathBuf>,
+    out: &mut Vec<PathBuf>,
+) -> Result<(), SemanticPackLoadError> {
+    let mut entries = Vec::new();
+    for entry in std::fs::read_dir(path).map_err(|source| SemanticPackLoadError::Io {
+        path: path.to_path_buf(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| SemanticPackLoadError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let entry_path = entry.path();
+        if entry_path.extension().is_some_and(|ext| ext == "json") {
+            entries.push(entry_path);
+        }
+    }
+    entries.sort();
+    if entries.is_empty() {
+        return Err(SemanticPackLoadError::DirectoryHasNoManifests {
+            path: path.to_path_buf(),
+        });
+    }
+    for entry in entries {
+        push_unique_manifest(&entry, seen, out)?;
+    }
+    Ok(())
+}
+
+fn push_unique_manifest(
+    path: &Path,
+    seen: &mut HashSet<PathBuf>,
+    out: &mut Vec<PathBuf>,
+) -> Result<(), SemanticPackLoadError> {
+    let canonical = path
+        .canonicalize()
+        .map_err(|source| SemanticPackLoadError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    if seen.insert(canonical.clone()) {
+        out.push(canonical);
+    }
+    Ok(())
+}
+
+pub fn load_local_manifest(path: &Path) -> Result<SemanticPackSummary, SemanticPackLoadError> {
+    let text = std::fs::read_to_string(path).map_err(|source| SemanticPackLoadError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let manifest = serde_json::from_str::<SemanticPackManifest>(&text).map_err(|source| {
+        SemanticPackLoadError::Json {
+            path: path.to_path_buf(),
+            source,
+        }
+    })?;
+    SemanticPackSummary::from_manifest(path.to_path_buf(), manifest).map_err(|message| {
+        SemanticPackLoadError::InvalidManifest {
+            path: path.to_path_buf(),
+            message,
+        }
+    })
+}
+
+#[derive(Debug)]
+pub enum SemanticPackLoadError {
+    NotFound {
+        path: PathBuf,
+    },
+    DirectoryHasNoManifests {
+        path: PathBuf,
+    },
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Json {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    InvalidManifest {
+        path: PathBuf,
+        message: String,
+    },
+    DuplicatePackId {
+        id: String,
+        first_path: Option<PathBuf>,
+        second_path: Option<PathBuf>,
+    },
+}
+
+impl fmt::Display for SemanticPackLoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SemanticPackLoadError::NotFound { path } => {
+                write!(f, "semantic pack path not found: {}", path.display())
+            }
+            SemanticPackLoadError::DirectoryHasNoManifests { path } => write!(
+                f,
+                "semantic pack directory contains no JSON manifests: {}",
+                path.display()
+            ),
+            SemanticPackLoadError::Io { path, source } => {
+                write!(f, "reading semantic pack {}: {source}", path.display())
+            }
+            SemanticPackLoadError::Json { path, source } => {
+                write!(f, "parsing semantic pack {}: {source}", path.display())
+            }
+            SemanticPackLoadError::InvalidManifest { path, message } => {
+                write!(f, "invalid semantic pack {}: {message}", path.display())
+            }
+            SemanticPackLoadError::DuplicatePackId {
+                id,
+                first_path,
+                second_path,
+            } => write!(
+                f,
+                "duplicate semantic pack id `{id}` between {} and {}",
+                display_optional_path(first_path),
+                display_optional_path(second_path)
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SemanticPackLoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SemanticPackLoadError::Io { source, .. } => Some(source),
+            SemanticPackLoadError::Json { source, .. } => Some(source),
+            SemanticPackLoadError::NotFound { .. }
+            | SemanticPackLoadError::DirectoryHasNoManifests { .. }
+            | SemanticPackLoadError::InvalidManifest { .. }
+            | SemanticPackLoadError::DuplicatePackId { .. } => None,
+        }
+    }
+}
+
+fn display_optional_path(path: &Option<PathBuf>) -> String {
+    path.as_ref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "<compiled first-party>".to_string())
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SemanticPackManifest {
+    #[serde(rename = "$schema")]
+    _schema: Option<String>,
+    api_version: String,
+    pack: ManifestPack,
+    provenance: ManifestProvenance,
+    compatibility: ManifestCompatibility,
+    supported_languages: Vec<ManifestLanguage>,
+    #[serde(default)]
+    packages: Vec<ManifestPackage>,
+    #[serde(default)]
+    dependencies: Vec<ManifestDependency>,
+    declares: ManifestDeclares,
+    conformance: ManifestConformance,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestPack {
+    id: String,
+    kind: SemanticPackKind,
+    version: String,
+    display_name: String,
+    #[serde(default)]
+    description: Option<String>,
+    trust: PackTrust,
+    enabled_by_default: bool,
+    #[serde(default, rename = "status")]
+    _status: Option<SemanticPackStatus>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestProvenance {
+    provider: ManifestProvider,
+    license: String,
+    repository: String,
+    #[serde(default)]
+    source_revision: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestProvider {
+    name: String,
+    #[serde(default)]
+    contact: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestCompatibility {
+    nose: String,
+    #[serde(default, rename = "schema")]
+    _schema: Option<SemanticPackSchemaVersion>,
+    #[serde(default)]
+    notes: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestLanguage {
+    id: String,
+    #[serde(default)]
+    language_version: Option<String>,
+    #[serde(default)]
+    runtime: Option<String>,
+    #[serde(default)]
+    runtime_versions: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestDependency {
+    id: String,
+    version: String,
+    required: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestPackage {
+    ecosystem: String,
+    name: String,
+    versions: String,
+    #[serde(default, rename = "stdlib")]
+    _stdlib: Option<bool>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestDeclares {
+    evidence_producers: Vec<ManifestEvidenceProducer>,
+    contracts: Vec<ManifestContract>,
+    #[serde(default)]
+    value_laws: Vec<ManifestValueLaw>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestEvidenceProducer {
+    id: String,
+    kind: String,
+    anchors: Vec<SemanticPackAnchor>,
+    channel: SemanticPackChannel,
+    #[serde(default)]
+    emits: Vec<String>,
+    #[serde(default)]
+    requires: Vec<ManifestRequirement>,
+    stable_hash_inputs: Vec<String>,
+    conflict_policy: String,
+    #[serde(default)]
+    notes: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestContract {
+    id: String,
+    surface: serde_json::Value,
+    requires: Vec<ManifestRequirement>,
+    semantics: serde_json::Value,
+    channel: SemanticPackChannel,
+    proof_status: SemanticPackProofStatus,
+    conformance_refs: Vec<String>,
+    #[serde(default)]
+    known_unsupported: Vec<String>,
+    #[serde(default)]
+    notes: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestValueLaw {
+    id: String,
+    requires: Vec<ManifestRequirement>,
+    semantics: serde_json::Value,
+    channel: SemanticPackChannel,
+    proof_status: SemanticPackProofStatus,
+    conformance_refs: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestRequirement {
+    #[serde(rename = "ref")]
+    ref_id: String,
+    subject: String,
+    required: bool,
+    #[serde(default)]
+    same_anchor_as: Option<String>,
+    #[serde(default)]
+    within_scope: Option<String>,
+    #[serde(default)]
+    before: Option<String>,
+    #[serde(default)]
+    after: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestConformance {
+    positive_fixtures: Vec<ManifestFixture>,
+    hard_negatives: Vec<ManifestFixture>,
+    known_unsupported: Vec<String>,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    proofs: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestFixture {
+    id: String,
+    description: String,
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    expectation: Option<String>,
+}
+
+fn validate_manifest(manifest: &SemanticPackManifest) -> Result<(), String> {
+    if manifest.api_version != SEMANTIC_PACK_API_VERSION {
+        return Err(format!(
+            "`api_version` must be {SEMANTIC_PACK_API_VERSION}, got `{}`",
+            manifest.api_version
+        ));
+    }
+    require_stable_id("pack.id", &manifest.pack.id)?;
+    require_non_empty("pack.version", &manifest.pack.version)?;
+    require_non_empty("pack.display_name", &manifest.pack.display_name)?;
+    optional_non_empty("pack.description", manifest.pack.description.as_deref())?;
+    require_non_empty(
+        "provenance.provider.name",
+        &manifest.provenance.provider.name,
+    )?;
+    optional_non_empty(
+        "provenance.provider.contact",
+        manifest.provenance.provider.contact.as_deref(),
+    )?;
+    require_non_empty("provenance.license", &manifest.provenance.license)?;
+    require_non_empty("provenance.repository", &manifest.provenance.repository)?;
+    optional_non_empty(
+        "provenance.source_revision",
+        manifest.provenance.source_revision.as_deref(),
+    )?;
+    require_non_empty("compatibility.nose", &manifest.compatibility.nose)?;
+    optional_non_empty(
+        "compatibility.notes",
+        manifest.compatibility.notes.as_deref(),
+    )?;
+    if manifest.pack.trust == PackTrust::ExternalOptIn && manifest.pack.enabled_by_default {
+        return Err("external-opt-in packs must not be enabled by default".to_string());
+    }
+    if manifest.supported_languages.is_empty() {
+        return Err("`supported_languages` must contain at least one language".to_string());
+    }
+    for language in &manifest.supported_languages {
+        require_non_empty("supported_languages[].id", &language.id)?;
+        optional_non_empty(
+            "supported_languages[].language_version",
+            language.language_version.as_deref(),
+        )?;
+        optional_non_empty("supported_languages[].runtime", language.runtime.as_deref())?;
+        for version in &language.runtime_versions {
+            require_non_empty("supported_languages[].runtime_versions[]", version)?;
+        }
+    }
+    for package in &manifest.packages {
+        require_non_empty("packages[].ecosystem", &package.ecosystem)?;
+        require_non_empty("packages[].name", &package.name)?;
+        require_non_empty("packages[].versions", &package.versions)?;
+    }
+    for dependency in &manifest.dependencies {
+        require_stable_id("dependencies[].id", &dependency.id)?;
+        require_non_empty("dependencies[].version", &dependency.version)?;
+        let _required = dependency.required;
+    }
+
+    let mut known_refs = HashSet::new();
+    collect_unique_refs(
+        "dependencies",
+        manifest.dependencies.iter().map(|dep| &dep.id),
+        &mut known_refs,
+    )?;
+    collect_unique_refs(
+        "declares.evidence_producers",
+        manifest
+            .declares
+            .evidence_producers
+            .iter()
+            .map(|producer| &producer.id),
+        &mut known_refs,
+    )?;
+    collect_unique_refs(
+        "declares.contracts",
+        manifest
+            .declares
+            .contracts
+            .iter()
+            .map(|contract| &contract.id),
+        &mut known_refs,
+    )?;
+    collect_unique_refs(
+        "declares.value_laws",
+        manifest.declares.value_laws.iter().map(|law| &law.id),
+        &mut known_refs,
+    )?;
+
+    if manifest.conformance.positive_fixtures.is_empty() {
+        return Err("`conformance.positive_fixtures` must not be empty".to_string());
+    }
+    if manifest.conformance.hard_negatives.is_empty() {
+        return Err("`conformance.hard_negatives` must not be empty".to_string());
+    }
+    for fixture in manifest
+        .conformance
+        .positive_fixtures
+        .iter()
+        .chain(&manifest.conformance.hard_negatives)
+    {
+        require_stable_id("conformance fixture id", &fixture.id)?;
+        require_non_empty("conformance fixture description", &fixture.description)?;
+        optional_non_empty("conformance fixture path", fixture.path.as_deref())?;
+        optional_non_empty(
+            "conformance fixture expectation",
+            fixture.expectation.as_deref(),
+        )?;
+    }
+    for unsupported in &manifest.conformance.known_unsupported {
+        require_non_empty("conformance.known_unsupported[]", unsupported)?;
+    }
+    optional_non_empty(
+        "conformance.command",
+        manifest.conformance.command.as_deref(),
+    )?;
+    for proof in &manifest.conformance.proofs {
+        require_non_empty("conformance.proofs[]", proof)?;
+    }
+    let mut conformance_refs = HashSet::new();
+    collect_unique_refs(
+        "conformance fixtures",
+        manifest
+            .conformance
+            .positive_fixtures
+            .iter()
+            .chain(&manifest.conformance.hard_negatives)
+            .map(|fixture| &fixture.id),
+        &mut conformance_refs,
+    )?;
+
+    for producer in &manifest.declares.evidence_producers {
+        validate_evidence_producer(producer, &known_refs)?;
+    }
+    for contract in &manifest.declares.contracts {
+        if !contract.surface.is_object() {
+            return Err(format!(
+                "contract `{}` surface must be an object",
+                contract.id
+            ));
+        }
+        for unsupported in &contract.known_unsupported {
+            require_non_empty("contract.known_unsupported[]", unsupported)?;
+        }
+        optional_non_empty("contract.notes", contract.notes.as_deref())?;
+        validate_contract(
+            &contract.id,
+            &contract.requires,
+            &contract.semantics,
+            contract.channel,
+            contract.proof_status,
+            &contract.conformance_refs,
+            &known_refs,
+            &conformance_refs,
+            true,
+        )?;
+    }
+    for law in &manifest.declares.value_laws {
+        validate_contract(
+            &law.id,
+            &law.requires,
+            &law.semantics,
+            law.channel,
+            law.proof_status,
+            &law.conformance_refs,
+            &known_refs,
+            &conformance_refs,
+            false,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_evidence_producer(
+    producer: &ManifestEvidenceProducer,
+    known_refs: &HashSet<String>,
+) -> Result<(), String> {
+    require_stable_id("declares.evidence_producers[].id", &producer.id)?;
+    if !producer.kind.starts_with_evidence_prefix() {
+        return Err(format!(
+            "evidence producer `{}` has unknown kind `{}`",
+            producer.id, producer.kind
+        ));
+    }
+    if producer.anchors.is_empty() {
+        return Err(format!(
+            "evidence producer `{}` must declare at least one anchor",
+            producer.id
+        ));
+    }
+    if producer.stable_hash_inputs.is_empty()
+        || !producer
+            .stable_hash_inputs
+            .iter()
+            .any(|input| input == "pack.id")
+        || !producer
+            .stable_hash_inputs
+            .iter()
+            .any(|input| input == "producer.id")
+    {
+        return Err(format!(
+            "evidence producer `{}` stable_hash_inputs must include pack.id and producer.id",
+            producer.id
+        ));
+    }
+    if producer.conflict_policy != "fail-closed" && producer.conflict_policy != "near-only" {
+        return Err(format!(
+            "evidence producer `{}` conflict_policy must be fail-closed or near-only",
+            producer.id
+        ));
+    }
+    if producer.channel.exact_capable() && producer.conflict_policy != "fail-closed" {
+        return Err(format!(
+            "exact-capable evidence producer `{}` must fail closed on conflicts",
+            producer.id
+        ));
+    }
+    for emitted in &producer.emits {
+        if !emitted.starts_with_evidence_prefix() {
+            return Err(format!(
+                "evidence producer `{}` emits unknown evidence kind `{emitted}`",
+                producer.id
+            ));
+        }
+    }
+    for requirement in &producer.requires {
+        validate_requirement(&producer.id, requirement, known_refs)?;
+    }
+    optional_non_empty("producer.notes", producer.notes.as_deref())?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_contract(
+    id: &str,
+    requirements: &[ManifestRequirement],
+    semantics: &serde_json::Value,
+    channel: SemanticPackChannel,
+    _proof_status: SemanticPackProofStatus,
+    conformance_refs: &[String],
+    known_refs: &HashSet<String>,
+    fixture_refs: &HashSet<String>,
+    requires_surface: bool,
+) -> Result<(), String> {
+    require_stable_id("declares.contracts[].id", id)?;
+    if requires_surface && !semantics.is_object() {
+        return Err(format!("contract `{id}` semantics must be an object"));
+    }
+    for ref_id in conformance_refs {
+        if !fixture_refs.contains(ref_id) {
+            return Err(format!(
+                "contract `{id}` references missing conformance fixture `{ref_id}`"
+            ));
+        }
+    }
+    if channel.exact_capable() {
+        if requirements.is_empty() {
+            return Err(format!(
+                "exact-capable contract `{id}` must declare evidence requirements"
+            ));
+        }
+        let semantics = semantics
+            .as_object()
+            .ok_or_else(|| format!("exact-capable contract `{id}` semantics must be an object"))?;
+        if !semantics.contains_key("demand") || !semantics.contains_key("effects") {
+            return Err(format!(
+                "exact-capable contract `{id}` must declare demand and effects"
+            ));
+        }
+    }
+    for requirement in requirements {
+        validate_requirement(id, requirement, known_refs)?;
+    }
+    Ok(())
+}
+
+fn validate_requirement(
+    context: &str,
+    requirement: &ManifestRequirement,
+    known_refs: &HashSet<String>,
+) -> Result<(), String> {
+    require_non_empty("requirement.ref", &requirement.ref_id)?;
+    require_non_empty("requirement.subject", &requirement.subject)?;
+    let _required = requirement.required;
+    optional_non_empty(
+        "requirement.same_anchor_as",
+        requirement.same_anchor_as.as_deref(),
+    )?;
+    optional_non_empty(
+        "requirement.within_scope",
+        requirement.within_scope.as_deref(),
+    )?;
+    optional_non_empty("requirement.before", requirement.before.as_deref())?;
+    optional_non_empty("requirement.after", requirement.after.as_deref())?;
+    if !known_refs.contains(&requirement.ref_id)
+        && !ALLOWED_REQUIREMENT_PREFIXES
+            .iter()
+            .any(|prefix| requirement.ref_id.starts_with(prefix))
+    {
+        return Err(format!(
+            "`{context}` requirement references unknown id `{}`",
+            requirement.ref_id
+        ));
+    }
+    Ok(())
+}
+
+fn collect_unique_refs<'a>(
+    label: &str,
+    ids: impl Iterator<Item = &'a String>,
+    out: &mut HashSet<String>,
+) -> Result<(), String> {
+    for id in ids {
+        require_stable_id(label, id)?;
+        if !out.insert(id.clone()) {
+            return Err(format!("duplicate id `{id}` in `{label}`"));
+        }
+    }
+    Ok(())
+}
+
+fn require_non_empty(label: &str, value: &str) -> Result<(), String> {
+    if value.is_empty() {
+        return Err(format!("`{label}` must be a non-empty string"));
+    }
+    Ok(())
+}
+
+fn optional_non_empty(label: &str, value: Option<&str>) -> Result<(), String> {
+    if matches!(value, Some("")) {
+        return Err(format!("`{label}` must be a non-empty string when present"));
+    }
+    Ok(())
+}
+
+fn require_stable_id(label: &str, value: &str) -> Result<(), String> {
+    require_non_empty(label, value)?;
+    let mut chars = value.chars();
+    if !chars.next().is_some_and(|c| c.is_ascii_alphanumeric())
+        || !chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | ':' | '-'))
+    {
+        return Err(format!("`{label}` has invalid stable id `{value}`"));
+    }
+    Ok(())
+}
+
+trait EvidenceKindPrefix {
+    fn starts_with_evidence_prefix(&self) -> bool;
+}
+
+impl EvidenceKindPrefix for str {
+    fn starts_with_evidence_prefix(&self) -> bool {
+        ALLOWED_REQUIREMENT_PREFIXES[..ALLOWED_REQUIREMENT_PREFIXES.len() - 1]
+            .iter()
+            .any(|prefix| self.starts_with(prefix))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn unique_dir(tag: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("nose_semantic_pack_{tag}_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn manifest(id: &str) -> String {
+        format!(
+            r#"{{
+  "api_version": "nose.semantic-pack.v0",
+  "pack": {{
+    "id": "{id}",
+    "kind": "LibraryPack",
+    "version": "0.1.0",
+    "display_name": "Example",
+    "trust": "external-opt-in",
+    "enabled_by_default": false
+  }},
+  "provenance": {{
+    "provider": {{ "name": "Example" }},
+    "license": "MIT",
+    "repository": "https://example.invalid"
+  }},
+  "compatibility": {{ "nose": ">=0.5.0 <0.6.0" }},
+  "supported_languages": [{{ "id": "python" }}],
+  "declares": {{
+    "evidence_producers": [{{
+      "id": "python.library-api.example",
+      "kind": "LibraryApi.Contract",
+      "anchors": ["node"],
+      "channel": "exact-empirical",
+      "stable_hash_inputs": ["pack.id", "producer.id", "call_span"],
+      "conflict_policy": "fail-closed"
+    }}],
+    "contracts": [{{
+      "id": "python.example.contract",
+      "surface": {{ "kind": "function" }},
+      "requires": [{{
+        "ref": "python.library-api.example",
+        "subject": "call",
+        "required": true
+      }}],
+      "semantics": {{
+        "operation": "Example",
+        "demand": {{ "arguments": "eager-left-to-right" }},
+        "effects": ["argument-effects-in-order"]
+      }},
+      "channel": "exact-empirical",
+      "proof_status": "covered",
+      "conformance_refs": ["positive", "negative"]
+    }}],
+    "value_laws": []
+  }},
+  "conformance": {{
+    "positive_fixtures": [{{ "id": "positive", "description": "positive" }}],
+    "hard_negatives": [{{ "id": "negative", "description": "negative" }}],
+    "known_unsupported": []
+  }}
+}}"#
+        )
+    }
+
+    #[test]
+    fn first_party_pack_hash_matches_evidence_provenance_hash_policy() {
+        let pack = first_party_semantic_pack();
+        assert_eq!(pack.id, FIRST_PARTY_PACK_ID);
+        assert_eq!(pack.hash, stable_symbol_hash(FIRST_PARTY_PACK_ID));
+        assert_eq!(pack.influence, SemanticPackInfluence::EvidenceAndContracts);
+    }
+
+    #[test]
+    fn local_manifest_loads_as_metadata_only_opt_in() {
+        let dir = unique_dir("load");
+        let path = dir.join("pack.json");
+        fs::write(&path, manifest("com.example.pack")).unwrap();
+        let set = SemanticPackSet::new_local(&[path]).expect("pack loads");
+        assert_eq!(set.packs().len(), 2);
+        let external = &set.packs()[1];
+        assert_eq!(external.id, "com.example.pack");
+        assert_eq!(external.hash, stable_symbol_hash("com.example.pack"));
+        assert_eq!(external.trust, PackTrust::ExternalOptIn);
+        assert_eq!(external.source, SemanticPackSource::LocalManifest);
+        assert_eq!(external.influence, SemanticPackInfluence::MetadataOnly);
+        assert_eq!(external.counts.contracts, 1);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn external_pack_enabled_by_default_is_rejected() {
+        let dir = unique_dir("trust");
+        let path = dir.join("pack.json");
+        fs::write(
+            &path,
+            manifest("com.example.pack").replace(
+                r#""trust": "external-opt-in",
+    "enabled_by_default": false"#,
+                r#""trust": "external-opt-in",
+    "enabled_by_default": true"#,
+            ),
+        )
+        .unwrap();
+        let err = load_local_manifest(&path).expect_err("must reject implicit external default");
+        assert!(err
+            .to_string()
+            .contains("external-opt-in packs must not be enabled"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn package_entries_must_match_manifest_shape() {
+        let dir = unique_dir("package");
+        let path = dir.join("pack.json");
+        fs::write(
+            &path,
+            manifest("com.example.pack").replace(
+                r#"  "supported_languages": [{ "id": "python" }],
+"#,
+                r#"  "supported_languages": [{ "id": "python" }],
+  "packages": [{ "ecosystem": "pypi", "name": "example" }],
+"#,
+            ),
+        )
+        .unwrap();
+        let err = load_local_manifest(&path).expect_err("package versions are required");
+        assert!(err.to_string().contains("missing field `versions`"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn evidence_producer_anchors_must_be_known_anchor_names() {
+        let dir = unique_dir("anchor");
+        let path = dir.join("pack.json");
+        fs::write(
+            &path,
+            manifest("com.example.pack")
+                .replace(r#""anchors": ["node"]"#, r#""anchors": ["raw-selector"]"#),
+        )
+        .unwrap();
+        let err = load_local_manifest(&path).expect_err("unknown anchors must not load");
+        assert!(err.to_string().contains("unknown variant"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn duplicate_pack_ids_fail_closed() {
+        let dir = unique_dir("dupe");
+        let one = dir.join("one.json");
+        let two = dir.join("two.json");
+        fs::write(&one, manifest("com.example.pack")).unwrap();
+        fs::write(&two, manifest("com.example.pack")).unwrap();
+        let err = SemanticPackSet::new_local(&[one, two]).expect_err("duplicate id");
+        assert!(err.to_string().contains("duplicate semantic pack id"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn directory_discovery_sorts_json_manifests() {
+        let dir = unique_dir("dir");
+        fs::write(dir.join("b.json"), manifest("com.example.b")).unwrap();
+        fs::write(dir.join("a.json"), manifest("com.example.a")).unwrap();
+        let paths = discover_manifest_paths(std::slice::from_ref(&dir)).expect("discover");
+        let names = paths
+            .iter()
+            .map(|path| path.file_name().unwrap().to_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["a.json", "b.json"]);
+        let _ = fs::remove_dir_all(dir);
+    }
+}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -111,12 +111,18 @@ release so it can't drift.
 | `commands.stable` | array | Stable user-facing commands that integrations may invoke. Hidden research commands are intentionally omitted. |
 | `schemas.capabilities` | array | Supported capabilities schema versions. |
 | `schemas.scan_json` | array | Supported `nose scan --format json` schema versions. |
+| `schemas.semantic_packs` | array | Supported semantic-pack manifest API versions, currently `nose.semantic-pack.v0`. |
 | `scan.modes` | array | Supported `--mode` values. |
 | `scan.default_modes` | array | Modes used by `nose scan` when `--mode` is omitted. |
 | `scan.output_formats` | array | Supported `nose scan --format` values. |
 | `scan.sort_keys` | array | Supported `nose scan --sort` values. |
 | `scan.config_keys` | array | Supported `[scan]` keys in `nose.toml` / `.nose.toml`. |
 | `scan.capabilities` | object | Stable boolean capability flags for scan workflows. |
+| `semantic_packs.api_versions` | array | Supported semantic-pack manifest API versions. |
+| `semantic_packs.loading` | array | Supported loading sources: compiled first-party and local manifest files/directories. |
+| `semantic_packs.trust` | array | Supported trust policy labels. |
+| `semantic_packs.external_packs_enabled_by_default` | boolean | Always `false`; external packs require explicit CLI/config opt-in. |
+| `semantic_packs.external_pack_influence` | string | Current influence of loaded external packs, `metadata-only`. |
 | `il.output_formats` | array | Supported `nose il --format` values. |
 | `il.normalized` | boolean | Whether `nose il --normalized` is supported. |
 | `il.cfg_norm_toggle` | boolean | Whether `nose il --no-cfg-norm` is supported. |
@@ -142,4 +148,5 @@ Version 1 defines these `scan.capabilities` keys:
 | `hotspots` | the `--show hotspots` directory duplicated-line summary is supported. |
 | `inline_suppression` | Source-level `nose-ignore` markers are supported. |
 | `proposal` | the `--show proposal` extraction-skeleton view is supported. |
+| `semantic_pack_loading` | local semantic-pack v0 manifest files/directories can be loaded for provenance reporting. |
 | `structured_ignores` | `nose.ignore.json` / `--ignore-file` audited suppressions are supported. |

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -46,7 +46,8 @@ nose capabilities
   },
   "schemas": {
     "capabilities": [1],
-    "scan_json": [1]
+    "scan_json": [1],
+    "semantic_packs": ["nose.semantic-pack.v0"]
   },
   "scan": {
     "modes": ["syntax", "semantic", "near"],
@@ -61,6 +62,7 @@ nose capabilities
       "min-size",
       "min-value",
       "mode",
+      "semantic-packs",
       "sort",
       "top"
     ],
@@ -73,8 +75,24 @@ nose capabilities
       "hotspots": true,
       "inline_suppression": true,
       "proposal": true,
+      "semantic_pack_loading": true,
       "structured_ignores": true
     }
+  },
+  "semantic_packs": {
+    "api_versions": ["nose.semantic-pack.v0"],
+    "loading": [
+      "compiled-first-party",
+      "local-manifest-file",
+      "local-manifest-directory"
+    ],
+    "trust": [
+      "default-first-party",
+      "first-party-optional",
+      "external-opt-in"
+    ],
+    "external_packs_enabled_by_default": false,
+    "external_pack_influence": "metadata-only"
   },
   "il": {
     "output_formats": ["sexpr", "json"],

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,15 +18,16 @@ min-members = 3
 min-size    = 30
 top         = 50
 ignore-file = "nose.ignore.json"
+semantic-packs = ["semantic-packs/python-math-prod.json"]
 ```
 
 Pass an alternate file with `--config <file>`. A malformed config is a **hard
 error** — a silently-ignored typo'd setting would be worse than a crash.
 
 Put stable project policy in `nose.toml`: excludes, scan modes, ranking, size/value
-thresholds, report limits, and the structured-ignore file. Keep one-off workflow choices on
-the command line: output format, `--show` views, baselines, cache location, and CI failure
-mode.
+thresholds, report limits, the structured-ignore file, and explicit local
+semantic-pack opt-ins. Keep one-off workflow choices on the command line: output
+format, `--show` views, baselines, cache location, and CI failure mode.
 
 ### Keys
 
@@ -44,6 +45,7 @@ the built-in default". Keys are kebab-case and live under the `[scan]` table.
 | `min-lines` | int (advanced) | `5` | `--min-lines` |
 | `top` | int | `30` | `--top` |
 | `ignore-file` | string path | auto-read `nose.ignore.json` when present | `--ignore-file` |
+| `semantic-packs` | list of file or directory paths | `[]` | `--semantic-pack` |
 
 `mode` is a TOML array, even for one channel:
 
@@ -72,6 +74,12 @@ cutoff.
 ```sh
 nose scan src --mode syntax,semantic,near:0.70
 ```
+
+`semantic-packs` is additive with repeated `--semantic-pack` flags. Each entry is
+an explicit local opt-in to a semantic-pack v0 manifest file or a directory of
+direct `*.json` manifests. Loaded external packs are reported as
+`metadata-only`; they do not emit evidence or enable exact contracts yet. See
+[semantic-pack-loading](semantic-pack-loading.md).
 
 ## Excludes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,9 +77,11 @@ nose scan src --mode syntax,semantic,near:0.70
 
 `semantic-packs` is additive with repeated `--semantic-pack` flags. Each entry is
 an explicit local opt-in to a semantic-pack v0 manifest file or a directory of
-direct `*.json` manifests. Loaded external packs are reported as
-`metadata-only`; they do not emit evidence or enable exact contracts yet. See
-[semantic-pack-loading](semantic-pack-loading.md).
+direct `*.json` manifests. Relative config paths are resolved from the config
+file's directory, so committed project opt-ins do not depend on where `nose` was
+invoked; CLI `--semantic-pack` paths remain current-working-directory relative.
+Loaded external packs are reported as `metadata-only`; they do not emit evidence
+or enable exact contracts yet. See [semantic-pack-loading](semantic-pack-loading.md).
 
 ## Excludes
 

--- a/docs/examples/semantic-packs/v0/language-pack.json
+++ b/docs/examples/semantic-packs/v0/language-pack.json
@@ -6,7 +6,7 @@
     "kind": "LanguagePack",
     "version": "0.1.0",
     "display_name": "Example JavaScript core surface pack",
-    "description": "Illustrative v0 language pack metadata for source and symbol facts. This is not a loadable pack.",
+    "description": "Illustrative v0 language pack metadata for source and symbol facts. It can be loaded for metadata/provenance reporting only.",
     "trust": "external-opt-in",
     "enabled_by_default": false,
     "status": "draft-example"
@@ -186,6 +186,6 @@
       "Dynamic eval and with-scope semantics are outside this example.",
       "This example does not model JavaScript object identity or equality conversion rules."
     ],
-    "command": "nose-semantic-pack check --manifest language-pack.json"
+    "command": "nose scan fixtures --semantic-pack language-pack.json --format json"
   }
 }

--- a/docs/examples/semantic-packs/v0/library-pack.json
+++ b/docs/examples/semantic-packs/v0/library-pack.json
@@ -6,7 +6,7 @@
     "kind": "LibraryPack",
     "version": "0.1.0",
     "display_name": "Example Python math.prod semantic pack",
-    "description": "Illustrative v0 library pack metadata for one imported namespace function. This is not a loadable pack.",
+    "description": "Illustrative v0 library pack metadata for one imported namespace function. It can be loaded for metadata/provenance reporting only.",
     "trust": "external-opt-in",
     "enabled_by_default": false,
     "status": "draft-example"
@@ -198,7 +198,7 @@
       "This example does not prove numeric algebraic product laws.",
       "This example does not certify behavior for monkey-patched module objects."
     ],
-    "command": "nose-semantic-pack check --manifest library-pack.json",
+    "command": "nose scan fixtures --semantic-pack library-pack.json --format json",
     "proofs": [
       "https://example.invalid/semantic-packs/python-math-prod/conformance"
     ]

--- a/docs/home.md
+++ b/docs/home.md
@@ -53,6 +53,7 @@ You want to *change* nose or understand how it works inside.
 - [normalization](normalization.md) — the passes that make behaviorally-equivalent code converge (the hard part).
 - [semantic-kernel](semantic-kernel.md) — semantic-kernel and pack architecture: language/library semantics, extension boundaries, responsibility model, and exact-channel eligibility.
 - [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) — versioned v0 schema and provider-facing extension API for language/library semantic packs, with examples and a conformance checklist.
+- [semantic-pack-loading](semantic-pack-loading.md) — local pack manifest loading, explicit opt-in trust policy, and scan JSON provenance reporting.
 - [evidence-records](evidence-records.md) — the internal pack-facing evidence substrate for source, domain, import, symbol, type, guard, place/effect, library API, and sequence-surface facts.
 - [demand-effect-semantics](demand-effect-semantics.md) — the internal demand/effect contract model for eager, lazy, short-circuit, async, generator, and channel boundaries.
 - [source-facts](source-facts.md) — source-origin evidence for semantic contracts: construct syntax, async/generator/error boundaries, literal/operator provenance, pack boundaries, and fail-closed exact admission.

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -66,6 +66,7 @@ source metadata.
 | `tool_version` | string | The `nose` package version that emitted the report. |
 | `scope.files` | integer | Number of supported source files scanned after ignores and excludes. |
 | `scope.languages` | array | Per-language file counts, largest first. |
+| `semantic_packs` | array | Active semantic packs for this scan. Always includes compiled `nose.first_party`; local `--semantic-pack`/config packs are listed with `metadata-only` influence. |
 | `ranking.sort` | string | Sort key used for `families`: `extractability` (default), `value`, `sites`, or `hazard`. |
 | `ranking.total_families` | integer | Active families remaining after rank-time pruning, filters, baseline suppression, and structured ignores, before `--top`. |
 | `ranking.shown_families` | integer | Families present in `families`. |
@@ -83,6 +84,26 @@ new families and changed families. Exact baseline matches are counted in
 When structured ignores are active, `families` contains only active findings.
 Ignored current families are omitted from `ranking.total_families` and appear in
 `ignored_families` instead.
+
+## Semantic pack fields
+
+Each `semantic_packs[]` entry has:
+
+| field | type | meaning |
+|---|---|---|
+| `id` | string | Stable manifest pack id. |
+| `hash` | string | Stable 16-hex-digit hash derived from the pack id; first-party evidence provenance uses the same id-hash policy. |
+| `kind` | string | `LanguagePack`, `StdlibPack`, `LibraryPack`, `ProtocolPack`, or `LawPack`. |
+| `version` | string | Pack version from the manifest or the nose package version for `nose.first_party`. |
+| `display_name` | string | Human-readable pack name. |
+| `trust` | string | `default-first-party`, `first-party-optional`, or `external-opt-in`. |
+| `enabled_by_default` | boolean | Whether the pack claims default enablement. External opt-in packs with `true` are rejected before reporting. |
+| `source` | string | `compiled-first-party` or `local-manifest`. |
+| `influence` | string | `evidence-and-contracts` for compiled first-party semantics, `metadata-only` for loaded local external packs today. |
+| `path` | string, optional | Local manifest path for loaded manifests. |
+| `provider`, `repository`, `license` | string | Manifest provenance fields. |
+| `supported_languages` | array | Manifest language ids. |
+| `counts` | object | Counts of declared evidence producers, contracts, value laws, positive fixtures, and hard negatives. |
 
 ## Baseline fields
 

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -20,6 +20,30 @@ The top-level value is always an object:
       { "language": "python", "files": 4 }
     ]
   },
+  "semantic_packs": [
+    {
+      "id": "nose.first_party",
+      "hash": "87b19e582546aed9",
+      "kind": "LanguagePack",
+      "version": "<version>",
+      "display_name": "nose first-party semantic kernel",
+      "trust": "default-first-party",
+      "enabled_by_default": true,
+      "source": "compiled-first-party",
+      "influence": "evidence-and-contracts",
+      "provider": "Corca, Inc.",
+      "repository": "https://github.com/corca-ai/nose",
+      "license": "MIT",
+      "supported_languages": [],
+      "counts": {
+        "evidence_producers": 0,
+        "contracts": 0,
+        "value_laws": 0,
+        "positive_fixtures": 0,
+        "hard_negatives": 0
+      }
+    }
+  ],
   "ranking": {
     "sort": "extractability",
     "total_families": 12,
@@ -66,7 +90,7 @@ source metadata.
 | `tool_version` | string | The `nose` package version that emitted the report. |
 | `scope.files` | integer | Number of supported source files scanned after ignores and excludes. |
 | `scope.languages` | array | Per-language file counts, largest first. |
-| `semantic_packs` | array | Active semantic packs for this scan. Always includes compiled `nose.first_party`; local `--semantic-pack`/config packs are listed with `metadata-only` influence. |
+| `semantic_packs` | array, optional in v1 | Active semantic packs for this scan. Binaries that advertise `scan.capabilities.semantic_pack_loading` in [capabilities](capabilities.md) emit it and include compiled `nose.first_party`; local `--semantic-pack`/config packs are listed with `metadata-only` influence. Older v1 binaries omit this field. |
 | `ranking.sort` | string | Sort key used for `families`: `extractability` (default), `value`, `sites`, or `hazard`. |
 | `ranking.total_families` | integer | Active families remaining after rank-time pruning, filters, baseline suppression, and structured ignores, before `--top`. |
 | `ranking.shown_families` | integer | Families present in `families`. |
@@ -87,7 +111,7 @@ Ignored current families are omitted from `ranking.total_families` and appear in
 
 ## Semantic pack fields
 
-Each `semantic_packs[]` entry has:
+When `semantic_packs` is present, each entry has:
 
 | field | type | meaning |
 |---|---|---|
@@ -96,8 +120,8 @@ Each `semantic_packs[]` entry has:
 | `kind` | string | `LanguagePack`, `StdlibPack`, `LibraryPack`, `ProtocolPack`, or `LawPack`. |
 | `version` | string | Pack version from the manifest or the nose package version for `nose.first_party`. |
 | `display_name` | string | Human-readable pack name. |
-| `trust` | string | `default-first-party`, `first-party-optional`, or `external-opt-in`. |
-| `enabled_by_default` | boolean | Whether the pack claims default enablement. External opt-in packs with `true` are rejected before reporting. |
+| `trust` | string | `default-first-party`, `first-party-optional`, or `external-opt-in`. Local manifests are rejected unless they use `external-opt-in`; first-party trust comes only from compiled packs. |
+| `enabled_by_default` | boolean | Whether the pack is default-enabled. Local manifests are rejected unless this is `false`; compiled `nose.first_party` reports `true`. |
 | `source` | string | `compiled-first-party` or `local-manifest`. |
 | `influence` | string | `evidence-and-contracts` for compiled first-party semantics, `metadata-only` for loaded local external packs today. |
 | `path` | string, optional | Local manifest path for loaded manifests. |

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -819,17 +819,22 @@ Remaining in this phase:
 ## Phase 4: external pack contract
 
 - The first versioned pack manifest schema is defined in
-  [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md). It is a
-  design/API artifact, not a loader.
-- Start with data-only external packs for simple APIs once pack loading exists.
+  [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md). Local
+  metadata loading is implemented for manifest files/directories and documented
+  in [semantic-pack-loading](semantic-pack-loading.md); external packs remain
+  metadata-only.
+- Start with data-only external packs for simple APIs once producer execution and
+  conformance checks exist.
 - Add restricted recognizer hooks only after the manifest path is stable.
 - Require pack metadata: provider, license, version range, supported analysis
   channels, evidence status, conformance commands, and semantic provenance ids.
 - Document the pack conformance checklist as part of the extension schema; make
   clear that conformance evidence is provider/user responsibility unless the pack
   is first-party.
-- Add user configuration for enabling external packs explicitly.
-- Report which external packs influenced `near` candidates and exact matches.
+- User configuration and `--semantic-pack` can enable local manifests explicitly.
+- Scan JSON reports active pack provenance and whether each pack influenced
+  evidence/contracts or metadata only. Per-finding contract/law provenance and
+  external pack influence on `near`/exact results remain open.
 
 The external schema must make proof obligations first-class. For example, a pack
 claiming `pkg.Foo.map` maps to the `Map` protocol must say how `pkg.Foo` is

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -75,8 +75,10 @@ still being migrated toward it.
   library API contract identities, library API row constructors, library API
   evidence-hash registry helpers, negative API guard rows, and library API
   occurrence/admission logic are split into focused modules.
-- The external pack API is documented as a v0 manifest/schema with examples, but
-  there is still no filesystem/network pack loader. First-party producers remain
+- The external pack API is documented as a v0 manifest/schema with examples.
+  `nose-semantics` can load local manifest files/directories for metadata and
+  provenance reporting, and `nose scan --format json` reports active packs.
+  External packs are still `metadata-only`; first-party producers remain
   compiled Rust and are expected to map onto the same vocabulary.
 - `nose-frontend` owns tree-sitter parsing, per-language lowering, embedded
   `<script>` extraction, source/domain/import/symbol/type/guard/place/effect/API/
@@ -723,13 +725,14 @@ language.
   reduction, and HOF callback shapes, but pull-lazy, call-by-need, async,
   generator, channel/protocol, and richer observable-effect behavior are not
   represented by a common pack-facing demand/effect abstraction.
-- External extension points do not exist. New languages and libraries must be
-  added inside the main crates.
-- Report output does not yet expose semantic provenance such as pack id, contract
-  id, law id, or proof status.
-- First-party and external responsibility boundaries are documented and
-  represented in the internal facade as provenance/trust policy, but there are no
-  loadable external packs or report-level pack provenance fields yet.
+- External producer execution does not exist. New languages and libraries that
+  affect analysis must still be added inside the main crates.
+- Report output now exposes pack-level provenance, but not contract-id, law-id,
+  or proof-status provenance per finding.
+- First-party and external responsibility boundaries are documented, represented
+  in the internal facade as provenance/trust policy, and visible in scan JSON.
+  Loaded external manifests remain metadata-only until a producer runtime and
+  conformance harness exist.
 
 ## Current fail-closed choices
 

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -28,7 +28,9 @@ makes soundness depend on scattered `Lang` checks.
 
 The semantic kernel is the boundary that all exact semantic reasoning must cross.
 The first internal facade now lives in `nose-semantics`; it is still a compiled
-first-party implementation, not a loadable external pack runtime.
+first-party implementation for evidence/contract execution. Local external
+manifests can be loaded for metadata/provenance reporting, but they are not an
+external producer runtime.
 The external API design starts at
 [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md): it narrows
 the current internal evidence and contract vocabulary into a manifest shape for
@@ -269,9 +271,9 @@ separately.
 | `external-opt-in` | provider/user responsibility; enabled only by explicit user choice |
 
 External packs may declare their intended eligibility, but users choose whether
-to trust that declaration. The default nose distribution should enable exact
-matching only for default first-party packs and any external packs the user
-explicitly opts into.
+to trust that declaration. Today, explicitly loaded external packs are reported
+as `metadata-only`; exact matching is enabled only by compiled first-party
+evidence/contracts.
 
 ## Pack conformance
 

--- a/docs/semantic-pack-extension-api-v0.md
+++ b/docs/semantic-pack-extension-api-v0.md
@@ -12,10 +12,13 @@ Schema artifacts:
 - [semantic-pack-v0 schema](schemas/semantic-pack-v0.schema.json)
 - [language-pack example](examples/semantic-packs/v0/language-pack.json)
 - [library-pack example](examples/semantic-packs/v0/library-pack.json)
+- [semantic-pack-loading](semantic-pack-loading.md)
 
-Status: design v0. nose does not load external packs yet. This page defines the
-extension surface that first-party compiled packs and future external packs must
-use.
+Status: design v0 plus local metadata loading. nose can load local manifests for
+explicit opt-in provenance reporting, but external packs are still
+`metadata-only`: they do not emit evidence or open exact contracts. This page
+defines the extension surface that first-party compiled packs and future
+external packs must use.
 
 ## Context
 
@@ -29,7 +32,8 @@ The current implementation already has the internal pieces that this API narrows
 into a public boundary: `EvidenceRecord` facts in `nose-il`, contract rows and
 admission helpers in `nose-semantics`, and evidence-only consumers in normalize,
 detect, value-graph, fragment, and oracle paths. v0 is intentionally a schema and
-contract vocabulary, not a loader.
+contract vocabulary. The current loader validates local manifest shape and
+reports provenance; it does not execute external producers.
 
 ## Goal
 
@@ -47,8 +51,8 @@ contract vocabulary, not a loader.
 
 ## Non-goals
 
-- Do not implement filesystem, network, or registry pack loading in this issue.
-- Do not add a user configuration path for enabling packs.
+- Do not implement network or registry pack loading.
+- Do not let local pack loading make external producers executable yet.
 - Do not expand language or library coverage.
 - Do not let packs mint fingerprints, rewrite value graphs directly, approve
   exact clone pairs, or bypass the law registry.
@@ -91,9 +95,11 @@ A v0 manifest has these top-level sections:
 | `conformance` | positive fixtures, hard negatives, commands, proof links, and unsupported edges |
 
 The manifest is declarative. It is not a hook API. A data-only external pack can
-declare rows that a future loader can validate and feed into kernel helpers.
-First-party compiled packs can generate the same manifest metadata for reports
-and conformance gates while still emitting facts from Rust.
+declare rows that the local metadata loader validates and reports. A later
+producer runtime may feed compatible rows into kernel helpers only after the same
+fail-closed evidence obligations are satisfied. First-party compiled packs can
+generate the same manifest metadata for reports and conformance gates while
+still emitting facts from Rust.
 
 ## Pack Kinds
 
@@ -402,8 +408,8 @@ nose should validate:
   proof status, positive fixtures, and hard negatives;
 - external packs are opt-in and not enabled by default;
 - declared compatibility ranges are syntactically valid enough to compare;
-- examples and fixtures are present at declared paths when a loader or harness
-  supports them.
+- examples and fixtures are present at declared paths when a producer runtime or
+  conformance harness supports them.
 
 nose does not validate or certify for external packs:
 

--- a/docs/semantic-pack-extension-api-v0.md
+++ b/docs/semantic-pack-extension-api-v0.md
@@ -71,9 +71,10 @@ Every manifest must declare:
 - stable ids for packs, evidence producers, contracts, laws, fixtures, and
   dependencies.
 
-v0 is allowed to evolve only by adding optional fields or new enum values that
-old consumers can ignore. Removing fields, changing the meaning of an existing
-field, or changing exact-channel admission rules requires a new API version.
+v0 is a strict manifest contract: the published schema rejects unknown fields,
+and the local loader rejects unknown fields and enum values. Adding fields,
+adding enum values, removing fields, changing the meaning of an existing field,
+or changing exact-channel admission rules requires a new API version.
 
 ## Manifest Shape
 
@@ -126,10 +127,12 @@ Trust policy is separate from channel eligibility.
 | `first-party-optional` | maintained and tested by nose, but not enabled by default |
 | `external-opt-in` | provider/user responsibility; must be enabled explicitly by the user |
 
-External packs must set `enabled_by_default: false`. A manifest may declare that
-a contract is intended for `exact-empirical` or `exact-proven`, but nose does not
-certify that claim for external packs. A user may still opt into such a pack, and
-nose should surface provenance so the user can see which external pack affected a
+Local external manifests must set `trust: "external-opt-in"` and
+`enabled_by_default: false`. The loader rejects local manifests that claim
+first-party trust or default enablement. A manifest may declare that a contract
+is intended for `exact-empirical` or `exact-proven`, but nose does not certify
+that claim for external packs. A user may still opt into such a pack, and nose
+should surface provenance so the user can see which external pack affected a
 match.
 
 ## Channel Eligibility

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -1,0 +1,61 @@
+# Semantic pack loading
+
+Back to [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) and
+[semantic-kernel](semantic-kernel.md).
+
+Status: nose can load local semantic-pack v0 manifests for provenance and trust
+reporting. External packs are explicit opt-ins and are currently
+`metadata-only`: they do not emit evidence, open exact contracts, mint
+fingerprints, or approve clone pairs.
+
+## Local entry points
+
+Use `--semantic-pack <file-or-dir>` on `nose scan` to opt into local pack
+metadata for one run:
+
+```sh
+nose scan src --format json --semantic-pack semantic-packs/python-math-prod.json
+```
+
+Commit stable project opt-ins in `nose.toml`:
+
+```toml
+[scan]
+semantic-packs = ["semantic-packs/python-math-prod.json"]
+```
+
+Each path may be a manifest file or a directory. Directory loading reads direct
+`*.json` children in sorted order; it does not recurse and it does not contact a
+registry or network service.
+
+## Trust policy
+
+Trust is separate from channel eligibility.
+
+- The compiled first-party pack `nose.first_party` is enabled by default and is
+  the only pack that currently influences evidence and contracts.
+- Local external packs require explicit user opt-in through CLI or config.
+- A manifest with `trust = "external-opt-in"` and `enabled_by_default = true` is
+  rejected.
+- Duplicate pack ids fail the scan instead of letting provenance become
+  ambiguous.
+
+`scan --format json` reports every active pack under `semantic_packs`, including
+its stable hash, trust, source, influence, provider, repository, supported
+languages, and declaration counts. Human and Markdown reports print a short
+semantic-pack line when local opt-in packs are loaded.
+
+## Current limits
+
+The loader validates manifest shape and pack provenance only. It does not yet:
+
+- execute external evidence producers;
+- register external contract rows with exact consumers;
+- validate fixture files or run a conformance harness;
+- compare semantic version ranges beyond requiring the declared compatibility
+  field;
+- install packs from a registry or remote source.
+
+Future loader work should keep this boundary: external pack claims can become
+usable only through dependency-backed evidence records and fail-closed kernel
+contracts, never through raw selectors or manifest presence alone.

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -24,9 +24,11 @@ Commit stable project opt-ins in `nose.toml`:
 semantic-packs = ["semantic-packs/python-math-prod.json"]
 ```
 
-Each path may be a manifest file or a directory. Directory loading reads direct
-`*.json` children in sorted order; it does not recurse and it does not contact a
-registry or network service.
+Each path may be a manifest file or a directory. Paths from `[scan].semantic-packs`
+are resolved relative to the config file that declared them; paths from
+`--semantic-pack` are resolved by the shell/current working directory like other
+CLI paths. Directory loading reads direct `*.json` children in sorted order; it
+does not recurse and it does not contact a registry or network service.
 
 ## Trust policy
 
@@ -35,8 +37,9 @@ Trust is separate from channel eligibility.
 - The compiled first-party pack `nose.first_party` is enabled by default and is
   the only pack that currently influences evidence and contracts.
 - Local external packs require explicit user opt-in through CLI or config.
-- A manifest with `trust = "external-opt-in"` and `enabled_by_default = true` is
-  rejected.
+- Local manifests must declare `trust = "external-opt-in"` and
+  `enabled_by_default = false`; manifests that claim first-party trust or default
+  enablement are rejected.
 - Duplicate pack ids fail the scan instead of letting provenance become
   ambiguous.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,6 +70,7 @@ Grouped by what they do. Config-backed scan defaults are listed in
 | `--mode MODE` | one or more of `syntax`, `semantic`, `near[:T]`; comma-list or repeatable; when present, replaces the default. Experimental `abstraction[:T]` is accepted but not a stable capabilities mode. |
 | `--exclude <glob>` | skip paths matching a gitignore-syntax glob (repeatable) |
 | `--ignore-file <file>` | suppress reviewed families using a structured ignore file with reason/owner/expiry metadata |
+| `--semantic-pack <file-or-dir>` | explicitly load local semantic-pack v0 manifest metadata for provenance reporting; external packs are metadata-only today |
 
 ### Ranking
 
@@ -109,8 +110,9 @@ chance** — see [hazard-ranking](hazard-ranking.md) for the full, honest evalua
 scan scope, ranking metadata, and a `families` array. The stable contract and
 compatibility rule are documented in [scan-json](scan-json.md).
 
-**Workflow** (`--baseline`, `--write-baseline`, `--fail-on any|new`, `--ignore-file`, `--cache-dir`, `--config`) is covered in
-[continuous-integration](continuous-integration.md) and [configuration](configuration.md).
+**Workflow** (`--baseline`, `--write-baseline`, `--fail-on any|new`, `--ignore-file`, `--cache-dir`, `--config`, `--semantic-pack`) is covered in
+[continuous-integration](continuous-integration.md), [configuration](configuration.md), and
+[semantic-pack-loading](semantic-pack-loading.md).
 Structured suppressions are covered in [structured-ignores](structured-ignores.md).
 
 ### Scan modes


### PR DESCRIPTION
Closes #152.

## Summary
- add semantic-pack v0 local manifest loading with stable pack ids/hashes, trust checks, duplicate-id fail-closed behavior, and metadata-only external pack influence
- report active semantic packs in scan JSON and capabilities, plus CLI/config opt-in via `--semantic-pack` and `[scan].semantic-packs`
- update semantic-pack, configuration, usage, scan JSON, capabilities, snapshot, and roadmap docs

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `awiki lint --root docs`
- `python3 scripts/check-semantic-pack-examples.py`
- `cargo test -p nose-cli -p nose-semantics`
- `cargo clippy -p nose-cli -p nose-semantics --all-targets -- -D warnings`