### PR TITLE
[codex] Produce imported call-target evidence

### DIFF
--- a/crates/nose-detect/src/strict_exact.rs
+++ b/crates/nose-detect/src/strict_exact.rs
@@ -1667,6 +1667,7 @@ mod tests {
         EvidenceKind, EvidenceProvenance, EvidenceRecord, EvidenceStatus, FileId, FileMeta,
         IlBuilder, Lang, LibraryApiEvidenceKind, Span, Unit, UnitKind,
     };
+    use nose_normalize::{normalize, NormalizeOptions};
     use nose_semantics::{
         library_api_callee_contract_hash, library_api_contract_id_hash, library_map_get_contract,
         library_method_call_contract, FIRST_PARTY_PACK_ID,
@@ -1674,6 +1675,35 @@ mod tests {
 
     fn sp(line: u32) -> Span {
         Span::new(FileId(0), line, line, line, line)
+    }
+
+    fn normalized_python(src: &str, interner: &Interner) -> Il {
+        let raw =
+            nose_frontend::lower_source(FileId(0), "t.py", src.as_bytes(), Lang::Python, interner)
+                .expect("lower python source");
+        normalize(&raw, interner, &NormalizeOptions::default())
+    }
+
+    fn first_call_with_target(
+        il: &Il,
+        interner: &Interner,
+        target_matches: impl Fn(CallTargetEvidenceKind) -> bool,
+    ) -> NodeId {
+        il.nodes
+            .iter()
+            .enumerate()
+            .find_map(|(idx, node)| {
+                if node.kind != NodeKind::Call {
+                    return None;
+                }
+                let call = NodeId(idx as u32);
+                matches!(
+                    call_target_evidence_status_at_call(il, interner, call),
+                    CallTargetEvidenceStatus::Admitted(target) if target_matches(target)
+                )
+                .then_some(call)
+            })
+            .expect("admitted call-target call")
     }
 
     fn evidence(
@@ -2081,6 +2111,53 @@ mod tests {
             },
             Vec::new(),
         ));
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(strict_exact_safe_tree(&il, &interner, &facts, call));
+    }
+
+    #[test]
+    fn normalized_imported_function_call_target_opens_opaque_exact_identity() {
+        let interner = Interner::new();
+        let il = normalized_python(
+            "from acme.ops import transform as tx\n\ndef f(x):\n    return tx(x)\n",
+            &interner,
+        );
+        let call = first_call_with_target(&il, &interner, |target| {
+            matches!(
+                target,
+                CallTargetEvidenceKind::ImportedFunction {
+                    module_hash,
+                    exported_hash,
+                    ..
+                } if module_hash == stable_symbol_hash("acme.ops")
+                    && exported_hash == stable_symbol_hash("transform")
+            )
+        });
+
+        let facts = StrictFacts::collect(&il, &interner);
+        assert!(strict_exact_safe_tree(&il, &interner, &facts, call));
+    }
+
+    #[test]
+    fn normalized_imported_namespace_member_target_opens_static_member_identity() {
+        let interner = Interner::new();
+        let il = normalized_python(
+            "import acme.ops as ops\n\ndef f(x):\n    return ops.transform(x)\n",
+            &interner,
+        );
+        let call = first_call_with_target(&il, &interner, |target| {
+            matches!(
+                target,
+                CallTargetEvidenceKind::ImportedMember {
+                    module_hash,
+                    exported_hash,
+                    member_hash,
+                } if module_hash == stable_symbol_hash("acme.ops")
+                    && exported_hash == stable_symbol_hash("transform")
+                    && member_hash == stable_symbol_hash("transform")
+            )
+        });
+
         let facts = StrictFacts::collect(&il, &interner);
         assert!(strict_exact_safe_tree(&il, &interner, &facts, call));
     }

--- a/crates/nose-normalize/src/call_target_evidence.rs
+++ b/crates/nose-normalize/src/call_target_evidence.rs
@@ -2,16 +2,23 @@
 //!
 //! Consumers must not resolve user calls from raw spelling. This pass is the
 //! narrow boundary where the lowered file's binding shape is checked and a
-//! direct in-file callable target is materialized as evidence.
+//! direct in-file or imported callable target is materialized as evidence.
 
 use nose_il::{
-    CallTargetEvidenceKind, EvidenceAnchor, EvidenceKind, Il, Interner, LoopKind, NodeId, NodeKind,
-    Payload, Symbol, UnitKind,
+    CallTargetEvidenceKind, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
+    EvidenceProvenance, EvidenceRecord, EvidenceStatus, Il, Interner, LoopKind, NodeId, NodeKind,
+    Payload, Symbol, SymbolEvidenceKind, UnitKind,
 };
