### PR TITLE
[codex] Add semantic pack conformance harness

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -6,6 +6,7 @@ mod config;
 mod fnv;
 mod ignores;
 mod review;
+mod semantic_pack;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -46,6 +47,12 @@ enum Cmd {
         /// Disable control-flow normalization (ablation).
         #[arg(long)]
         no_cfg_norm: bool,
+    },
+    /// Validate semantic-pack v0 manifests and declared conformance fixtures.
+    #[command(name = "semantic-pack")]
+    SemanticPack {
+        #[command(subcommand)]
+        cmd: SemanticPackCmd,
     },
     /// Research interface for raw unit clone pairs/groups.
     /// Hidden: `scan` is the user-facing command; `detect` is the strict/research
@@ -350,6 +357,19 @@ enum Cmd {
         /// Input battery: `standard` (leap 2) or `wide` (leap 3, larger domain).
         #[arg(long, default_value = "standard")]
         battery: BatteryKind,
+    },
+}
+
+#[derive(Subcommand)]
+enum SemanticPackCmd {
+    /// Check local semantic-pack v0 manifests for structural conformance.
+    Check {
+        /// Semantic-pack manifest file or directory of direct `*.json` manifests.
+        #[arg(required = true, value_name = "FILE_OR_DIR")]
+        paths: Vec<PathBuf>,
+        /// Output format.
+        #[arg(long, default_value = "human")]
+        format: semantic_pack::CheckFormat,
     },
 }
 
@@ -732,6 +752,7 @@ struct CapabilitiesSchemas {
     capabilities: Vec<u32>,
     scan_json: Vec<u32>,
     semantic_packs: Vec<&'static str>,
+    semantic_pack_conformance: Vec<u32>,
 }
 
 #[derive(serde::Serialize)]
@@ -748,6 +769,8 @@ struct CapabilitiesScan {
 struct CapabilitiesSemanticPacks {
     api_versions: Vec<&'static str>,
     loading: Vec<&'static str>,
+    conformance: Vec<&'static str>,
+    conformance_output_formats: Vec<&'static str>,
     trust: Vec<&'static str>,
     external_packs_enabled_by_default: bool,
     external_pack_influence: &'static str,
@@ -784,12 +807,20 @@ impl CapabilitiesReport {
                 doctor_json: false,
             },
             commands: CapabilitiesCommands {
-                stable: vec!["capabilities", "il", "review", "scan", "stats"],
+                stable: vec![
+                    "capabilities",
+                    "il",
+                    "review",
+                    "scan",
+                    "semantic-pack",
+                    "stats",
+                ],
             },
             schemas: CapabilitiesSchemas {
                 capabilities: vec![CAPABILITIES_SCHEMA_VERSION],
                 scan_json: vec![SCAN_JSON_SCHEMA_VERSION],
                 semantic_packs: vec![nose_semantics::SEMANTIC_PACK_API_VERSION],
+                semantic_pack_conformance: vec![semantic_pack::CONFORMANCE_SCHEMA_VERSION],
             },
             scan: CapabilitiesScan {
                 modes: vec!["syntax", "semantic", "near"],
@@ -817,6 +848,8 @@ impl CapabilitiesReport {
                     "local-manifest-file",
                     "local-manifest-directory",
                 ],
+                conformance: vec!["local-manifest-file", "local-manifest-directory"],
+                conformance_output_formats: vec!["human", "json"],
                 trust: vec![
                     "default-first-party",
                     "first-party-optional",
@@ -1322,6 +1355,9 @@ fn run() -> Result<()> {
             no_cfg_norm,
         } => cmd_il(path, format, normalized, no_cfg_norm),
         Cmd::Capabilities => cmd_capabilities(),
+        Cmd::SemanticPack { cmd } => match cmd {
+            SemanticPackCmd::Check { paths, format } => semantic_pack::cmd_check(paths, format),
+        },
         Cmd::Detect {
             paths,
             min_lines,

--- a/crates/nose-cli/src/semantic_pack.rs
+++ b/crates/nose-cli/src/semantic_pack.rs
@@ -1,0 +1,201 @@
+use anyhow::Result;
+use std::path::PathBuf;
+
+pub(crate) const CONFORMANCE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone, Copy, PartialEq, clap::ValueEnum)]
+pub(crate) enum CheckFormat {
+    Human,
+    Json,
+}
+
+#[derive(serde::Serialize)]
+struct CheckJsonReport {
+    schema_version: u32,
+    status: &'static str,
+    totals: CheckJsonTotals,
+    manifests: Vec<CheckJsonManifest>,
+}
+
+#[derive(serde::Serialize)]
+struct CheckJsonTotals {
+    manifests: usize,
+    positive_fixtures: usize,
+    hard_negatives: usize,
+    fixture_issues: usize,
+}
+
+#[derive(serde::Serialize)]
+struct CheckJsonManifest {
+    id: String,
+    version: String,
+    display_name: String,
+    trust: &'static str,
+    source: &'static str,
+    influence: &'static str,
+    manifest_path: String,
+    provider: String,
+    repository: String,
+    license: String,
+    supported_languages: Vec<String>,
+    counts: CheckJsonCounts,
+    conformance_command: Option<String>,
+    proof_links: Vec<String>,
+    fixture_issues: usize,
+    fixtures: Vec<CheckJsonFixture>,
+}
+
+#[derive(serde::Serialize)]
+struct CheckJsonCounts {
+    evidence_producers: usize,
+    contracts: usize,
+    value_laws: usize,
+    positive_fixtures: usize,
+    hard_negatives: usize,
+}
+
+#[derive(serde::Serialize)]
+struct CheckJsonFixture {
+    kind: &'static str,
+    id: String,
+    description: String,
+    declared_path: Option<String>,
+    resolved_path: Option<String>,
+    expectation: Option<String>,
+    issues: Vec<&'static str>,
+}
+
+impl CheckJsonReport {
+    fn new(report: &nose_semantics::SemanticPackConformanceReport) -> Self {
+        Self {
+            schema_version: CONFORMANCE_SCHEMA_VERSION,
+            status: if report.passed() { "ok" } else { "failed" },
+            totals: CheckJsonTotals {
+                manifests: report.manifest_count(),
+                positive_fixtures: report.positive_fixture_count(),
+                hard_negatives: report.hard_negative_count(),
+                fixture_issues: report.fixture_issue_count(),
+            },
+            manifests: report
+                .manifests
+                .iter()
+                .map(|manifest| CheckJsonManifest {
+                    id: manifest.pack.id.clone(),
+                    version: manifest.pack.version.clone(),
+                    display_name: manifest.pack.display_name.clone(),
+                    trust: manifest.pack.trust.as_manifest_str(),
+                    source: manifest.pack.source.as_str(),
+                    influence: manifest.pack.influence.as_str(),
+                    manifest_path: manifest.manifest_path.display().to_string(),
+                    provider: manifest.pack.provider.clone(),
+                    repository: manifest.pack.repository.clone(),
+                    license: manifest.pack.license.clone(),
+                    supported_languages: manifest.pack.supported_languages.clone(),
+                    counts: CheckJsonCounts {
+                        evidence_producers: manifest.pack.counts.evidence_producers,
+                        contracts: manifest.pack.counts.contracts,
+                        value_laws: manifest.pack.counts.value_laws,
+                        positive_fixtures: manifest.pack.counts.positive_fixtures,
+                        hard_negatives: manifest.pack.counts.hard_negatives,
+                    },
+                    conformance_command: manifest.conformance_command.clone(),
+                    proof_links: manifest.proof_links.clone(),
+                    fixture_issues: manifest.fixture_issue_count(),
+                    fixtures: manifest
+                        .fixtures
+                        .iter()
+                        .map(|fixture| CheckJsonFixture {
+                            kind: fixture.kind.as_str(),
+                            id: fixture.id.clone(),
+                            description: fixture.description.clone(),
+                            declared_path: fixture.declared_path.clone(),
+                            resolved_path: fixture
+                                .resolved_path
+                                .as_ref()
+                                .map(|path| path.display().to_string()),
+                            expectation: fixture.expectation.clone(),
+                            issues: fixture.issues.iter().map(|issue| issue.as_str()).collect(),
+                        })
+                        .collect(),
+                })
+                .collect(),
+        }
+    }
+}
+
+pub(crate) fn cmd_check(paths: Vec<PathBuf>, format: CheckFormat) -> Result<()> {
+    let report = nose_semantics::check_semantic_pack_conformance(&paths)?;
+    match format {
+        CheckFormat::Human => print_human(&report),
+        CheckFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&CheckJsonReport::new(&report))?
+            );
+        }
+    }
+    if !report.passed() {
+        anyhow::bail!(
+            "semantic pack conformance failed: {} fixture issue(s)",
+            report.fixture_issue_count()
+        );
+    }
+    Ok(())
+}
+
+fn print_human(report: &nose_semantics::SemanticPackConformanceReport) {
+    println!(
+        "semantic pack conformance: {}",
+        if report.passed() { "ok" } else { "failed" }
+    );
+    println!(
+        "manifests: {}; fixtures: {} positive, {} hard-negative; fixture issues: {}",
+        report.manifest_count(),
+        report.positive_fixture_count(),
+        report.hard_negative_count(),
+        report.fixture_issue_count()
+    );
+    println!(
+        "checks: schema/ref/trust/version ok; fixture files {}",
+        if report.fixture_issue_count() == 0 {
+            "ok"
+        } else {
+            "failed"
+        }
+    );
+    for manifest in &report.manifests {
+        println!(
+            "  {}@{}: {} fixture issue(s) ({})",
+            manifest.pack.id,
+            manifest.pack.version,
+            manifest.fixture_issue_count(),
+            manifest.manifest_path.display()
+        );
+        if let Some(command) = &manifest.conformance_command {
+            println!("    command: {command}");
+        }
+        for fixture in &manifest.fixtures {
+            let issue_text = if fixture.issues.is_empty() {
+                "ok".to_string()
+            } else {
+                fixture
+                    .issues
+                    .iter()
+                    .map(|issue| issue.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            let path_text = fixture
+                .declared_path
+                .as_deref()
+                .unwrap_or("<no fixture path>");
+            println!(
+                "    {} {}: {} ({})",
+                fixture.kind.as_str(),
+                fixture.id,
+                issue_text,
+                path_text
+            );
+        }
+    }
+}

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -523,12 +523,113 @@ fn semantic_pack_manifest(id: &str) -> String {
     "value_laws": []
   }},
   "conformance": {{
-    "positive_fixtures": [{{ "id": "positive", "description": "positive" }}],
-    "hard_negatives": [{{ "id": "negative", "description": "negative" }}],
+    "positive_fixtures": [{{
+      "id": "positive",
+      "description": "positive",
+      "path": "fixtures/positive.py",
+      "expectation": "exact-contract-open"
+    }}],
+    "hard_negatives": [{{
+      "id": "negative",
+      "description": "negative",
+      "path": "fixtures/negative.py",
+      "expectation": "exact-contract-closed"
+    }}],
     "known_unsupported": []
   }}
 }}"#
     )
