### PR TITLE
fix: fail on invalid exclude globs

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -2569,6 +2569,7 @@ pub(crate) fn detect_families(
     min_tokens: usize,
     min_lines: u32,
 ) -> Result<Vec<nose_detect::RefactorFamily>> {
+    validate_exclude_globs(exclude)?;
     let refs = paths_as_refs(paths);
     let channels = ScanChannels::resolve(mode, cfg_mode)?;
     let threshold = channels.threshold();
@@ -2597,6 +2598,20 @@ pub(crate) fn detect_families(
         families.retain(|f| f.abstraction_witness.is_some());
     }
     Ok(families)
+}
+
+fn validate_exclude_globs(exclude: &[String]) -> Result<()> {
+    if exclude.is_empty() {
+        return Ok(());
+    }
+    let mut builder = ignore::overrides::OverrideBuilder::new(".");
+    for glob in exclude {
+        builder
+            .add(&format!("!{glob}"))
+            .with_context(|| format!("invalid exclude glob {glob:?}"))?;
+    }
+    builder.build().context("building exclude glob matcher")?;
+    Ok(())
 }
 
 fn scan_detector(
@@ -2725,6 +2740,7 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
     // Excludes are additive: config patterns plus any given on the command line.
     let mut exclude = cfg.exclude;
     exclude.extend(args.exclude.iter().cloned());
+    validate_exclude_globs(&exclude)?;
     let ignore_set = ignores::load_for_scan(ignore_file.as_deref())?;
     if let Some(ignore_set) = &ignore_set {
         ignore_set.warn_expired();

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -82,6 +82,32 @@ fn exclude_supports_globs() {
 }
 
 #[test]
+fn invalid_exclude_glob_fails_clearly() {
+    let dir = make_project("bad_exclude_glob");
+    let out = Command::new(bin())
+        .args([
+            "scan",
+            dir.to_str().unwrap(),
+            "--min-size",
+            "12",
+            "--exclude",
+            "[",
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        !out.status.success(),
+        "invalid exclude glob should fail instead of being ignored"
+    );
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("invalid exclude glob"),
+        "stderr should explain the bad exclude glob: {stderr}"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn min_value_filters_low_value_families() {
     let dir = make_project("minval");
     let p = dir.to_str().unwrap();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,9 @@ they do not emit evidence or enable exact contracts yet. See
 `exclude` is **additive**: the config's globs and any `--exclude` flags on the
 command line are combined. Globs use gitignore syntax (`tests/**`,
 `**/*.test.ts`, `vendor/**`) and are applied *during the directory walk*, so an
-excluded directory is pruned, not just filtered out afterward.
+excluded directory is pruned, not just filtered out afterward. Invalid exclude
+globs are hard errors; silently scanning a path the user meant to exclude is
+worse than failing early.
 
 `.gitignore` files inside each scanned tree are respected automatically, even when that
 tree is not a git checkout, so vendored dependencies, build output, and the like are


### PR DESCRIPTION
## Summary
- Fail early when configured or CLI `exclude` globs are invalid instead of silently ignoring them.
- Validate the shared family-detection path as well as the `scan` command entrypoint.
- Document that invalid exclude globs are hard errors.

## Red / Green
- RED: `cargo test -p nose-cli invalid_exclude_glob_fails_clearly -- --nocapture` failed because `--exclude "["` was silently ignored and scan succeeded.
- GREEN: the same test now passes and stderr reports `invalid exclude glob`.

## Verification
- `cargo test -p nose-cli invalid_exclude_glob_fails_clearly -- --nocapture`
- `cargo test -p nose-cli exclude`
- `cargo test -p nose-cli config`
- `cargo test -p nose-cli`
- `cargo clippy -p nose-cli --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `awiki lint --root docs`