-use nose_semantics::FIRST_PARTY_PACK_ID;
+use nose_semantics::{imported_occurrence_symbol_dependencies_valid, FIRST_PARTY_PACK_ID};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 const DIRECT_FUNCTION_RULE: &str = "normalize.call_target.direct_function";
+const IMPORTED_FUNCTION_RULE: &str = "normalize.call_target.imported_function";
+const IMPORTED_MEMBER_RULE: &str = "normalize.call_target.imported_member";
+const IMPORTED_BINDING_OCCURRENCE_RULE: &str =
+    "normalize.symbol_imported_binding_occurrence_for_call_target";
+const IMPORTED_NAMESPACE_OCCURRENCE_RULE: &str =
+    "normalize.symbol_imported_namespace_occurrence_for_call_target";
 
 #[derive(Clone, Copy)]
 struct DirectFunctionTarget {
@@ -19,23 +26,48 @@ struct DirectFunctionTarget {
     name_hash: u64,
 }
 
+#[derive(Clone, Copy)]
+struct ImportedFunctionTarget {
+    module_hash: u64,
+    exported_hash: u64,
+    local_hash: u64,
+    dependency: EvidenceId,
+}
+
+#[derive(Clone, Copy)]
+struct ImportedMemberTarget {
+    module_hash: u64,
+    exported_hash: u64,
+    member_hash: u64,
+    dependency: EvidenceId,
+}
+
+#[derive(Clone, Copy)]
+enum ImportedBindingUse {
+    FunctionCallee,
+    MemberReceiver,
+}
+
 pub(crate) fn run(il: &mut Il, interner: &Interner) {
     let targets = unique_direct_function_targets(il, interner);
-    if targets.is_empty() {
-        return;
-    }
+    let mut calls = Vec::new();
+    collect_call_nodes(il, il.root, &mut calls);
+
     let function_names = function_unit_names(il);
     let scope_bound = scope_bound_symbols(il, &function_names);
     let mut proven = Vec::new();
     let mut scope_stack = Vec::new();
-    collect_call_targets(
-        il,
-        il.root,
-        &mut scope_stack,
-        &targets,
-        &scope_bound,
-        &mut proven,
-    );
+    if !targets.is_empty() {
+        collect_call_targets(
+            il,
+            interner,
+            il.root,
+            &mut scope_stack,
+            &targets,
+            &scope_bound,
+            &mut proven,
+        );
+    }
     for (call, target) in proven {
         il.find_or_push_first_party_evidence(
             EvidenceAnchor::node(il.node(call).span, NodeKind::Call),
@@ -47,6 +79,9 @@ pub(crate) fn run(il: &mut Il, interner: &Interner) {
             DIRECT_FUNCTION_RULE,
             Vec::new(),
         );
+    }
+    for call in calls {
+        record_imported_call_target(il, interner, call);
     }
 }
 
@@ -192,6 +227,7 @@ fn collect_target_symbols(il: &Il, node: NodeId, out: &mut FxHashSet<Symbol>) {
 
 fn collect_call_targets(
     il: &Il,
+    interner: &Interner,
     node: NodeId,
     scope_stack: &mut Vec<NodeId>,
     targets: &FxHashMap<Symbol, DirectFunctionTarget>,
@@ -202,11 +238,12 @@ fn collect_call_targets(
     if entered_scope {
         scope_stack.push(node);
     }
-    if let Some(target) = direct_call_target(il, node, scope_stack, targets, scope_bound) {
+    if let Some(target) = direct_call_target(il, interner, node, scope_stack, targets, scope_bound)
+    {
         out.push((node, target));
     }
     for &child in il.children(node) {
-        collect_call_targets(il, child, scope_stack, targets, scope_bound, out);
+        collect_call_targets(il, interner, child, scope_stack, targets, scope_bound, out);
     }
     if entered_scope {
         scope_stack.pop();
@@ -215,6 +252,7 @@ fn collect_call_targets(
 
 fn direct_call_target(
     il: &Il,
+    interner: &Interner,
     node: NodeId,
     scope_stack: &[NodeId],
     targets: &FxHashMap<Symbol, DirectFunctionTarget>,
@@ -225,6 +263,9 @@ fn direct_call_target(
     }
     let callee = *il.children(node).first()?;
     if il.kind(callee) != NodeKind::Var {
+        return None;
+    }
+    if var_has_symbol_identity_evidence(il, interner, callee) {
         return None;
     }
     let Payload::Name(name) = il.node(callee).payload else {
@@ -240,6 +281,273 @@ fn direct_call_target(
     targets.get(&name).copied()
 }
 
+fn collect_call_nodes(il: &Il, node: NodeId, out: &mut Vec<NodeId>) {
+    if il.kind(node) == NodeKind::Call {
+        out.push(node);
+    }
+    for &child in il.children(node) {
+        collect_call_nodes(il, child, out);
+    }
+}
+
+fn record_imported_call_target(il: &mut Il, interner: &Interner, call: NodeId) {
+    if il.kind(call) != NodeKind::Call || !matches!(il.node(call).payload, Payload::None) {
+        return;
+    }
+    let Some(&callee) = il.children(call).first() else {
+        return;
+    };
+    match il.kind(callee) {
+        NodeKind::Var => {
+            if let Some(target) = imported_function_target(il, interner, callee) {
+                il.find_or_push_first_party_evidence(
+                    EvidenceAnchor::node(il.node(call).span, NodeKind::Call),
+                    EvidenceKind::CallTarget(CallTargetEvidenceKind::ImportedFunction {
+                        module_hash: target.module_hash,
+                        exported_hash: target.exported_hash,
+                        local_hash: target.local_hash,
+                    }),
+                    FIRST_PARTY_PACK_ID,
+                    IMPORTED_FUNCTION_RULE,
+                    vec![target.dependency],
+                );
+            }
+        }
+        NodeKind::Field => {
+            if let Some(target) = imported_member_target(il, interner, callee) {
+                il.find_or_push_first_party_evidence(
+                    EvidenceAnchor::node(il.node(call).span, NodeKind::Call),
+                    EvidenceKind::CallTarget(CallTargetEvidenceKind::ImportedMember {
+                        module_hash: target.module_hash,
+                        exported_hash: target.exported_hash,
+                        member_hash: target.member_hash,
+                    }),
+                    FIRST_PARTY_PACK_ID,
+                    IMPORTED_MEMBER_RULE,
+                    vec![target.dependency],
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+fn imported_function_target(
+    il: &mut Il,
+    interner: &Interner,
+    callee: NodeId,
+) -> Option<ImportedFunctionTarget> {
+    let local_hash = node_name_hash(il, interner, callee)?;
+    let (symbol, binding_dependency) =
+        unique_binding_symbol_for_var(il, interner, callee, ImportedBindingUse::FunctionCallee)?;
+    let SymbolEvidenceKind::ImportedBinding {
+        module_hash,
+        exported_hash,
+    } = symbol
+    else {
+        return None;
+    };
+    let dependency =
+        upsert_valid_imported_symbol_occurrence(il, interner, callee, symbol, binding_dependency)?;
+    Some(ImportedFunctionTarget {
+        module_hash,
+        exported_hash,
+        local_hash,
+        dependency,
+    })
+}
+
+fn imported_member_target(
+    il: &mut Il,
+    interner: &Interner,
+    callee: NodeId,
+) -> Option<ImportedMemberTarget> {
+    let Payload::Name(member) = il.node(callee).payload else {
+        return None;
+    };
+    let member_hash = interner.symbol_hash(member);
+    let receiver = *il.children(callee).first()?;
+    if il.kind(receiver) != NodeKind::Var {
+        return None;
+    }
+    let (symbol, binding_dependency) =
+        unique_binding_symbol_for_var(il, interner, receiver, ImportedBindingUse::MemberReceiver)?;
+    let dependency = upsert_valid_imported_symbol_occurrence(
+        il,
+        interner,
+        receiver,
+        symbol,
+        binding_dependency,
+    )?;
+    match symbol {
+        SymbolEvidenceKind::ImportedBinding {
+            module_hash,
+            exported_hash,
+        } => Some(ImportedMemberTarget {
+            module_hash,
+            exported_hash,
+            member_hash,
+            dependency,
+        }),
+        SymbolEvidenceKind::ImportedNamespace { module_hash } => Some(ImportedMemberTarget {
+            module_hash,
+            exported_hash: member_hash,
+            member_hash,
+            dependency,
+        }),
+        _ => None,
+    }
+}
+
+fn unique_binding_symbol_for_var(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    imported_use: ImportedBindingUse,
+) -> Option<(SymbolEvidenceKind, EvidenceId)> {
+    let local_hash = node_name_hash(il, interner, node)?;
+    let mut found = None;
+    for record in &il.evidence {
+        if !matches!(
+            record.anchor,
+            EvidenceAnchor::Binding {
+                local_hash: anchor_hash,
+                ..
+            } if anchor_hash == local_hash
+        ) {
+            continue;
+        }
+        let EvidenceKind::Symbol(symbol) = record.kind else {
+            continue;
+        };
+        if record.status != EvidenceStatus::Asserted || !il.evidence_dependencies_asserted(record) {
+            return None;
+        }
+        if !imported_symbol_allowed_for_use(symbol, imported_use) {
+            return None;
+        }
+        match found {
+            None => found = Some((symbol, record.id)),
+            Some((existing, _)) if existing == symbol => {}
+            Some(_) => return None,
+        }
+    }
+    found
+}
+
+fn imported_symbol_allowed_for_use(
+    symbol: SymbolEvidenceKind,
+    imported_use: ImportedBindingUse,
+) -> bool {
+    match imported_use {
+        ImportedBindingUse::FunctionCallee => {
+            matches!(symbol, SymbolEvidenceKind::ImportedBinding { .. })
+        }
+        ImportedBindingUse::MemberReceiver => matches!(
+            symbol,
+            SymbolEvidenceKind::ImportedBinding { .. }
+                | SymbolEvidenceKind::ImportedNamespace { .. }
+        ),
+    }
+}
+
+fn upsert_valid_imported_symbol_occurrence(
+    il: &mut Il,
+    interner: &Interner,
+    node: NodeId,
+    symbol: SymbolEvidenceKind,
+    binding_dependency: EvidenceId,
+) -> Option<EvidenceId> {
+    if !imported_symbol_occurrence_can_be_upserted(il, interner, node, symbol) {
+        return None;
+    }
+    let rule = match symbol {
+        SymbolEvidenceKind::ImportedBinding { .. } => IMPORTED_BINDING_OCCURRENCE_RULE,
+        SymbolEvidenceKind::ImportedNamespace { .. } => IMPORTED_NAMESPACE_OCCURRENCE_RULE,
+        _ => return None,
+    };
+    let anchor = EvidenceAnchor::node(il.node(node).span, NodeKind::Var);
+    let kind = EvidenceKind::Symbol(symbol);
+    let dependencies = vec![binding_dependency];
+    let candidate = EvidenceRecord {
+        id: EvidenceId(u32::MAX),
+        anchor,
+        kind,
+        provenance: EvidenceProvenance {
+            emitter: EvidenceEmitter::FirstParty,
+            pack_hash: None,
+            rule_hash: None,
+        },
+        dependencies: dependencies.clone(),
+        status: EvidenceStatus::Asserted,
+    };
+    if !imported_occurrence_symbol_dependencies_valid(il, interner, &candidate, symbol) {
+        return None;
+    }
+    let id =
+        il.find_or_push_first_party_evidence(anchor, kind, FIRST_PARTY_PACK_ID, rule, dependencies);
+    Some(id)
+}
+
+fn imported_symbol_occurrence_can_be_upserted(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    expected: SymbolEvidenceKind,
+) -> bool {
+    let anchor = EvidenceAnchor::node(il.node(node).span, NodeKind::Var);
+    for record in &il.evidence {
+        if record.anchor != anchor {
+            continue;
+        }
+        let EvidenceKind::Symbol(actual) = record.kind else {
+            continue;
+        };
+        if record.status != EvidenceStatus::Asserted
+            || actual != expected
+            || !il.evidence_dependencies_asserted(record)
+            || !imported_occurrence_symbol_dependencies_valid(il, interner, record, expected)
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn var_has_symbol_identity_evidence(il: &Il, interner: &Interner, node: NodeId) -> bool {
+    let anchor = EvidenceAnchor::node(il.node(node).span, NodeKind::Var);
+    if il
+        .evidence
+        .iter()
+        .any(|record| record.anchor == anchor && matches!(record.kind, EvidenceKind::Symbol(_)))
+    {
+        return true;
+    }
+    let Some(local_hash) = node_name_hash(il, interner, node) else {
+        return false;
+    };
+    il.evidence.iter().any(|record| {
+        matches!(
+            record.anchor,
+            EvidenceAnchor::Binding {
+                local_hash: anchor_hash,
+                ..
+            } if anchor_hash == local_hash
+        ) && matches!(record.kind, EvidenceKind::Symbol(_))
+    })
+}
+
+fn node_name_hash(il: &Il, interner: &Interner, node: NodeId) -> Option<u64> {
+    match il.node(node).payload {
+        Payload::Name(symbol) => Some(interner.symbol_hash(symbol)),
+        Payload::Cid(cid) => il
+            .cid_names
+            .get(cid as usize)
+            .map(|&symbol| interner.symbol_hash(symbol)),
+        _ => None,
+    }
+}
+
 fn is_scope(kind: NodeKind) -> bool {
     matches!(kind, NodeKind::Module | NodeKind::Func | NodeKind::Lambda)
 }
@@ -247,11 +555,58 @@ fn is_scope(kind: NodeKind) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_il::{FileId, FileMeta, IlBuilder, Lang, Span, Unit};
-    use nose_semantics::direct_function_call_target_at_call;
+    use nose_il::{
+        stable_symbol_hash, EvidenceEmitter, EvidenceProvenance, EvidenceRecord, FileId, FileMeta,
+        IlBuilder, Lang, Span, Unit,
+    };
+    use nose_semantics::{
+        call_target_evidence_at_call, direct_function_call_target_at_call,
+        imported_function_call_target_at_call, imported_member_call_target_at_call,
+    };
 
     fn sp(n: u32) -> Span {
         Span::new(FileId(0), n, n + 1, n, n)
+    }
+
+    fn wide_sp(start: u32, end: u32) -> Span {
+        Span::new(FileId(0), start, end, start, end)
+    }
+
+    fn evidence_with_dependencies(
+        id: u32,
+        anchor: EvidenceAnchor,
+        kind: EvidenceKind,
+        status: EvidenceStatus,
+        dependencies: Vec<EvidenceId>,
+    ) -> EvidenceRecord {
+        EvidenceRecord {
+            id: EvidenceId(id),
+            anchor,
+            kind,
+            provenance: EvidenceProvenance {
+                emitter: EvidenceEmitter::FirstParty,
+                pack_hash: Some(stable_symbol_hash(FIRST_PARTY_PACK_ID)),
+                rule_hash: Some(stable_symbol_hash("test")),
+            },
+            dependencies,
+            status,
+        }
+    }
+
+    fn binding_symbol(
+        id: u32,
+        span: Span,
+        local: &str,
+        symbol: SymbolEvidenceKind,
+        status: EvidenceStatus,
+    ) -> EvidenceRecord {
+        evidence_with_dependencies(
+            id,
+            EvidenceAnchor::binding(span, stable_symbol_hash(local)),
+            EvidenceKind::Symbol(symbol),
+            status,
+            Vec::new(),
+        )
     }
 
     fn function_with_call(
@@ -448,5 +803,271 @@ mod tests {
 
         run(&mut il, &interner);
         assert!(!direct_function_call_target_at_call(&il, call, target));
+    }
+
+    #[test]
+    fn emits_imported_function_call_target_from_binding_symbol() {
+        let interner = Interner::new();
+        let p = interner.intern("p");
+        let mut b = IlBuilder::new(FileId(0));
+        let callee = b.add(NodeKind::Var, Payload::Name(p), sp(10), &[]);
+        let arg = b.add(NodeKind::Lit, Payload::LitInt(3), sp(11), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(12), &[callee, arg]);
+        let ret = b.add(NodeKind::Return, Payload::None, sp(13), &[call]);
+        let body = b.add(NodeKind::Block, Payload::None, sp(14), &[ret]);
+        let func = b.add(NodeKind::Func, Payload::None, wide_sp(8, 20), &[body]);
+        let module = b.add(NodeKind::Module, Payload::None, wide_sp(0, 30), &[func]);
+        let mut il = b.finish(
+            module,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.evidence.push(binding_symbol(
+            0,
+            sp(1),
+            "p",
+            SymbolEvidenceKind::ImportedBinding {
+                module_hash: stable_symbol_hash("math"),
+                exported_hash: stable_symbol_hash("prod"),
+            },
+            EvidenceStatus::Asserted,
+        ));
+
+        run(&mut il, &interner);
+
+        let expected = CallTargetEvidenceKind::ImportedFunction {
+            module_hash: stable_symbol_hash("math"),
+            exported_hash: stable_symbol_hash("prod"),
+            local_hash: interner.symbol_hash(p),
+        };
+        assert_eq!(
+            call_target_evidence_at_call(&il, &interner, call),
+            Some(expected)
+        );
+        assert!(imported_function_call_target_at_call(&il, &interner, call));
+        let target_record = il
+            .evidence
+            .iter()
+            .find(|record| record.kind == EvidenceKind::CallTarget(expected))
+            .expect("imported function call-target evidence");
+        let [occurrence_dependency] = target_record.dependencies.as_slice() else {
+            panic!("call-target should depend on exactly one occurrence symbol");
+        };
+        let occurrence = il
+            .evidence_record_by_id(*occurrence_dependency)
+            .expect("occurrence dependency");
+        assert_eq!(
+            occurrence.kind,
+            EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+                module_hash: stable_symbol_hash("math"),
+                exported_hash: stable_symbol_hash("prod"),
+            })
+        );
+        assert_eq!(occurrence.dependencies, vec![EvidenceId(0)]);
+    }
+
+    #[test]
+    fn emits_imported_member_call_target_from_namespace_symbol() {
+        let interner = Interner::new();
+        let m = interner.intern("m");
+        let prod = interner.intern("prod");
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(NodeKind::Var, Payload::Name(m), sp(10), &[]);
+        let callee = b.add(NodeKind::Field, Payload::Name(prod), sp(11), &[receiver]);
+        let arg = b.add(NodeKind::Lit, Payload::LitInt(3), sp(12), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(13), &[callee, arg]);
+        let ret = b.add(NodeKind::Return, Payload::None, sp(14), &[call]);
+        let body = b.add(NodeKind::Block, Payload::None, sp(15), &[ret]);
+        let func = b.add(NodeKind::Func, Payload::None, wide_sp(8, 20), &[body]);
+        let module = b.add(NodeKind::Module, Payload::None, wide_sp(0, 30), &[func]);
+        let mut il = b.finish(
+            module,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.evidence.push(binding_symbol(
+            0,
+            sp(1),
+            "m",
+            SymbolEvidenceKind::ImportedNamespace {
+                module_hash: stable_symbol_hash("math"),
+            },
+            EvidenceStatus::Asserted,
+        ));
+
+        run(&mut il, &interner);
+
+        let member_hash = interner.symbol_hash(prod);
+        assert_eq!(
+            call_target_evidence_at_call(&il, &interner, call),
+            Some(CallTargetEvidenceKind::ImportedMember {
+                module_hash: stable_symbol_hash("math"),
+                exported_hash: member_hash,
+                member_hash,
+            })
+        );
+        assert!(imported_member_call_target_at_call(&il, &interner, call));
+    }
+
+    #[test]
+    fn emits_imported_member_call_target_from_imported_binding_receiver() {
+        let interner = Interner::new();
+        let map = interner.intern("Map");
+        let of = interner.intern("of");
+        let mut b = IlBuilder::new(FileId(0));
+        let receiver = b.add(NodeKind::Var, Payload::Name(map), sp(10), &[]);
+        let callee = b.add(NodeKind::Field, Payload::Name(of), sp(11), &[receiver]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(12), &[callee]);
+        let ret = b.add(NodeKind::Return, Payload::None, sp(13), &[call]);
+        let body = b.add(NodeKind::Block, Payload::None, sp(14), &[ret]);
+        let func = b.add(NodeKind::Func, Payload::None, wide_sp(8, 20), &[body]);
+        let module = b.add(NodeKind::Module, Payload::None, wide_sp(0, 30), &[func]);
+        let mut il = b.finish(
+            module,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Java,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.evidence.push(binding_symbol(
+            0,
+            sp(1),
+            "Map",
+            SymbolEvidenceKind::ImportedBinding {
+                module_hash: stable_symbol_hash("java.util"),
+                exported_hash: stable_symbol_hash("Map"),
+            },
+            EvidenceStatus::Asserted,
+        ));
+
+        run(&mut il, &interner);
+
+        assert_eq!(
+            call_target_evidence_at_call(&il, &interner, call),
+            Some(CallTargetEvidenceKind::ImportedMember {
+                module_hash: stable_symbol_hash("java.util"),
+                exported_hash: stable_symbol_hash("Map"),
+                member_hash: interner.symbol_hash(of),
+            })
+        );
+    }
+
+    #[test]
+    fn does_not_emit_imported_function_target_for_ambiguous_binding_symbol() {
+        let interner = Interner::new();
+        let p = interner.intern("p");
+        let mut b = IlBuilder::new(FileId(0));
+        let callee = b.add(NodeKind::Var, Payload::Name(p), sp(10), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp(11), &[callee]);
+        let ret = b.add(NodeKind::Return, Payload::None, sp(12), &[call]);
+        let body = b.add(NodeKind::Block, Payload::None, sp(13), &[ret]);
+        let func = b.add(NodeKind::Func, Payload::None, wide_sp(8, 20), &[body]);
+        let module = b.add(NodeKind::Module, Payload::None, wide_sp(0, 30), &[func]);
+        let mut il = b.finish(
+            module,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.evidence.push(binding_symbol(
+            0,
+            sp(1),
+            "p",
+            SymbolEvidenceKind::ImportedBinding {
+                module_hash: stable_symbol_hash("math"),
+                exported_hash: stable_symbol_hash("prod"),
+            },
+            EvidenceStatus::Ambiguous,
+        ));
+
+        run(&mut il, &interner);
+        assert_eq!(call_target_evidence_at_call(&il, &interner, call), None);
+    }
+
+    #[test]
+    fn does_not_emit_imported_function_target_when_local_assignment_rebinds_alias() {
+        let interner = Interner::new();
+        let p = interner.intern("p");
+        let mut b = IlBuilder::new(FileId(0));
+        let lhs = b.add(NodeKind::Var, Payload::Name(p), wide_sp(10, 11), &[]);
+        let rhs = b.add(NodeKind::Lit, Payload::LitInt(1), wide_sp(12, 13), &[]);
+        let assign = b.add(
+            NodeKind::Assign,
+            Payload::None,
+            wide_sp(10, 13),
+            &[lhs, rhs],
+        );
+        let callee = b.add(NodeKind::Var, Payload::Name(p), wide_sp(30, 31), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, wide_sp(31, 32), &[callee]);
+        let ret = b.add(NodeKind::Return, Payload::None, wide_sp(31, 33), &[call]);
+        let body = b.add(
+            NodeKind::Block,
+            Payload::None,
+            wide_sp(9, 40),
+            &[assign, ret],
+        );
+        let func = b.add(NodeKind::Func, Payload::None, wide_sp(8, 50), &[body]);
+        let module = b.add(NodeKind::Module, Payload::None, wide_sp(0, 60), &[func]);
+        let mut il = b.finish(
+            module,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.evidence.push(binding_symbol(
+            0,
+            sp(1),
+            "p",
+            SymbolEvidenceKind::ImportedBinding {
+                module_hash: stable_symbol_hash("math"),
+                exported_hash: stable_symbol_hash("prod"),
+            },
+            EvidenceStatus::Asserted,
+        ));
+
+        run(&mut il, &interner);
+
+        assert_eq!(call_target_evidence_at_call(&il, &interner, call), None);
+        assert!(!il.evidence.iter().any(|record| {
+            record.anchor == EvidenceAnchor::node(wide_sp(30, 31), NodeKind::Var)
+                && matches!(record.kind, EvidenceKind::Symbol(_))
+        }));
+    }
+
+    #[test]
+    fn symbol_evidence_suppresses_direct_function_raw_name_fallback() {
+        let interner = Interner::new();
+        let (mut il, func, call) = function_with_call(&interner, "f", "f", false);
+        il.evidence.push(binding_symbol(
+            0,
+            sp(1),
+            "f",
+            SymbolEvidenceKind::ImportedBinding {
+                module_hash: stable_symbol_hash("other"),
+                exported_hash: stable_symbol_hash("f"),
+            },
+            EvidenceStatus::Asserted,
+        ));
+
+        run(&mut il, &interner);
+
+        assert!(!direct_function_call_target_at_call(&il, call, func));
+        assert_eq!(call_target_evidence_at_call(&il, &interner, call), None);
     }
 }

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -38,8 +38,8 @@ use evidence::{
 };
 pub use library_api::*;
 use library_api::{
-    imported_occurrence_symbol_dependencies_valid, language_core_builtin_at_call,
-    library_api_dependency_id_for_normalized_hof, library_method_selector_name,
+    language_core_builtin_at_call, library_api_dependency_id_for_normalized_hof,
+    library_method_selector_name,
 };
 pub use module_exports::*;
 pub use nose_il::DomainEvidence;

--- a/crates/nose-semantics/src/library_api.rs
+++ b/crates/nose-semantics/src/library_api.rs
@@ -2355,7 +2355,10 @@ fn dependency_has_imported_symbol_anchor(
     imported_occurrence_symbol_dependencies_valid(il, interner, symbol_record, expected)
 }
 
-pub(crate) fn imported_occurrence_symbol_dependencies_valid(
+/// Validate that an occurrence-level imported symbol record is backed by a
+/// still-visible import binding and not reopened through a rebound or shadowed
+/// local alias.
+pub fn imported_occurrence_symbol_dependencies_valid(
     il: &Il,
     interner: &Interner,
     symbol_record: &EvidenceRecord,

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -106,12 +106,30 @@ vocabulary separates concrete exact identity from broader dispatch facts:
 - `DynamicDispatch` names a protocol/dispatch family and method selector, but it
   does not by itself prove one concrete implementation target.
 
-The first-party producer currently emits `DirectFunction` only for unique
-top-level in-file `Function` units when neither the current lexical scope nor
-any enclosing lexical scope has a parameter, assignment target, loop-pattern
-binding, or nested function definition that shadows the callee name. Duplicate
-function names, lexical shadowing, nested/non-top-level functions, methods
-without explicit target proof, computed callees, selector mismatches,
+The first-party call-target producer currently emits:
+
+- `DirectFunction` for unique top-level in-file `Function` units when neither
+  the current lexical scope nor any enclosing lexical scope has a parameter,
+  assignment target, loop-pattern binding, or nested function definition that
+  shadows the callee name. If the callee already carries symbol-identity
+  evidence or an imported binding proof for the same local name, this direct
+  raw-name path stays closed instead of overriding that proof.
+- `ImportedFunction` for variable callees whose local binding has a unique
+  asserted `Symbol(ImportedBinding)` proof and whose call-site occurrence can be
+  materialized as dependency-backed imported-symbol evidence. Alias rebinding,
+  local shadowing, ambiguous/conflicting symbol evidence, dependency-broken
+  import proof, and locally visible same-name function units keep the call
+  target closed.
+- `ImportedMember` for field callees whose receiver has a unique asserted
+  `Symbol(ImportedNamespace)` or `Symbol(ImportedBinding)` proof. Imported
+  namespace receivers use the module/member coordinate; imported binding
+  receivers use the module/export/member coordinate. Receiver rebinding,
+  ambiguous/conflicting symbol evidence, dependency-broken import proof, and
+  selector mismatches stay closed.
+
+There is not yet a first-party producer for `DirectMethod` or `DynamicDispatch`.
+Duplicate function names, lexical shadowing, nested/non-top-level functions,
+methods without explicit target proof, computed callees, selector mismatches,
 dependency-broken records, and conflicting evidence stay closed.
 
 Current first-party `LibraryApi` callee coordinates are intentionally specific:

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -577,17 +577,18 @@ and pack ecosystem.
   a spelling hash, so internal-looking payload names such as `record_guard` or
   `own_property_guard` cannot become semantic proof channels.
 - Raw user-call spelling no longer proves direct recursion or in-file call
-  execution. `nose-il` now has `CallTarget::DirectFunction` evidence, the
-  first-party normalize producer emits it only for unique top-level in-file
-  function targets with no current or enclosing lexical shadowing, and
-  recursion, interpreter, value-graph pure-inline, and strict exact
-  direct-function callee consumers require that occurrence proof.
-  The follow-up call-target slice expanded the vocabulary to `DirectMethod`,
-  `ImportedFunction`, `ImportedMember`, and `DynamicDispatch`, added a shared
-  fail-closed resolver, and taught strict exact to admit imported function/member
-  opaque identity only through explicit evidence. Direct methods still require
-  exact receiver identity, and dynamic-dispatch records do not by themselves
-  prove one concrete target.
+  execution. `nose-il` now has `CallTarget` evidence, the first-party normalize
+  producer emits `DirectFunction` only for unique top-level in-file function
+  targets with no current or enclosing lexical shadowing, and recursion,
+  interpreter, value-graph pure-inline, and strict exact direct-function callee
+  consumers require that occurrence proof. The follow-up call-target producer
+  slice emits `ImportedFunction` and `ImportedMember` only from
+  dependency-backed imported binding or imported namespace symbol proof, added a
+  shared fail-closed resolver, and taught strict exact to admit imported
+  function/member opaque identity only through explicit evidence. The vocabulary
+  also includes `DirectMethod` and `DynamicDispatch`, but no first-party producer
+  emits those records yet; direct methods still require exact receiver identity,
+  and dynamic-dispatch records do not by themselves prove one concrete target.
 - C byte-pack proof moved onto evidence-backed alias and cast records. Local
   typedefs and direct quote includes emit `Type(CTypeAlias)` evidence, included
   aliases depend on `Import(CQuoteInclude)`, alias-based `Domain(ByteArray)` and
@@ -712,8 +713,9 @@ Remaining after the foundation tranche:
 - Ship a narrow first-party pack pilot (#166) so the v0 API, metadata loading,
   conformance workflow, provenance, and evidence vocabulary are exercised by an
   actual default pack-shaped implementation.
-- Broaden evidence producer coverage (#169) for call targets, richer domains,
-  guards, aggregates, and module/export dependencies without reopening raw
+- Continue producer coverage beyond the call-target imported-function/member
+  slice for direct methods, dynamic dispatch, richer domains, guards,
+  aggregates, and module/export dependencies without reopening raw
   selector/name/type/tag fallbacks.
 - Expand demand/effect contracts (#168) for lazy, iterator, generator, async,
   channel, repeated, and call-by-need semantics before ecosystem APIs can enter
@@ -808,7 +810,7 @@ Remaining after the foundation tranche:
   with same-span root dependencies, but general qualified-member resolution,
   namespace export identity, provider/export dependency manifests, richer
   scope/rebinding facts, broader producer coverage for module-defined local
-  functions/methods and imported namespace members, and manifest-level
+  methods/dynamic dispatch, richer nested-function scope, and manifest-level
   cross-module dependency evidence are not.
 - Generalize dedicated guard evidence beyond the first JS/TS record-shape and
   own-property contracts, including richer source-clause records, API dependency

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -558,18 +558,21 @@ migrated.
   and manually constructed calls without admitted occurrence evidence stay
   exact-closed.
 - User-defined and imported opaque call identity now consume `CallTarget`
-  evidence. The first-party producer admits only `DirectFunction` records for
-  unique top-level in-file function targets with no current or enclosing lexical
-  shadowing by parameters, assignments, loop patterns, or nested function
-  definitions; recursion normalization and the interpreter oracle, value-graph
-  pure helper inlining, and strict exact direct-function callee gates no longer
-  treat same raw callee spelling as call-target proof. The shared resolver also
-  understands `DirectMethod`, `ImportedFunction`, `ImportedMember`, and
-  `DynamicDispatch` records. Strict exact admits imported function/member
-  identity only through explicit evidence, requires exact receiver identity for
-  direct methods, treats dynamic-dispatch records as non-concrete by themselves,
-  and closes on selector mismatch, dependency-broken records, or conflicting
-  target evidence.
+  evidence. The first-party producer admits `DirectFunction` records for unique
+  top-level in-file function targets with no current or enclosing lexical
+  shadowing, and imported function/member records only from dependency-backed
+  imported binding or imported namespace symbol proof at the call occurrence.
+  Same raw callee spelling, same field selector spelling, rebinding, ambiguous
+  import proof, conflicting symbol evidence, dependency-broken proof, and
+  locally visible same-name function units stay closed. Recursion normalization,
+  the interpreter oracle, value-graph pure helper inlining, and strict exact
+  direct-function callee gates no longer treat same raw callee spelling as
+  call-target proof. The shared resolver also understands `DirectMethod` and
+  `DynamicDispatch` records, but no first-party producer emits them yet. Strict
+  exact admits imported function/member identity only through explicit evidence,
+  requires exact receiver identity for direct methods, treats dynamic-dispatch
+  records as non-concrete by themselves, and closes on selector mismatch,
+  dependency-broken records, or conflicting target evidence.
 - JS-like `typeof` exact-safety now consumes a language- and arity-constrained
   operator contract plus `Source::Operator(Typeof)` evidence at the call span.
   A raw `Call(Var("typeof"), arg)` shape, same-named function from another


### PR DESCRIPTION
## Summary

- emit `CallTarget::ImportedFunction` from proven imported-binding callees
- emit `CallTarget::ImportedMember` from proven imported namespace or imported binding receivers
- keep direct-function call-target production closed when symbol/import identity evidence exists for the same callee local
- add producer hard negatives and lower+normalize strict-exact consumer tests
- update semantic-kernel snapshot, roadmap, and evidence-record docs

Closes #169

## Validation

- `cargo test -p nose-normalize call_target_evidence -- --nocapture`
- `cargo test -p nose-detect imported -- --nocapture`
- `cargo test -p nose-semantics -p nose-normalize -p nose-detect`
- `cargo test -p nose-semantics -p nose-frontend -p nose-normalize -p nose-detect -p nose-cli`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `awiki lint --root docs`
- `git diff --check`
- `cargo run -p nose-cli -- semantic-pack check docs/examples/semantic-packs/v0/python-typing-domain-pack.json --format json`