### PR TITLE
[codex] Expand call-target dispatch evidence

### DIFF
--- a/crates/nose-detect/src/strict_exact.rs
+++ b/crates/nose-detect/src/strict_exact.rs
@@ -5,8 +5,8 @@
 //! orchestration in `units.rs`; proof policy lives here.
 
 use nose_il::{
-    Builtin, HoFKind, Il, Interner, LitClass, NodeId, NodeKind, Op, Payload,
-    SourceComprehensionKind, Symbol,
+    Builtin, CallTargetEvidenceKind, HoFKind, Il, Interner, LitClass, NodeId, NodeKind, Op,
+    Payload, SourceComprehensionKind, Symbol,
 };
 use nose_normalize::module_facts::collect_module_mutations;
 use nose_semantics::{
@@ -21,16 +21,18 @@ use nose_semantics::{
     admitted_regex_test_at_call, admitted_ruby_set_factory_at_call,
     admitted_rust_option_none_sentinel_at_node, admitted_rust_vec_macro_factory_at_call,
     admitted_rust_vec_new_factory_at_call, admitted_static_index_membership_at_call,
-    asserted_unshadowed_global_symbol, construct_syntax_proof, direct_function_call_target_at_call,
+    asserted_unshadowed_global_symbol, call_target_evidence_status_at_call, construct_syntax_proof,
+    direct_function_call_target_at_call, direct_method_call_target_at_call,
     exact_static_membership_predicate_operator, go_zero_map_default_kind,
     go_zero_map_entry_contract_for_node, go_zero_map_literal_contract_for_node,
     go_zero_map_lookup_contract, nullish_global_contract, own_property_guard_for_node,
     record_shape_guard_for_node, semantics, seq_surface_contract_for_node,
     source_comprehension_at_node, source_fact_at_node, source_operator_at_node,
-    typeof_operator_contract, DomainRequirement, IndexMembershipThreshold, JavaMapFactoryKind,
-    LibraryCollectionFactoryResult, LibraryMapFactoryResult, LibraryMethodCallContract,
-    MapKeyViewKind, MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract,
-    ReceiverDomainEvidenceIndex, StaticIndexMembershipKind,
+    typeof_operator_contract, CallTargetEvidenceStatus, DomainRequirement,
+    IndexMembershipThreshold, JavaMapFactoryKind, LibraryCollectionFactoryResult,
+    LibraryMapFactoryResult, LibraryMethodCallContract, MapKeyViewKind, MethodBuiltinArgs,
+    MethodReceiverContract, MethodSemanticContract, ReceiverDomainEvidenceIndex,
+    StaticIndexMembershipKind,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -60,6 +62,12 @@ impl<'a> StrictFacts<'a> {
         self.function_roots
             .iter()
             .any(|&root| direct_function_call_target_at_call(il, call, root))
+    }
+
+    fn direct_method_target_at_call(&self, il: &Il, interner: &Interner, call: NodeId) -> bool {
+        self.function_roots
+            .iter()
+            .any(|&root| direct_method_call_target_at_call(il, interner, call, root))
     }
 
     fn receiver_satisfies_domain(&self, receiver: NodeId, requirement: DomainRequirement) -> bool {
@@ -696,7 +704,7 @@ fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, nod
         return true;
     }
     if il.kind(callee) != NodeKind::Field {
-        return strict_exact_callee_identity(il, facts, node, callee)
+        return strict_exact_callee_identity(il, interner, facts, node, callee)
             && strict_exact_call_args_safe(il, interner, facts, node);
     }
     let Payload::Name(name) = il.node(callee).payload else {
@@ -729,7 +737,7 @@ fn strict_exact_safe_call(il: &Il, interner: &Interner, facts: &StrictFacts, nod
     // Opaque exact method identity: this keeps same-callee calls eligible as exact clones
     // without assigning semantic meaning to the method name. Cross-language/builtin
     // convergence still has to pass the proof-backed contracts above or in normalization.
-    strict_exact_callee_identity(il, facts, node, callee)
+    strict_exact_callee_identity(il, interner, facts, node, callee)
         && strict_exact_call_args_safe(il, interner, facts, node)
 }
 
@@ -1584,20 +1592,55 @@ fn strict_exact_call_args_safe(
 
 fn strict_exact_callee_identity(
     il: &Il,
+    interner: &Interner,
     facts: &StrictFacts,
     call: NodeId,
     callee: NodeId,
 ) -> bool {
+    let target_status = call_target_evidence_status_at_call(il, interner, call);
     match il.kind(callee) {
-        NodeKind::Var => {
-            strict_exact_safe_var(il, facts, callee)
-                || facts.direct_function_target_at_call(il, call)
-        }
+        NodeKind::Var => match target_status {
+            CallTargetEvidenceStatus::Rejected => false,
+            CallTargetEvidenceStatus::Admitted(CallTargetEvidenceKind::ImportedFunction {
+                ..
+            }) => true,
+            CallTargetEvidenceStatus::Admitted(CallTargetEvidenceKind::DirectFunction {
+                ..
+            }) => facts.direct_function_target_at_call(il, call),
+            CallTargetEvidenceStatus::Admitted(
+                CallTargetEvidenceKind::DirectMethod { .. }
+                | CallTargetEvidenceKind::ImportedMember { .. }
+                | CallTargetEvidenceKind::DynamicDispatch { .. },
+            ) => false,
+            CallTargetEvidenceStatus::Missing => {
+                strict_exact_safe_var(il, facts, callee)
+                    || facts.direct_function_target_at_call(il, call)
+            }
+        },
         NodeKind::Field => {
-            matches!(il.node(callee).payload, Payload::Name(_))
-                && il.children(callee).first().is_some_and(|&receiver| {
-                    strict_exact_callee_receiver_identity(il, facts, receiver)
-                })
+            let exact_receiver = il.children(callee).first().is_some_and(|&receiver| {
+                strict_exact_callee_receiver_identity(il, facts, receiver)
+            });
+            if !matches!(il.node(callee).payload, Payload::Name(_)) {
+                return false;
+            }
+            match target_status {
+                CallTargetEvidenceStatus::Rejected => false,
+                CallTargetEvidenceStatus::Admitted(CallTargetEvidenceKind::ImportedMember {
+                    ..
+                }) => true,
+                CallTargetEvidenceStatus::Admitted(CallTargetEvidenceKind::DirectMethod {
+                    ..
+                }) => exact_receiver && facts.direct_method_target_at_call(il, interner, call),
+                CallTargetEvidenceStatus::Admitted(CallTargetEvidenceKind::DynamicDispatch {
+                    ..
+                }) => exact_receiver,
+                CallTargetEvidenceStatus::Admitted(
+                    CallTargetEvidenceKind::DirectFunction { .. }
+                    | CallTargetEvidenceKind::ImportedFunction { .. },
+                ) => false,
+                CallTargetEvidenceStatus::Missing => exact_receiver,
+            }
         }
         _ => false,
     }
@@ -1691,6 +1734,20 @@ mod tests {
                 callee_hash: library_api_callee_contract_hash(contract.callee),
                 arity: 1,
             }),
+            dependencies,
+        )
+    }
+
+    fn call_target_evidence(
+        id: u32,
+        call_span: Span,
+        target: CallTargetEvidenceKind,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceRecord {
+        evidence(
+            id,
+            EvidenceAnchor::node(call_span, NodeKind::Call),
+            EvidenceKind::CallTarget(target),
             dependencies,
         )
     }
@@ -1883,6 +1940,196 @@ mod tests {
         ));
         let facts = StrictFacts::collect(&il, &interner);
         assert!(strict_exact_safe_tree(&il, &interner, &facts, call));
+    }
+
+    #[test]
+    fn imported_function_call_target_opens_opaque_exact_identity() {
+        let interner = Interner::new();
+        let prod = interner.intern("prod");
+        let mut b = IlBuilder::new(FileId(0));
+        let callee = b.add(NodeKind::Var, Payload::Name(prod), sp(80), &[]);
+        let arg = b.add(NodeKind::Lit, Payload::LitInt(2), sp(81), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(82), &[callee, arg]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(79), &[call]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.py".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(
+            !strict_exact_safe_tree(&il, &interner, &facts, call),
+            "same local function spelling must not prove imported call identity"
+        );
+
+        il.evidence.push(call_target_evidence(
+            0,
+            sp(82),
+            CallTargetEvidenceKind::ImportedFunction {
+                module_hash: stable_symbol_hash("math"),
+                exported_hash: stable_symbol_hash("prod"),
+                local_hash: interner.symbol_hash(prod),
+            },
+            Vec::new(),
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(strict_exact_safe_tree(&il, &interner, &facts, call));
+    }
+
+    #[test]
+    fn ambiguous_call_target_evidence_blocks_parameter_callee_fallback() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let callee_param = b.add(NodeKind::Param, Payload::Cid(0), sp(90), &[]);
+        let value_param = b.add(NodeKind::Param, Payload::Cid(1), sp(91), &[]);
+        let callee = b.add(NodeKind::Var, Payload::Cid(0), sp(92), &[]);
+        let value = b.add(NodeKind::Var, Payload::Cid(1), sp(93), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(94), &[callee, value]);
+        let root = b.add(
+            NodeKind::Func,
+            Payload::None,
+            sp(89),
+            &[callee_param, value_param, call],
+        );
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.py".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(strict_exact_safe_tree(&il, &interner, &facts, call));
+
+        il.evidence.push(call_target_evidence(
+            0,
+            sp(94),
+            CallTargetEvidenceKind::ImportedFunction {
+                module_hash: stable_symbol_hash("math"),
+                exported_hash: stable_symbol_hash("prod"),
+                local_hash: stable_symbol_hash("prod"),
+            },
+            Vec::new(),
+        ));
+        il.evidence.push(call_target_evidence(
+            1,
+            sp(94),
+            CallTargetEvidenceKind::ImportedFunction {
+                module_hash: stable_symbol_hash("statistics"),
+                exported_hash: stable_symbol_hash("prod"),
+                local_hash: stable_symbol_hash("prod"),
+            },
+            Vec::new(),
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(
+            !strict_exact_safe_tree(&il, &interner, &facts, call),
+            "conflicting call-target evidence must not reopen opaque callee identity"
+        );
+    }
+
+    #[test]
+    fn imported_member_call_target_opens_static_member_identity() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("math")),
+            sp(100),
+            &[],
+        );
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("prod")),
+            sp(101),
+            &[receiver],
+        );
+        let arg = b.add(NodeKind::Lit, Payload::LitInt(3), sp(102), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(103), &[callee, arg]);
+        let root = b.add(NodeKind::Block, Payload::None, sp(99), &[call]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.py".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(
+            !strict_exact_safe_tree(&il, &interner, &facts, call),
+            "namespace/member spelling without proof is not exact call identity"
+        );
+
+        il.evidence.push(call_target_evidence(
+            0,
+            sp(103),
+            CallTargetEvidenceKind::ImportedMember {
+                module_hash: stable_symbol_hash("math"),
+                exported_hash: stable_symbol_hash("math"),
+                member_hash: interner.symbol_hash(interner.intern("prod")),
+            },
+            Vec::new(),
+        ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(strict_exact_safe_tree(&il, &interner, &facts, call));
+    }
+
+    #[test]
+    fn direct_method_call_target_does_not_skip_receiver_identity() {
+        let interner = Interner::new();
+        let mut b = IlBuilder::new(FileId(0));
+        let method_body = b.add(NodeKind::Block, Payload::None, sp(110), &[]);
+        let method = b.add(NodeKind::Func, Payload::None, sp(111), &[method_body]);
+        let receiver = b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern("worker")),
+            sp(112),
+            &[],
+        );
+        let callee = b.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern("run")),
+            sp(113),
+            &[receiver],
+        );
+        let call = b.add(NodeKind::Call, Payload::None, sp(114), &[callee]);
+        let root = b.add(NodeKind::Module, Payload::None, sp(109), &[method, call]);
+        let mut il = b.finish(
+            root,
+            FileMeta {
+                path: "t.ts".into(),
+                lang: Lang::TypeScript,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.evidence.push(call_target_evidence(
+            0,
+            sp(114),
+            CallTargetEvidenceKind::DirectMethod {
+                target_span: il.node(method).span,
+                receiver_type_hash: stable_symbol_hash("Worker"),
+                method_hash: interner.symbol_hash(interner.intern("run")),
+            },
+            Vec::new(),
+        ));
+
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(
+            !strict_exact_safe_tree(&il, &interner, &facts, call),
+            "direct method target proof does not prove the receiver value identity"
+        );
     }
 
     #[test]

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -419,7 +419,40 @@ pub enum LibraryApiEvidenceKind {
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub enum CallTargetEvidenceKind {
+    /// A call to a file-local function unit proven by lexical binding/scope
+    /// evidence. This is opaque call identity, not a library semantic contract.
     DirectFunction { target_span: Span, name_hash: u64 },
+    /// A call to a file-local method/function body whose receiver dispatch has
+    /// been proven by a language producer. Exact consumers must still prove the
+    /// receiver expression is exact-safe before treating the call as opaque
+    /// same-target identity.
+    DirectMethod {
+        target_span: Span,
+        receiver_type_hash: u64,
+        method_hash: u64,
+    },
+    /// A call through a local binding proven to denote a specific imported
+    /// function coordinate. This records target identity only; library semantics
+    /// still require `LibraryApi` evidence.
+    ImportedFunction {
+        module_hash: u64,
+        exported_hash: u64,
+        local_hash: u64,
+    },
+    /// A static/member call where the receiver/member pair is proven to denote a
+    /// specific imported coordinate, such as an imported namespace member.
+    ImportedMember {
+        module_hash: u64,
+        exported_hash: u64,
+        member_hash: u64,
+    },
+    /// A method dispatch proof that names a protocol/dispatch family but does
+    /// not prove one concrete implementation target. By itself this is not exact
+    /// opaque call identity.
+    DynamicDispatch {
+        protocol_hash: u64,
+        method_hash: u64,
+    },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]

--- a/crates/nose-semantics/src/evidence.rs
+++ b/crates/nose-semantics/src/evidence.rs
@@ -205,7 +205,145 @@ pub fn direct_function_call_target_at_call(il: &Il, call: NodeId, target_root: N
             target_span: proven_span,
             ..
         }) => proven_span == target_span,
+        EvidenceResolution::Found(
+            CallTargetEvidenceKind::DirectMethod { .. }
+            | CallTargetEvidenceKind::ImportedFunction { .. }
+            | CallTargetEvidenceKind::ImportedMember { .. }
+            | CallTargetEvidenceKind::DynamicDispatch { .. },
+        ) => false,
         EvidenceResolution::Ambiguous | EvidenceResolution::Missing => false,
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CallTargetEvidenceStatus {
+    Missing,
+    Admitted(CallTargetEvidenceKind),
+    Rejected,
+}
+
+pub fn call_target_evidence_at_call(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+) -> Option<CallTargetEvidenceKind> {
+    match call_target_evidence_status_at_call(il, interner, call) {
+        CallTargetEvidenceStatus::Admitted(target) => Some(target),
+        CallTargetEvidenceStatus::Missing | CallTargetEvidenceStatus::Rejected => None,
+    }
+}
+
+pub fn call_target_evidence_status_at_call(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+) -> CallTargetEvidenceStatus {
+    if il.kind(call) != NodeKind::Call {
+        return CallTargetEvidenceStatus::Missing;
+    }
+    let call_span = il.node(call).span;
+    let target = match unique_asserted_evidence_at(
+        il,
+        |anchor| matches!(anchor, EvidenceAnchor::Node { span, kind } if span == call_span && kind == NodeKind::Call),
+        |evidence| match evidence {
+            EvidenceKind::CallTarget(target) => Some(target),
+            _ => None,
+        },
+    ) {
+        EvidenceResolution::Found(target) => target,
+        EvidenceResolution::Ambiguous => return CallTargetEvidenceStatus::Rejected,
+        EvidenceResolution::Missing => return CallTargetEvidenceStatus::Missing,
+    };
+    if call_target_matches_call_shape(il, interner, call, target) {
+        CallTargetEvidenceStatus::Admitted(target)
+    } else {
+        CallTargetEvidenceStatus::Rejected
+    }
+}
+
+pub fn imported_function_call_target_at_call(il: &Il, interner: &Interner, call: NodeId) -> bool {
+    matches!(
+        call_target_evidence_at_call(il, interner, call),
+        Some(CallTargetEvidenceKind::ImportedFunction { .. })
+    )
+}
+
+pub fn imported_member_call_target_at_call(il: &Il, interner: &Interner, call: NodeId) -> bool {
+    matches!(
+        call_target_evidence_at_call(il, interner, call),
+        Some(CallTargetEvidenceKind::ImportedMember { .. })
+    )
+}
+
+pub fn direct_method_call_target_at_call(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    target_root: NodeId,
+) -> bool {
+    if il.kind(call) != NodeKind::Call || il.kind(target_root) != NodeKind::Func {
+        return false;
+    }
+    matches!(
+        call_target_evidence_at_call(il, interner, call),
+        Some(CallTargetEvidenceKind::DirectMethod { target_span, .. })
+            if target_span == il.node(target_root).span
+    )
+}
+
+fn call_target_matches_call_shape(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    target: CallTargetEvidenceKind,
+) -> bool {
+    let Some(&callee) = il.children(call).first() else {
+        return false;
+    };
+    match target {
+        CallTargetEvidenceKind::DirectFunction { name_hash, .. }
+        | CallTargetEvidenceKind::ImportedFunction {
+            local_hash: name_hash,
+            ..
+        } => var_selector_matches_if_available(il, interner, callee, name_hash),
+        CallTargetEvidenceKind::DirectMethod { method_hash, .. }
+        | CallTargetEvidenceKind::DynamicDispatch { method_hash, .. } => {
+            field_selector_matches(il, interner, callee, method_hash)
+        }
+        CallTargetEvidenceKind::ImportedMember { member_hash, .. } => {
+            field_selector_matches(il, interner, callee, member_hash)
+        }
+    }
+}
+
+fn var_selector_matches_if_available(
+    il: &Il,
+    interner: &Interner,
+    callee: NodeId,
+    expected_hash: u64,
+) -> bool {
+    if il.kind(callee) != NodeKind::Var {
+        return false;
+    }
+    match il.node(callee).payload {
+        Payload::Name(name) => interner.symbol_hash(name) == expected_hash,
+        Payload::Cid(_) => true,
+        _ => false,
+    }
+}
+
+fn field_selector_matches(
+    il: &Il,
+    interner: &Interner,
+    callee: NodeId,
+    expected_hash: u64,
+) -> bool {
+    if il.kind(callee) != NodeKind::Field {
+        return false;
+    }
+    match il.node(callee).payload {
+        Payload::Name(name) => interner.symbol_hash(name) == expected_hash,
+        _ => false,
     }
 }
 

--- a/crates/nose-semantics/src/tests.rs
+++ b/crates/nose-semantics/src/tests.rs
@@ -1,12 +1,14 @@
 use super::*;
 use nose_il::{
-    EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance, EvidenceRecord,
-    EvidenceStatus, FileId, FileMeta, GuardEvidenceKind, IlBuilder, ImportEvidenceKind, Interner,
-    JsRecordGuardComparison, JsRecordGuardNullCheck, LibraryApiEvidenceKind, ParamSemantic,
-    PlaceEvidenceKind, SequenceSurfaceKind, SourceCastKind, SourceFactKind, SourcePatternKind,
-    SourceRangeKind, Span, Symbol, SymbolEvidenceKind, Unit, UnitKind,
+    CallTargetEvidenceKind, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
+    EvidenceProvenance, EvidenceRecord, EvidenceStatus, FileId, FileMeta, GuardEvidenceKind,
+    IlBuilder, ImportEvidenceKind, Interner, JsRecordGuardComparison, JsRecordGuardNullCheck,
+    LibraryApiEvidenceKind, ParamSemantic, PlaceEvidenceKind, SequenceSurfaceKind, SourceCastKind,
+    SourceFactKind, SourcePatternKind, SourceRangeKind, Span, Symbol, SymbolEvidenceKind, Unit,
+    UnitKind,
 };
 
+mod call_targets;
 mod effects_and_places;
 mod js_symbol_guards;
 mod library_api_contracts;

--- a/crates/nose-semantics/src/tests/call_targets.rs
+++ b/crates/nose-semantics/src/tests/call_targets.rs
@@ -1,0 +1,223 @@
+use super::*;
+
+fn call_target_record(
+    id: u32,
+    span: Span,
+    target: CallTargetEvidenceKind,
+    status: EvidenceStatus,
+    dependencies: &[u32],
+) -> EvidenceRecord {
+    evidence_with_dependencies(
+        id,
+        EvidenceAnchor::node(span, NodeKind::Call),
+        EvidenceKind::CallTarget(target),
+        status,
+        dependencies.iter().copied().map(EvidenceId).collect(),
+    )
+}
+
+fn imported_function_call_il(interner: &Interner) -> (Il, NodeId) {
+    let mut b = IlBuilder::new(FileId(0));
+    let local = b.add(
+        NodeKind::Var,
+        Payload::Name(interner.intern("prod")),
+        sp(10),
+        &[],
+    );
+    let arg = b.add(NodeKind::Lit, Payload::LitInt(3), sp(11), &[]);
+    let call = b.add(NodeKind::Call, Payload::None, sp(12), &[local, arg]);
+    (finish_il(b, call, Lang::Python), call)
+}
+
+fn field_call_il(interner: &Interner, method: &str) -> (Il, NodeId, NodeId) {
+    let mut b = IlBuilder::new(FileId(0));
+    let receiver = b.add(
+        NodeKind::Var,
+        Payload::Name(interner.intern("ns")),
+        sp(20),
+        &[],
+    );
+    let callee = b.add(
+        NodeKind::Field,
+        Payload::Name(interner.intern(method)),
+        sp(21),
+        &[receiver],
+    );
+    let arg = b.add(NodeKind::Lit, Payload::LitInt(4), sp(22), &[]);
+    let call = b.add(NodeKind::Call, Payload::None, sp(23), &[callee, arg]);
+    (finish_il(b, call, Lang::Python), call, callee)
+}
+
+#[test]
+fn imported_function_call_target_requires_matching_local_selector() {
+    let interner = Interner::new();
+    let (mut il, call) = imported_function_call_il(&interner);
+    il.evidence.push(call_target_record(
+        0,
+        sp(12),
+        CallTargetEvidenceKind::ImportedFunction {
+            module_hash: stable_symbol_hash("math"),
+            exported_hash: stable_symbol_hash("prod"),
+            local_hash: interner.symbol_hash(interner.intern("prod")),
+        },
+        EvidenceStatus::Asserted,
+        &[],
+    ));
+
+    assert_eq!(
+        call_target_evidence_at_call(&il, &interner, call),
+        Some(CallTargetEvidenceKind::ImportedFunction {
+            module_hash: stable_symbol_hash("math"),
+            exported_hash: stable_symbol_hash("prod"),
+            local_hash: interner.symbol_hash(interner.intern("prod")),
+        })
+    );
+    assert!(imported_function_call_target_at_call(&il, &interner, call));
+}
+
+#[test]
+fn wrong_imported_function_selector_is_rejected_not_missing() {
+    let interner = Interner::new();
+    let (mut il, call) = imported_function_call_il(&interner);
+    il.evidence.push(call_target_record(
+        0,
+        sp(12),
+        CallTargetEvidenceKind::ImportedFunction {
+            module_hash: stable_symbol_hash("math"),
+            exported_hash: stable_symbol_hash("prod"),
+            local_hash: stable_symbol_hash("sum"),
+        },
+        EvidenceStatus::Asserted,
+        &[],
+    ));
+
+    assert_eq!(
+        call_target_evidence_status_at_call(&il, &interner, call),
+        CallTargetEvidenceStatus::Rejected
+    );
+    assert_eq!(call_target_evidence_at_call(&il, &interner, call), None);
+}
+
+#[test]
+fn dependency_broken_call_target_is_rejected() {
+    let interner = Interner::new();
+    let (mut il, call) = imported_function_call_il(&interner);
+    il.evidence.push(evidence(
+        0,
+        EvidenceAnchor::node(sp(10), NodeKind::Var),
+        EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+            module_hash: stable_symbol_hash("math"),
+            exported_hash: stable_symbol_hash("prod"),
+        }),
+        EvidenceStatus::Ambiguous,
+    ));
+    il.evidence.push(call_target_record(
+        1,
+        sp(12),
+        CallTargetEvidenceKind::ImportedFunction {
+            module_hash: stable_symbol_hash("math"),
+            exported_hash: stable_symbol_hash("prod"),
+            local_hash: interner.symbol_hash(interner.intern("prod")),
+        },
+        EvidenceStatus::Asserted,
+        &[0],
+    ));
+
+    assert_eq!(
+        call_target_evidence_status_at_call(&il, &interner, call),
+        CallTargetEvidenceStatus::Rejected
+    );
+}
+
+#[test]
+fn conflicting_call_targets_stay_closed() {
+    let interner = Interner::new();
+    let (mut il, call) = imported_function_call_il(&interner);
+    il.evidence.push(call_target_record(
+        0,
+        sp(12),
+        CallTargetEvidenceKind::ImportedFunction {
+            module_hash: stable_symbol_hash("math"),
+            exported_hash: stable_symbol_hash("prod"),
+            local_hash: interner.symbol_hash(interner.intern("prod")),
+        },
+        EvidenceStatus::Asserted,
+        &[],
+    ));
+    il.evidence.push(call_target_record(
+        1,
+        sp(12),
+        CallTargetEvidenceKind::ImportedFunction {
+            module_hash: stable_symbol_hash("statistics"),
+            exported_hash: stable_symbol_hash("prod"),
+            local_hash: interner.symbol_hash(interner.intern("prod")),
+        },
+        EvidenceStatus::Asserted,
+        &[],
+    ));
+
+    assert_eq!(
+        call_target_evidence_status_at_call(&il, &interner, call),
+        CallTargetEvidenceStatus::Rejected
+    );
+}
+
+#[test]
+fn direct_method_target_requires_matching_selector_and_target_span() {
+    let interner = Interner::new();
+    let mut b = IlBuilder::new(FileId(0));
+    let target_body = b.add(NodeKind::Block, Payload::None, sp(30), &[]);
+    let target = b.add(NodeKind::Func, Payload::None, sp(31), &[target_body]);
+    let receiver = b.add(
+        NodeKind::Var,
+        Payload::Name(interner.intern("worker")),
+        sp(32),
+        &[],
+    );
+    let callee = b.add(
+        NodeKind::Field,
+        Payload::Name(interner.intern("run")),
+        sp(33),
+        &[receiver],
+    );
+    let call = b.add(NodeKind::Call, Payload::None, sp(34), &[callee]);
+    let root = b.add(NodeKind::Module, Payload::None, sp(35), &[target, call]);
+    let mut il = finish_il(b, root, Lang::TypeScript);
+    il.evidence.push(call_target_record(
+        0,
+        sp(34),
+        CallTargetEvidenceKind::DirectMethod {
+            target_span: il.node(target).span,
+            receiver_type_hash: stable_symbol_hash("Worker"),
+            method_hash: interner.symbol_hash(interner.intern("run")),
+        },
+        EvidenceStatus::Asserted,
+        &[],
+    ));
+
+    assert!(direct_method_call_target_at_call(
+        &il, &interner, call, target
+    ));
+}
+
+#[test]
+fn dynamic_dispatch_is_evidence_but_not_imported_member_identity() {
+    let interner = Interner::new();
+    let (mut il, call, _) = field_call_il(&interner, "next");
+    il.evidence.push(call_target_record(
+        0,
+        sp(23),
+        CallTargetEvidenceKind::DynamicDispatch {
+            protocol_hash: stable_symbol_hash("Iterator"),
+            method_hash: interner.symbol_hash(interner.intern("next")),
+        },
+        EvidenceStatus::Asserted,
+        &[],
+    ));
+
+    assert!(matches!(
+        call_target_evidence_at_call(&il, &interner, call),
+        Some(CallTargetEvidenceKind::DynamicDispatch { .. })
+    ));
+    assert!(!imported_member_call_target_at_call(&il, &interner, call));
+}

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -70,7 +70,7 @@ The current implemented kinds are:
 | `Place` | fixed receiver/place facts currently covering `SelfReceiver` and `SelfField` |
 | `Effect` | observable effect and mutation-risk facts currently covering canonical builder append calls, non-overloadable index writes, fixed self-field writes, binding writes, receiver-mutating calls, and opaque argument escapes |
 | `LibraryApi` | proof that a specific API occurrence matches a language/API contract coordinate, currently for selected call, property, and sentinel occurrences across JS-like static/global/static-index APIs, selected Python/Rust/Ruby/Java/regex APIs, generic Python/Go free-function builtins, and selected receiver-method families |
