### PR TITLE
[codex] Close out semantic kernel foundation tranche

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -60,6 +60,7 @@ You want to *change* nose or understand how it works inside.
 - [source-facts](source-facts.md) — source-origin evidence for semantic contracts: construct syntax, async/generator/error boundaries, literal/operator provenance, pack boundaries, and fail-closed exact admission.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
 - [semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md) — post-PR #147 audit of remaining raw/local semantic pockets and follow-up owners.
+- [semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md) — closeout for the first #109 foundation tranche and the next semantic-kernel issue map.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.
 - [fragment-contracts](fragment-contracts.md) — how exact sub-function fragments are modeled: classification, contract, the wrapper-synthesis behavior oracle, the effect algebra, and fail-closed receiver identity.
 - [formal-soundness](formal-soundness.md) — Lean 4 proof-obligation registry for proof-sensitive IL, normalization, fragment, and oracle contracts.

--- a/docs/semantic-kernel-audit-2026-06-09.md
+++ b/docs/semantic-kernel-audit-2026-06-09.md
@@ -2,7 +2,9 @@
 
 Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
 in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); remaining work is
-tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md).
+tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The later
+closeout for the #150-#157 foundation tranche is in
+[semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
 
 This audit closes issue #150. It assumes PR #147 is merged and asks whether any
 remaining first-party semantic consumer still opens exact semantics from raw
@@ -162,27 +164,19 @@ semantic meaning.
   also require exact receiver identity; dynamic-dispatch records do not prove a
   single concrete target by themselves.
 
-## Remaining Backlog
+## Closeout Update
 
-These are not #150 fixes; they are the next independent work items.
+This audit's follow-up queue was completed in the #109 foundation tranche:
 
-| priority | owner | remaining pocket | why it remains |
-|---|---|---|---|
-| P0 | #151 | Pack extension API v0 | First-party producers still call compiled Rust helper functions directly. The external boundary needs stable fact, contract, dependency, and channel-eligibility schemas before those producers can be expressed as packs. |
-| P0 | #153 | Demand/effect substrate | Lazy, repeated, async, generator, channel, observable, and callback effect visibility cannot be represented by the current first-party demand profiles. Exact laws for those surfaces must remain closed. |
-| P0 | #155 | Call-target and dispatch evidence | The shared vocabulary and resolver now cover direct functions, direct methods, imported functions/members, and dynamic-dispatch facts. Remaining work is broader producer coverage for method/imported/module targets, trait/interface dispatch, and overload-specific target proof. |
-| P0 | #156 | Type/domain evidence expansion | The shared vocabulary now covers richer scalar, protocol, record, future/result, and nominal domains. Remaining work is broader producer coverage for constructor result domains, field/property domains, protocol receiver facts with demand/effect obligations, and versioned library domains. |
-| P1 | #154 | Async and Promise receiver proof | `crates/nose-normalize/src/value_graph/rules/promise_then.rs` has a JS-like `.then` contract but returns fail-closed until Promise-like receiver proof exists. This should depend on #153 and #156. |
-| P1 | #152 | Pack loading, provenance, and opt-in trust | The internal provenance/trust model exists, but there is no loadable pack runtime, manifest validation, user opt-in path, or report-level pack provenance. |
-| P1 | #157 | Pack conformance harness and ecosystem workflow | The first-party regression suite covers many hard negatives, but external pack providers need a defined conformance fixture layout and workflow. |
-| P2 | #153/#156 | Guard, sequence, and aggregate surfaces | JS/TS record/own-property guards and selected sequence surfaces are evidence-backed where covered, but richer guard clauses, nested aggregate surfaces, iterator materialization, map-entry variants, and protocol-specific aggregate facts need versioned records. |
-| P2 | #153/#157 | LawPack-facing value laws | Named value-graph rules and formal-obligation metadata exist, but reduction, parity/toggle, byte-pack, and ecosystem laws remain local first-party code rather than pack-facing law contracts. |
+- #151 defined the provider-facing extension API v0.
+- #152 added local metadata loading, opt-in trust plumbing, and scan JSON pack
+  provenance.
+- #153 added the internal demand/effect substrate.
+- #154 added Promise receiver proof for the supported first-party `.then`
+  surface.
+- #155 expanded call-target and dispatch evidence.
+- #156 expanded type/domain evidence.
+- #157 added the semantic pack conformance harness and provider/user workflow.
 
-## Follow-up Guidance
-
-Start #151 and #153 first. #151 defines the extension shape that producers will
-target; #153 defines the semantic axes that prevent lazy, async, and callback
-APIs from being squeezed into unsafe API rows. #155 and #156 should then expand
-the evidence vocabulary consumed by both. #154 should stay closed until those
-receiver/demand pieces exist. #152 and #157 should follow the API shape from
-#151 and feed conformance requirements back into it early.
+The next issue map is recorded in
+[semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -5,7 +5,9 @@ Back to [semantic-kernel](semantic-kernel.md). Current code shape is recorded in
 of remaining raw/local semantic pockets is in
 [semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md). The
 provider-facing v0 extension API is in
-[semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md).
+[semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md). The
+closeout for the first #109 foundation tranche is in
+[semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
 
 This page tracks decisions, history, and remaining work for the semantic kernel
 and pack ecosystem.
@@ -660,6 +662,11 @@ and pack ecosystem.
   dependencies, channel eligibility, trust/default status, provider/user
   responsibility boundaries, examples, local metadata loading, and local
   conformance checks for manifests plus declared fixture assets.
+- The first #109 foundation tranche closed issues #150-#157. The closeout
+  records the landed API/loading/conformance/demand/effect/Promise/call-target/
+  domain foundation and opens the next tranche around first-party pack pilots,
+  broader producer coverage, richer demand/effect contracts, and pack-facing
+  value-law provenance.
 
 ## Phase 0: documentation and vocabulary (landed)
 
@@ -674,7 +681,7 @@ and pack ecosystem.
   roadmap so current implementation status, history, and extension design do not
   blur together.
 
-## Phase 1: kernel facade and fail-closed migration (first slice landed)
+## Phase 1: kernel facade and fail-closed migration (foundation tranche landed)
 
 Landed in PR #100 and PR #101:
 
@@ -691,20 +698,22 @@ Landed in PR #100 and PR #101:
   obligations for the migrated facade paths.
 - Parser and lowering dispatch remain unchanged.
 
-Remaining in this phase:
+Remaining after the foundation tranche:
 
-- Continue replacing proof-sensitive `Lang`/selector checks that are still local
-  to normalize, detect, and import proof.
-- Move the next raw fallback cluster behind pack-shaped contracts/evidence:
-  JS/TS guard recognizer dependencies, parsed/versioned type-surface manifests
-  for external type-domain producers, broader C type-system evidence beyond
-  current byte-pack aliases and scalar/pointer guards, remaining lowered
-  sequence/tag surfaces, and exact-fragment predicate code that is now
-  differential/debug support rather than production authority.
+- Ship a narrow first-party pack pilot (#166) so the v0 API, metadata loading,
+  conformance workflow, provenance, and evidence vocabulary are exercised by an
+  actual default pack-shaped implementation.
+- Broaden evidence producer coverage (#169) for call targets, richer domains,
+  guards, aggregates, and module/export dependencies without reopening raw
+  selector/name/type/tag fallbacks.
+- Expand demand/effect contracts (#168) for lazy, iterator, generator, async,
+  channel, repeated, and call-by-need semantics before ecosystem APIs can enter
+  exact matching.
+- Move internal value laws toward pack-facing law ids, conformance status, and
+  per-finding provenance (#167).
 - Keep behavior-changing recall reductions documented when missing evidence
-  blocks exact convergence.
-- Preserve the current precision gates while moving more first-party surfaces
-  behind shared contracts.
+  blocks exact convergence, and preserve the current precision gates while more
+  first-party surfaces move behind shared contracts.
 
 ## Phase 2: shared contracts for duplicated gates
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -9,7 +9,9 @@ post-PR #147 raw/local pocket audit is recorded in
 v0 provider-facing extension API is defined in
 [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md), and the
 local provider/user conformance workflow is in
-[semantic-pack-conformance](semantic-pack-conformance.md).
+[semantic-pack-conformance](semantic-pack-conformance.md). The closeout for the
+first #109 foundation tranche is in
+[semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
 
 Snapshot date: 2026-06-09. The current implementation has an internal
 semantic-kernel facade, evidence-gated field state, sequence-surface contracts,
@@ -799,6 +801,8 @@ These reduce recall in affected cases, but they are the correct precision trade
 until packs can emit the missing facts.
 
 Remaining migration targets are tracked in
-[semantic-kernel-roadmap](semantic-kernel-roadmap.md), with the post-PR #147
-classification snapshot in
-[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md).
+[semantic-kernel-roadmap](semantic-kernel-roadmap.md). The post-PR #147
+classification snapshot is in
+[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md), and
+the completed #150-#157 foundation tranche plus next issue map are in
+[semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).

--- a/docs/semantic-kernel-tranche-closeout-2026-06-09.md
+++ b/docs/semantic-kernel-tranche-closeout-2026-06-09.md
@@ -1,0 +1,89 @@
+# Semantic kernel tranche closeout, 2026-06-09
+
+Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
+in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); long-range phases
+and history are in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). This
+closeout updates the post-PR #147 audit recorded in
+[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md).
+
+## Scope
+
+This page closes the first semantic-kernel foundation tranche under GitHub issue
+#109. It covers the follow-up issues created from the post-PR #147 audit:
+
+| issue | PR | outcome |
+|---|---|---|
+| #150 | #158 | completed the post-PR #147 raw/local semantic pocket audit |
+| #151 | #160 | defined the provider-facing semantic pack extension API v0 |
+| #152 | #161 | added local pack manifest loading, opt-in trust plumbing, and scan JSON pack provenance |
+| #153 | #159 | added the internal demand/effect semantic substrate |
+| #154 | #162 | added Promise receiver proof and conservative `.then` continuation reduction |
+| #155 | #164 | expanded call-target and dispatch evidence vocabulary and resolvers |
+| #156 | #165 | expanded type/domain evidence vocabulary and nominal type-domain proof |
+| #157 | #163 | added semantic pack conformance harness and contribution workflow |
+
+## Current state
+
+The tranche is complete as a foundation, not as a finished ecosystem. The code
+now has:
+
+- a documented v0 pack extension shape for language/library semantics,
+  contracts, evidence producers, dependencies, channel eligibility, trust, and
+  provider/user responsibility;
+- local pack manifest discovery and explicit opt-in loading, with external packs
+  still treated as `metadata-only`;
+- structural conformance checks for local manifests and declared fixture assets,
+  without implying nose approval of external semantic correctness;
+- an internal demand/effect model for admitted eager, lazy, short-circuit,
+  callback, async-continuation, generator, channel, and protocol-boundary
+  surfaces;
+- Promise-like receiver proof for the supported first-party
+  `Promise.resolve(...).then(...)` chain, while shadowed promises, custom
+  thenables, unsafe assimilation, and synchronous equivalence stay closed;
+- shared call-target evidence for direct functions, direct methods, imported
+  functions, imported members, and dynamic-dispatch facts, with strict exact
+  admitting only concrete, dependency-backed opaque identity;
+- richer domain evidence for arrays, collections, iterables, iterators, sets,
+  maps, records, options, results, promise/future-like values, strings,
+  booleans, integer/float/number distinctions, byte arrays, and hashed nominal
+  domains.
+
+The core policy is unchanged: selectors, names, payload tags, raw IL shapes, and
+broad type-text substrings are not proof. Missing, ambiguous, conflicting,
+shadowed, or dependency-broken evidence must keep exact semantic convergence
+closed.
+
+## What remains
+
+The remaining work is no longer "finish #151-#157." Those issues are closed.
+The next work is to prove that the new extension boundary is practical and then
+broaden producer coverage without reopening the old raw fallbacks.
+
+| priority | issue | work | reason |
+|---|---|---|---|
+| P0 | #166 | first-party pack pilot | The extension boundary needs one narrow default pack-shaped implementation before broad first-party conversion or external executable producers. |
+| P1 | #169 | broaden evidence producer coverage | Shared vocabularies exist, but producer coverage for call targets, richer domains, guards, aggregates, and module/export dependencies is still selective. |
+| P1 | #168 | expand demand and effect contracts | Lazy, iterator, generator, async, channel, repeated, and call-by-need semantics need more precise obligations before ecosystem APIs can enter exact matching. |
+| P2 | #167 | pack-facing value laws and provenance | Current `ValueLaw`/rule ids are internal; pack-facing law contracts, proof status, fixture expectations, and per-finding provenance remain open. |
+| quality | #149 | quality-gate ratchets and large-file cleanup | The semantic foundation is now broad enough that the remaining large/high-complexity modules should be split before more kernel behavior accumulates there. |
+
+## Recommended order
+
+Start #166 first. A small first-party pack pilot is the best pressure test for
+the API, loading, conformance, provenance, and evidence vocabulary already
+landed. It should use compiled first-party execution and preserve current exact
+behavior.
+
+Run #149 in parallel with #166 when two workers are available. It lowers the
+cost of the next semantic tranche by splitting broad files and ratcheting quality
+gates, and it should not need to touch the same pack-pilot surfaces if scoped
+carefully.
+
+Start #169 after the #166 pilot has clarified the first-party pack shape, or in
+parallel only for a producer family that does not depend on that shape. Start
+#168 when a concrete protocol family is chosen and its demand/effect hard
+negatives are clear. Start #167 after #166 has established how first-party pack
+metadata and conformance results should identify semantic contributions.
+
+Keep #109 open as the parent tracker until at least one first-party pack-shaped
+semantic surface ships and the next producer/runtime tranche is re-evaluated.

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -4,8 +4,10 @@ Back to [home](home.md). Current implementation status is in
 [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and remaining
 work are tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The
 post-PR #147 raw/local pocket audit is recorded in
-[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md). The
-versioned provider-facing extension surface is defined in
+[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md), and the
+first #109 foundation tranche closeout is recorded in
+[semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
+The versioned provider-facing extension surface is defined in
 [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md). Source
 origin evidence is detailed in [source-facts](source-facts.md); the shared
 internal evidence substrate is described in


### PR DESCRIPTION
Updates #109.

## Summary
- add a dedicated closeout page for the completed #150-#157 semantic-kernel foundation tranche
- replace the stale post-PR #147 audit backlog with a closeout pointer now that #151-#157 have landed
- link the closeout from home, semantic-kernel, snapshot, and roadmap docs
- update the roadmap to point at the next issue map: #166, #169, #168, #167, plus #149 as the quality/refactor companion

## Next tranche issues opened
- #166 Semantic kernel: first-party pack pilot
- #167 Semantic kernel: pack-facing value laws and provenance
- #168 Semantic kernel: expand demand and effect contracts
- #169 Semantic kernel: broaden evidence producer coverage

## Validation
- `awiki lint --root docs`
- `git diff --check`
