### PR TITLE
fix: close operator/seed false merges, index hot evidence lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ break.
 
 ## [Unreleased]
 
+### Fixed
+- **Soundness:** a seeded selection loop (`best = 0; … if v > best: best = v`) no
+  longer merges with the true builtin selection (`max(…)`) — the seed clamps the
+  result (empty or all-negative input returns the seed), so it is
+  behavior-defining. Selection reductions now carry their seed in the value
+  fingerprint; equally-seeded loops still converge with each other. Found by
+  `nose verify` the moment 2-argument `min`/`max` became interpretable; the
+  mislabeled adversarial benchmark case was flipped to a hard negative.
+- **Soundness:** Python `//` no longer shares a fingerprint with `/`. Floor division
+  is its own IL operator (`FloorDiv`, quotient toward −∞) with matching interpreter
+  semantics, so `5 / 2` (2.5) can never merge with `5 // 2` (2).
+- **Soundness:** JS/TS `>>>` (zero-fill shift) no longer collapses onto `>>`
+  (sign-extending shift); Python `@` (matmul) no longer collapses onto `*`. Both
+  keep a raw shape keyed by their own operator spelling.
+- **Soundness:** a strict null check (`x === null` / `x !== null`) no longer merges
+  with the nullish family (`x ?? d`, `x == null ? d : x`) — strict and loose checks
+  differ on every `undefined` input. `=== undefined` against a proven typed
+  `Map.get` result still converges with `??` (there the strict check is the
+  faithful absence test). `x ?? d` still converges with `x == null ? d : x`.
+- **Soundness:** compound assignments with an operator the IL does not model no
+  longer silently degrade: JS `x ??= y` now desugars to `x = x ?? y` (it lowered
+  as `x += y`); Java `x >>>= y` lowered as `x = y`; unmapped operators across
+  Python/JS/Go/Rust/Java/C/Ruby now keep a raw shape keyed by the operator
+  spelling instead of defaulting to `Add` or plain assignment.
+- Two different unmapped binary operators over the same operands no longer share a
+  raw fingerprint — the raw fallback now keys by the operator spelling.
+- The interpreter oracle evaluates 2-argument `min`/`max` (the 2-way selection
+  `[a, b].min()` canonicalizes to) instead of erring — closing an oracle blind
+  spot on exactly the convergences the value graph claims.
+
+### Added
+- Ruby `**` now lowers to the shared exponentiation operator and converges with
+  Python/JS `**`.
+
+### Performance
+- Minified-bundle-sized files no longer hit a quadratic cliff: `nearest_scope`
+  and evidence-record lookups were per-query linear scans over all IL
+  nodes/records and are now lazy per-file indexes. A 246 KB minified JS file
+  went from 227 s to ≈ 2 s in normalize+extract (~118×), and ordinary repos get
+  ~3× faster normalize+extract. Profiler-driven (`sample` + `NOSE_TIME=1`).
+
+### Removed
+- Pre-release compat shims: `seq_surface_contract_evidence_for_node`,
+  `unshadowed_global_symbol` (spelling fallback), `builtin_demand` and the legacy
+  `BuiltinDemand` enum (superseded by `builtin_demand_profile`), the superseded
+  `lcs_ratio` scorer, the unused `minhash::estimate`, and the never-constructed
+  `EvidenceEmitter::Legacy` variant.
+
 ## [0.5.0] - 2026-06-05
 
 ### Added

--- a/bench/type4/adversarial/cases/cases.v1.json
+++ b/bench/type4/adversarial/cases/cases.v1.json
@@ -112,14 +112,14 @@
     },
     {
       "id": "max_flat_map_nested_loop",
-      "kind": "positive",
+      "kind": "hard-negative",
       "semantic_family": "hof.flat_map",
-      "claim": "A max selection over a flat-map stream equals the corresponding nested selection loop.",
+      "claim": "A zero-seeded nested selection loop clamps at its seed (returns 0 on empty or all-negative input); true max over the flat-map stream does not.",
       "fixtures": [
         "bench/type4/adversarial/cases/flat_map_aggregate/max_flat.py",
         "bench/type4/adversarial/cases/flat_map_aggregate/max_loop.py"
       ],
-      "evidence": "Focused equivalence test converges max(x + y for x in xs for y in ys) with the nested best-update loop."
+      "evidence": "nose verify flagged the previous positive labeling as a false merge (10 differing inputs) once 2-argument min/max became interpretable; selection reductions now key their seed, and the focused equivalence test asserts the fingerprints differ while equal-seeded loops still converge."
     },
     {
       "id": "any_flat_map_nested_loop",

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -2405,6 +2405,11 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
         "def g(xs, ys):\n    best = 0\n    for x in xs:\n        for y in ys:\n            v = x + y\n            if v > best:\n                best = v\n    return best\n",
         Lang::Python,
     );
+    let max_loop_same_seed = value_fp(
+        &i,
+        "def h(left, right):\n    top = 0\n    for a in left:\n        for b in right:\n            cand = a + b\n            if cand > top:\n                top = cand\n    return top\n",
+        Lang::Python,
+    );
     let any_gen = value_fp(
         &i,
         "def f(xs, ys):\n    return any(x + y > 0 for x in xs for y in ys)\n",
@@ -2517,9 +2522,16 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
         sum_gen, nested_list,
         "aggregating nested list rows is not aggregating the flattened stream"
     );