-| `CallTarget` | proof that a specific user call occurrence resolves to a direct in-file callable unit target |
+| `CallTarget` | proof that a specific call occurrence resolves to an explicit function, method, imported function/member, or dispatch-family target identity |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, import proof, guard surfaces, Go composite map literals, or Go map entries |
 
 `LibraryApi` evidence is an occurrence fact, not the whole contract. It records
@@ -86,18 +86,33 @@ exact or value-graph path. A future external pack schema may expose library API
 contracts, but providers still emit facts and contracts rather than exact-clone
 verdicts.
 
-`CallTarget` evidence is the occurrence proof for user-defined calls. A raw
-callee spelling such as `f(...)` is only a selector that a producer may inspect;
-recursion normalization, the interpreter oracle, value-graph pure helper
-inlining, and strict exact direct-function callee gates consume only
-`CallTarget::DirectFunction` records anchored to the exact `Call` node and
-matching the target function span. The first-party producer currently emits this
-fact only for unique top-level in-file `Function` units when neither the current
-lexical scope nor any enclosing lexical scope has a parameter, assignment
-target, loop-pattern binding, or nested function definition that shadows the
-callee name. Duplicate function names, lexical shadowing, nested/non-top-level
-functions, methods without an explicit target proof, computed callees, and
-missing or conflicting evidence stay closed.
+`CallTarget` evidence is occurrence proof for call target identity. A raw callee
+spelling such as `f(...)`, `obj.f(...)`, or `ns.f(...)` is only a selector that a
+producer may inspect; consumers must require an asserted, dependency-closed,
+unambiguous `CallTarget` record anchored to the exact `Call` node. The current
+vocabulary separates concrete exact identity from broader dispatch facts:
+
+- `DirectFunction` names a unique in-file function target by function span and
+  selector hash. Recursion normalization, the interpreter oracle, value-graph
+  pure helper inlining, and strict exact direct-function gates consume this
+  variant only when the target function itself is exact-safe.
+- `DirectMethod` names a concrete in-file method/function target plus receiver
+  type and method selector hashes. Strict exact still separately requires the
+  receiver expression to have exact identity before treating the call as opaque
+  same-target identity.
+- `ImportedFunction` and `ImportedMember` name imported function/member
+  coordinates. They prove opaque call identity only; standard-library or
+  ecosystem semantics still require `LibraryApi` occurrence evidence.
+- `DynamicDispatch` names a protocol/dispatch family and method selector, but it
+  does not by itself prove one concrete implementation target.
+
+The first-party producer currently emits `DirectFunction` only for unique
+top-level in-file `Function` units when neither the current lexical scope nor
+any enclosing lexical scope has a parameter, assignment target, loop-pattern
+binding, or nested function definition that shadows the callee name. Duplicate
+function names, lexical shadowing, nested/non-top-level functions, methods
+without explicit target proof, computed callees, selector mismatches,
+dependency-broken records, and conflicting evidence stay closed.
 
 Current first-party `LibraryApi` callee coordinates are intentionally specific:
 

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -284,8 +284,10 @@ converge with hand-written iteration.
 
 Both schemes require exactly one self-call, and self-call identity is evidence-backed:
 the call occurrence must carry `CallTarget::DirectFunction` evidence that points at the
