### PR TITLE
fix: harden semantic fail-closed gates

### DIFF
--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -16,7 +16,7 @@ use nose_semantics::{
     asserted_unshadowed_global_symbol, imported_namespace_symbol, seq_surface_contract_for_node,
     BuiltinArgContract, DomainRequirement, LibraryMapFactoryResult, MapKeyViewKind,
     MethodBuiltinArgs, MethodCallContract, MethodReceiverContract, MethodSemanticContract,
-    ReceiverDomainEvidenceIndex, SEQ_VALUE_MAP,
+    ReceiverDomainEvidenceIndex, SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP,
 };
 
 #[cfg(test)]
@@ -604,6 +604,11 @@ fn rust_std_map_factory_call(old: &Il, interner: &Interner, node: NodeId) -> boo
     let LibraryMapFactoryResult::EntrySequence { entry_seq_tag } = admitted.contract.result else {
         return false;
     };
+    if seq_surface_contract_for_node(old, interner, kids[1])
+        .is_none_or(|contract| contract.value_tag != SEQ_VALUE_COLLECTION)
+    {
+        return false;
+    }
     map_factory_entries_match_surface(old, interner, kids[1], entry_seq_tag)
 }
 
@@ -1665,7 +1670,11 @@ mod tests {
         );
     }
 
-    fn rust_hash_map_from_call(entry_surface: &str, shadow_std: bool) -> (Il, Interner, NodeId) {
+    fn rust_hash_map_from_call(
+        entry_surface: &str,
+        shadow_std: bool,
+        with_entries_surface: bool,
+    ) -> (Il, Interner, NodeId) {
         let interner = Interner::new();
         let mut b = IlBuilder::new(FileId(0));
         let entry_span = sp_at(10, 20, 1);
@@ -1721,12 +1730,14 @@ mod tests {
             EvidenceKind::SequenceSurface(entry_kind),
             EvidenceStatus::Asserted,
         ));
-        il.evidence.push(evidence(
-            1,
-            EvidenceAnchor::sequence(entries_span),
-            EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
-            EvidenceStatus::Asserted,
-        ));
+        if with_entries_surface {
+            il.evidence.push(evidence(
+                1,
+                EvidenceAnchor::sequence(entries_span),
+                EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+                EvidenceStatus::Asserted,
+            ));
+        }
         (il, interner, call)
     }
 
