### PR TITLE
[codex] Add first-party Python type-domain pack pilot

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -2676,6 +2676,11 @@ fn warn_no_files(paths: &[PathBuf]) {
 }
 
 fn semantic_pack_summary_line(packs: &nose_semantics::SemanticPackSet) -> Option<String> {
+    let first_party_count = packs
+        .packs()
+        .iter()
+        .filter(|pack| pack.source == nose_semantics::SemanticPackSource::CompiledFirstParty)
+        .count();
     let local = packs
         .packs()
         .iter()
@@ -2684,8 +2689,7 @@ fn semantic_pack_summary_line(packs: &nose_semantics::SemanticPackSet) -> Option
         .collect::<Vec<_>>();
     (!local.is_empty()).then(|| {
         format!(
-            "semantic packs: {} first-party default · {} local opt-in: {}",
-            nose_semantics::FIRST_PARTY_PACK_ID,
+            "semantic packs: {first_party_count} first-party default · {} local opt-in: {}",
             local.len(),
             local.join(", ")
         )

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -652,16 +652,26 @@ fn scan_json_reports_first_party_and_local_semantic_pack_provenance() {
     let packs = json["semantic_packs"]
         .as_array()
         .expect("semantic_packs array");
-    assert_eq!(packs.len(), 2, "first-party + local opt-in pack: {json}");
+    assert_eq!(
+        packs.len(),
+        3,
+        "first-party packs + local opt-in pack: {json}"
+    );
     assert_eq!(packs[0]["id"], "nose.first_party");
     assert_eq!(packs[0]["source"], "compiled-first-party");
     assert_eq!(packs[0]["influence"], "evidence-and-contracts");
-    assert_eq!(packs[1]["id"], "com.example.semantic-pack");
-    assert_eq!(packs[1]["trust"], "external-opt-in");
-    assert_eq!(packs[1]["source"], "local-manifest");
-    assert_eq!(packs[1]["influence"], "metadata-only");
+    assert_eq!(packs[1]["id"], "nose.python.stdlib.type_domain");
+    assert_eq!(packs[1]["kind"], "StdlibPack");
+    assert_eq!(packs[1]["source"], "compiled-first-party");
+    assert_eq!(packs[1]["influence"], "evidence-and-contracts");
+    assert_eq!(packs[1]["counts"]["evidence_producers"], 1);
     assert_eq!(packs[1]["counts"]["contracts"], 1);
-    assert!(packs[1]["hash"]
+    assert_eq!(packs[2]["id"], "com.example.semantic-pack");
+    assert_eq!(packs[2]["trust"], "external-opt-in");
+    assert_eq!(packs[2]["source"], "local-manifest");
+    assert_eq!(packs[2]["influence"], "metadata-only");
+    assert_eq!(packs[2]["counts"]["contracts"], 1);
+    assert!(packs[2]["hash"]
         .as_str()
         .is_some_and(|hash| hash.len() == 16));
     let _ = fs::remove_dir_all(&dir);
@@ -683,7 +693,7 @@ fn scan_human_reports_local_semantic_pack_opt_in() {
     ]);
     assert!(
         out.contains(
-            "semantic packs: nose.first_party first-party default · 1 local opt-in: \
+            "semantic packs: 2 first-party default · 1 local opt-in: \
              com.example.semantic-pack@0.1.0 (metadata-only)"
         ),
         "human scan output should disclose local semantic pack opt-ins: {out}"

--- a/crates/nose-cli/tests/fixtures/scan-json-v1.json
+++ b/crates/nose-cli/tests/fixtures/scan-json-v1.json
@@ -32,6 +32,30 @@
         "positive_fixtures": 0,
         "hard_negatives": 0
       }
+    },
+    {
+      "id": "nose.python.stdlib.type_domain",
+      "hash": "783a582a461f58f3",
+      "kind": "StdlibPack",
+      "version": "<version>",
+      "display_name": "nose Python stdlib type-domain pack",
+      "trust": "default-first-party",
+      "enabled_by_default": true,
+      "source": "compiled-first-party",
+      "influence": "evidence-and-contracts",
+      "provider": "Corca, Inc.",
+      "repository": "https://github.com/corca-ai/nose",
+      "license": "MIT",
+      "supported_languages": [
+        "python"
+      ],
+      "counts": {
+        "evidence_producers": 1,
+        "contracts": 1,
+        "value_laws": 0,
+        "positive_fixtures": 36,
+        "hard_negatives": 2
+      }
     }
   ],
   "ranking": {

--- a/crates/nose-frontend/src/go.rs
+++ b/crates/nose-frontend/src/go.rs
@@ -237,8 +237,8 @@ fn lower_params(lo: &mut Lowering, params: TsNode, out: &mut Vec<NodeId>) {
             for n in names {
                 let span = lo.span(n);
                 let sym = lo.sym(lo.text(n));
-                if let Some((domain, dependencies)) = &domain {
-                    lo.record_param_domain_with_dependencies(span, *domain, dependencies.clone());
+                if let Some(domain) = &domain {
+                    lo.record_param_domain_resolution(span, domain.clone());
                 }
                 out.push(lo.add(NodeKind::Param, Payload::Name(sym), span, &[]));
             }

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -353,9 +353,8 @@ fn lower_params(lo: &mut Lowering, params: TsNode, out: &mut Vec<NodeId>) {
             Some(s) => Payload::Name(lo.sym(s)),
             None => Payload::None,
         };
-        if let Some((domain, dependencies)) = lo.type_domain_from_text_with_dependencies(lo.text(p))
-        {
-            lo.record_param_domain_with_dependencies(span, domain, dependencies);
+        if let Some(domain) = lo.type_domain_from_text_with_dependencies(lo.text(p)) {
+            lo.record_param_domain_resolution(span, domain);
         }
         out.push(lo.add(NodeKind::Param, payload, span, &[]));
     }

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -2,7 +2,9 @@
 //! Language-specific walks build IL through this, so the arena/span/intern
 //! mechanics live in one place.
 
-use crate::type_domain_aliases::TypeDomainAliases;
+use crate::type_domain_aliases::{
+    ResolvedTypeDomain, TypeDomainAliases, TypeDomainEvidenceProvenance,
+};
 use nose_il::{
     stable_symbol_hash, DomainEvidence, EffectEvidenceKind, EvidenceAnchor, EvidenceEmitter,
     EvidenceId, EvidenceKind, EvidenceProvenance, EvidenceRecord, EvidenceStatus, FileId, FileMeta,
@@ -904,10 +906,39 @@ impl<'a> Lowering<'a> {
         domain: DomainEvidence,
         dependencies: Vec<EvidenceId>,
     ) {
-        self.record_evidence_with_dependencies(
+        self.record_param_domain_with_provenance(
+            span,
+            domain,
+            dependencies,
+            first_party_param_domain_provenance(),
+        );
+    }
+
+    pub(crate) fn record_param_domain_resolution(
+        &mut self,
+        span: Span,
+        domain: ResolvedTypeDomain,
+    ) {
+        self.record_param_domain_with_provenance(
+            span,
+            domain.domain,
+            domain.dependencies,
+            domain.provenance,
+        );
+    }
+
+    pub(crate) fn record_param_domain_with_provenance(
+        &mut self,
+        span: Span,
+        domain: DomainEvidence,
+        dependencies: Vec<EvidenceId>,
+        provenance: TypeDomainEvidenceProvenance,
+    ) {
+        self.record_evidence_with_pack_dependencies(
             EvidenceAnchor::param(span),
             EvidenceKind::Domain(domain),
-            "param_domain",
+            provenance.pack_id,
+            provenance.rule,
             dependencies,
         );
     }
@@ -936,6 +967,23 @@ impl<'a> Lowering<'a> {
         rule: &str,
         dependencies: Vec<EvidenceId>,
     ) -> EvidenceId {
+        self.record_evidence_with_pack_dependencies(
+            anchor,
+            kind,
+            nose_semantics::FIRST_PARTY_PACK_ID,
+            rule,
+            dependencies,
+        )
+    }
+
+    pub(crate) fn record_evidence_with_pack_dependencies(
+        &mut self,
+        anchor: EvidenceAnchor,
+        kind: EvidenceKind,
+        pack_id: &str,
+        rule: &str,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceId {
         let id = EvidenceId(self.evidence.len() as u32);
         self.evidence.push(EvidenceRecord {
             id,
@@ -943,7 +991,7 @@ impl<'a> Lowering<'a> {
             kind,
             provenance: EvidenceProvenance {
                 emitter: EvidenceEmitter::FirstParty,
-                pack_hash: Some(stable_symbol_hash(nose_semantics::FIRST_PARTY_PACK_ID)),
+                pack_hash: Some(stable_symbol_hash(pack_id)),
                 rule_hash: Some(stable_symbol_hash(rule)),
             },
             dependencies,
@@ -952,14 +1000,15 @@ impl<'a> Lowering<'a> {
         id
     }
 
-    pub(crate) fn record_type_domain_alias_with_evidence(
+    pub(crate) fn record_type_domain_alias_with_pack_evidence(
         &mut self,
         local: &str,
         domain: DomainEvidence,
         evidence: Option<EvidenceId>,
+        provenance: TypeDomainEvidenceProvenance,
     ) {
         self.type_domain_aliases
-            .record_normalized(local, domain, evidence);
+            .record_normalized(local, domain, evidence, provenance);
     }
 
     pub(crate) fn record_type_domain_alias_exact_with_evidence(
@@ -968,8 +1017,12 @@ impl<'a> Lowering<'a> {
         domain: DomainEvidence,
         evidence: Option<EvidenceId>,
     ) {
-        self.type_domain_aliases
-            .record_exact(local, domain, evidence);
+        self.type_domain_aliases.record_exact(
+            local,
+            domain,
+            evidence,
+            first_party_param_domain_provenance(),
+        );
     }
 
     pub(crate) fn clear_type_domain_alias(&mut self, local: &str) {
@@ -1002,14 +1055,14 @@ impl<'a> Lowering<'a> {
     pub(crate) fn type_domain_from_text_with_dependencies(
         &self,
         text: &str,
-    ) -> Option<(DomainEvidence, Vec<EvidenceId>)> {
-        type_domain_from_source_text(self.lang, text)
-            .map(|domain| (domain, Vec::new()))
-            .or_else(|| {
-                self.type_domain_aliases
-                    .resolve_text(text)
-                    .map(|resolved| (resolved.domain, resolved.dependencies))
+    ) -> Option<ResolvedTypeDomain> {
+        self.type_domain_aliases.resolve_text(text).or_else(|| {
+            type_domain_from_source_text(self.lang, text).map(|domain| ResolvedTypeDomain {
+                domain,
+                dependencies: Vec::new(),
+                provenance: first_party_param_domain_provenance(),
             })
+        })
     }
 
     /// An empty `Block` (used for absent loop init/update slots, empty bodies).
@@ -1194,6 +1247,13 @@ impl<'a> Lowering<'a> {
         n.named_children(&mut cur)
             .filter(|c| !is_trivia(c.kind()))
             .collect()
+    }
+}
+
+fn first_party_param_domain_provenance() -> TypeDomainEvidenceProvenance {
+    TypeDomainEvidenceProvenance {
+        pack_id: nose_semantics::FIRST_PARTY_PACK_ID,
+        rule: "param_domain",
     }
 }
 
@@ -2914,6 +2974,18 @@ mod tests {
         param_domain_records(evidence, domain).len()
     }
 
+    fn param_domain_record_count_from_pack(
+        evidence: &[EvidenceRecord],
+        domain: DomainEvidence,
+        pack_id: &str,
+    ) -> usize {
+        let pack_hash = stable_symbol_hash(pack_id);
+        param_domain_records(evidence, domain)
+            .into_iter()
+            .filter(|record| record.provenance.pack_hash == Some(pack_hash))
+            .count()
+    }
+
     fn imported_binding_symbol_ids(
         evidence: &[EvidenceRecord],
         module: &str,
@@ -3702,6 +3774,36 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
         let py_domains = param_domain_records(&py_alias.evidence, DomainEvidence::Collection);
         assert_eq!(py_domains.len(), 1);
         assert_eq!(py_domains[0].dependencies, import_ids);
+        assert_eq!(
+            py_domains[0].provenance.pack_hash,
+            Some(stable_symbol_hash(
+                nose_semantics::PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID
+            )),
+            "imported Python stdlib type aliases should carry the pilot pack provenance"
+        );
+
+        let py_direct_import_alias = crate::lower_source(
+            FileId(0),
+            "typing_direct_import_alias.py",
+            b"from typing import List\ndef f(xs: List[int]):\n    return len(xs)\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        let import_ids =
+            imported_binding_symbol_ids(&py_direct_import_alias.evidence, "typing", "List");
+        assert_eq!(import_ids.len(), 1);
+        let py_domains =
+            param_domain_records(&py_direct_import_alias.evidence, DomainEvidence::Collection);
+        assert_eq!(py_domains.len(), 1);
+        assert_eq!(py_domains[0].dependencies, import_ids);
+        assert_eq!(
+            py_domains[0].provenance.pack_hash,
+            Some(stable_symbol_hash(
+                nose_semantics::PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID
+            )),
+            "a direct imported alias should not fall through to first-party text heuristics"
+        );
 
         let py_iter_alias = crate::lower_source(
             FileId(0),
@@ -3716,6 +3818,12 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
         let py_domains = param_domain_records(&py_iter_alias.evidence, DomainEvidence::Iterable);
         assert_eq!(py_domains.len(), 1);
         assert_eq!(py_domains[0].dependencies, import_ids);
+        assert_eq!(
+            py_domains[0].provenance.pack_hash,
+            Some(stable_symbol_hash(
+                nose_semantics::PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID
+            ))
+        );
 
         let py_iter_shadowed = crate::lower_source(
             FileId(0),
@@ -3731,6 +3839,73 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             "a rebound iterable alias must not emit parameter Domain evidence"
         );
 
+        let py_iter_class_shadowed = crate::lower_source(
+            FileId(0),
+            "typing_iter_alias_class_shadowed.py",
+            b"from typing import Iterable as I\nclass I:\n    pass\ndef f(xs: I[int]):\n    return xs\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        assert_eq!(
+            param_domain_record_count(&py_iter_class_shadowed.evidence, DomainEvidence::Iterable),
+            0,
+            "a class definition with the alias name must close later Domain evidence"
+        );
+
+        let py_iter_function_shadowed = crate::lower_source(
+            FileId(0),
+            "typing_iter_alias_function_shadowed.py",
+            b"from typing import Iterable as I\ndef I():\n    return None\ndef f(xs: I[int]):\n    return xs\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        assert_eq!(
+            param_domain_record_count(
+                &py_iter_function_shadowed.evidence,
+                DomainEvidence::Iterable
+            ),
+            0,
+            "a function definition with the alias name must close later Domain evidence"
+        );
+
+        let py_mapping_alias = crate::lower_source(
+            FileId(0),
+            "collections_abc_mapping_alias.py",
+            b"from collections.abc import Mapping as M\ndef f(xs: M[str, int]):\n    return xs\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        assert_eq!(
+            param_domain_record_count_from_pack(
+                &py_mapping_alias.evidence,
+                DomainEvidence::Map,
+                nose_semantics::PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID
+            ),
+            1,
+            "collections.abc aliases should resolve through the same pilot pack"
+        );
+
+        let py_future_alias = crate::lower_source(
+            FileId(0),
+            "asyncio_future_alias.py",
+            b"from asyncio import Future as Fut\ndef f(x: Fut[int]):\n    return x\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        assert_eq!(
+            param_domain_record_count_from_pack(
+                &py_future_alias.evidence,
+                DomainEvidence::FutureLike,
+                nose_semantics::PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID
+            ),
+            1,
+            "asyncio Future aliases should resolve through the same pilot pack"
+        );
+
         let py_shadowed = crate::lower_source(
             FileId(0),
             "typing_alias_shadowed.py",
@@ -3743,6 +3918,20 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             param_domain_record_count(&py_shadowed.evidence, DomainEvidence::Collection),
             0,
             "a rebound typing alias must not emit parameter Domain evidence"
+        );
+
+        let py_wrong_module_alias = crate::lower_source(
+            FileId(0),
+            "typing_alias_wrong_module.py",
+            b"from project.typing import Iterable as I\ndef f(xs: I[int]):\n    return xs\n",
+            Lang::Python,
+            &interner,
+        )
+        .expect("python lowering should succeed");
+        assert_eq!(
+            param_domain_record_count(&py_wrong_module_alias.evidence, DomainEvidence::Iterable),
+            0,
+            "a same-named alias from another module must not satisfy the stdlib pack"
         );
 
         let ts = crate::lower_source(

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -42,13 +42,21 @@ fn lower_module(lo: &mut Lowering, node: TsNode) -> NodeId {
 fn lower_stmt(lo: &mut Lowering, node: TsNode, in_class: bool) -> Option<NodeId> {
     let span = lo.span(node);
     match node.kind() {
-        "function_definition" => Some(lower_func(lo, node, in_class)),
+        "function_definition" => {
+            let out = lower_func(lo, node, in_class);
+            clear_defined_param_alias(lo, node);
+            Some(out)
+        }
         "decorated_definition" => {
             // Ignore decorators; lower the wrapped definition.
             let def = node.child_by_field_name("definition")?;
             lower_stmt(lo, def, in_class)
         }
-        "class_definition" => Some(lower_class(lo, node)),
+        "class_definition" => {
+            let out = lower_class(lo, node);
+            clear_defined_param_alias(lo, node);
+            Some(out)
+        }
         "if_statement" => Some(lower_if(lo, node)),
         "match_statement" => Some(lower_match(lo, node)),
         "for_statement" => Some(lower_for(lo, node)),
@@ -139,9 +147,18 @@ fn lower_static_import(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
                 module.trim(),
                 exported,
             );
-            if let Some(domain) = nose_semantics::python_stdlib_type_domain(module.trim(), exported)
+            if let Some(contract) =
+                nose_semantics::python_stdlib_type_domain_contract(module.trim(), exported)
             {
-                lo.record_type_domain_alias_with_evidence(local, domain, import_evidence);
+                lo.record_type_domain_alias_with_pack_evidence(
+                    local,
+                    contract.domain,
+                    import_evidence,
+                    crate::type_domain_aliases::TypeDomainEvidenceProvenance {
+                        pack_id: contract.pack_id,
+                        rule: contract.producer_id,
+                    },
+                );
             } else {
                 lo.clear_type_domain_alias(local);
             }
@@ -244,9 +261,8 @@ fn lower_params(lo: &mut Lowering, params: TsNode, out: &mut Vec<NodeId>) {
             Some(s) => Payload::Name(lo.sym(s)),
             None => Payload::None,
         };
-        if let Some((domain, dependencies)) = lo.type_domain_from_text_with_dependencies(lo.text(p))
-        {
-            lo.record_param_domain_with_dependencies(span, domain, dependencies);
+        if let Some(domain) = lo.type_domain_from_text_with_dependencies(lo.text(p)) {
+            lo.record_param_domain_resolution(span, domain);
         }
         out.push(lo.add(NodeKind::Param, payload, span, &[]));
     }
@@ -314,6 +330,13 @@ fn lower_aug_assignment(lo: &mut Lowering, node: TsNode) -> NodeId {
 fn clear_assigned_param_alias(lo: &mut Lowering, node: TsNode) {
     if node.kind() == "identifier" {
         let name = lo.text(node).to_string();
+        lo.clear_type_domain_alias(&name);
+    }
+}
+
+fn clear_defined_param_alias(lo: &mut Lowering, node: TsNode) {
+    if let Some(name) = node.child_by_field_name("name") {
+        let name = lo.text(name).to_string();
         lo.clear_type_domain_alias(&name);
     }
 }

--- a/crates/nose-frontend/src/rust.rs
+++ b/crates/nose-frontend/src/rust.rs
@@ -185,14 +185,12 @@ fn lower_params(lo: &mut Lowering, params: TsNode, out: &mut Vec<NodeId>) {
             "parameter" => {
                 if let Some(pat) = p.child_by_field_name("pattern") {
                     let semantic_text = p.child_by_field_name("type").map(|ty| lo.text(ty));
-                    if let Some((domain, dependencies)) = lo
-                        .type_domain_from_text_with_dependencies(
-                            semantic_text.unwrap_or_else(|| lo.text(p)),
-                        )
-                    {
+                    if let Some(domain) = lo.type_domain_from_text_with_dependencies(
+                        semantic_text.unwrap_or_else(|| lo.text(p)),
+                    ) {
                         if let Some(sym) = ident_of(lo, pat) {
                             let pspan = lo.span(pat);
-                            lo.record_param_domain_with_dependencies(pspan, domain, dependencies);
+                            lo.record_param_domain_resolution(pspan, domain);
                             out.push(lo.add(NodeKind::Param, Payload::Name(sym), pspan, &[]));
                             continue;
                         }

--- a/crates/nose-frontend/src/type_domain_aliases.rs
+++ b/crates/nose-frontend/src/type_domain_aliases.rs
@@ -1,14 +1,23 @@
 use nose_il::{DomainEvidence, EvidenceId};
 
+#[derive(Clone, Copy)]
+pub(crate) struct TypeDomainEvidenceProvenance {
+    pub pack_id: &'static str,
+    pub rule: &'static str,
+}
+
+#[derive(Clone)]
 pub(crate) struct ResolvedTypeDomain {
     pub domain: DomainEvidence,
     pub dependencies: Vec<EvidenceId>,
+    pub provenance: TypeDomainEvidenceProvenance,
 }
 
 pub(crate) struct TypeDomainAlias {
     pub alias: String,
     pub domain: DomainEvidence,
     pub evidence: Option<EvidenceId>,
+    pub provenance: TypeDomainEvidenceProvenance,
 }
 
 #[derive(Default)]
@@ -22,8 +31,9 @@ impl TypeDomainAliases {
         local: &str,
         domain: DomainEvidence,
         evidence: Option<EvidenceId>,
+        provenance: TypeDomainEvidenceProvenance,
     ) {
-        self.record_inner(normalize_type_text(local), domain, evidence);
+        self.record_inner(normalize_type_text(local), domain, evidence, provenance);
     }
 
     pub(crate) fn record_exact(
@@ -31,8 +41,9 @@ impl TypeDomainAliases {
         local: &str,
         domain: DomainEvidence,
         evidence: Option<EvidenceId>,
+        provenance: TypeDomainEvidenceProvenance,
     ) {
-        self.record_inner(local.trim().to_string(), domain, evidence);
+        self.record_inner(local.trim().to_string(), domain, evidence, provenance);
     }
 
     pub(crate) fn clear_normalized(&mut self, local: &str) {
@@ -50,6 +61,7 @@ impl TypeDomainAliases {
                 .then(|| ResolvedTypeDomain {
                     domain: known.domain,
                     dependencies: known.evidence.into_iter().collect(),
+                    provenance: known.provenance,
                 })
         })
     }
@@ -63,6 +75,7 @@ impl TypeDomainAliases {
         alias: String,
         domain: DomainEvidence,
         evidence: Option<EvidenceId>,
+        provenance: TypeDomainEvidenceProvenance,
     ) {
         if alias.is_empty() {
             return;
@@ -70,12 +83,14 @@ impl TypeDomainAliases {
         if let Some(existing) = self.aliases.iter_mut().find(|known| known.alias == alias) {
             existing.domain = domain;
             existing.evidence = evidence;
+            existing.provenance = provenance;
             return;
         }
         self.aliases.push(TypeDomainAlias {
             alias,
             domain,
             evidence,
+            provenance,
         });
     }
 }

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -44,7 +44,11 @@ use library_api::{
 pub use module_exports::*;
 pub use nose_il::DomainEvidence;
 pub use packs::*;
-pub use type_domain::{python_stdlib_type_domain, type_domain_from_source_text};
+pub use type_domain::{
+    python_stdlib_type_domain, python_stdlib_type_domain_contract, type_domain_from_source_text,
+    FirstPartyTypeDomainAliasContract, PYTHON_STDLIB_TYPE_DOMAIN_ALIAS_CONTRACTS,
+    PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID, PYTHON_STDLIB_TYPE_DOMAIN_PRODUCER_ID,
+};
 
 /// Stable pack id for the first-party language/stdlib contracts compiled into nose.
 pub const FIRST_PARTY_PACK_ID: &str = "nose.first_party";

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -4,7 +4,10 @@
 //! emit evidence or approve exact results from this module; consumers must still
 //! require occurrence evidence and kernel-owned admission checks.
 
-use crate::{PackTrust, FIRST_PARTY_PACK_ID};
+use crate::{
+    PackTrust, FIRST_PARTY_PACK_ID, PYTHON_STDLIB_TYPE_DOMAIN_ALIAS_CONTRACTS,
+    PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID,
+};
 use nose_il::stable_symbol_hash;
 use serde::Deserialize;
 use std::collections::HashSet;
@@ -269,6 +272,45 @@ pub fn first_party_semantic_pack() -> SemanticPackSummary {
     }
 }
 
+pub fn python_stdlib_type_domain_pack() -> SemanticPackSummary {
+    SemanticPackSummary {
+        id: PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID.to_string(),
+        hash: semantic_pack_hash(PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID),
+        kind: SemanticPackKind::StdlibPack,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        display_name: "nose Python stdlib type-domain pack".to_string(),
+        trust: PackTrust::DefaultFirstParty,
+        enabled_by_default: true,
+        source: SemanticPackSource::CompiledFirstParty,
+        influence: SemanticPackInfluence::EvidenceAndContracts,
+        manifest_path: None,
+        provider: "Corca, Inc.".to_string(),
+        repository: "https://github.com/corca-ai/nose".to_string(),
+        license: "MIT".to_string(),
+        supported_languages: vec!["python".to_string()],
+        counts: SemanticPackCounts {
+            evidence_producers: 1,
+            contracts: 1,
+            value_laws: 0,
+            positive_fixtures: PYTHON_STDLIB_TYPE_DOMAIN_ALIAS_CONTRACTS.len(),
+            hard_negatives: 2,
+        },
+    }
+}
+
+fn compiled_first_party_packs() -> Vec<SemanticPackSummary> {
+    vec![
+        first_party_semantic_pack(),
+        python_stdlib_type_domain_pack(),
+    ]
+}
+
+fn is_compiled_first_party_pack_id(pack_id: &str) -> bool {
+    compiled_first_party_packs()
+        .iter()
+        .any(|pack| pack.id == pack_id)
+}
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct SemanticPackSet {
     packs: Vec<SemanticPackSummary>,
@@ -277,7 +319,7 @@ pub struct SemanticPackSet {
 impl SemanticPackSet {
     pub fn new_local(paths: &[PathBuf]) -> Result<Self, SemanticPackLoadError> {
         let manifest_paths = discover_manifest_paths(paths)?;
-        let mut packs = vec![first_party_semantic_pack()];
+        let mut packs = compiled_first_party_packs();
         for path in manifest_paths {
             let pack = load_local_manifest(&path)?;
             if let Some(existing) = packs.iter().find(|existing| existing.id == pack.id) {
@@ -294,7 +336,7 @@ impl SemanticPackSet {
 
     pub fn first_party_only() -> Self {
         Self {
-            packs: vec![first_party_semantic_pack()],
+            packs: compiled_first_party_packs(),
         }
     }
 
@@ -429,7 +471,7 @@ pub fn check_semantic_pack_conformance(
                     message,
                 }
             })?;
-        if pack.id == FIRST_PARTY_PACK_ID {
+        if is_compiled_first_party_pack_id(&pack.id) {
             return Err(SemanticPackLoadError::DuplicatePackId {
                 id: pack.id,
                 first_path: None,
@@ -1348,6 +1390,23 @@ mod tests {
         assert_eq!(pack.id, FIRST_PARTY_PACK_ID);
         assert_eq!(pack.hash, stable_symbol_hash(FIRST_PARTY_PACK_ID));
         assert_eq!(pack.influence, SemanticPackInfluence::EvidenceAndContracts);
+        let python = python_stdlib_type_domain_pack();
+        assert_eq!(python.id, PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID);
+        assert_eq!(
+            python.hash,
+            stable_symbol_hash(PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID)
+        );
+        assert_eq!(python.kind, SemanticPackKind::StdlibPack);
+        assert_eq!(
+            python.influence,
+            SemanticPackInfluence::EvidenceAndContracts
+        );
+        assert_eq!(python.counts.evidence_producers, 1);
+        assert_eq!(python.counts.contracts, 1);
+        assert_eq!(
+            python.counts.positive_fixtures,
+            PYTHON_STDLIB_TYPE_DOMAIN_ALIAS_CONTRACTS.len()
+        );
     }
 
     #[test]
@@ -1356,8 +1415,9 @@ mod tests {
         let path = dir.join("pack.json");
         fs::write(&path, manifest("com.example.pack")).unwrap();
         let set = SemanticPackSet::new_local(&[path]).expect("pack loads");
-        assert_eq!(set.packs().len(), 2);
-        let external = &set.packs()[1];
+        assert_eq!(set.packs().len(), 3);
+        assert_eq!(set.packs()[1].id, PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID);
+        let external = &set.packs()[2];
         assert_eq!(external.id, "com.example.pack");
         assert_eq!(external.hash, stable_symbol_hash("com.example.pack"));
         assert_eq!(external.trust, PackTrust::ExternalOptIn);
@@ -1574,6 +1634,26 @@ mod tests {
         fs::write(&one, manifest("com.example.pack")).unwrap();
         fs::write(&two, manifest("com.example.pack")).unwrap();
         let err = SemanticPackSet::new_local(&[one, two]).expect_err("duplicate id");
+        assert!(err.to_string().contains("duplicate semantic pack id"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn local_manifest_cannot_claim_compiled_first_party_pack_id() {
+        let dir = unique_dir("compiled_first_party_id");
+        let path = dir.join("pack.json");
+        fs::write(&path, manifest(PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID)).unwrap();
+        let err = SemanticPackSet::new_local(&[path]).expect_err("compiled id is reserved");
+        assert!(err.to_string().contains("duplicate semantic pack id"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn conformance_check_cannot_claim_compiled_first_party_pack_id() {
+        let dir = unique_dir("compiled_first_party_conformance");
+        let path = dir.join("pack.json");
+        fs::write(&path, manifest(PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID)).unwrap();
+        let err = check_semantic_pack_conformance(&[path]).expect_err("compiled id is reserved");
         assert!(err.to_string().contains("duplicate semantic pack id"));
         let _ = fs::remove_dir_all(dir);
     }

--- a/crates/nose-semantics/src/tests/semantic_evidence.rs
+++ b/crates/nose-semantics/src/tests/semantic_evidence.rs
@@ -227,6 +227,37 @@ fn type_domain_contracts_are_language_scoped_and_exact_enough() {
         type_domain_from_source_text(Lang::Go, "type User struct { id int }"),
         Some(DomainEvidence::Record)
     );
+
+    let iterable = python_stdlib_type_domain_contract("typing", "Iterable")
+        .expect("typing.Iterable should be a first-party pack row");
+    assert_eq!(iterable.pack_id, PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID);
+    assert_eq!(iterable.producer_id, PYTHON_STDLIB_TYPE_DOMAIN_PRODUCER_ID);
+    assert_eq!(iterable.domain, DomainEvidence::Iterable);
+    assert_eq!(
+        python_stdlib_type_domain("collections.abc", "Mapping"),
+        Some(DomainEvidence::Map)
+    );
+    assert_eq!(
+        python_stdlib_type_domain("collections.abc", "Awaitable"),
+        Some(DomainEvidence::FutureLike)
+    );
+    assert_eq!(
+        python_stdlib_type_domain("asyncio", "Future"),
+        Some(DomainEvidence::FutureLike)
+    );
+    assert_eq!(python_stdlib_type_domain("typing", "Blacklist"), None);
+    assert_eq!(python_stdlib_type_domain("typing", "Future"), None);
+    assert_eq!(python_stdlib_type_domain("collections.abc", "Dict"), None);
+    assert_eq!(
+        python_stdlib_type_domain("collections.abc", "FrozenSet"),
+        None
+    );
+    assert_eq!(python_stdlib_type_domain("collections.abc", "Deque"), None);
+    assert_eq!(python_stdlib_type_domain("collections.abc", "List"), None);
+    assert_eq!(python_stdlib_type_domain("collections.abc", "Tuple"), None);
+    assert_eq!(python_stdlib_type_domain("asyncio", "Awaitable"), None);
+    assert_eq!(python_stdlib_type_domain("asyncio", "Coroutine"), None);
+    assert_eq!(python_stdlib_type_domain("custom.typing", "Iterable"), None);
 }
 
 #[test]

--- a/crates/nose-semantics/src/type_domain.rs
+++ b/crates/nose-semantics/src/type_domain.rs
@@ -1,5 +1,294 @@
 use nose_il::{DomainEvidence, Lang};
 
+pub const PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID: &str = "nose.python.stdlib.type_domain";
+pub const PYTHON_STDLIB_TYPE_DOMAIN_PRODUCER_ID: &str = "python.stdlib.type-domain-alias-domain";
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct FirstPartyTypeDomainAliasContract {
+    pub pack_id: &'static str,
+    pub producer_id: &'static str,
+    pub contract_id: &'static str,
+    pub module: &'static str,
+    pub exported: &'static str,
+    pub domain: DomainEvidence,
+    pub positive_fixture: &'static str,
+    pub hard_negative_fixture: &'static str,
+}
+
+pub const PYTHON_STDLIB_TYPE_DOMAIN_ALIAS_CONTRACTS: &[FirstPartyTypeDomainAliasContract] = &[
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "Dict",
+        DomainEvidence::Map,
+        "python-typing-dict-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "Mapping",
+        DomainEvidence::Map,
+        "python-typing-mapping-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "MutableMapping",
+        DomainEvidence::Map,
+        "python-typing-mutablemapping-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "Mapping",
+        DomainEvidence::Map,
+        "python-collections-abc-mapping-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "MutableMapping",
+        DomainEvidence::Map,
+        "python-collections-abc-mutablemapping-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "Iterable",
+        DomainEvidence::Iterable,
+        "python-typing-iterable-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "AsyncIterable",
+        DomainEvidence::Iterable,
+        "python-typing-asynciterable-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "Iterable",
+        DomainEvidence::Iterable,
+        "python-collections-abc-iterable-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "AsyncIterable",
+        DomainEvidence::Iterable,
+        "python-collections-abc-asynciterable-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "Iterator",
+        DomainEvidence::Iterator,
+        "python-typing-iterator-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "AsyncIterator",
+        DomainEvidence::Iterator,
+        "python-typing-asynciterator-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "Iterator",
+        DomainEvidence::Iterator,
+        "python-collections-abc-iterator-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "AsyncIterator",
+        DomainEvidence::Iterator,
+        "python-collections-abc-asynciterator-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "FrozenSet",
+        DomainEvidence::Set,
+        "python-typing-frozenset-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "MutableSet",
+        DomainEvidence::Set,
+        "python-typing-mutableset-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "Set",
+        DomainEvidence::Set,
+        "python-typing-set-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "MutableSet",
+        DomainEvidence::Set,
+        "python-collections-abc-mutableset-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "Set",
+        DomainEvidence::Set,
+        "python-collections-abc-set-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "Optional",
+        DomainEvidence::Option,
+        "python-typing-optional-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "TypedDict",
+        DomainEvidence::Record,
+        "python-typing-typeddict-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "Awaitable",
+        DomainEvidence::FutureLike,
+        "python-typing-awaitable-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "Coroutine",
+        DomainEvidence::FutureLike,
+        "python-typing-coroutine-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "Awaitable",
+        DomainEvidence::FutureLike,
+        "python-collections-abc-awaitable-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "Coroutine",
+        DomainEvidence::FutureLike,
+        "python-collections-abc-coroutine-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "asyncio",
+        "Future",
+        DomainEvidence::FutureLike,
+        "python-asyncio-future-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "Collection",
+        DomainEvidence::Collection,
+        "python-typing-collection-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "Container",
+        DomainEvidence::Collection,
+        "python-typing-container-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "Deque",
+        DomainEvidence::Collection,
+        "python-typing-deque-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "List",
+        DomainEvidence::Collection,
+        "python-typing-list-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "MutableSequence",
+        DomainEvidence::Collection,
+        "python-typing-mutablesequence-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "Sequence",
+        DomainEvidence::Collection,
+        "python-typing-sequence-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "typing",
+        "Tuple",
+        DomainEvidence::Collection,
+        "python-typing-tuple-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "Collection",
+        DomainEvidence::Collection,
+        "python-collections-abc-collection-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "Container",
+        DomainEvidence::Collection,
+        "python-collections-abc-container-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "MutableSequence",
+        DomainEvidence::Collection,
+        "python-collections-abc-mutablesequence-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+    python_stdlib_type_domain_alias_contract(
+        "collections.abc",
+        "Sequence",
+        DomainEvidence::Collection,
+        "python-collections-abc-sequence-domain-positive",
+        "python-typing-alias-rebound-hard-negative",
+    ),
+];
+
+const fn python_stdlib_type_domain_alias_contract(
+    module: &'static str,
+    exported: &'static str,
+    domain: DomainEvidence,
+    positive_fixture: &'static str,
+    hard_negative_fixture: &'static str,
+) -> FirstPartyTypeDomainAliasContract {
+    FirstPartyTypeDomainAliasContract {
+        pack_id: PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID,
+        producer_id: PYTHON_STDLIB_TYPE_DOMAIN_PRODUCER_ID,
+        contract_id: "python.stdlib.type-domain-alias.contract",
+        module,
+        exported,
+        domain,
+        positive_fixture,
+        hard_negative_fixture,
+    }
+}
+
 pub fn type_domain_from_source_text(lang: Lang, text: &str) -> Option<DomainEvidence> {
     match lang {
         Lang::TypeScript => ts_type_domain(text),
@@ -12,55 +301,19 @@ pub fn type_domain_from_source_text(lang: Lang, text: &str) -> Option<DomainEvid
     }
 }
 
-pub fn python_stdlib_type_domain(module: &str, exported: &str) -> Option<DomainEvidence> {
+pub fn python_stdlib_type_domain_contract(
+    module: &str,
+    exported: &str,
+) -> Option<&'static FirstPartyTypeDomainAliasContract> {
     let module = module.trim();
     let exported = exported.trim();
-    if matches!(module, "typing" | "collections.abc")
-        && matches!(exported, "Dict" | "Mapping" | "MutableMapping")
-    {
-        return Some(DomainEvidence::Map);
-    }
-    if matches!(module, "typing" | "collections.abc")
-        && matches!(exported, "Iterable" | "AsyncIterable")
-    {
-        return Some(DomainEvidence::Iterable);
-    }
-    if matches!(module, "typing" | "collections.abc")
-        && matches!(exported, "Iterator" | "AsyncIterator")
-    {
-        return Some(DomainEvidence::Iterator);
-    }
-    if matches!(module, "typing" | "collections.abc")
-        && matches!(exported, "FrozenSet" | "MutableSet" | "Set")
-    {
-        return Some(DomainEvidence::Set);
-    }
-    if matches!(module, "typing") && matches!(exported, "Optional") {
-        return Some(DomainEvidence::Option);
-    }
-    if matches!(module, "typing") && matches!(exported, "TypedDict") {
-        return Some(DomainEvidence::Record);
-    }
-    if matches!(module, "typing" | "asyncio")
-        && matches!(exported, "Awaitable" | "Coroutine" | "Future")
-    {
-        return Some(DomainEvidence::FutureLike);
-    }
-    if matches!(module, "typing" | "collections.abc")
-        && matches!(
-            exported,
-            "Collection"
-                | "Container"
-                | "Deque"
-                | "List"
-                | "MutableSequence"
-                | "Sequence"
-                | "Tuple"
-        )
-    {
-        return Some(DomainEvidence::Collection);
-    }
-    None
+    PYTHON_STDLIB_TYPE_DOMAIN_ALIAS_CONTRACTS
+        .iter()
+        .find(|row| row.module == module && row.exported == exported)
+}
+
+pub fn python_stdlib_type_domain(module: &str, exported: &str) -> Option<DomainEvidence> {
+    python_stdlib_type_domain_contract(module, exported).map(|row| row.domain)
 }
 
 fn ts_type_domain(text: &str) -> Option<DomainEvidence> {

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -204,9 +204,10 @@ container/protocol domains (`Array`, `Collection`, `Iterable`, `Iterator`,
 `PromiseLike`, `FutureLike`), scalar domains (`String`, `Boolean`, `Integer`,
 `Float`, `Number`, `ByteArray`), and a hashed `Nominal` domain for
 provider-proven user/library types. The frontend owns evidence emission and
-alias lifecycle: for example, Python `typing`/`collections.abc` aliases record
-dependency-backed parameter `Domain` evidence that depends on the corresponding
-`ImportedBinding` symbol evidence, and a rebound alias closes that path.
+alias lifecycle: for example, Python `typing`, `collections.abc`, and `asyncio`
+aliases record dependency-backed parameter `Domain` evidence that depends on the
+corresponding `ImportedBinding` symbol evidence, and a rebound alias closes that
+path.
 `Type(NominalDomain)` rows can map a scoped nominal type hash to a domain, but
 type names alone are not proof; the dependent `Domain` record still needs a
 valid symbol/import/scope chain. `nose-semantics` resolves `Domain` evidence on

--- a/docs/examples/semantic-packs/v0/fixtures/python/typing_domain_positive.py
+++ b/docs/examples/semantic-packs/v0/fixtures/python/typing_domain_positive.py
@@ -1,0 +1,5 @@
+from typing import Iterable as Values
+
+
+def f(values: Values[int]):
+    return values

--- a/docs/examples/semantic-packs/v0/fixtures/python/typing_domain_rebound.py
+++ b/docs/examples/semantic-packs/v0/fixtures/python/typing_domain_rebound.py
@@ -1,0 +1,7 @@
+from typing import Iterable as Values
+
+Values = object
+
+
+def f(values: Values[int]):
+    return values

--- a/docs/examples/semantic-packs/v0/fixtures/python/typing_domain_wrong_module.py
+++ b/docs/examples/semantic-packs/v0/fixtures/python/typing_domain_wrong_module.py
@@ -1,0 +1,5 @@
+from project.typing import Iterable as Values
+
+
+def f(values: Values[int]):
+    return values

--- a/docs/examples/semantic-packs/v0/python-typing-domain-pack.json
+++ b/docs/examples/semantic-packs/v0/python-typing-domain-pack.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "../../../schemas/semantic-pack-v0.schema.json",
+  "api_version": "nose.semantic-pack.v0",
+  "pack": {
+    "id": "com.example.python-typing-domain",
+    "kind": "StdlibPack",
+    "version": "0.1.0",
+    "display_name": "Example Python stdlib type-domain pack",
+    "description": "Illustrative v0 metadata mirroring nose's compiled first-party Python typing, collections.abc, and asyncio type-domain pilot. Loading this example is metadata-only.",
+    "trust": "external-opt-in",
+    "enabled_by_default": false,
+    "status": "draft-example"
+  },
+  "provenance": {
+    "provider": {
+      "name": "Example Semantic Packs",
+      "contact": "semantics@example.invalid"
+    },
+    "license": "MIT",
+    "repository": "https://example.invalid/semantic-packs/python-typing-domain",
+    "source_revision": "0000000000000000000000000000000000000000"
+  },
+  "compatibility": {
+    "nose": ">=0.5.0 <0.6.0",
+    "schema": "v0",
+    "notes": "Example only. nose's built-in pilot uses compiled first-party code and reports as nose.python.stdlib.type_domain."
+  },
+  "supported_languages": [
+    {
+      "id": "python",
+      "language_version": ">=3.8",
+      "runtime": "cpython",
+      "runtime_versions": [
+        ">=3.8"
+      ]
+    }
+  ],
+  "packages": [
+    {
+      "ecosystem": "python-stdlib",
+      "name": "typing",
+      "versions": ">=3.8",
+      "stdlib": true
+    },
+    {
+      "ecosystem": "python-stdlib",
+      "name": "collections.abc",
+      "versions": ">=3.8",
+      "stdlib": true
+    },
+    {
+      "ecosystem": "python-stdlib",
+      "name": "asyncio",
+      "versions": ">=3.8",
+      "stdlib": true
+    }
+  ],
+  "declares": {
+    "evidence_producers": [
+      {
+        "id": "python.stdlib.type-domain-alias-domain",
+        "kind": "Domain.TypeAlias",
+        "anchors": [
+          "param"
+        ],
+        "channel": "exact-empirical",
+        "emits": [
+          "Domain.Collection",
+          "Domain.Iterable",
+          "Domain.Iterator",
+          "Domain.Map",
+          "Domain.Option",
+          "Domain.Record",
+          "Domain.Set",
+          "Domain.FutureLike"
+        ],
+        "requires": [
+          {
+            "ref": "Symbol.ImportedBinding",
+            "subject": "annotation.alias",
+            "required": true,
+            "within_scope": "parameter"
+          }
+        ],
+        "stable_hash_inputs": [
+          "api_version",
+          "pack.id",
+          "producer.id",
+          "language.id",
+          "module_name",
+          "exported_name",
+          "local_alias_hash",
+          "param_span",
+          "dependency_ids"
+        ],
+        "conflict_policy": "fail-closed",
+        "notes": "The producer maps exact imported stdlib typing aliases to Domain evidence. Rebound aliases and same-named local classes do not satisfy the requirement."
+      }
+    ],
+    "contracts": [
+      {
+        "id": "python.stdlib.type-domain-alias.contract",
+        "surface": {
+          "kind": "imported-type-domain-alias",
+          "language": "python",
+          "packages": [
+            "typing",
+            "collections.abc",
+            "asyncio"
+          ],
+          "anchor": "param"
+        },
+        "requires": [
+          {
+            "ref": "python.stdlib.type-domain-alias-domain",
+            "subject": "parameter.annotation",
+            "required": true,
+            "same_anchor_as": "param"
+          },
+          {
+            "ref": "Symbol.ImportedBinding",
+            "subject": "annotation.alias",
+            "required": true,
+            "within_scope": "parameter"
+          }
+        ],
+        "semantics": {
+          "operation": "TypeDomain.AliasToDomain",
+          "result_domain": "Domain",
+          "demand": {
+            "arguments": "not-applicable",
+            "callbacks": "none"
+          },
+          "effects": [
+            "no-runtime-effect"
+          ],
+          "exceptions": "none",
+          "mutation": "does-not-mutate-runtime-values",
+          "identity": "no-runtime-identity-claim"
+        },
+        "channel": "exact-empirical",
+        "proof_status": "covered",
+        "conformance_refs": [
+          "python-typing-domain-positive",
+          "python-typing-domain-rebound-hard-negative",
+          "python-typing-domain-wrong-module-hard-negative"
+        ],
+        "known_unsupported": [
+          "This contract does not implement a Python type checker.",
+          "Subscript element types are not interpreted; only the imported alias surface maps to a coarse Domain fact."
+        ],
+        "notes": "A type alias is evidence for a receiver/value domain only when import proof and alias lifetime are both present."
+      }
+    ],
+    "value_laws": []
+  },
+  "conformance": {
+    "positive_fixtures": [
+      {
+        "id": "python-typing-domain-positive",
+        "description": "A dependency-backed imported typing alias can emit parameter Domain evidence.",
+        "path": "fixtures/python/typing_domain_positive.py",
+        "expectation": "domain-evidence-present"
+      }
+    ],
+    "hard_negatives": [
+      {
+        "id": "python-typing-domain-rebound-hard-negative",
+        "description": "A rebound typing alias must not emit Domain evidence for later annotations.",
+        "path": "fixtures/python/typing_domain_rebound.py",
+        "expectation": "domain-evidence-closed"
+      },
+      {
+        "id": "python-typing-domain-wrong-module-hard-negative",
+        "description": "A same-named alias from a non-stdlib module must not satisfy the Python stdlib typing contract.",
+        "path": "fixtures/python/typing_domain_wrong_module.py",
+        "expectation": "domain-evidence-closed"
+      }
+    ],
+    "known_unsupported": [
+      "The example manifest is metadata-only when loaded locally.",
+      "The compiled first-party pilot currently covers selected typing, collections.abc, and asyncio alias rows."
+    ],
+    "command": "nose semantic-pack check python-typing-domain-pack.json --format json"
+  }
+}

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -42,6 +42,30 @@ The top-level value is always an object:
         "positive_fixtures": 0,
         "hard_negatives": 0
       }
+    },
+    {
+      "id": "nose.python.stdlib.type_domain",
+      "hash": "783a582a461f58f3",
+      "kind": "StdlibPack",
+      "version": "<version>",
+      "display_name": "nose Python stdlib type-domain pack",
+      "trust": "default-first-party",
+      "enabled_by_default": true,
+      "source": "compiled-first-party",
+      "influence": "evidence-and-contracts",
+      "provider": "Corca, Inc.",
+      "repository": "https://github.com/corca-ai/nose",
+      "license": "MIT",
+      "supported_languages": [
+        "python"
+      ],
+      "counts": {
+        "evidence_producers": 1,
+        "contracts": 1,
+        "value_laws": 0,
+        "positive_fixtures": 36,
+        "hard_negatives": 2
+      }
     }
   ],
   "ranking": {
@@ -90,7 +114,7 @@ source metadata.
 | `tool_version` | string | The `nose` package version that emitted the report. |
 | `scope.files` | integer | Number of supported source files scanned after ignores and excludes. |
 | `scope.languages` | array | Per-language file counts, largest first. |
-| `semantic_packs` | array, optional in v1 | Active semantic packs for this scan. Binaries that advertise `scan.capabilities.semantic_pack_loading` in [capabilities](capabilities.md) emit it and include compiled `nose.first_party`; local `--semantic-pack`/config packs are listed with `metadata-only` influence. Older v1 binaries omit this field. |
+| `semantic_packs` | array, optional in v1 | Active semantic packs for this scan. Binaries that advertise `scan.capabilities.semantic_pack_loading` in [capabilities](capabilities.md) emit it and include compiled first-party packs such as `nose.first_party` and `nose.python.stdlib.type_domain`; local `--semantic-pack`/config packs are listed with `metadata-only` influence. Older v1 binaries omit this field. |
 | `ranking.sort` | string | Sort key used for `families`: `extractability` (default), `value`, `sites`, or `hazard`. |
 | `ranking.total_families` | integer | Active families remaining after rank-time pruning, filters, baseline suppression, and structured ignores, before `--top`. |
 | `ranking.shown_families` | integer | Families present in `families`. |
@@ -118,10 +142,10 @@ When `semantic_packs` is present, each entry has:
 | `id` | string | Stable manifest pack id. |
 | `hash` | string | Stable 16-hex-digit hash derived from the pack id; first-party evidence provenance uses the same id-hash policy. |
 | `kind` | string | `LanguagePack`, `StdlibPack`, `LibraryPack`, `ProtocolPack`, or `LawPack`. |
-| `version` | string | Pack version from the manifest or the nose package version for `nose.first_party`. |
+| `version` | string | Pack version from the manifest or the nose package version for compiled first-party packs. |
 | `display_name` | string | Human-readable pack name. |
 | `trust` | string | `default-first-party`, `first-party-optional`, or `external-opt-in`. Local manifests are rejected unless they use `external-opt-in`; first-party trust comes only from compiled packs. |
-| `enabled_by_default` | boolean | Whether the pack is default-enabled. Local manifests are rejected unless this is `false`; compiled `nose.first_party` reports `true`. |
+| `enabled_by_default` | boolean | Whether the pack is default-enabled. Local manifests are rejected unless this is `false`; compiled first-party packs report `true`. |
 | `source` | string | `compiled-first-party` or `local-manifest`. |
 | `influence` | string | `evidence-and-contracts` for compiled first-party semantics, `metadata-only` for loaded local external packs today. |
 | `path` | string, optional | Local manifest path for loaded manifests. |

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -87,10 +87,16 @@ and pack ecosystem.
 - The common parameter-type substring recognizer moved behind first-party,
   language-scoped type-domain contracts in `nose-semantics`. Frontends now emit
   parameter `Domain` evidence from those contracts, while imported Python
-  `typing`/`collections.abc` aliases carry `ImportedBinding` dependencies and
-  rebound aliases close the path. `ParamSemantic` remains a compatibility
-  vocabulary in tests and lower-level helpers, not the producer boundary for
-  newly emitted parameter-domain facts.
+  `typing`, `collections.abc`, and `asyncio` aliases carry `ImportedBinding`
+  dependencies and rebound aliases close the path. `ParamSemantic` remains a
+  compatibility vocabulary in tests and lower-level helpers, not the producer
+  boundary for newly emitted parameter-domain facts.
+- The first first-party pack pilot moved Python stdlib type-domain aliases from
+  a raw helper table into a pack-shaped contract row set. Imported
+  `typing`, `collections.abc`, and `asyncio` alias-derived `Domain` evidence now
+  reports `nose.python.stdlib.type_domain` provenance while preserving
+  shadow/rebind hard negatives and metadata-only behavior for local external
+  manifests.
 - Rust scalar integer methods (`abs`, `min`, `max`, `clamp`) now consume a
   language-, signature-, and integer-domain-constrained first-party contract
   instead of a bare method-name recognizer. Float/NaN-sensitive methods remain a
@@ -667,6 +673,9 @@ and pack ecosystem.
   domain foundation and opens the next tranche around first-party pack pilots,
   broader producer coverage, richer demand/effect contracts, and pack-facing
   value-law provenance.
+- The first first-party pack pilot moved Python stdlib type-domain aliases from
+  a raw helper table into a pack-shaped contract row set with active
+  `nose.python.stdlib.type_domain` provenance.
 
 ## Phase 0: documentation and vocabulary (landed)
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -84,7 +84,10 @@ still being migrated toward it.
   provenance reporting, `nose scan --format json` reports active packs, and
   `nose semantic-pack check` validates local manifests plus declared fixture
   assets. External packs are still `metadata-only`; first-party producers remain
-  compiled Rust and are expected to map onto the same vocabulary.
+  compiled Rust and are expected to map onto the same vocabulary. The first
+  compiled pilot is `nose.python.stdlib.type_domain`, a default first-party
+  stdlib pack-shaped surface for Python `typing`, `collections.abc`, and
+  `asyncio` type-domain alias evidence.
 - `nose-frontend` owns tree-sitter parsing, per-language lowering, embedded
   `<script>` extraction, source/domain/import/symbol/type/guard/place/effect/API/
   sequence evidence emission, and Raw-node coverage.
@@ -211,8 +214,12 @@ migrated.
   annotation text is ignored before array/varargs recognition, Rust fully
   qualified `std::collections` paths are covered, and C pointer parameters do
   not inherit scalar integer domains. Python imported type aliases from
-  `typing`/`collections.abc` carry `ImportedBinding` symbol-evidence
-  dependencies, and rebound aliases stop emitting parameter-domain evidence.
+  `typing`, `collections.abc`, and `asyncio` carry `ImportedBinding`
+  symbol-evidence dependencies, and rebound aliases stop emitting
+  parameter-domain evidence.
+  Imported Python stdlib alias-derived `Domain` evidence now carries
+  `nose.python.stdlib.type_domain` pack provenance, making this the first
+  compiled first-party pack-shaped pilot surface.
   `nose-semantics` resolves receiver-domain evidence through a shared
   `DomainRequirement` contract. Consumers check exact receiver node evidence
   first, then immutable binding evidence for local or module variables, then

--- a/docs/semantic-kernel-tranche-closeout-2026-06-09.md
+++ b/docs/semantic-kernel-tranche-closeout-2026-06-09.md
@@ -72,7 +72,8 @@ broaden producer coverage without reopening the old raw fallbacks.
 Start #166 first. A small first-party pack pilot is the best pressure test for
 the API, loading, conformance, provenance, and evidence vocabulary already
 landed. It should use compiled first-party execution and preserve current exact
-behavior.
+behavior. The first pilot target is Python stdlib type-domain aliases from
+`typing`, `collections.abc`, and `asyncio`.
 
 Run #149 in parallel with #166 when two workers are available. It lowers the
 cost of the next semantic tranche by splitting broad files and ratcheting quality

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -42,7 +42,10 @@ The harness does not:
 
 First-party default packs are different. nose owns their tests, hard negatives,
 proof obligations, release gates, and documentation because those packs ship with
-the binary and affect exact analysis by default.
+the binary and affect exact analysis by default. The Python stdlib type-domain
+example manifest mirrors the first compiled first-party pilot pack, but local
+copies of that manifest still load only as external metadata unless nose ships
+the pack as compiled first-party code.
 
 ## Command
 
@@ -59,10 +62,10 @@ JSON children only, sorted by filename, no recursion, no registry, and no networ
 Relative fixture paths are resolved from the manifest's directory.
 
 The command exits non-zero when any manifest is invalid, when pack ids collide
-with each other or `nose.first_party`, or when declared conformance fixtures are
-missing a path, missing an expectation, or point at a file that does not exist.
-For `--format json`, the command still writes the report before returning the
-non-zero exit.
+with each other or any compiled first-party pack id, or when declared conformance
+fixtures are missing a path, missing an expectation, or point at a file that does
+not exist. For `--format json`, the command still writes the report before
+returning the non-zero exit.
 
 ## JSON Report
 

--- a/docs/semantic-pack-extension-api-v0.md
+++ b/docs/semantic-pack-extension-api-v0.md
@@ -12,6 +12,7 @@ Schema artifacts:
 - [semantic-pack-v0 schema](schemas/semantic-pack-v0.schema.json)
 - [language-pack example](examples/semantic-packs/v0/language-pack.json)
 - [library-pack example](examples/semantic-packs/v0/library-pack.json)
+- [Python stdlib type-domain pack example](examples/semantic-packs/v0/python-typing-domain-pack.json)
 - [semantic-pack-conformance](semantic-pack-conformance.md)
 - [semantic-pack-loading](semantic-pack-loading.md)
 
@@ -19,8 +20,10 @@ Status: design v0 plus local metadata loading and a local conformance harness.
 nose can load local manifests for explicit opt-in provenance reporting, and pack
 authors can run `nose semantic-pack check` against manifests and declared fixture
 assets. External packs are still `metadata-only`: they do not emit evidence or
-open exact contracts. This page defines the extension surface that first-party
-compiled packs and future external packs must use.
+open exact contracts. The first compiled first-party pilot pack now reports
+Python `typing`, `collections.abc`, and `asyncio` stdlib type-domain alias
+evidence through this vocabulary. This page defines the extension surface that
+first-party compiled packs and future external packs must use.
 
 ## Context
 
@@ -103,6 +106,9 @@ producer runtime may feed compatible rows into kernel helpers only after the sam
 fail-closed evidence obligations are satisfied. First-party compiled packs can
 generate the same manifest metadata for reports and conformance gates while
 still emitting facts from Rust.
+The Python stdlib type-domain example mirrors the first compiled first-party pilot
+surface; loading that example locally remains metadata-only because local
+manifests cannot claim first-party trust.
 
 ## Pack Kinds
 

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -52,8 +52,11 @@ external producers or certify semantic correctness. See
 
 Trust is separate from channel eligibility.
 
-- The compiled first-party pack `nose.first_party` is enabled by default and is
-  the only pack that currently influences evidence and contracts.
+- Compiled first-party packs are enabled by default and are the only packs that
+  currently influence evidence and contracts. `nose.first_party` is the core
+  kernel facade; `nose.python.stdlib.type_domain` is the first narrow stdlib
+  pilot pack for Python `typing`, `collections.abc`, and `asyncio`
+  type-domain aliases.
 - Local external packs require explicit user opt-in through CLI or config.
 - Local manifests must declare `trust = "external-opt-in"` and
   `enabled_by_default = false`; manifests that claim first-party trust or default


### PR DESCRIPTION
## Summary
- add compiled first-party stdlib pack `nose.python.stdlib.type_domain` for exact Python imported type-domain alias rows
- route `typing`, `collections.abc`, and `asyncio` imported aliases through pack-shaped contract data with pack-level evidence provenance
- keep local external manifests metadata-only, reject compiled first-party pack id collisions, and update scan JSON/docs/example conformance fixtures

## Validation
- `cargo test -p nose-semantics -p nose-frontend -p nose-normalize -p nose-detect -p nose-cli`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `awiki lint --root docs`
- `git diff --check`
- `cargo run -p nose-cli -- semantic-pack check docs/examples/semantic-packs/v0/python-typing-domain-pack.json --format json`

Closes #166