-enclosing function or method unit. A raw callee spelling is not enough. Anything else is
-left untouched.
+enclosing function unit. A raw callee spelling is not enough. Anything else is
+left untouched. Broader call-target records such as `DirectMethod`,
+`ImportedFunction`, `ImportedMember`, and `DynamicDispatch` are available to exact
+callee-identity consumers, but they do not currently authorize recursion rewrites.
 The proof obligations
 [normalize.recursion.tail](../formal/obligations/normalize/recursion/tail/Proof.lean)
 and
@@ -294,7 +296,7 @@ record the tail-loop equivalence, the numeric `+`/`*` fold laws, and boundary
 counterexamples for cyclic tail-call bindings, subtraction, and wrong identities.
 **Soundness** is checked, not assumed: the interpreter
 ([interp](../crates/nose-normalize/src/interp.rs)) executes user-defined calls only when
-`CallTarget` evidence resolves the exact occurrence to an in-file function or method root, so
+`CallTarget::DirectFunction` evidence resolves the exact occurrence to an in-file function root, so
 `nose verify` interprets proven original recursion *and* the rewritten loop and flags any
 behavioral difference (when the recursion terminates on the input battery — a guard like
 `n == 0` that loops forever on negatives is excluded on both sides, identically). On real

--- a/docs/semantic-kernel-audit-2026-06-09.md
+++ b/docs/semantic-kernel-audit-2026-06-09.md
@@ -150,10 +150,12 @@ semantic meaning.
 
 - `crates/nose-detect/src/strict_exact.rs::strict_exact_callee_identity` keeps
   exact same-callee calls eligible when the callee itself is exact-safe or when a
