### PR TITLE
semantics: expose pack-facing value law provenance

### DIFF
--- a/crates/nose-cli/src/cache.rs
+++ b/crates/nose-cli/src/cache.rs
@@ -16,10 +16,9 @@ use rayon::prelude::*;
 use std::path::Path;
 
 /// Bump when the cached payload's layout, extraction, or feature hashing changes — old
-/// cache entries then live under a different directory and are ignored. (v5: exact
-/// Type-4 features include the newly modeled record, membership, flag-loop, and ordered
-/// string-builder idioms.)
-const SCHEMA: u32 = 6;
+/// cache entries then live under a different directory and are ignored. (v7: cached
+/// units include pack-facing value-law provenance.)
+const SCHEMA: u32 = 7;
 
 pub(crate) struct CachedUnits {
     pub units: Vec<UnitFeat>,

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -4011,6 +4011,7 @@ mod tests {
             scope: "prod",
             discount: 1.0,
             abstraction_witness: None,
+            semantic_laws: Vec::new(),
         }
     }
 

--- a/crates/nose-cli/src/review.rs
+++ b/crates/nose-cli/src/review.rs
@@ -710,6 +710,7 @@ index 1111111..2222222 100644
             scope: "prod",
             discount: 1.0,
             abstraction_witness: None,
