### PR TITLE
[codex] Expand type and domain evidence

### DIFF
--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -3703,6 +3703,34 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
         assert_eq!(py_domains.len(), 1);
         assert_eq!(py_domains[0].dependencies, import_ids);
 
+        let py_iter_alias = crate::lower_source(
+            FileId(0),
+            "typing_iter_alias.py",
+            b"from typing import Iterable as I\ndef f(xs: I[int]):\n    return xs\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        let import_ids = imported_binding_symbol_ids(&py_iter_alias.evidence, "typing", "Iterable");
+        assert_eq!(import_ids.len(), 1);
+        let py_domains = param_domain_records(&py_iter_alias.evidence, DomainEvidence::Iterable);
+        assert_eq!(py_domains.len(), 1);
+        assert_eq!(py_domains[0].dependencies, import_ids);
+
+        let py_iter_shadowed = crate::lower_source(
+            FileId(0),
+            "typing_iter_alias_shadowed.py",
+            b"from typing import Iterable as I\nI = object\ndef f(xs: I[int]):\n    return xs\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        assert_eq!(
+            param_domain_record_count(&py_iter_shadowed.evidence, DomainEvidence::Iterable),
+            0,
+            "a rebound iterable alias must not emit parameter Domain evidence"
+        );
+
         let py_shadowed = crate::lower_source(
             FileId(0),
             "typing_alias_shadowed.py",
@@ -3744,6 +3772,39 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             param_domain_record_count(&ts.evidence, DomainEvidence::Set),
             1,
             "Set<T> should still emit set domain evidence"
+        );
+
+        let ts_rich = crate::lower_source(
+            FileId(0),
+            "domain_types_rich.ts",
+            b"function f(a: Iterable<string>, b: Iterator<string>, c: Promise<string>, d: Record<string, number>, e: Result<string, Error>, f: boolean) { return f; }\n",
+            Lang::TypeScript,
+            &interner,
+        )
+        .expect("typescript lowering should succeed");
+        assert_eq!(
+            param_domain_record_count(&ts_rich.evidence, DomainEvidence::Iterable),
+            1
+        );
+        assert_eq!(
+            param_domain_record_count(&ts_rich.evidence, DomainEvidence::Iterator),
+            1
+        );
+        assert_eq!(
+            param_domain_record_count(&ts_rich.evidence, DomainEvidence::PromiseLike),
+            1
+        );
+        assert_eq!(
+            param_domain_record_count(&ts_rich.evidence, DomainEvidence::Record),
+            1
+        );
+        assert_eq!(
+            param_domain_record_count(&ts_rich.evidence, DomainEvidence::Result),
+            1
+        );
+        assert_eq!(
+            param_domain_record_count(&ts_rich.evidence, DomainEvidence::Boolean),
+            1
         );
 
         let java = crate::lower_source(

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -129,12 +129,19 @@ pub enum Payload {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub enum ParamSemantic {
     Array,
+    Boolean,
     ByteArray,
     Collection,
+    Float,
+    FutureLike,
     Integer,
+    Iterable,
+    Iterator,
     Map,
     Number,
     Option,
+    Record,
+    Result,
     Set,
     String,
 }
@@ -145,13 +152,21 @@ pub enum ParamSemantic {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub enum DomainEvidence {
     Array,
+    Boolean,
     ByteArray,
     Collection,
+    Float,
+    FutureLike,
     Integer,
+    Iterable,
+    Iterator,
     Map,
+    Nominal { type_hash: u64 },
     Number,
     Option,
     PromiseLike,
+    Record,
+    Result,
     Set,
     String,
 }
@@ -160,12 +175,19 @@ impl DomainEvidence {
     pub fn from_param_semantic(semantic: ParamSemantic) -> Self {
         match semantic {
             ParamSemantic::Array => DomainEvidence::Array,
+            ParamSemantic::Boolean => DomainEvidence::Boolean,
             ParamSemantic::ByteArray => DomainEvidence::ByteArray,
             ParamSemantic::Collection => DomainEvidence::Collection,
+            ParamSemantic::Float => DomainEvidence::Float,
+            ParamSemantic::FutureLike => DomainEvidence::FutureLike,
             ParamSemantic::Integer => DomainEvidence::Integer,
+            ParamSemantic::Iterable => DomainEvidence::Iterable,
+            ParamSemantic::Iterator => DomainEvidence::Iterator,
             ParamSemantic::Map => DomainEvidence::Map,
             ParamSemantic::Number => DomainEvidence::Number,
             ParamSemantic::Option => DomainEvidence::Option,
+            ParamSemantic::Record => DomainEvidence::Record,
+            ParamSemantic::Result => DomainEvidence::Result,
             ParamSemantic::Set => DomainEvidence::Set,
             ParamSemantic::String => DomainEvidence::String,
         }
@@ -177,6 +199,10 @@ impl DomainEvidence {
 
     pub fn is_byte_array(self) -> bool {
         self == DomainEvidence::ByteArray
+    }
+
+    pub fn is_boolean(self) -> bool {
+        self == DomainEvidence::Boolean
     }
 
     pub fn is_collection_or_set(self) -> bool {
@@ -198,8 +224,35 @@ impl DomainEvidence {
         self == DomainEvidence::Set
     }
 
+    pub fn is_float(self) -> bool {
+        self == DomainEvidence::Float
+    }
+
+    pub fn is_future_like(self) -> bool {
+        matches!(
+            self,
+            DomainEvidence::FutureLike | DomainEvidence::PromiseLike
+        )
+    }
+
     pub fn is_map(self) -> bool {
         self == DomainEvidence::Map
+    }
+
+    pub fn is_iterable(self) -> bool {
+        self == DomainEvidence::Iterable
+    }
+
+    pub fn is_iterator(self) -> bool {
+        self == DomainEvidence::Iterator
+    }
+
+    pub fn is_iterable_or_iterator(self) -> bool {
+        matches!(self, DomainEvidence::Iterable | DomainEvidence::Iterator)
+    }
+
+    pub fn is_nominal(self, expected_hash: u64) -> bool {
+        matches!(self, DomainEvidence::Nominal { type_hash } if type_hash == expected_hash)
     }
 
     pub fn is_option(self) -> bool {
@@ -214,12 +267,23 @@ impl DomainEvidence {
         self == DomainEvidence::String
     }
 
+    pub fn is_record(self) -> bool {
+        self == DomainEvidence::Record
+    }
+
+    pub fn is_result(self) -> bool {
+        self == DomainEvidence::Result
+    }
+
     pub fn is_integer(self) -> bool {
         self == DomainEvidence::Integer
     }
 
     pub fn is_integer_or_number(self) -> bool {
-        matches!(self, DomainEvidence::Integer | DomainEvidence::Number)
+        matches!(
+            self,
+            DomainEvidence::Integer | DomainEvidence::Float | DomainEvidence::Number
+        )
     }
 }
 
@@ -332,6 +396,10 @@ pub enum TypeEvidenceKind {
     CTypeAlias {
         alias_hash: u64,
         target: CTypeTarget,
+    },
+    NominalDomain {
+        type_hash: u64,
+        domain: DomainEvidence,
     },
 }
 

--- a/crates/nose-semantics/src/evidence.rs
+++ b/crates/nose-semantics/src/evidence.rs
@@ -423,6 +423,8 @@ impl ValueDomain {
     pub fn from_domain_evidence(domain: DomainEvidence) -> Option<ValueDomain> {
         if domain.is_integer_or_number() {
             Some(ValueDomain::Number)
+        } else if domain.is_boolean() {
+            Some(ValueDomain::Boolean)
         } else if domain.is_string() {
             Some(ValueDomain::String)
         } else if domain.is_array_collection_or_set() {
@@ -526,17 +528,27 @@ pub fn domain_evidence_for_param(il: &Il, param: NodeId) -> Option<DomainEvidenc
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum DomainRequirement {
     Array,
+    Boolean,
     ByteArray,
     Collection,
     CollectionOrSet,
     CollectionOrMap,
+    Float,
+    FutureLike,
     ArrayOrCollection,
     ArrayCollectionOrSet,
+    Iterable,
+    IterableOrIterator,
+    Iterator,
     Set,
     SetOrMap,
     Map,
+    Nominal { type_hash: u64 },
+    Number,
     Option,
     PromiseLike,
+    Record,
+    Result,
     String,
     Integer,
     IntegerOrNumber,
@@ -546,23 +558,56 @@ impl DomainRequirement {
     pub fn accepts(self, domain: DomainEvidence) -> bool {
         match self {
             DomainRequirement::Array => domain.is_array(),
+            DomainRequirement::Boolean => domain.is_boolean(),
             DomainRequirement::ByteArray => domain.is_byte_array(),
             DomainRequirement::Collection => domain == DomainEvidence::Collection,
             DomainRequirement::CollectionOrSet => domain.is_collection_or_set(),
             DomainRequirement::CollectionOrMap => {
                 domain.is_array_collection_or_set() || domain.is_map()
             }
+            DomainRequirement::Float => domain.is_float(),
+            DomainRequirement::FutureLike => domain.is_future_like(),
             DomainRequirement::ArrayOrCollection => domain.is_array_or_collection(),
             DomainRequirement::ArrayCollectionOrSet => domain.is_array_collection_or_set(),
+            DomainRequirement::Iterable => domain.is_iterable(),
+            DomainRequirement::IterableOrIterator => domain.is_iterable_or_iterator(),
+            DomainRequirement::Iterator => domain.is_iterator(),
             DomainRequirement::Set => domain.is_set(),
             DomainRequirement::SetOrMap => domain.is_set() || domain.is_map(),
             DomainRequirement::Map => domain.is_map(),
+            DomainRequirement::Nominal { type_hash } => domain.is_nominal(type_hash),
+            DomainRequirement::Number => {
+                matches!(domain, DomainEvidence::Number | DomainEvidence::Float)
+            }
             DomainRequirement::Option => domain.is_option(),
             DomainRequirement::PromiseLike => domain.is_promise_like(),
+            DomainRequirement::Record => domain.is_record(),
+            DomainRequirement::Result => domain.is_result(),
             DomainRequirement::String => domain.is_string(),
             DomainRequirement::Integer => domain.is_integer(),
             DomainRequirement::IntegerOrNumber => domain.is_integer_or_number(),
         }
+    }
+}
+
+pub fn nominal_type_domain_at_node(
+    il: &Il,
+    node: NodeId,
+    type_hash: u64,
+) -> Option<DomainEvidence> {
+    match unique_asserted_evidence_at(
+        il,
+        |anchor| anchor == EvidenceAnchor::node(il.node(node).span, il.kind(node)),
+        |evidence| match evidence {
+            EvidenceKind::Type(TypeEvidenceKind::NominalDomain {
+                type_hash: actual_hash,
+                domain,
+            }) if actual_hash == type_hash => Some(domain),
+            _ => None,
+        },
+    ) {
+        EvidenceResolution::Found(domain) => Some(domain),
+        EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
     }
 }
 

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -13,7 +13,7 @@ use nose_il::{
     LibraryApiEvidenceKind, LitClass, NodeId, NodeKind, Op, ParamSemantic, Payload,
     SequenceSurfaceKind, SourceCallKind, SourceCastKind, SourceComprehensionKind, SourceFactKind,
     SourceLiteralKind, SourceOperatorKind, SourcePatternKind, SourceProtocolKind, SourceRangeKind,
-    Span, Symbol, SymbolEvidenceKind,
+    Span, Symbol, SymbolEvidenceKind, TypeEvidenceKind,
 };
 use rustc_hash::FxHashMap;
 

--- a/crates/nose-semantics/src/tests.rs
+++ b/crates/nose-semantics/src/tests.rs
@@ -4,8 +4,8 @@ use nose_il::{
     EvidenceProvenance, EvidenceRecord, EvidenceStatus, FileId, FileMeta, GuardEvidenceKind,
     IlBuilder, ImportEvidenceKind, Interner, JsRecordGuardComparison, JsRecordGuardNullCheck,
     LibraryApiEvidenceKind, ParamSemantic, PlaceEvidenceKind, SequenceSurfaceKind, SourceCastKind,
-    SourceFactKind, SourcePatternKind, SourceRangeKind, Span, Symbol, SymbolEvidenceKind, Unit,
-    UnitKind,
+    SourceFactKind, SourcePatternKind, SourceRangeKind, Span, Symbol, SymbolEvidenceKind,
+    TypeEvidenceKind, Unit, UnitKind,
 };
 
 mod call_targets;

--- a/crates/nose-semantics/src/tests/semantic_evidence.rs
+++ b/crates/nose-semantics/src/tests/semantic_evidence.rs
@@ -28,27 +28,93 @@ fn domain_evidence_preserves_param_semantic_boundaries() {
         domain_evidence_from_param_semantic(ParamSemantic::Array),
         DomainEvidence::Array
     );
+    assert_eq!(
+        domain_evidence_from_param_semantic(ParamSemantic::Boolean),
+        DomainEvidence::Boolean
+    );
+    assert_eq!(
+        domain_evidence_from_param_semantic(ParamSemantic::Float),
+        DomainEvidence::Float
+    );
+    assert_eq!(
+        domain_evidence_from_param_semantic(ParamSemantic::FutureLike),
+        DomainEvidence::FutureLike
+    );
+    assert_eq!(
+        domain_evidence_from_param_semantic(ParamSemantic::Iterable),
+        DomainEvidence::Iterable
+    );
+    assert_eq!(
+        domain_evidence_from_param_semantic(ParamSemantic::Iterator),
+        DomainEvidence::Iterator
+    );
+    assert_eq!(
+        domain_evidence_from_param_semantic(ParamSemantic::Record),
+        DomainEvidence::Record
+    );
+    assert_eq!(
+        domain_evidence_from_param_semantic(ParamSemantic::Result),
+        DomainEvidence::Result
+    );
     assert!(DomainEvidence::Array.is_array_collection_or_set());
+    assert!(DomainEvidence::Boolean.is_boolean());
     assert!(DomainEvidence::Collection.is_array_or_collection());
     assert!(DomainEvidence::Set.is_collection_or_set());
+    assert!(DomainEvidence::Float.is_float());
+    assert!(DomainEvidence::FutureLike.is_future_like());
+    assert!(DomainEvidence::PromiseLike.is_future_like());
+    assert!(DomainEvidence::Iterable.is_iterable_or_iterator());
+    assert!(DomainEvidence::Iterator.is_iterable_or_iterator());
     assert!(DomainEvidence::Map.is_map());
+    assert!(DomainEvidence::Nominal {
+        type_hash: stable_symbol_hash("pkg.Widget")
+    }
+    .is_nominal(stable_symbol_hash("pkg.Widget")));
     assert!(DomainEvidence::Option.is_option());
     assert!(DomainEvidence::PromiseLike.is_promise_like());
+    assert!(DomainEvidence::Record.is_record());
+    assert!(DomainEvidence::Result.is_result());
     assert!(DomainEvidence::String.is_string());
     assert!(DomainEvidence::ByteArray.is_byte_array());
     assert!(DomainEvidence::Integer.is_integer());
     assert!(DomainEvidence::Number.is_integer_or_number());
+    assert!(DomainEvidence::Float.is_integer_or_number());
     assert!(DomainEvidence::Integer.is_integer_or_number());
     assert!(!DomainEvidence::Number.is_integer());
     assert!(!DomainEvidence::Array.is_collection_or_set());
     assert!(!DomainEvidence::Set.is_array_or_collection());
+    assert!(DomainRequirement::Boolean.accepts(DomainEvidence::Boolean));
     assert!(DomainRequirement::CollectionOrMap.accepts(DomainEvidence::Array));
     assert!(DomainRequirement::CollectionOrMap.accepts(DomainEvidence::Map));
+    assert!(DomainRequirement::Float.accepts(DomainEvidence::Float));
+    assert!(DomainRequirement::FutureLike.accepts(DomainEvidence::FutureLike));
+    assert!(DomainRequirement::FutureLike.accepts(DomainEvidence::PromiseLike));
+    assert!(DomainRequirement::Iterable.accepts(DomainEvidence::Iterable));
+    assert!(DomainRequirement::Iterator.accepts(DomainEvidence::Iterator));
+    assert!(DomainRequirement::IterableOrIterator.accepts(DomainEvidence::Iterable));
+    assert!(DomainRequirement::IterableOrIterator.accepts(DomainEvidence::Iterator));
+    assert!(DomainRequirement::Nominal {
+        type_hash: stable_symbol_hash("pkg.Widget")
+    }
+    .accepts(DomainEvidence::Nominal {
+        type_hash: stable_symbol_hash("pkg.Widget")
+    }));
+    assert!(DomainRequirement::Number.accepts(DomainEvidence::Float));
+    assert!(DomainRequirement::Record.accepts(DomainEvidence::Record));
+    assert!(DomainRequirement::Result.accepts(DomainEvidence::Result));
     assert!(DomainRequirement::SetOrMap.accepts(DomainEvidence::Set));
     assert!(DomainRequirement::SetOrMap.accepts(DomainEvidence::Map));
     assert!(!DomainRequirement::SetOrMap.accepts(DomainEvidence::Collection));
     assert!(DomainRequirement::PromiseLike.accepts(DomainEvidence::PromiseLike));
     assert!(!DomainRequirement::PromiseLike.accepts(DomainEvidence::String));
+    assert_eq!(
+        ValueDomain::from_domain_evidence(DomainEvidence::Boolean),
+        Some(ValueDomain::Boolean)
+    );
+    assert_eq!(
+        ValueDomain::from_domain_evidence(DomainEvidence::Float),
+        Some(ValueDomain::Number)
+    );
     assert_eq!(
         ValueDomain::from_domain_evidence(DomainEvidence::PromiseLike),
         None
@@ -66,6 +132,30 @@ fn type_domain_contracts_are_language_scoped_and_exact_enough() {
         Some(DomainEvidence::Array)
     );
     assert_eq!(
+        type_domain_from_source_text(Lang::TypeScript, "xs: Iterable<string>"),
+        Some(DomainEvidence::Iterable)
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::TypeScript, "xs: Iterator<string>"),
+        Some(DomainEvidence::Iterator)
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::TypeScript, "xs: Promise<string>"),
+        Some(DomainEvidence::PromiseLike)
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::TypeScript, "xs: Record<string, number>"),
+        Some(DomainEvidence::Record)
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::TypeScript, "xs: Result<string, Error>"),
+        Some(DomainEvidence::Result)
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::TypeScript, "xs: boolean"),
+        Some(DomainEvidence::Boolean)
+    );
+    assert_eq!(
         type_domain_from_source_text(Lang::TypeScript, "xs: Bitmap<string, number>"),
         None
     );
@@ -77,6 +167,18 @@ fn type_domain_contracts_are_language_scoped_and_exact_enough() {
     assert_eq!(
         type_domain_from_source_text(Lang::Java, "@Nonnull List<String> xs"),
         Some(DomainEvidence::Collection)
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::Java, "Iterator<String> xs"),
+        Some(DomainEvidence::Iterator)
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::Java, "CompletableFuture<String> xs"),
+        Some(DomainEvidence::FutureLike)
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::Java, "boolean value"),
+        Some(DomainEvidence::Boolean)
     );
     assert_eq!(
         type_domain_from_source_text(Lang::Java, "@Ann(\"...\") String value"),
@@ -91,11 +193,106 @@ fn type_domain_contracts_are_language_scoped_and_exact_enough() {
         type_domain_from_source_text(Lang::Rust, "HashSet<i32>"),
         Some(DomainEvidence::Set)
     );
+    assert_eq!(
+        type_domain_from_source_text(Lang::Rust, "Result<String, Error>"),
+        Some(DomainEvidence::Result)
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::Rust, "impl Iterator<Item = i32>"),
+        Some(DomainEvidence::Iterator)
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::Rust, "std::pin::Pin<Box<T>>"),
+        None
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::Rust, "bool"),
+        Some(DomainEvidence::Boolean)
+    );
 
     assert_eq!(type_domain_from_source_text(Lang::C, "int *xs"), None);
     assert_eq!(
         type_domain_from_source_text(Lang::C, "int xs"),
         Some(DomainEvidence::Integer)
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::C, "_Bool ok"),
+        Some(DomainEvidence::Boolean)
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::Go, "value bool"),
+        Some(DomainEvidence::Boolean)
+    );
+    assert_eq!(
+        type_domain_from_source_text(Lang::Go, "type User struct { id int }"),
+        Some(DomainEvidence::Record)
+    );
+}
+
+#[test]
+fn nominal_type_domain_evidence_is_dependency_backed_and_fail_closed() {
+    let interner = Interner::new();
+    let mut b = IlBuilder::new(FileId(0));
+    let receiver = b.add(
+        NodeKind::Var,
+        Payload::Name(interner.intern("value")),
+        sp(12),
+        &[],
+    );
+    let root = b.add(NodeKind::Block, Payload::None, sp(11), &[receiver]);
+    let mut il = finish_il(b, root, Lang::TypeScript);
+    let widget = stable_symbol_hash("pkg.Widget");
+    il.evidence.push(evidence(
+        0,
+        EvidenceAnchor::node(sp(12), NodeKind::Var),
+        EvidenceKind::Type(TypeEvidenceKind::NominalDomain {
+            type_hash: widget,
+            domain: DomainEvidence::Record,
+        }),
+        EvidenceStatus::Asserted,
+    ));
+
+    assert_eq!(
+        nominal_type_domain_at_node(&il, receiver, widget),
+        Some(DomainEvidence::Record)
+    );
+
+    il.evidence.push(evidence(
+        1,
+        EvidenceAnchor::node(sp(12), NodeKind::Var),
+        EvidenceKind::Domain(DomainEvidence::Record),
+        EvidenceStatus::Ambiguous,
+    ));
+    let gadget = stable_symbol_hash("pkg.Gadget");
+    il.evidence.push(evidence_with_dependencies(
+        2,
+        EvidenceAnchor::node(sp(12), NodeKind::Var),
+        EvidenceKind::Type(TypeEvidenceKind::NominalDomain {
+            type_hash: gadget,
+            domain: DomainEvidence::Record,
+        }),
+        EvidenceStatus::Asserted,
+        vec![EvidenceId(1)],
+    ));
+    assert_eq!(
+        nominal_type_domain_at_node(&il, receiver, gadget),
+        None,
+        "dependency-broken nominal type-domain records must fail closed"
+    );
+
+    il.evidence.push(evidence(
+        3,
+        EvidenceAnchor::node(sp(12), NodeKind::Var),
+        EvidenceKind::Type(TypeEvidenceKind::NominalDomain {
+            type_hash: widget,
+            domain: DomainEvidence::Map,
+        }),
+        EvidenceStatus::Asserted,
+    ));
+    assert_eq!(
+        nominal_type_domain_at_node(&il, receiver, widget),
+        None,
+        "conflicting nominal type-domain records must fail closed"
     );
 }
 

--- a/crates/nose-semantics/src/type_domain.rs
+++ b/crates/nose-semantics/src/type_domain.rs
@@ -21,9 +21,30 @@ pub fn python_stdlib_type_domain(module: &str, exported: &str) -> Option<DomainE
         return Some(DomainEvidence::Map);
     }
     if matches!(module, "typing" | "collections.abc")
