### PR TITLE
docs: close out semantic kernel tracker

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -60,7 +60,7 @@ You want to *change* nose or understand how it works inside.
 - [source-facts](source-facts.md) — source-origin evidence for semantic contracts: construct syntax, async/generator/error boundaries, literal/operator provenance, pack boundaries, and fail-closed exact admission.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
 - [semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md) — post-PR #147 audit of remaining raw/local semantic pockets and follow-up owners.
-- [semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md) — closeout for the first #109 foundation tranche and the next semantic-kernel issue map.
+- [semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md) — closeout for the #109 semantic-kernel foundation and follow-up tranche.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.
 - [fragment-contracts](fragment-contracts.md) — how exact sub-function fragments are modeled: classification, contract, the wrapper-synthesis behavior oracle, the effect algebra, and fail-closed receiver identity.
 - [formal-soundness](formal-soundness.md) — Lean 4 proof-obligation registry for proof-sensitive IL, normalization, fragment, and oracle contracts.

--- a/docs/semantic-kernel-audit-2026-06-09.md
+++ b/docs/semantic-kernel-audit-2026-06-09.md
@@ -166,8 +166,10 @@ semantic meaning.
 
 ## Closeout Update
 
-This audit's follow-up queue was completed in the #109 foundation tranche:
+This audit's follow-up queue was completed in the #109 foundation and follow-up
+tranches:
 
+- #150 completed the post-PR #147 raw/local semantic pocket audit.
 - #151 defined the provider-facing extension API v0.
 - #152 added local metadata loading, opt-in trust plumbing, and scan JSON pack
   provenance.
@@ -177,6 +179,11 @@ This audit's follow-up queue was completed in the #109 foundation tranche:
 - #155 expanded call-target and dispatch evidence.
 - #156 expanded type/domain evidence.
 - #157 added the semantic pack conformance harness and provider/user workflow.
+- #166 shipped the first compiled first-party pack pilot.
+- #169 broadened first-party producer coverage for imported call-target facts.
+- #168 expanded demand/effect contracts for admitted library HOF timing.
+- #167 shipped the first compiled LawPack pilot and family-level value-law
+  provenance.
 