@@ -1759,7 +1770,7 @@ mod tests {
 
     #[test]
     fn rust_std_map_factory_requires_entry_surface_and_shadow_proof() {
-        let (mut il, interner, call) = rust_hash_map_from_call("tuple", false);
+        let (mut il, interner, call) = rust_hash_map_from_call("tuple", false, true);
         assert!(
             !rust_std_map_factory_call(&il, &interner, call),
             "raw Rust std path proof must not prove the migrated factory"
@@ -1767,18 +1778,28 @@ mod tests {
         push_rust_hash_map_library_api_evidence(&mut il);
         assert!(rust_std_map_factory_call(&il, &interner, call));
 
-        let (mut il, interner, call) = rust_hash_map_from_call("array", false);
+        let (mut il, interner, call) = rust_hash_map_from_call("array", false, true);
         push_rust_hash_map_library_api_evidence(&mut il);
         assert!(
             !rust_std_map_factory_call(&il, &interner, call),
             "HashMap::from exact map proof requires tuple-shaped entries"
         );
 
-        let (mut il, interner, call) = rust_hash_map_from_call("tuple", true);
+        let (mut il, interner, call) = rust_hash_map_from_call("tuple", true, true);
         push_rust_hash_map_library_api_evidence(&mut il);
         assert!(
             !rust_std_map_factory_call(&il, &interner, call),
             "a local std binding must close the Rust stdlib factory path"
+        );
+    }
+
+    #[test]
+    fn rust_std_map_factory_requires_outer_entries_sequence_surface() {
+        let (mut il, interner, call) = rust_hash_map_from_call("tuple", false, false);
+        push_rust_hash_map_library_api_evidence(&mut il);
+        assert!(
+            !rust_std_map_factory_call(&il, &interner, call),
+            "HashMap::from exact map proof requires evidence for the outer entry list surface"
         );
     }
 

--- a/crates/nose-normalize/src/value_graph/control.rs
+++ b/crates/nose-normalize/src/value_graph/control.rs
@@ -817,7 +817,10 @@ impl<'a> Builder<'a> {
                 self.call_args_have_static_runtime_err(kids.iter().copied(), env)
                     || self.range_has_static_zero_step(&kids)
             }
-            Payload::Builtin(_) => self.call_args_have_static_runtime_err(kids, env),
+            Payload::Builtin(builtin) if self.admitted_builtin_call(call, builtin) => {
+                self.call_args_have_static_runtime_err(kids, env)
+            }
+            Payload::Builtin(_) => false,
             _ => self.call_args_have_static_runtime_err(kids.into_iter().skip(1), env),
         }
     }

--- a/crates/nose-normalize/src/value_graph/tests/source_evidence.rs
+++ b/crates/nose-normalize/src/value_graph/tests/source_evidence.rs
@@ -442,6 +442,28 @@ fn library_hof_static_callback_error_requires_explicit_eager_demand() {
 }
 
 #[test]
+fn raw_builtin_payload_does_not_prove_static_error_demand() {
+    let interner = Interner::new();
+    let mut b = IlBuilder::new(FileId(0));
+    let value = b.add(NodeKind::Lit, Payload::LitInt(1), sp(1), &[]);
+    let lhs = b.add(NodeKind::Lit, Payload::LitInt(1), sp(2), &[]);
+    let rhs = b.add(NodeKind::Lit, Payload::LitInt(0), sp(2), &[]);
+    let fallback = b.add(NodeKind::BinOp, Payload::Op(Op::Div), sp(2), &[lhs, rhs]);
+    let call = b.add(
+        NodeKind::Call,
+        Payload::Builtin(Builtin::ValueOrDefault),
+        sp(3),
+        &[value, fallback],
+    );
+    let il = finish_test_il(b, call, Lang::JavaScript);
+    let mut builder = Builder::new(&il, &interner);
+    assert!(
+        !builder.expr_is_static_runtime_err(call, &FxHashMap::default()),
+        "raw builtin payloads do not prove fallback demand without admitted semantics"
+    );
+}
+
+#[test]
 fn len_of_library_hof_requires_materialized_demand_profile() {
     let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -409,6 +409,7 @@ pub enum SemanticPackFixtureIssue {
     MissingPath,
     MissingFile,
     MissingExpectation,
+    AbsolutePath,
 }
 
 impl SemanticPackFixtureIssue {
@@ -417,6 +418,7 @@ impl SemanticPackFixtureIssue {
             SemanticPackFixtureIssue::MissingPath => "missing-path",
             SemanticPackFixtureIssue::MissingFile => "missing-file",
             SemanticPackFixtureIssue::MissingExpectation => "missing-expectation",
+            SemanticPackFixtureIssue::AbsolutePath => "absolute-path",
         }
     }
 }
@@ -663,8 +665,13 @@ fn fixture_check(
     let mut issues = Vec::new();
     if fixture.path.is_none() {
         issues.push(SemanticPackFixtureIssue::MissingPath);
-    } else if !resolved_path.as_ref().is_some_and(|path| path.is_file()) {
-        issues.push(SemanticPackFixtureIssue::MissingFile);
+    } else if let Some(declared_path) = fixture.path.as_deref() {
+        if Path::new(declared_path).is_absolute() {
+            issues.push(SemanticPackFixtureIssue::AbsolutePath);
+        }
+        if !resolved_path.as_ref().is_some_and(|path| path.is_file()) {
+            issues.push(SemanticPackFixtureIssue::MissingFile);
+        }
     }
     if fixture.expectation.is_none() {
         issues.push(SemanticPackFixtureIssue::MissingExpectation);
@@ -1102,7 +1109,6 @@ fn validate_manifest(manifest: &SemanticPackManifest) -> Result<(), String> {
             &contract.conformance_refs,
             &known_refs,
             &conformance_refs,
-            true,
         )?;
     }
     for law in &manifest.declares.value_laws {
@@ -1116,7 +1122,6 @@ fn validate_manifest(manifest: &SemanticPackManifest) -> Result<(), String> {
             &law.conformance_refs,
             &known_refs,
             &conformance_refs,
-            false,
         )?;
     }
     Ok(())
@@ -1168,7 +1173,7 @@ fn validate_evidence_producer(
     known_refs: &HashSet<String>,
 ) -> Result<(), String> {
     require_stable_id("declares.evidence_producers[].id", &producer.id)?;
-    if !producer.kind.starts_with_evidence_prefix() {
+    if !is_valid_evidence_kind(&producer.kind) {
         return Err(format!(
             "evidence producer `{}` has unknown kind `{}`",
             producer.id, producer.kind
@@ -1208,7 +1213,7 @@ fn validate_evidence_producer(
         ));
     }
     for emitted in &producer.emits {
-        if !emitted.starts_with_evidence_prefix() {
+        if !is_valid_evidence_kind(emitted) {
             return Err(format!(
                 "evidence producer `{}` emits unknown evidence kind `{emitted}`",
                 producer.id
@@ -1233,12 +1238,11 @@ fn validate_contract(
     conformance_refs: &[String],
     known_refs: &HashSet<String>,
     fixture_refs: &ConformanceFixtureRefs,
-    requires_surface: bool,
 ) -> Result<(), String> {
     require_stable_id("declares.contracts[].id", id)?;
-    if requires_surface && !semantics.is_object() {
-        return Err(format!("{kind} `{id}` semantics must be an object"));
-    }
+    let semantics = semantics
+        .as_object()
+        .ok_or_else(|| format!("{kind} `{id}` semantics must be an object"))?;
     for ref_id in conformance_refs {
         if !fixture_refs.all.contains(ref_id) {
             return Err(format!(
@@ -1247,14 +1251,11 @@ fn validate_contract(
         }
     }
     if channel.exact_capable() {
-        if requirements.is_empty() {
+        if !requirements.iter().any(|requirement| requirement.required) {
             return Err(format!(
-                "exact-capable {kind} `{id}` must declare evidence requirements"
+                "exact-capable {kind} `{id}` must declare at least one required evidence requirement"
             ));
         }
-        let semantics = semantics
-            .as_object()
-            .ok_or_else(|| format!("exact-capable {kind} `{id}` semantics must be an object"))?;
         if !semantics.contains_key("demand") || !semantics.contains_key("effects") {
             return Err(format!(
                 "exact-capable {kind} `{id}` must declare demand and effects"
@@ -1297,6 +1298,14 @@ fn validate_requirement(
     {
         return Err(format!(
             "`{context}` requirement references unknown id `{}`",
+            requirement.ref_id
+        ));
+    }
+    if requirement.ref_id.starts_with_evidence_prefix()
+        && !is_valid_evidence_kind(&requirement.ref_id)
+    {
+        return Err(format!(
+            "`{context}` requirement has invalid evidence ref `{}`",
             requirement.ref_id
         ));
     }
@@ -1385,6 +1394,20 @@ impl EvidenceKindPrefix for str {
             .iter()
             .any(|prefix| self.starts_with(prefix))
     }
+}
+
+fn is_valid_evidence_kind(value: &str) -> bool {
+    let Some(prefix) = ALLOWED_REQUIREMENT_PREFIXES[..ALLOWED_REQUIREMENT_PREFIXES.len() - 1]
+        .iter()
+        .find(|prefix| value.starts_with(**prefix))
+    else {
+        return false;
+    };
+    let suffix = &value[prefix.len()..];
+    !suffix.is_empty()
+        && suffix
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | ':' | '-'))
 }
 
 #[cfg(test)]
@@ -1722,6 +1745,100 @@ mod tests {
             "{err}"
         );
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn value_law_semantics_must_be_an_object_even_when_not_exact_capable() {
+        let dir = unique_dir("value_law_semantics_shape");
+        let path = dir.join("pack.json");
+        fs::write(
+            &path,
+            manifest("com.example.pack").replace(
+                r#""value_laws": []"#,
+                r#""value_laws": [{
+      "id": "python.example.near-law",
+      "requires": [],
+      "semantics": "not an object",
+      "channel": "near-only",
+      "proof_status": "missing",
+      "conformance_refs": []
+    }]"#,
+            ),
+        )
+        .unwrap();
+        let err = load_local_manifest(&path).expect_err("value law semantics must match schema");
+        assert!(
+            err.to_string().contains("semantics must be an object"),
+            "{err}"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn exact_capable_contracts_must_have_required_evidence_requirements() {
+        let dir = unique_dir("required_evidence_requirement");
+        let path = dir.join("pack.json");
+        fs::write(
+            &path,
+            manifest("com.example.pack").replace(r#""required": true"#, r#""required": false"#),
+        )
+        .unwrap();
+        let err =
+            load_local_manifest(&path).expect_err("optional-only requirements must not open exact");
+        assert!(
+            err.to_string()
+                .contains("must declare at least one required evidence requirement"),
+            "{err}"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn evidence_kind_must_match_schema_shape() {
+        let dir = unique_dir("evidence_kind_shape");
+        let path = dir.join("pack.json");
+        fs::write(
+            &path,
+            manifest("com.example.pack").replace(
+                r#""kind": "LibraryApi.Contract""#,
+                r#""kind": "LibraryApi.""#,
+            ),
+        )
+        .unwrap();
+        let err = load_local_manifest(&path).expect_err("empty evidence-kind suffix is invalid");
+        assert!(
+            err.to_string().contains("unknown kind `LibraryApi.`"),
+            "{err}"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn conformance_fixtures_must_use_manifest_relative_paths() {
+        let dir = unique_dir("absolute_fixture_path");
+        let outside = unique_dir("absolute_fixture_path_outside");
+        let absolute_fixture = outside.join("positive.py");
+        fs::write(&absolute_fixture, "print('external fixture')\n").unwrap();
+        let path = dir.join("pack.json");
+        fs::write(
+            &path,
+            manifest("com.example.pack")
+                .replace("fixtures/positive.py", absolute_fixture.to_str().unwrap()),
+        )
+        .unwrap();
+
+        let report =
+            check_semantic_pack_conformance(&[path]).expect("manifest is structurally valid");
+
+        assert!(!report.passed());
+        let issues = report.manifests[0]
+            .fixtures
+            .iter()
+            .flat_map(|fixture| fixture.issues.iter().map(|issue| issue.as_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(issues, vec!["absolute-path", "missing-file"]);
+        let _ = fs::remove_dir_all(dir);
+        let _ = fs::remove_dir_all(outside);
     }
 
     #[test]

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -679,6 +679,13 @@ and pack ecosystem.
 - The first first-party pack pilot moved Python stdlib type-domain aliases from
   a raw helper table into a pack-shaped contract row set with active
   `nose.python.stdlib.type_domain` provenance.
+- Post-closeout hardening tightened the local pack validator to match the
+  published v0 schema shape more closely, rejected absolute conformance fixture
+  paths, required exact-capable rows to contain required evidence obligations,
+  and closed two raw-shape exact fallbacks: unadmitted builtin payloads no
+  longer prove static argument demand, and Rust `HashMap::from` map proof now
+  requires outer entry-list sequence-surface evidence as well as per-entry
+  tuple evidence.
 
 ## Phase 0: documentation and vocabulary (landed)
 

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -19,8 +19,8 @@ pack meets the extension contract's minimum structural obligations:
   declarations are present;
 - evidence producers, contracts, laws, dependencies, and conformance references
   are internally linked;
-- exact-capable contracts declare evidence requirements plus demand/effect
-  semantics;
+- contracts and value laws declare object-shaped semantics, and exact-capable
+  declarations add evidence requirements plus demand/effect semantics;
 - positive fixtures and hard negatives are declared with expectation labels;
 - fixture files exist at paths relative to the manifest file.
 
@@ -95,7 +95,8 @@ execute them.
 
 Each manifest entry includes pack provenance, declaration counts, the optional
 provider-supplied conformance command, proof links, and per-fixture issue labels
-such as `missing-path`, `missing-expectation`, and `missing-file`.
+such as `missing-path`, `missing-expectation`, `missing-file`, and
+`absolute-path`.
 
 Integrations should discover support through [capabilities](capabilities.md):
 `commands.stable` includes `semantic-pack`, `schemas.semantic_pack_conformance`


### PR DESCRIPTION
## Summary
- Tighten semantic-pack manifest validation to match the published v0 shape more closely:
  - value-law semantics must be object-shaped even below exact channels
  - exact-capable rows need at least one required evidence requirement
  - evidence kind refs must have a non-empty schema-shaped suffix
  - conformance fixture paths must be manifest-relative, not absolute machine-local paths
- Keep raw builtin payloads from proving static argument demand unless the builtin occurrence is admitted.
- Require Rust `HashMap::from` exact map proof to have outer entry-list `SequenceSurface(Collection)` evidence in addition to per-entry tuple evidence.
- Record the post-closeout hardening in the semantic-kernel roadmap.

## Red / Green
- RED: `cargo test -p nose-semantics value_law_semantics_must_be_an_object_even_when_not_exact_capable -- --nocapture` failed because a near-only value law with string `semantics` loaded successfully.
- RED: `cargo test -p nose-normalize raw_builtin_payload_does_not_prove_static_error_demand -- --nocapture` failed because raw `Builtin::ValueOrDefault` demanded its fallback without admitted semantics.
- RED: `cargo test -p nose-normalize rust_std_map_factory_requires_outer_entries_sequence_surface -- --nocapture` failed because `HashMap::from` accepted per-entry tuple evidence without outer entry-list surface evidence.
- GREEN: all three targeted tests now pass, and the broader gates below pass.

## Verification
- `cargo test -p nose-normalize`
- `cargo test -p nose-semantics`
- `cargo test -p nose-cli semantic_pack`
- `cargo run -q -p nose-cli -- semantic-pack check docs/examples/semantic-packs/v0 --format json`
- `cargo test -p nose-cli map_default_lookup -- --nocapture`
- `cargo test -p nose-cli value_graph_runs_try_handler_after_static_builtin_arg_err -- --nocapture`
- `cargo test -p nose-cli`
- `cargo clippy -p nose-semantics -p nose-normalize -p nose-cli --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `awiki lint --root docs`

## Notes
- A strict-exact nested-HOF audit candidate was investigated but not included here because I could not reproduce a fail-open case in the current exact-safety path; the constructed hard negative was already closed.