+        && matches!(exported, "Iterable" | "AsyncIterable")
+    {
+        return Some(DomainEvidence::Iterable);
+    }
+    if matches!(module, "typing" | "collections.abc")
+        && matches!(exported, "Iterator" | "AsyncIterator")
+    {
+        return Some(DomainEvidence::Iterator);
+    }
+    if matches!(module, "typing" | "collections.abc")
         && matches!(exported, "FrozenSet" | "MutableSet" | "Set")
     {
         return Some(DomainEvidence::Set);
+    }
+    if matches!(module, "typing") && matches!(exported, "Optional") {
+        return Some(DomainEvidence::Option);
+    }
+    if matches!(module, "typing") && matches!(exported, "TypedDict") {
+        return Some(DomainEvidence::Record);
+    }
+    if matches!(module, "typing" | "asyncio")
+        && matches!(exported, "Awaitable" | "Coroutine" | "Future")
+    {
+        return Some(DomainEvidence::FutureLike);
     }
     if matches!(module, "typing" | "collections.abc")
         && matches!(
@@ -54,6 +75,24 @@ fn ts_type_domain(text: &str) -> Option<DomainEvidence> {
     if ty.starts_with("set<") || ty.starts_with("readonlyset<") {
         return Some(DomainEvidence::Set);
     }
+    if ty.starts_with("iterable<") || ty.starts_with("asynciterable<") {
+        return Some(DomainEvidence::Iterable);
+    }
+    if ty.starts_with("iterator<") || ty.starts_with("asynciterator<") {
+        return Some(DomainEvidence::Iterator);
+    }
+    if ty.starts_with("promise<") {
+        return Some(DomainEvidence::PromiseLike);
+    }
+    if ty.starts_with("record<") {
+        return Some(DomainEvidence::Record);
+    }
+    if ty.starts_with("result<") {
+        return Some(DomainEvidence::Result);
+    }
+    if ty == "boolean" {
+        return Some(DomainEvidence::Boolean);
+    }
     if ty == "string" {
         return Some(DomainEvidence::String);
     }
@@ -71,8 +110,26 @@ fn python_type_domain(text: &str) -> Option<DomainEvidence> {
     if ty.starts_with("dict[") || ty.starts_with("mapping[") || ty.starts_with("mutablemapping[") {
         return Some(DomainEvidence::Map);
     }
+    if ty.starts_with("typeddict[") {
+        return Some(DomainEvidence::Record);
+    }
     if ty.starts_with("set[") || ty.starts_with("frozenset[") || ty.starts_with("mutableset[") {
         return Some(DomainEvidence::Set);
+    }
+    if ty.starts_with("iterable[") || ty.starts_with("asynciterable[") {
+        return Some(DomainEvidence::Iterable);
+    }
+    if ty.starts_with("iterator[") || ty.starts_with("asynciterator[") {
+        return Some(DomainEvidence::Iterator);
+    }
+    if ty.starts_with("optional[") {
+        return Some(DomainEvidence::Option);
+    }
+    if ty.starts_with("awaitable[") || ty.starts_with("coroutine[") || ty.starts_with("future[") {
+        return Some(DomainEvidence::FutureLike);
+    }
+    if ty.starts_with("result[") {
+        return Some(DomainEvidence::Result);
     }
     if ty.starts_with("list[")
         || ty.starts_with("tuple[")
@@ -81,14 +138,14 @@ fn python_type_domain(text: &str) -> Option<DomainEvidence> {
         || ty.starts_with("deque[")
         || ty.starts_with("sequence[")
         || ty.starts_with("mutablesequence[")
-        || ty.starts_with("iterable[")
     {
         return Some(DomainEvidence::Collection);
     }
     match ty {
+        "bool" => Some(DomainEvidence::Boolean),
         "str" => Some(DomainEvidence::String),
         "int" => Some(DomainEvidence::Integer),
-        "float" => Some(DomainEvidence::Number),
+        "float" => Some(DomainEvidence::Float),
         _ => None,
     }
 }
@@ -103,6 +160,12 @@ fn rust_type_domain(text: &str) -> Option<DomainEvidence> {
     if matches!(type_name, "vec" | "vecdeque") {
         return Some(DomainEvidence::Collection);
     }
+    if matches!(type_name, "iter" | "iterator" | "intoiter" | "impliterator") {
+        return Some(DomainEvidence::Iterator);
+    }
+    if type_name == "intoiterator" {
+        return Some(DomainEvidence::Iterable);
+    }
     if matches!(type_name, "hashmap" | "btreemap") {
         return Some(DomainEvidence::Map);
     }
@@ -112,6 +175,15 @@ fn rust_type_domain(text: &str) -> Option<DomainEvidence> {
     if type_name == "option" {
         return Some(DomainEvidence::Option);
     }
+    if type_name == "result" {
+        return Some(DomainEvidence::Result);
+    }
+    if matches!(type_name, "future" | "ready") {
+        return Some(DomainEvidence::FutureLike);
+    }
+    if type_name == "bool" {
+        return Some(DomainEvidence::Boolean);
+    }
     if matches!(type_name, "str" | "string") {
         return Some(DomainEvidence::String);
     }
@@ -119,7 +191,7 @@ fn rust_type_domain(text: &str) -> Option<DomainEvidence> {
         return Some(DomainEvidence::Integer);
     }
     if matches!(type_name, "f32" | "f64") {
-        return Some(DomainEvidence::Number);
+        return Some(DomainEvidence::Float);
     }
     None
 }
@@ -136,13 +208,18 @@ fn java_type_domain(text: &str) -> Option<DomainEvidence> {
             Some(DomainEvidence::Map)
         }
         "set" | "hashset" | "linkedhashset" | "treeset" => Some(DomainEvidence::Set),
-        "list" | "arraylist" | "linkedlist" | "collection" | "deque" | "queue" | "iterable" => {
+        "iterable" => Some(DomainEvidence::Iterable),
+        "iterator" | "listiterator" => Some(DomainEvidence::Iterator),
+        "list" | "arraylist" | "linkedlist" | "collection" | "deque" | "queue" => {
             Some(DomainEvidence::Collection)
         }
+        "completablefuture" | "completionstage" | "future" => Some(DomainEvidence::FutureLike),
         "optional" => Some(DomainEvidence::Option),
+        "record" => Some(DomainEvidence::Record),
+        "boolean" => Some(DomainEvidence::Boolean),
         "string" => Some(DomainEvidence::String),
         "byte" | "short" | "int" | "integer" | "long" => Some(DomainEvidence::Integer),
-        "float" | "double" => Some(DomainEvidence::Number),
+        "float" | "double" => Some(DomainEvidence::Float),
         _ => None,
     }
 }
@@ -155,12 +232,16 @@ fn go_type_domain(text: &str) -> Option<DomainEvidence> {
     if compact.contains("[]") {
         return Some(DomainEvidence::Collection);
     }
+    if compact.contains("struct{") {
+        return Some(DomainEvidence::Record);
+    }
     let ty = last_identifier(text)?;
     if go_integer_type(&ty) {
         return Some(DomainEvidence::Integer);
     }
     match ty.as_str() {
-        "float32" | "float64" => Some(DomainEvidence::Number),
+        "bool" => Some(DomainEvidence::Boolean),
+        "float32" | "float64" => Some(DomainEvidence::Float),
         "string" => Some(DomainEvidence::String),
         _ => None,
     }
@@ -181,7 +262,13 @@ fn c_type_domain(text: &str) -> Option<DomainEvidence> {
         .iter()
         .any(|token| matches!(*token, "float" | "double"))
     {
-        return Some(DomainEvidence::Number);
+        return Some(DomainEvidence::Float);
+    }
+    if tokens
+        .iter()
+        .any(|token| matches!(*token, "bool" | "_Bool"))
+    {
+        return Some(DomainEvidence::Boolean);
     }
     None
 }
@@ -330,11 +417,9 @@ fn strip_java_leading_annotation(text: &str) -> Option<&str> {
 }
 
 fn last_identifier(text: &str) -> Option<String> {
-    let compact = compact_lower(text);
-    compact
-        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+    text.split(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
         .rfind(|token| !token.is_empty())
-        .map(str::to_string)
+        .map(|token| token.to_ascii_lowercase())
 }
 
 fn identifier_tokens(text: &str) -> Vec<&str> {

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -62,10 +62,10 @@ The current implemented kinds are:
 | kind | purpose |
 |---|---|
 | `Source` | construct syntax, Rust macro invocation/range/pattern syntax, async/generator/error and Go concurrency/channel protocol boundary syntax, Python comprehension surface provenance, C unsigned-cast syntax, regex literal provenance, and source operator family including JS-like unary `typeof` |
-| `Domain` | parameter, receiver-expression, or value/binding domain such as collection, map, option, string, integer, or byte array |
+| `Domain` | parameter, receiver-expression, or value/binding domain such as array, collection, iterable, iterator, set, map, record, option/result, promise/future-like, string, boolean, integer/float/number, byte array, or nominal type |
 | `Import` | static import binding/namespace proof, Python wildcard-import ambiguity proof, Java wildcard import proof, C quote-include proof, Ruby `require` module proof, and imported-literal snapshot provenance |
 | `Symbol` | resolved or proven symbol identity, with record kinds for unshadowed globals, static imported binding/namespace aliases, and selected qualified global API paths |
-| `Type` | type alias proof, currently exact-spelling C aliases to unsigned 8-bit and supported unsigned 32-bit integer forms |
+| `Type` | type alias or type-to-domain proof, currently exact-spelling C aliases to unsigned 8-bit and supported unsigned 32-bit integer forms plus nominal type-domain rows |
 | `Guard` | multi-obligation guard proof facts such as JS/TS record-shape and own-property guard contracts |
 | `Place` | fixed receiver/place facts currently covering `SelfReceiver` and `SelfField` |
 | `Effect` | observable effect and mutation-risk facts currently covering canonical builder append calls, non-overloadable index writes, fixed self-field writes, binding writes, receiver-mutating calls, and opaque argument escapes |
@@ -198,35 +198,46 @@ symbol fact or stronger scope-resolution evidence exists.
 Domain evidence follows the same fail-closed rule. First-party parameter
 annotations emit `Domain` evidence on `Param` anchors only through
 language-scoped type-domain contracts in `nose-semantics`, not through a shared
-substring fallback over arbitrary parameter text. The frontend owns evidence
-emission and alias lifecycle: for example, Python `typing`/`collections.abc`
-aliases record dependency-backed parameter `Domain` evidence that depends on the
-corresponding `ImportedBinding` symbol evidence, and a rebound alias closes that
-path. `nose-semantics` resolves `Domain` evidence on exact receiver-expression
-node anchors, then binding anchors for immutable local/module variables, then
-parameter anchors. A conflicting, ambiguous, or dependency-broken
-receiver-domain record closes that receiver proof and must not fall back to
-side-table mirrors or selector spelling. Binding-anchor lookup matches both
-source span and `local_hash`, and a binding proof is applied to a receiver only
-when the assignment is visible before that receiver use. When a receiver is an
-alpha-renamed parameter or local binding reference, lookup is constrained to the
-nearest function/lambda scope where appropriate so same-numbered parameter/local
-ids from other units do not prove the current receiver. Method receiver
-contracts expose their domain-backed obligations through `DomainRequirement`;
-obligations such as imported namespace, unshadowed global, exact map literal, and
-future demand/effect constraints remain separate checks.
+substring fallback over arbitrary parameter text. The current vocabulary covers
+container/protocol domains (`Array`, `Collection`, `Iterable`, `Iterator`,
+`Set`, `Map`, `Record`), nullable/effect domains (`Option`, `Result`,
+`PromiseLike`, `FutureLike`), scalar domains (`String`, `Boolean`, `Integer`,
+`Float`, `Number`, `ByteArray`), and a hashed `Nominal` domain for
+provider-proven user/library types. The frontend owns evidence emission and
+alias lifecycle: for example, Python `typing`/`collections.abc` aliases record
+dependency-backed parameter `Domain` evidence that depends on the corresponding
+`ImportedBinding` symbol evidence, and a rebound alias closes that path.
+`Type(NominalDomain)` rows can map a scoped nominal type hash to a domain, but
+type names alone are not proof; the dependent `Domain` record still needs a
+valid symbol/import/scope chain. `nose-semantics` resolves `Domain` evidence on
+exact receiver-expression node anchors, then binding anchors for immutable
+local/module variables, then parameter anchors. A conflicting, ambiguous, or
+dependency-broken receiver-domain record closes that receiver proof and must not
+fall back to side-table mirrors or selector spelling. Binding-anchor lookup
+matches both source span and `local_hash`, and a binding proof is applied to a
+receiver only when the assignment is visible before that receiver use. When a
+receiver is an alpha-renamed parameter or local binding reference, lookup is
+constrained to the nearest function/lambda scope where appropriate so
+same-numbered parameter/local ids from other units do not prove the current
+receiver. Method receiver contracts expose their domain-backed obligations
+through `DomainRequirement`; obligations such as imported namespace, unshadowed
+global, exact map literal, and future demand/effect constraints remain separate
+checks.
 
 Parameter `Domain` evidence also seeds the semantic-kernel `ValueDomain`
 contract used by value-graph and recursion laws. That bridge is intentionally
-narrow: integer/number domains seed `Number`, string seeds `String`, and
-array/collection/set domains seed `Sequence`. The value graph may additionally
-infer a domain from strict operator use, literal result domains, modeled builtin
-result domains, and subexpression result domains, but the law itself is admitted
-only through a `ValueLaw` contract in `nose-semantics`. This keeps string and
-sequence concatenation ordered when evidence proves those domains, while numeric
-and boolean laws still require positive domain proof. Today that contract records
-the law id and domain requirement; pack-facing per-use value-law provenance and
-conformance status remain future work rather than an emitted evidence family.
+narrow: integer/float/number domains seed `Number`, boolean seeds `Boolean`,
+string seeds `String`, and only array/collection/set domains seed `Sequence`.
+Iterable, iterator, record, option/result, future-like, and nominal domains do
+not automatically become sequence or exact value-law proof. The value graph may
+additionally infer a domain from strict operator use, literal result domains,
+modeled builtin result domains, and subexpression result domains, but the law
+itself is admitted only through a `ValueLaw` contract in `nose-semantics`. This
+keeps string and sequence concatenation ordered when evidence proves those
+domains, while numeric and boolean laws still require positive domain proof.
+Today that contract records the law id and domain requirement; pack-facing
+per-use value-law provenance and conformance status remain future work rather
+than an emitted evidence family.
 
 Selected `LibraryApi` result-domain evidence follows the same model. A
 first-party factory call result may carry `Domain(Collection)`, `Domain(Set)`,

--- a/docs/semantic-kernel-audit-2026-06-09.md
+++ b/docs/semantic-kernel-audit-2026-06-09.md
@@ -100,8 +100,13 @@ semantic meaning.
   asserted evidence, admitted occurrence evidence, or kernel contracts before
   assigning exact meaning.
 - `crates/nose-semantics/src/type_domain.rs` still recognizes first-party
-  type-domain surfaces from source text. This is accepted as a first-party
-  producer; it is not yet a parsed/versioned external pack surface.
+  type-domain surfaces from source text for arrays, collections,
+  iterable/iterator facts, records, options/results, promise/future-like facts,
+  strings, booleans, integer/float/number distinctions, maps, sets, and byte
+  arrays where the language-specific annotation surface is exact enough. This is
+  accepted as a first-party producer; it is not yet a parsed/versioned external
+  pack surface. Alias lifecycle and shadowing remain the frontend or pack
+  producer's responsibility.
 - `crates/nose-semantics/src/module_exports.rs` and import helpers consume
   evidence-backed provider/import facts. Raw import-coordinate `Seq` values may
   still carry lowered structure, but they no longer prove import identity by
@@ -166,7 +171,7 @@ These are not #150 fixes; they are the next independent work items.
 | P0 | #151 | Pack extension API v0 | First-party producers still call compiled Rust helper functions directly. The external boundary needs stable fact, contract, dependency, and channel-eligibility schemas before those producers can be expressed as packs. |
 | P0 | #153 | Demand/effect substrate | Lazy, repeated, async, generator, channel, observable, and callback effect visibility cannot be represented by the current first-party demand profiles. Exact laws for those surfaces must remain closed. |
 | P0 | #155 | Call-target and dispatch evidence | The shared vocabulary and resolver now cover direct functions, direct methods, imported functions/members, and dynamic-dispatch facts. Remaining work is broader producer coverage for method/imported/module targets, trait/interface dispatch, and overload-specific target proof. |
-| P0 | #156 | Type/domain evidence expansion | Receiver/domain proof covers current parameter, binding, and selected API-result facts. Broader type aliases, constructor result domains, field/property domains, protocol receiver facts, and versioned library domains still need evidence vocabulary. |
+| P0 | #156 | Type/domain evidence expansion | The shared vocabulary now covers richer scalar, protocol, record, future/result, and nominal domains. Remaining work is broader producer coverage for constructor result domains, field/property domains, protocol receiver facts with demand/effect obligations, and versioned library domains. |
 | P1 | #154 | Async and Promise receiver proof | `crates/nose-normalize/src/value_graph/rules/promise_then.rs` has a JS-like `.then` contract but returns fail-closed until Promise-like receiver proof exists. This should depend on #153 and #156. |
 | P1 | #152 | Pack loading, provenance, and opt-in trust | The internal provenance/trust model exists, but there is no loadable pack runtime, manifest validation, user opt-in path, or report-level pack provenance. |
 | P1 | #157 | Pack conformance harness and ecosystem workflow | The first-party regression suite covers many hard negatives, but external pack providers need a defined conformance fixture layout and workflow. |

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -366,6 +366,13 @@ and pack ecosystem.
   `MethodReceiverContract` exposes the subset of receiver obligations that are
   domain-backed, while imported namespace, unshadowed global, map-literal,
   demand, and effect obligations remain separate checks.
+- The type/domain expansion slice broadened `DomainEvidence` and
+  `DomainRequirement` beyond the initial container/scalar set. The vocabulary now
+  includes iterable/iterator, record, result, future-like, boolean, float, and
+  nominal domains; `Type(NominalDomain)` rows can tie provider-proven nominal
+  type identities to domains without letting raw type names prove semantics.
+  The value-law bridge remains narrow, so these richer facts do not automatically
+  become sequence or exact algebraic proof.
 - Selected first-party library/API factory result domains now produce
   node-anchored `Domain` evidence after the call occurrence has admitted
   `LibraryApi` evidence. This covers Python builtin/imported collection
@@ -793,14 +800,15 @@ Remaining in this phase:
   exported-literal eligibility. Current exact/value-graph consumers are
   evidence-only for covered lowered surfaces, but richer aggregate semantics
   still need versioned records beyond the first tag-kind vocabulary.
-- Continue expanding domain evidence beyond parameter annotations. The shared
-  receiver-domain consumer contract now accepts exact node-anchored receiver
-  facts, binding-anchored immutable local/module facts, and selected admitted
-  library/API factory result facts. Remaining work is broader inferred receiver
-  domains, Java constructor call-domain evidence if that lowering stops
-  collapsing directly to sequence surfaces, richer field/property mutation
-  facts, and protocol-specific receiver facts that include demand/effect
-  obligations.
+- Continue expanding domain evidence producers beyond the current first-party
+  annotation/alias and selected API-result facts. The shared receiver-domain
+  consumer contract now accepts exact node-anchored receiver facts,
+  binding-anchored immutable local/module facts, selected admitted library/API
+  factory result facts, and a broader domain vocabulary. Remaining work is
+  broader inferred receiver domains, richer field/property and nominal-type
+  producer coverage, Java constructor call-domain evidence if that lowering
+  stops collapsing directly to sequence surfaces, and protocol-specific receiver
+  facts that include demand/effect obligations.
 - Turn named value-graph rule modules into LawPack-facing law ids/contracts while
   retaining formal-obligation metadata as the first-party proof boundary. The
   first `ValueLaw` contract surface now covers current arithmetic/boolean

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -377,6 +377,15 @@ migrated.
   `len(filter(...))`, explicit reductions over a filter, and static literal
   membership shortcuts reuse HOF admission as well, so raw `HoF(Filter)` cannot
   bypass the source/API HOF gate by appearing under another operation.
+- Type/domain evidence now has vocabulary for arrays, collections, iterables,
+  iterators, sets, maps, records, options, results, promise/future-like values,
+  strings, booleans, integer/float/number distinctions, byte arrays, and hashed
+  nominal domains. `Type(NominalDomain)` rows can connect provider-proven
+  nominal type identities to domains, while raw type names still do not prove
+  semantics. The `ValueDomain` bridge remains deliberately narrow:
+  integer/float/number, boolean, string, and array/collection/set facts can seed
+  current value laws; iterable, iterator, record, option/result, future-like, and
+  nominal facts stay separate until a consumer names those obligations.
 - Java empty collection constructor contracts cover `new ArrayList<>()` and
   `new LinkedList<>()` through `LibraryApiContract` rows only for the Java
   `java.util` list types. Simple names require exact `java.util` import proof or

--- a/docs/semantic-pack-extension-api-v0.md
+++ b/docs/semantic-pack-extension-api-v0.md
@@ -164,8 +164,8 @@ schema:
 | `Source` | construct syntax, macro invocation, regex literal, equality/operator family, ranges, patterns, async/generator/error and Go channel/concurrency protocol boundaries, Python comprehension surfaces |
 | `Symbol` | unshadowed language global, imported binding, imported namespace, qualified global path |
 | `Import` | binding import, namespace import, wildcard import, Ruby require, C quote include, imported literal snapshot |
-| `Domain` | array, collection, set, map, option, promise-like, string, integer, number, byte array |
-| `Type` | currently C type-alias proofs for exact byte-pack surfaces |
+| `Domain` | array, collection, iterable, iterator, set, map, record, option/result, promise/future-like, string, boolean, integer/float/number, byte array, nominal type |
+| `Type` | C type-alias proofs for exact byte-pack surfaces and nominal type-domain rows |
 | `Guard` | JS/TS record-shape and own-property guard facts |
 | `Place` | fixed receiver/place facts such as self receiver and self field |
 | `Effect` | builder append, non-overloadable index write, self-field write, binding write, receiver mutation, opaque argument escape |


### PR DESCRIPTION
Closes #156.

## Summary
- expand `ParamSemantic`, `DomainEvidence`, and `DomainRequirement` with boolean, float, iterable/iterator, record, result, future-like, and nominal domains
- add dependency-backed `Type(NominalDomain)` resolution that fails closed on ambiguous, conflicting, or dependency-broken evidence
- broaden language-scoped type-domain helpers and frontend alias tests without using raw substring guesses or rebound aliases as proof
- document the richer domain vocabulary, narrow `ValueDomain` bridge, and pack-facing provider obligations

## Boundaries
- no external pack loading in this slice
- no full language type checker
- no function/type-name-only semantic proof; producers still need scoped source, import, or binding evidence and dependencies
- protocol, future-like, record, result, and nominal domains do not automatically seed exact value laws

## Validation
- `cargo test -p nose-semantics semantic_evidence -- --nocapture`
- `cargo test -p nose-frontend parameter_type_domains_are_dependency_backed_and_not_substring_guesses -- --nocapture`
- `cargo test -p nose-semantics -p nose-normalize -p nose-frontend`
- `cargo clippy -p nose-semantics -p nose-normalize -p nose-frontend --all-targets -- -D warnings`
- `cargo fmt --check`
- `awiki lint --root docs`
- `git diff --check`
- earlier on this branch before final cleanup: `cargo build -p nose-cli`, `NOSE_BIN=target/debug/nose ./scripts/check-duplication.sh`, `cargo test -p nose-cli semantic -- --nocapture`