-    assert_eq!(
+    // `max(gen)` errs on empty input and tracks all-negative maxima; a `best = 0`
+    // seeded loop clamps at 0 in both cases. The seed is behavior-defining, so the
+    // two must NOT merge — while equal-seeded loops still converge with each other.
+    assert_ne!(
         max_gen, max_loop,
-        "max over a flat-map generator should match the nested selection loop"
+        "a zero-seeded selection loop clamps at its seed; true max(...) does not"
+    );
+    assert_eq!(
+        max_loop, max_loop_same_seed,
+        "equally-seeded nested selection loops should still converge"
     );
     assert_eq!(
         any_gen, any_loop,
@@ -6216,5 +6228,203 @@ fn c_hex_literal_with_e_lowers_to_int_not_float() {
     assert!(
         !s.to_lowercase().contains("float"),
         "0xE5 (hex int) must not lower to a float literal: {s}"
+    );
+}
+
+#[test]
+fn python_true_division_stays_distinct_from_floor_division() {
+    // `5 / 2 == 2.5` but `5 // 2 == 2` — collapsing both onto one Div op merged
+    // behaviorally-different functions into one semantic family (a false merge).
+    let i = Interner::new();
+    let true_div = "def f(xs, d):\n    out = []\n    for x in xs:\n        out.append(x / d)\n    return out\n";
+    let floor_div = "def g(xs, d):\n    out = []\n    for x in xs:\n        out.append(x // d)\n    return out\n";
+    assert_ne!(
+        value_fp(&i, true_div, Lang::Python),
+        value_fp(&i, floor_div, Lang::Python),
+        "true division and floor division must not share a fingerprint"
+    );
+    // Floor division still converges with itself across renames.
+    let floor_div2 = "def h(items, n):\n    res = []\n    for v in items:\n        res.append(v // n)\n    return res\n";
+    assert_eq!(
+        value_fp(&i, floor_div, Lang::Python),
+        value_fp(&i, floor_div2, Lang::Python),
+        "alpha-renamed floor divisions must still converge"
+    );
+}
+
+#[test]
+fn python_floor_division_interprets_with_floor_semantics() {
+    // The oracle's FloorDiv rounds toward −∞ like Python `//` — NOT toward zero
+    // like `Op::Div` — so a bad canonicalization between the two cannot hide.
+    let i = Interner::new();
+    let il = nose_frontend::lower_source(
+        FileId(0),
+        "t",
+        b"def f(a, b):\n    return a // b\n",
+        Lang::Python,
+        &i,
+    )
+    .unwrap();
+    let n = normalize(&il, &i, &NormalizeOptions::default());
+    let f = first_func(&n);
+    use nose_normalize::{run_unit, Value};
+    let run = |a: i64, b: i64| {
+        run_unit(&n, &i, f, &[Value::Int(a), Value::Int(b)])
+            .unwrap()
+            .ret
+    };
+    assert_eq!(run(5, 2), Value::Int(2));
+    assert_eq!(run(-5, 2), Value::Int(-3), "-5 // 2 floors to -3");
+    assert_eq!(run(5, -2), Value::Int(-3), "5 // -2 floors to -3");
+    assert_eq!(run(-5, -2), Value::Int(2));
+    assert_eq!(run(7, 0), Value::Err, "division by zero errs");
+}
+
+#[test]
+fn python_matmul_stays_distinct_from_elementwise_mul() {
+    // `a @ b` (matrix product) is not `a * b` (elementwise); mapping `@` onto Mul
+    // merged the two. `@` keeps a raw shape keyed by its own spelling.
+    let i = Interner::new();
+    let mul = "def f(a, b):\n    c = a * b\n    d = a * c\n    return c, d\n";
+    let matmul = "def g(a, b):\n    c = a @ b\n    d = a @ c\n    return c, d\n";
+    assert_ne!(
+        value_fp(&i, mul, Lang::Python),
+        value_fp(&i, matmul, Lang::Python),
+        "matmul must not share a fingerprint with elementwise mul"
+    );
+}
+
+#[test]
+fn js_unsigned_shift_stays_distinct_from_signed_shift() {
+    // `-5 >> 1 == -3` (sign-extends) but `-5 >>> 1 == 2147483645` (zero-fills);
+    // collapsing `>>>` onto Shr merged the two shifts.
+    let i = Interner::new();
+    let signed = "function f(xs, n) {\n  const out = [];\n  for (const x of xs) out.push(x >> n);\n  return out;\n}";
+    let unsigned = "function g(xs, n) {\n  const out = [];\n  for (const x of xs) out.push(x >>> n);\n  return out;\n}";
+    assert_ne!(
+        value_fp(&i, signed, Lang::JavaScript),
+        value_fp(&i, unsigned, Lang::JavaScript),
+        "signed and unsigned right shift must not share a fingerprint"
+    );
+    let unsigned2 = "function h(ys, k) {\n  const res = [];\n  for (const y of ys) res.push(y >>> k);\n  return res;\n}";
+    assert_eq!(
+        value_fp(&i, unsigned, Lang::JavaScript),
+        value_fp(&i, unsigned2, Lang::JavaScript),
+        "alpha-renamed unsigned shifts must still converge"
+    );
+}
+
+#[test]
+fn js_nullish_assignment_desugars_to_nullish_coalescing() {
+    // `x ??= y` is `x = x ?? y` — and is NOT `x += y` (the old unmapped-operator
+    // fallback silently defaulted compound assignments to Add).
+    let i = Interner::new();
+    let compound = "function f(x, y) {\n  x ??= y;\n  return x;\n}";
+    let spelled = "function g(x, y) {\n  x = x ?? y;\n  return x;\n}";
+    let add = "function h(x, y) {\n  x += y;\n  return x;\n}";
+    assert_eq!(
+        value_fp(&i, compound, Lang::JavaScript),
+        value_fp(&i, spelled, Lang::JavaScript),
+        "`x ??= y` should converge with `x = x ?? y`"
+    );
+    assert_ne!(
+        value_fp(&i, compound, Lang::JavaScript),
+        value_fp(&i, add, Lang::JavaScript),
+        "`x ??= y` must not merge with `x += y`"
+    );
+}
+
+#[test]
+fn js_strict_null_ternary_stays_distinct_from_nullish_coalescing() {
+    // `x ?? d` and `x == null ? d : x` both default null AND undefined — they are
+    // the same computation. `x === null ? d : x` passes undefined through, so it
+    // must NOT join that family (it differs on every undefined input).
+    let i = Interner::new();
+    let nullish = "function f(x, d) {\n  return x ?? d;\n}";
+    let loose = "function g(x, d) {\n  return x == null ? d : x;\n}";
+    let strict = "function h(x, d) {\n  return x === null ? d : x;\n}";
+    assert_eq!(
+        value_fp(&i, nullish, Lang::JavaScript),
+        value_fp(&i, loose, Lang::JavaScript),
+        "`??` should converge with the loose-equality ternary"
+    );
+    assert_ne!(
+        value_fp(&i, nullish, Lang::JavaScript),
+        value_fp(&i, strict, Lang::JavaScript),
+        "`??` must not merge with the strict-null ternary"
+    );
+    // Strict checks still converge with the same strict spelling…
+    let strict2 = "function k(v, fb) {\n  return v === null ? fb : v;\n}";
+    assert_eq!(
+        value_fp(&i, strict, Lang::JavaScript),
+        value_fp(&i, strict2, Lang::JavaScript),
+        "alpha-renamed strict-null ternaries must still converge"
+    );
+    // …but `=== null` and `=== undefined` are different checks.
+    let strict_undef = "function m(x, d) {\n  return x === undefined ? d : x;\n}";
+    assert_ne!(
+        value_fp(&i, strict, Lang::JavaScript),
+        value_fp(&i, strict_undef, Lang::JavaScript),
+        "`=== null` and `=== undefined` must not share a fingerprint"
+    );
+}
+
+#[test]
+fn java_unsigned_shift_assignment_keeps_its_operator() {
+    // Java `x >>>= y` used to fall through the unmapped-compound path and lower
+    // as a plain `x = y` — merging it with reassignment.
+    let i = Interner::new();
+    let ushift = "class C { static int f(int x, int y) { x >>>= y; return x; } }";
+    let assign = "class D { static int g(int x, int y) { x = y; return x; } }";
+    let add = "class E { static int h(int x, int y) { x += y; return x; } }";
+    assert_ne!(
+        value_fp(&i, ushift, Lang::Java),
+        value_fp(&i, assign, Lang::Java),
+        "`x >>>= y` must not merge with `x = y`"
+    );
+    assert_ne!(
+        value_fp(&i, ushift, Lang::Java),
+        value_fp(&i, add, Lang::Java),
+        "`x >>>= y` must not merge with `x += y`"
+    );
+}
+
+#[test]
+fn ruby_exponent_converges_with_python_pow() {
+    // Ruby `**` was unmapped (raw); it is the same exponentiation Python spells `**`.
+    let i = Interner::new();
+    let rb = "def area(base, exp)\n  base ** exp\nend\n";
+    let py = "def area(base, exp):\n    return base ** exp\n";
+    assert_eq!(
+        value_fp(&i, rb, Lang::Ruby),
+        value_fp(&i, py, Lang::Python),
+        "Ruby `**` should converge with Python `**`"
+    );
+}
+
+#[test]
+fn two_argument_min_max_interpret_as_two_way_selection() {
+    // `min(a, b)` (the 2-way selection `[a, b].min()` also canonicalizes to) used to
+    // evaluate to Err in the oracle — leaving exactly the convergences the value
+    // graph claims for it unverifiable.
+    let i = Interner::new();
+    let il = nose_frontend::lower_source(
+        FileId(0),
+        "t",
+        b"def f(a, b):\n    return min(a, b), max(a, b)\n",
+        Lang::Python,
+        &i,
+    )
+    .unwrap();
+    let n = normalize(&il, &i, &NormalizeOptions::default());
+    let f = first_func(&n);
+    use nose_normalize::{run_unit, Value};
+    let out = run_unit(&n, &i, f, &[Value::Int(3), Value::Int(1)])
+        .expect("two-scalar min/max is interpretable")
+        .ret;
+    assert_eq!(
+        out,
+        Value::List(vec![Value::Int(1), Value::Int(3)]),
+        "min(3, 1) is 1 and max(3, 1) is 3"
     );
 }

--- a/crates/nose-detect/src/align.rs
+++ b/crates/nose-detect/src/align.rs
@@ -1,5 +1,5 @@
 //! Pairwise similarity: a cheap multiset Jaccard over shape features (the bulk
-//! signal) plus an LCS-based alignment over the linearized node-tag sequences
+//! signal) plus a RANSAC-style alignment over the linearized node-tag sequences
 //! (the discriminative signal that token-set methods lack — it rewards units
 //! whose structure lines up *in order*, not just in aggregate).
 
@@ -36,10 +36,14 @@ pub(crate) fn multiset_jaccard(a: &[u64], b: &[u64]) -> f64 {
     inter as f64 / union as f64
 }
 
+/// Cap on linearization length for alignment scoring, bounding the per-pair cost
+/// on pathological units.
+const ALIGN_CAP: usize = 600;
+
 /// RANSAC-style geometric verification (computer vision): treat token matches as
 /// point correspondences, find the dominant position-offset (a 1-D "translation"
 /// consensus), and score by the fraction of `a` positions consistent with it.
-/// Tolerant to a block being shifted, unlike LCS.
+/// Tolerant to a block being shifted, unlike an LCS alignment.
 pub(crate) fn ransac_ratio(a: &[u64], b: &[u64]) -> f64 {
     use rustc_hash::FxHashMap;
     use std::cell::RefCell;
@@ -50,8 +54,8 @@ pub(crate) fn ransac_ratio(a: &[u64], b: &[u64]) -> f64 {
         static POS: RefCell<FxHashMap<u64, Vec<i32>>> = RefCell::new(FxHashMap::default());
         static VOTES: RefCell<FxHashMap<i32, u32>> = RefCell::new(FxHashMap::default());
     }
-    let a = &a[..a.len().min(LCS_CAP)];
-    let b = &b[..b.len().min(LCS_CAP)];
+    let a = &a[..a.len().min(ALIGN_CAP)];
+    let b = &b[..b.len().min(ALIGN_CAP)];
     let maxlen = a.len().max(b.len());
     if maxlen == 0 {
         return 1.0;
@@ -98,36 +102,6 @@ pub(crate) fn ransac_ratio(a: &[u64], b: &[u64]) -> f64 {
     })
 }
 
-/// Cap on sequence length for LCS, to bound the O(n·m) DP on pathological units.
-const LCS_CAP: usize = 600;
-
-/// Longest-common-subsequence length / max(len), over linearized node tags.
-/// Superseded by [`ransac_ratio`] in the default scorer (measured: RANSAC
-/// generalizes better + is more precise), but kept as a tested alternative.
-#[allow(dead_code)]
-pub(crate) fn lcs_ratio(a: &[u64], b: &[u64]) -> f64 {
-    let a = &a[..a.len().min(LCS_CAP)];
-    let b = &b[..b.len().min(LCS_CAP)];
-    let maxlen = a.len().max(b.len());
-    if maxlen == 0 {
-        return 1.0;
-    }
-    // Rolling 1-D DP.
-    let mut prev = vec![0u32; b.len() + 1];
-    let mut cur = vec![0u32; b.len() + 1];
-    for &x in a {
-        for j in 0..b.len() {
-            cur[j + 1] = if x == b[j] {
-                prev[j] + 1
-            } else {
-                prev[j + 1].max(cur[j])
-            };
-        }
-        std::mem::swap(&mut prev, &mut cur);
-    }
-    prev[b.len()] as f64 / maxlen as f64
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -155,20 +129,5 @@ mod tests {
         let big: Vec<u64> = (0..500u64).flat_map(|x| [x, x ^ 0x5a5a]).collect();
         let _ = ransac_ratio(&big, &big);
         assert_eq!(ransac_ratio(&a, &b), 0.2);
-    }
-
-    /// Exercises `lcs_ratio` (the kept-but-unused alternative scorer) so it stays
-    /// compiling and correct rather than silently bit-rotting.
-    #[test]
-    fn lcs_ratio_scores_longest_common_subsequence() {
-        // Identical, disjoint, and both-empty boundary cases.
-        assert_eq!(lcs_ratio(&[1, 2, 3, 4], &[1, 2, 3, 4]), 1.0);
-        assert_eq!(lcs_ratio(&[1, 2, 3, 4], &[9, 8, 7]), 0.0);
-        assert_eq!(lcs_ratio(&[], &[]), 1.0);
-        // LCS of [1,2,3,4] and [1,3,4] is [1,3,4] (len 3); maxlen 4 → 0.75. It's a
-        // subsequence, not a set intersection.
-        assert_eq!(lcs_ratio(&[1, 2, 3, 4], &[1, 3, 4]), 0.75);
-        // Order matters: [1,2,3] vs [3,2,1] share length-1 as a subsequence, not 3.
-        assert_eq!(lcs_ratio(&[1, 2, 3], &[3, 2, 1]), 1.0 / 3.0);
     }
 }

--- a/crates/nose-detect/src/minhash.rs
+++ b/crates/nose-detect/src/minhash.rs
@@ -32,13 +32,3 @@ pub(crate) fn sign(distinct: &[u64], seeds: &[u64]) -> Vec<u64> {
     }
     sig
 }
-
-/// Estimated Jaccard similarity from two signatures (fraction of equal slots).
-#[allow(dead_code)]
-pub(crate) fn estimate(a: &[u64], b: &[u64]) -> f64 {
-    if a.is_empty() {
-        return 0.0;
-    }
-    let eq = a.iter().zip(b).filter(|(x, y)| x == y).count();
-    eq as f64 / a.len() as f64
-}

--- a/crates/nose-frontend/src/c.rs
+++ b/crates/nose-frontend/src/c.rs
@@ -667,14 +667,17 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                 .map(|x| lower_expr(lo, x))
                 .unwrap_or_else(|| lo.empty_block(span));
             if opt.len() > 1 {
-                if let Some(op) = common_bin_op(opt.trim_end_matches('=')) {
-                    let l2 = node
-                        .child_by_field_name("left")
-                        .map(|x| lower_expr(lo, x))
-                        .unwrap_or_else(|| lo.empty_block(span));
-                    let bin = lo.add(NodeKind::BinOp, Payload::Op(op), span, &[l2, r]);
-                    return lo.add(NodeKind::Assign, Payload::None, span, &[l, bin]);
-                }
+                let l2 = node
+                    .child_by_field_name("left")
+                    .map(|x| lower_expr(lo, x))
+                    .unwrap_or_else(|| lo.empty_block(span));
+                // An unmapped compound operator keeps its own raw shape —
+                // dropping the operator would merge it with `x = y`.
+                let value = match common_bin_op(opt.trim_end_matches('=')) {
+                    Some(op) => lo.add(NodeKind::BinOp, Payload::Op(op), span, &[l2, r]),
+                    None => lo.raw(&format!("compound_assignment {opt}"), span, &[l2, r]),
+                };
+                return lo.add(NodeKind::Assign, Payload::None, span, &[l, value]);
             }
             lo.add(NodeKind::Assign, Payload::None, span, &[l, r])
         }

--- a/crates/nose-frontend/src/go.rs
+++ b/crates/nose-frontend/src/go.rs
@@ -378,9 +378,12 @@ fn lower_assign_like(lo: &mut Lowering, node: TsNode) -> NodeId {
             // `a &^= b` → `a = a & ^b`, same bit-clear desugar as the binary form.
             if op_text.trim_end_matches('=') == "&^" {
                 go_bitclear(lo, lspan, lhs2, r)
-            } else {
-                let op = js_like_compound_op(op_text).unwrap_or(Op::Add);
+            } else if let Some(op) = js_like_compound_op(op_text) {
                 lo.add(NodeKind::BinOp, Payload::Op(op), lspan, &[lhs2, r])
+            } else {
+                // Unmapped compound operator: keep its own raw shape rather than
+                // defaulting to `Add` (which would merge it with `a += b`).
+                lo.raw(&format!("compound_assignment {op_text}"), lspan, &[lhs2, r])
             }
         } else {
             rights

--- a/crates/nose-frontend/src/java.rs
+++ b/crates/nose-frontend/src/java.rs
@@ -502,14 +502,17 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                 .map(|x| lower_expr(lo, x))
                 .unwrap_or_else(|| lo.empty_block(span));
             if opt.len() > 1 {
-                if let Some(op) = common_bin_op(opt.trim_end_matches('=')) {
-                    let l2 = node
-                        .child_by_field_name("left")
-                        .map(|x| lower_expr(lo, x))
-                        .unwrap_or_else(|| lo.empty_block(span));
-                    let bin = lo.add(NodeKind::BinOp, Payload::Op(op), span, &[l2, r]);
-                    return lo.add(NodeKind::Assign, Payload::None, span, &[l, bin]);
-                }
+                let l2 = node
+                    .child_by_field_name("left")
+                    .map(|x| lower_expr(lo, x))
+                    .unwrap_or_else(|| lo.empty_block(span));
+                // An unmapped compound operator (e.g. `>>>=`) keeps its own raw
+                // shape — dropping the operator would merge it with `x = y`.
+                let value = match common_bin_op(opt.trim_end_matches('=')) {
+                    Some(op) => lo.add(NodeKind::BinOp, Payload::Op(op), span, &[l2, r]),
+                    None => lo.raw(&format!("compound_assignment {opt}"), span, &[l2, r]),
+                };
+                return lo.add(NodeKind::Assign, Payload::None, span, &[l, value]);
             }
             lo.add(NodeKind::Assign, Payload::None, span, &[l, r])
         }

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -487,26 +487,40 @@ fn static_string_key(lo: &Lowering, node: TsNode) -> Option<String> {
     Some(inner.to_string())
 }
 
