### PR TITLE
fix: resolve config ignore files relative to config

### DIFF
--- a/crates/nose-cli/src/config.rs
+++ b/crates/nose-cli/src/config.rs
@@ -71,6 +71,11 @@ fn discover() -> Option<PathBuf> {
 
 fn resolve_config_relative_paths(mut cfg: ScanConfig, path: &Path) -> ScanConfig {
     let base = path.parent().unwrap_or_else(|| Path::new(""));
+    if let Some(ignore_file) = &mut cfg.ignore_file {
+        if ignore_file.is_relative() {
+            *ignore_file = base.join(&ignore_file);
+        }
+    }
     for pack in &mut cfg.semantic_packs {
         if pack.is_relative() {
             *pack = base.join(&pack);
@@ -114,11 +119,15 @@ mod tests {
     fn valid_config_still_loads() {
         let p = write_cfg(
             "ok",
-            "[scan]\nmin-value = 200\nmin-size = 30\nsemantic-packs = [\"packs\"]\n",
+            "[scan]\nmin-value = 200\nmin-size = 30\nignore-file = \"nose.ignore.json\"\nsemantic-packs = [\"packs\"]\n",
         );
         let cfg = load_scan(Some(&p)).expect("valid config must load");
         assert_eq!(cfg.min_value, Some(200.0));
         assert_eq!(cfg.min_size, Some(30));
+        assert_eq!(
+            cfg.ignore_file,
+            Some(p.parent().unwrap().join("nose.ignore.json"))
+        );
         assert_eq!(cfg.semantic_packs, vec![p.parent().unwrap().join("packs")]);
     }
 }

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -876,6 +876,56 @@ fn explicit_config_semantic_pack_paths_resolve_from_config_directory() {
 }
 
 #[test]
+fn explicit_config_ignore_file_resolves_from_config_directory() {
+    let dir = make_project("ignore_explicit_cfg");
+    fs::write(
+        dir.join("nose.ignore.json"),
+        "{\"ignores\":[{\"paths\":[\"**/a/**\"],\"reason\":\"template-copy\"}]}\n",
+    )
+    .unwrap();
+    let config = dir.join("nose.toml");
+    fs::write(
+        &config,
+        "[scan]\nmin-size = 12\nignore-file = \"nose.ignore.json\"\n",
+    )
+    .unwrap();
+
+    let out = Command::new(bin())
+        .args([
+            "scan",
+            dir.to_str().unwrap(),
+            "--config",
+            config.to_str().unwrap(),
+            "--mode",
+            "semantic",
+            "--format",
+            "json",
+            "--top",
+            "0",
+        ])
+        .current_dir(dir.parent().expect("test project has a parent"))
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "scan should load config-relative ignore file: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let json = scan_json(&stdout);
+    assert!(
+        scan_families(&json).is_empty(),
+        "config-relative ignore file should suppress the family: {stdout}"
+    );
+    assert_eq!(json["ignore"]["active_entries"], 1);
+    assert_eq!(json["ignore"]["ignored_families"], 1);
+    assert!(json["ignore"]["path"]
+        .as_str()
+        .is_some_and(|path| path.ends_with("nose.ignore.json")));
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn inline_nose_ignore_suppresses_a_site() {
     // A `nose-ignore` marker above a function drops that site; with only one copy
     // left there's no family.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,13 +75,16 @@ cutoff.
 nose scan src --mode syntax,semantic,near:0.70
 ```
 
+Config file paths are resolved from the config file's directory, so committed
+project paths do not depend on where `nose` was invoked. This applies to
+`ignore-file` and `semantic-packs`. CLI path flags such as `--ignore-file` and
+`--semantic-pack` remain current-working-directory relative.
+
 `semantic-packs` is additive with repeated `--semantic-pack` flags. Each entry is
 an explicit local opt-in to a semantic-pack v0 manifest file or a directory of
-direct `*.json` manifests. Relative config paths are resolved from the config
-file's directory, so committed project opt-ins do not depend on where `nose` was
-invoked; CLI `--semantic-pack` paths remain current-working-directory relative.
-Loaded external packs are reported as `metadata-only`; they do not emit evidence
-or enable exact contracts yet. See [semantic-pack-loading](semantic-pack-loading.md).
+direct `*.json` manifests. Loaded external packs are reported as `metadata-only`;
+they do not emit evidence or enable exact contracts yet. See
+[semantic-pack-loading](semantic-pack-loading.md).
 
 ## Excludes
 


### PR DESCRIPTION
## Summary
- Fixes a config path-resolution bug: `ignore-file = "..."` from an explicit `--config` file was interpreted relative to the current working directory, while other config-owned local paths were config-directory relative.
- Resolve config-provided `ignore-file` paths from the config file directory, while preserving cwd-relative behavior for CLI `--ignore-file`.
- Document the path policy for config file paths.

## TDD Evidence
- Red: `cargo test -p nose-cli explicit_config_ignore_file_resolves_from_config_directory -- --nocapture` failed with `reading ignore file nose.ignore.json` when run from outside the config directory.
- Green: the same command now passes and the configured ignore suppresses the family.

## Validation
- `cargo test -p nose-cli explicit_config_ignore_file_resolves_from_config_directory -- --nocapture`
- `cargo test -p nose-cli config`
- `cargo test -p nose-cli structured_ignore`
- `cargo test -p nose-cli`
- `cargo clippy -p nose-cli --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `awiki lint --root docs`