-  `CallTarget::DirectFunction` fact proves a direct local function target. This
-  is deliberately not library/API semantics: the call only remains an opaque
-  same-call value, and cross-language or builtin convergence must still use
-  admitted semantic contracts.
+  concrete `CallTarget` fact proves a direct local, imported function, or
+  imported member target. This is deliberately not library/API semantics: the
+  call only remains an opaque same-call value, and cross-language or builtin
+  convergence must still use admitted semantic contracts. Direct method records
+  also require exact receiver identity; dynamic-dispatch records do not prove a
+  single concrete target by themselves.
 
 ## Remaining Backlog
 
@@ -163,7 +165,7 @@ These are not #150 fixes; they are the next independent work items.
 |---|---|---|---|
 | P0 | #151 | Pack extension API v0 | First-party producers still call compiled Rust helper functions directly. The external boundary needs stable fact, contract, dependency, and channel-eligibility schemas before those producers can be expressed as packs. |
 | P0 | #153 | Demand/effect substrate | Lazy, repeated, async, generator, channel, observable, and callback effect visibility cannot be represented by the current first-party demand profiles. Exact laws for those surfaces must remain closed. |
-| P0 | #155 | Call-target and dispatch evidence | Direct function call target proof is unique-top-level and in-file. Method dispatch, imported/local module targets, trait/interface dispatch, overload resolution, and dynamic dispatch need explicit evidence rather than same-name fallback. |
+| P0 | #155 | Call-target and dispatch evidence | The shared vocabulary and resolver now cover direct functions, direct methods, imported functions/members, and dynamic-dispatch facts. Remaining work is broader producer coverage for method/imported/module targets, trait/interface dispatch, and overload-specific target proof. |
 | P0 | #156 | Type/domain evidence expansion | Receiver/domain proof covers current parameter, binding, and selected API-result facts. Broader type aliases, constructor result domains, field/property domains, protocol receiver facts, and versioned library domains still need evidence vocabulary. |
 | P1 | #154 | Async and Promise receiver proof | `crates/nose-normalize/src/value_graph/rules/promise_then.rs` has a JS-like `.then` contract but returns fail-closed until Promise-like receiver proof exists. This should depend on #153 and #156. |
 | P1 | #152 | Pack loading, provenance, and opt-in trust | The internal provenance/trust model exists, but there is no loadable pack runtime, manifest validation, user opt-in path, or report-level pack provenance. |

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -567,8 +567,12 @@ and pack ecosystem.
   function targets with no current or enclosing lexical shadowing, and
   recursion, interpreter, value-graph pure-inline, and strict exact
   direct-function callee consumers require that occurrence proof.