+/// `a OP= b`  →  `a = a OP b`. `??=` gets the same `If(Eq(a, null), b, a)` shape
+/// as `??` so the compound and spelled-out forms converge; the rest go through
+/// the shared compound-assignment lowering.
 fn lower_aug_assignment(lo: &mut Lowering, node: TsNode) -> NodeId {
-    let span = lo.span(node);
-    let left = node.child_by_field_name("left");
-    let right = node.child_by_field_name("right");
-    let op = node
+    if node
         .child_by_field_name("operator")
-        .map(|o| lo.text(o))
-        .and_then(|t| js_bin_op(t.trim_end_matches('=')))
-        .unwrap_or(Op::Add);
-    let lhs1 = left
-        .map(|l| lower_expr(lo, l))
-        .unwrap_or_else(|| lo.empty_block(span));
-    let lhs2 = left
-        .map(|l| lower_expr(lo, l))
-        .unwrap_or_else(|| lo.empty_block(span));
-    let rhs = right
-        .map(|r| lower_expr(lo, r))
-        .unwrap_or_else(|| lo.empty_block(span));
-    let binop = lo.add(NodeKind::BinOp, Payload::Op(op), span, &[lhs2, rhs]);
-    lo.add(NodeKind::Assign, Payload::None, span, &[lhs1, binop])
+        .is_some_and(|o| lo.text(o) == "??=")
+    {
+        let span = lo.span(node);
+        let left = node.child_by_field_name("left");
+        let lhs1 = left
+            .map(|l| lower_expr(lo, l))
+            .unwrap_or_else(|| lo.empty_block(span));
+        let lhs2 = left
+            .map(|l| lower_expr(lo, l))
+            .unwrap_or_else(|| lo.empty_block(span));
+        let rhs = node
+            .child_by_field_name("right")
+            .map(|r| lower_expr(lo, r))
+            .unwrap_or_else(|| lo.empty_block(span));
+        let null_lit = lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[]);
+        let cond = lo.add(
+            NodeKind::BinOp,
+            Payload::Op(Op::Eq),
+            span,
+            &[lhs2, null_lit],
+        );
+        let lhs3 = left
+            .map(|l| lower_expr(lo, l))
+            .unwrap_or_else(|| lo.empty_block(span));
+        let value = lo.add(NodeKind::If, Payload::None, span, &[cond, rhs, lhs3]);
+        return lo.add(NodeKind::Assign, Payload::None, span, &[lhs1, value]);
+    }
+    crate::lower::compound_assignment(lo, node, js_bin_op, lower_expr)
 }
 
 /// `x++` / `++x` / `x--`  →  `x = x +/- 1`.