+}
+
+#[test]
+fn semantic_pack_check_json_reports_conformance_success() {
+    let dir = make_project("semantic_pack_check_ok");
+    let fixture_dir = dir.join("fixtures");
+    fs::create_dir_all(&fixture_dir).unwrap();
+    fs::write(
+        fixture_dir.join("positive.py"),
+        "def positive(xs):\n    return sum(xs)\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture_dir.join("negative.py"),
+        "def negative(xs):\n    return list(xs)\n",
+    )
+    .unwrap();
+    let pack = dir.join("pack.json");
+    fs::write(&pack, semantic_pack_manifest("com.example.semantic-pack")).unwrap();
+
+    let out = Command::new(bin())
+        .args([
+            "semantic-pack",
+            "check",
+            pack.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("semantic pack check");
+
+    assert!(
+        out.status.success(),
+        "semantic-pack check should pass: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("check should emit JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["totals"]["manifests"], 1);
+    assert_eq!(json["totals"]["positive_fixtures"], 1);
+    assert_eq!(json["totals"]["hard_negatives"], 1);
+    assert_eq!(json["totals"]["fixture_issues"], 0);
+    assert_eq!(json["manifests"][0]["id"], "com.example.semantic-pack");
+    assert_eq!(
+        json["manifests"][0]["fixtures"][0]["issues"]
+            .as_array()
+            .unwrap()
+            .len(),
+        0
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn semantic_pack_check_fails_on_missing_fixture_files() {
+    let dir = make_project("semantic_pack_check_missing");
+    let pack = dir.join("pack.json");
+    fs::write(&pack, semantic_pack_manifest("com.example.semantic-pack")).unwrap();
+
+    let out = Command::new(bin())
+        .args([
+            "semantic-pack",
+            "check",
+            pack.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("semantic pack check");
+
+    assert!(
+        !out.status.success(),
+        "semantic-pack check should fail when declared fixtures are missing"
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("failed check should still emit JSON");
+    assert_eq!(json["status"], "failed");
+    assert_eq!(json["totals"]["fixture_issues"], 2);
+    assert_eq!(
+        json["manifests"][0]["fixtures"][0]["issues"][0],
+        "missing-file"
+    );
+    assert!(
+        stderr.contains("semantic pack conformance failed"),
+        "stderr should name the conformance failure: {stderr}"
+    );
+    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
@@ -1062,7 +1163,14 @@ fn capabilities_command_emits_machine_readable_contract() {
 
     assert_eq!(
         json_array_strings(&json["commands"], "stable"),
-        vec!["capabilities", "il", "review", "scan", "stats"]
+        vec![
+            "capabilities",
+            "il",
+            "review",
+            "scan",
+            "semantic-pack",
+            "stats"
+        ]
     );
     assert_eq!(json["schemas"]["capabilities"][0], 1);
     assert_eq!(json["schemas"]["scan_json"][0], 1);
@@ -1070,6 +1178,7 @@ fn capabilities_command_emits_machine_readable_contract() {
         json["schemas"]["semantic_packs"][0],
         "nose.semantic-pack.v0"
     );
+    assert_eq!(json["schemas"]["semantic_pack_conformance"][0], 1);
     assert_eq!(
         json_array_strings(&json["scan"], "modes"),
         vec!["syntax", "semantic", "near"]
@@ -1096,6 +1205,14 @@ fn capabilities_command_emits_machine_readable_contract() {
     assert_eq!(
         json["semantic_packs"]["external_pack_influence"],
         "metadata-only"
+    );
+    assert_eq!(
+        json_array_strings(&json["semantic_packs"], "conformance"),
+        vec!["local-manifest-file", "local-manifest-directory"]
+    );
+    assert_eq!(
+        json_array_strings(&json["semantic_packs"], "conformance_output_formats"),
+        vec!["human", "json"]
     );
     assert_eq!(
         json["semantic_packs"]["external_packs_enabled_by_default"],

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -303,6 +303,160 @@ impl SemanticPackSet {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SemanticPackFixtureKind {
+    Positive,
+    HardNegative,
+}
+
+impl SemanticPackFixtureKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            SemanticPackFixtureKind::Positive => "positive",
+            SemanticPackFixtureKind::HardNegative => "hard-negative",
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SemanticPackFixtureIssue {
+    MissingPath,
+    MissingFile,
+    MissingExpectation,
+}
+
+impl SemanticPackFixtureIssue {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            SemanticPackFixtureIssue::MissingPath => "missing-path",
+            SemanticPackFixtureIssue::MissingFile => "missing-file",
+            SemanticPackFixtureIssue::MissingExpectation => "missing-expectation",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SemanticPackFixtureCheck {
+    pub kind: SemanticPackFixtureKind,
+    pub id: String,
+    pub description: String,
+    pub declared_path: Option<String>,
+    pub resolved_path: Option<PathBuf>,
+    pub expectation: Option<String>,
+    pub issues: Vec<SemanticPackFixtureIssue>,
+}
+
+impl SemanticPackFixtureCheck {
+    pub fn passed(&self) -> bool {
+        self.issues.is_empty()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SemanticPackConformanceManifest {
+    pub pack: SemanticPackSummary,
+    pub manifest_path: PathBuf,
+    pub conformance_command: Option<String>,
+    pub proof_links: Vec<String>,
+    pub fixtures: Vec<SemanticPackFixtureCheck>,
+}
+
+impl SemanticPackConformanceManifest {
+    pub fn passed(&self) -> bool {
+        self.fixture_issue_count() == 0
+    }
+
+    pub fn fixture_issue_count(&self) -> usize {
+        self.fixtures
+            .iter()
+            .map(|fixture| fixture.issues.len())
+            .sum()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SemanticPackConformanceReport {
+    pub manifests: Vec<SemanticPackConformanceManifest>,
+}
+
+impl SemanticPackConformanceReport {
+    pub fn passed(&self) -> bool {
+        self.manifests
+            .iter()
+            .all(SemanticPackConformanceManifest::passed)
+    }
+
+    pub fn manifest_count(&self) -> usize {
+        self.manifests.len()
+    }
+
+    pub fn positive_fixture_count(&self) -> usize {
+        self.manifests
+            .iter()
+            .map(|manifest| manifest.pack.counts.positive_fixtures)
+            .sum()
+    }
+
+    pub fn hard_negative_count(&self) -> usize {
+        self.manifests
+            .iter()
+            .map(|manifest| manifest.pack.counts.hard_negatives)
+            .sum()
+    }
+
+    pub fn fixture_issue_count(&self) -> usize {
+        self.manifests
+            .iter()
+            .map(SemanticPackConformanceManifest::fixture_issue_count)
+            .sum()
+    }
+}
+
+pub fn check_semantic_pack_conformance(
+    paths: &[PathBuf],
+) -> Result<SemanticPackConformanceReport, SemanticPackLoadError> {
+    let manifest_paths = discover_manifest_paths(paths)?;
+    let mut manifests: Vec<SemanticPackConformanceManifest> = Vec::new();
+    for path in manifest_paths {
+        let manifest = read_local_manifest(&path)?;
+        let conformance_command = manifest.conformance.command.clone();
+        let proof_links = manifest.conformance.proofs.clone();
+        let fixtures = collect_fixture_checks(&path, &manifest);
+        let pack =
+            SemanticPackSummary::from_manifest(path.clone(), manifest).map_err(|message| {
+                SemanticPackLoadError::InvalidManifest {
+                    path: path.clone(),
+                    message,
+                }
+            })?;
+        if pack.id == FIRST_PARTY_PACK_ID {
+            return Err(SemanticPackLoadError::DuplicatePackId {
+                id: pack.id,
+                first_path: None,
+                second_path: Some(path),
+            });
+        }
+        if let Some(existing) = manifests
+            .iter()
+            .find(|existing| existing.pack.id == pack.id)
+        {
+            return Err(SemanticPackLoadError::DuplicatePackId {
+                id: pack.id,
+                first_path: Some(existing.manifest_path.clone()),
+                second_path: Some(path),
+            });
+        }
+        manifests.push(SemanticPackConformanceManifest {
+            pack,
+            manifest_path: path,
+            conformance_command,
+            proof_links,
+            fixtures,
+        });
+    }
+    Ok(SemanticPackConformanceReport { manifests })
+}
+
 pub fn discover_manifest_paths(paths: &[PathBuf]) -> Result<Vec<PathBuf>, SemanticPackLoadError> {
     let mut out = Vec::new();
     let mut seen = HashSet::new();
@@ -367,22 +521,88 @@ fn push_unique_manifest(
 }
 
 pub fn load_local_manifest(path: &Path) -> Result<SemanticPackSummary, SemanticPackLoadError> {
-    let text = std::fs::read_to_string(path).map_err(|source| SemanticPackLoadError::Io {
-        path: path.to_path_buf(),
-        source,
-    })?;
-    let manifest = serde_json::from_str::<SemanticPackManifest>(&text).map_err(|source| {
-        SemanticPackLoadError::Json {
-            path: path.to_path_buf(),
-            source,
-        }
-    })?;
+    let manifest = read_local_manifest(path)?;
     SemanticPackSummary::from_manifest(path.to_path_buf(), manifest).map_err(|message| {
         SemanticPackLoadError::InvalidManifest {
             path: path.to_path_buf(),
             message,
         }
     })
+}
+
+fn read_local_manifest(path: &Path) -> Result<SemanticPackManifest, SemanticPackLoadError> {
+    let text = std::fs::read_to_string(path).map_err(|source| SemanticPackLoadError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    serde_json::from_str::<SemanticPackManifest>(&text).map_err(|source| {
+        SemanticPackLoadError::Json {
+            path: path.to_path_buf(),
+            source,
+        }
+    })
+}
+
+fn collect_fixture_checks(
+    manifest_path: &Path,
+    manifest: &SemanticPackManifest,
+) -> Vec<SemanticPackFixtureCheck> {
+    let mut checks = Vec::new();
+    for fixture in &manifest.conformance.positive_fixtures {
+        checks.push(fixture_check(
+            manifest_path,
+            SemanticPackFixtureKind::Positive,
+            fixture,
+        ));
+    }
+    for fixture in &manifest.conformance.hard_negatives {
+        checks.push(fixture_check(
+            manifest_path,
+            SemanticPackFixtureKind::HardNegative,
+            fixture,
+        ));
+    }
+    checks
+}
+
+fn fixture_check(
+    manifest_path: &Path,
+    kind: SemanticPackFixtureKind,
+    fixture: &ManifestFixture,
+) -> SemanticPackFixtureCheck {
+    let resolved_path = fixture
+        .path
+        .as_deref()
+        .map(|path| resolve_fixture_path(manifest_path, path));
+    let mut issues = Vec::new();
+    if fixture.path.is_none() {
+        issues.push(SemanticPackFixtureIssue::MissingPath);
+    } else if !resolved_path.as_ref().is_some_and(|path| path.is_file()) {
+        issues.push(SemanticPackFixtureIssue::MissingFile);
+    }
+    if fixture.expectation.is_none() {
+        issues.push(SemanticPackFixtureIssue::MissingExpectation);
+    }
+    SemanticPackFixtureCheck {
+        kind,
+        id: fixture.id.clone(),
+        description: fixture.description.clone(),
+        declared_path: fixture.path.clone(),
+        resolved_path,
+        expectation: fixture.expectation.clone(),
+        issues,
+    }
+}
+
+fn resolve_fixture_path(manifest_path: &Path, declared_path: &str) -> PathBuf {
+    let path = Path::new(declared_path);
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    manifest_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(path)
 }
 
 #[derive(Debug)]
@@ -674,7 +894,7 @@ fn validate_manifest(manifest: &SemanticPackManifest) -> Result<(), String> {
         "provenance.source_revision",
         manifest.provenance.source_revision.as_deref(),
     )?;
-    require_non_empty("compatibility.nose", &manifest.compatibility.nose)?;
+    validate_nose_version_requirement("compatibility.nose", &manifest.compatibility.nose)?;
     optional_non_empty(
         "compatibility.notes",
         manifest.compatibility.notes.as_deref(),
@@ -986,6 +1206,39 @@ fn optional_non_empty(label: &str, value: Option<&str>) -> Result<(), String> {
     Ok(())
 }
 
+fn validate_nose_version_requirement(label: &str, value: &str) -> Result<(), String> {
+    require_non_empty(label, value)?;
+    for constraint in value
+        .split(|c: char| c.is_ascii_whitespace() || c == ',')
+        .filter(|constraint| !constraint.is_empty())
+    {
+        let version = constraint
+            .strip_prefix(">=")
+            .or_else(|| constraint.strip_prefix("<="))
+            .or_else(|| constraint.strip_prefix('>'))
+            .or_else(|| constraint.strip_prefix('<'))
+            .or_else(|| constraint.strip_prefix('='))
+            .or_else(|| constraint.strip_prefix('^'))
+            .or_else(|| constraint.strip_prefix('~'))
+            .unwrap_or(constraint);
+        if !is_version_like(version) {
+            return Err(format!(
+                "`{label}` contains unsupported version constraint `{constraint}`"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn is_version_like(value: &str) -> bool {
+    let value = value.strip_prefix('v').unwrap_or(value);
+    value == "*"
+        || value.chars().next().is_some_and(|c| c.is_ascii_digit())
+            && value.chars().all(|c| {
+                c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '+' | '*' | 'x' | 'X')
+            })
+}
+
 fn require_stable_id(label: &str, value: &str) -> Result<(), String> {
     require_non_empty(label, value)?;
     let mut chars = value.chars();
@@ -1022,6 +1275,7 @@ mod tests {
         dir
     }
 
+    // nose-ignore: inline semantic-pack manifest fixture; keeping the JSON shape visible matters here.
     fn manifest(id: &str) -> String {
         format!(
             r#"{{
@@ -1070,8 +1324,18 @@ mod tests {
     "value_laws": []
   }},
   "conformance": {{
-    "positive_fixtures": [{{ "id": "positive", "description": "positive" }}],
-    "hard_negatives": [{{ "id": "negative", "description": "negative" }}],
+    "positive_fixtures": [{{
+      "id": "positive",
+      "description": "positive",
+      "path": "fixtures/positive.py",
+      "expectation": "exact-contract-open"
+    }}],
+    "hard_negatives": [{{
+      "id": "negative",
+      "description": "negative",
+      "path": "fixtures/negative.py",
+      "expectation": "exact-contract-closed"
+    }}],
     "known_unsupported": []
   }}
 }}"#
@@ -1100,6 +1364,110 @@ mod tests {
         assert_eq!(external.source, SemanticPackSource::LocalManifest);
         assert_eq!(external.influence, SemanticPackInfluence::MetadataOnly);
         assert_eq!(external.counts.contracts, 1);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn conformance_check_reports_declared_fixture_files() {
+        let dir = unique_dir("conformance_ok");
+        let fixture_dir = dir.join("fixtures");
+        fs::create_dir_all(&fixture_dir).unwrap();
+        fs::write(
+            fixture_dir.join("positive.py"),
+            "import math\nmath.prod([1, 2])\n",
+        )
+        .unwrap();
+        fs::write(
+            fixture_dir.join("negative.py"),
+            "math = object()\nmath.prod([1, 2])\n",
+        )
+        .unwrap();
+        let path = dir.join("pack.json");
+        fs::write(&path, manifest("com.example.pack")).unwrap();
+
+        let report = check_semantic_pack_conformance(&[path]).expect("conformance loads");
+
+        assert!(report.passed());
+        assert_eq!(report.manifest_count(), 1);
+        assert_eq!(report.positive_fixture_count(), 1);
+        assert_eq!(report.hard_negative_count(), 1);
+        assert_eq!(report.fixture_issue_count(), 0);
+        let fixture_ids = report.manifests[0]
+            .fixtures
+            .iter()
+            .map(|fixture| (fixture.kind.as_str(), fixture.id.as_str(), fixture.passed()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            fixture_ids,
+            vec![
+                ("positive", "positive", true),
+                ("hard-negative", "negative", true)
+            ]
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn conformance_check_fails_closed_on_missing_fixture_files() {
+        let dir = unique_dir("conformance_missing");
+        let path = dir.join("pack.json");
+        fs::write(&path, manifest("com.example.pack")).unwrap();
+
+        let report =
+            check_semantic_pack_conformance(&[path]).expect("manifest is structurally valid");
+
+        assert!(!report.passed());
+        assert_eq!(report.fixture_issue_count(), 2);
+        let issues = report.manifests[0]
+            .fixtures
+            .iter()
+            .flat_map(|fixture| fixture.issues.iter().map(|issue| issue.as_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(issues, vec!["missing-file", "missing-file"]);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn conformance_check_requires_fixture_paths_and_expectations() {
+        let dir = unique_dir("conformance_metadata");
+        let path = dir.join("pack.json");
+        fs::write(
+            &path,
+            manifest("com.example.pack")
+                .replace(
+                    r#",
+      "path": "fixtures/positive.py",
+      "expectation": "exact-contract-open""#,
+                    "",
+                )
+                .replace(
+                    r#",
+      "path": "fixtures/negative.py",
+      "expectation": "exact-contract-closed""#,
+                    "",
+                ),
+        )
+        .unwrap();
+
+        let report =
+            check_semantic_pack_conformance(&[path]).expect("manifest is structurally valid");
+
+        assert!(!report.passed());
+        assert_eq!(report.fixture_issue_count(), 4);
+        let issues = report.manifests[0]
+            .fixtures
+            .iter()
+            .flat_map(|fixture| fixture.issues.iter().map(|issue| issue.as_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            issues,
+            vec![
+                "missing-path",
+                "missing-expectation",
+                "missing-path",
+                "missing-expectation"
+            ]
+        );
         let _ = fs::remove_dir_all(dir);
     }
 
@@ -1161,6 +1529,25 @@ mod tests {
         .unwrap();
         let err = load_local_manifest(&path).expect_err("package versions are required");
         assert!(err.to_string().contains("missing field `versions`"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn compatibility_nose_must_be_version_requirement_like() {
+        let dir = unique_dir("compatibility");
+        let path = dir.join("pack.json");
+        fs::write(
+            &path,
+            manifest("com.example.pack").replace(
+                r#""compatibility": { "nose": ">=0.5.0 <0.6.0" }"#,
+                r#""compatibility": { "nose": "current stable" }"#,
+            ),
+        )
+        .unwrap();
+        let err = load_local_manifest(&path).expect_err("version range should be comparable");
+        assert!(err
+            .to_string()
+            .contains("unsupported version constraint `current`"));
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -42,12 +42,13 @@ nose capabilities
     "doctor_json": false
   },
   "commands": {
-    "stable": ["capabilities", "il", "review", "scan", "stats"]
+    "stable": ["capabilities", "il", "review", "scan", "semantic-pack", "stats"]
   },
   "schemas": {
     "capabilities": [1],
     "scan_json": [1],
-    "semantic_packs": ["nose.semantic-pack.v0"]
+    "semantic_packs": ["nose.semantic-pack.v0"],
+    "semantic_pack_conformance": [1]
   },
   "scan": {
     "modes": ["syntax", "semantic", "near"],
@@ -86,6 +87,11 @@ nose capabilities
       "local-manifest-file",
       "local-manifest-directory"
     ],
+    "conformance": [
+      "local-manifest-file",
+      "local-manifest-directory"
+    ],
+    "conformance_output_formats": ["human", "json"],
     "trust": [
       "default-first-party",
       "first-party-optional",
@@ -130,6 +136,7 @@ release so it can't drift.
 | `schemas.capabilities` | array | Supported capabilities schema versions. |
 | `schemas.scan_json` | array | Supported `nose scan --format json` schema versions. |
 | `schemas.semantic_packs` | array | Supported semantic-pack manifest API versions, currently `nose.semantic-pack.v0`. |
+| `schemas.semantic_pack_conformance` | array | Supported `nose semantic-pack check --format json` schema versions. |
 | `scan.modes` | array | Supported `--mode` values. |
 | `scan.default_modes` | array | Modes used by `nose scan` when `--mode` is omitted. |
 | `scan.output_formats` | array | Supported `nose scan --format` values. |
@@ -138,6 +145,8 @@ release so it can't drift.
 | `scan.capabilities` | object | Stable boolean capability flags for scan workflows. |
 | `semantic_packs.api_versions` | array | Supported semantic-pack manifest API versions. |
 | `semantic_packs.loading` | array | Supported loading sources: compiled first-party and local manifest files/directories. |
+| `semantic_packs.conformance` | array | Supported conformance input sources: local manifest files/directories. |
+| `semantic_packs.conformance_output_formats` | array | Supported `nose semantic-pack check --format` values. |
 | `semantic_packs.trust` | array | Supported trust policy labels. |
 | `semantic_packs.external_packs_enabled_by_default` | boolean | Always `false`; external packs require explicit CLI/config opt-in. |
 | `semantic_packs.external_pack_influence` | string | Current influence of loaded external packs, `metadata-only`. |

--- a/docs/examples/semantic-packs/v0/fixtures/javascript/loose_equality.js
+++ b/docs/examples/semantic-packs/v0/fixtures/javascript/loose_equality.js
@@ -1,0 +1,3 @@
+export function looseId(left, right) {
+  return left == right;
+}

--- a/docs/examples/semantic-packs/v0/fixtures/javascript/shadowed_global.js
+++ b/docs/examples/semantic-packs/v0/fixtures/javascript/shadowed_global.js
@@ -1,0 +1,8 @@
+export function fromLocalPromise(value) {
+  const Promise = {
+    resolve(input) {
+      return input;
+    },
+  };
+  return Promise.resolve(value);
+}

--- a/docs/examples/semantic-packs/v0/fixtures/javascript/strict_equality.js
+++ b/docs/examples/semantic-packs/v0/fixtures/javascript/strict_equality.js
@@ -1,0 +1,3 @@
+export function sameId(left, right) {
+  return left === right;
+}

--- a/docs/examples/semantic-packs/v0/fixtures/python/math_prod_positive.py
+++ b/docs/examples/semantic-packs/v0/fixtures/python/math_prod_positive.py
@@ -1,0 +1,5 @@
+import math
+
+
+def product(values):
+    return math.prod(values)

--- a/docs/examples/semantic-packs/v0/fixtures/python/math_prod_shadowed_math.py
+++ b/docs/examples/semantic-packs/v0/fixtures/python/math_prod_shadowed_math.py
@@ -1,0 +1,10 @@
+class LocalMath:
+    def prod(self, values):
+        return values
+
+
+math = LocalMath()
+
+
+def product(values):
+    return math.prod(values)

--- a/docs/examples/semantic-packs/v0/fixtures/python/math_prod_wrong_namespace.py
+++ b/docs/examples/semantic-packs/v0/fixtures/python/math_prod_wrong_namespace.py
@@ -1,0 +1,5 @@
+import functools as other
+
+
+def product(values):
+    return other.reduce(lambda acc, value: acc * value, values, 1)

--- a/docs/examples/semantic-packs/v0/language-pack.json
+++ b/docs/examples/semantic-packs/v0/language-pack.json
@@ -186,6 +186,6 @@
       "Dynamic eval and with-scope semantics are outside this example.",
       "This example does not model JavaScript object identity or equality conversion rules."
     ],
-    "command": "nose scan fixtures --semantic-pack language-pack.json --format json"
+    "command": "nose semantic-pack check language-pack.json --format json"
   }
 }

--- a/docs/examples/semantic-packs/v0/library-pack.json
+++ b/docs/examples/semantic-packs/v0/library-pack.json
@@ -198,7 +198,7 @@
       "This example does not prove numeric algebraic product laws.",
       "This example does not certify behavior for monkey-patched module objects."
     ],
-    "command": "nose scan fixtures --semantic-pack library-pack.json --format json",
+    "command": "nose semantic-pack check library-pack.json --format json",
     "proofs": [
       "https://example.invalid/semantic-packs/python-math-prod/conformance"
     ]

--- a/docs/home.md
+++ b/docs/home.md
@@ -52,7 +52,8 @@ You want to *change* nose or understand how it works inside.
 - [architecture](architecture.md) — the crates and the lower → normalize → detect → rank pipeline.
 - [normalization](normalization.md) — the passes that make behaviorally-equivalent code converge (the hard part).
 - [semantic-kernel](semantic-kernel.md) — semantic-kernel and pack architecture: language/library semantics, extension boundaries, responsibility model, and exact-channel eligibility.
-- [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) — versioned v0 schema and provider-facing extension API for language/library semantic packs, with examples and a conformance checklist.
+- [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) — versioned v0 schema and provider-facing extension API for language/library semantic packs.
+- [semantic-pack-conformance](semantic-pack-conformance.md) — provider/user workflow for checking local pack manifests and declared fixture assets without implying nose approval.
 - [semantic-pack-loading](semantic-pack-loading.md) — local pack manifest loading, explicit opt-in trust policy, and scan JSON provenance reporting.
 - [evidence-records](evidence-records.md) — the internal pack-facing evidence substrate for source, domain, import, symbol, type, guard, place/effect, library API, and sequence-surface facts.
 - [demand-effect-semantics](demand-effect-semantics.md) — the internal demand/effect contract model for eager, lazy, short-circuit, async, generator, and channel boundaries.

--- a/docs/schemas/semantic-pack-v0.schema.json
+++ b/docs/schemas/semantic-pack-v0.schema.json
@@ -122,7 +122,8 @@
       "properties": {
         "nose": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "^(\\s*(>=|<=|>|<|=|\\^|~)?v?([0-9][A-Za-z0-9.*xX+.-]*|\\*)\\s*,?)+$"
         },
         "schema": {
           "const": "v0"

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -647,7 +647,8 @@ and pack ecosystem.
 - The v0 pack extension API defined the first provider-facing manifest shape for
   language/library packs, including evidence producers, contract rows, anchors,
   dependencies, channel eligibility, trust/default status, provider/user
-  responsibility boundaries, examples, and a lightweight checked example gate.
+  responsibility boundaries, examples, local metadata loading, and local
+  conformance checks for manifests plus declared fixture assets.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -821,16 +822,18 @@ Remaining in this phase:
 - The first versioned pack manifest schema is defined in
   [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md). Local
   metadata loading is implemented for manifest files/directories and documented
-  in [semantic-pack-loading](semantic-pack-loading.md); external packs remain
-  metadata-only.
+  in [semantic-pack-loading](semantic-pack-loading.md); local structural
+  conformance is implemented in
+  [semantic-pack-conformance](semantic-pack-conformance.md); external packs
+  remain metadata-only.
 - Start with data-only external packs for simple APIs once producer execution and
-  conformance checks exist.
+  executable fixture/oracle checks exist.
 - Add restricted recognizer hooks only after the manifest path is stable.
 - Require pack metadata: provider, license, version range, supported analysis
   channels, evidence status, conformance commands, and semantic provenance ids.
-- Document the pack conformance checklist as part of the extension schema; make
-  clear that conformance evidence is provider/user responsibility unless the pack
-  is first-party.
+- Keep the pack conformance checklist explicit: structural harness results,
+  semantic correctness evidence, and enablement risk are provider/user
+  responsibility unless the pack is first-party.
 - User configuration and `--semantic-pack` can enable local manifests explicitly.
 - Scan JSON reports active pack provenance and whether each pack influenced
   evidence/contracts or metadata only. Per-finding contract/law provenance and

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -7,7 +7,9 @@ record substrate is described in [evidence-records](evidence-records.md). The
 post-PR #147 raw/local pocket audit is recorded in
 [semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md). The
 v0 provider-facing extension API is defined in
-[semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md).
+[semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md), and the
+local provider/user conformance workflow is in
+[semantic-pack-conformance](semantic-pack-conformance.md).
 
 Snapshot date: 2026-06-09. The current implementation has an internal
 semantic-kernel facade, evidence-gated field state, sequence-surface contracts,
@@ -77,8 +79,9 @@ still being migrated toward it.
   occurrence/admission logic are split into focused modules.
 - The external pack API is documented as a v0 manifest/schema with examples.
   `nose-semantics` can load local manifest files/directories for metadata and
-  provenance reporting, and `nose scan --format json` reports active packs.
-  External packs are still `metadata-only`; first-party producers remain
+  provenance reporting, `nose scan --format json` reports active packs, and
+  `nose semantic-pack check` validates local manifests plus declared fixture
+  assets. External packs are still `metadata-only`; first-party producers remain
   compiled Rust and are expected to map onto the same vocabulary.
 - `nose-frontend` owns tree-sitter parsing, per-language lowering, embedded
   `<script>` extraction, source/domain/import/symbol/type/guard/place/effect/API/
@@ -732,7 +735,7 @@ language.
 - First-party and external responsibility boundaries are documented, represented
   in the internal facade as provenance/trust policy, and visible in scan JSON.
   Loaded external manifests remain metadata-only until a producer runtime and
-  conformance harness exist.
+  executable fixture/oracle workflow exist.
 
 ## Current fail-closed choices
 

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -34,7 +34,8 @@ external producer runtime.
 The external API design starts at
 [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md): it narrows
 the current internal evidence and contract vocabulary into a manifest shape for
-future language/library packs.
+future language/library packs. The provider/user conformance workflow is in
+[semantic-pack-conformance](semantic-pack-conformance.md).
 
 Evidence records are one kernel input at that boundary. They preserve facts that
 the IL deliberately abstracts away, but they do not approve semantic equivalence
@@ -298,9 +299,10 @@ Every pack should declare:
 - provenance labels that can appear in reports.
 
 Packs that claim exact eligibility should also provide a reproducible conformance
-command. First-party packs must run that command in nose CI. External packs should
-ship it so users can run it, but nose does not promise to execute or approve it
-unless the pack is adopted as first-party.
+command. First-party packs must run that command in nose CI. External packs
+should ship it so users can run `nose semantic-pack check`, but passing the
+structural harness is not nose approval of external semantic correctness unless
+the pack is adopted as first-party.
 
 ## Practical architecture
 

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -1,0 +1,122 @@
+# Semantic pack conformance
+
+Back to [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md),
+[semantic-pack-loading](semantic-pack-loading.md), and
+[semantic-kernel](semantic-kernel.md).
+
+Status: nose provides a local semantic-pack v0 conformance harness for manifest
+structure and declared fixture assets. The harness is a provider/user workflow,
+not nose approval of third-party semantic correctness. External packs remain
+`metadata-only` when loaded by `nose scan`.
+
+## Goal
+
+The conformance workflow gives pack providers a reproducible way to show that a
+pack meets the extension contract's minimum structural obligations:
+
+- the manifest parses as semantic-pack v0;
+- stable ids, enum values, trust/default policy, provenance, and compatibility
+  declarations are present;
+- evidence producers, contracts, laws, dependencies, and conformance references
+  are internally linked;
+- exact-capable contracts declare evidence requirements plus demand/effect
+  semantics;
+- positive fixtures and hard negatives are declared with expectation labels;
+- fixture files exist at paths relative to the manifest file.
+
+This keeps the ecosystem boundary narrow: packs publish evidence, contracts, and
+fixtures; the kernel decides whether evidence is admissible for a channel; users
+decide whether to enable external packs.
+
+## Non-goals
+
+The harness does not:
+
+- execute external evidence producers;
+- register external contract rows with exact consumers;
+- run a behavioral oracle over fixture contents;
+- prove that the provider's semantic claims are complete or true;
+- certify, approve, rank, or endorse external packs;
+- compare `compatibility.nose` against the installed nose version beyond checking
+  that the declared requirement is parseable as a version constraint.
+
+First-party default packs are different. nose owns their tests, hard negatives,
+proof obligations, release gates, and documentation because those packs ship with
+the binary and affect exact analysis by default.
+
+## Command
+
+Run the harness against a manifest file or a directory of direct `*.json`
+manifests:
+
+```sh
+nose semantic-pack check semantic-packs/python-math-prod.json
+nose semantic-pack check docs/examples/semantic-packs/v0 --format json
+```
+
+Directory checking follows the same local discovery rule as pack loading: direct
+JSON children only, sorted by filename, no recursion, no registry, and no network.
+Relative fixture paths are resolved from the manifest's directory.
+
+The command exits non-zero when any manifest is invalid, when pack ids collide
+with each other or `nose.first_party`, or when declared conformance fixtures are
+missing a path, missing an expectation, or point at a file that does not exist.
+For `--format json`, the command still writes the report before returning the
+non-zero exit.
+
+## JSON Report
+
+`--format json` emits schema version 1:
+
+```json
+{
+  "schema_version": 1,
+  "status": "ok",
+  "totals": {
+    "manifests": 1,
+    "positive_fixtures": 1,
+    "hard_negatives": 2,
+    "fixture_issues": 0
+  },
+  "manifests": []
+}
+```
+
+Each manifest entry includes pack provenance, declaration counts, the optional
+provider-supplied conformance command, proof links, and per-fixture issue labels
+such as `missing-path`, `missing-expectation`, and `missing-file`.
+
+Integrations should discover support through [capabilities](capabilities.md):
+`commands.stable` includes `semantic-pack`, `schemas.semantic_pack_conformance`
+lists supported report schema versions, and `semantic_packs.conformance` lists
+accepted local input sources.
+
+## Provider Responsibilities
+
+External pack providers own:
+
+- the truth of every language, runtime, package, API, protocol, law, demand,
+  effect, mutation, exception, and version claim;
+- fixture quality and hard-negative coverage;
+- proof quality for any `exact-proven` claim;
+- provenance, license, repository, support contact, and release notes;
+- the decision to publish updates or deprecate unsupported claims.
+
+Passing `nose semantic-pack check` means the pack is structurally well-formed and
+its declared fixtures are present. It does not mean the pack is safe to enable in
+every user's risk model.
+
+## User Responsibilities
+
+Users who opt into external packs own the enablement decision. They should review:
+
+- provider identity and repository history;
+- package/version ranges and unsupported boundaries;
+- positive and hard-negative fixtures;
+- whether exact-capable contracts are appropriate for their codebase;
+- the pack's own test or proof evidence outside nose.
+
+`nose scan --semantic-pack` and `[scan].semantic-packs` report loaded external
+packs under `semantic_packs` with `metadata-only` influence today. Future producer
+execution must keep the same provenance and fail-closed behavior before external
+packs can affect `near` or exact results.

--- a/docs/semantic-pack-extension-api-v0.md
+++ b/docs/semantic-pack-extension-api-v0.md
@@ -12,13 +12,15 @@ Schema artifacts:
 - [semantic-pack-v0 schema](schemas/semantic-pack-v0.schema.json)
 - [language-pack example](examples/semantic-packs/v0/language-pack.json)
 - [library-pack example](examples/semantic-packs/v0/library-pack.json)
+- [semantic-pack-conformance](semantic-pack-conformance.md)
 - [semantic-pack-loading](semantic-pack-loading.md)
 
-Status: design v0 plus local metadata loading. nose can load local manifests for
-explicit opt-in provenance reporting, but external packs are still
-`metadata-only`: they do not emit evidence or open exact contracts. This page
-defines the extension surface that first-party compiled packs and future
-external packs must use.
+Status: design v0 plus local metadata loading and a local conformance harness.
+nose can load local manifests for explicit opt-in provenance reporting, and pack
+authors can run `nose semantic-pack check` against manifests and declared fixture
+assets. External packs are still `metadata-only`: they do not emit evidence or
+open exact contracts. This page defines the extension surface that first-party
+compiled packs and future external packs must use.
 
 ## Context
 
@@ -400,7 +402,8 @@ from those ids. The human ids remain the public contract.
 
 ## Structural Validation Versus Trust
 
-nose should validate:
+nose validates the following through manifest loading and
+`nose semantic-pack check`:
 
 - manifest JSON parses and matches the v0 schema;
 - required sections and ids exist;
@@ -410,9 +413,9 @@ nose should validate:
 - exact-capable contracts declare required evidence, demand, effect, channel,
   proof status, positive fixtures, and hard negatives;
 - external packs are opt-in and not enabled by default;
-- declared compatibility ranges are syntactically valid enough to compare;
-- examples and fixtures are present at declared paths when a producer runtime or
-  conformance harness supports them.
+- declared compatibility ranges are syntactically valid enough to compare later;
+- conformance fixtures have expectation labels and point at files that exist
+  relative to the manifest path.
 
 nose does not validate or certify for external packs:
 
@@ -448,7 +451,9 @@ vocabulary that an external pack would use later.
 
 ## Conformance Checklist
 
-A pack provider should publish:
+The operational workflow is in
+[semantic-pack-conformance](semantic-pack-conformance.md). A pack provider should
+publish:
 
 - manifest with stable ids, provenance, license, repository, support contact,
   compatibility, dependencies, trust policy, and default status;
@@ -467,8 +472,9 @@ A pack provider should publish:
 - a reproducible conformance command.
 
 First-party packs must run this checklist in nose CI before becoming default.
-External packs should ship it so users can evaluate the pack, but passing the
-checklist is not nose certification.
+External packs should ship it so users can evaluate the pack. Passing
+`nose semantic-pack check` is not nose certification; it only proves the local
+manifest and declared fixture assets satisfy the v0 structural contract.
 
 ## v0 Acceptance
 
@@ -476,7 +482,7 @@ This issue is complete when:
 
 - the v0 schema and design document are linked from home, snapshot, and roadmap;
 - the schema has at least one language-pack and one library-pack example;
-- examples are checked by a lightweight harness;
+- examples are checked by the local conformance harness and docs example gate;
 - the docs state that external pack correctness is provider/user responsibility;
 - the docs state that first-party built-in semantics use the same extension
   vocabulary even if they remain compiled in initially.

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -1,10 +1,12 @@
 # Semantic pack loading
 
-Back to [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) and
+Back to [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md),
+[semantic-pack-conformance](semantic-pack-conformance.md), and
 [semantic-kernel](semantic-kernel.md).
 
 Status: nose can load local semantic-pack v0 manifests for provenance and trust
-reporting. External packs are explicit opt-ins and are currently
+reporting, and it can run a separate local conformance check for manifests and
+declared fixture assets. External packs are explicit opt-ins and are currently
 `metadata-only`: they do not emit evidence, open exact contracts, mint
 fingerprints, or approve clone pairs.
 
@@ -30,6 +32,22 @@ are resolved relative to the config file that declared them; paths from
 CLI paths. Directory loading reads direct `*.json` children in sorted order; it
 does not recurse and it does not contact a registry or network service.
 
+## Conformance entry point
+
+Pack authors and users can check the same local manifest paths without loading
+them into a scan:
+
+```sh
+nose semantic-pack check semantic-packs/python-math-prod.json
+nose semantic-pack check semantic-packs --format json
+```
+
+The conformance command validates manifest structure, trust policy, dependency
+references, exact-capable contract obligations, conformance fixture references,
+fixture expectation labels, and fixture file existence. It does not execute
+external producers or certify semantic correctness. See
+[semantic-pack-conformance](semantic-pack-conformance.md).
+
 ## Trust policy
 
 Trust is separate from channel eligibility.
@@ -54,9 +72,9 @@ The loader validates manifest shape and pack provenance only. It does not yet:
 
 - execute external evidence producers;
 - register external contract rows with exact consumers;
-- validate fixture files or run a conformance harness;
-- compare semantic version ranges beyond requiring the declared compatibility
-  field;
+- execute fixture contents or run a behavioral oracle;
+- compare semantic version ranges against the installed nose version beyond
+  requiring a parseable declared compatibility field;
 - install packs from a registry or remote source.
 
 Future loader work should keep this boundary: external pack claims can become

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,6 +29,7 @@ from-source `./target/release/nose`.
 | Find refactoring candidates in a tree | `nose scan <paths...>` |
 | Catch a missed sibling edit in a diff or PR | `nose review --base <ref>` |
 | Ask what an installed binary supports | `nose capabilities` |
+| Check a local semantic-pack manifest | `nose semantic-pack check <file-or-dir>` |
 | Inspect lowering coverage for a language | `nose stats <paths...>` |
 | Debug why two snippets do or do not converge | `nose il <file> --normalized` |
 
@@ -197,6 +198,10 @@ and may change to improve readability. The stable contract is documented in
   Raw-node ratio), with the top unhandled surface kinds (`--top`, default 30; `--json`
   for machine output). Use it to spot a language/construct that isn't lowering well; see
   [languages](languages.md).
+- `nose semantic-pack check <file-or-dir> [--format human|json]` — validate local
+  semantic-pack v0 manifest structure and declared fixture assets. It is a
+  pack-author/user workflow, not external pack certification; see
+  [semantic-pack-conformance](semantic-pack-conformance.md).
 - `nose il <file> [--normalized] [--no-cfg-norm] [--format sexpr|json]` — dump the IL
   for one file (`--normalized` shows the canonical form after the
   [normalization](normalization.md) passes). A debugging tool for understanding why two

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Docs quality gate. The semantic-pack example check keeps checked-in v0
-# manifests structurally honest; awiki checks the docs/ wiki is a single
+# manifests and fixture paths structurally honest; awiki checks the docs/ wiki is a single
 # connected graph with no orphan pages or disconnected islands. Mirrors the
 # `docs` job in .github/workflows/ci.yml.
 #

--- a/scripts/check-semantic-pack-examples.py
+++ b/scripts/check-semantic-pack-examples.py
@@ -2,8 +2,8 @@
 """Validate checked-in semantic-pack v0 schema examples.
 
 This is intentionally a lightweight structural check, not a full JSON Schema
-implementation. It keeps the design examples honest until nose has a real pack
-loader and conformance harness.
+implementation. It keeps the checked-in design examples honest in the docs job;
+the Rust CLI provides the pack-author conformance harness.
 """
 
 from __future__ import annotations
@@ -270,6 +270,12 @@ def validate_pack(path: Path, doc: dict[str, Any]) -> None:
     negatives = require_array(path, conformance, "hard_negatives", min_items=1)
     conformance_ids = require_unique_ids(path, positives + negatives, "conformance fixtures")
     require_array(path, conformance, "known_unsupported")
+    for fixture in positives + negatives:
+        fixture_path = require_string(path, fixture, "path")
+        require_string(path, fixture, "expectation")
+        resolved = path.parent / fixture_path
+        if not resolved.is_file():
+            fail(path, f"conformance fixture `{fixture['id']}` path does not exist: {fixture_path}")
 
     for producer in producers:
         validate_evidence_producer(path, producer, known_refs)


### PR DESCRIPTION
Closes #157.

## What changed

- Added `nose semantic-pack check <file-or-dir>` with human and JSON output (`schema_version: 1`).
- Added a `nose-semantics` conformance report API for local semantic-pack v0 manifests.
- The harness validates manifest loading/shape, duplicate pack ids including `nose.first_party`, dependency/conformance refs, exact-capable demand/effect obligations, trust/default policy, parseable `compatibility.nose`, fixture expectation labels, and fixture file existence relative to the manifest.
- Added checked fixture files for the v0 language-pack and library-pack examples.
- Added `docs/semantic-pack-conformance.md` and linked it through home, extension API, loading, kernel, snapshot, roadmap, usage, and capabilities docs.
- Updated `nose capabilities` to advertise stable `semantic-pack`, conformance report schema versions, input sources, and output formats.

## Responsibility boundary

External packs remain `metadata-only` when loaded by `nose scan`. This harness does not execute external producers, run a behavioral oracle over fixtures, certify third-party semantics, or approve external packs. Providers own semantic claims; users own opt-in decisions; nose owns first-party/default packs.

## Validation

- `cargo test -p nose-cli -p nose-semantics`
- `cargo clippy -p nose-cli -p nose-semantics --all-targets -- -D warnings`
- `cargo fmt --check`
- `python3 scripts/check-semantic-pack-examples.py`
- `awiki lint --root docs`
- `git diff --check`
- `target/debug/nose semantic-pack check docs/examples/semantic-packs/v0`
- `NOSE_BIN=target/debug/nose ./scripts/check-duplication.sh`