-  Method/dynamic-dispatch target proof remains a future pack/source extension
-  rather than a same-name fallback.
+  The follow-up call-target slice expanded the vocabulary to `DirectMethod`,
+  `ImportedFunction`, `ImportedMember`, and `DynamicDispatch`, added a shared
+  fail-closed resolver, and taught strict exact to admit imported function/member
+  opaque identity only through explicit evidence. Direct methods still require
+  exact receiver identity, and dynamic-dispatch records do not by themselves
+  prove one concrete target.
 - C byte-pack proof moved onto evidence-backed alias and cast records. Local
   typedefs and direct quote includes emit `Type(CTypeAlias)` evidence, included
   aliases depend on `Import(CQuoteInclude)`, alias-based `Domain(ByteArray)` and
@@ -778,9 +782,9 @@ Remaining in this phase:
   `nose-semantics` helper, and selected JS/TS `QualifiedGlobal` paths are covered
   with same-span root dependencies, but general qualified-member resolution,
   namespace export identity, provider/export dependency manifests, richer
-  scope/rebinding facts, opaque call receiver identity for module-defined locals
-  versus imported namespaces, and manifest-level cross-module dependency evidence
-  are not.
+  scope/rebinding facts, broader producer coverage for module-defined local
+  functions/methods and imported namespace members, and manifest-level
+  cross-module dependency evidence are not.
 - Generalize dedicated guard evidence beyond the first JS/TS record-shape and
   own-property contracts, including richer source-clause records, API dependency
   validation, subject/place identity, and truthiness/null semantics.

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -462,9 +462,11 @@ migrated.
   Java map entries, map `get`, and map-key view/wrapper calls.
 - Opaque exact callee identity remains separate from library/API admission. A
   parameter callee or proof-backed immutable/imported callee may keep an exact