-The next issue map is recorded in
+The #109 closeout is recorded in
 [semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -6,7 +6,7 @@ of remaining raw/local semantic pockets is in
 [semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md). The
 provider-facing v0 extension API is in
 [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md). The
-closeout for the first #109 foundation tranche is in
+closeout for the #109 semantic-kernel migration is in
 [semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
 
 This page tracks decisions, history, and remaining work for the semantic kernel
@@ -671,11 +671,11 @@ and pack ecosystem.
   dependencies, channel eligibility, trust/default status, provider/user
   responsibility boundaries, examples, local metadata loading, and local
   conformance checks for manifests plus declared fixture assets.
-- The first #109 foundation tranche closed issues #150-#157. The closeout
-  records the landed API/loading/conformance/demand/effect/Promise/call-target/
-  domain foundation and opens the next tranche around first-party pack pilots,
-  broader producer coverage, richer demand/effect contracts, and pack-facing
-  value-law provenance.
+- The #109 semantic-kernel migration closed issues #150-#157, #166, #169, #168,
+  and #167. The closeout records the landed API/loading/conformance/demand/
+  effect/Promise/call-target/domain foundation, the first compiled first-party
+  pack pilot, broader imported call-target producer coverage, admitted library
+  HOF demand/effect contracts, and the first compiled LawPack provenance pilot.
 - The first first-party pack pilot moved Python stdlib type-domain aliases from
   a raw helper table into a pack-shaped contract row set with active
   `nose.python.stdlib.type_domain` provenance.
@@ -710,23 +710,20 @@ Landed in PR #100 and PR #101:
   obligations for the migrated facade paths.
 - Parser and lowering dispatch remain unchanged.
 
-Remaining after the foundation tranche:
+Remaining after the #109 closeout:
 
-- Ship a narrow first-party pack pilot (#166) so the v0 API, metadata loading,
-  conformance workflow, provenance, and evidence vocabulary are exercised by an
-  actual default pack-shaped implementation.
-- Continue producer coverage beyond the call-target imported-function/member
-  slice for direct methods, dynamic dispatch, richer domains, guards,
-  aggregates, and module/export dependencies without reopening raw
-  selector/name/type/tag fallbacks.
-- Expand demand/effect contracts (#168) for lazy, iterator, generator, async,
-  channel, repeated, and call-by-need semantics before ecosystem APIs can enter
-  exact matching. The first iterator/HOF slice now distinguishes eager
-  JS-like/Ruby library HOF callback demand from pull-lazy Rust iterator/Java
-  Stream callback demand; broader protocol families and pack-facing schema rows
-  remain open.
+- Broaden first-party compiled packs beyond the Python stdlib type-domain pilot
+  and the value-graph LawPack pilot, keeping external packs metadata-only until
+  an executable producer runtime and trust policy are explicitly designed.
+- Continue producer coverage beyond the imported call-target slice for direct
+  methods, dynamic dispatch, richer domains, guards, aggregates, and
+  module/export dependencies without reopening raw selector/name/type/tag
+  fallbacks.
+- Expand demand/effect contracts beyond the first admitted library HOF timing
+  slice into lazy, iterator, generator, async, channel, repeated, and
+  call-by-need semantics before ecosystem APIs can enter exact matching.
 - Expand the first pack-facing value-law provenance pilot beyond
-  `factor_distribute` and `clamp` (#167) to reduction laws, parity/toggle laws,
+  `factor_distribute` and `clamp` to reduction laws, parity/toggle laws,
   low-level byte-pack laws, structural recursion, ecosystem law packs, and
   external LawPack producer execution.
 - Keep behavior-changing recall reductions documented when missing evidence

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -10,7 +10,7 @@ v0 provider-facing extension API is defined in
 [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md), and the
 local provider/user conformance workflow is in
 [semantic-pack-conformance](semantic-pack-conformance.md). The closeout for the
-first #109 foundation tranche is in
+#109 semantic-kernel migration is in
 [semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
 
 Snapshot date: 2026-06-09. The current implementation has an internal
@@ -677,7 +677,7 @@ Semantic knowledge still appears in several forms outside the facade:
   unsigned-cast syntax. Consumption is still limited to narrow contracts such as
   JS-like static membership callbacks, the strict `typeof` exact gate, Python
   HOF/comprehension admission, and C byte-pack casts. General equality
-  dispatch, report provenance, and external pack manifests remain open;
+  dispatch and producer-executed external pack influence remain open;
 - language-specific import, symbol, or module proof mechanics that are still
   local to frontend, normalize, detect, or value-graph callers;
 - C quote-include and typedef alias proof now has `Import`/`Type` evidence for
@@ -754,8 +754,9 @@ language.
 - Language semantics are not first-class. Many rules ask "which language is this?"
   instead of "which semantic capability has been proven?"
 - Library semantics are still compiled into engine/first-party facade code.
-  Internal `LibraryApiContract` rows exist, but they are not yet versioned
-  external pack manifest contracts.
+  Internal `LibraryApiContract` rows exist, and v0 manifests can describe
+  contract metadata, but local external packs cannot yet execute producers or
+  open exact consumers.
 - Evaluation strategy is only partially shared. Internal demand profiles now
   cover the currently admitted eager, short-circuit, append, nullish-default,
   reduction, eager HOF callback, pull-lazy library iterator/stream HOF, and
@@ -821,5 +822,5 @@ Remaining migration targets are tracked in
 [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The post-PR #147
 classification snapshot is in
 [semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md), and
-the completed #150-#157 foundation tranche plus next issue map are in
+the completed #109 foundation and follow-up tranche is in
 [semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).

--- a/docs/semantic-kernel-tranche-closeout-2026-06-09.md
+++ b/docs/semantic-kernel-tranche-closeout-2026-06-09.md
@@ -1,4 +1,4 @@
-# Semantic kernel tranche closeout, 2026-06-09
+# Semantic kernel #109 closeout, 2026-06-09
 
 Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
 in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); long-range phases
@@ -8,8 +8,9 @@ closeout updates the post-PR #147 audit recorded in
 
 ## Scope
 
-This page closes the first semantic-kernel foundation tranche under GitHub issue
-#109. It covers the follow-up issues created from the post-PR #147 audit:
+This page closes the semantic-kernel foundation work tracked under GitHub issue
+#109. The first tranche covered the follow-up issues created from the post-PR
+#147 audit:
 
 | issue | PR | outcome |
 |---|---|---|
@@ -22,10 +23,20 @@ This page closes the first semantic-kernel foundation tranche under GitHub issue
 | #156 | #165 | expanded type/domain evidence vocabulary and nominal type-domain proof |
 | #157 | #163 | added semantic pack conformance harness and contribution workflow |
 
+The follow-up tranche then pressure-tested the extension boundary and producer
+model:
+
+| issue | PR | outcome |
+|---|---|---|
+| #166 | #171 | shipped the first compiled first-party pack pilot, `nose.python.stdlib.type_domain` |
+| #169 | #172 | broadened evidence producer coverage for imported call-target facts |
+| #168 | #173 | expanded demand/effect contracts for admitted library HOF timing |
+| #167 | #174 | shipped the first compiled LawPack pilot, `nose.value_graph.laws`, with family-level value-law provenance |
+
 ## Current state
 
-The tranche is complete as a foundation, not as a finished ecosystem. The code
-now has:
+The #109 migration is complete as a foundation, not as a finished ecosystem. The
+code now has:
 
 - a documented v0 pack extension shape for language/library semantics,
   contracts, evidence producers, dependencies, channel eligibility, trust, and
@@ -46,45 +57,29 @@ now has:
 - richer domain evidence for arrays, collections, iterables, iterators, sets,
   maps, records, options, results, promise/future-like values, strings,
   booleans, integer/float/number distinctions, byte arrays, and hashed nominal
-  domains.
+  domains;
+- a compiled first-party stdlib pack pilot for Python type-domain aliases,
+  exposed as `nose.python.stdlib.type_domain`;
+- broader first-party producer coverage for dependency-backed imported
+  call-target evidence;
+- demand/effect contracts that distinguish eager JS-like/Ruby library HOF
+  callbacks from pull-lazy Rust iterator and Java Stream callbacks;
+- a compiled first-party LawPack pilot, `nose.value_graph.laws`, with stable
+  law ids and family-level provenance for numeric common-factor distribution
+  and integer ordered min/max clamp.
 
 The core policy is unchanged: selectors, names, payload tags, raw IL shapes, and
 broad type-text substrings are not proof. Missing, ambiguous, conflicting,
 shadowed, or dependency-broken evidence must keep exact semantic convergence
 closed.
 
-## What remains
+## Closeout Decision
 
-The remaining work is no longer "finish #151-#157." Those issues are closed.
-The next work is to prove that the new extension boundary is practical and then
-broaden producer coverage without reopening the old raw fallbacks.
+#109 can close. All operational child issues created for this foundation and
+follow-up tranche are complete: #150-#157, #166, #169, #168, and #167.
 
-| priority | issue | work | reason |
-|---|---|---|---|
-| P0 | #166 | first-party pack pilot | The extension boundary needs one narrow default pack-shaped implementation before broad first-party conversion or external executable producers. |
-| P1 | #169 | broaden evidence producer coverage | Shared vocabularies exist, but producer coverage for call targets, richer domains, guards, aggregates, and module/export dependencies is still selective. |
-| P1 | #168 | expand demand and effect contracts | Lazy, iterator, generator, async, channel, repeated, and call-by-need semantics need more precise obligations before ecosystem APIs can enter exact matching. |
-| P2 | #167 | pack-facing value laws and provenance | Current `ValueLaw`/rule ids are internal; pack-facing law contracts, proof status, fixture expectations, and per-finding provenance remain open. |
-| quality | #149 | quality-gate ratchets and large-file cleanup | The semantic foundation is now broad enough that the remaining large/high-complexity modules should be split before more kernel behavior accumulates there. |
-
-## Recommended order
-
-Start #166 first. A small first-party pack pilot is the best pressure test for
-the API, loading, conformance, provenance, and evidence vocabulary already
-landed. It should use compiled first-party execution and preserve current exact
-behavior. The first pilot target is Python stdlib type-domain aliases from
-`typing`, `collections.abc`, and `asyncio`.
-
-Run #149 in parallel with #166 when two workers are available. It lowers the
-cost of the next semantic tranche by splitting broad files and ratcheting quality
-gates, and it should not need to touch the same pack-pilot surfaces if scoped
-carefully.
-
-Start #169 after the #166 pilot has clarified the first-party pack shape, or in
-parallel only for a producer family that does not depend on that shape. Start
-#168 when a concrete protocol family is chosen and its demand/effect hard
-negatives are clear. Start #167 after #166 has established how first-party pack
-metadata and conformance results should identify semantic contributions.
-
-Keep #109 open as the parent tracker until at least one first-party pack-shaped
-semantic surface ships and the next producer/runtime tranche is re-evaluated.
+The remaining semantic-kernel direction is no longer blocked on #109. Future
+work should be opened as new, scoped issues when a concrete language surface,
+producer family, LawPack family, or ecosystem-pack runtime slice is selected.
+The active companion issue is #149, which is a quality-gate ratchet and
+large-file cleanup track rather than a semantic-kernel behavior migration.

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -5,7 +5,7 @@ Back to [home](home.md). Current implementation status is in
 work are tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The
 post-PR #147 raw/local pocket audit is recorded in
 [semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md), and the
-first #109 foundation tranche closeout is recorded in
+#109 closeout is recorded in
 [semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
 The versioned provider-facing extension surface is defined in
 [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md). Source

--- a/docs/source-facts.md
+++ b/docs/source-facts.md
@@ -51,7 +51,7 @@ preconditions.
 | term | meaning |
 |---|---|
 | Source evidence | `EvidenceKind::Source` records keyed by stable source anchors. |
-| Evidence record | Current internal form of a source or semantic fact, with stable ids, anchors, dependencies, status, and provenance. The external pack manifest is not defined yet. |
+| Evidence record | Current internal form of a source or semantic fact, with stable ids, anchors, dependencies, status, and provenance. The v0 external pack manifest is defined separately and remains metadata-only when loaded locally. |
 | Contract | Kernel rule that maps a proven source/API surface to a semantic operation or law under explicit preconditions. |
 | Pack provenance | The pack id, provider, trust policy, version range, contract id, and evidence status behind an admitted fact or contract. |
 


### PR DESCRIPTION
Closes #109.

## Summary

- Update the #109 closeout document now that all operational child issues are complete: #150-#157, #166, #169, #168, and #167.
- Replace the old “next tranche” guidance with the final closeout decision for the umbrella tracker.
- Refresh linked semantic-kernel docs, snapshot, roadmap, audit, home, and source-facts wording so they no longer describe #166/#168/#167 or external pack manifest shape as future work.

## Validation

- `awiki lint --root docs`
- `git diff --check`
- `cargo fmt --all -- --check`

## Notes

This is a docs-only closeout PR. #149 remains a quality-gate companion issue, not a semantic-kernel behavior migration blocker.