+            semantic_laws: Vec::new(),
         }
     }
 

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -654,7 +654,7 @@ fn scan_json_reports_first_party_and_local_semantic_pack_provenance() {
         .expect("semantic_packs array");
     assert_eq!(
         packs.len(),
-        3,
+        4,
         "first-party packs + local opt-in pack: {json}"
     );
     assert_eq!(packs[0]["id"], "nose.first_party");
@@ -666,14 +666,111 @@ fn scan_json_reports_first_party_and_local_semantic_pack_provenance() {
     assert_eq!(packs[1]["influence"], "evidence-and-contracts");
     assert_eq!(packs[1]["counts"]["evidence_producers"], 1);
     assert_eq!(packs[1]["counts"]["contracts"], 1);
-    assert_eq!(packs[2]["id"], "com.example.semantic-pack");
-    assert_eq!(packs[2]["trust"], "external-opt-in");
-    assert_eq!(packs[2]["source"], "local-manifest");
-    assert_eq!(packs[2]["influence"], "metadata-only");
-    assert_eq!(packs[2]["counts"]["contracts"], 1);
-    assert!(packs[2]["hash"]
+    assert_eq!(packs[2]["id"], "nose.value_graph.laws");
+    assert_eq!(packs[2]["kind"], "LawPack");
+    assert_eq!(packs[2]["source"], "compiled-first-party");
+    assert_eq!(packs[2]["influence"], "evidence-and-contracts");
+    assert_eq!(packs[2]["counts"]["value_laws"], 2);
+    assert_eq!(packs[3]["id"], "com.example.semantic-pack");
+    assert_eq!(packs[3]["trust"], "external-opt-in");
+    assert_eq!(packs[3]["source"], "local-manifest");
+    assert_eq!(packs[3]["influence"], "metadata-only");
+    assert_eq!(packs[3]["counts"]["contracts"], 1);
+    assert!(packs[3]["hash"]
         .as_str()
         .is_some_and(|hash| hash.len() == 16));
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn scan_json_reports_value_law_provenance_for_semantic_family() {
+    let dir = std::env::temp_dir().join(format!("nose_cli_law_provenance_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("left.rs"),
+        "fn f(a: i64, b: i64, c: i64) -> i64 {\n    a * c + b * c\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("right.rs"),
+        "fn g(a: i64, b: i64, c: i64) -> i64 {\n    (a + b) * c\n}\n",
+    )
+    .unwrap();
+    let json = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--min-size",
+        "1",
+        "--min-lines",
+        "1",
+        "--top",
+        "0",
+        "--format",
+        "json",
+    ]));
+    let families = json["families"].as_array().expect("families array");
+    assert_eq!(
+        families.len(),
+        1,
+        "factor-distribution family expected: {json}"
+    );
+    let laws = families[0]["semantic_laws"]
+        .as_array()
+        .expect("semantic_laws array");
+    assert_eq!(laws.len(), 1, "one law provenance row expected: {json}");
+    assert_eq!(laws[0]["pack_id"], "nose.value_graph.laws");
+    assert_eq!(
+        laws[0]["law_id"],
+        "value-graph.factor-distribute.numeric-common-factor"
+    );
+    assert_eq!(
+        laws[0]["proof_obligation_id"],
+        "normalize.value_graph.factor_distribute"
+    );
+    assert_eq!(laws[0]["proof_status"], "proven");
+    assert_eq!(laws[0]["channel"], "exact-proven");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn scan_json_keeps_python_repetition_out_of_numeric_law_provenance() {
+    let dir =
+        std::env::temp_dir().join(format!("nose_cli_law_hard_negative_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("repetition.py"),
+        "def repeated(a, b):\n    return a * 2 + b * 2\n\n\ndef grouped(a, b):\n    return (a + b) * 2\n",
+    )
+    .unwrap();
+    let json = scan_json(&run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--min-size",
+        "1",
+        "--min-lines",
+        "1",
+        "--top",
+        "0",
+        "--format",
+        "json",
+    ]));
+    let families = json["families"].as_array().expect("families array");
+    assert!(
+        families
+            .iter()
+            .all(|family| family["semantic_laws"].is_null()),
+        "Python repetition must not report numeric factor-distribution provenance: {json}"
+    );
+    assert!(
+        families.is_empty(),
+        "Python repetition must fail closed for the semantic exact channel: {json}"
+    );
     let _ = fs::remove_dir_all(&dir);
 }
 
@@ -693,7 +790,7 @@ fn scan_human_reports_local_semantic_pack_opt_in() {
     ]);
     assert!(
         out.contains(
-            "semantic packs: 2 first-party default · 1 local opt-in: \
+            "semantic packs: 3 first-party default · 1 local opt-in: \
              com.example.semantic-pack@0.1.0 (metadata-only)"
         ),
         "human scan output should disclose local semantic pack opt-ins: {out}"

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -5589,23 +5589,35 @@ fn normalization_is_idempotent() {
 /// a shared multiplicand out of a sum of products when every leaf is proven numeric
 /// (`value_graph/rules/factor_distribute.rs`, Lean obligation
 /// `normalize.value_graph.factor_distribute`). The `*`
-/// operands here are provably `Num`, so the factoring fires and the two forms converge.
+/// operands here are statically typed integers, so the factoring fires and the two forms converge.
 #[test]
 fn distribution_factors_common_multiplicand() {
     let i = Interner::new();
     assert_eq!(
-        value_fp(&i, "def f(a,b,c):\n    return a*c+b*c\n", Lang::Python),
-        value_fp(&i, "def g(a,b,c):\n    return (a+b)*c\n", Lang::Python),
+        value_fp(
+            &i,
+            "fn f(a: i64, b: i64, c: i64) -> i64 { a*c+b*c }\n",
+            Lang::Rust
+        ),
+        value_fp(
+            &i,
+            "fn g(a: i64, b: i64, c: i64) -> i64 { (a+b)*c }\n",
+            Lang::Rust
+        ),
         "a*c+b*c should factor to (a+b)*c on proven-numeric leaves"
     );
     // Three-term chain factors transitively: `a*c + b*c + d*c` ≡ `(a+b+d)*c`.
     assert_eq!(
         value_fp(
             &i,
-            "def f(a,b,c,d):\n    return a*c+b*c+d*c\n",
-            Lang::Python
+            "fn f(a: i64, b: i64, c: i64, d: i64) -> i64 { a*c+b*c+d*c }\n",
+            Lang::Rust
         ),
-        value_fp(&i, "def g(a,b,c,d):\n    return (a+b+d)*c\n", Lang::Python),
+        value_fp(
+            &i,
+            "fn g(a: i64, b: i64, c: i64, d: i64) -> i64 { (a+b+d)*c }\n",
+            Lang::Rust
+        ),
         "a*c+b*c+d*c should factor to (a+b+d)*c"
     );
 }

--- a/crates/nose-cli/tests/fixtures/scan-json-v1.json
+++ b/crates/nose-cli/tests/fixtures/scan-json-v1.json
@@ -56,6 +56,28 @@
         "positive_fixtures": 36,
         "hard_negatives": 2
       }
+    },
+    {
+      "id": "nose.value_graph.laws",
+      "hash": "f65998031968ccc9",
+      "kind": "LawPack",
+      "version": "<version>",
+      "display_name": "nose value-graph law pack",
+      "trust": "default-first-party",
+      "enabled_by_default": true,
+      "source": "compiled-first-party",
+      "influence": "evidence-and-contracts",
+      "provider": "Corca, Inc.",
+      "repository": "https://github.com/corca-ai/nose",
+      "license": "MIT",
+      "supported_languages": [],
+      "counts": {
+        "evidence_producers": 0,
+        "contracts": 0,
+        "value_laws": 2,
+        "positive_fixtures": 2,
+        "hard_negatives": 4
+      }
     }
   ],
   "ranking": {

--- a/crates/nose-detect/src/contiguous.rs
+++ b/crates/nose-detect/src/contiguous.rs
@@ -234,6 +234,7 @@ pub(crate) fn detect(streams: &[Stream], min_tokens: usize, min_lines: u32) -> V
         groups.push(crate::Group {
             score: 1.0,
             members: members.iter().map(|&m| locs[m].clone()).collect(),
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         });
     }

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -35,6 +35,7 @@ pub fn file_stream(il: &Il, interner: &Interner) -> Stream {
 
 use nose_il::{Corpus, Il, Interner, NodeKind};
 use nose_normalize::NormalizeOptions;
+use nose_semantics::ValueLaw;
 use rayon::prelude::*;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -589,6 +590,8 @@ pub struct AbstractionHole {
 pub struct Group {
     pub score: f64,
     pub members: Vec<Loc>,
+    #[serde(skip)]
+    pub semantic_laws: Vec<ValueLaw>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub abstraction_witness: Option<AbstractionWitness>,
 }
@@ -1010,6 +1013,7 @@ pub fn detect_from_units(
             Group {
                 score: round3(score),
                 members: locs,
+                semantic_laws: semantic_laws_for_members(members, &units),
                 abstraction_witness: if opts.abstraction_witnesses {
                     units::abstraction_family_witness(members.iter().map(|&m| &units[m]))
                 } else {
@@ -1068,6 +1072,16 @@ pub fn detect_from_units(
     };
 
     (report, dump)
+}
+
+fn semantic_laws_for_members(members: &[usize], units: &[UnitFeat]) -> Vec<ValueLaw> {
+    let mut laws = members
+        .iter()
+        .flat_map(|&member| units[member].semantic_laws.iter().copied())
+        .collect::<Vec<_>>();
+    laws.sort_unstable();
+    laws.dedup();
+    laws
 }
 
 fn exact_value_candidates(units: &[UnitFeat]) -> Vec<(usize, usize)> {

--- a/crates/nose-detect/src/report.rs
+++ b/crates/nose-detect/src/report.rs
@@ -10,6 +10,7 @@
 //!     missing abstraction, weighted above a local copy-paste.
 
 use crate::{AbstractionWitness, Group, Loc, Report};
+use nose_semantics::{value_law_provenance, ValueLawProvenance};
 use serde::Serialize;
 use std::path::Path;
 
@@ -66,6 +67,9 @@ pub struct RefactorFamily {
     /// supported literal leaf position. It is not a semantic-equivalence proof.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub abstraction_witness: Option<AbstractionWitness>,
+    /// Pack-facing semantic laws that influenced this family-level value fingerprint.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub semantic_laws: Vec<ValueLawProvenance>,
 }
 
 impl RefactorFamily {
@@ -487,6 +491,11 @@ fn family_of(group: &Group) -> RefactorFamily {
         scope,
         discount,
         abstraction_witness: group.abstraction_witness.clone(),
+        semantic_laws: group
+            .semantic_laws
+            .iter()
+            .filter_map(|&law| value_law_provenance(law))
+            .collect(),
     }
 }
 
@@ -667,6 +676,7 @@ mod tests {
             scope: "prod",
             discount: 1.0,
             abstraction_witness: None,
+            semantic_laws: Vec::new(),
         }
     }
 
@@ -885,6 +895,7 @@ mod tests {
                 loc("a.rs", 1, 20, "rust"),
                 loc("b.rs", 1, 20, "rust"),
             ],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let f = &rank_families(&report(vec![g]))[0];
@@ -902,11 +913,13 @@ mod tests {
         let outer = Group {
             score: 0.9,
             members: vec![loc("a.rs", 10, 40, "rust"), loc("b.rs", 10, 40, "rust")],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let inner = Group {
             score: 1.0,
             members: vec![loc("a.rs", 15, 25, "rust"), loc("b.rs", 15, 25, "rust")],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let fams = rank_families(&report(vec![inner, outer]));
@@ -926,6 +939,7 @@ mod tests {
         let mk = |f1: &'static str, f2: &'static str| Group {
             score: 1.0,
             members: vec![loc(f1, 1, 20, "rust"), loc(f2, 1, 20, "rust")],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let keys = |groups| {
@@ -961,6 +975,7 @@ mod tests {
                 loc("con.py", 143, 167, "python"),
                 loc("con.py", 144, 167, "python"), // off-by-one near-duplicate
             ],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let f = &rank_families(&report(vec![g]))[0];
@@ -981,6 +996,7 @@ mod tests {
                 loc("p.py", 763, 794, "python"),
                 loc("p.py", 795, 818, "python"),
             ],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let f = &rank_families(&report(vec![g]))[0];
@@ -1000,6 +1016,7 @@ mod tests {
                 loc("y/b.rs", 1, 10, "rust"),
                 loc("z/c.rs", 1, 10, "rust"),
             ],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let f = &rank_families(&report(vec![g]))[0];
@@ -1017,11 +1034,13 @@ mod tests {
             members: (0..10)
                 .map(|i| loc(&format!("m{i}/f.rs"), 1, 30, "rust"))
                 .collect(),
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let small = Group {
             score: 1.0,
             members: vec![loc("p/a.rs", 1, 6, "rust"), loc("p/b.rs", 1, 6, "rust")],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let fams = rank_families(&report(vec![small, big]));
@@ -1037,6 +1056,7 @@ mod tests {
         let mono = Group {
             score: 0.9,
             members: vec![loc("a.py", 1, 10, "python"), loc("b.py", 1, 10, "python")],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let cross = Group {
@@ -1045,6 +1065,7 @@ mod tests {
                 loc("a.py", 1, 10, "python"),
                 loc("b.ts", 1, 10, "typescript"),
             ],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let fm = family_of(&mono);
@@ -1066,6 +1087,7 @@ mod tests {
                 loc("src/a.rs", 1, 30, "rust"),
                 loc("src/b.rs", 1, 30, "rust"),
             ],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let test = Group {
@@ -1074,6 +1096,7 @@ mod tests {
                 loc("tests/a.rs", 1, 30, "rust"),
                 loc("tests/b.rs", 1, 30, "rust"),
             ],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let fp = family_of(&prod);
@@ -1098,6 +1121,7 @@ mod tests {
         let mixed = Group {
             score: 1.0,
             members: vec![loc("src/a.rs", 1, 30, "rust"), test_named],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let pure = Group {
@@ -1106,6 +1130,7 @@ mod tests {
                 loc("src/a.rs", 1, 30, "rust"),
                 loc("src/b.rs", 1, 30, "rust"),
             ],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let fmixed = family_of(&mixed);
@@ -1114,6 +1139,47 @@ mod tests {
         assert_eq!(
             fmixed.value, fpure.value,
             "test↔prod duplication is not discounted"
+        );
+    }
+
+    #[test]
+    fn pack_facing_laws_become_family_provenance_only_when_registered() {
+        let proven = Group {
+            score: 1.0,
+            members: vec![
+                loc("src/a.py", 1, 30, "python"),
+                loc("src/b.py", 1, 30, "python"),
+            ],
+            semantic_laws: vec![nose_semantics::ValueLaw::NumericFactorDistribution],
+            abstraction_witness: None,
+        };
+        let family = family_of(&proven);
+        assert_eq!(family.semantic_laws.len(), 1);
+        assert_eq!(
+            family.semantic_laws[0].pack_id,
+            nose_semantics::FIRST_PARTY_VALUE_LAW_PACK_ID
+        );
+        assert_eq!(
+            family.semantic_laws[0].law_id,
+            "value-graph.factor-distribute.numeric-common-factor"
+        );
+        assert_eq!(
+            family.semantic_laws[0].proof_obligation_id,
+            "normalize.value_graph.factor_distribute"
+        );
+
+        let internal_only = Group {
+            score: 1.0,
+            members: vec![
+                loc("src/c.py", 1, 30, "python"),
+                loc("src/d.py", 1, 30, "python"),
+            ],
+            semantic_laws: vec![nose_semantics::ValueLaw::AddCommutativity],
+            abstraction_witness: None,
+        };
+        assert!(
+            family_of(&internal_only).semantic_laws.is_empty(),
+            "historical internal value-law gates must not be over-reported as pack-facing laws"
         );
     }
 
@@ -1226,6 +1292,7 @@ mod tests {
                 loc_k("src/a.rs", 1, 30, Class, 5),
                 loc_k("src/b.rs", 1, 30, Class, 5),
             ],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         // A behavior-rich class of the same size is a genuine candidate.
@@ -1235,6 +1302,7 @@ mod tests {
                 loc_k("src/c.rs", 1, 30, Class, 80),
                 loc_k("src/d.rs", 1, 30, Class, 80),
             ],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let ftd = family_of(&typedef);
@@ -1250,6 +1318,7 @@ mod tests {
                 loc_k("src/e.rs", 1, 30, Function, 5),
                 loc_k("src/f.rs", 1, 30, Function, 5),
             ],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         assert!(
@@ -1267,11 +1336,13 @@ mod tests {
                 loc("a/vendor/x.go", 1, 30, "go"),
                 loc("b/vendor/y.go", 1, 30, "go"),
             ],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         let owned = Group {
             score: 1.0,
             members: vec![loc("src/x.go", 1, 30, "go"), loc("src/y.go", 1, 30, "go")],
+            semantic_laws: Vec::new(),
             abstraction_witness: None,
         };
         assert!(

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -24,7 +24,7 @@ use nose_semantics::{
     admitted_builtin_semantics_at_call, builder_append_call_args, exact_java_return_this,
     exact_non_overloadable_index_assignment, exact_non_overloadable_index_assignment_parts,
     exact_self_field_write_assignment, opaque_argument_escape_args,
-    receiver_mutation_call_receiver,
+    receiver_mutation_call_receiver, ValueLaw,
 };
 #[cfg(test)]
 use nose_semantics::{library_free_name_collection_factory_contract, LibraryApiCalleeContract};
@@ -79,6 +79,9 @@ pub struct UnitFeat {
     /// the shared computation lives).
     #[serde(default)]
     pub anchors: Vec<nose_normalize::Anchor>,
+    /// Pack-facing value laws that actually rewrote or bridged this unit's value graph.
+    #[serde(default)]
+    pub semantic_laws: Vec<ValueLaw>,
     /// Whether the value fingerprint is safe to use as a strict semantic proof.
     ///
     /// `semantic` mode must not report units whose fingerprint passed through lossy
@@ -496,10 +499,12 @@ pub(crate) fn extract(
         // literal-only multiset for data-table detection. Computed before the size
         // gate so the gate can consult semantic richness (below).
         let value_start = unit_timer.start();
-        let (value, lits, returns, anchors) = if let Some(context) = &value_context {
-            nose_normalize::value_fingerprint_lits_anchors_with_context(il, root, interner, context)
+        let (value, lits, returns, anchors, semantic_laws) = if let Some(context) = &value_context {
+            nose_normalize::value_fingerprint_lits_anchors_laws_with_context(
+                il, root, interner, context,
+            )
         } else {
-            nose_normalize::value_fingerprint_lits_anchors(il, root, interner)
+            nose_normalize::value_fingerprint_lits_anchors_laws(il, root, interner)
         };
         let value_ms = UnitTimer::elapsed(value_start);
 
@@ -636,6 +641,7 @@ pub(crate) fn extract(
             lits,
             returns,
             anchors,
+            semantic_laws,
             exact_safe,
             fragment_kind,
             proof_facts,

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -35,9 +35,10 @@ pub use commutative::{node_tag, node_tag_valued, subtree_hashes};
 pub use interp::{run_unit, Behavior, Value};
 pub use value_graph::{
     value_anchors, value_fingerprint, value_fingerprint_and_contracts, value_fingerprint_contracts,
-    value_fingerprint_lits, value_fingerprint_lits_anchors,
-    value_fingerprint_lits_anchors_with_context, value_fingerprint_lits_with_context, Anchor,
-    Anchors, FingerprintBundle, ValueFingerprintContext, ANCHOR_MIN_WEIGHT,
+    value_fingerprint_lits, value_fingerprint_lits_anchors, value_fingerprint_lits_anchors_laws,
+    value_fingerprint_lits_anchors_laws_with_context, value_fingerprint_lits_anchors_with_context,
+    value_fingerprint_lits_with_context, Anchor, Anchors, FingerprintBundle, FingerprintLawBundle,
+    ValueFingerprintContext, ANCHOR_MIN_WEIGHT,
 };
 
 use nose_il::{FileMeta, Il, IlBuilder, Interner, NodeId, NodeKind, Payload, Symbol, Unit};

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -44,9 +44,10 @@ mod stdlib;
 
 pub use api::{
     value_anchors, value_fingerprint, value_fingerprint_and_contracts, value_fingerprint_contracts,
-    value_fingerprint_lits, value_fingerprint_lits_anchors,
-    value_fingerprint_lits_anchors_with_context, value_fingerprint_lits_with_context, Anchor,
-    Anchors, FingerprintBundle, ANCHOR_MIN_WEIGHT,
+    value_fingerprint_lits, value_fingerprint_lits_anchors, value_fingerprint_lits_anchors_laws,
+    value_fingerprint_lits_anchors_laws_with_context, value_fingerprint_lits_anchors_with_context,
+    value_fingerprint_lits_with_context, Anchor, Anchors, FingerprintBundle, FingerprintLawBundle,
+    ANCHOR_MIN_WEIGHT,
 };
 pub use context::ValueFingerprintContext;
 

--- a/crates/nose-normalize/src/value_graph/api.rs
+++ b/crates/nose-normalize/src/value_graph/api.rs
@@ -17,6 +17,7 @@ pub type Anchors = Vec<Anchor>;
 /// One value-graph build's fingerprints: `(value, literal, return)` hash multisets plus the
 /// heavy sub-DAG [`Anchors`].
 pub type FingerprintBundle = (Vec<u64>, Vec<u64>, Vec<u64>, Anchors);
+pub type FingerprintLawBundle = (Vec<u64>, Vec<u64>, Vec<u64>, Anchors, Vec<ValueLaw>);
 
 /// Public entry: the value-graph fingerprint of the unit rooted at `root`
 /// (sorted multiset of `u64` value hashes). Equivalent computations → equal
@@ -58,11 +59,20 @@ pub fn value_fingerprint_lits_anchors(
     root: NodeId,
     interner: &Interner,
 ) -> FingerprintBundle {
+    let (v, l, r, a, _) = value_fingerprint_lits_anchors_laws(il, root, interner);
+    (v, l, r, a)
+}
+
+/// `value_fingerprint_lits_anchors` plus pack-facing value-law provenance for laws that
+/// actually rewrote or bridged the unit's value graph.
+pub fn value_fingerprint_lits_anchors_laws(
+    il: &Il,
+    root: NodeId,
+    interner: &Interner,
+) -> FingerprintLawBundle {
     let mut b = Builder::new(il, interner);
     b.build_unit(root);
-    let (v, l, r) = b.fingerprint_lits();
-    let a = b.anchors(ANCHOR_MIN_WEIGHT);
-    (v, l, r, a)
+    finish_fingerprint_law_bundle(b)
 }
 
 /// Context-shared variant of [`value_fingerprint_lits_anchors`].
@@ -72,11 +82,29 @@ pub fn value_fingerprint_lits_anchors_with_context(
     interner: &Interner,
     context: &ValueFingerprintContext,
 ) -> FingerprintBundle {
+    let (v, l, r, a, _) =
+        value_fingerprint_lits_anchors_laws_with_context(il, root, interner, context);
+    (v, l, r, a)
+}
+
+/// Context-shared variant of [`value_fingerprint_lits_anchors_laws`].
+pub fn value_fingerprint_lits_anchors_laws_with_context(
+    il: &Il,
+    root: NodeId,
+    interner: &Interner,
+    context: &ValueFingerprintContext,
+) -> FingerprintLawBundle {
     let mut b = Builder::new(il, interner).with_context(context);
     b.build_unit_with_context(root, Some(context));
+    finish_fingerprint_law_bundle(b)
+}
+
+fn finish_fingerprint_law_bundle(mut b: Builder<'_>) -> FingerprintLawBundle {
     let (v, l, r) = b.fingerprint_lits();
     let a = b.anchors(ANCHOR_MIN_WEIGHT);
-    (v, l, r, a)
+    b.value_laws.sort_unstable();
+    b.value_laws.dedup();
+    (v, l, r, a, b.value_laws)
 }
 
 pub fn value_fingerprint_lits_with_context(

--- a/crates/nose-normalize/src/value_graph/control.rs
+++ b/crates/nose-normalize/src/value_graph/control.rs
@@ -443,7 +443,9 @@ impl<'a> Builder<'a> {
             && self.is_safe_clamp_integer_value(hi)
             && self.has_bound_order_fact(lo, hi)
         {
-            Some(self.mk(ValOp::Clamp, vec![x, lo, hi]))
+            let value = self.mk(ValOp::Clamp, vec![x, lo, hi]);
+            self.record_value_law(ValueLaw::IntegerClampOrderedMinMax);
+            Some(value)
         } else {
             None
         }

--- a/crates/nose-normalize/src/value_graph/model.rs
+++ b/crates/nose-normalize/src/value_graph/model.rs
@@ -193,6 +193,8 @@ pub(super) struct Builder<'a> {
     /// fires where the value graph actually used the contract (it cannot mask a non-contract
     /// false merge). Sorted+deduped on read for determinism.
     pub(super) contracts: Vec<(u32, u32)>,
+    /// Pack-facing value laws that actually rewrote or bridged this unit's value graph.
+    pub(super) value_laws: Vec<ValueLaw>,
     /// Internal test counters for clamp canonicalization. They record clamp-shaped min/max
     /// nodes seen by `mk`, and the subset with a unique integer-domain `lo <= hi` proof.
     pub(super) clamp_candidate_count: usize,

--- a/crates/nose-normalize/src/value_graph/rules/factor_distribute.rs
+++ b/crates/nose-normalize/src/value_graph/rules/factor_distribute.rs
@@ -37,6 +37,7 @@ pub(in super::super) fn apply(
         return None;
     }
     let sum = builder.mk(ValOp::Bin(Op::Add as u32), vec![x, y]);
+    builder.record_value_law(ValueLaw::NumericFactorDistribution);
     Some(builder.mk(ValOp::Bin(mul), vec![sum, f]))
 }
 

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -34,6 +34,7 @@ impl<'a> Builder<'a> {
             loop_recurrence: None,
             next_loop_key_base: 0,
             contracts: Vec::new(),
+            value_laws: Vec::new(),
             clamp_candidate_count: 0,
             clamp_proof_backed_candidate_count: 0,
         }
@@ -59,6 +60,12 @@ impl<'a> Builder<'a> {
 
     pub(super) fn add_values_not_concat(&self, law: ValueLaw, values: &[ValueId]) -> bool {
         self.value_law_satisfied(law, values)
+    }
+
+    pub(super) fn record_value_law(&mut self, law: ValueLaw) {
+        if nose_semantics::pack_facing_value_law(law).is_some() {
+            self.value_laws.push(law);
+        }
     }
 
     /// Bottom-up kernel value domain of a fresh node from its op and operands.

--- a/crates/nose-normalize/src/value_graph/tests/clamp.rs
+++ b/crates/nose-normalize/src/value_graph/tests/clamp.rs
@@ -154,7 +154,11 @@ fn guarded_function(
     )
 }
 
-fn literal_bound_function(shape: ClampShape, lo_value: i64, hi_value: i64) -> (usize, usize) {
+fn literal_bound_function(
+    shape: ClampShape,
+    lo_value: i64,
+    hi_value: i64,
+) -> (usize, usize, Vec<ValueLaw>) {
     let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));
     let px = param(&mut b, 0, 1);
@@ -190,13 +194,20 @@ fn literal_bound_function(shape: ClampShape, lo_value: i64, hi_value: i64) -> (u
     (
         builder.clamp_candidate_count,
         builder.clamp_proof_backed_candidate_count,
+        builder.value_laws,
     )
 }
 
 #[test]
 fn literal_bound_order_is_proof_backed_only_when_ordered() {
-    assert_eq!(literal_bound_function(ClampShape::MinMax, 1, 10), (1, 1));
-    assert_eq!(literal_bound_function(ClampShape::MinMax, 10, 1), (1, 0));
+    assert_eq!(
+        literal_bound_function(ClampShape::MinMax, 1, 10),
+        (1, 1, vec![ValueLaw::IntegerClampOrderedMinMax])
+    );
+    assert_eq!(
+        literal_bound_function(ClampShape::MinMax, 10, 1),
+        (1, 0, Vec::new())
+    );
 }
 
 #[test]

--- a/crates/nose-semantics/src/evidence.rs
+++ b/crates/nose-semantics/src/evidence.rs
@@ -468,7 +468,9 @@ impl ValueDomain {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(
+    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, serde::Serialize, serde::Deserialize,
+)]
 pub enum ValueLaw {
     AddCommutativity,
     AddAssociativity,
@@ -479,6 +481,7 @@ pub enum ValueLaw {
     BooleanAssociativity,
     NumericFactorDistribution,
     StructuralNumericFold,
+    IntegerClampOrderedMinMax,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -520,6 +523,122 @@ pub struct ValueLawContract {
     pub requirement: ValueDomainRequirement,
     pub channel: ChannelEligibility,
     pub evidence: ValueDomainEvidence,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ValueLawProofStatus {
+    Proven,
+    Covered,
+    Missing,
+    EmpiricalOnly,
+    RejectedCounterexample,
+}
+
+impl ValueLawProofStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ValueLawProofStatus::Proven => "proven",
+            ValueLawProofStatus::Covered => "covered",
+            ValueLawProofStatus::Missing => "missing",
+            ValueLawProofStatus::EmpiricalOnly => "empirical-only",
+            ValueLawProofStatus::RejectedCounterexample => "rejected-counterexample",
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ValueLawRegistryEntry {
+    pub law: ValueLaw,
+    pub pack_id: &'static str,
+    pub law_id: &'static str,
+    pub channel: ChannelEligibility,
+    pub proof_status: ValueLawProofStatus,
+    pub proof_obligation_id: &'static str,
+    pub requirements: &'static [&'static str],
+    pub conformance_refs: &'static [&'static str],
+}
+
+#[derive(
+    Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, serde::Serialize, serde::Deserialize,
+)]
+pub struct ValueLawProvenance {
+    pub pack_id: String,
+    pub pack_hash: String,
+    pub law_id: String,
+    pub channel: String,
+    pub proof_status: String,
+    pub proof_obligation_id: String,
+}
+
+const VALUE_GRAPH_LAW_PACK_ID: &str = FIRST_PARTY_VALUE_LAW_PACK_ID;
+
+const FACTOR_DISTRIBUTE_REQUIREMENTS: &[&str] = &[
+    "ValueDomain.Number for distributed operands and shared factor",
+    "numeric domain comes from a strict numeric operator surface or explicit domain evidence",
+];
+const FACTOR_DISTRIBUTE_CONFORMANCE: &[&str] = &[
+    "factor-distribute-numeric-positive",
+    "factor-distribute-string-repetition-hard-negative",
+];
+
+const CLAMP_REQUIREMENTS: &[&str] = &[
+    "ValueDomain.Integer-compatible operands",
+    "lo <= hi bound-order proof",
+    "unique min/max or clamp-surface candidate",
+];
+const CLAMP_CONFORMANCE: &[&str] = &[
+    "clamp-ordered-minmax-positive",
+    "clamp-unproven-bound-hard-negative",
+    "clamp-swapped-bound-hard-negative",
+    "clamp-float-hard-negative",
+];
+
+static PACK_FACING_VALUE_LAWS: &[ValueLawRegistryEntry] = &[
+    ValueLawRegistryEntry {
+        law: ValueLaw::NumericFactorDistribution,
+        pack_id: VALUE_GRAPH_LAW_PACK_ID,
+        law_id: "value-graph.factor-distribute.numeric-common-factor",
+        channel: ChannelEligibility::ExactProven,
+        proof_status: ValueLawProofStatus::Proven,
+        proof_obligation_id: "normalize.value_graph.factor_distribute",
+        requirements: FACTOR_DISTRIBUTE_REQUIREMENTS,
+        conformance_refs: FACTOR_DISTRIBUTE_CONFORMANCE,
+    },
+    ValueLawRegistryEntry {
+        law: ValueLaw::IntegerClampOrderedMinMax,
+        pack_id: VALUE_GRAPH_LAW_PACK_ID,
+        law_id: "value-graph.clamp.integer-ordered-minmax",
+        channel: ChannelEligibility::ExactProven,
+        proof_status: ValueLawProofStatus::Proven,
+        proof_obligation_id: "normalize.value_graph.clamp",
+        requirements: CLAMP_REQUIREMENTS,
+        conformance_refs: CLAMP_CONFORMANCE,
+    },
+];
+
+pub fn pack_facing_value_laws() -> &'static [ValueLawRegistryEntry] {
+    PACK_FACING_VALUE_LAWS
+}
+
+pub fn pack_facing_value_law(law: ValueLaw) -> Option<&'static ValueLawRegistryEntry> {
+    PACK_FACING_VALUE_LAWS.iter().find(|entry| entry.law == law)
+}
+
+impl ValueLawRegistryEntry {
+    pub fn provenance(self) -> ValueLawProvenance {
+        ValueLawProvenance {
+            pack_id: self.pack_id.to_string(),
+            pack_hash: format!("{:016x}", semantic_pack_hash(self.pack_id)),
+            law_id: self.law_id.to_string(),
+            channel: self.channel.as_str().to_string(),
+            proof_status: self.proof_status.as_str().to_string(),
+            proof_obligation_id: self.proof_obligation_id.to_string(),
+        }
+    }
+}
+
+pub fn value_law_provenance(law: ValueLaw) -> Option<ValueLawProvenance> {
+    pack_facing_value_law(law).map(|entry| entry.provenance())
 }
 
 pub(crate) fn strict_numeric_operand_operator(op: Op) -> bool {

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -52,6 +52,7 @@ pub use type_domain::{
 
 /// Stable pack id for the first-party language/stdlib contracts compiled into nose.
 pub const FIRST_PARTY_PACK_ID: &str = "nose.first_party";
+pub const FIRST_PARTY_VALUE_LAW_PACK_ID: &str = "nose.value_graph.laws";
 
 /// Channel a semantic fact or contract is safe to influence.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -60,6 +61,17 @@ pub enum ChannelEligibility {
     NearOnly,
     ExactEmpirical,
     ExactProven,
+}
+
+impl ChannelEligibility {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ChannelEligibility::SyntaxOnly => "syntax-only",
+            ChannelEligibility::NearOnly => "near-only",
+            ChannelEligibility::ExactEmpirical => "exact-empirical",
+            ChannelEligibility::ExactProven => "exact-proven",
+        }
+    }
 }
 
 /// Trust/provenance policy for a pack, separate from which analysis channel a fact may enter.
@@ -1301,6 +1313,7 @@ impl OperatorSemantics {
             ValueLaw::BooleanIdempotence
             | ValueLaw::BooleanCommutativity
             | ValueLaw::BooleanAssociativity => ValueDomainRequirement::BooleanOperands,
+            ValueLaw::IntegerClampOrderedMinMax => return None,
         };
         Some(ValueLawContract {
             law,
@@ -1311,11 +1324,18 @@ impl OperatorSemantics {
     }
 
     pub fn strict_operand_domain(self, op: Op) -> Option<ValueDomain> {
-        if strict_numeric_operand_operator(op) {
+        if self.strict_numeric_operand_operator(op) {
             Some(ValueDomain::Number)
         } else {
             None
         }
+    }
+
+    fn strict_numeric_operand_operator(self, op: Op) -> bool {
+        if op == Op::Mul && matches!(self.lang, Lang::Python | Lang::Ruby) {
+            return false;
+        }
+        strict_numeric_operand_operator(op)
     }
 
     pub fn unary_operand_domain(self, op: Op) -> Option<ValueDomain> {
@@ -1341,7 +1361,7 @@ impl OperatorSemantics {
     ) -> ValueDomain {
         if op == Op::Mul && (left == ValueDomain::String || right == ValueDomain::String) {
             ValueDomain::String
-        } else if strict_numeric_operand_operator(op) {
+        } else if self.strict_numeric_operand_operator(op) {
             if left.is_known() || right.is_known() {
                 if left == ValueDomain::Number && right == ValueDomain::Number {
                     ValueDomain::Number

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -5,8 +5,8 @@
 //! require occurrence evidence and kernel-owned admission checks.
 
 use crate::{
-    PackTrust, FIRST_PARTY_PACK_ID, PYTHON_STDLIB_TYPE_DOMAIN_ALIAS_CONTRACTS,
-    PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID,
+    pack_facing_value_laws, PackTrust, FIRST_PARTY_PACK_ID, FIRST_PARTY_VALUE_LAW_PACK_ID,
+    PYTHON_STDLIB_TYPE_DOMAIN_ALIAS_CONTRACTS, PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID,
 };
 use nose_il::stable_symbol_hash;
 use serde::Deserialize;
@@ -298,10 +298,54 @@ pub fn python_stdlib_type_domain_pack() -> SemanticPackSummary {
     }
 }
 
+pub fn first_party_value_law_pack() -> SemanticPackSummary {
+    let laws = pack_facing_value_laws();
+    SemanticPackSummary {
+        id: FIRST_PARTY_VALUE_LAW_PACK_ID.to_string(),
+        hash: semantic_pack_hash(FIRST_PARTY_VALUE_LAW_PACK_ID),
+        kind: SemanticPackKind::LawPack,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        display_name: "nose value-graph law pack".to_string(),
+        trust: PackTrust::DefaultFirstParty,
+        enabled_by_default: true,
+        source: SemanticPackSource::CompiledFirstParty,
+        influence: SemanticPackInfluence::EvidenceAndContracts,
+        manifest_path: None,
+        provider: "Corca, Inc.".to_string(),
+        repository: "https://github.com/corca-ai/nose".to_string(),
+        license: "MIT".to_string(),
+        supported_languages: Vec::new(),
+        counts: SemanticPackCounts {
+            evidence_producers: 0,
+            contracts: 0,
+            value_laws: laws.len(),
+            positive_fixtures: laws
+                .iter()
+                .map(|law| {
+                    law.conformance_refs
+                        .iter()
+                        .filter(|id| !id.contains("hard-negative"))
+                        .count()
+                })
+                .sum(),
+            hard_negatives: laws
+                .iter()
+                .map(|law| {
+                    law.conformance_refs
+                        .iter()
+                        .filter(|id| id.contains("hard-negative"))
+                        .count()
+                })
+                .sum(),
+        },
+    }
+}
+
 fn compiled_first_party_packs() -> Vec<SemanticPackSummary> {
     vec![
         first_party_semantic_pack(),
         python_stdlib_type_domain_pack(),
+        first_party_value_law_pack(),
     ]
 }
 
@@ -1407,6 +1451,13 @@ mod tests {
             python.counts.positive_fixtures,
             PYTHON_STDLIB_TYPE_DOMAIN_ALIAS_CONTRACTS.len()
         );
+        let laws = first_party_value_law_pack();
+        assert_eq!(laws.id, FIRST_PARTY_VALUE_LAW_PACK_ID);
+        assert_eq!(laws.hash, stable_symbol_hash(FIRST_PARTY_VALUE_LAW_PACK_ID));
+        assert_eq!(laws.kind, SemanticPackKind::LawPack);
+        assert_eq!(laws.counts.value_laws, pack_facing_value_laws().len());
+        assert_eq!(laws.counts.positive_fixtures, 2);
+        assert_eq!(laws.counts.hard_negatives, 4);
     }
 
     #[test]
@@ -1415,9 +1466,10 @@ mod tests {
         let path = dir.join("pack.json");
         fs::write(&path, manifest("com.example.pack")).unwrap();
         let set = SemanticPackSet::new_local(&[path]).expect("pack loads");
-        assert_eq!(set.packs().len(), 3);
+        assert_eq!(set.packs().len(), 4);
         assert_eq!(set.packs()[1].id, PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID);
-        let external = &set.packs()[2];
+        assert_eq!(set.packs()[2].id, FIRST_PARTY_VALUE_LAW_PACK_ID);
+        let external = &set.packs()[3];
         assert_eq!(external.id, "com.example.pack");
         assert_eq!(external.hash, stable_symbol_hash("com.example.pack"));
         assert_eq!(external.trust, PackTrust::ExternalOptIn);

--- a/crates/nose-semantics/src/tests/semantic_evidence.rs
+++ b/crates/nose-semantics/src/tests/semantic_evidence.rs
@@ -13,6 +13,48 @@ fn value_domain_inference_treats_retained_float_literals_as_numeric() {
 }
 
 #[test]
+fn value_domain_inference_does_not_treat_python_repetition_as_numeric_proof() {
+    assert_eq!(
+        inferred_domains_for_multiplied_literal(Lang::Python),
+        vec![ValueDomain::Unknown],
+        "Python `*` can be string/list repetition, so untyped operands must fail closed"
+    );
+    assert_eq!(
+        inferred_domains_for_multiplied_literal(Lang::Ruby),
+        vec![ValueDomain::Unknown],
+        "Ruby `*` can be repetition, so untyped operands must fail closed"
+    );
+    assert_eq!(
+        inferred_domains_for_multiplied_literal(Lang::Rust),
+        vec![ValueDomain::Number],
+        "Rust `*` remains a strict numeric operator for the first-party language profile"
+    );
+}
+
+fn inferred_domains_for_multiplied_literal(lang: Lang) -> Vec<ValueDomain> {
+    let sp = Span::synthetic(FileId(0));
+    let mut b = IlBuilder::new(FileId(0));
+    let param = b.add(NodeKind::Param, Payload::Cid(0), sp, &[]);
+    let varx = b.add(NodeKind::Var, Payload::Cid(0), sp, &[]);
+    let lit = b.add(NodeKind::Lit, Payload::LitInt(2), sp, &[]);
+    let mul = b.add(NodeKind::BinOp, Payload::Op(Op::Mul), sp, &[varx, lit]);
+    let ret = b.add(NodeKind::Return, Payload::None, sp, &[mul]);
+    let func = b.add(NodeKind::Func, Payload::None, sp, &[param, ret]);
+    let il = b.finish(
+        func,
+        FileMeta {
+            path: "t".into(),
+            lang,
+        },
+        Vec::new(),
+        Vec::new(),
+    );
+    semantics(lang)
+        .operators()
+        .infer_param_value_domains(&il, func)
+}
+
+#[test]
 fn first_party_profile_wraps_each_language() {
     for &lang in ALL_LANGS {
         let profile = semantics(lang);

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -254,9 +254,14 @@ modeled builtin result domains, and subexpression result domains, but the law
 itself is admitted only through a `ValueLaw` contract in `nose-semantics`. This
 keeps string and sequence concatenation ordered when evidence proves those
 domains, while numeric and boolean laws still require positive domain proof.
-Today that contract records the law id and domain requirement; pack-facing
-per-use value-law provenance and conformance status remain future work rather
-than an emitted evidence family.
+The first pack-facing law pilot now reports per-family provenance for selected
+compiled first-party value laws through `nose.value_graph.laws`: numeric
+common-factor distribution and integer ordered min/max clamp. That provenance
+records the pack id, stable law id, exact channel, proof status, and formal
+obligation id only when the value graph actually applied the law. It is not a
+new `EvidenceRecord` family, and external LawPack manifests remain
+`metadata-only` until a future producer/runtime path can satisfy the same
+kernel-owned law registry boundary.
 
 Selected `LibraryApi` result-domain evidence follows the same model. A
 first-party factory call result may carry `Domain(Collection)`, `Domain(Set)`,

--- a/docs/examples/semantic-packs/v0/fixtures/python/factor_distribute_string_repetition.py
+++ b/docs/examples/semantic-packs/v0/fixtures/python/factor_distribute_string_repetition.py
@@ -1,0 +1,6 @@
+def repeated(a, b):
+    return a * 2 + b * 2
+
+
+def grouped(a, b):
+    return (a + b) * 2

--- a/docs/examples/semantic-packs/v0/fixtures/rust/clamp_float.rs
+++ b/docs/examples/semantic-packs/v0/fixtures/rust/clamp_float.rs
@@ -1,0 +1,7 @@
+fn float_minmax(x: f64) -> f64 {
+    x.max(0.0).min(10.0)
+}
+
+fn float_clamp(x: f64) -> f64 {
+    x.clamp(0.0, 10.0)
+}

--- a/docs/examples/semantic-packs/v0/fixtures/rust/clamp_ordered_minmax.rs
+++ b/docs/examples/semantic-packs/v0/fixtures/rust/clamp_ordered_minmax.rs
@@ -1,0 +1,7 @@
+fn minmax(x: i64) -> i64 {
+    std::cmp::min(std::cmp::max(x, 0), 10)
+}
+
+fn direct(x: i64) -> i64 {
+    x.clamp(0, 10)
+}

--- a/docs/examples/semantic-packs/v0/fixtures/rust/clamp_swapped_bound.rs
+++ b/docs/examples/semantic-packs/v0/fixtures/rust/clamp_swapped_bound.rs
@@ -1,0 +1,13 @@
+fn swapped(x: i64, lo: i64, hi: i64) -> i64 {
+    if hi < lo {
+        panic!();
+    }
+    std::cmp::min(std::cmp::max(x, hi), lo)
+}
+
+fn direct(x: i64, lo: i64, hi: i64) -> i64 {
+    if hi < lo {
+        panic!();
+    }
+    x.clamp(lo, hi)
+}

--- a/docs/examples/semantic-packs/v0/fixtures/rust/clamp_unproven_bound.rs
+++ b/docs/examples/semantic-packs/v0/fixtures/rust/clamp_unproven_bound.rs
@@ -1,0 +1,7 @@
+fn unproven(x: i64, lo: i64, hi: i64) -> i64 {
+    std::cmp::min(std::cmp::max(x, lo), hi)
+}
+
+fn direct(x: i64, lo: i64, hi: i64) -> i64 {
+    x.clamp(lo, hi)
+}

--- a/docs/examples/semantic-packs/v0/fixtures/rust/factor_distribute_positive.rs
+++ b/docs/examples/semantic-packs/v0/fixtures/rust/factor_distribute_positive.rs
@@ -1,0 +1,7 @@
+fn distributed(a: i64, b: i64, c: i64) -> i64 {
+    a * c + b * c
+}
+
+fn factored(a: i64, b: i64, c: i64) -> i64 {
+    (a + b) * c
+}

--- a/docs/examples/semantic-packs/v0/law-pack.json
+++ b/docs/examples/semantic-packs/v0/law-pack.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "../../../schemas/semantic-pack-v0.schema.json",
+  "api_version": "nose.semantic-pack.v0",
+  "pack": {
+    "id": "com.example.value-graph-laws",
+    "kind": "LawPack",
+    "version": "0.1.0",
+    "display_name": "Example value-graph law pack",
+    "description": "Illustrative v0 metadata for reusable value laws. Loading this example is metadata-only and does not register external laws.",
+    "trust": "external-opt-in",
+    "enabled_by_default": false,
+    "status": "draft-example"
+  },
+  "provenance": {
+    "provider": {
+      "name": "Example Semantic Packs",
+      "contact": "semantics@example.invalid"
+    },
+    "license": "MIT",
+    "repository": "https://example.invalid/semantic-packs/value-graph-laws",
+    "source_revision": "0000000000000000000000000000000000000000"
+  },
+  "compatibility": {
+    "nose": ">=0.5.0 <0.6.0",
+    "schema": "v0",
+    "notes": "Example only. nose's built-in value-graph law pack uses compiled first-party code and reports as nose.value_graph.laws."
+  },
+  "supported_languages": [
+    {
+      "id": "python",
+      "language_version": ">=3.8",
+      "runtime": "cpython",
+      "runtime_versions": [
+        ">=3.8"
+      ]
+    },
+    {
+      "id": "rust",
+      "language_version": ">=1.70",
+      "runtime": "rustc",
+      "runtime_versions": [
+        ">=1.70"
+      ]
+    },
+    {
+      "id": "java",
+      "language_version": ">=17",
+      "runtime": "jvm",
+      "runtime_versions": [
+        ">=17"
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "id": "nose.protocol.core",
+      "version": ">=0.1.0 <1.0.0",
+      "required": true
+    }
+  ],
+  "declares": {
+    "evidence_producers": [],
+    "contracts": [],
+    "value_laws": [
+      {
+        "id": "value-graph.factor-distribute.numeric-common-factor",
+        "requires": [
+          {
+            "ref": "Domain.Number",
+            "subject": "distributed-operands-and-shared-factor",
+            "required": true
+          },
+          {
+            "ref": "nose.formal.normalize.value_graph.factor_distribute",
+            "subject": "proof-obligation",
+            "required": true
+          }
+        ],
+        "semantics": {
+          "law": "x*f + y*f == (x+y)*f",
+          "domain": "numeric-only",
+          "demand": {
+            "arguments": "preserve-original-expression-demand",
+            "callbacks": "none"
+          },
+          "effects": [
+            "no-new-effects",
+            "preserve-operand-effect-order"
+          ],
+          "proof_obligation": "normalize.value_graph.factor_distribute"
+        },
+        "channel": "exact-proven",
+        "proof_status": "proven",
+        "conformance_refs": [
+          "factor-distribute-numeric-positive",
+          "factor-distribute-string-repetition-hard-negative"
+        ]
+      },
+      {
+        "id": "value-graph.clamp.integer-ordered-minmax",
+        "requires": [
+          {
+            "ref": "Domain.Integer",
+            "subject": "x-lo-hi-operands",
+            "required": true
+          },
+          {
+            "ref": "Guard.BoundOrder",
+            "subject": "lo-before-hi",
+            "required": true
+          },
+          {
+            "ref": "nose.formal.normalize.value_graph.clamp",
+            "subject": "proof-obligation",
+            "required": true
+          }
+        ],
+        "semantics": {
+          "law": "min(max(x, lo), hi) == clamp(x, lo, hi)",
+          "domain": "integer-only",
+          "demand": {
+            "arguments": "preserve-original-expression-demand",
+            "callbacks": "none"
+          },
+          "effects": [
+            "no-new-effects",
+            "preserve-operand-effect-order"
+          ],
+          "proof_obligation": "normalize.value_graph.clamp"
+        },
+        "channel": "exact-proven",
+        "proof_status": "proven",
+        "conformance_refs": [
+          "clamp-ordered-minmax-positive",
+          "clamp-unproven-bound-hard-negative",
+          "clamp-swapped-bound-hard-negative",
+          "clamp-float-hard-negative"
+        ]
+      }
+    ]
+  },
+  "conformance": {
+    "positive_fixtures": [
+      {
+        "id": "factor-distribute-numeric-positive",
+        "description": "Typed Rust integer a*c + b*c converges with (a+b)*c under the factor-distribution law.",
+        "path": "fixtures/rust/factor_distribute_positive.rs",
+        "expectation": "semantic-law-provenance-present"
+      },
+      {
+        "id": "clamp-ordered-minmax-positive",
+        "description": "Integer min(max(x, lo), hi) can enter the clamp law only when lo <= hi is proven by literal or source facts.",
+        "path": "fixtures/rust/clamp_ordered_minmax.rs",
+        "expectation": "internal-law-unit-positive"
+      }
+    ],
+    "hard_negatives": [
+      {
+        "id": "factor-distribute-string-repetition-hard-negative",
+        "description": "String/list repetition must not satisfy numeric factor distribution.",
+        "path": "fixtures/python/factor_distribute_string_repetition.py",
+        "expectation": "exact-contract-closed"
+      },
+      {
+        "id": "clamp-unproven-bound-hard-negative",
+        "description": "Parameter bounds without lo <= hi proof must not satisfy clamp equivalence.",
+        "path": "fixtures/rust/clamp_unproven_bound.rs",
+        "expectation": "exact-contract-closed"
+      },
+      {
+        "id": "clamp-swapped-bound-hard-negative",
+        "description": "Swapped min/max bounds are not the same clamp law.",
+        "path": "fixtures/rust/clamp_swapped_bound.rs",
+        "expectation": "exact-contract-closed"
+      },
+      {
+        "id": "clamp-float-hard-negative",
+        "description": "Float/NaN-sensitive clamp behavior needs a separate law and proof.",
+        "path": "fixtures/rust/clamp_float.rs",
+        "expectation": "exact-contract-closed"
+      }
+    ],
+    "known_unsupported": [
+      "External LawPack declarations are metadata-only in v0 and do not register new value-graph laws.",
+      "The first-party law registry owns exact fingerprint rewrites."
+    ],
+    "command": "nose semantic-pack check law-pack.json --format json",
+    "proofs": [
+      "https://example.invalid/semantic-packs/value-graph-laws/conformance"
+    ]
+  }
+}

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -114,7 +114,7 @@ source metadata.
 | `tool_version` | string | The `nose` package version that emitted the report. |
 | `scope.files` | integer | Number of supported source files scanned after ignores and excludes. |
 | `scope.languages` | array | Per-language file counts, largest first. |
-| `semantic_packs` | array, optional in v1 | Active semantic packs for this scan. Binaries that advertise `scan.capabilities.semantic_pack_loading` in [capabilities](capabilities.md) emit it and include compiled first-party packs such as `nose.first_party` and `nose.python.stdlib.type_domain`; local `--semantic-pack`/config packs are listed with `metadata-only` influence. Older v1 binaries omit this field. |
+| `semantic_packs` | array, optional in v1 | Active semantic packs for this scan. Binaries that advertise `scan.capabilities.semantic_pack_loading` in [capabilities](capabilities.md) emit it and include compiled first-party packs such as `nose.first_party`, `nose.python.stdlib.type_domain`, and `nose.value_graph.laws`; local `--semantic-pack`/config packs are listed with `metadata-only` influence. Older v1 binaries omit this field. |
 | `ranking.sort` | string | Sort key used for `families`: `extractability` (default), `value`, `sites`, or `hazard`. |
 | `ranking.total_families` | integer | Active families remaining after rank-time pruning, filters, baseline suppression, and structured ignores, before `--top`. |
 | `ranking.shown_families` | integer | Families present in `families`. |
@@ -220,6 +220,7 @@ schema version 1:
 | `recommended_surface` | string | Product placement hint. Current detector output uses `default`, `review`, or `hidden`; `debug` is reserved for diagnostics/regression tooling. This is ranking/presentation policy, not detector exactness. |
 | `baseline_status` | string, optional | `new` or `changed` when this family is shown because of `--baseline`. |
 | `abstraction_witness` | object, optional | Experimental weak-claim witness emitted only for `--mode abstraction` families that share a normalized template with one supported literal leaf hole. |
+| `semantic_laws` | array, optional | Deduped pack-facing law provenance for value-graph laws that actually rewrote or bridged this family. Current first-party rows include `pack_id`, `pack_hash`, `law_id`, `channel`, `proof_status`, and `proof_obligation_id`. External local LawPack manifests are `metadata-only` today and do not appear here unless future producer execution admits them through the kernel. |
 
 Each `locations[]` item has:
 

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -725,8 +725,10 @@ Remaining after the foundation tranche:
   JS-like/Ruby library HOF callback demand from pull-lazy Rust iterator/Java
   Stream callback demand; broader protocol families and pack-facing schema rows
   remain open.
-- Move internal value laws toward pack-facing law ids, conformance status, and
-  per-finding provenance (#167).
+- Expand the first pack-facing value-law provenance pilot beyond
+  `factor_distribute` and `clamp` (#167) to reduction laws, parity/toggle laws,
+  low-level byte-pack laws, structural recursion, ecosystem law packs, and
+  external LawPack producer execution.
 - Keep behavior-changing recall reductions documented when missing evidence
   blocks exact convergence, and preserve the current precision gates while more
   first-party surfaces move behind shared contracts.
@@ -834,11 +836,13 @@ Remaining after the foundation tranche:
   producer coverage, Java constructor call-domain evidence if that lowering
   stops collapsing directly to sequence surfaces, and protocol-specific receiver
   facts that include demand/effect obligations.
-- Turn named value-graph rule modules into LawPack-facing law ids/contracts while
-  retaining formal-obligation metadata as the first-party proof boundary. The
-  first `ValueLaw` contract surface now covers current arithmetic/boolean
-  domain gates, but reduction laws, parity/toggle laws, low-level byte-pack
-  laws, and ecosystem law packs remain local first-party code.
+- Turn the remaining named value-graph rule modules into LawPack-facing law
+  ids/contracts while retaining formal-obligation metadata as the first-party
+  proof boundary. The first compiled `nose.value_graph.laws` pilot now reports
+  per-family provenance for numeric common-factor distribution and integer
+  ordered min/max clamp. Reduction laws, parity/toggle laws, low-level byte-pack
+  laws, structural recursion, and ecosystem law packs remain local first-party
+  code or metadata-only declarations.
 - Add receiver/place facts so field read/write and property contracts are not
   field-name-only.
 - Add provenance fields internally before exposing them in scan JSON.

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -162,9 +162,12 @@ migrated.
   type helper. Unknown remains optimistic only for the historical non-concat
   `+` policy; explicit string/sequence domain evidence keeps concatenation
   ordered, and numeric/boolean laws require positive domain proof. The current
-  `ValueLawContract` is still an internal law-id/requirement facade: per-use
-  provenance and independent conformance status are not yet tracked as separate
-  value-law evidence records.
+  `ValueLawContract` remains the internal domain gate, and the first compiled
+  first-party `LawPack` pilot now reports per-family provenance for selected
+  proof-backed value-graph laws through `nose.value_graph.laws`. The pilot covers
+  numeric common-factor distribution and integer ordered min/max clamp, including
+  stable law ids, exact-proven channel, proven status, and formal obligation ids.
+  Broader internal laws and external LawPack execution remain closed.
 - Source facts are now first-class internal evidence for source distinctions that
   the shared IL erases. JS/TS frontends emit construct syntax, async `await`,
   generator `yield` boundaries, regex literal, strict/loose equality,
@@ -697,11 +700,10 @@ Semantic knowledge still appears in several forms outside the facade:
   evidence subgraph into the importer, preserves provider source-origin spans,
   rewires dependency ids, and records `ImportedLiteralSnapshot` provenance tied
   to the importer static import proof;
-- broader value-domain evidence and LawPack records beyond the first
-  `ValueDomain` / `ValueLaw` contracts now used by value-graph arithmetic,
-  boolean, factor, large-formula, and structural-recursion gates;
+- broader value-domain evidence and LawPack records beyond the current
+  first-party `nose.value_graph.laws` pilot for factor distribution and clamp;
 - named value-graph rule modules that still consume internal `Builder` facts
-  instead of versioned `LawPack` records;
+  without pack-facing per-family provenance;
 - oracle evaluation rules for admitted eager calls, short-circuit quantifiers,
   append mutation, nullish defaulting, reductions, and HOF callback execution
   now consume internal demand profiles, but broader lazy, async, generator,

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -127,9 +127,11 @@ that require code. In both cases, packs emit kernel-defined facts and contracts,
 not private value-graph operations.
 
 Current named value-graph rule modules such as `value_graph/rules/clamp.rs` are
-the internal precursor to `LawPack` law ids. External packs may declare evidence
-and API facts that make a law applicable, but they must not bypass the first-party
-law registry or emit private canonical value-graph nodes.
+the internal precursor to `LawPack` law ids. The first compiled first-party pilot,
+`nose.value_graph.laws`, reports per-family provenance for numeric
+factor-distribution and integer ordered-clamp laws. External packs may declare
+evidence and API facts that make a law applicable, but they must not bypass the
+first-party law registry or emit private canonical value-graph nodes.
 
 ## Extension boundary
 

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -66,6 +66,14 @@ with each other or any compiled first-party pack id, or when declared conformanc
 fixtures are missing a path, missing an expectation, or point at a file that does
 not exist. For `--format json`, the command still writes the report before
 returning the non-zero exit.
+The example [law pack](examples/semantic-packs/v0/law-pack.json) uses this
+workflow to declare value-law positives and hard negatives. Passing the check
+confirms only that the law metadata and fixture assets are structurally present;
+it does not register those external laws with exact consumers.
+Its expectation labels distinguish report-visible positives such as
+`semantic-law-provenance-present` from narrower unit-level fixtures such as
+`internal-law-unit-positive`; the harness preserves those labels but does not
+execute them.
 
 ## JSON Report
 

--- a/docs/semantic-pack-extension-api-v0.md
+++ b/docs/semantic-pack-extension-api-v0.md
@@ -12,6 +12,7 @@ Schema artifacts:
 - [semantic-pack-v0 schema](schemas/semantic-pack-v0.schema.json)
 - [language-pack example](examples/semantic-packs/v0/language-pack.json)
 - [library-pack example](examples/semantic-packs/v0/library-pack.json)
+- [law-pack example](examples/semantic-packs/v0/law-pack.json)
 - [Python stdlib type-domain pack example](examples/semantic-packs/v0/python-typing-domain-pack.json)
 - [semantic-pack-conformance](semantic-pack-conformance.md)
 - [semantic-pack-loading](semantic-pack-loading.md)
@@ -369,6 +370,14 @@ External law declarations do not let a pack bypass the first-party law registry
 or emit private value-graph nodes. Until the law registry is pack-facing, external
 law packs should stay `near-only` unless nose adopts them as first-party.
 
+The first compiled first-party `LawPack` pilot is `nose.value_graph.laws`. It
+reports pack-facing law provenance for two proof-backed value-graph laws:
+numeric common-factor distribution and integer ordered min/max clamp. Those laws
+still execute from compiled first-party Rust and their exact status is tied to
+the project's formal obligation registry. The [law-pack example](examples/semantic-packs/v0/law-pack.json)
+shows the external v0 declaration shape and fixtures, but loading that manifest
+locally remains `metadata-only`.
+
 ## Conflict And Ambiguity Policy
 
 The default policy is fail closed:
@@ -434,6 +443,11 @@ nose does not validate or certify for external packs:
 
 First-party default packs are different: nose owns their tests, hard negatives,
 proof obligations, release gating, and documentation.
+
+Expectation labels are provider-authored strings. The example LawPack uses
+`semantic-law-provenance-present` only for report-visible provenance and
+`internal-law-unit-positive` for narrower fixtures that exercise a first-party
+law without promising a scan-family JSON row.
 
 ## First-Party Mapping
 

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -56,7 +56,8 @@ Trust is separate from channel eligibility.
   currently influence evidence and contracts. `nose.first_party` is the core
   kernel facade; `nose.python.stdlib.type_domain` is the first narrow stdlib
   pilot pack for Python `typing`, `collections.abc`, and `asyncio`
-  type-domain aliases.
+  type-domain aliases; `nose.value_graph.laws` is the first LawPack pilot for
+  selected proof-backed value-graph law provenance.
 - Local external packs require explicit user opt-in through CLI or config.
 - Local manifests must declare `trust = "external-opt-in"` and
   `enabled_by_default = false`; manifests that claim first-party trust or default


### PR DESCRIPTION
Closes #167.

## Summary

- Add compiled first-party LawPack summary `nose.value_graph.laws` with stable law ids for numeric factor distribution and integer clamp min/max.
- Record value-law provenance in the value graph and expose it only at scan family level as `semantic_laws` after a registered law actually rewrites/bridges a fingerprint.
- Keep internal value laws internal unless registered in the pack-facing registry.
- Add LawPack example manifest/fixtures and update docs for scan JSON, evidence records, pack loading, and the semantic kernel snapshot/roadmap.
- Tighten Python/Ruby `*` value-domain inference so untyped repetition-like surfaces fail closed instead of proving numeric factor distribution.
- Bump CLI cache schema for cached `UnitFeat.semantic_laws`.

## Validation

- `cargo test -p nose-semantics -p nose-normalize -p nose-detect -p nose-cli`
- `cargo clippy -p nose-semantics -p nose-normalize -p nose-detect -p nose-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `awiki lint --root docs`
- `cargo run -q -p nose-cli -- semantic-pack check docs/examples/semantic-packs/v0 --format json`
- `scripts/check-formal-obligations.py`
- `cargo build --release`
- `scripts/check-duplication.sh`

## Notes

A sidecar review caught an important hard-negative leak before PR creation: the old operator inference treated Python `*` as strict numeric and could report factor-distribution provenance for repetition-shaped code. This PR fixes that path and adds CLI/semantics regression tests.