-  same-callee call comparable as an opaque value operation, while same-spelled
-  file-local functions still require `CallTarget` evidence and library semantics
-  still require admitted API occurrence evidence.
+  same-callee call comparable as an opaque value operation. Same-spelled
+  file-local functions still require `CallTarget::DirectFunction` evidence,
+  imported function/member calls can enter opaque identity only through explicit
+  `CallTarget::ImportedFunction` or `CallTarget::ImportedMember` records, and
+  library semantics still require admitted API occurrence evidence.
 - Java stream source adapters are split by proof through library API contracts:
   `receiver.stream()` requires an exact iterable receiver, while
   `Arrays.stream(xs)` requires the `java.util.Arrays` import binding and no local
@@ -537,14 +539,19 @@ migrated.
   from other languages, including JS `min(...)`, locally shadowed Python names,
   and manually constructed calls without admitted occurrence evidence stay
   exact-closed.
-- User-defined direct calls now consume `CallTarget` evidence. The first-party
-  producer admits only unique top-level in-file function targets with no
-  current or enclosing lexical shadowing by parameters, assignments, loop
-  patterns, or nested function definitions; recursion normalization and the
-  interpreter oracle, value-graph pure helper inlining, and strict exact
-  direct-function callee gates no longer treat same raw callee spelling as
-  call-target proof. Method and dynamic-dispatch targets require explicit
-  pack/source evidence.
+- User-defined and imported opaque call identity now consume `CallTarget`
+  evidence. The first-party producer admits only `DirectFunction` records for
+  unique top-level in-file function targets with no current or enclosing lexical
+  shadowing by parameters, assignments, loop patterns, or nested function
+  definitions; recursion normalization and the interpreter oracle, value-graph
+  pure helper inlining, and strict exact direct-function callee gates no longer
+  treat same raw callee spelling as call-target proof. The shared resolver also
+  understands `DirectMethod`, `ImportedFunction`, `ImportedMember`, and
+  `DynamicDispatch` records. Strict exact admits imported function/member
+  identity only through explicit evidence, requires exact receiver identity for
+  direct methods, treats dynamic-dispatch records as non-concrete by themselves,
+  and closes on selector mismatch, dependency-broken records, or conflicting
+  target evidence.
 - JS-like `typeof` exact-safety now consumes a language- and arity-constrained
   operator contract plus `Source::Operator(Typeof)` evidence at the call span.
   A raw `Call(Var("typeof"), arg)` shape, same-named function from another