@@ -1919,13 +1933,14 @@ fn is_ts_type(k: &str) -> bool {
 }
 
 fn js_bin_op(text: &str) -> Option<Op> {
-    // shared C-family set, plus JS's strict-equality, exponent, unsigned
-    // shift, and the type-test operators (the last two collapse lossily).
+    // shared C-family set, plus JS's strict-equality, exponent, and type-test
+    // operators. `>>>` (zero-fill shift) is deliberately UNMAPPED: collapsing it
+    // onto `Shr` merged `-5 >> 1` (sign-extending, `-3`) with `-5 >>> 1`
+    // (zero-filling, `2147483645`) — a false merge. The raw fallback keys it by
+    // its own operator spelling instead.
     crate::lower::common_bin_op(text).or(match text {
-        "**" => Some(Op::Pow),
         "===" => Some(Op::Eq),
         "!==" => Some(Op::Ne),
-        ">>>" => Some(Op::Shr),
         // `x in obj` is a directional membership/key test — its own non-commutative op.
         // `instanceof` is a type-identity check; equality-shaped is an acceptable approx.
         "in" => Some(Op::In),

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -2618,9 +2618,8 @@ pub(crate) fn binary(
     let r = node
         .child_by_field_name("right")
         .map(|x| lower_operand(lo, x));
-    let op = node
-        .child_by_field_name("operator")
-        .and_then(|o| op_of(lo.text(o)));
+    let op_text = node.child_by_field_name("operator").map(|o| lo.text(o));
+    let op = op_text.and_then(op_of);
     match (l, r, op) {
         (Some(l), Some(r), Some(op)) => lo.add(NodeKind::BinOp, Payload::Op(op), span, &[l, r]),
         _ => {
@@ -2628,9 +2627,54 @@ pub(crate) fn binary(
                 .into_iter()
                 .map(|c| lower_operand(lo, c))
                 .collect();
-            lo.raw(node.kind(), span, &kids)
+            // Key the raw node by the operator spelling, not just the CST kind:
+            // two different unmapped operators over the same operands must not
+            // share a fingerprint (`a >>> b` is not `a @ b`).
+            match op_text {
+                Some(text) => lo.raw(&format!("{} {text}", node.kind()), span, &kids),
+                None => lo.raw(node.kind(), span, &kids),
+            }
         }
     }
+}
+
+/// `a OP= b`  →  `a = a OP b` for grammars with `left`/`operator`/`right` fields
+/// (Python/JS/Rust). The lhs is lowered twice (two faithful subtrees). The
+/// operator is looked up by its compound spelling minus the trailing `=`; an
+/// unmapped operator keeps its own raw shape keyed by the spelling — defaulting
+/// it to `Add` (or dropping it) would merge `a @= b` / `a >>>= b` with
+/// `a += b` / `a = b`.
+pub(crate) fn compound_assignment(
+    lo: &mut Lowering,
+    node: TsNode,
+    op_of: impl FnOnce(&str) -> Option<Op>,
+    mut lower_operand: impl FnMut(&mut Lowering, TsNode) -> NodeId,
+) -> NodeId {
+    let span = lo.span(node);
+    let left = node.child_by_field_name("left");
+    let right = node.child_by_field_name("right");
+    let op_text = node.child_by_field_name("operator").map(|o| lo.text(o));
+    let op = op_text.and_then(|t| op_of(t.trim_end_matches('=')));
+    let lhs1 = left
+        .map(|l| lower_operand(lo, l))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let lhs2 = left
+        .map(|l| lower_operand(lo, l))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let rhs = right
+        .map(|r| lower_operand(lo, r))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let value = match op {
+        Some(op) => lo.add(NodeKind::BinOp, Payload::Op(op), span, &[lhs2, rhs]),
+        None => {
+            let kind = match op_text {
+                Some(text) => format!("{} {text}", node.kind()),
+                None => node.kind().to_string(),
+            };
+            lo.raw(&kind, span, &[lhs2, rhs])
+        }
+    };
+    lo.add(NodeKind::Assign, Payload::None, span, &[lhs1, value])
 }
 
 /// Lower a `left`/`right` assignment-expression node into an `Assign`.
@@ -2745,6 +2789,9 @@ pub(crate) fn common_bin_op(text: &str) -> Option<Op> {
         "*" => Op::Mul,
         "/" => Op::Div,
         "%" => Op::Mod,
+        // Exponentiation in the languages that spell it `**` (Python/JS/Ruby);
+        // the C-family grammars never produce it as a binary operator.
+        "**" => Op::Pow,
         "==" => Op::Eq,
         "!=" => Op::Ne,
         "<" => Op::Lt,

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -297,34 +297,11 @@ fn lower_assignment(lo: &mut Lowering, node: TsNode) -> NodeId {
     lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs])
 }
 
-/// `a OP= b`  →  `a = a OP b`. The lhs is lowered twice (two faithful subtrees).
 fn lower_aug_assignment(lo: &mut Lowering, node: TsNode) -> NodeId {
-    let span = lo.span(node);
-    let left = node.child_by_field_name("left");
-    if let Some(l) = left {
+    if let Some(l) = node.child_by_field_name("left") {
         clear_assigned_param_alias(lo, l);
     }
-    let right = node.child_by_field_name("right");
-    let op = node
-        .child_by_field_name("operator")
-        .map(|o| lo.text(o))
-        .and_then(py_aug_op)
-        .unwrap_or(Op::Add);
-
-    let lhs1 = match left {
-        Some(l) => lower_expr(lo, l),
-        None => lo.empty_block(span),
-    };
-    let lhs2 = match left {
-        Some(l) => lower_expr(lo, l),
-        None => lo.empty_block(span),
-    };
-    let rhs = match right {
-        Some(r) => lower_expr(lo, r),
-        None => lo.empty_block(span),
-    };
-    let binop = lo.add(NodeKind::BinOp, Payload::Op(op), span, &[lhs2, rhs]);
-    lo.add(NodeKind::Assign, Payload::None, span, &[lhs1, binop])
+    crate::lower::compound_assignment(lo, node, py_bin_op, lower_expr)
 }
 
 fn clear_assigned_param_alias(lo: &mut Lowering, node: TsNode) {
@@ -1181,8 +1158,14 @@ fn py_bin_op(text: &str) -> Option<Op> {
     Some(match text {
         "+" => Op::Add,
         "-" => Op::Sub,
-        "*" | "@" => Op::Mul,
-        "/" | "//" => Op::Div,
+        // `@` (matmul) is deliberately UNMAPPED: it is not elementwise `*`, so
+        // mapping it to `Mul` merged `a @ b` with `a * b` — a false merge. The
+        // raw fallback keys it by its own operator spelling instead.
+        "*" => Op::Mul,
+        // True division and floor division are distinct operations (`5 / 2 == 2.5`
+        // vs `5 // 2 == 2`); each gets its own op so they never share a fingerprint.
+        "/" => Op::Div,
+        "//" => Op::FloorDiv,
         "%" => Op::Mod,
         "**" => Op::Pow,
         "&" => Op::BitAnd,
@@ -1192,10 +1175,6 @@ fn py_bin_op(text: &str) -> Option<Op> {
         ">>" => Op::Shr,
         _ => return None,
     })
-}
-
-fn py_aug_op(text: &str) -> Option<Op> {
-    py_bin_op(text.trim_end_matches('='))
 }
 
 /// Map a comparison operator string to `(op, negated, source fact)`. `not in` / `is not`

--- a/crates/nose-frontend/src/ruby.rs
+++ b/crates/nose-frontend/src/ruby.rs
@@ -297,14 +297,17 @@ fn lower_assign(lo: &mut Lowering, node: TsNode) -> NodeId {
             .child_by_field_name("operator")
             .map(|o| lo.text(o))
             .unwrap_or("+=");
-        if let Some(op) = common_bin_op(opt.trim_end_matches('=')) {
-            let l2 = node
-                .child_by_field_name("left")
-                .map(|x| lower_expr(lo, x))
-                .unwrap_or_else(|| lo.empty_block(span));
-            let bin = lo.add(NodeKind::BinOp, Payload::Op(op), span, &[l2, r]);
-            return lo.add(NodeKind::Assign, Payload::None, span, &[l, bin]);
-        }
+        let l2 = node
+            .child_by_field_name("left")
+            .map(|x| lower_expr(lo, x))
+            .unwrap_or_else(|| lo.empty_block(span));
+        // An unmapped compound operator keeps its own raw shape — dropping the
+        // operator would merge it with `x = y`.
+        let value = match common_bin_op(opt.trim_end_matches('=')) {
+            Some(op) => lo.add(NodeKind::BinOp, Payload::Op(op), span, &[l2, r]),
+            None => lo.raw(&format!("compound_assignment {opt}"), span, &[l2, r]),
+        };
+        return lo.add(NodeKind::Assign, Payload::None, span, &[l, value]);
     }
     lo.add(NodeKind::Assign, Payload::None, span, &[l, r])
 }

--- a/crates/nose-frontend/src/rust.rs
+++ b/crates/nose-frontend/src/rust.rs
@@ -673,27 +673,8 @@ fn lower_unary(lo: &mut Lowering, node: TsNode) -> NodeId {
     lo.add(NodeKind::UnOp, Payload::Op(op), span, &[operand])
 }
 
-/// `x op= y` → `x = x op y`.
 fn lower_compound_assign(lo: &mut Lowering, node: TsNode) -> NodeId {
-    let span = lo.span(node);
-    let left = node.child_by_field_name("left");
-    let right = node.child_by_field_name("right");
-    let op = node
-        .child_by_field_name("operator")
-        .map(|o| lo.text(o).trim_end_matches('='))
-        .and_then(rust_bin_op)
-        .unwrap_or(Op::Add);
-    let lhs1 = left
-        .map(|l| lower_expr(lo, l))
-        .unwrap_or_else(|| lo.empty_block(span));
-    let lhs2 = left
-        .map(|l| lower_expr(lo, l))
-        .unwrap_or_else(|| lo.empty_block(span));
-    let rhs = right
-        .map(|r| lower_expr(lo, r))
-        .unwrap_or_else(|| lo.empty_block(span));
-    let binop = lo.add(NodeKind::BinOp, Payload::Op(op), span, &[lhs2, rhs]);
-    lo.add(NodeKind::Assign, Payload::None, span, &[lhs1, binop])
+    crate::lower::compound_assignment(lo, node, rust_bin_op, lower_expr)
 }
 
 fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -54,7 +54,7 @@ pub enum UnitKind {
 /// One lowered source file. `nodes` is the arena; child links live out-of-line in
 /// `edges` so each [`Node`] stays small. `file == ` this file's index in the
 /// owning [`Corpus`].
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Il {
     pub nodes: Vec<Node>,
     pub edges: Vec<NodeId>,
@@ -77,6 +77,94 @@ pub struct Il {
     /// consumers must not use side-table mirrors as alternate proof channels.
     #[serde(default)]
     pub evidence: Vec<EvidenceRecord>,
+    /// Lazy whole-arena nearest-enclosing-scope index (see [`Il::nearest_scope`]).
+    /// Never serialized; recomputed on first use. Sound to cache because nodes are
+    /// immutable once an `Il` is built — passes rebuild the arena instead.
+    #[serde(skip)]
+    scope_index: std::sync::OnceLock<Vec<Option<NodeId>>>,
+    /// Lazy evidence lookup index (see [`Il::evidence_anchored_at`]). Appends to
+    /// `evidence` are picked up incrementally (the index tracks how many records
+    /// it has seen); code that mutates existing records IN PLACE must call
+    /// [`Il::invalidate_evidence_index`]. Never serialized.
+    #[serde(skip)]
+    evidence_index: std::sync::RwLock<Option<EvidenceIndex>>,
+}
+
+/// See [`Il::evidence_anchored_at`]: exact-anchor-span buckets and id→index
+/// resolution, replacing the per-query linear `evidence` scans that were
+/// quadratic on minified-bundle-sized files. Only the IMMUTABLE parts of a
+/// record (anchor, id) are indexed; `status`/`dependencies` are always read
+/// live, so in-place mutation of those fields needs no invalidation.
+#[derive(Debug, Default)]
+struct EvidenceIndex {
+    indexed_len: usize,
+    by_anchor_span: std::collections::HashMap<(u32, u32, u32), Vec<u32>>,
+    by_id: std::collections::HashMap<u32, u32>,
+}
+
+impl EvidenceIndex {
+    fn extend_from(&mut self, evidence: &[EvidenceRecord]) {
+        for (idx, record) in evidence.iter().enumerate().skip(self.indexed_len) {
+            let span = record.anchor.span();
+            self.by_anchor_span
+                .entry((span.file.0, span.start_byte, span.end_byte))
+                .or_default()
+                .push(idx as u32);
+            // Mirror `evidence_record_by_id`: the record at position `id` wins;
+            // otherwise the first record with that id.
+            let id = record.id.0;
+            if id as usize == idx {
+                self.by_id.insert(id, idx as u32);
+            } else {
+                self.by_id.entry(id).or_insert(idx as u32);
+            }
+        }
+        self.indexed_len = evidence.len();
+    }
+
+    /// The same walk as the pre-index `evidence_dependencies_asserted`: every
+    /// transitively-reachable dependency must resolve and be `Asserted`; a cycle
+    /// is benign (revisits are skipped). Statuses and dependency lists are read
+    /// live from `evidence` — only id resolution uses the index.
+    fn deps_walk(&self, evidence: &[EvidenceRecord], dependencies: &[EvidenceId]) -> bool {
+        let mut stack = dependencies.to_vec();
+        let mut seen = Vec::new();
+        while let Some(id) = stack.pop() {
+            if seen.contains(&id) {
+                continue;
+            }
+            seen.push(id);
+            let Some(&dep_idx) = self.by_id.get(&id.0) else {
+                return false;
+            };
+            let dep = &evidence[dep_idx as usize];
+            if dep.status != EvidenceStatus::Asserted {
+                return false;
+            }
+            stack.extend_from_slice(&dep.dependencies);
+        }
+        true
+    }
+}
+
+impl Clone for Il {
+    fn clone(&self) -> Self {
+        Il {
+            nodes: self.nodes.clone(),
+            edges: self.edges.clone(),
+            root: self.root,
+            file: self.file,
+            meta: self.meta.clone(),
+            units: self.units.clone(),
+            cid_names: self.cid_names.clone(),
+            suppressed: self.suppressed.clone(),
+            evidence: self.evidence.clone(),
+            // Caches are cheap to recompute and a clone is usually about to be
+            // mutated — start fresh.
+            scope_index: std::sync::OnceLock::new(),
+            evidence_index: std::sync::RwLock::new(None),
+        }
+    }
 }
 
 impl Il {
@@ -131,6 +219,85 @@ impl Il {
         (self.kind(lhs) == NodeKind::Var).then_some((lhs, rhs))
     }
 
+    /// The nearest enclosing `Func`/`Lambda` scope of `node` by source span: the
+    /// smallest-width scope whose span contains the node's span, ties broken by
+    /// the lowest scope id. Computed for the whole arena on first use and cached —
+    /// the per-query linear scan this replaces was O(nodes) *per call*, which went
+    /// quadratic (4-minute single files) on minified-bundle-sized inputs.
+    pub fn nearest_scope(&self, node: NodeId) -> Option<NodeId> {
+        let index = self.scope_index.get_or_init(|| self.build_scope_index());
+        index.get(node.0 as usize).copied().flatten()
+    }
+
+    /// One-pass exact computation of [`Il::nearest_scope`] for every node.
+    ///
+    /// Scopes are visited in (width asc, id asc) order — the same preference order
+    /// a per-node argmin would use — and each scope claims every still-unclaimed
+    /// node whose span it contains, so the first claim is the best one. A
+    /// path-compressed "next unclaimed position" skip list over the start-sorted
+    /// node order makes each node's claim O(α); per scope, only nodes that start
+    /// inside but end outside its span (its ancestors — O(depth) of them) are
+    /// re-examined later.
+    fn build_scope_index(&self) -> Vec<Option<NodeId>> {
+        let n = self.nodes.len();
+        let mut scopes: Vec<(u32, u32)> = self
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|(_, node)| matches!(node.kind, NodeKind::Func | NodeKind::Lambda))
+            .map(|(idx, node)| {
+                let width = node.span.end_byte.saturating_sub(node.span.start_byte);
+                (width, idx as u32)
+            })
+            .collect();
+        scopes.sort_unstable();
+
+        let mut order: Vec<u32> = (0..n as u32).collect();
+        order.sort_unstable_by_key(|&idx| (self.nodes[idx as usize].span.start_byte, idx));
+        let starts: Vec<u32> = order
+            .iter()
+            .map(|&idx| self.nodes[idx as usize].span.start_byte)
+            .collect();
+
+        let mut by_node: Vec<Option<NodeId>> = vec![None; n];
+        // next[pos] = the next possibly-unclaimed position at or after pos.
+        let mut next: Vec<u32> = (0..=n as u32).collect();
+        fn next_unclaimed(next: &mut [u32], from: u32) -> u32 {
+            let mut root = from;
+            while next[root as usize] != root {
+                root = next[root as usize];
+            }
+            let mut cur = from;
+            while next[cur as usize] != root {
+                let hop = next[cur as usize];
+                next[cur as usize] = root;
+                cur = hop;
+            }
+            root
+        }
+
+        for (_, scope_idx) in scopes {
+            let scope_span = self.nodes[scope_idx as usize].span;
+            let lo = starts.partition_point(|&start| start < scope_span.start_byte) as u32;
+            let mut pos = next_unclaimed(&mut next, lo);
+            while (pos as usize) < n {
+                let target = order[pos as usize];
+                let target_span = self.nodes[target as usize].span;
+                if target_span.start_byte > scope_span.end_byte {
+                    break;
+                }
+                if target_span.file == scope_span.file
+                    && target_span.end_byte <= scope_span.end_byte
+                {
+                    by_node[target as usize] = Some(NodeId(scope_idx));
+                    next[pos as usize] = pos + 1;
+                }
+                pos = next_unclaimed(&mut next, pos + 1);
+            }
+        }
+        by_node
+    }
+
     pub fn find_or_push_first_party_evidence(
         &mut self,
         anchor: EvidenceAnchor,
@@ -177,23 +344,59 @@ impl Il {
             .or_else(|| self.evidence.iter().find(|record| record.id == id))
     }
 
+    /// Whether every dependency of `record` (transitively) resolves and is
+    /// `Asserted`. Id resolution goes through the lazy evidence index — the
+    /// previous per-call resolution was a top hot spot on evidence-dense
+    /// minified inputs.
     pub fn evidence_dependencies_asserted(&self, record: &EvidenceRecord) -> bool {
-        let mut stack = record.dependencies.clone();
-        let mut seen = Vec::new();
-        while let Some(id) = stack.pop() {
-            if seen.contains(&id) {
-                continue;
-            }
-            seen.push(id);
-            let Some(dep) = self.evidence_record_by_id(id) else {
-                return false;
-            };
-            if dep.status != EvidenceStatus::Asserted {
-                return false;
-            }
-            stack.extend_from_slice(&dep.dependencies);
+        if record.dependencies.is_empty() {
+            return true;
         }
-        true
+        self.with_evidence_index(|index| index.deps_walk(&self.evidence, &record.dependencies))
+    }
+
+    /// Evidence records whose anchor sits exactly at `span` (all anchor kinds
+    /// match by exact span equality). Backed by the lazy evidence index, so a
+    /// caller no longer pays a full `evidence` scan per query.
+    pub fn evidence_anchored_at(&self, span: Span) -> impl Iterator<Item = &EvidenceRecord> {
+        let indices = self.with_evidence_index(|index| {
+            index
+                .by_anchor_span
+                .get(&(span.file.0, span.start_byte, span.end_byte))
+                .cloned()
+                .unwrap_or_default()
+        });
+        indices
+            .into_iter()
+            .map(move |idx| &self.evidence[idx as usize])
+    }
+
+    /// Drop the lazy evidence index. Appends are picked up automatically,
+    /// removals trigger a rebuild, and `status`/`dependencies` are read live —
+    /// call this only after rewriting a record's `anchor` or `id` in place.
+    pub fn invalidate_evidence_index(&mut self) {
+        *self.evidence_index.write().unwrap() = None;
+    }
+
+    fn with_evidence_index<T>(&self, read: impl FnOnce(&EvidenceIndex) -> T) -> T {
+        {
+            let guard = self.evidence_index.read().unwrap();
+            if let Some(index) = guard.as_ref() {
+                if index.indexed_len == self.evidence.len() {
+                    return read(index);
+                }
+            }
+        }
+        let mut guard = self.evidence_index.write().unwrap();
+        let index = guard.get_or_insert_with(EvidenceIndex::default);
+        if index.indexed_len > self.evidence.len() {
+            // Records were removed (e.g. a `retain`); indices are stale — rebuild.
+            *index = EvidenceIndex::default();
+        }
+        if index.indexed_len != self.evidence.len() {
+            index.extend_from(&self.evidence);
+        }
+        read(index)
     }
 
     /// Render a subtree as an s-expression (used by `nose il --format sexpr`).
@@ -340,6 +543,8 @@ impl IlBuilder {
             cid_names,
             suppressed: Vec::new(),
             evidence: Vec::new(),
+            scope_index: std::sync::OnceLock::new(),
+            evidence_index: std::sync::RwLock::new(None),
         }
     }
 }

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -323,14 +323,21 @@ impl EvidenceAnchor {
         EvidenceAnchor::Sequence { span }
     }
 
-    pub fn matches_span(self, span: Span) -> bool {
+    /// The anchor's subject span. Every anchor kind addresses exactly one span,
+    /// and all matching is exact span equality — which is what makes anchors
+    /// indexable by span (see `Il::evidence_anchored_at`).
+    pub fn span(self) -> Span {
         match self {
-            EvidenceAnchor::SourceSpan(subject)
-            | EvidenceAnchor::Node { span: subject, .. }
-            | EvidenceAnchor::Param { span: subject }
-            | EvidenceAnchor::Binding { span: subject, .. }
-            | EvidenceAnchor::Sequence { span: subject } => subject == span,
+            EvidenceAnchor::SourceSpan(span)
+            | EvidenceAnchor::Node { span, .. }
+            | EvidenceAnchor::Param { span }
+            | EvidenceAnchor::Binding { span, .. }
+            | EvidenceAnchor::Sequence { span } => span,
         }
+    }
+
+    pub fn matches_span(self, span: Span) -> bool {
+        self.span() == span
     }
 }
 
@@ -338,7 +345,6 @@ impl EvidenceAnchor {
 pub enum EvidenceEmitter {
     FirstParty,
     External,
-    Legacy,
 }
 
 /// Provenance attached to semantic evidence. Hashes are stable symbol hashes so
@@ -685,6 +691,11 @@ pub enum Op {
     // unary arithmetic
     Neg,
     Pos,
+    /// Floor division (quotient rounded toward −∞): Python `//`. DISTINCT from
+    /// [`Op::Div`], whose integer model truncates toward zero — the two differ on
+    /// any negative operand (`-5 // 2 == -3` vs `-5 / 2 == -2`), so conflating
+    /// them is a false merge.
+    FloorDiv,
 }
 
 impl Op {

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -677,8 +677,8 @@ impl<'a> Interp<'a> {
                 _ => Ok(Value::Err),
             },
             EagerBuiltinContract::Sum => Ok(fold_ints(args.first(), 0, |a, x| a + x)),
-            EagerBuiltinContract::Min => Ok(fold_opt(args.first(), |a, x| a.min(x))),
-            EagerBuiltinContract::Max => Ok(fold_opt(args.first(), |a, x| a.max(x))),
+            EagerBuiltinContract::Min => Ok(min_max_value(&args, |a, x| a.min(x))),
+            EagerBuiltinContract::Max => Ok(min_max_value(&args, |a, x| a.max(x))),
             EagerBuiltinContract::Range => range_values(&args),
             EagerBuiltinContract::Zip => match (args.first(), args.get(1)) {
                 (Some(Value::List(a)), Some(Value::List(b))) => Ok(Value::List(
@@ -1116,6 +1116,17 @@ fn fold_ints(v: Option<&Value>, init: i64, f: impl Fn(i64, i64) -> i64) -> Value
     }
 }
 
+/// `min`/`max` over either canonical form: a single collection (`min(xs)`) or two
+/// scalars (`min(a, b)` — the 2-way selection that `[a, b].min()` and the
+/// `a if a < b else b` ternary also canonicalize to). Without the scalar form the
+/// oracle was blind to exactly the convergences the value graph claims for it.
+fn min_max_value(args: &[Value], f: impl Fn(i64, i64) -> i64) -> Value {
+    match args {
+        [Value::Int(a), Value::Int(b)] => Value::Int(f(*a, *b)),
+        _ => fold_opt(args.first(), f),
+    }
+}
+
 fn fold_opt(v: Option<&Value>, f: impl Fn(i64, i64) -> i64) -> Value {
     match v {
         Some(Value::List(xs)) => {
@@ -1211,6 +1222,22 @@ fn bin(op: Op, a: &Value, b: &Value) -> Value {
                     Value::Err
                 } else {
                     Int(x.wrapping_rem(*y))
+                }
+            }
+            // Floor division rounds the quotient toward −∞ (Python `//`): the
+            // truncating quotient is decremented when the remainder is nonzero
+            // and the operands disagree in sign (`-5 // 2 == -3`, `5 // -2 == -3`).
+            Op::FloorDiv => {
+                if *y == 0 {
+                    Value::Err
+                } else {
+                    let q = x.wrapping_div(*y);
+                    let r = x.wrapping_rem(*y);
+                    Int(if r != 0 && (r < 0) != (*y < 0) {
+                        q - 1
+                    } else {
+                        q
+                    })
                 }
             }
             // An exponent that isn't a non-negative `u32` has no usable value here: a

--- a/crates/nose-normalize/src/library_api_evidence.rs
+++ b/crates/nose-normalize/src/library_api_evidence.rs
@@ -226,29 +226,7 @@ fn local_collection_seed_dependency_id(
 }
 
 fn nearest_scope(il: &Il, node: NodeId) -> Option<NodeId> {
-    let target = il.node(node).span;
-    let mut best: Option<(u32, NodeId)> = None;
-    for (idx, candidate) in il.nodes.iter().enumerate() {
-        if !matches!(candidate.kind, NodeKind::Func | NodeKind::Lambda)
-            || !span_contains(candidate.span, target)
-        {
-            continue;
-        }
-        let width = candidate
-            .span
-            .end_byte
-            .saturating_sub(candidate.span.start_byte);
-        if best.is_none_or(|(best_width, _)| width < best_width) {
-            best = Some((width, NodeId(idx as u32)));
-        }
-    }
-    best.map(|(_, scope)| scope)
-}
-
-fn span_contains(outer: nose_il::Span, inner: nose_il::Span) -> bool {
-    outer.file == inner.file
-        && outer.start_byte <= inner.start_byte
-        && outer.end_byte >= inner.end_byte
+    il.nearest_scope(node)
 }
 
 fn collection_seed_dependency_id(il: &Il, node: NodeId) -> Option<EvidenceId> {

--- a/crates/nose-normalize/src/value_graph/collections.rs
+++ b/crates/nose-normalize/src/value_graph/collections.rs
@@ -221,14 +221,16 @@ impl<'a> Builder<'a> {
                 } else {
                     contrib
                 };
-                let init = kids
-                    .get(2)
-                    .map(|&i| self.eval(i, env))
-                    .unwrap_or_else(|| self.int_const(0));
-                let args = if is_selection_code(op) {
-                    vec![contrib]
-                } else {
-                    vec![init, contrib]
+                // `reduce(λ, init)` carries its seed — for a selection (min/max)
+                // the seed clamps the result, so dropping it merged
+                // `reduce(max-λ, 0)` with true `max(…)`. A seedless `reduce(λ)`
+                // folds from the first element: for a selection that IS the true
+                // min/max — the same 1-arg shape the builtin builds.
+                let init = kids.get(2).map(|&i| self.eval(i, env));
+                let args = match (init, is_selection_code(op)) {
+                    (Some(init), _) => vec![init, contrib],
+                    (None, true) => vec![contrib],
+                    (None, false) => vec![self.int_const(0), contrib],
                 };
                 Some(self.mk(ValOp::Reduce(op), args))
             }
@@ -248,8 +250,9 @@ impl<'a> Builder<'a> {
                 }
                 let av = self.eval(*kids.first()?, env);
                 // `max(f(x) for x in xs)` → the mapped per-element value; `max(xs)` →
-                // the raw element. No init (selection reductions carry none), so it
-                // matches a `best = max(best, f(x))` loop regardless of its seed.
+                // the raw element. Seedless (1-arg) by construction: a SEEDED loop
+                // (`best = 0; …`) clamps at its seed, so it keys differently and
+                // must not merge with the true builtin selection.
                 let (op, args) = {
                     let n = &self.nodes[av as usize];
                     (n.op.clone(), n.args.clone())

--- a/crates/nose-normalize/src/value_graph/control.rs
+++ b/crates/nose-normalize/src/value_graph/control.rs
@@ -767,7 +767,7 @@ impl<'a> Builder<'a> {
         }
         let rhs = self.eval(kids[1], env);
         match op {
-            Op::Div | Op::Mod => self.int_const_eq(rhs, 0),
+            Op::Div | Op::FloorDiv | Op::Mod => self.int_const_eq(rhs, 0),
             Op::Pow => self
                 .static_int_expr(kids[1])
                 .is_some_and(|exp| !(0..=u32::MAX as i64).contains(&exp)),
@@ -1512,13 +1512,13 @@ impl<'a> Builder<'a> {
                 self.as_loop_reduction_step(newv, loopv, &loop_context, &mut reduction_cache),
             ) {
                 (Some(init), Some((op, contrib))) => {
-                    // Selection reductions (min/max) carry no init; folds carry one.
-                    let args = if is_selection_code(op) {
-                        vec![contrib]
-                    } else {
-                        vec![init, contrib]
-                    };
-                    let red = self.mk(ValOp::Reduce(op), args);
+                    // Every loop reduction carries its seed. For folds the seed is
+                    // the init operand; for selections (min/max) the seed CLAMPS the
+                    // result — `best = 0; …max…` returns 0 on all-negative input,
+                    // which true `max(…)` does not — so it is behavior-defining and
+                    // must reach the fingerprint. The builtins build a seedless
+                    // 1-arg `Reduce`, so they can never merge with a seeded loop.
+                    let red = self.mk(ValOp::Reduce(op), vec![init, contrib]);
                     env.insert(cid, red);
                 }
                 (init, _) => {

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -3,6 +3,97 @@ use super::*;
 const LARGE_AC_EXPR_OPERANDS: usize = 64;
 
 impl<'a> Builder<'a> {
+    /// JS strict (in)equality. The value model conflates `null`/`undefined` into
+    /// ONE constant, so the model's Eq-against-null means the LOOSE check
+    /// (`x == null`, true for both) — which is also what `x ?? d` desugars to. A
+    /// strict `x === null` (false for undefined) cannot be expressed in that
+    /// model: keep it a distinct shape keyed by the spelled operand, so strict
+    /// checks converge only with the same strict spelling and never feed the
+    /// nullish-default fold (`null_condition` → `ValueOrDefault`).
+    fn eval_strict_equality_comparison(
+        &mut self,
+        expr: NodeId,
+        op: u32,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if (op != Op::Eq as u32 && op != Op::Ne as u32) || kids.len() != 2 {
+            return None;
+        }
+        let strict = matches!(
+            source_operator_at_node(self.il, expr),
+            Some(
+                nose_il::SourceOperatorKind::StrictEquality
+                    | nose_il::SourceOperatorKind::StrictInequality
+            )
+        );
+        if !strict {
+            return None;
+        }
+        let a = self.eval(kids[0], env);
+        let b = self.eval(kids[1], env);
+        let null_kid = if self.is_null_value(a) {
+            Some((kids[0], b))
+        } else if self.is_null_value(b) {
+            Some((kids[1], a))
+        } else {
+            None
+        };
+        if let Some((null_kid, value_side)) = null_kid {
+            // Exception: `=== undefined` against a value that provably cannot be
+            // null IS the faithful absence check — a typed `Map.get` result is
+            // `V | undefined`. Keep the model's Eq shape there so the map-default
+            // fold still proves `m.get(k) ?? d` ≡ the `=== undefined` guarded form.
+            let undefined_spelling = matches!(
+                (self.il.kind(null_kid), self.il.node(null_kid).payload),
+                (NodeKind::Var, Payload::Name(_))
+            );
+            let undefined_only_absence = self.proven_map_get_value(value_side).is_some();
+            if !(undefined_spelling && undefined_only_absence) {
+                let salt = combine(JS_STRICT_NULL_CMP_TAG, self.valued_subtree_hash(null_kid));
+                let eq = self.mk(ValOp::Opaque(salt), vec![value_side]);
+                return Some(if op == Op::Ne as u32 {
+                    self.mk(ValOp::Un(Op::Not as u32), vec![eq])
+                } else {
+                    eq
+                });
+            }
+        }
+        // Strict comparison the model expresses faithfully: the model's Eq IS
+        // strict. Operands are already evaluated — don't evaluate them twice.
+        Some(self.mk(ValOp::Bin(op), vec![a, b]))
+    }
+
+    /// `a in b` — directional membership. JS `in` tests prototype-chain keys (its
+    /// own shape); a language with no modeled membership operator stays opaque;
+    /// otherwise membership over a proven map key-view or collection.
+    fn eval_membership_binop(
+        &mut self,
+        expr: NodeId,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> ValueId {
+        let element = self.eval(kids[0], env);
+        if self.is_js_like_lang() {
+            let collection = self.eval(kids[1], env);
+            return self.mk(ValOp::Call(JS_PROTOTYPE_IN_CODE), vec![element, collection]);
+        }
+        if semantics(self.il.meta.lang)
+            .operators()
+            .membership_operator(Op::In)
+            .is_none()
+        {
+            let collection = self.eval(kids[1], env);
+            let salt = self.source_salted_hash(expr, 0x494E_4F50);
+            return self.mk(ValOp::Opaque(salt), vec![element, collection]);
+        }
+        if let Some(map) = self.proven_map_key_view_expr(kids[1], env) {
+            return self.mk(ValOp::Bin(Op::In as u32), vec![element, map]);
+        }
+        let collection = self.eval_membership_collection(kids[1], env);
+        self.mk(ValOp::Bin(Op::In as u32), vec![element, collection])
+    }
+
     pub(super) fn eval(&mut self, expr: NodeId, env: &FxHashMap<u32, ValueId>) -> ValueId {
         // Track the enclosing source expression so EVERY node created while evaluating it (the top
         // node AND the intermediate nodes a reduce/map unfolds via `mk`) is stamped with its span
@@ -66,26 +157,7 @@ impl<'a> Builder<'a> {
                 let op = op_code(node.payload);
                 let kids = self.il.children(expr).to_vec();
                 if op == Op::In as u32 && kids.len() == 2 {
-                    let element = self.eval(kids[0], env);
-                    if self.is_js_like_lang() {
-                        let collection = self.eval(kids[1], env);
-                        return self
-                            .mk(ValOp::Call(JS_PROTOTYPE_IN_CODE), vec![element, collection]);
-                    }
-                    if semantics(self.il.meta.lang)
-                        .operators()
-                        .membership_operator(Op::In)
-                        .is_none()
-                    {
-                        let collection = self.eval(kids[1], env);
-                        let salt = self.source_salted_hash(expr, 0x494E_4F50);
-                        return self.mk(ValOp::Opaque(salt), vec![element, collection]);
-                    }
-                    if let Some(map) = self.proven_map_key_view_expr(kids[1], env) {
-                        return self.mk(ValOp::Bin(op), vec![element, map]);
-                    }
-                    let collection = self.eval_membership_collection(kids[1], env);
-                    return self.mk(ValOp::Bin(op), vec![element, collection]);
+                    return self.eval_membership_binop(expr, &kids, env);
                 }
                 if let Some(v) = self.eval_rust_option_some_pattern_comparison(op, &kids, env) {
                     return v;
@@ -102,6 +174,9 @@ impl<'a> Builder<'a> {
                     {
                         return v;
                     }
+                }
+                if let Some(v) = self.eval_strict_equality_comparison(expr, op, &kids, env) {
+                    return v;
                 }
                 if op == Op::Add as u32 || op == Op::Sub as u32 {
                     let mut operands = Vec::new();

--- a/crates/nose-normalize/src/value_graph/ops.rs
+++ b/crates/nose-normalize/src/value_graph/ops.rs
@@ -186,6 +186,7 @@ pub(super) fn op_from_code(opc: u32) -> Option<Op> {
         Op::Sub,
         Op::Mul,
         Op::Div,
+        Op::FloorDiv,
         Op::Mod,
         Op::Pow,
         Op::Eq,
@@ -265,6 +266,10 @@ pub(super) const ABS_CODE: u32 = 0xAB5;
 pub(super) const MIN_CODE: u32 = 0x319;
 pub(super) const MAX_CODE: u32 = 0x32A;
 pub(super) const JS_PROTOTYPE_IN_CODE: u32 = 0x4A53_494E;
+/// Salt for a strict (`===`/`!==`) comparison against a null-ish operand — a shape
+/// the null/undefined-conflating value model cannot express as `Bin(Eq)` without
+/// merging it with the loose check (see `eval`'s strict-null handling).
+pub(super) const JS_STRICT_NULL_CMP_TAG: u64 = 0x4A53_534E_4351;
 pub(super) const C_U16_BE_BYTE_PACK_CODE: u32 = 0x4331_3642;
 pub(super) const C_U32_BE_BYTE_PACK_CODE: u32 = 0x4333_3242;
 pub(super) const EFFECT_ORDINAL_SINK_TAG: u64 = 0xEFFE_C701;

--- a/crates/nose-semantics/src/demand.rs
+++ b/crates/nose-semantics/src/demand.rs
@@ -96,15 +96,6 @@ impl DemandEffectProfile {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum BuiltinDemand {
-    Eager,
-    Reduce,
-    AnyAll { all: bool },
-    Append,
-    ValueOrDefault,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum BuiltinDemandProfile {
     Eager { contract: EagerBuiltinContract },
     FoldReduction,
@@ -114,16 +105,6 @@ pub enum BuiltinDemandProfile {
 }
 
 impl BuiltinDemandProfile {
-    pub fn legacy_demand(self) -> BuiltinDemand {
-        match self {
-            BuiltinDemandProfile::Eager { .. } => BuiltinDemand::Eager,
-            BuiltinDemandProfile::FoldReduction => BuiltinDemand::Reduce,
-            BuiltinDemandProfile::ShortCircuitQuantifier { all } => BuiltinDemand::AnyAll { all },
-            BuiltinDemandProfile::AppendMutation => BuiltinDemand::Append,
-            BuiltinDemandProfile::NullishDefault => BuiltinDemand::ValueOrDefault,
-        }
-    }
-
     pub fn eager_contract(self) -> Option<EagerBuiltinContract> {
         match self {
             BuiltinDemandProfile::Eager { contract } => Some(contract),
@@ -185,10 +166,6 @@ pub fn builtin_demand_profile(builtin: Builtin) -> BuiltinDemandProfile {
 
 pub fn builtin_demand_effect_profile(builtin: Builtin) -> DemandEffectProfile {
     builtin_demand_profile(builtin).demand_effect_profile()
-}
-
-pub fn builtin_demand(builtin: Builtin) -> BuiltinDemand {
-    builtin_demand_profile(builtin).legacy_demand()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/crates/nose-semantics/src/effects.rs
+++ b/crates/nose-semantics/src/effects.rs
@@ -353,6 +353,7 @@ fn exact_effect_evidence_for_node(il: &Il, node: NodeId) -> EvidenceResolution<E
     let kind = il.kind(node);
     unique_asserted_evidence_at(
         il,
+        span,
         |anchor| {
             matches!(
                 anchor,
@@ -376,10 +377,9 @@ fn exact_effect_evidence_for_node(il: &Il, node: NodeId) -> EvidenceResolution<E
 pub(crate) fn asserted_effect_at_node(il: &Il, node: NodeId, wanted: EffectEvidenceKind) -> bool {
     let span = il.node(node).span;
     let kind = il.kind(node);
-    il.evidence.iter().any(|record| {
-        record.status == EvidenceStatus::Asserted
-            && il.evidence_dependencies_asserted(record)
-            && record.kind == EvidenceKind::Effect(wanted)
+    il.evidence_anchored_at(span).any(|record| {
+        record.kind == EvidenceKind::Effect(wanted)
+            && record.status == EvidenceStatus::Asserted
             && matches!(
                 record.anchor,
                 EvidenceAnchor::Node {
@@ -387,18 +387,18 @@ pub(crate) fn asserted_effect_at_node(il: &Il, node: NodeId, wanted: EffectEvide
                     kind: anchor_kind,
                 } if anchor_span == span && anchor_kind == kind
             )
+            && il.evidence_dependencies_asserted(record)
     })
 }
 
 fn asserted_library_api_suppresses_opaque_escape_at_node(il: &Il, node: NodeId) -> bool {
     let span = il.node(node).span;
     let kind = il.kind(node);
-    il.evidence.iter().any(|record| {
+    il.evidence_anchored_at(span).any(|record| {
         let EvidenceKind::LibraryApi(api) = record.kind else {
             return false;
         };
         record.status == EvidenceStatus::Asserted
-            && il.evidence_dependencies_asserted(record)
             && library_api_suppresses_opaque_argument_escape(api)
             && matches!(
                 record.anchor,
@@ -407,6 +407,7 @@ fn asserted_library_api_suppresses_opaque_escape_at_node(il: &Il, node: NodeId) 
                     kind: anchor_kind,
                 } if anchor_span == span && anchor_kind == kind
             )
+            && il.evidence_dependencies_asserted(record)
     })
 }
 
@@ -424,6 +425,7 @@ fn place_evidence_for_node(il: &Il, node: NodeId) -> EvidenceResolution<PlaceEvi
     let kind = il.kind(node);
     unique_asserted_evidence_at(
         il,
+        span,
         |anchor| {
             matches!(
                 anchor,

--- a/crates/nose-semantics/src/evidence.rs
+++ b/crates/nose-semantics/src/evidence.rs
@@ -26,13 +26,17 @@ pub(crate) enum EvidenceResolution<T> {
     Ambiguous,
 }
 
+/// Resolve the unique evidence value projected by `project` among the records
+/// anchored exactly at `span` (anchors only ever match by exact span equality,
+/// so the span-bucketed index replaces a full `evidence` scan per query).
 pub(crate) fn unique_evidence_at<T: Copy + Eq>(
     il: &Il,
+    span: Span,
     anchor_matches: impl Fn(EvidenceAnchor) -> bool,
     project: impl Fn(EvidenceKind) -> Option<T>,
 ) -> EvidenceResolution<T> {
     let mut found = None;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(span) {
         if !anchor_matches(record.anchor) {
             continue;
         }
@@ -53,11 +57,12 @@ pub(crate) fn unique_evidence_at<T: Copy + Eq>(
 
 pub(crate) fn unique_asserted_evidence_at<T: Copy + Eq>(
     il: &Il,
+    span: Span,
     anchor_matches: impl Fn(EvidenceAnchor) -> bool,
     project: impl Fn(EvidenceKind) -> Option<T>,
 ) -> EvidenceResolution<T> {
     let mut found = None;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(span) {
         if !anchor_matches(record.anchor) {
             continue;
         }
@@ -81,7 +86,7 @@ fn evidence_at_span<T: Copy + Eq>(
     span: Span,
     project: impl Fn(EvidenceKind) -> Option<T>,
 ) -> EvidenceResolution<T> {
-    unique_asserted_evidence_at(il, |anchor| anchor.matches_span(span), project)
+    unique_asserted_evidence_at(il, span, |anchor| anchor.matches_span(span), project)
 }
 
 pub fn source_fact_at_node(il: &Il, node: NodeId, kind: SourceFactKind) -> bool {
@@ -195,6 +200,7 @@ pub fn direct_function_call_target_at_call(il: &Il, call: NodeId, target_root: N
     let target_span = il.node(target_root).span;
     match unique_asserted_evidence_at(
         il,
+        call_span,
         |anchor| matches!(anchor, EvidenceAnchor::Node { span, kind } if span == call_span && kind == NodeKind::Call),
         |evidence| match evidence {
             EvidenceKind::CallTarget(target) => Some(target),
@@ -244,6 +250,7 @@ pub fn call_target_evidence_status_at_call(
     let call_span = il.node(call).span;
     let target = match unique_asserted_evidence_at(
         il,
+        call_span,
         |anchor| matches!(anchor, EvidenceAnchor::Node { span, kind } if span == call_span && kind == NodeKind::Call),
         |evidence| match evidence {
             EvidenceKind::CallTarget(target) => Some(target),
@@ -647,6 +654,7 @@ pub(crate) fn strict_numeric_operand_operator(op: Op) -> bool {
         Op::Sub
             | Op::Mul
             | Op::Div
+            | Op::FloorDiv
             | Op::Mod
             | Op::Pow
             | Op::BitAnd
@@ -660,6 +668,7 @@ pub(crate) fn strict_numeric_operand_operator(op: Op) -> bool {
 pub fn domain_evidence_at_span(il: &Il, span: Span) -> Option<DomainEvidence> {
     match unique_asserted_evidence_at(
         il,
+        span,
         |anchor| anchor.matches_span(span),
         |evidence| match evidence {
             EvidenceKind::Domain(domain) => Some(domain),
@@ -749,6 +758,7 @@ pub fn nominal_type_domain_at_node(
 ) -> Option<DomainEvidence> {
     match unique_asserted_evidence_at(
         il,
+        il.node(node).span,
         |anchor| anchor == EvidenceAnchor::node(il.node(node).span, il.kind(node)),
         |evidence| match evidence {
             EvidenceKind::Type(TypeEvidenceKind::NominalDomain {
@@ -769,6 +779,7 @@ fn domain_evidence_at_exact_anchor(
 ) -> EvidenceResolution<DomainEvidence> {
     unique_asserted_evidence_at(
         il,
+        expected.span(),
         |anchor| anchor == expected,
         |evidence| match evidence {
             EvidenceKind::Domain(domain) => Some(domain),
@@ -946,6 +957,7 @@ fn domain_evidence_at_binding_lhs(
     };
     unique_asserted_evidence_at(
         il,
+        span,
         |anchor| {
             matches!(
                 anchor,
@@ -1112,22 +1124,5 @@ fn cid_is_assigned_in_scope(il: &Il, cid: u32, scope: NodeId) -> bool {
 }
 
 pub(crate) fn nearest_scope(il: &Il, node: NodeId) -> Option<NodeId> {
-    let target = il.node(node).span;
-    let mut best: Option<(u32, NodeId)> = None;
-    for (idx, candidate) in il.nodes.iter().enumerate() {
-        if !matches!(candidate.kind, NodeKind::Func | NodeKind::Lambda) {
-            continue;
-        }
-        if !span_contains(candidate.span, target) {
-            continue;
-        }
-        let width = candidate
-            .span
-            .end_byte
-            .saturating_sub(candidate.span.start_byte);
-        if best.is_none_or(|(best_width, _)| width < best_width) {
-            best = Some((width, NodeId(idx as u32)));
-        }
-    }
-    best.map(|(_, scope)| scope)
+    il.nearest_scope(node)
 }

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -224,21 +224,13 @@ pub fn seq_surface_contract_for_node(
     }
 }
 
-/// Backward-compatible name for the evidence-only `Seq` surface resolver.
-pub fn seq_surface_contract_evidence_for_node(
-    il: &Il,
-    interner: &Interner,
-    node: NodeId,
-) -> Option<SeqSurfaceContract> {
-    seq_surface_contract_for_node(il, interner, node)
-}
-
 fn sequence_surface_evidence_at_sequence_span(
     il: &Il,
     span: Span,
 ) -> EvidenceResolution<SequenceSurfaceKind> {
     unique_evidence_at(
         il,
+        span,
         |anchor| matches!(anchor, EvidenceAnchor::Sequence { span: anchor_span } if anchor_span == span),
         |evidence| match evidence {
             EvidenceKind::SequenceSurface(kind) => Some(kind),
@@ -561,6 +553,7 @@ pub struct ImportFact {
 fn import_fact_evidence_at_sequence_span(il: &Il, span: Span) -> EvidenceResolution<ImportFact> {
     unique_evidence_at(
         il,
+        span,
         |anchor| matches!(anchor, EvidenceAnchor::Sequence { span: anchor_span } if anchor_span == span),
         |evidence| match evidence {
             EvidenceKind::Import(ImportEvidenceKind::Binding {
@@ -659,6 +652,7 @@ fn symbol_evidence_at_node_anchor(
 ) -> EvidenceResolution<SymbolEvidenceKind> {
     unique_asserted_evidence_at(
         il,
+        span,
         |anchor| {
             matches!(
                 anchor,
@@ -682,6 +676,7 @@ fn symbol_evidence_for_binding(
 ) -> EvidenceResolution<SymbolEvidenceKind> {
     unique_evidence_at(
         il,
+        span,
         |anchor| {
             matches!(
                 anchor,
@@ -760,30 +755,10 @@ fn binding_identity_matches(
     }
 }
 
-/// Prove that `node` denotes a language-defined unshadowed global with the exact
-/// requested name. The raw spelling is not enough: when symbol evidence exists it
-/// is authoritative, and ambiguous/conflicting evidence keeps the exact path
-/// closed instead of falling back to spelling checks.
-pub fn unshadowed_global_symbol(il: &Il, interner: &Interner, node: NodeId, name: &str) -> bool {
-    if il.kind(node) != NodeKind::Var {
-        return false;
-    }
-    let expected = SymbolEvidenceKind::UnshadowedGlobal {
-        name_hash: stable_symbol_hash(name),
-    };
-    match symbol_identity_at_node_matches(il, node, expected) {
-        EvidenceResolution::Found(matches) => return matches,
-        EvidenceResolution::Ambiguous => return false,
-        EvidenceResolution::Missing => {}
-    }
-    node_name(il, interner, node) == Some(name) && !file_defines_name(il, interner, name)
-}
-
-/// Evidence-only proof that `node` denotes a language-defined unshadowed global.
-///
-/// This is the consumer-side API for exact value semantics. Producer-side scans may
-/// still use `unshadowed_global_symbol` as a compatibility bridge while migrating
-/// old frontend paths onto explicit `Symbol` evidence.
+/// Evidence-only proof that `node` denotes a language-defined unshadowed global
+/// with the exact requested name. The raw spelling is never enough: only explicit
+/// `Symbol` evidence opens the exact path, and ambiguous or conflicting evidence
+/// keeps it closed.
 pub fn asserted_unshadowed_global_symbol(il: &Il, node: NodeId, name: &str) -> bool {
     if il.kind(node) != NodeKind::Var {
         return false;
@@ -1069,29 +1044,6 @@ fn unit_defines_hash_visible_at(
                 .name
                 .is_some_and(|symbol| stable_symbol_hash(interner.resolve(symbol)) == name_hash)
     })
-}
-
-fn file_defines_name(il: &Il, interner: &Interner, name: &str) -> bool {
-    let name_hash = stable_symbol_hash(name);
-    il.units.iter().any(|unit| {
-        unit.name.is_some_and(|symbol| {
-            symbol_defines_name(il.meta.lang, interner.resolve(symbol), name, name_hash)
-        })
-    }) || il
-        .nodes
-        .iter()
-        .enumerate()
-        .any(|(idx, node)| match node.kind {
-            NodeKind::Module | NodeKind::Block | NodeKind::Param => {
-                node_defines_name(il, interner, NodeId(idx as u32), name, name_hash)
-            }
-            NodeKind::Assign => il
-                .children(NodeId(idx as u32))
-                .first()
-                .copied()
-                .is_some_and(|lhs| node_defines_name(il, interner, lhs, name, name_hash)),
-            _ => false,
-        })
 }
 
 pub fn file_defines_name_visible_at(

--- a/crates/nose-semantics/src/library_api.rs
+++ b/crates/nose-semantics/src/library_api.rs
@@ -209,7 +209,6 @@ pub fn library_api_receiver_dependencies_for_call(
 
 #[derive(Default)]
 pub struct LibraryApiDependencyCache {
-    nearest_scope_by_node: FxHashMap<NodeId, Option<NodeId>>,
     binding_lhs_by_reference: FxHashMap<NodeId, EvidenceResolution<NodeId>>,
     receiver_param_span_by_reference: FxHashMap<NodeId, Option<Span>>,
     name_assigned_in_scope: FxHashMap<(NodeId, Symbol), bool>,
@@ -1360,14 +1359,10 @@ fn unique_binding_lhs_for_var_reference_with_cache(
 fn nearest_scope_cached(
     il: &Il,
     node: NodeId,
-    cache: &mut LibraryApiDependencyCache,
+    _cache: &mut LibraryApiDependencyCache,
 ) -> Option<NodeId> {
-    if let Some(cached) = cache.nearest_scope_by_node.get(&node).copied() {
-        return cached;
-    }
-    let scope = nearest_scope(il, node);
-    cache.nearest_scope_by_node.insert(node, scope);
-    scope
+    // `Il::nearest_scope` is already a whole-arena lazy index; no per-call cache needed.
+    nearest_scope(il, node)
 }
 
 fn receiver_param_span_cached(
@@ -2050,6 +2045,7 @@ fn dependency_has_source_call(
     matches!(
         unique_evidence_at(
             il,
+            anchor.span(),
             |candidate| candidate == anchor,
             |evidence| match evidence {
                 EvidenceKind::Source(SourceFactKind::Call(call)) => Some(call),
@@ -2079,6 +2075,7 @@ fn dependency_has_source_fact_anchor(
     matches!(
         unique_evidence_at(
             il,
+            anchor.span(),
             |candidate| candidate == anchor,
             |evidence| match evidence {
                 EvidenceKind::Source(fact) => Some(fact),

--- a/crates/nose-semantics/src/module_exports.rs
+++ b/crates/nose-semantics/src/module_exports.rs
@@ -3,7 +3,7 @@
 use crate::{
     admitted_free_name_map_factory_at_call, admitted_java_map_entry_at_call,
     admitted_java_map_factory_at_call, import_fact_evidence_rhs, semantics,
-    seq_surface_contract_evidence_for_node, ImportedMapFactoryContract, JavaMapFactoryKind,
+    seq_surface_contract_for_node, ImportedMapFactoryContract, JavaMapFactoryKind,
     LibraryMapFactoryResult,
 };
 use nose_il::{Il, Interner, NodeId, NodeKind};
@@ -13,7 +13,7 @@ use nose_il::{Il, Interner, NodeId, NodeKind};
 pub fn imported_literal_export_safe(il: &Il, interner: &Interner, node: NodeId) -> bool {
     match il.kind(node) {
         NodeKind::Seq => {
-            seq_surface_contract_evidence_for_node(il, interner, node)
+            seq_surface_contract_for_node(il, interner, node)
                 .is_some_and(|contract| contract.imported_literal)
                 && il
                     .children(node)
@@ -32,7 +32,7 @@ fn literal_export_value_safe(il: &Il, interner: &Interner, node: NodeId) -> bool
             if import_fact_evidence_rhs(il, node).is_some() {
                 return false;
             }
-            if !seq_surface_contract_evidence_for_node(il, interner, node)
+            if !seq_surface_contract_for_node(il, interner, node)
                 .is_some_and(|contract| contract.exact_tree_safe)
             {
                 return false;

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -807,6 +807,8 @@ struct ManifestPack {
     description: Option<String>,
     trust: PackTrust,
     enabled_by_default: bool,
+    // Documented v0 schema field the engine does not consume; listed (typed) so
+    // `deny_unknown_fields` still accepts and validates conforming manifests.
     #[serde(default, rename = "status")]
     _status: Option<SemanticPackStatus>,
 }

--- a/crates/nose-semantics/src/tests/library_api_contracts.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts.rs
@@ -644,18 +644,13 @@ fn builtin_contracts_preserve_current_special_demand_split() {
     for &builtin in ALL_BUILTINS {
         assert_eq!(builtin_tag(builtin), builtin as u32 + 1);
     }
-    assert_eq!(builtin_demand(Builtin::Reduce), BuiltinDemand::Reduce);
     assert_eq!(
         builtin_demand_profile(Builtin::Reduce),
         BuiltinDemandProfile::FoldReduction
     );
     assert_eq!(
-        builtin_demand(Builtin::Any),
-        BuiltinDemand::AnyAll { all: false }
-    );
-    assert_eq!(
-        builtin_demand(Builtin::All),
-        BuiltinDemand::AnyAll { all: true }
+        builtin_demand_profile(Builtin::Any),
+        BuiltinDemandProfile::ShortCircuitQuantifier { all: false }
     );
     assert_eq!(
         builtin_demand_profile(Builtin::All),
@@ -681,20 +676,14 @@ fn builtin_contracts_preserve_current_special_demand_split() {
             effect_visibility: EffectVisibility::OnlyIfDemanded,
         }
     );
-    assert_eq!(builtin_demand(Builtin::Append), BuiltinDemand::Append);
     assert_eq!(
         builtin_demand_profile(Builtin::Append),
         BuiltinDemandProfile::AppendMutation
     );
     assert_eq!(
-        builtin_demand(Builtin::ValueOrDefault),
-        BuiltinDemand::ValueOrDefault
-    );
-    assert_eq!(
         builtin_demand_profile(Builtin::ValueOrDefault),
         BuiltinDemandProfile::NullishDefault
     );
-    assert_eq!(builtin_demand(Builtin::Len), BuiltinDemand::Eager);
     assert_eq!(
         builtin_demand_profile(Builtin::Len),
         BuiltinDemandProfile::Eager {

--- a/crates/nose-semantics/src/tests/semantic_evidence.rs
+++ b/crates/nose-semantics/src/tests/semantic_evidence.rs
@@ -1415,7 +1415,7 @@ fn binding_symbol_evidence_does_not_prove_rebound_alias_uses() {
 }
 
 #[test]
-fn ambiguous_global_symbol_evidence_blocks_name_fallback() {
+fn global_symbol_requires_asserted_evidence() {
     let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));
     let math = b.add(
@@ -1427,7 +1427,10 @@ fn ambiguous_global_symbol_evidence_blocks_name_fallback() {
     let root = b.add(NodeKind::Module, Payload::None, sp(23), &[math]);
     let mut il = finish_il(b, root, Lang::JavaScript);
 
-    assert!(unshadowed_global_symbol(&il, &interner, math, "Math"));
+    assert!(
+        !asserted_unshadowed_global_symbol(&il, math, "Math"),
+        "a bare spelling without Symbol evidence must not open the exact path"
+    );
 
     il.evidence.push(evidence(
         0,
@@ -1437,5 +1440,22 @@ fn ambiguous_global_symbol_evidence_blocks_name_fallback() {
         }),
         EvidenceStatus::Ambiguous,
     ));
-    assert!(!unshadowed_global_symbol(&il, &interner, math, "Math"));
+    assert!(
+        !asserted_unshadowed_global_symbol(&il, math, "Math"),
+        "ambiguous Symbol evidence keeps the exact path closed"
+    );
+
+    il.evidence.clear();
+    il.evidence.push(evidence(
+        0,
+        EvidenceAnchor::node(sp(23), NodeKind::Var),
+        EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+            name_hash: stable_symbol_hash("Math"),
+        }),
+        EvidenceStatus::Asserted,
+    ));
+    assert!(
+        asserted_unshadowed_global_symbol(&il, math, "Math"),
+        "asserted Symbol evidence proves the unshadowed global"
+    );
 }

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -110,6 +110,11 @@ core canonicalizations, but not a per-scan or whole-pipeline proof. See
   carry no per-pair behavioral proof.
 - Type-4 coverage is a **growing set of modeled equivalences**, not a guarantee about any
   given pair of semantically-equal fragments.
+- **The value model is coarser than full JS semantics for loose equality on non-null
+  operands**: `a == b` and `a === b` over arbitrary values share a fingerprint (the model's
+  equality is strict/structural; coercion is not modeled). Null-ish checks are handled
+  precisely — `x === null` never merges with `x == null` / `x ?? d`, and `null` and
+  `undefined` spellings stay distinct in strict checks.
 - Sub-function semantic coverage is intentionally bounded: nose extracts control-flow
   blocks and exact-safe single-statement fragments (return/throw expressions and simple
   conditional return/throw/effect guards, including bare returns, explicit empty no-op

--- a/docs/field-evaluation.md
+++ b/docs/field-evaluation.md
@@ -134,3 +134,38 @@ This shipped as a ranking-time policy layer (experiments §U):
 
 The remaining refactor-worthiness discount targets generated-looking and computation-poor
 type-definition families, not test scope. See [usage](usage.md) for the scope tags.
+
+## Third pass — performance pathology and an oracle-exposed false merge
+
+A third read-only pass (ten unrelated local projects: Go CLIs, TypeScript
+games/tools, Python services, mixed monorepos) confirmed the interactive-speed
+claim for normal repositories — every project scanned in ≤ 0.13 s end-to-end,
+lowering coverage stayed under 0.1 % Raw, and the semantic channel's findings
+were true positives on inspection (e.g. two identically-shaped `` `${x},${z}` ``
+key-builder methods in different modules of a TypeScript game; a duplicated
+HSL→RGB conversion helper surfaced by the near channel).
+
+Two substantive findings came out of this pass:
+
+1. **Minified bundle artifacts were a performance cliff.** One monorepo carried
+   committed build output (a multi-megabyte minified `*.js` bundle). A single
+   246 KB minified file took **227 s** in normalize+extract: `nearest_scope`
+   and the evidence-record lookups were linear scans *per query*, which goes
+   quadratic when one file has hundreds of thousands of IL nodes and evidence
+   records. Both are now lazy per-file indexes (a whole-arena
+   nearest-enclosing-scope table and an exact-anchor-span evidence index), and
+   the same file scans in **≈ 2 s** — with small-repo scans getting ~3× faster
+   normalize+extract as a side effect. The fix was profiler-driven
+   (`sample` on the live process; `NOSE_TIME=1` stage timing).
+2. **The oracle blind spot it closed found a real false merge.** Making
+   2-argument `min`/`max` interpretable let `nose verify` check the
+   selection-reduction convergences for the first time — and it immediately
+   flagged `max(x + y for x in xs for y in ys)` ≡ a `best = 0`-seeded nested
+   loop as a false merge (the seed clamps: empty or all-negative input returns
+   0, true `max(...)` errs or goes negative). Selection reductions now carry
+   their seed in the fingerprint; seedless builtin forms stay 1-arg, so
+   equally-seeded loops still converge with each other and the mislabeled
+   benchmark case was flipped to a hard negative.
+
+The practical advice stands: scan source roots, not build output — but a
+committed bundle must degrade gracefully, and now it does.

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -343,6 +343,14 @@ seed). Fixed in the same change: the recurrence now carries its seed as an opera
 seed reaches the fingerprint. It reproduced with hand-written loops alone — the recursion
 rewrite merely made it reachable from recursive functions too.)
 
+The same lesson later repeated for **selection reductions**: min/max loop accumulators
+originally dropped their seed on the theory that a selection has no identity element to
+normalize away — but that is exactly why the seed is behavior-defining (`best = 0` clamps
+at 0 on empty or all-negative input; true `max(…)` does not). `nose verify` flagged the
+merge the moment 2-argument `min`/`max` became interpretable. Selection reductions now
+carry their seed; the seedless builtin forms (`max(xs)`, first-element-seeded `reduce`)
+stay 1-arg so they only converge with each other.
+
 ---
 
 ### Why semantic normalization is still worth trying

--- a/docs/structured-ignores.md
+++ b/docs/structured-ignores.md
@@ -88,7 +88,7 @@ Each entry must have:
 | `languages` | one selector required | Language names such as `python`, `typescript`, or `rust`. Best as a broad guard combined with another selector. |
 | `note` | no | Human review context. Explain where the real refactoring point is. |
 | `owner` | no | Team or person responsible for revisiting the decision. |
-| `expires_at` | no | `YYYY-MM-DD`. The entry applies through that date; after it, nose reports it as expired and does not apply it. |
+| `expires_at` | no | `YYYY-MM-DD`. The entry applies through that date; after it, nose reports it as expired and does not apply it. The date is evaluated against the current **UTC** day (deterministic across machines), so near a boundary an entry may expire up to one local day earlier or later than local midnight. |
 
 When an entry has multiple selectors, all of them must match. For example, an
 entry with both `paths` and `languages` suppresses only families that touch one


### PR DESCRIPTION
## Summary

Soundness — every false merge below was **reproduced end-to-end** (two files, `nose scan --mode semantic` merging them) before fixing, and each fix carries a regression test in `equivalence.rs`:

- **Python `/` vs `//`** — both lowered to `Div`, so `5 / 2` (2.5) fingerprint-merged with `5 // 2` (2). `//` is now a first-class `Op::FloorDiv` (quotient toward −∞) with matching interpreter semantics.
- **JS `>>` vs `>>>`**, **Python `*` vs `@`** — the lossy collapses are gone; unmapped operators lower to a raw shape keyed by their own spelling (two *different* unmapped operators no longer share a fingerprint either).
- **Strict null checks** — `x === null ? d : x` no longer joins the nullish family (`x ?? d` ≡ `x == null ? d : x` still converges; the typed `Map.get(...) === undefined` guard still proves the map-default fold; `=== null` vs `=== undefined` stay distinct).
- **Compound assignments fail closed** — JS `x ??= y` lowered as `x += y` (now desugars to `x = x ?? y` and converges with the spelled-out form); Java `x >>>= y` lowered as `x = y`; Ruby `x **= y` lowered as `x = y`. One shared `compound_assignment` lowering now serves Python/JS/Rust (the dogfood gate caught the initial copy-paste of this fix and forced the extraction).
- **Selection-reduction seeds** — `best = 0; … if v > best: best = v` clamps at its seed (empty / all-negative input ⇒ 0) yet merged with true `max(…)`. Selection reductions now carry their seed in the fingerprint; seedless builtin forms stay 1-arg. Found by `nose verify` the moment 2-argument `min`/`max` became interpretable (an oracle blind spot this PR also closes); the mislabeled `max_flat_map_nested_loop` adversarial case is relabeled hard-negative with the verify evidence.
- Recall win: Ruby `**` now lowers to the shared `Pow` and converges with Python/JS `**`.

Perf — profiler-driven (`sample` on the live process + `NOSE_TIME=1` stage timing), no design change:

- `nearest_scope` and evidence-record lookups were **per-query linear scans** over all IL nodes / records — quadratic on minified-bundle-sized files. Both are lazy per-file indexes now (whole-arena nearest-scope table preserving the exact (width, id) argmin semantics; exact-anchor-span evidence buckets indexing only immutable fields, so `status`/`dependencies` stay live-read and appends are picked up incrementally).
- A 246 KB minified JS file: **227 s → ≈ 2 s** normalize+extract (~118×). Ordinary repos get ~3× faster normalize+extract.

Cleanup — pre-release compat shims deleted: `seq_surface_contract_evidence_for_node`, `unshadowed_global_symbol` (spelling fallback), `builtin_demand`/`BuiltinDemand`, `lcs_ratio`, `minhash::estimate`, `EvidenceEmitter::Legacy`.

Docs: CHANGELOG, normalization (selection-seed lesson), clone-types (honest JS loose-equality model limit), structured-ignores (UTC expiry), field-evaluation (third pass: 10 local projects, all ≤ 0.13 s, semantic findings verified true on inspection).

## Test plan

- [x] `cargo test --workspace --release` — green (9 new regression tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 0 warnings
- [x] `cargo llvm-cov --fail-under-lines 86` — 87.19%
- [x] `./scripts/check-duplication.sh` — 23/23 budget
- [x] `nose verify bench/type4 --max-violations 0` — 0 false merges, vj[1.0] 100% behavior-equal
- [x] `./scripts/check-lean-proofs.sh`, formal obligations, `cargo machete`, `awiki lint` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)