### PR TITLE
quality: tighten ratchet gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,10 @@ jobs:
         with:
           tool: cargo-llvm-cov
       # Line-coverage ratchet. The bar starts lenient (current line coverage is
-      # ~87%); raise --fail-under-lines over time as coverage improves. Keep it
+      # ~86%); raise --fail-under-lines over time as coverage improves. Keep it
       # in sync with scripts/check-ci-local.sh.
-      - name: coverage gate (>= 85% lines)
-        run: cargo llvm-cov --workspace --summary-only --fail-under-lines 85
+      - name: coverage gate (>= 86% lines)
+        run: cargo llvm-cov --workspace --summary-only --fail-under-lines 86
 
   msrv:
     name: minimum supported rust version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ full run here is a green CI. The full gates are:
 | **docs** | `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace` | no broken/private intra-doc links |
 | **build** | `cargo build --release` | the workspace compiles in release |
 | **tests** | `cargo test --release` | the full suite, incl. cross-language convergence |
-| **coverage** | `cargo llvm-cov --workspace --summary-only --fail-under-lines 85` | line coverage stays above the ratchet floor (currently ~87%) |
+| **coverage** | `cargo llvm-cov --workspace --summary-only --fail-under-lines 86` | line coverage stays above the ratchet floor (currently ~86%) |
 | **copy-paste** | `./scripts/check-duplication.sh` | nose run on its own source — substantial duplicate families stay within budget |
 | **MSRV** | `cargo +$MSRV check --workspace --all-targets` | the crates still build on the declared minimum Rust (`rust-version` in `Cargo.toml`) |
 | **unused deps** | `cargo machete` | no dependency declared but unused (à la *knip*) |
@@ -49,11 +49,12 @@ and checked by its own CI job. Bumping the MSRV is a conscious change — update
 
 The lint policy is defined once in the root `Cargo.toml` under `[workspace.lints]`
 and inherited by every crate via `[lints] workspace = true`. The tunable
-complexity thresholds (`cognitive-complexity-threshold`, `too-many-arguments`,
-`type-complexity`) live in `clippy.toml`. Both the clippy thresholds and the
-coverage floor start lenient and are **ratchets** — tighten them over time
-(lower the clippy thresholds, raise `--fail-under-lines`) as the code is
-simplified and tests are added; never loosen them to make a red build pass.
+thresholds (`cognitive-complexity-threshold`, `too-many-lines-threshold`,
+`too-many-arguments`, `type-complexity`) live in `clippy.toml`. Both the clippy
+thresholds and the coverage floor start lenient and are **ratchets** — tighten
+them over time (lower the clippy thresholds, raise `--fail-under-lines`) as the
+code is simplified and tests are added; never loosen them to make a red build
+pass.
 
 ### One-time tool install
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ uninlined_format_args = "warn"    # prefer `format!("{x}")` to `format!("{}", x)
 # file). These are `warn` here, which CI's `clippy -D warnings` promotes to a
 # hard gate.
 cognitive_complexity = "warn"     # cap per-function branching complexity (tunable)
+too_many_lines = "warn"           # cap per-function length (tunable)
 # Exhaustiveness: a `_ =>` arm that only stands in for a single remaining enum
 # variant silently swallows the next variant added. Spell it out instead.
 # (The blunter `wildcard_enum_match_arm` is intentionally NOT used — the IL-kind

--- a/clippy.toml
+++ b/clippy.toml
@@ -8,9 +8,14 @@
 # Run locally with: cargo clippy --all-targets --all-features -- -D warnings
 
 # Per-function cognitive complexity (branch/nesting weighted). Clippy's default
-# is 25; nose's current production ceiling is 68, so this lenient baseline sits
-# just above it. Ratchet downward as complex functions are simplified.
-cognitive-complexity-threshold = 80
+# is 25; nose's current production ceiling is 64, so this baseline sits just
+# above it. Ratchet downward as complex functions are simplified.
+cognitive-complexity-threshold = 65
+
+# Per-function length. Clippy's default is 100; nose's current production
+# ceiling is 399, with three intentionally broad fixture-matrix tests allowed
+# above this threshold. Ratchet downward as large functions are split.
+too-many-lines-threshold = 400
 
 # Already enforced by clippy's default `complexity` group; pinned here so the
 # thresholds are visible and ratchetable alongside the others.

--- a/crates/nose-cli/tests/cli/semantic_idioms.rs
+++ b/crates/nose-cli/tests/cli/semantic_idioms.rs
@@ -652,6 +652,9 @@ fn scan_mode_semantic_proves_rust_integer_methods() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for literal collection membership contracts. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn scan_mode_semantic_proves_literal_collection_membership() {
     let dir = std::env::temp_dir().join(format!("nose_literal_membership_{}", std::process::id()));
@@ -2165,6 +2168,9 @@ fn scan_mode_semantic_proves_typed_typescript_map_default_lookup() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for literal map default contracts. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn scan_mode_semantic_proves_literal_map_default_lookup() {
     let dir = std::env::temp_dir().join(format!("nose_map_default_{}", std::process::id()));

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -3708,9 +3708,9 @@ export const replaceRootDirInPath = (rootDir: string, filePath: string): string 
 }
 
 // A long, flat sequence of independent convergence assertions — its cognitive
-// complexity (133) is breadth, not deep branching, so it sits above the gate's
-// production-oriented threshold. Splitting it would not aid readability.
-#[allow(clippy::cognitive_complexity)]
+// complexity (133) and line count are breadth, not deep branching, so it sits
+// above the production-oriented gates. Splitting it would not aid readability.
+#[allow(clippy::cognitive_complexity, clippy::too_many_lines)]
 #[test]
 fn collection_membership_set_construction_converges_with_boundaries() {
     let i = Interner::new();

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -101,9 +101,9 @@ cargo build --release
 step "test (release)"
 cargo test --release
 
-step "coverage gate (cargo-llvm-cov, >= 85% lines)"
+step "coverage gate (cargo-llvm-cov, >= 86% lines)"
 need_cmd cargo-llvm-cov "install it with: cargo install cargo-llvm-cov"
-cargo llvm-cov --workspace --summary-only --fail-under-lines 85
+cargo llvm-cov --workspace --summary-only --fail-under-lines 86
 
 step "duplication gate (nose on itself)"
 ./scripts/check-duplication.sh


### PR DESCRIPTION
## Summary
- Closes #149.
- Re-measure the current quality baseline after the semantic-kernel split work.
- Enable `clippy::too_many_lines` as a workspace lint with a tunable 400-line threshold, which sits just above the current production ceiling of 399 lines.
- Allow the only three current functions above 400 lines, all broad fixture-matrix tests, instead of scattering production allows.
- Ratchet `cognitive-complexity-threshold` from 80 to 65, just above the current production ceiling of 64.
- Raise the line coverage floor from 85% to 86% in CI, local CI, and contributor docs.

## Baseline Notes
- `too_many_lines` at the default 100-line threshold currently reports 86 unique functions.
- Current functions above 400 lines are limited to:
  - `crates/nose-cli/tests/cli/semantic_idioms.rs:656` (683 lines)
  - `crates/nose-cli/tests/cli/semantic_idioms.rs:2169` (622 lines)
  - `crates/nose-cli/tests/equivalence.rs:3715` (533 lines)
- Current line coverage measured by `cargo llvm-cov --workspace --summary-only --fail-under-lines 86`: 86.21%.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo llvm-cov --workspace --summary-only --fail-under-lines 86`
- `git diff --check`
- `awiki lint --root docs`