--- a/docs/semantic-pack-extension-api-v0.md
+++ b/docs/semantic-pack-extension-api-v0.md
@@ -170,7 +170,7 @@ schema:
 | `Place` | fixed receiver/place facts such as self receiver and self field |
 | `Effect` | builder append, non-overloadable index write, self-field write, binding write, receiver mutation, opaque argument escape |
 | `LibraryApi` | occurrence proof that a call, field, property, constructor, macro, or sentinel matches one contract coordinate |
-| `CallTarget` | direct user-defined call target proof |
+| `CallTarget` | explicit call target proof for direct functions/methods, imported function/member coordinates, and dispatch-family facts |
 | `SequenceSurface` | lowered aggregate surface such as collection, tuple, map, pair, record guard, own-property guard, Go map literal, or Go map entry |
 
 The producer declaration must include:


### PR DESCRIPTION
Closes #155.

## What changed

- Expanded `CallTargetEvidenceKind` beyond `DirectFunction` with explicit `DirectMethod`, `ImportedFunction`, `ImportedMember`, and `DynamicDispatch` records.
- Added shared `nose-semantics` call-target resolution that distinguishes missing evidence from rejected evidence caused by conflicts, bad shape, or broken dependencies.
- Updated strict exact callee identity to consume imported function/member target evidence without treating it as library semantics, require exact receiver identity for direct method targets, and keep dynamic dispatch non-concrete by itself.
- Added hard negatives for selector mismatch, dependency-broken records, conflicting target evidence, and method target proof without receiver identity.
- Updated semantic-kernel, evidence, extension API, audit, roadmap, and normalization docs.

## Boundaries

This does not add broad producer coverage for methods, traits/interfaces, overload resolution, or cross-module manifests. It defines and consumes the evidence boundary so producers can add those facts without name-based guessing.

## Validation

- `cargo test -p nose-semantics -p nose-normalize -p nose-detect`
- `cargo clippy -p nose-semantics -p nose-normalize -p nose-detect --all-targets -- -D warnings`
- `cargo fmt --check`
- `awiki lint --root docs`
- `git diff --check`
- `NOSE_BIN=target/debug/nose ./scripts/check-duplication.sh`
