### PR TITLE
quality: ratchet cognitive complexity to 20 and function length to 100

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,21 +1,20 @@
 # Clippy configuration — complexity / readability ratchets.
 #
 # These thresholds are the tunable half of the lints enabled in
-# `[workspace.lints.clippy]` (Cargo.toml). They start at deliberately lenient
-# values so today's code passes `clippy -D warnings`; the plan is to ratchet them
-# DOWN (stricter) over time as the code is simplified. Lower = stricter.
+# `[workspace.lints.clippy]` (Cargo.toml). They are ratchets: tighten them
+# (lower) over time as the code is simplified; never loosen them to make a
+# red build pass.
 #
 # Run locally with: cargo clippy --all-targets --all-features -- -D warnings
 
 # Per-function cognitive complexity (branch/nesting weighted). Clippy's default
-# is 25; nose's current production ceiling is 64, so this baseline sits just
-# above it. Ratchet downward as complex functions are simplified.
-cognitive-complexity-threshold = 65
+# is 25; nose holds itself below that. Ratchet downward as functions simplify.
+cognitive-complexity-threshold = 20
 
-# Per-function length. Clippy's default is 100; nose's current production
-# ceiling is 399, with three intentionally broad fixture-matrix tests allowed
-# above this threshold. Ratchet downward as large functions are split.
-too-many-lines-threshold = 400
+# Per-function length, counted on code lines (comments/blanks excluded).
+# Intentionally broad fixture-matrix tests may carry a justified
+# `#[allow(clippy::too_many_lines)]`; production code may not.
+too-many-lines-threshold = 100
 
 # Already enforced by clippy's default `complexity` group; pinned here so the
 # thresholds are visible and ratchetable alongside the others.

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -1415,116 +1415,15 @@ fn run() -> Result<()> {
         Cmd::SemanticPack { cmd } => match cmd {
             SemanticPackCmd::Check { paths, format } => semantic_pack::cmd_check(paths, format),
         },
-        Cmd::Detect {
-            paths,
-            min_lines,
-            min_tokens,
-            threshold,
-            candidates,
-            minhash_k,
-            bands,
-            no_cfg_norm,
-            dce,
-            no_blocks,
-            out,
-            summary,
-            bench_schema,
-            repos_root,
-            dump,
-        } => cmd_detect(DetectArgs {
-            paths,
-            min_lines,
-            min_tokens,
-            threshold,
-            candidates,
-            minhash_k,
-            bands,
-            no_cfg_norm,
-            dce,
-            no_blocks,
-            out,
-            summary,
-            bench_schema,
-            repos_root,
-            dump,
-        }),
+        cmd @ Cmd::Detect { .. } => run_detect_cmd(cmd),
         Cmd::Eval {
             gold,
             predictions,
             hard_negatives,
             corpus,
         } => cmd_eval(gold, predictions, hard_negatives, corpus),
-        Cmd::Scan {
-            paths,
-            top,
-            min_members,
-            min_value,
-            sort,
-            config,
-            mode,
-            show,
-            cache_dir,
-            fail_on,
-            baseline,
-            ignore_file,
-            semantic_pack,
-            write_baseline,
-            format,
-            exclude,
-            min_size,
-            min_lines,
-        } => cmd_scan(ScanArgs {
-            paths,
-            top,
-            min_members,
-            min_value,
-            sort,
-            config,
-            mode,
-            show,
-            cache_dir,
-            fail_on,
-            baseline,
-            ignore_file,
-            semantic_pack,
-            write_baseline,
-            format,
-            exclude,
-            min_size,
-            min_lines,
-        }),
-        Cmd::Review {
-            paths,
-            base,
-            mode,
-            min_size,
-            min_lines,
-            exclude,
-            config,
-            ignore_file,
-            format,
-            top,
-            fail,
-        } => {
-            let paths = if paths.is_empty() {
-                vec![PathBuf::from(".")]
-            } else {
-                paths
-            };
-            review::cmd_review(review::ReviewArgs {
-                paths,
-                base,
-                mode,
-                min_size,
-                min_lines,
-                exclude,
-                config,
-                ignore_file,
-                format,
-                top,
-                fail,
-            })
-        }
+        cmd @ Cmd::Scan { .. } => run_scan_cmd(cmd),
+        cmd @ Cmd::Review { .. } => run_review_cmd(cmd),
         Cmd::Ceiling {
             gold,
             units,
@@ -1551,6 +1450,129 @@ fn run() -> Result<()> {
             battery,
         } => cmd_behavioral_gate(paths, manifest, battery),
     }
+}
+
+fn run_detect_cmd(cmd: Cmd) -> Result<()> {
+    let Cmd::Detect {
+        paths,
+        min_lines,
+        min_tokens,
+        threshold,
+        candidates,
+        minhash_k,
+        bands,
+        no_cfg_norm,
+        dce,
+        no_blocks,
+        out,
+        summary,
+        bench_schema,
+        repos_root,
+        dump,
+    } = cmd
+    else {
+        unreachable!("run_detect_cmd requires Cmd::Detect")
+    };
+    cmd_detect(DetectArgs {
+        paths,
+        min_lines,
+        min_tokens,
+        threshold,
+        candidates,
+        minhash_k,
+        bands,
+        no_cfg_norm,
+        dce,
+        no_blocks,
+        out,
+        summary,
+        bench_schema,
+        repos_root,
+        dump,
+    })
+}
+
+fn run_scan_cmd(cmd: Cmd) -> Result<()> {
+    let Cmd::Scan {
+        paths,
+        top,
+        min_members,
+        min_value,
+        sort,
+        config,
+        mode,
+        show,
+        cache_dir,
+        fail_on,
+        baseline,
+        ignore_file,
+        semantic_pack,
+        write_baseline,
+        format,
+        exclude,
+        min_size,
+        min_lines,
+    } = cmd
+    else {
+        unreachable!("run_scan_cmd requires Cmd::Scan")
+    };
+    cmd_scan(ScanArgs {
+        paths,
+        top,
+        min_members,
+        min_value,
+        sort,
+        config,
+        mode,
+        show,
+        cache_dir,
+        fail_on,
+        baseline,
+        ignore_file,
+        semantic_pack,
+        write_baseline,
+        format,
+        exclude,
+        min_size,
+        min_lines,
+    })
+}
+
+fn run_review_cmd(cmd: Cmd) -> Result<()> {
+    let Cmd::Review {
+        paths,
+        base,
+        mode,
+        min_size,
+        min_lines,
+        exclude,
+        config,
+        ignore_file,
+        format,
+        top,
+        fail,
+    } = cmd
+    else {
+        unreachable!("run_review_cmd requires Cmd::Review")
+    };
+    let paths = if paths.is_empty() {
+        vec![PathBuf::from(".")]
+    } else {
+        paths
+    };
+    review::cmd_review(review::ReviewArgs {
+        paths,
+        base,
+        mode,
+        min_size,
+        min_lines,
+        exclude,
+        config,
+        ignore_file,
+        format,
+        top,
+        fail,
+    })
 }
 
 /// Deterministic input battery for an `arity`-parameter function. The parameters range
@@ -1708,44 +1730,92 @@ fn cmd_behavioral_gate(
     manifest: PathBuf,
     battery_kind: BatteryKind,
 ) -> Result<()> {
-    use nose_normalize::{run_unit, Behavior, NormalizeOptions, Value};
-    use std::collections::hash_map::DefaultHasher;
-    use std::collections::{HashMap, HashSet};
-    use std::hash::{Hash, Hasher};
-
     let refs = paths_as_refs(&paths);
     let corpus = nose_frontend::lower_corpus_many(&refs);
     warn_if_empty(&corpus, &paths);
-    let opts = NormalizeOptions::default();
-    let oracle_opts = NormalizeOptions {
-        oracle: true,
-        ..opts
-    };
     let battery = match battery_kind {
         BatteryKind::Standard => verify_battery(&verify_probes(&corpus)),
         BatteryKind::Wide => wide_battery(&verify_probes(&corpus)),
     };
+    let units = gate_units(&corpus, &battery);
+    let m: GateManifest = serde_json::from_str(&std::fs::read_to_string(&manifest)?)?;
+    let outcome = tally_gate(&m, &units);
+    print_gate_report(battery_kind, battery.len(), &outcome);
+    Ok(())
+}
 
-    // One interpretable record per generated source file (each holds exactly one function).
-    struct U {
-        fp: Vec<u64>,
-        beh_hash: u64,
-        trivial: bool,
+/// Index every `Func` in `il` by its source byte span, so a fully-normalized unit can
+/// be matched (by span) to the same function in the pre-canon core IL.
+fn func_span_index(il: &nose_il::Il) -> std::collections::HashMap<(u32, u32), nose_il::NodeId> {
+    let mut index = std::collections::HashMap::new();
+    let mut stk = vec![il.root];
+    while let Some(x) = stk.pop() {
+        if il.kind(x) == nose_il::NodeKind::Func {
+            let s = il.node(x).span;
+            index.entry((s.start_byte, s.end_byte)).or_insert(x);
+        }
+        stk.extend(il.children(x).iter().copied());
     }
-    let mut units: HashMap<String, U> = HashMap::new();
+    index
+}
 
+/// Interpret `root` on every battery row (under the unit's pointer-length contracts);
+/// `None` when any input fails to run — the unit is not interpretable on this battery.
+fn run_battery(
+    il: &nose_il::Il,
+    interner: &Interner,
+    root: nose_il::NodeId,
+    battery: &[Vec<nose_normalize::Value>],
+    contracts: &[(u32, u32)],
+) -> Option<Vec<nose_normalize::Behavior>> {
+    let mut beh = Vec::with_capacity(battery.len());
+    for inputs in battery {
+        let row = apply_contracts(inputs, contracts);
+        beh.push(nose_normalize::run_unit(il, interner, root, &row)?);
+    }
+    Some(beh)
+}
+
+/// Trivial behavior (constant / all-Err) is coincidental, never evidence of a
+/// clone — exclude it from behavioral merging.
+fn is_trivial_behavior(beh: &[nose_normalize::Behavior]) -> bool {
+    use nose_normalize::Value;
+    let distinct: std::collections::HashSet<&Value> = beh.iter().map(|b| &b.ret).collect();
+    distinct.len() < 2
+        || beh
+            .iter()
+            .all(|b| matches!(b.ret, Value::Null | Value::Err))
+}
+
+/// Stable hash of a behavior battery (equal hash ⟺ behaviorally equal on the battery).
+fn behavior_hash(beh: &[nose_normalize::Behavior]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    beh.hash(&mut h);
+    h.finish()
+}
+
+/// One interpretable record per generated source file (each holds exactly one function).
+struct GateUnit {
+    fp: Vec<u64>,
+    beh_hash: u64,
+    trivial: bool,
+}
+
+fn gate_units(
+    corpus: &Corpus,
+    battery: &[Vec<nose_normalize::Value>],
+) -> std::collections::HashMap<String, GateUnit> {
+    let opts = nose_normalize::NormalizeOptions::default();
+    let oracle_opts = nose_normalize::NormalizeOptions {
+        oracle: true,
+        ..opts
+    };
+    let mut units = std::collections::HashMap::new();
     for il in &corpus.files {
         let n = nose_normalize::normalize(il, &corpus.interner, &opts);
         let core = nose_normalize::normalize(il, &corpus.interner, &oracle_opts);
-        let mut core_func: HashMap<(u32, u32), nose_il::NodeId> = HashMap::new();
-        let mut stk = vec![core.root];
-        while let Some(x) = stk.pop() {
-            if core.kind(x) == nose_il::NodeKind::Func {
-                let s = core.node(x).span;
-                core_func.entry((s.start_byte, s.end_byte)).or_insert(x);
-            }
-            stk.extend(core.children(x).iter().copied());
-        }
+        let core_func = func_span_index(&core);
         for u in &n.units {
             let root = u.root;
             if n.kind(root) != nose_il::NodeKind::Func {
@@ -1761,91 +1831,89 @@ fn cmd_behavioral_gate(
             if fp.is_empty() {
                 continue;
             }
-            let mut beh: Vec<Behavior> = Vec::with_capacity(battery.len());
-            let mut ok = true;
-            for inputs in &battery {
-                let row = apply_contracts(inputs, &contracts);
-                match run_unit(&core, &corpus.interner, core_root, &row) {
-                    Some(b) => beh.push(b),
-                    None => {
-                        ok = false;
-                        break;
-                    }
-                }
-            }
-            if !ok {
+            let Some(beh) = run_battery(&core, &corpus.interner, core_root, battery, &contracts)
+            else {
                 continue;
-            }
-            // Trivial behavior (constant / all-Err) is coincidental, never evidence of a
-            // clone — exclude it from behavioral merging (matches the verify completeness gate).
-            let distinct: HashSet<&Value> = beh.iter().map(|b| &b.ret).collect();
-            let trivial = distinct.len() < 2
-                || beh
-                    .iter()
-                    .all(|b| matches!(b.ret, Value::Null | Value::Err));
-            let mut h = DefaultHasher::new();
-            beh.hash(&mut h);
+            };
+            let trivial = is_trivial_behavior(&beh);
             units.insert(
                 manifest_key(&il.meta.path),
-                U {
+                GateUnit {
                     fp,
-                    beh_hash: h.finish(),
+                    beh_hash: behavior_hash(&beh),
                     trivial,
                 },
             );
         }
     }
+    units
+}
 
-    // Cross-reference the manifest's labeled pairs.
-    #[derive(serde::Deserialize)]
-    struct Side {
-        path: String,
-    }
-    #[derive(serde::Deserialize)]
-    struct Item {
-        left: Side,
-        right: Side,
-        semantic_status: String,
-        split: String,
-    }
-    #[derive(serde::Deserialize)]
-    struct Manifest {
-        items: Vec<Item>,
-    }
-    let m: Manifest = serde_json::from_str(&std::fs::read_to_string(&manifest)?)?;
+// The manifest's labeled pairs, cross-referenced against the interpretable units.
+#[derive(serde::Deserialize)]
+struct GateSide {
+    path: String,
+}
+#[derive(serde::Deserialize)]
+struct GateItem {
+    left: GateSide,
+    right: GateSide,
+    semantic_status: String,
+    split: String,
+}
+#[derive(serde::Deserialize)]
+struct GateManifest {
+    items: Vec<GateItem>,
+}
 
-    // Tally, restricted to pairs where BOTH units are interpretable (the slice this gate
-    // can speak to). For each: did exact-fingerprint merge them? did the behavioral gate?
-    struct Tally {
-        pairs: usize,
-        fp_merge: usize,
-        beh_merge: usize,
-        beh_only: usize, // behavioral merge that fingerprint missed (the leap value / cost)
-    }
-    impl Tally {
-        fn new() -> Self {
-            Tally {
-                pairs: 0,
-                fp_merge: 0,
-                beh_merge: 0,
-                beh_only: 0,
-            }
+/// Per-class tally: did exact-fingerprint merge the pair? did the behavioral gate?
+struct GateTally {
+    pairs: usize,
+    fp_merge: usize,
+    beh_merge: usize,
+    beh_only: usize, // behavioral merge that fingerprint missed (the leap value / cost)
+}
+
+impl GateTally {
+    fn new() -> Self {
+        GateTally {
+            pairs: 0,
+            fp_merge: 0,
+            beh_merge: 0,
+            beh_only: 0,
         }
     }
-    let mut pos = Tally::new();
-    let mut neg = Tally::new();
-    let mut pos_heldout = 0usize;
-    let mut pos_heldout_beh_only = 0usize;
-    let mut uninterp_pairs = 0usize;
+}
 
+struct GateOutcome {
+    pos: GateTally,
+    neg: GateTally,
+    pos_heldout: usize,
+    pos_heldout_beh_only: usize,
+    uninterp_pairs: usize,
+}
+
+/// Tally, restricted to pairs where BOTH units are interpretable (the slice this gate
+/// can speak to).
+fn tally_gate(
+    m: &GateManifest,
+    units: &std::collections::HashMap<String, GateUnit>,
+) -> GateOutcome {
+    let mut out = GateOutcome {
+        pos: GateTally::new(),
+        neg: GateTally::new(),
+        pos_heldout: 0,
+        pos_heldout_beh_only: 0,
+        uninterp_pairs: 0,
+    };
     for it in &m.items {
         let (lk, rk) = (manifest_key(&it.left.path), manifest_key(&it.right.path));
         let (Some(lu), Some(ru)) = (units.get(&lk), units.get(&rk)) else {
-            uninterp_pairs += 1;
+            out.uninterp_pairs += 1;
             continue;
         };
         let positive = it.semantic_status == "equivalent";
-        let t = if positive { &mut pos } else { &mut neg };
+        let t = if positive { &mut out.pos } else { &mut out.neg };
         t.pairs += 1;
         let fp_merge = lu.fp == ru.fp;
         // A behavioral merge requires identical behavior on EVERY battery input and a
@@ -1860,20 +1928,30 @@ fn cmd_behavioral_gate(
         if beh_merge && !fp_merge {
             t.beh_only += 1;
             if positive && it.split == "heldout" {
-                pos_heldout_beh_only += 1;
+                out.pos_heldout_beh_only += 1;
             }
         }
         if positive && it.split == "heldout" {
-            pos_heldout += 1;
+            out.pos_heldout += 1;
         }
     }
+    out
+}
 
+fn print_gate_report(battery_kind: BatteryKind, battery_rows: usize, outcome: &GateOutcome) {
+    let GateOutcome {
+        pos,
+        neg,
+        pos_heldout,
+        pos_heldout_beh_only,
+        uninterp_pairs,
+    } = outcome;
     let kind = match battery_kind {
         BatteryKind::Standard => "standard (leap 2)",
         BatteryKind::Wide => "wide (leap 3)",
     };
     println!("=== behavioral-equivalence acceptance gate — battery: {kind} ===");
-    println!("battery rows: {}", battery.len());
+    println!("battery rows: {battery_rows}");
     println!(
         "manifest pairs: {} interpretable-both / {} excluded (a unit not interpretable)",
         pos.pairs + neg.pairs,
@@ -1918,7 +1996,6 @@ fn cmd_behavioral_gate(
         pct(neg.beh_merge, neg.pairs)
     );
     println!("  → INTRODUCED beyond fingerprint: {}", neg.beh_only);
-    Ok(())
 }
 
 fn pct(a: usize, b: usize) -> f64 {
@@ -1986,14 +2063,10 @@ fn cmd_verify(
     max_violations: Option<usize>,
     leads: Option<PathBuf>,
 ) -> Result<()> {
-    use nose_normalize::{run_unit, Behavior, NormalizeOptions, Value};
-    use std::collections::HashMap;
-    use std::hash::{Hash, Hasher};
-
     let refs = paths_as_refs(&paths);
     let corpus = nose_frontend::lower_corpus_many(&refs);
     warn_if_empty(&corpus, &paths);
-    let opts = NormalizeOptions {
+    let opts = nose_normalize::NormalizeOptions {
         cfg_norm: !no_cfg_norm,
         ..Default::default()
     };
@@ -2001,193 +2074,210 @@ fn cmd_verify(
     // battery is identical for every unit (a function uses only its first `arity`
     // inputs), so behavior vectors are always length-comparable.
     let battery = verify_battery(&verify_probes(&corpus));
+    let oracle = collect_verify_recs(&corpus, &opts, &battery);
 
-    // One record per interpretable unit.
-    struct Rec {
-        fp: Vec<u64>,
-        beh: Vec<Behavior>,
-        file: String,
-        start: u32,
-        end: u32,
-        tokens: usize,
-        loc: String,
-    }
-    let mut recs: Vec<Rec> = Vec::new();
-    let mut total = 0usize;
-    // CANON PRESERVATION: a stricter, pair-free soundness check — does the full
-    // normalization pipeline preserve each unit's behavior vs the pre-canon core IL? A
-    // mismatch is a behavior-changing canon bug, even if no corpus twin collides with it.
-    let mut canon_checked = 0usize;
-    let mut canon_violations: Vec<String> = Vec::new();
-
-    let oracle_opts = NormalizeOptions {
-        oracle: true,
-        ..opts
-    };
-    for il in &corpus.files {
-        let n = nose_normalize::normalize(il, &corpus.interner, &opts);
-        // The behavioral ground truth comes from the pre-canonicalization core IL (so a
-        // behavior-changing canon can't mask itself), matched to each fully-normalized
-        // unit by source span. Walk the core IL once, indexing every Func by its byte span.
-        let core = nose_normalize::normalize(il, &corpus.interner, &oracle_opts);
-        let mut core_func: HashMap<(u32, u32), nose_il::NodeId> = HashMap::new();
-        {
-            let mut stk = vec![core.root];
-            while let Some(x) = stk.pop() {
-                if core.kind(x) == nose_il::NodeKind::Func {
-                    let s = core.node(x).span;
-                    core_func.entry((s.start_byte, s.end_byte)).or_insert(x);
-                }
-                stk.extend(core.children(x).iter().copied());
-            }
-        }
-        for u in &n.units {
-            let root = u.root;
-            if n.kind(root) != nose_il::NodeKind::Func {
-                continue;
-            }
-            total += 1;
-            // The same function in the core IL (by span) — interpret THAT, not `n`.
-            let span0 = n.node(root).span;
-            let Some(&core_root) = core_func.get(&(span0.start_byte, span0.end_byte)) else {
-                continue;
-            };
-            // Soundness is about merges on the VALUE fingerprint. A unit whose value
-            // graph is EMPTY (`fn resumed() {}`, or a body the graph captures nothing of)
-            // has no value fingerprint to merge on — the detector keys candidates on
-            // structure there, never on an empty value multiset — so distinct empty-fp
-            // bodies "colliding" is not a product false merge. Exclude empty fingerprints
-            // (only those — small non-empty ones stay, so completeness is unaffected).
-            // Fingerprint AND pointer-length contracts from ONE value-graph build (the
-            // oracle needs both; building twice doubled the per-unit cost). The contract
-            // binds n = len(array) so the oracle interprets `f(xs,n)` under the same
-            // convention the value graph used to merge it; gated on the contract actually
-            // firing, so a non-contract false merge is still exposed by the free battery.
-            let (fp, contracts) =
-                nose_normalize::value_fingerprint_and_contracts(&n, root, &corpus.interner);
-            if fp.is_empty() {
-                continue;
-            }
-            // Run the battery; the unit is interpretable only if every input runs.
-            let mut beh = Vec::new();
-            let mut ok = true;
-            for inputs in &battery {
-                let row = apply_contracts(inputs, &contracts);
-                match run_unit(&core, &corpus.interner, core_root, &row) {
-                    Some(b) => beh.push(b),
-                    None => {
-                        ok = false;
-                        break;
-                    }
-                }
-            }
-            if !ok {
-                continue;
-            }
-            // Stricter canon check: the SAME function interpreted on the fully-normalized
-            // IL must agree with the core IL on every input — else a canon pass changed
-            // behavior. (Only when the full IL is itself fully interpretable on the battery.)
-            {
-                let mut full_beh = Vec::with_capacity(battery.len());
-                let mut full_ok = true;
-                for inputs in &battery {
-                    let row = apply_contracts(inputs, &contracts);
-                    match run_unit(&n, &corpus.interner, root, &row) {
-                        Some(b) => full_beh.push(b),
-                        None => {
-                            full_ok = false;
-                            break;
-                        }
-                    }
-                }
-                if full_ok {
-                    canon_checked += 1;
-                    if full_beh != beh && canon_violations.len() < 20 {
-                        let s = n.node(root).span;
-                        canon_violations.push(format!("{}:{}", il.meta.path, s.start_line));
-                    }
-                }
-            }
-            let span = n.node(root).span;
-            // Subtree node count — the same size signal the detector gates on, so the
-            // value-add evaluator can restrict its gold to meaningful-size units.
-            let mut tokens = 0usize;
-            let mut stack = vec![root];
-            while let Some(x) = stack.pop() {
-                tokens += 1;
-                stack.extend(n.children(x).iter().copied());
-            }
-            recs.push(Rec {
-                fp,
-                beh,
-                file: il.meta.path.clone(),
-                start: span.start_line,
-                end: span.end_line,
-                tokens,
-                loc: format!("{}:{}", il.meta.path, span.start_line),
-            });
-        }
-    }
-
-    // Behavioral ground truth for the value-add evaluator: each interpretable unit with
-    // a stable hash of its behavior battery (equal hash ⟺ behaviorally equal on the
-    // battery) and whether that behavior is trivial (constant / all-Err — coincidental,
-    // not evidence of a real clone). The evaluator groups by behavior to form gold clone
-    // pairs, then scores jscpd and nose against them on equal footing.
     if json {
-        let recs_json: Vec<_> = recs
-            .iter()
-            .map(|r| {
-                let mut h = std::collections::hash_map::DefaultHasher::new();
-                r.beh.hash(&mut h);
-                let distinct: std::collections::HashSet<&Value> =
-                    r.beh.iter().map(|b| &b.ret).collect();
-                let trivial = distinct.len() < 2
-                    || r.beh
-                        .iter()
-                        .all(|b| matches!(b.ret, Value::Null | Value::Err));
-                serde_json::json!({
-                    "file": r.file,
-                    "start_line": r.start,
-                    "end_line": r.end,
-                    "tokens": r.tokens,
-                    "behavior": format!("{:016x}", h.finish()),
-                    "trivial": trivial,
-                })
-            })
-            .collect();
-        println!(
-            "{}",
-            serde_json::to_string(&serde_json::json!({ "units": recs_json }))?
-        );
-        return Ok(());
+        return print_verify_json(&oracle.recs);
     }
 
     println!("=== value-graph oracle (soundness + completeness) ===");
     println!(
-        "units: {total} total, {} interpretable ({} excluded)",
-        recs.len(),
-        total - recs.len()
+        "units: {} total, {} interpretable ({} excluded)",
+        oracle.total,
+        oracle.recs.len(),
+        oracle.total - oracle.recs.len()
     );
 
     // --- Canon preservation: full-normalize behavior must equal pre-canon core behavior. ---
     println!("\nCANON PRESERVATION — normalization preserves behavior:");
-    println!("  units checked (interpretable both ways): {canon_checked}");
-    if canon_violations.is_empty() {
+    println!(
+        "  units checked (interpretable both ways): {}",
+        oracle.canon_checked
+    );
+    if oracle.canon_violations.is_empty() {
         println!("  PRESERVED: every canon-changed unit computes the same thing ✓");
     } else {
         println!(
             "  [!] {} unit(s) whose behavior CHANGED under canonicalization:",
-            canon_violations.len()
+            oracle.canon_violations.len()
         );
-        for loc in &canon_violations {
+        for loc in &oracle.canon_violations {
             println!("    {loc}");
         }
     }
 
-    // --- Soundness: fingerprint-equal ⟹ behavior-equal. ---
-    let mut by_fp: HashMap<&[u64], Vec<&Rec>> = HashMap::new();
-    for r in &recs {
+    let n_violations = report_verify_soundness(&oracle.recs);
+    report_verify_completeness(&oracle.recs, leads.as_deref())?;
+    report_verify_calibration(&oracle.recs);
+
+    // CI soundness gate: fail if false merges exceed the budget. The independent oracle thus
+    // becomes a permanent regression gate on the detection campaign — a new canon that
+    // introduces a real false merge pushes the count over budget here.
+    if let Some(budget) = max_violations {
+        if n_violations > budget {
+            anyhow::bail!("verify gate: {n_violations} false merges exceed the budget of {budget}");
+        }
+        println!("\nGATE: {n_violations} ≤ {budget} false merges — OK ✓");
+    }
+    Ok(())
+}
+
+/// One record per interpretable unit.
+struct VerifyRec {
+    fp: Vec<u64>,
+    beh: Vec<nose_normalize::Behavior>,
+    file: String,
+    start: u32,
+    end: u32,
+    tokens: usize,
+    loc: String,
+}
+
+/// The oracle's interpretation pass: every interpretable unit's record, plus the
+/// CANON PRESERVATION tallies — a stricter, pair-free soundness check: does the full
+/// normalization pipeline preserve each unit's behavior vs the pre-canon core IL? A
+/// mismatch is a behavior-changing canon bug, even if no corpus twin collides with it.
+struct VerifyOracle {
+    recs: Vec<VerifyRec>,
+    total: usize,
+    canon_checked: usize,
+    canon_violations: Vec<String>,
+}
+
+fn collect_verify_recs(
+    corpus: &Corpus,
+    opts: &nose_normalize::NormalizeOptions,
+    battery: &[Vec<nose_normalize::Value>],
+) -> VerifyOracle {
+    let mut oracle = VerifyOracle {
+        recs: Vec::new(),
+        total: 0,
+        canon_checked: 0,
+        canon_violations: Vec::new(),
+    };
+    let oracle_opts = nose_normalize::NormalizeOptions {
+        oracle: true,
+        ..*opts
+    };
+    for il in &corpus.files {
+        let n = nose_normalize::normalize(il, &corpus.interner, opts);
+        // The behavioral ground truth comes from the pre-canonicalization core IL (so a
+        // behavior-changing canon can't mask itself), matched to each fully-normalized
+        // unit by source span.
+        let core = nose_normalize::normalize(il, &corpus.interner, &oracle_opts);
+        collect_file_verify_recs(il, &n, &core, &corpus.interner, battery, &mut oracle);
+    }
+    oracle
+}
+
+fn collect_file_verify_recs(
+    il: &nose_il::Il,
+    n: &nose_il::Il,
+    core: &nose_il::Il,
+    interner: &Interner,
+    battery: &[Vec<nose_normalize::Value>],
+    oracle: &mut VerifyOracle,
+) {
+    let core_func = func_span_index(core);
+    for u in &n.units {
+        let root = u.root;
+        if n.kind(root) != nose_il::NodeKind::Func {
+            continue;
+        }
+        oracle.total += 1;
+        // The same function in the core IL (by span) — interpret THAT, not `n`.
+        let span0 = n.node(root).span;
+        let Some(&core_root) = core_func.get(&(span0.start_byte, span0.end_byte)) else {
+            continue;
+        };
+        // Soundness is about merges on the VALUE fingerprint. A unit whose value
+        // graph is EMPTY (`fn resumed() {}`, or a body the graph captures nothing of)
+        // has no value fingerprint to merge on — the detector keys candidates on
+        // structure there, never on an empty value multiset — so distinct empty-fp
+        // bodies "colliding" is not a product false merge. Exclude empty fingerprints
+        // (only those — small non-empty ones stay, so completeness is unaffected).
+        // Fingerprint AND pointer-length contracts from ONE value-graph build (the
+        // oracle needs both; building twice doubled the per-unit cost). The contract
+        // binds n = len(array) so the oracle interprets `f(xs,n)` under the same
+        // convention the value graph used to merge it; gated on the contract actually
+        // firing, so a non-contract false merge is still exposed by the free battery.
+        let (fp, contracts) = nose_normalize::value_fingerprint_and_contracts(n, root, interner);
+        if fp.is_empty() {
+            continue;
+        }
+        // Run the battery; the unit is interpretable only if every input runs.
+        let Some(beh) = run_battery(core, interner, core_root, battery, &contracts) else {
+            continue;
+        };
+        // Stricter canon check: the SAME function interpreted on the fully-normalized
+        // IL must agree with the core IL on every input — else a canon pass changed
+        // behavior. (Only when the full IL is itself fully interpretable on the battery.)
+        if let Some(full_beh) = run_battery(n, interner, root, battery, &contracts) {
+            oracle.canon_checked += 1;
+            if full_beh != beh && oracle.canon_violations.len() < 20 {
+                let s = n.node(root).span;
+                oracle
+                    .canon_violations
+                    .push(format!("{}:{}", il.meta.path, s.start_line));
+            }
+        }
+        let span = n.node(root).span;
+        oracle.recs.push(VerifyRec {
+            fp,
+            beh,
+            file: il.meta.path.clone(),
+            start: span.start_line,
+            end: span.end_line,
+            tokens: subtree_node_count(n, root),
+            loc: format!("{}:{}", il.meta.path, span.start_line),
+        });
+    }
+}
+
+/// Subtree node count — the same size signal the detector gates on, so the
+/// value-add evaluator can restrict its gold to meaningful-size units.
+fn subtree_node_count(il: &nose_il::Il, root: nose_il::NodeId) -> usize {
+    let mut tokens = 0usize;
+    let mut stack = vec![root];
+    while let Some(x) = stack.pop() {
+        tokens += 1;
+        stack.extend(il.children(x).iter().copied());
+    }
+    tokens
+}
+
+/// Behavioral ground truth for the value-add evaluator: each interpretable unit with
+/// a stable hash of its behavior battery (equal hash ⟺ behaviorally equal on the
+/// battery) and whether that behavior is trivial (constant / all-Err — coincidental,
+/// not evidence of a real clone). The evaluator groups by behavior to form gold clone
+/// pairs, then scores jscpd and nose against them on equal footing.
+fn print_verify_json(recs: &[VerifyRec]) -> Result<()> {
+    let recs_json: Vec<_> = recs
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "file": r.file,
+                "start_line": r.start,
+                "end_line": r.end,
+                "tokens": r.tokens,
+                "behavior": format!("{:016x}", behavior_hash(&r.beh)),
+                "trivial": is_trivial_behavior(&r.beh),
+            })
+        })
+        .collect();
+    println!(
+        "{}",
+        serde_json::to_string(&serde_json::json!({ "units": recs_json }))?
+    );
+    Ok(())
+}
+
+/// Soundness: fingerprint-equal ⟹ behavior-equal. Prints the section and returns the
+/// false-merge count (the input to the `--max-violations` gate).
+fn report_verify_soundness(recs: &[VerifyRec]) -> usize {
+    let mut by_fp: std::collections::HashMap<&[u64], Vec<&VerifyRec>> =
+        std::collections::HashMap::new();
+    for r in recs {
         by_fp.entry(&r.fp).or_default().push(r);
     }
     let mut fp_groups = 0usize;
@@ -2216,24 +2306,21 @@ fn cmd_verify(
             println!("    {a}  ≡?  {b}   ({d} differing inputs)");
         }
     }
+    n_violations
+}
 
-    // --- Completeness: behavior-equal ⟹ fingerprint-equal (the under-merge / recall
-    // direction). Restricted to *non-trivial* behaviors (the return value varies across
-    // inputs and isn't uniformly Err/Null) — trivial functions agree coincidentally and
-    // aren't evidence of a missed clone. A behavior group split across ≥2 fingerprints
-    // is a real Type-4 clone the value graph fails to recognize. Behavior-equal on the
-    // battery is necessary-not-sufficient for equivalence, so this is a lower bound on
-    // completeness / upper bound on misses — but each surfaced pair is a concrete lead.
-    let trivial = |beh: &[Behavior]| -> bool {
-        let distinct: std::collections::HashSet<&Value> = beh.iter().map(|b| &b.ret).collect();
-        distinct.len() < 2
-            || beh
-                .iter()
-                .all(|b| matches!(b.ret, Value::Null | Value::Err))
-    };
-    let mut by_beh: HashMap<&[Behavior], Vec<&Rec>> = HashMap::new();
-    for r in &recs {
-        if !trivial(&r.beh) {
+/// Completeness: behavior-equal ⟹ fingerprint-equal (the under-merge / recall
+/// direction). Restricted to *non-trivial* behaviors (the return value varies across
+/// inputs and isn't uniformly Err/Null) — trivial functions agree coincidentally and
+/// aren't evidence of a missed clone. A behavior group split across ≥2 fingerprints
+/// is a real Type-4 clone the value graph fails to recognize. Behavior-equal on the
+/// battery is necessary-not-sufficient for equivalence, so this is a lower bound on
+/// completeness / upper bound on misses — but each surfaced pair is a concrete lead.
+fn report_verify_completeness(recs: &[VerifyRec], leads: Option<&std::path::Path>) -> Result<()> {
+    let mut by_beh: std::collections::HashMap<&[nose_normalize::Behavior], Vec<&VerifyRec>> =
+        std::collections::HashMap::new();
+    for r in recs {
+        if !is_trivial_behavior(&r.beh) {
             by_beh.entry(&r.beh).or_default().push(r);
         }
     }
@@ -2252,7 +2339,8 @@ fn cmd_verify(
         let k = members.len();
         beh_pairs += k * (k - 1) / 2;
         // partition by fingerprint
-        let mut by_fp2: HashMap<&[u64], Vec<&&Rec>> = HashMap::new();
+        let mut by_fp2: std::collections::HashMap<&[u64], Vec<&&VerifyRec>> =
+            std::collections::HashMap::new();
         for r in members {
             by_fp2.entry(&r.fp).or_default().push(r);
         }
@@ -2262,33 +2350,11 @@ fn cmd_verify(
         }
         if by_fp2.len() > 1 {
             split_groups += 1;
-            // one representative per distinct fingerprint; find the max-vj cross pair.
-            // Sort the reps by location so the chosen pair (and so the printed output) is
-            // deterministic: `by_fp2.values()` iterates a `HashMap` in an unspecified order
-            // that varies across runs/thread counts, which would otherwise pick a different
-            // max-vj pair on ties and break byte-identical output.
-            let mut reps: Vec<&&Rec> = by_fp2.values().map(|v| v[0]).collect();
-            reps.sort_by(|a, b| a.loc.cmp(&b.loc));
-            let mut best = (0.0f64, &reps[0], &reps[0]);
-            for i in 0..reps.len() {
-                for j in (i + 1)..reps.len() {
-                    let vj = multiset_jaccard_u64(&reps[i].fp, &reps[j].fp);
-                    if vj >= best.0 {
-                        best = (vj, &reps[i], &reps[j]);
-                    }
-                }
-            }
-            if best.0 >= 0.7 {
+            let (a, b, vj) = best_split_pair(by_fp2.values().map(|v| *v[0]).collect());
+            if vj >= 0.7 {
                 near_groups += 1;
             }
-            // Canonical orientation (smaller location first) so the pair reads identically
-            // regardless of which rep the scan happened to encounter first.
-            let (a, b) = if best.1.loc <= best.2.loc {
-                (best.1.loc.clone(), best.2.loc.clone())
-            } else {
-                (best.2.loc.clone(), best.1.loc.clone())
-            };
-            misses.push((a, b, best.0));
+            misses.push((a, b, vj));
         }
     }
     // Total order: vj desc, then the two locations — `misses` is collected in `HashMap`
@@ -2317,39 +2383,73 @@ fn cmd_verify(
     for (a, b, vj) in misses.iter().take(30) {
         println!("    vj={vj:.2}  {a}  ↮  {b}");
     }
-    // D1: export the under-merged pairs as detection leads — oracle-discovered candidates the
-    // detection campaign can turn into convergence proposals. Sorted by vj (already), so the
-    // strongest (structurally-near AND behavior-equal) come first.
-    if let Some(path) = &leads {
-        let items: Vec<_> = misses
-            .iter()
-            .map(|(a, b, vj)| {
-                serde_json::json!({ "a": a, "b": b, "vj": vj, "structurally_near": *vj >= 0.7 })
-            })
-            .collect();
-        let near = misses.iter().filter(|(_, _, vj)| *vj >= 0.7).count();
-        std::fs::write(
-            path,
-            serde_json::to_string_pretty(&serde_json::json!({
-                "under_merged_pairs": items.len(),
-                "structurally_near": near,
-                "leads": items,
-            }))?,
-        )?;
-        println!(
-            "\nLEADS: wrote {} under-merged pairs ({near} structurally-near) to {}",
-            misses.len(),
-            path.display()
-        );
+    if let Some(path) = leads {
+        write_verify_leads(path, &misses)?;
     }
+    Ok(())
+}
 
-    // --- Calibration: P(behavior-equal | value-Jaccard bin). The detector currently
-    // trusts only an *exact* fingerprint match (vj = 1.0). This measures how safe it
-    // would be to also accept *near* matches — for each vj band, the fraction of pairs
-    // that are actually behavior-equal = the precision of accepting at that band. Pairs
-    // are sampled by sorting units by fingerprint and comparing each to a window of
-    // neighbors (so high-vj pairs are well represented, unlike uniform random pairs).
-    let mut sorted: Vec<&Rec> = recs.iter().collect();
+/// One representative per distinct fingerprint; find the max-vj cross pair.
+/// Sort the reps by location so the chosen pair (and so the printed output) is
+/// deterministic: `HashMap` iteration is an unspecified order that varies across
+/// runs/thread counts, which would otherwise pick a different max-vj pair on ties
+/// and break byte-identical output. The pair comes back in canonical orientation
+/// (smaller location first) so it reads identically regardless of which rep the
+/// scan happened to encounter first.
+fn best_split_pair(mut reps: Vec<&VerifyRec>) -> (String, String, f64) {
+    reps.sort_by(|a, b| a.loc.cmp(&b.loc));
+    let mut best = (0.0f64, reps[0], reps[0]);
+    for i in 0..reps.len() {
+        for j in (i + 1)..reps.len() {
+            let vj = multiset_jaccard_u64(&reps[i].fp, &reps[j].fp);
+            if vj >= best.0 {
+                best = (vj, reps[i], reps[j]);
+            }
+        }
+    }
+    let (a, b) = if best.1.loc <= best.2.loc {
+        (best.1.loc.clone(), best.2.loc.clone())
+    } else {
+        (best.2.loc.clone(), best.1.loc.clone())
+    };
+    (a, b, best.0)
+}
+
+/// D1: export the under-merged pairs as detection leads — oracle-discovered candidates the
+/// detection campaign can turn into convergence proposals. Sorted by vj (already), so the
+/// strongest (structurally-near AND behavior-equal) come first.
+fn write_verify_leads(path: &std::path::Path, misses: &[(String, String, f64)]) -> Result<()> {
+    let items: Vec<_> = misses
+        .iter()
+        .map(|(a, b, vj)| {
+            serde_json::json!({ "a": a, "b": b, "vj": vj, "structurally_near": *vj >= 0.7 })
+        })
+        .collect();
+    let near = misses.iter().filter(|(_, _, vj)| *vj >= 0.7).count();
+    std::fs::write(
+        path,
+        serde_json::to_string_pretty(&serde_json::json!({
+            "under_merged_pairs": items.len(),
+            "structurally_near": near,
+            "leads": items,
+        }))?,
+    )?;
+    println!(
+        "\nLEADS: wrote {} under-merged pairs ({near} structurally-near) to {}",
+        misses.len(),
+        path.display()
+    );
+    Ok(())
+}
+
+/// Calibration: P(behavior-equal | value-Jaccard bin). The detector currently
+/// trusts only an *exact* fingerprint match (vj = 1.0). This measures how safe it
+/// would be to also accept *near* matches — for each vj band, the fraction of pairs
+/// that are actually behavior-equal = the precision of accepting at that band. Pairs
+/// are sampled by sorting units by fingerprint and comparing each to a window of
+/// neighbors (so high-vj pairs are well represented, unlike uniform random pairs).
+fn report_verify_calibration(recs: &[VerifyRec]) {
+    let mut sorted: Vec<&VerifyRec> = recs.iter().collect();
     sorted.sort_unstable_by(|a, b| a.fp.cmp(&b.fp));
     const BINS: usize = 5; // [.5,.7) [.7,.8) [.8,.9) [.9,1.0) [1.0]
     let mut tot = [0usize; BINS];
@@ -2387,16 +2487,6 @@ fn cmd_verify(
             );
         }
     }
-    // CI soundness gate: fail if false merges exceed the budget. The independent oracle thus
-    // becomes a permanent regression gate on the detection campaign — a new canon that
-    // introduces a real false merge pushes the count over budget here.
-    if let Some(budget) = max_violations {
-        if n_violations > budget {
-            anyhow::bail!("verify gate: {n_violations} false merges exceed the budget of {budget}");
-        }
-        println!("\nGATE: {n_violations} ≤ {budget} false merges — OK ✓");
-    }
-    Ok(())
 }
 
 /// Multiset Jaccard over two sorted `u64` vectors (intersection / union by count).
@@ -2629,9 +2719,25 @@ pub(crate) fn detect_families(
     validate_exclude_globs(exclude)?;
     let refs = paths_as_refs(paths);
     let channels = ScanChannels::resolve(mode, cfg_mode)?;
-    let threshold = channels.threshold();
-    let opts = nose_detect::DetectOptions {
-        threshold,
+    let opts = scan_detect_options(channels, min_tokens, min_lines);
+    let detector = scan_detector(channels, &opts);
+    let corpus = nose_frontend::lower_corpus_filtered(&refs, exclude);
+    let report = nose_detect::detect(&corpus, &opts, detector.as_ref());
+    let mut families = nose_detect::rank_families(&report);
+    if channels.abstraction_only() {
+        families.retain(|f| f.abstraction_witness.is_some());
+    }
+    Ok(families)
+}
+
+/// Detection options for the resolved scan channels — shared by `scan` and `review`.
+fn scan_detect_options(
+    channels: ScanChannels,
+    min_tokens: usize,
+    min_lines: u32,
+) -> nose_detect::DetectOptions {
+    nose_detect::DetectOptions {
+        threshold: channels.threshold(),
         min_lines,
         min_tokens,
         contiguous_min_tokens: min_tokens,
@@ -2646,15 +2752,7 @@ pub(crate) fn detect_families(
         shape_features: channels.near || channels.abstraction,
         abstraction_witnesses: channels.abstraction,
         ..Default::default()
-    };
-    let detector = scan_detector(channels, &opts);
-    let corpus = nose_frontend::lower_corpus_filtered(&refs, exclude);
-    let report = nose_detect::detect(&corpus, &opts, detector.as_ref());
-    let mut families = nose_detect::rank_families(&report);
-    if channels.abstraction_only() {
-        families.retain(|f| f.abstraction_witness.is_some());
     }
-    Ok(families)
 }
 
 fn validate_exclude_globs(exclude: &[String]) -> Result<()> {
@@ -2779,81 +2877,16 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
     }
 
     let refs = paths_as_refs(&args.paths);
-
-    // Resolve each setting: CLI flag wins, else config file, else built-in default.
-    let cfg = config::load_scan(args.config.as_deref())?;
-    let top = args.top.or(cfg.top).unwrap_or(30);
-    let min_members = args.min_members.or(cfg.min_members).unwrap_or(2);
-    let min_value = validate_min_value(args.min_value.or(cfg.min_value).unwrap_or(0.0))?;
-    let sort = args.sort.or(cfg.sort).unwrap_or(SortKey::Extractability);
-    let channels = ScanChannels::resolve(args.mode, cfg.mode)?;
-    let threshold = channels.threshold();
-    let min_lines = args.min_lines.or(cfg.min_lines).unwrap_or(5);
-    let min_tokens = args.min_size.or(cfg.min_size).unwrap_or(24);
-    let ignore_file = args.ignore_file.or(cfg.ignore_file);
-    let mut semantic_pack_paths = cfg.semantic_packs;
-    semantic_pack_paths.extend(args.semantic_pack.iter().cloned());
-    let semantic_packs = nose_semantics::SemanticPackSet::new_local(&semantic_pack_paths)?;
-    // Excludes are additive: config patterns plus any given on the command line.
-    let mut exclude = cfg.exclude;
-    exclude.extend(args.exclude.iter().cloned());
-    validate_exclude_globs(&exclude)?;
-    let ignore_set = ignores::load_for_scan(ignore_file.as_deref())?;
-    if let Some(ignore_set) = &ignore_set {
-        ignore_set.warn_expired();
-    }
-
-    let opts = nose_detect::DetectOptions {
-        threshold,
-        min_lines,
-        min_tokens,
-        contiguous_min_tokens: min_tokens,
-        contiguous_min_lines: min_lines,
-        structural: channels.structural(),
-        contiguous: channels.syntax,
-        // Near also generates VALUE candidates so behaviorally-convergent but shape-divergent
-        // pairs (async `.then` ≡ await, impure loop ≡ comprehension) reach the candidate scorer —
-        // they share no shape band, so shape-LSH alone would never propose them.
-        value_candidates: channels.semantic || channels.near || channels.abstraction,
-        shape_candidates: channels.near || channels.abstraction,
-        shape_features: channels.near || channels.abstraction,
-        abstraction_witnesses: channels.abstraction,
-        ..Default::default()
-    };
-    let detector = scan_detector(channels, &opts);
-
-    // With --cache-dir, build units per file through the on-disk cache (skips
-    // parse/normalize/extract for unchanged files); otherwise lower the whole corpus.
-    let (report, scope) = if let Some(dir) = &args.cache_dir {
-        let cache::CachedUnits {
-            units,
-            streams,
-            files,
-            langs,
-        } = time_lower(|| cache::build_units_cached(&refs, &exclude, &opts, dir));
-        if files == 0 {
-            warn_no_files(&args.paths);
-        }
-        // The cache path supplies both cached unit features and syntax streams, so every
-        // selected scan channel behaves the same as the non-cached path.
-        let report =
-            nose_detect::detect_from_units(units, files, &streams, &opts, detector.as_ref()).0;
-        (report, ScanScope { files, langs })
-    } else {
-        let corpus = time_lower(|| nose_frontend::lower_corpus_filtered(&refs, &exclude));
-        warn_if_empty(&corpus, &args.paths);
-        let scope = ScanScope::from_corpus(&corpus);
-        (
-            nose_detect::detect(&corpus, &opts, detector.as_ref()),
-            scope,
-        )
-    };
+    let settings = resolve_scan_settings(&args)?;
+    let opts = scan_detect_options(settings.channels, settings.min_tokens, settings.min_lines);
+    let detector = scan_detector(settings.channels, &opts);
+    let (report, scope) = scan_report(&args, &refs, &settings.exclude, &opts, detector.as_ref());
 
     let mut families = nose_detect::rank_families(&report);
-    if channels.abstraction_only() {
+    if settings.channels.abstraction_only() {
         families.retain(|f| f.abstraction_witness.is_some());
     }
-    families.retain(|f| f.members >= min_members && f.value >= min_value);
+    families.retain(|f| f.members >= settings.min_members && f.value >= settings.min_value);
     // Show paths relative to the working directory — absolute paths are unreadable
     // in CI logs and reviews, and relative ones are clickable and portable.
     if let Ok(cwd) = std::env::current_dir() {
@@ -2863,43 +2896,8 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
             }
         }
     }
-    // Compute the honest shared-line count for each family, then rank. This layer has
-    // source access; the detector deals only in IL.
-    //
-    // `shared_lines` (displayed) is the count of *all* lines invariant across the family
-    // — including boilerplate, so it matches what `--show proposal` shows. For *ranking*
-    // (`shared_weight`) we separate signal from noise: sum the IDF weight of the
-    // substantive lines (non-trivial, and rare across the corpus — a `if err != nil {`
-    // that appears in most files contributes ~0), then use that as a **gate** on the
-    // full block. A family whose shared lines are all boilerplate/idiom has ~0
-    // substantive weight → it scores ~0 however much it "shares"; a family with real
-    // shared content is credited for its whole extractable block (boilerplate included).
-    // Cross-language families have no shared *source* lines to diff, so they keep
-    // `shared_weight = 0` and fall back to the structural estimate in `extractability()`.
-    // Only same-language families with ≥2 sites get an honest shared-line count; the
-    // rest keep the detector's structural estimate. Computing the corpus line-IDF means
-    // re-reading every scanned file, so skip it entirely when no family qualifies (a
-    // clean repo, or a run where `--min-value`/`--min-members` filtered everything) —
-    // otherwise a quiet scan pays a full second corpus read for nothing.
-    let needs_shared = |f: &nose_detect::RefactorFamily| f.languages == 1 && f.locations.len() >= 2;
-    if families.iter().any(needs_shared) {
-        let mut lines = FileLineCache::default();
-        let idf = corpus_line_idf(&refs, &exclude, &mut lines);
-        for f in families.iter_mut().filter(|f| needs_shared(f)) {
-            if let Some((shared, params)) = shared_lines_of(&f.locations, &mut lines) {
-                let substantive: f64 = shared
-                    .iter()
-                    .filter(|l| !is_trivial_line(l))
-                    .map(|l| idf.weight(l))
-                    .sum();
-                // Gate ramps 0→1 as substantive shared content goes 0→2 lines.
-                let gate = (substantive / 2.0).clamp(0.0, 1.0);
-                f.shared_lines = shared.len() as u32;
-                f.shared_weight = shared.len() as f64 * gate;
-                f.params = params;
-            }
-        }
-    }
+    weight_shared_lines(&mut families, &refs, &settings.exclude);
+    let sort = settings.sort;
     families.sort_by(|a, b| {
         sort.score(b)
             .total_cmp(&sort.score(a))
@@ -2910,18 +2908,7 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
     // Baseline: write the current state, or hide already-accepted families so only
     // new/changed duplication is reported and gated.
     if args.write_baseline {
-        let path = args
-            .baseline
-            .as_ref()
-            .expect("--write-baseline requires --baseline");
-        baseline::write(path, &families, family_hint)
-            .with_context(|| format!("writing baseline {}", path.display()))?;
-        eprintln!(
-            "nose: wrote baseline of {} families to {}",
-            families.len(),
-            path.display()
-        );
-        return Ok(());
+        return write_scan_baseline(&args, &families);
     }
     let baseline_comparison = if let Some(path) = args.baseline.as_ref() {
         let accepted = baseline::load(path)?;
@@ -2931,28 +2918,21 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
     } else {
         None
     };
-    let mut ignored_families = Vec::new();
-    if let Some(ignore_set) = &ignore_set {
-        let mut active = Vec::with_capacity(families.len());
-        for family in families {
-            if let Some(ignore) = ignore_set.match_family(&family) {
-                ignored_families.push(IgnoredFamily { family, ignore });
-            } else {
-                active.push(family);
-            }
-        }
-        families = active;
-    }
+    let (families, ignored_families) = partition_ignored(families, settings.ignore_set.as_ref());
     let needs_default_surface =
         !matches!(args.format, ReportFormat::Json) || args.fail_on.is_some();
     let generated_sources = if needs_default_surface && !families.is_empty() {
-        generated_source_index(&refs, &exclude)
+        generated_source_index(&refs, &settings.exclude)
     } else {
         std::collections::HashSet::new()
     };
 
     // `--top 0` means "no limit": show every family (documented in docs/usage.md).
-    let limit = if top == 0 { usize::MAX } else { top };
+    let limit = if settings.top == 0 {
+        usize::MAX
+    } else {
+        settings.top
+    };
     let shown = families.iter().take(limit).collect::<Vec<_>>();
     let reportable_families = families
         .iter()
@@ -2965,64 +2945,20 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
         .collect::<Vec<_>>();
     let omitted_note = surface_omission_note(&families, &generated_sources);
 
-    match args.format {
-        ReportFormat::Json => {
-            let json = ScanJsonReport::new(ScanJsonInput {
-                scope: &scope,
-                sort,
-                top,
-                families: &families,
-                shown: &shown,
-                baseline: baseline_comparison.as_ref(),
-                ignore_set: ignore_set.as_ref(),
-                ignored_families: &ignored_families,
-                semantic_packs: &semantic_packs,
-            });
-            println!("{}", serde_json::to_string_pretty(&json)?);
-        }
-        ReportFormat::Markdown => {
-            // Scope line first — tells the reader what was actually scanned (so a small
-            // count from `.gitignore`/`--exclude` pruning is visible, not a silent gap).
-            println!("{}\n", scope.summary());
-            if let Some(line) = semantic_pack_summary_line(&semantic_packs) {
-                println!("{line}\n");
-            }
-            print_refactor_markdown(
-                &reportable_families,
-                &shown_reportable,
-                channels,
-                baseline_comparison.as_ref(),
-                ignore_set.as_ref(),
-                ignored_families.len(),
-                omitted_note.as_deref(),
-            );
-        }
-        ReportFormat::Human => {
-            println!("{}", scope.summary());
-            if let Some(line) = semantic_pack_summary_line(&semantic_packs) {
-                println!("{line}");
-            }
-            if let Some(comparison) = &baseline_comparison {
-                println!("{}", comparison.summary.line());
-            }
-            if let Some(ignore_set) = &ignore_set {
-                println!("{}", ignore_set.summary(ignored_families.len()).line());
-            }
-            print_refactor_human(
-                &reportable_families,
-                &shown_reportable,
-                sort,
-                channels,
-                args.show.contains(&ShowView::Diff),
-                args.show.contains(&ShowView::Proposal),
-                omitted_note.as_deref(),
-            )
-        }
-        ReportFormat::Sarif => println!(
-            "{}",
-            refactor_sarif(&shown_reportable, reportable_families.len())?
-        ),
-    }
+    render_scan_report(
+        &args,
+        &ScanReportView {
+            scope: &scope,
+            settings: &settings,
+            families: &families,
+            shown: &shown,
+            reportable: &reportable_families,
+            shown_reportable: &shown_reportable,
+            baseline: baseline_comparison.as_ref(),
+            ignored_families: &ignored_families,
+            omitted_note: omitted_note.as_deref(),
+        },
+    )?;
     if args.show.contains(&ShowView::Hotspots)
         && matches!(args.format, ReportFormat::Human | ReportFormat::Markdown)
     {
@@ -3030,13 +2966,264 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
     }
     // CI gate: report is already printed; a non-empty (filtered) family set is a
     // failure when --fail-on is set.
-    if let (true, Some(comparison)) = (
-        matches!(args.fail_on, Some(FailOn::New)) && !reportable_families.is_empty(),
+    enforce_scan_fail_on(
+        &args,
+        settings.channels,
+        &reportable_families,
         baseline_comparison.as_ref(),
+    );
+    Ok(())
+}
+
+/// The scan settings after layering: CLI flag wins, else config file, else built-in
+/// default.
+struct ScanSettings {
+    top: usize,
+    min_members: usize,
+    min_value: f64,
+    sort: SortKey,
+    channels: ScanChannels,
+    min_lines: u32,
+    min_tokens: usize,
+    semantic_packs: nose_semantics::SemanticPackSet,
+    exclude: Vec<String>,
+    ignore_set: Option<ignores::IgnoreSet>,
+}
+
+fn resolve_scan_settings(args: &ScanArgs) -> Result<ScanSettings> {
+    let cfg = config::load_scan(args.config.as_deref())?;
+    let top = args.top.or(cfg.top).unwrap_or(30);
+    let min_members = args.min_members.or(cfg.min_members).unwrap_or(2);
+    let min_value = validate_min_value(args.min_value.or(cfg.min_value).unwrap_or(0.0))?;
+    let sort = args.sort.or(cfg.sort).unwrap_or(SortKey::Extractability);
+    let channels = ScanChannels::resolve(args.mode.clone(), cfg.mode)?;
+    let min_lines = args.min_lines.or(cfg.min_lines).unwrap_or(5);
+    let min_tokens = args.min_size.or(cfg.min_size).unwrap_or(24);
+    let ignore_file = args.ignore_file.clone().or(cfg.ignore_file);
+    let mut semantic_pack_paths = cfg.semantic_packs;
+    semantic_pack_paths.extend(args.semantic_pack.iter().cloned());
+    let semantic_packs = nose_semantics::SemanticPackSet::new_local(&semantic_pack_paths)?;
+    // Excludes are additive: config patterns plus any given on the command line.
+    let mut exclude = cfg.exclude;
+    exclude.extend(args.exclude.iter().cloned());
+    validate_exclude_globs(&exclude)?;
+    let ignore_set = ignores::load_for_scan(ignore_file.as_deref())?;
+    if let Some(ignore_set) = &ignore_set {
+        ignore_set.warn_expired();
+    }
+    Ok(ScanSettings {
+        top,
+        min_members,
+        min_value,
+        sort,
+        channels,
+        min_lines,
+        min_tokens,
+        semantic_packs,
+        exclude,
+        ignore_set,
+    })
+}
+
+/// With --cache-dir, build units per file through the on-disk cache (skips
+/// parse/normalize/extract for unchanged files); otherwise lower the whole corpus.
+fn scan_report(
+    args: &ScanArgs,
+    refs: &[&std::path::Path],
+    exclude: &[String],
+    opts: &nose_detect::DetectOptions,
+    detector: &dyn nose_detect::Detector,
+) -> (nose_detect::Report, ScanScope) {
+    if let Some(dir) = &args.cache_dir {
+        let cache::CachedUnits {
+            units,
+            streams,
+            files,
+            langs,
+        } = time_lower(|| cache::build_units_cached(refs, exclude, opts, dir));
+        if files == 0 {
+            warn_no_files(&args.paths);
+        }
+        // The cache path supplies both cached unit features and syntax streams, so every
+        // selected scan channel behaves the same as the non-cached path.
+        let report = nose_detect::detect_from_units(units, files, &streams, opts, detector).0;
+        (report, ScanScope { files, langs })
+    } else {
+        let corpus = time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude));
+        warn_if_empty(&corpus, &args.paths);
+        let scope = ScanScope::from_corpus(&corpus);
+        (nose_detect::detect(&corpus, opts, detector), scope)
+    }
+}
+
+/// Compute the honest shared-line count for each family, before ranking. This layer has
+/// source access; the detector deals only in IL.
+///
+/// `shared_lines` (displayed) is the count of *all* lines invariant across the family
+/// — including boilerplate, so it matches what `--show proposal` shows. For *ranking*
+/// (`shared_weight`) we separate signal from noise: sum the IDF weight of the
+/// substantive lines (non-trivial, and rare across the corpus — a `if err != nil {`
+/// that appears in most files contributes ~0), then use that as a **gate** on the
+/// full block. A family whose shared lines are all boilerplate/idiom has ~0
+/// substantive weight → it scores ~0 however much it "shares"; a family with real
+/// shared content is credited for its whole extractable block (boilerplate included).
+/// Cross-language families have no shared *source* lines to diff, so they keep
+/// `shared_weight = 0` and fall back to the structural estimate in `extractability()`.
+/// Only same-language families with ≥2 sites get an honest shared-line count; the
+/// rest keep the detector's structural estimate. Computing the corpus line-IDF means
+/// re-reading every scanned file, so skip it entirely when no family qualifies (a
+/// clean repo, or a run where `--min-value`/`--min-members` filtered everything) —
+/// otherwise a quiet scan pays a full second corpus read for nothing.
+fn weight_shared_lines(
+    families: &mut [nose_detect::RefactorFamily],
+    refs: &[&std::path::Path],
+    exclude: &[String],
+) {
+    let needs_shared = |f: &nose_detect::RefactorFamily| f.languages == 1 && f.locations.len() >= 2;
+    if !families.iter().any(needs_shared) {
+        return;
+    }
+    let mut lines = FileLineCache::default();
+    let idf = corpus_line_idf(refs, exclude, &mut lines);
+    for f in families.iter_mut().filter(|f| needs_shared(f)) {
+        if let Some((shared, params)) = shared_lines_of(&f.locations, &mut lines) {
+            let substantive: f64 = shared
+                .iter()
+                .filter(|l| !is_trivial_line(l))
+                .map(|l| idf.weight(l))
+                .sum();
+            // Gate ramps 0→1 as substantive shared content goes 0→2 lines.
+            let gate = (substantive / 2.0).clamp(0.0, 1.0);
+            f.shared_lines = shared.len() as u32;
+            f.shared_weight = shared.len() as f64 * gate;
+            f.params = params;
+        }
+    }
+}
+
+fn write_scan_baseline(args: &ScanArgs, families: &[nose_detect::RefactorFamily]) -> Result<()> {
+    let path = args
+        .baseline
+        .as_ref()
+        .expect("--write-baseline requires --baseline");
+    baseline::write(path, families, family_hint)
+        .with_context(|| format!("writing baseline {}", path.display()))?;
+    eprintln!(
+        "nose: wrote baseline of {} families to {}",
+        families.len(),
+        path.display()
+    );
+    Ok(())
+}
+
+fn partition_ignored(
+    families: Vec<nose_detect::RefactorFamily>,
+    ignore_set: Option<&ignores::IgnoreSet>,
+) -> (Vec<nose_detect::RefactorFamily>, Vec<IgnoredFamily>) {
+    let Some(ignore_set) = ignore_set else {
+        return (families, Vec::new());
+    };
+    let mut active = Vec::with_capacity(families.len());
+    let mut ignored_families = Vec::new();
+    for family in families {
+        if let Some(ignore) = ignore_set.match_family(&family) {
+            ignored_families.push(IgnoredFamily { family, ignore });
+        } else {
+            active.push(family);
+        }
+    }
+    (active, ignored_families)
+}
+
+/// Everything the format arms need to render one scan's report.
+struct ScanReportView<'a> {
+    scope: &'a ScanScope,
+    settings: &'a ScanSettings,
+    families: &'a [nose_detect::RefactorFamily],
+    shown: &'a [&'a nose_detect::RefactorFamily],
+    reportable: &'a [&'a nose_detect::RefactorFamily],
+    shown_reportable: &'a [&'a nose_detect::RefactorFamily],
+    baseline: Option<&'a BaselineComparison>,
+    ignored_families: &'a [IgnoredFamily],
+    omitted_note: Option<&'a str>,
+}
+
+fn render_scan_report(args: &ScanArgs, view: &ScanReportView) -> Result<()> {
+    let settings = view.settings;
+    match args.format {
+        ReportFormat::Json => {
+            let json = ScanJsonReport::new(ScanJsonInput {
+                scope: view.scope,
+                sort: settings.sort,
+                top: settings.top,
+                families: view.families,
+                shown: view.shown,
+                baseline: view.baseline,
+                ignore_set: settings.ignore_set.as_ref(),
+                ignored_families: view.ignored_families,
+                semantic_packs: &settings.semantic_packs,
+            });
+            println!("{}", serde_json::to_string_pretty(&json)?);
+        }
+        ReportFormat::Markdown => {
+            // Scope line first — tells the reader what was actually scanned (so a small
+            // count from `.gitignore`/`--exclude` pruning is visible, not a silent gap).
+            println!("{}\n", view.scope.summary());
+            if let Some(line) = semantic_pack_summary_line(&settings.semantic_packs) {
+                println!("{line}\n");
+            }
+            print_refactor_markdown(
+                view.reportable,
+                view.shown_reportable,
+                settings.channels,
+                view.baseline,
+                settings.ignore_set.as_ref(),
+                view.ignored_families.len(),
+                view.omitted_note,
+            );
+        }
+        ReportFormat::Human => {
+            println!("{}", view.scope.summary());
+            if let Some(line) = semantic_pack_summary_line(&settings.semantic_packs) {
+                println!("{line}");
+            }
+            if let Some(comparison) = view.baseline {
+                println!("{}", comparison.summary.line());
+            }
+            if let Some(ignore_set) = &settings.ignore_set {
+                println!("{}", ignore_set.summary(view.ignored_families.len()).line());
+            }
+            print_refactor_human(
+                view.reportable,
+                view.shown_reportable,
+                settings.sort,
+                settings.channels,
+                args.show.contains(&ShowView::Diff),
+                args.show.contains(&ShowView::Proposal),
+                view.omitted_note,
+            )
+        }
+        ReportFormat::Sarif => println!(
+            "{}",
+            refactor_sarif(view.shown_reportable, view.reportable.len())?
+        ),
+    }
+    Ok(())
+}
+
+fn enforce_scan_fail_on(
+    args: &ScanArgs,
+    channels: ScanChannels,
+    reportable: &[&nose_detect::RefactorFamily],
+    baseline_comparison: Option<&BaselineComparison>,
+) {
+    if let (true, Some(comparison)) = (
+        matches!(args.fail_on, Some(FailOn::New)) && !reportable.is_empty(),
+        baseline_comparison,
     ) {
         let mut new_families = 0usize;
         let mut changed_families = 0usize;
-        for family in &reportable_families {
+        for family in reportable {
             match comparison.statuses.get(&baseline::family_key(family)) {
                 Some(BaselineStatus::Changed) => changed_families += 1,
                 Some(BaselineStatus::New) => new_families += 1,
@@ -3052,15 +3239,14 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
         );
         std::process::exit(1);
     }
-    if matches!(args.fail_on, Some(FailOn::Any)) && !reportable_families.is_empty() {
+    if matches!(args.fail_on, Some(FailOn::Any)) && !reportable.is_empty() {
         eprintln!(
             "\nnose: {} {} found (--fail-on any)",
-            reportable_families.len(),
-            channels.report_label(reportable_families.len())
+            reportable.len(),
+            channels.report_label(reportable.len())
         );
         std::process::exit(1);
     }
-    Ok(())
 }
 
 fn print_hotspots_refs(families: &[&nose_detect::RefactorFamily]) {

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -754,6 +754,13 @@ fn semantic_pack_check_fails_on_missing_fixture_files() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// Compiled-in pack rows share the same provenance coordinates.
+fn assert_compiled_first_party_pack(pack: &serde_json::Value, id: &str) {
+    assert_eq!(pack["id"], id);
+    assert_eq!(pack["source"], "compiled-first-party");
+    assert_eq!(pack["influence"], "evidence-and-contracts");
+}
+
 #[test]
 fn scan_json_reports_first_party_and_local_semantic_pack_provenance() {
     let dir = make_project("semantic_pack_cli");
@@ -779,19 +786,13 @@ fn scan_json_reports_first_party_and_local_semantic_pack_provenance() {
         4,
         "first-party packs + local opt-in pack: {json}"
     );
-    assert_eq!(packs[0]["id"], "nose.first_party");
-    assert_eq!(packs[0]["source"], "compiled-first-party");
-    assert_eq!(packs[0]["influence"], "evidence-and-contracts");
-    assert_eq!(packs[1]["id"], "nose.python.stdlib.type_domain");
+    assert_compiled_first_party_pack(&packs[0], "nose.first_party");
+    assert_compiled_first_party_pack(&packs[1], "nose.python.stdlib.type_domain");
     assert_eq!(packs[1]["kind"], "StdlibPack");
-    assert_eq!(packs[1]["source"], "compiled-first-party");
-    assert_eq!(packs[1]["influence"], "evidence-and-contracts");
     assert_eq!(packs[1]["counts"]["evidence_producers"], 1);
     assert_eq!(packs[1]["counts"]["contracts"], 1);
-    assert_eq!(packs[2]["id"], "nose.value_graph.laws");
+    assert_compiled_first_party_pack(&packs[2], "nose.value_graph.laws");
     assert_eq!(packs[2]["kind"], "LawPack");
-    assert_eq!(packs[2]["source"], "compiled-first-party");
-    assert_eq!(packs[2]["influence"], "evidence-and-contracts");
     assert_eq!(packs[2]["counts"]["value_laws"], 2);
     assert_eq!(packs[3]["id"], "com.example.semantic-pack");
     assert_eq!(packs[3]["trust"], "external-opt-in");
@@ -1439,6 +1440,13 @@ fn capabilities_command_emits_machine_readable_contract() {
     assert_eq!(json["interfaces"]["capabilities_json"], true);
     assert_eq!(json["interfaces"]["version_json"], false);
     assert_eq!(json["interfaces"]["doctor_json"], false);
+}
+
+#[test]
+fn capabilities_command_lists_stable_commands_and_schemas() {
+    let out = run(&["capabilities"]);
+    let json: serde_json::Value =
+        serde_json::from_str(&out).expect("capabilities must emit valid JSON");
 
     assert_eq!(
         json_array_strings(&json["commands"], "stable"),
@@ -1458,6 +1466,14 @@ fn capabilities_command_emits_machine_readable_contract() {
         "nose.semantic-pack.v0"
     );
     assert_eq!(json["schemas"]["semantic_pack_conformance"][0], 1);
+}
+
+#[test]
+fn capabilities_command_reports_scan_surface() {
+    let out = run(&["capabilities"]);
+    let json: serde_json::Value =
+        serde_json::from_str(&out).expect("capabilities must emit valid JSON");
+
     assert_eq!(
         json_array_strings(&json["scan"], "modes"),
         vec!["syntax", "semantic", "near"]
@@ -1477,6 +1493,14 @@ fn capabilities_command_emits_machine_readable_contract() {
     assert_eq!(json["scan"]["capabilities"]["baseline"], true);
     assert_eq!(json["scan"]["capabilities"]["semantic_pack_loading"], true);
     assert_eq!(json["scan"]["capabilities"]["structured_ignores"], true);
+}
+
+#[test]
+fn capabilities_command_reports_semantic_pack_il_and_stats_surfaces() {
+    let out = run(&["capabilities"]);
+    let json: serde_json::Value =
+        serde_json::from_str(&out).expect("capabilities must emit valid JSON");
+
     assert_eq!(
         json["semantic_packs"]["api_versions"][0],
         "nose.semantic-pack.v0"

--- a/crates/nose-cli/tests/cli/exact_fragments.rs
+++ b/crates/nose-cli/tests/cli/exact_fragments.rs
@@ -1,5 +1,147 @@
 use super::*;
 
+type FragmentScan = (PathBuf, String, Vec<serde_json::Value>);
+
+/// Write `fixtures` into a unique temp dir and run a semantic JSON scan,
+/// returning the project dir, the raw scan output, and the parsed families.
+fn scan_fragment_fixtures(tag: &str, fixtures: &[(&str, &str)]) -> FragmentScan {
+    scan_fragment_fixtures_with(tag, fixtures, &[])
+}
+
+/// Like [`scan_fragment_fixtures`], but raises the size gates so only exact
+/// fragments can report.
+fn scan_fragment_only_fixtures(tag: &str, fixtures: &[(&str, &str)]) -> FragmentScan {
+    scan_fragment_fixtures_with(tag, fixtures, &["--min-lines", "100", "--min-size", "100"])
+}
+
+fn scan_fragment_fixtures_with(
+    tag: &str,
+    fixtures: &[(&str, &str)],
+    size_args: &[&str],
+) -> FragmentScan {
+    let dir = std::env::temp_dir().join(format!("{tag}_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    for (name, src) in fixtures {
+        fs::write(dir.join(name), src).unwrap();
+    }
+    let mut args = vec!["scan", dir.to_str().unwrap(), "--mode", "semantic"];
+    args.extend_from_slice(size_args);
+    args.extend_from_slice(&["--format", "json", "--top", "0"]);
+    let out = run(&args);
+    let families = scan_families(&scan_json(&out)).to_vec();
+    (dir, out, families)
+}
+
+fn family_locations(family: &serde_json::Value) -> &[serde_json::Value] {
+    family["locations"].as_array().expect("locations")
+}
+
+fn location_files(family: &serde_json::Value) -> Vec<&str> {
+    family_locations(family)
+        .iter()
+        .filter_map(|loc| loc["file"].as_str())
+        .collect()
+}
+
+fn family_all_blocks(family: &serde_json::Value) -> bool {
+    family_locations(family)
+        .iter()
+        .all(|loc| loc["kind"] == "Block")
+}
+
+/// Locations of `family` whose file ends with `left` or `right`.
+fn pair_locations<'a>(
+    family: &'a serde_json::Value,
+    left: &str,
+    right: &str,
+) -> Vec<&'a serde_json::Value> {
+    family_locations(family)
+        .iter()
+        .filter(|loc| {
+            loc["file"].as_str().unwrap_or("").ends_with(left)
+                || loc["file"].as_str().unwrap_or("").ends_with(right)
+        })
+        .collect()
+}
+
+/// First family whose locations include both a `left` and a `right` file.
+fn find_pair_family<'a>(
+    families: &'a [serde_json::Value],
+    left: &str,
+    right: &str,
+) -> Option<&'a serde_json::Value> {
+    families.iter().find(|family| {
+        let files = location_files(family);
+        files.iter().any(|file| file.ends_with(left))
+            && files.iter().any(|file| file.ends_with(right))
+    })
+}
+
+fn has_pair_family(families: &[serde_json::Value], left: &str, right: &str) -> bool {
+    find_pair_family(families, left, right).is_some()
+}
+
+/// First all-Block family that pairs `left` with `right` and excludes `negative`.
+fn find_block_pair_family<'a>(
+    families: &'a [serde_json::Value],
+    left: &str,
+    right: &str,
+    negative: &str,
+) -> Option<&'a serde_json::Value> {
+    families.iter().find(|family| {
+        let files = location_files(family);
+        files.iter().any(|file| file.ends_with(left))
+            && files.iter().any(|file| file.ends_with(right))
+            && family_all_blocks(family)
+            && files.iter().all(|file| !file.ends_with(negative))
+    })
+}
+
+/// Like [`find_block_pair_family`], but `left`/`right` must report the
+/// `start_line..end_line` span.
+fn find_block_pair_family_at<'a>(
+    families: &'a [serde_json::Value],
+    left: &str,
+    right: &str,
+    negative: &str,
+    start_line: u64,
+    end_line: u64,
+) -> Option<&'a serde_json::Value> {
+    families.iter().find(|family| {
+        let span_files: Vec<&str> = family_locations(family)
+            .iter()
+            .filter(|loc| loc["start_line"] == start_line && loc["end_line"] == end_line)
+            .filter_map(|loc| loc["file"].as_str())
+            .collect();
+        span_files.iter().any(|file| file.ends_with(left))
+            && span_files.iter().any(|file| file.ends_with(right))
+            && family_all_blocks(family)
+            && location_files(family)
+                .iter()
+                .all(|file| !file.ends_with(negative))
+    })
+}
+
+/// Like [`find_block_pair_family`], but some location must span multiple lines.
+fn find_multiline_block_pair_family<'a>(
+    families: &'a [serde_json::Value],
+    left: &str,
+    right: &str,
+    negative: &str,
+) -> Option<&'a serde_json::Value> {
+    families.iter().find(|family| {
+        let files = location_files(family);
+        files.iter().any(|file| file.ends_with(left))
+            && files.iter().any(|file| file.ends_with(right))
+            && family_all_blocks(family)
+            && family_locations(family).iter().any(|loc| {
+                loc["end_line"].as_u64().unwrap_or(0) > loc["start_line"].as_u64().unwrap_or(0) + 1
+            })
+            && files.iter().all(|file| !file.ends_with(negative))
+    })
+}
+
 #[test]
 fn feature_extraction_keeps_dense_small_functions_and_exact_fragments_but_not_small_control_blocks()
 {
@@ -248,13 +390,6 @@ fn semantic_scan_reports_exact_safe_conditional_return_fragments_under_opaque_fu
 
 #[test]
 fn semantic_scan_reports_exact_safe_conditional_throw_fragments_under_opaque_functions() {
-    let dir = std::env::temp_dir().join(format!(
-        "nose_exact_throw_guard_fragments_{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-
     let fixtures = [
         (
             "square_throw_guard_a.js",
@@ -293,48 +428,21 @@ fn semantic_scan_reports_exact_safe_conditional_throw_fragments_under_opaque_fun
             "function bothThrowMutated(zs) {\n  zs.push(1);\n  if (zs[0] > 0 && zs[1] > 0) {\n    throw zs[0] + zs[1];\n  }\n  audit(zs);\n}\n",
         ),
     ];
-    for (name, src) in fixtures {
-        fs::write(dir.join(name), src).unwrap();
-    }
-
-    let out = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
-    let json = scan_json(&out);
-    let families = scan_families(&json);
+    let (dir, out, families) =
+        scan_fragment_fixtures("nose_exact_throw_guard_fragments", &fixtures);
 
     let assert_guard_family = |left: &str, right: &str, negative: &str| {
-        let family = families
-            .iter()
-            .find(|family| {
-                let files: Vec<&str> = family["locations"]
-                    .as_array()
-                    .expect("locations")
-                    .iter()
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
-                files.iter().any(|file| file.ends_with(left))
-                    && files.iter().any(|file| file.ends_with(right))
-            })
-            .unwrap_or_else(|| {
-                panic!("missing exact conditional throw fragment family {left}/{right}: {out}")
-            });
-        let locations = family["locations"].as_array().expect("locations");
+        let family = find_pair_family(&families, left, right).unwrap_or_else(|| {
+            panic!("missing exact conditional throw fragment family {left}/{right}: {out}")
+        });
         assert!(
-            locations.iter().all(|loc| loc["kind"] == "Block"),
+            family_all_blocks(family),
             "conditional throw fragments should report as Block units: {family:?}"
         );
         assert!(
-            locations
+            location_files(family)
                 .iter()
-                .all(|loc| !loc["file"].as_str().unwrap_or("").ends_with(negative)),
+                .all(|file| !file.ends_with(negative)),
             "hard negative must not merge into {left}/{right}: {family:?}"
         );
     };
@@ -360,13 +468,6 @@ fn semantic_scan_reports_exact_safe_conditional_throw_fragments_under_opaque_fun
 #[test]
 fn semantic_scan_reports_exact_safe_empty_branch_conditional_exit_fragments_under_opaque_functions()
 {
-    let dir = std::env::temp_dir().join(format!(
-        "nose_exact_empty_branch_fragments_{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-
     let fixtures = [
         (
             "empty_else_return_a.js",
@@ -405,48 +506,21 @@ fn semantic_scan_reports_exact_safe_empty_branch_conditional_exit_fragments_unde
             "function emptyThenThrowMutated(zs) {\n  zs.push(1);\n  if (zs[0] > 0 && zs[1] > 0) {\n  } else {\n    throw zs[0] + zs[1];\n  }\n  audit(zs);\n}\n",
         ),
     ];
-    for (name, src) in fixtures {
-        fs::write(dir.join(name), src).unwrap();
-    }
-
-    let out = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
-    let json = scan_json(&out);
-    let families = scan_families(&json);
+    let (dir, out, families) =
+        scan_fragment_fixtures("nose_exact_empty_branch_fragments", &fixtures);
 
     let assert_guard_family = |left: &str, right: &str, negative: &str| {
-        let family = families
-            .iter()
-            .find(|family| {
-                let files: Vec<&str> = family["locations"]
-                    .as_array()
-                    .expect("locations")
-                    .iter()
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
-                files.iter().any(|file| file.ends_with(left))
-                    && files.iter().any(|file| file.ends_with(right))
-            })
-            .unwrap_or_else(|| {
-                panic!("missing exact empty-branch fragment family {left}/{right}: {out}")
-            });
-        let locations = family["locations"].as_array().expect("locations");
+        let family = find_pair_family(&families, left, right).unwrap_or_else(|| {
+            panic!("missing exact empty-branch fragment family {left}/{right}: {out}")
+        });
         assert!(
-            locations.iter().all(|loc| loc["kind"] == "Block"),
+            family_all_blocks(family),
             "empty-branch conditional fragments should report as Block units: {family:?}"
         );
         assert!(
-            locations
+            location_files(family)
                 .iter()
-                .all(|loc| !loc["file"].as_str().unwrap_or("").ends_with(negative)),
+                .all(|file| !file.ends_with(negative)),
             "hard negative must not merge into {left}/{right}: {family:?}"
         );
     };
@@ -667,6 +741,9 @@ fn semantic_scan_reports_exact_safe_conditional_expr_effect_fragments_under_opaq
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for exact branch temp-consumption fragments. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn semantic_scan_reports_exact_safe_branch_temp_consumption_fragments_under_opaque_functions() {
     let dir = std::env::temp_dir().join(format!(
@@ -927,13 +1004,6 @@ fn semantic_scan_reports_exact_safe_branch_temp_consumption_fragments_under_opaq
 
 #[test]
 fn semantic_scan_reports_exact_safe_nested_conditional_effect_fragments_under_opaque_functions() {
-    let dir = std::env::temp_dir().join(format!(
-        "nose_exact_nested_fragments_{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-
     let fixtures = [
         (
             "nested_push_a.js",
@@ -972,54 +1042,17 @@ fn semantic_scan_reports_exact_safe_nested_conditional_effect_fragments_under_op
             "function nestedPushProductWrong(zs, out) {\n  if ((zs[0] + 2) > 10) {\n    out.push((zs[0] + 2) * 2);\n  } else {\n    if (zs[1] + zs[2] > 0) {\n      out.push(zs[1] + zs[2]);\n    }\n  }\n  audit(zs);\n}\n",
         ),
     ];
-    for (name, src) in fixtures {
-        fs::write(dir.join(name), src).unwrap();
-    }
-
-    let out = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "100",
-        "--min-size",
-        "100",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
-    let json = scan_json(&out);
-    let families = scan_families(&json);
+    let (dir, out, families) =
+        scan_fragment_only_fixtures("nose_exact_nested_fragments", &fixtures);
 
     let assert_guard_family = |left: &str, right: &str, negative: &str| {
-        let family = families
-            .iter()
-            .find(|family| {
-                let locations = family["locations"].as_array().expect("locations");
-                let full_nested_files: Vec<&str> = locations
-                    .iter()
-                    .filter(|loc| loc["start_line"] == 2 && loc["end_line"] == 8)
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
-                full_nested_files.iter().any(|file| file.ends_with(left))
-                    && full_nested_files.iter().any(|file| file.ends_with(right))
-                    && locations.iter().all(|loc| loc["kind"] == "Block")
-                    && locations
-                        .iter()
-                        .filter_map(|loc| loc["file"].as_str())
-                        .all(|file| !file.ends_with(negative))
-            })
+        let family = find_block_pair_family_at(&families, left, right, negative, 2, 8)
             .unwrap_or_else(|| {
                 panic!("missing exact nested conditional effect family {left}/{right}: {out}")
             });
-        let locations = family["locations"].as_array().expect("locations");
         assert!(
-            locations
+            pair_locations(family, left, right)
                 .iter()
-                .filter(|loc| loc["file"].as_str().unwrap_or("").ends_with(left)
-                    || loc["file"].as_str().unwrap_or("").ends_with(right))
                 .all(|loc| loc["start_line"] == 2 && loc["end_line"] == 8),
             "nested conditional effect fragments should report the full nested if: {family:?}"
         );
@@ -1043,6 +1076,9 @@ fn semantic_scan_reports_exact_safe_nested_conditional_effect_fragments_under_op
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for exact foreach append-effect fragments. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn semantic_scan_reports_exact_safe_foreach_append_effect_fragments_under_opaque_functions() {
     let dir = std::env::temp_dir().join(format!(
@@ -1306,6 +1342,9 @@ fn semantic_scan_reports_exact_safe_foreach_append_effect_fragments_under_opaque
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for exact Go foreach index-assignment fragments. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn semantic_scan_reports_exact_safe_foreach_index_assignment_fragments_for_go() {
     let dir = std::env::temp_dir().join(format!(
@@ -1535,13 +1574,6 @@ fn semantic_scan_reports_exact_safe_foreach_index_assignment_fragments_for_go() 
 #[test]
 fn semantic_scan_reports_exact_safe_conditional_foreach_append_effect_fragments_under_opaque_functions(
 ) {
-    let dir = std::env::temp_dir().join(format!(
-        "nose_exact_conditional_loop_effect_fragments_{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-
     let fixtures = [
         (
             "cond_loop_square_a.ts",
@@ -1592,79 +1624,30 @@ fn semantic_scan_reports_exact_safe_conditional_foreach_append_effect_fragments_
             "function condDirectUnused(enabled: boolean, out: number[]): void {\n  if (enabled) {\n    out.push(1);\n  }\n  audit(enabled);\n}\n",
         ),
     ];
-    for (name, src) in fixtures {
-        fs::write(dir.join(name), src).unwrap();
-    }
-
-    let out = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "100",
-        "--min-size",
-        "100",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
-    let json = scan_json(&out);
-    let families = scan_families(&json);
+    let (dir, out, families) =
+        scan_fragment_only_fixtures("nose_exact_conditional_loop_effect_fragments", &fixtures);
 
     let assert_conditional_loop_family = |left: &str,
                                           right: &str,
                                           negative: &str,
                                           start_line: u64,
                                           end_line: u64| {
-        let family = families
-                .iter()
-                .find(|family| {
-                    let locations = family["locations"].as_array().expect("locations");
-                    let fragment_files: Vec<&str> = locations
-                        .iter()
-                        .filter(|loc| {
-                            loc["start_line"] == start_line && loc["end_line"] == end_line
-                        })
-                        .filter_map(|loc| loc["file"].as_str())
-                        .collect();
-                    fragment_files.iter().any(|file| file.ends_with(left))
-                        && fragment_files.iter().any(|file| file.ends_with(right))
-                        && locations.iter().all(|loc| loc["kind"] == "Block")
-                        && locations
-                            .iter()
-                            .filter_map(|loc| loc["file"].as_str())
-                            .all(|file| !file.ends_with(negative))
-                })
-                .unwrap_or_else(|| {
-                    panic!(
-                        "missing exact conditional foreach append-effect fragment family {left}/{right}: {out}"
-                    )
-                });
+        let family =
+                find_block_pair_family_at(&families, left, right, negative, start_line, end_line)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "missing exact conditional foreach append-effect fragment family {left}/{right}: {out}"
+                        )
+                    });
         assert!(
-            family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .all(|loc| loc["kind"] == "Block"),
+            family_all_blocks(family),
             "conditional foreach append-effect fragments should report as Block units: {family:?}"
         );
     };
 
     let assert_no_pair = |left: &str, right: &str| {
-        let has_pair = families.iter().any(|family| {
-            let files: Vec<&str> = family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .filter_map(|loc| loc["file"].as_str())
-                .collect();
-            files.iter().any(|file| file.ends_with(left))
-                && files.iter().any(|file| file.ends_with(right))
-        });
         assert!(
-            !has_pair,
+            !has_pair_family(&families, left, right),
             "conditional foreach append effect boundary must not merge {left}/{right}: {out}"
         );
     };
@@ -1695,6 +1678,9 @@ fn semantic_scan_reports_exact_safe_conditional_foreach_append_effect_fragments_
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for ordered foreach-effect branch boundaries. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn semantic_scan_reports_exact_safe_ordered_foreach_effect_branch_fragments() {
     let dir = std::env::temp_dir().join(format!(
@@ -1917,6 +1903,9 @@ fn semantic_scan_reports_exact_safe_ordered_foreach_effect_branch_fragments() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for ordered mixed-effect branch boundaries. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn semantic_scan_reports_exact_safe_ordered_mixed_effect_branch_fragments() {
     let dir = std::env::temp_dir().join(format!(
@@ -2159,6 +2148,9 @@ fn semantic_scan_reports_exact_safe_ordered_mixed_effect_branch_fragments() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for ordered conditional-effect branch boundaries. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn semantic_scan_reports_exact_safe_ordered_conditional_effect_branch_fragments() {
     let dir = std::env::temp_dir().join(format!(
@@ -2401,6 +2393,9 @@ fn semantic_scan_reports_exact_safe_ordered_conditional_effect_branch_fragments(
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for ordered conditional mixed-effect branch boundaries. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn semantic_scan_reports_exact_safe_ordered_conditional_mixed_effect_branch_fragments() {
     let dir = std::env::temp_dir().join(format!(
@@ -2521,13 +2516,13 @@ fn semantic_scan_reports_exact_safe_ordered_conditional_mixed_effect_branch_frag
                 )
             });
         assert!(
-                family["locations"]
-                    .as_array()
-                    .expect("locations")
-                    .iter()
-                    .all(|loc| loc["kind"] == "Block"),
-                "ordered conditional mixed-effect branch fragments should report as Block units: {family:?}"
-            );
+            family["locations"]
+                .as_array()
+                .expect("locations")
+                .iter()
+                .all(|loc| loc["kind"] == "Block"),
+            "ordered conditional mixed-effect branch fragments should report as Block units: {family:?}"
+        );
     };
 
     let assert_no_branch_pair = |left: &str,
@@ -2658,6 +2653,9 @@ fn semantic_scan_reports_exact_safe_ordered_conditional_mixed_effect_branch_frag
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for ordered loop conditional-effect branch boundaries. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn semantic_scan_reports_exact_safe_ordered_loop_conditional_effect_branch_fragments() {
     let dir = std::env::temp_dir().join(format!(
@@ -2778,13 +2776,13 @@ fn semantic_scan_reports_exact_safe_ordered_loop_conditional_effect_branch_fragm
                 )
             });
         assert!(
-                family["locations"]
-                    .as_array()
-                    .expect("locations")
-                    .iter()
-                    .all(|loc| loc["kind"] == "Block"),
-                "ordered loop conditional-effect branch fragments should report as Block units: {family:?}"
-            );
+            family["locations"]
+                .as_array()
+                .expect("locations")
+                .iter()
+                .all(|loc| loc["kind"] == "Block"),
+            "ordered loop conditional-effect branch fragments should report as Block units: {family:?}"
+        );
     };
 
     let assert_no_branch_pair = |left: &str,
@@ -2915,6 +2913,9 @@ fn semantic_scan_reports_exact_safe_ordered_loop_conditional_effect_branch_fragm
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for ordered loop conditional mixed-effect branch boundaries. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn semantic_scan_reports_exact_safe_ordered_loop_conditional_mixed_effect_branch_fragments() {
     let dir = std::env::temp_dir().join(format!(
@@ -3035,13 +3036,13 @@ fn semantic_scan_reports_exact_safe_ordered_loop_conditional_mixed_effect_branch
                 )
             });
         assert!(
-                family["locations"]
-                    .as_array()
-                    .expect("locations")
-                    .iter()
-                    .all(|loc| loc["kind"] == "Block"),
-                "ordered loop conditional mixed-effect branch fragments should report as Block units: {family:?}"
-            );
+            family["locations"]
+                .as_array()
+                .expect("locations")
+                .iter()
+                .all(|loc| loc["kind"] == "Block"),
+            "ordered loop conditional mixed-effect branch fragments should report as Block units: {family:?}"
+        );
     };
 
     let assert_no_branch_pair = |left: &str,
@@ -3172,6 +3173,9 @@ fn semantic_scan_reports_exact_safe_ordered_loop_conditional_mixed_effect_branch
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for ordered append-effect branch boundaries. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn semantic_scan_reports_exact_safe_ordered_append_effect_branch_fragments() {
     let dir = std::env::temp_dir().join(format!(
@@ -3348,13 +3352,6 @@ fn semantic_scan_reports_exact_safe_ordered_append_effect_branch_fragments() {
 
 #[test]
 fn semantic_scan_reports_exact_safe_three_append_effect_branch_fragments() {
-    let dir = std::env::temp_dir().join(format!(
-        "nose_three_append_effect_boundary_{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-
     let fixtures = [
         (
             "append_three_a.ts",
@@ -3409,86 +3406,43 @@ fn semantic_scan_reports_exact_safe_three_append_effect_branch_fragments() {
             "function appendFourLeft(flag: boolean, out: number[], x: number): void {\n  if (flag) {\n    out.push(x + 1);\n    out.push(x + 2);\n    out.push(x + 3);\n    out.push(x + 4);\n  }\n  audit(/opaque/);\n}\n",
         ),
     ];
-    for (name, src) in fixtures {
-        fs::write(dir.join(name), src).unwrap();
-    }
+    let (dir, out, families) =
+        scan_fragment_only_fixtures("nose_three_append_effect_boundary", &fixtures);
 
-    let out = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "100",
-        "--min-size",
-        "100",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
-    let json = scan_json(&out);
-    let families = scan_families(&json);
-
-    let assert_block_pair = |left: &str, right: &str, negative: &str| {
-        let family = families
-            .iter()
-            .find(|family| {
-                let locations = family["locations"].as_array().expect("locations");
-                let files: Vec<&str> = locations
-                    .iter()
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
-                files.iter().any(|file| file.ends_with(left))
-                    && files.iter().any(|file| file.ends_with(right))
-                    && files.iter().all(|file| !file.ends_with(negative))
-                    && locations.iter().all(|loc| loc["kind"] == "Block")
-            })
-            .unwrap_or_else(|| {
+    for (left, right, negative) in [
+        (
+            "append_three_a.ts",
+            "append_three_b.ts",
+            "append_three_wrong_order.ts",
+        ),
+        (
+            "append_three_temp_a.ts",
+            "append_three_temp_b.ts",
+            "append_three_temp_wrong.ts",
+        ),
+        (
+            "append_three_chain_a.ts",
+            "append_three_chain_b.ts",
+            "append_three_chain_wrong.ts",
+        ),
+    ] {
+        let family =
+            find_block_pair_family(&families, left, right, negative).unwrap_or_else(|| {
                 panic!("missing three-append-effect branch family {left}/{right}: {out}")
             });
         assert!(
-            family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .all(|loc| loc["kind"] == "Block"),
+            family_all_blocks(family),
             "three append-effect branch fragments should report as Block units: {family:?}"
         );
-    };
+    }
 
     let assert_no_merge = |left: &str, right: &str| {
-        let merged = families.iter().any(|family| {
-            let files: Vec<&str> = family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .filter_map(|loc| loc["file"].as_str())
-                .collect();
-            files.iter().any(|file| file.ends_with(left))
-                && files.iter().any(|file| file.ends_with(right))
-        });
         assert!(
-            !merged,
+            !has_pair_family(&families, left, right),
             "semantic mode must not merge three append effects across the boundary ({left}/{right}): {out}"
         );
     };
 
-    assert_block_pair(
-        "append_three_a.ts",
-        "append_three_b.ts",
-        "append_three_wrong_order.ts",
-    );
-    assert_block_pair(
-        "append_three_temp_a.ts",
-        "append_three_temp_b.ts",
-        "append_three_temp_wrong.ts",
-    );
-    assert_block_pair(
-        "append_three_chain_a.ts",
-        "append_three_chain_b.ts",
-        "append_three_chain_wrong.ts",
-    );
     assert_no_merge("append_three_a.ts", "append_three_wrong_order.ts");
     assert_no_merge("append_three_a.ts", "append_three_wrong_receiver.ts");
     assert_no_merge("append_three_a.ts", "append_three_mutated.ts");
@@ -3503,13 +3457,6 @@ fn semantic_scan_reports_exact_safe_three_append_effect_branch_fragments() {
 
 #[test]
 fn semantic_scan_reports_exact_safe_ordered_index_assignment_branch_fragments_for_go() {
-    let dir = std::env::temp_dir().join(format!(
-        "nose_index_effect_order_boundary_{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-
     let fixtures = [
         (
             "index_pair_a.go",
@@ -3564,86 +3511,43 @@ fn semantic_scan_reports_exact_safe_ordered_index_assignment_branch_fragments_fo
             "function indexPairDynamicJs(flag, out, xs) {\n  if (flag) {\n    out[0] = xs[0] + 1;\n    out[1] = xs[0] + 2;\n  }\n  audit(/opaque/);\n}\n",
         ),
     ];
-    for (name, src) in fixtures {
-        fs::write(dir.join(name), src).unwrap();
-    }
+    let (dir, out, families) =
+        scan_fragment_only_fixtures("nose_index_effect_order_boundary", &fixtures);
 
-    let out = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "100",
-        "--min-size",
-        "100",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
-    let json = scan_json(&out);
-    let families = scan_families(&json);
-
-    let assert_block_pair = |left: &str, right: &str, negative: &str| {
-        let family = families
-            .iter()
-            .find(|family| {
-                let locations = family["locations"].as_array().expect("locations");
-                let files: Vec<&str> = locations
-                    .iter()
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
-                files.iter().any(|file| file.ends_with(left))
-                    && files.iter().any(|file| file.ends_with(right))
-                    && files.iter().all(|file| !file.ends_with(negative))
-                    && locations.iter().all(|loc| loc["kind"] == "Block")
-            })
-            .unwrap_or_else(|| {
+    for (left, right, negative) in [
+        (
+            "index_pair_a.go",
+            "index_pair_b.go",
+            "index_pair_wrong_order.go",
+        ),
+        (
+            "index_temp_pair_a.go",
+            "index_temp_pair_b.go",
+            "index_temp_pair_wrong.go",
+        ),
+        (
+            "index_chain_pair_a.go",
+            "index_chain_pair_b.go",
+            "index_chain_pair_wrong.go",
+        ),
+    ] {
+        let family =
+            find_block_pair_family(&families, left, right, negative).unwrap_or_else(|| {
                 panic!("missing ordered index-assignment branch family {left}/{right}: {out}")
             });
         assert!(
-            family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .all(|loc| loc["kind"] == "Block"),
+            family_all_blocks(family),
             "ordered index-assignment branch fragments should report as Block units: {family:?}"
         );
-    };
+    }
 
     let assert_no_merge = |left: &str, right: &str| {
-        let merged = families.iter().any(|family| {
-            let files: Vec<&str> = family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .filter_map(|loc| loc["file"].as_str())
-                .collect();
-            files.iter().any(|file| file.ends_with(left))
-                && files.iter().any(|file| file.ends_with(right))
-        });
         assert!(
-            !merged,
+            !has_pair_family(&families, left, right),
             "semantic mode must not merge ordered index-assignment effects across the boundary ({left}/{right}): {out}"
         );
     };
 
-    assert_block_pair(
-        "index_pair_a.go",
-        "index_pair_b.go",
-        "index_pair_wrong_order.go",
-    );
-    assert_block_pair(
-        "index_temp_pair_a.go",
-        "index_temp_pair_b.go",
-        "index_temp_pair_wrong.go",
-    );
-    assert_block_pair(
-        "index_chain_pair_a.go",
-        "index_chain_pair_b.go",
-        "index_chain_pair_wrong.go",
-    );
     assert_no_merge("index_pair_a.go", "index_pair_wrong_order.go");
     assert_no_merge("index_pair_a.go", "index_pair_wrong_receiver.go");
     assert_no_merge("index_pair_a.go", "index_pair_mutated.go");
@@ -3655,13 +3559,6 @@ fn semantic_scan_reports_exact_safe_ordered_index_assignment_branch_fragments_fo
 
 #[test]
 fn semantic_scan_reports_exact_safe_three_index_assignment_branch_fragments_for_go() {
-    let dir = std::env::temp_dir().join(format!(
-        "nose_three_index_effect_boundary_{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-
     let fixtures = [
         (
             "index_three_a.go",
@@ -3720,86 +3617,43 @@ fn semantic_scan_reports_exact_safe_three_index_assignment_branch_fragments_for_
             "function indexThreeDynamicJs(flag, out, xs) {\n  if (flag) {\n    out[0] = xs[0] + 1;\n    out[1] = xs[0] + 2;\n    out[2] = xs[0] + 3;\n  }\n  audit(/opaque/);\n}\n",
         ),
     ];
-    for (name, src) in fixtures {
-        fs::write(dir.join(name), src).unwrap();
-    }
+    let (dir, out, families) =
+        scan_fragment_only_fixtures("nose_three_index_effect_boundary", &fixtures);
 
-    let out = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "100",
-        "--min-size",
-        "100",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
-    let json = scan_json(&out);
-    let families = scan_families(&json);
-
-    let assert_block_pair = |left: &str, right: &str, negative: &str| {
-        let family = families
-            .iter()
-            .find(|family| {
-                let locations = family["locations"].as_array().expect("locations");
-                let files: Vec<&str> = locations
-                    .iter()
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
-                files.iter().any(|file| file.ends_with(left))
-                    && files.iter().any(|file| file.ends_with(right))
-                    && files.iter().all(|file| !file.ends_with(negative))
-                    && locations.iter().all(|loc| loc["kind"] == "Block")
-            })
-            .unwrap_or_else(|| {
+    for (left, right, negative) in [
+        (
+            "index_three_a.go",
+            "index_three_b.go",
+            "index_three_wrong_order.go",
+        ),
+        (
+            "index_three_temp_a.go",
+            "index_three_temp_b.go",
+            "index_three_temp_wrong.go",
+        ),
+        (
+            "index_three_chain_a.go",
+            "index_three_chain_b.go",
+            "index_three_chain_wrong.go",
+        ),
+    ] {
+        let family =
+            find_block_pair_family(&families, left, right, negative).unwrap_or_else(|| {
                 panic!("missing three-index-assignment branch family {left}/{right}: {out}")
             });
         assert!(
-            family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .all(|loc| loc["kind"] == "Block"),
+            family_all_blocks(family),
             "three index-assignment branch fragments should report as Block units: {family:?}"
         );
-    };
+    }
 
     let assert_no_merge = |left: &str, right: &str| {
-        let merged = families.iter().any(|family| {
-            let files: Vec<&str> = family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .filter_map(|loc| loc["file"].as_str())
-                .collect();
-            files.iter().any(|file| file.ends_with(left))
-                && files.iter().any(|file| file.ends_with(right))
-        });
         assert!(
-            !merged,
+            !has_pair_family(&families, left, right),
             "semantic mode must not merge three index-assignment effects across the boundary ({left}/{right}): {out}"
         );
     };
 
-    assert_block_pair(
-        "index_three_a.go",
-        "index_three_b.go",
-        "index_three_wrong_order.go",
-    );
-    assert_block_pair(
-        "index_three_temp_a.go",
-        "index_three_temp_b.go",
-        "index_three_temp_wrong.go",
-    );
-    assert_block_pair(
-        "index_three_chain_a.go",
-        "index_three_chain_b.go",
-        "index_three_chain_wrong.go",
-    );
     assert_no_merge("index_three_a.go", "index_three_wrong_order.go");
     assert_no_merge("index_three_a.go", "index_three_wrong_receiver.go");
     assert_no_merge("index_three_a.go", "index_three_mutated.go");
@@ -3812,13 +3666,6 @@ fn semantic_scan_reports_exact_safe_three_index_assignment_branch_fragments_for_
 
 #[test]
 fn semantic_scan_reports_exact_safe_index_assignment_fragments_for_non_overloaded_languages() {
-    let dir = std::env::temp_dir().join(format!(
-        "nose_exact_index_assign_fragments_{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-
     let fixtures = [
         (
             "index_square_a.c",
@@ -3873,50 +3720,17 @@ fn semantic_scan_reports_exact_safe_index_assignment_fragments_for_non_overloade
             "def py_index_right(ys, j, w):\n    ys[j] = w + 1\n    trace(ys)\n",
         ),
     ];
-    for (name, src) in fixtures {
-        fs::write(dir.join(name), src).unwrap();
-    }
-
-    let out = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "100",
-        "--min-size",
-        "100",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
-    let json = scan_json(&out);
-    let families = scan_families(&json);
+    let (dir, out, families) =
+        scan_fragment_only_fixtures("nose_exact_index_assign_fragments", &fixtures);
 
     let assert_assignment_family = |left: &str, right: &str, negative: &str| {
-        let family = families
-            .iter()
-            .find(|family| {
-                let locations = family["locations"].as_array().expect("locations");
-                let files: Vec<&str> = locations
-                    .iter()
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
-                files.iter().any(|file| file.ends_with(left))
-                    && files.iter().any(|file| file.ends_with(right))
-                    && locations.iter().all(|loc| loc["kind"] == "Block")
-                    && files.iter().all(|file| !file.ends_with(negative))
-            })
-            .unwrap_or_else(|| {
+        let family =
+            find_block_pair_family(&families, left, right, negative).unwrap_or_else(|| {
                 panic!("missing exact index-assignment fragment family {left}/{right}: {out}")
             });
-        let locations = family["locations"].as_array().expect("locations");
         assert!(
-            locations
+            pair_locations(family, left, right)
                 .iter()
-                .filter(|loc| loc["file"].as_str().unwrap_or("").ends_with(left)
-                    || loc["file"].as_str().unwrap_or("").ends_with(right))
                 .all(|loc| loc["start_line"] == loc["end_line"]
                     || loc["end_line"].as_u64().unwrap_or(0)
                         <= loc["start_line"].as_u64().unwrap_or(0) + 3),
@@ -3925,18 +3739,8 @@ fn semantic_scan_reports_exact_safe_index_assignment_fragments_for_non_overloade
     };
 
     let assert_no_pair = |left: &str, right: &str| {
-        let has_pair = families.iter().any(|family| {
-            let files: Vec<&str> = family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .filter_map(|loc| loc["file"].as_str())
-                .collect();
-            files.iter().any(|file| file.ends_with(left))
-                && files.iter().any(|file| file.ends_with(right))
-        });
         assert!(
-            !has_pair,
+            !has_pair_family(&families, left, right),
             "overloadable index-assignment pair must stay outside exact fragments: {left}/{right}: {out}"
         );
     };
@@ -3955,13 +3759,6 @@ fn semantic_scan_reports_exact_safe_index_assignment_fragments_for_non_overloade
 
 #[test]
 fn semantic_scan_reports_exact_safe_java_this_field_assignment_fragments() {
-    let dir = std::env::temp_dir().join(format!(
-        "nose_exact_this_field_assign_fragments_{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-
     let fixtures = [
         (
             "FieldSelfSquareA.java",
@@ -4016,50 +3813,17 @@ fn semantic_scan_reports_exact_safe_java_this_field_assignment_fragments() {
             "class PyFieldRight:\n    def f(self, w):\n        self.value = (1 + w) * (1 + w)\n        trace(self)\n",
         ),
     ];
-    for (name, src) in fixtures {
-        fs::write(dir.join(name), src).unwrap();
-    }
-
-    let out = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "100",
-        "--min-size",
-        "100",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
-    let json = scan_json(&out);
-    let families = scan_families(&json);
+    let (dir, out, families) =
+        scan_fragment_only_fixtures("nose_exact_this_field_assign_fragments", &fixtures);
 
     let assert_fragment_family = |left: &str, right: &str, negative: &str| {
-        let family = families
-            .iter()
-            .find(|family| {
-                let locations = family["locations"].as_array().expect("locations");
-                let files: Vec<&str> = locations
-                    .iter()
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
-                files.iter().any(|file| file.ends_with(left))
-                    && files.iter().any(|file| file.ends_with(right))
-                    && locations.iter().all(|loc| loc["kind"] == "Block")
-                    && files.iter().all(|file| !file.ends_with(negative))
-            })
-            .unwrap_or_else(|| {
+        let family =
+            find_block_pair_family(&families, left, right, negative).unwrap_or_else(|| {
                 panic!("missing exact this-field fragment family {left}/{right}: {out}")
             });
-        let locations = family["locations"].as_array().expect("locations");
         assert!(
-            locations
+            pair_locations(family, left, right)
                 .iter()
-                .filter(|loc| loc["file"].as_str().unwrap_or("").ends_with(left)
-                    || loc["file"].as_str().unwrap_or("").ends_with(right))
                 .all(|loc| loc["end_line"].as_u64().unwrap_or(0)
                     <= loc["start_line"].as_u64().unwrap_or(0) + 5),
             "this-field fragments should stay tightly scoped: {family:?}"
@@ -4067,18 +3831,8 @@ fn semantic_scan_reports_exact_safe_java_this_field_assignment_fragments() {
     };
 
     let assert_no_pair = |left: &str, right: &str| {
-        let has_pair = families.iter().any(|family| {
-            let files: Vec<&str> = family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .filter_map(|loc| loc["file"].as_str())
-                .collect();
-            files.iter().any(|file| file.ends_with(left))
-                && files.iter().any(|file| file.ends_with(right))
-        });
         assert!(
-            !has_pair,
+            !has_pair_family(&families, left, right),
             "dynamic or wrong-receiver field assignment must stay outside exact fragments: {left}/{right}: {out}"
         );
     };
@@ -4106,13 +3860,6 @@ fn semantic_scan_reports_exact_safe_java_this_field_assignment_fragments() {
 
 #[test]
 fn semantic_scan_reports_exact_safe_ordered_java_this_field_branch_fragments() {
-    let dir = std::env::temp_dir().join(format!(
-        "nose_ordered_this_field_branch_fragments_{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-
     let fixtures = [
         (
             "FieldBranchOrderedA.java",
@@ -4139,52 +3886,27 @@ fn semantic_scan_reports_exact_safe_ordered_java_this_field_branch_fragments() {
             "class FieldBranchTripleWrongReceiverBox { int limit; }\nclass FieldBranchTripleWrongReceiver {\n  int value;\n  int limit;\n  int score;\n  void f(FieldBranchTripleWrongReceiverBox other, boolean ready, int c, int d) {\n    if (ready) {\n      this.value = d + c;\n      other.limit = 2 * (d + c);\n      this.score = d - c;\n    }\n    audit(this);\n  }\n}\n",
         ),
     ];
-    for (name, src) in fixtures {
-        fs::write(dir.join(name), src).unwrap();
-    }
-
-    let out = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "100",
-        "--min-size",
-        "100",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
-    let json = scan_json(&out);
-    let families = scan_families(&json);
+    let (dir, out, families) =
+        scan_fragment_only_fixtures("nose_ordered_this_field_branch_fragments", &fixtures);
 
     let assert_branch_family = |left: &str, right: &str, negative: &str| {
         let family = families
             .iter()
             .find(|family| {
-                let locations = family["locations"].as_array().expect("locations");
-                let files: Vec<&str> = locations
-                    .iter()
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
+                let files = location_files(family);
                 files.iter().any(|file| file.ends_with(left))
                     && files.iter().any(|file| file.ends_with(right))
                     && files.iter().all(|file| !file.ends_with(negative))
-                    && locations
+                    && family_locations(family)
                         .iter()
                         .all(|loc| loc["fragment_kind"] == "conditional-guard")
             })
             .unwrap_or_else(|| {
                 panic!("missing ordered self-field branch fragment family {left}/{right}: {out}")
             });
-        let locations = family["locations"].as_array().expect("locations");
         assert!(
-            locations
+            pair_locations(family, left, right)
                 .iter()
-                .filter(|loc| loc["file"].as_str().unwrap_or("").ends_with(left)
-                    || loc["file"].as_str().unwrap_or("").ends_with(right))
                 .all(|loc| loc["end_line"].as_u64().unwrap_or(0)
                     <= loc["start_line"].as_u64().unwrap_or(0) + 5),
             "ordered self-field branch fragments should stay tightly scoped: {family:?}"
@@ -4193,16 +3915,12 @@ fn semantic_scan_reports_exact_safe_ordered_java_this_field_branch_fragments() {
 
     let assert_no_conditional_guard_location = |negative: &str| {
         let has_conditional_guard = families.iter().any(|family| {
-            family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .any(|loc| {
-                    loc["file"]
-                        .as_str()
-                        .is_some_and(|file| file.ends_with(negative))
-                        && loc["fragment_kind"] == "conditional-guard"
-                })
+            family_locations(family).iter().any(|loc| {
+                loc["file"]
+                    .as_str()
+                    .is_some_and(|file| file.ends_with(negative))
+                    && loc["fragment_kind"] == "conditional-guard"
+            })
         });
         assert!(
             !has_conditional_guard,
@@ -4227,13 +3945,6 @@ fn semantic_scan_reports_exact_safe_ordered_java_this_field_branch_fragments() {
 
 #[test]
 fn semantic_scan_reports_exact_safe_java_this_field_assignment_body_fragments() {
-    let dir = std::env::temp_dir().join(format!(
-        "nose_exact_this_field_body_fragments_{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-
     let fixtures = [
         (
             "FieldBodyDirectA.java",
@@ -4272,54 +3983,17 @@ fn semantic_scan_reports_exact_safe_java_this_field_assignment_body_fragments() 
             "class FieldBodyNestedWrongReceiverBox { int score; }\nclass FieldBodyNestedWrongReceiver {\n  int base;\n  int score;\n  void f(FieldBodyNestedWrongReceiverBox other, boolean ready, int c, int d) {\n    this.base = d + c;\n    if (ready) {\n      if (0 < c) {\n        other.score = (d + c) * (d + c);\n      }\n    }\n  }\n}\n",
         ),
     ];
-    for (name, src) in fixtures {
-        fs::write(dir.join(name), src).unwrap();
-    }
-
-    let out = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "100",
-        "--min-size",
-        "100",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
-    let json = scan_json(&out);
-    let families = scan_families(&json);
+    let (dir, out, families) =
+        scan_fragment_only_fixtures("nose_exact_this_field_body_fragments", &fixtures);
 
     let assert_body_family = |left: &str, right: &str, negative: &str| {
-        let family = families
-            .iter()
-            .find(|family| {
-                let locations = family["locations"].as_array().expect("locations");
-                let files: Vec<&str> = locations
-                    .iter()
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
-                files.iter().any(|file| file.ends_with(left))
-                    && files.iter().any(|file| file.ends_with(right))
-                    && locations.iter().all(|loc| loc["kind"] == "Block")
-                    && locations.iter().any(|loc| {
-                        loc["end_line"].as_u64().unwrap_or(0)
-                            > loc["start_line"].as_u64().unwrap_or(0) + 1
-                    })
-                    && files.iter().all(|file| !file.ends_with(negative))
-            })
+        let family = find_multiline_block_pair_family(&families, left, right, negative)
             .unwrap_or_else(|| {
                 panic!("missing exact this-field body fragment family {left}/{right}: {out}")
             });
-        let locations = family["locations"].as_array().expect("locations");
         assert!(
-            locations
+            pair_locations(family, left, right)
                 .iter()
-                .filter(|loc| loc["file"].as_str().unwrap_or("").ends_with(left)
-                    || loc["file"].as_str().unwrap_or("").ends_with(right))
                 .all(|loc| loc["end_line"].as_u64().unwrap_or(0)
                     <= loc["start_line"].as_u64().unwrap_or(0) + 7),
             "this-field body fragments should stay tightly scoped: {family:?}"
@@ -4327,18 +4001,8 @@ fn semantic_scan_reports_exact_safe_java_this_field_assignment_body_fragments() 
     };
 
     let assert_no_pair = |left: &str, right: &str| {
-        let has_pair = families.iter().any(|family| {
-            let files: Vec<&str> = family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .filter_map(|loc| loc["file"].as_str())
-                .collect();
-            files.iter().any(|file| file.ends_with(left))
-                && files.iter().any(|file| file.ends_with(right))
-        });
         assert!(
-            !has_pair,
+            !has_pair_family(&families, left, right),
             "wrong-receiver field body must stay outside exact fragments: {left}/{right}: {out}"
         );
     };
@@ -4364,13 +4028,6 @@ fn semantic_scan_reports_exact_safe_java_this_field_assignment_body_fragments() 
 
 #[test]
 fn semantic_scan_reports_exact_safe_java_this_field_return_this_body_fragments() {
-    let dir = std::env::temp_dir().join(format!(
-        "nose_exact_this_field_return_this_body_fragments_{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-
     let fixtures = [
         (
             "FluentBodyDirectA.java",
@@ -4409,56 +4066,21 @@ fn semantic_scan_reports_exact_safe_java_this_field_return_this_body_fragments()
             "class FluentBodyNestedWrongValue {\n  int base;\n  int score;\n  FluentBodyNestedWrongValue f(boolean ready, int c, int d) {\n    this.base = d + c;\n    if (ready) {\n      if (0 < c) {\n        this.score = (d + c) + (d + c);\n      }\n    }\n    return this;\n  }\n}\n",
         ),
     ];
-    for (name, src) in fixtures {
-        fs::write(dir.join(name), src).unwrap();
-    }
-
-    let out = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "100",
-        "--min-size",
-        "100",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
-    let json = scan_json(&out);
-    let families = scan_families(&json);
+    let (dir, out, families) = scan_fragment_only_fixtures(
+        "nose_exact_this_field_return_this_body_fragments",
+        &fixtures,
+    );
 
     let assert_body_family = |left: &str, right: &str, negative: &str| {
-        let family = families
-            .iter()
-            .find(|family| {
-                let locations = family["locations"].as_array().expect("locations");
-                let files: Vec<&str> = locations
-                    .iter()
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
-                files.iter().any(|file| file.ends_with(left))
-                    && files.iter().any(|file| file.ends_with(right))
-                    && locations.iter().all(|loc| loc["kind"] == "Block")
-                    && locations.iter().any(|loc| {
-                        loc["end_line"].as_u64().unwrap_or(0)
-                            > loc["start_line"].as_u64().unwrap_or(0) + 1
-                    })
-                    && files.iter().all(|file| !file.ends_with(negative))
-            })
+        let family = find_multiline_block_pair_family(&families, left, right, negative)
             .unwrap_or_else(|| {
                 panic!(
                     "missing exact this-field return-this body fragment family {left}/{right}: {out}"
                 )
             });
-        let locations = family["locations"].as_array().expect("locations");
         assert!(
-            locations
+            pair_locations(family, left, right)
                 .iter()
-                .filter(|loc| loc["file"].as_str().unwrap_or("").ends_with(left)
-                    || loc["file"].as_str().unwrap_or("").ends_with(right))
                 .all(|loc| loc["end_line"].as_u64().unwrap_or(0)
                     <= loc["start_line"].as_u64().unwrap_or(0) + 9),
             "this-field return-this body fragments should stay tightly scoped: {family:?}"
@@ -4466,18 +4088,8 @@ fn semantic_scan_reports_exact_safe_java_this_field_return_this_body_fragments()
     };
 
     let assert_no_pair = |left: &str, right: &str| {
-        let has_pair = families.iter().any(|family| {
-            let files: Vec<&str> = family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .filter_map(|loc| loc["file"].as_str())
-                .collect();
-            files.iter().any(|file| file.ends_with(left))
-                && files.iter().any(|file| file.ends_with(right))
-        });
         assert!(
-            !has_pair,
+            !has_pair_family(&families, left, right),
             "wrong-return field body must stay outside exact fragments: {left}/{right}: {out}"
         );
     };

--- a/crates/nose-cli/tests/cli/semantic_idioms.rs
+++ b/crates/nose-cli/tests/cli/semantic_idioms.rs
@@ -1390,6 +1390,9 @@ fn scan_mode_semantic_keeps_unproven_contains_calls_distinct() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for typed dynamic collection membership contracts. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn scan_mode_semantic_proves_typed_dynamic_collection_membership() {
     let dir = std::env::temp_dir().join(format!(
@@ -1548,6 +1551,9 @@ fn scan_mode_semantic_proves_typed_dynamic_collection_membership() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for proven Set membership receiver contracts. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn scan_mode_semantic_proves_set_membership_when_receiver_is_proven() {
     let dir = std::env::temp_dir().join(format!("nose_set_membership_{}", std::process::id()));
@@ -1800,6 +1806,9 @@ fn scan_mode_semantic_handles_shadowed_callback_collection_name() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for typed TypeScript map-key membership contracts. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn scan_mode_semantic_proves_typed_typescript_map_key_membership() {
     let dir = std::env::temp_dir().join(format!("nose_typed_ts_map_key_{}", std::process::id()));
@@ -1940,6 +1949,9 @@ fn scan_mode_semantic_proves_typed_typescript_map_key_membership() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+// Broad fixture matrix for typed TypeScript map default lookup contracts. The size is
+// intentional until the fixture setup has a clearer table-builder abstraction.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn scan_mode_semantic_proves_typed_typescript_map_default_lookup() {
     let dir =

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -1257,7 +1257,7 @@ fn scalar_abs_builtins_converge_cross_language_with_shadow_boundary() {
 }
 
 #[test]
-fn scalar_minmax_builtins_converge_cross_language_with_shadow_boundary() {
+fn scalar_minmax_builtins_converge_cross_language() {
     let i = Interner::new();
     let py_min = "def f(left, right, other):\n    selected = left if left <= right else right\n    return selected + other\n";
     let py_min_call =
@@ -1278,17 +1278,6 @@ fn scalar_minmax_builtins_converge_cross_language_with_shadow_boundary() {
     let rust_max = "pub fn f(left: i64, right: i64, other: i64) -> i64 { let selected = left.max(right); selected + other }\n";
     let py_wrong_value =
         "def f(left, right, other):\n    selected = min(left, other)\n    return selected + other\n";
-    let py_shadowed_min =
-        "def min(_left, _right):\n    return 0\n\ndef f(left, right, other):\n    selected = min(left, right)\n    return selected + other\n";
-    let py_local_shadowed_min =
-        "def f(left, right, other):\n    min = lambda _left, _right: 0\n    selected = min(left, right)\n    return selected + other\n";
-    let shadowed_js = "function f(left, right, other) { const Math = { min: function(_left, _right) { return 0; } }; const selected = Math.min(left, right); return selected + other; }";
-    let destructured_shadowed_js = "function f(scope, left, right, other) { const { Math } = scope; const selected = Math.min(left, right); return selected + other; }";
-    let java_shadowed_math_type = "class C { static int f(int left, int right, int other) { int selected = Math.min(left, right); return selected + other; } }\nclass Math { static int min(int left, int right) { return 0; } }\n";
-    let ts_number_method_min = "function f(left: number, right: number, other: number): number { const selected = left.min(right); return selected + other; }";
-    let rust_float_min = "pub fn f(left: f64, right: f64, other: f64) -> f64 { let selected = left.min(right); selected + other }\n";
-    let custom_rust_min = "struct Wrap(i64);\nimpl Wrap { fn min(&self, _right: i64) -> i64 { 0 } }\npub fn f(left: Wrap, right: i64, other: i64) -> i64 { let selected = left.min(right); selected + other }\n";
-    let custom_rust_max = "struct Wrap(i64);\nimpl Wrap { fn max(&self, _right: i64) -> i64 { 0 } }\npub fn f(left: Wrap, right: i64, other: i64) -> i64 { let selected = left.max(right); selected + other }\n";
 
     let fp = value_fp(&i, py_min, Lang::Python);
     assert_eq!(fp, value_fp(&i, py_min_call, Lang::Python));
@@ -1310,6 +1299,26 @@ fn scalar_minmax_builtins_converge_cross_language_with_shadow_boundary() {
         value_fp(&i, rust_max, Lang::Rust)
     );
     assert_ne!(fp, value_fp(&i, py_wrong_value, Lang::Python));
+}
+
+#[test]
+fn scalar_minmax_builtins_respect_shadow_boundaries() {
+    let i = Interner::new();
+    let py_min = "def f(left, right, other):\n    selected = left if left <= right else right\n    return selected + other\n";
+    let py_max = "def f(left, right, other):\n    selected = left if left >= right else right\n    return selected + other\n";
+    let py_shadowed_min =
+        "def min(_left, _right):\n    return 0\n\ndef f(left, right, other):\n    selected = min(left, right)\n    return selected + other\n";
+    let py_local_shadowed_min =
+        "def f(left, right, other):\n    min = lambda _left, _right: 0\n    selected = min(left, right)\n    return selected + other\n";
+    let shadowed_js = "function f(left, right, other) { const Math = { min: function(_left, _right) { return 0; } }; const selected = Math.min(left, right); return selected + other; }";
+    let destructured_shadowed_js = "function f(scope, left, right, other) { const { Math } = scope; const selected = Math.min(left, right); return selected + other; }";
+    let java_shadowed_math_type = "class C { static int f(int left, int right, int other) { int selected = Math.min(left, right); return selected + other; } }\nclass Math { static int min(int left, int right) { return 0; } }\n";
+    let ts_number_method_min = "function f(left: number, right: number, other: number): number { const selected = left.min(right); return selected + other; }";
+    let rust_float_min = "pub fn f(left: f64, right: f64, other: f64) -> f64 { let selected = left.min(right); selected + other }\n";
+    let custom_rust_min = "struct Wrap(i64);\nimpl Wrap { fn min(&self, _right: i64) -> i64 { 0 } }\npub fn f(left: Wrap, right: i64, other: i64) -> i64 { let selected = left.min(right); selected + other }\n";
+    let custom_rust_max = "struct Wrap(i64);\nimpl Wrap { fn max(&self, _right: i64) -> i64 { 0 } }\npub fn f(left: Wrap, right: i64, other: i64) -> i64 { let selected = left.max(right); selected + other }\n";
+
+    let fp = value_fp(&i, py_min, Lang::Python);
     assert_ne!(fp, value_fp(&i, py_shadowed_min, Lang::Python));
     assert_ne!(fp, value_fp(&i, py_local_shadowed_min, Lang::Python));
     assert_ne!(fp, value_fp(&i, shadowed_js, Lang::JavaScript));
@@ -2368,7 +2377,7 @@ fn multi_clause_comprehension_converges_as_flat_map() {
 /// mapped collection. Keep this bridge explicit so FlatMap is not accidentally treated as
 /// the filtered-Map representation (`Hof(Map, [contrib, pred])`).
 #[test]
-fn flat_map_aggregate_converges_with_nested_reduction_loop() {
+fn flat_map_sum_aggregate_converges_with_nested_reduction_loop() {
     let i = Interner::new();
     let sum_gen = value_fp(
         &i,
@@ -2395,6 +2404,28 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
         "def nested(xs, ys):\n    return sum([x + y for y in ys] for x in xs)\n",
         Lang::Python,
     );
+
+    assert_eq!(
+        sum_gen, sum_loop,
+        "sum over a flat-map generator should match the nested reduction loop"
+    );
+    assert_eq!(
+        sum_gen, sum_js,
+        "sum over a flatMap/map chain should match the flattened reduction"
+    );
+    assert_ne!(
+        sum_gen, wrong_seed,
+        "changing the additive seed changes aggregate behavior"
+    );
+    assert_ne!(
+        sum_gen, nested_list,
+        "aggregating nested list rows is not aggregating the flattened stream"
+    );
+}
+
+#[test]
+fn flat_map_max_aggregate_keeps_loop_seed_behavior_defining() {
+    let i = Interner::new();
     let max_gen = value_fp(
         &i,
         "def f(xs, ys):\n    return max(x + y for x in xs for y in ys)\n",
@@ -2410,6 +2441,23 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
         "def h(left, right):\n    top = 0\n    for a in left:\n        for b in right:\n            cand = a + b\n            if cand > top:\n                top = cand\n    return top\n",
         Lang::Python,
     );
+
+    // `max(gen)` errs on empty input and tracks all-negative maxima; a `best = 0`
+    // seeded loop clamps at 0 in both cases. The seed is behavior-defining, so the
+    // two must NOT merge — while equal-seeded loops still converge with each other.
+    assert_ne!(
+        max_gen, max_loop,
+        "a zero-seeded selection loop clamps at its seed; true max(...) does not"
+    );
+    assert_eq!(
+        max_loop, max_loop_same_seed,
+        "equally-seeded nested selection loops should still converge"
+    );
+}
+
+#[test]
+fn flat_map_any_aggregate_converges_with_nested_early_return_loop() {
+    let i = Interner::new();
     let any_gen = value_fp(
         &i,
         "def f(xs, ys):\n    return any(x + y > 0 for x in xs for y in ys)\n",
@@ -2425,6 +2473,20 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
         "def bad(xs, ys):\n    return any(x + y < 0 for x in xs for y in ys)\n",
         Lang::Python,
     );
+
+    assert_eq!(
+        any_gen, any_loop,
+        "any over a flat-map generator should match the nested early-return loop"
+    );
+    assert_ne!(
+        any_gen, any_bad_predicate,
+        "changing the flattened any predicate changes behavior"
+    );
+}
+
+#[test]
+fn flat_map_outer_independent_aggregate_keeps_outer_cardinality() {
+    let i = Interner::new();
     let outer_independent_flat = value_fp(
         &i,
         "def f(xs, ys):\n    return sum(y for x in xs for y in ys)\n",
@@ -2440,6 +2502,20 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
         "def h(xs, ys):\n    return sum(y for y in ys)\n",
         Lang::Python,
     );
+
+    assert_ne!(
+        outer_independent_flat, direct_inner_sum,
+        "a flat-map aggregate that ignores the outer value still depends on outer cardinality"
+    );
+    assert_ne!(
+        outer_independent_loop, direct_inner_sum,
+        "a nested loop that ignores the outer value still depends on outer cardinality"
+    );
+}
+
+#[test]
+fn filtered_flat_map_sum_converges_with_nested_guarded_reduction() {
+    let i = Interner::new();
     let filtered_sum_gen = value_fp(
         &i,
         "def f(xs, ys):\n    return sum(x + y for x in xs if x > 0 for y in ys if y < 10)\n",
@@ -2465,6 +2541,28 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
         "def bad(xs, ys):\n    return sum(x + y for x in xs if x > 0 for y in ys if False)\n",
         Lang::Python,
     );
+
+    assert_eq!(
+        filtered_sum_gen, filtered_sum_loop,
+        "filtered flat-map sums should match equivalent nested guarded reductions"
+    );
+    assert_eq!(
+        filtered_sum_gen, filtered_sum_js,
+        "filtered flatMap().reduce() should preserve carried outer and inner predicates"
+    );
+    assert_ne!(
+        filtered_sum_gen, filtered_sum_outer_changed,
+        "changing the outer flat-map aggregate predicate changes behavior"
+    );
+    assert_ne!(
+        filtered_sum_gen, filtered_sum_inner_changed,
+        "changing the inner flat-map aggregate predicate changes behavior"
+    );
+}
+
+#[test]
+fn filtered_flat_map_any_all_converge_with_nested_guarded_loops() {
+    let i = Interner::new();
     let filtered_any_gen = value_fp(
         &i,
         "def f(xs, ys):\n    return any(x + y > 0 for x in xs if x > 0 for y in ys if y < 10)\n",
@@ -2506,65 +2604,6 @@ fn flat_map_aggregate_converges_with_nested_reduction_loop() {
         Lang::TypeScript,
     );
 
-    assert_eq!(
-        sum_gen, sum_loop,
-        "sum over a flat-map generator should match the nested reduction loop"
-    );
-    assert_eq!(
-        sum_gen, sum_js,
-        "sum over a flatMap/map chain should match the flattened reduction"
-    );
-    assert_ne!(
-        sum_gen, wrong_seed,
-        "changing the additive seed changes aggregate behavior"
-    );
-    assert_ne!(
-        sum_gen, nested_list,
-        "aggregating nested list rows is not aggregating the flattened stream"
-    );
-    // `max(gen)` errs on empty input and tracks all-negative maxima; a `best = 0`
-    // seeded loop clamps at 0 in both cases. The seed is behavior-defining, so the
-    // two must NOT merge — while equal-seeded loops still converge with each other.
-    assert_ne!(
-        max_gen, max_loop,
-        "a zero-seeded selection loop clamps at its seed; true max(...) does not"
-    );
-    assert_eq!(
-        max_loop, max_loop_same_seed,
-        "equally-seeded nested selection loops should still converge"
-    );
-    assert_eq!(
-        any_gen, any_loop,
-        "any over a flat-map generator should match the nested early-return loop"
-    );
-    assert_ne!(
-        any_gen, any_bad_predicate,
-        "changing the flattened any predicate changes behavior"
-    );
-    assert_ne!(
-        outer_independent_flat, direct_inner_sum,
-        "a flat-map aggregate that ignores the outer value still depends on outer cardinality"
-    );
-    assert_ne!(
-        outer_independent_loop, direct_inner_sum,
-        "a nested loop that ignores the outer value still depends on outer cardinality"
-    );
-    assert_eq!(
-        filtered_sum_gen, filtered_sum_loop,
-        "filtered flat-map sums should match equivalent nested guarded reductions"
-    );
-    assert_eq!(
-        filtered_sum_gen, filtered_sum_js,
-        "filtered flatMap().reduce() should preserve carried outer and inner predicates"
-    );
-    assert_ne!(
-        filtered_sum_gen, filtered_sum_outer_changed,
-        "changing the outer flat-map aggregate predicate changes behavior"
-    );
-    assert_ne!(
-        filtered_sum_gen, filtered_sum_inner_changed,
-        "changing the inner flat-map aggregate predicate changes behavior"
-    );
     assert_eq!(
         filtered_any_gen, filtered_any_js,
         "method terminal predicates over filtered flatMap should preserve carried predicates"
@@ -2677,50 +2716,6 @@ fn rust_filter_map_converges_with_filtered_map_and_guarded_builder() {
         "fn f(xs: &[i32]) -> Vec<i32> { xs.iter().copied().filter_map(|x| if x > 0 { Some(x * 3) } else { None }).collect() }",
         Lang::Rust,
     );
-    let falsey_py = value_fp(
-        &i,
-        "def f(xs):\n    return [0 for x in xs if x > 0]\n",
-        Lang::Python,
-    );
-    let filtered_none_py = value_fp(
-        &i,
-        "def f(xs):\n    return [None for x in xs if x > 0]\n",
-        Lang::Python,
-    );
-    let falsey_rs = value_fp(
-        &i,
-        "fn f(xs: &[i32]) -> Vec<i32> { xs.iter().copied().filter_map(|x| if x > 0 { Some(0) } else { None }).collect() }",
-        Lang::Rust,
-    );
-    let wrapped_none_rs = value_fp(
-        &i,
-        "fn f(xs: &[i32]) -> Vec<Option<i32>> { xs.iter().copied().filter_map(|x| if x > 0 { Some(None) } else { None }).collect() }",
-        Lang::Rust,
-    );
-    let dropped_falsey_rs = value_fp(
-        &i,
-        "fn f(xs: &[i32]) -> Vec<i32> { xs.iter().copied().filter_map(|x| if x > 0 { Some(0) } else { None }).filter(|x| *x != 0).collect() }",
-        Lang::Rust,
-    );
-    let shadowed_some_rs = value_fp_named(
-        &i,
-        "fn Some(_value: i32) -> Option<i32> { None }\nfn f(xs: &[i32]) -> Vec<i32> { xs.iter().copied().filter_map(|x| if x > 0 { Some(x * 2) } else { None }).collect() }",
-        Lang::Rust,
-        "f",
-    );
-    let shadowed_none_rs = value_fp_named(
-        &i,
-        "const None: Option<i32> = Some(0);\nfn f(xs: &[i32]) -> Vec<i32> { xs.iter().copied().filter_map(|x| if x > 0 { Some(x * 2) } else { None }).collect() }",
-        Lang::Rust,
-        "f",
-    );
-    let shadowed_vec_rs = value_fp_named(
-        &i,
-        "struct Vec;\nimpl Vec { fn new() -> Vec { Vec } fn push(&self, _value: i32) {} }\nfn f(xs: &[i32]) -> Vec { let out = Vec::new(); for x in xs { if *x > 0 { out.push(*x * 2); } } out }",
-        Lang::Rust,
-        "f",
-    );
-
     assert_ne!(
         filtered_py, filtered_js,
         "untyped JS parameter method calls lack a receiver proof and must stay opaque"
@@ -2753,6 +2748,42 @@ fn rust_filter_map_converges_with_filtered_map_and_guarded_builder() {
         filtered_py, changed_value_rs,
         "changing the emitted Some value must stay distinct"
     );
+}
+
+#[test]
+fn rust_filter_map_keeps_falsey_and_none_payload_boundaries() {
+    let i = Interner::new();
+    let filtered_py = value_fp(
+        &i,
+        "def f(xs):\n    return [x * 2 for x in xs if x > 0]\n",
+        Lang::Python,
+    );
+    let falsey_py = value_fp(
+        &i,
+        "def f(xs):\n    return [0 for x in xs if x > 0]\n",
+        Lang::Python,
+    );
+    let filtered_none_py = value_fp(
+        &i,
+        "def f(xs):\n    return [None for x in xs if x > 0]\n",
+        Lang::Python,
+    );
+    let falsey_rs = value_fp(
+        &i,
+        "fn f(xs: &[i32]) -> Vec<i32> { xs.iter().copied().filter_map(|x| if x > 0 { Some(0) } else { None }).collect() }",
+        Lang::Rust,
+    );
+    let wrapped_none_rs = value_fp(
+        &i,
+        "fn f(xs: &[i32]) -> Vec<Option<i32>> { xs.iter().copied().filter_map(|x| if x > 0 { Some(None) } else { None }).collect() }",
+        Lang::Rust,
+    );
+    let dropped_falsey_rs = value_fp(
+        &i,
+        "fn f(xs: &[i32]) -> Vec<i32> { xs.iter().copied().filter_map(|x| if x > 0 { Some(0) } else { None }).filter(|x| *x != 0).collect() }",
+        Lang::Rust,
+    );
+
     assert_eq!(
         falsey_py, falsey_rs,
         "Some(0) is an emitted value, not an absence sentinel"
@@ -2769,6 +2800,35 @@ fn rust_filter_map_converges_with_filtered_map_and_guarded_builder() {
         falsey_rs, dropped_falsey_rs,
         "truthy filtering after emitting 0 must stay distinct"
     );
+}
+
+#[test]
+fn rust_filter_map_respects_shadowed_std_name_boundaries() {
+    let i = Interner::new();
+    let filtered_py = value_fp(
+        &i,
+        "def f(xs):\n    return [x * 2 for x in xs if x > 0]\n",
+        Lang::Python,
+    );
+    let shadowed_some_rs = value_fp_named(
+        &i,
+        "fn Some(_value: i32) -> Option<i32> { None }\nfn f(xs: &[i32]) -> Vec<i32> { xs.iter().copied().filter_map(|x| if x > 0 { Some(x * 2) } else { None }).collect() }",
+        Lang::Rust,
+        "f",
+    );
+    let shadowed_none_rs = value_fp_named(
+        &i,
+        "const None: Option<i32> = Some(0);\nfn f(xs: &[i32]) -> Vec<i32> { xs.iter().copied().filter_map(|x| if x > 0 { Some(x * 2) } else { None }).collect() }",
+        Lang::Rust,
+        "f",
+    );
+    let shadowed_vec_rs = value_fp_named(
+        &i,
+        "struct Vec;\nimpl Vec { fn new() -> Vec { Vec } fn push(&self, _value: i32) {} }\nfn f(xs: &[i32]) -> Vec { let out = Vec::new(); for x in xs { if *x > 0 { out.push(*x * 2); } } out }",
+        Lang::Rust,
+        "f",
+    );
+
     assert_ne!(
         filtered_py, shadowed_some_rs,
         "a local Rust Some definition must not be treated as Option::Some"
@@ -2905,6 +2965,19 @@ fn corpus_value_fp(corpus: &Corpus, path_suffix: &str, name: &str) -> Vec<u64> {
         .map(|unit| unit.root)
         .unwrap_or_else(|| panic!("expected function unit named {name} in {path_suffix}"));
     nose_normalize::value_fingerprint(&n, root, &corpus.interner)
+}
+
+/// Write `files` into a fresh per-process temp dir named after `tag` and lower
+/// them together as one corpus. Callers remove the returned dir when done.
+fn lower_temp_corpus(tag: &str, files: &[(&str, &str)]) -> (std::path::PathBuf, Corpus) {
+    let dir = std::env::temp_dir().join(format!("{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    for (name, contents) in files {
+        std::fs::write(dir.join(name), contents).unwrap();
+    }
+    let corpus = nose_frontend::lower_corpus_many(&[dir.as_path()]);
+    (dir, corpus)
 }
 
 #[test]
@@ -3550,7 +3623,7 @@ fn value_graph_distinguishes_membership_and_negation() {
 }
 
 #[test]
-fn map_key_membership_converges_cross_language_with_boundaries() {
+fn map_key_membership_converges_cross_language() {
     let i = Interner::new();
     let py = "def f(lookup, other_lookup, key, other):\n    return key in lookup\n";
     let py_method =
@@ -3567,19 +3640,6 @@ fn map_key_membership_converges_cross_language_with_boundaries() {
     let ts_array_from_keys = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return Array.from(lookup.keys()).includes(key); }";
     let ts_direct_keys_includes = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return lookup.keys().includes(key); }";
     let typed_set_same_names = "function f(lookup: Set<string>, other_lookup: Set<string>, key: string, other: string): boolean { return lookup.has(key); }";
-    let wrong_key =
-        "def f(lookup, other_lookup, key, other):\n    return lookup.__contains__(other)\n";
-    let wrong_map =
-        "def f(lookup, other_lookup, key, other):\n    return other_lookup.__contains__(key)\n";
-    let value_membership =
-        "def f(lookup, other_lookup, key, other):\n    return key in lookup.values()\n";
-    let py_keys_wrong_key = "def f(lookup: dict[str, str], other_lookup: dict[str, str], key: str, other: str) -> bool:\n    return other in lookup.keys()\n";
-    let py_keys_wrong_map = "def f(lookup: dict[str, str], other_lookup: dict[str, str], key: str, other: str) -> bool:\n    return key in other_lookup.keys()\n";
-    let py_values_view = "def f(lookup: dict[str, str], other_lookup: dict[str, str], key: str, other: str) -> bool:\n    return key in lookup.values()\n";
-    let ts_array_from_keys_wrong_key = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return Array.from(lookup.keys()).includes(other); }";
-    let ts_array_from_keys_wrong_map = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return Array.from(other_lookup.keys()).includes(key); }";
-    let ts_array_from_values = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return Array.from(lookup.values()).includes(key); }";
-    let ts_array_from_shadowed_array = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string, Array: any): boolean { return Array.from(lookup.keys()).includes(key); }";
 
     let fp = value_fp(&i, py, Lang::Python);
     assert_ne!(fp, value_fp(&i, py_method, Lang::Python));
@@ -3599,6 +3659,27 @@ fn map_key_membership_converges_cross_language_with_boundaries() {
         "Map.keys() is an iterator view; direct .includes is not a proven key-view collection"
     );
     assert_ne!(fp, value_fp(&i, typed_set_same_names, Lang::TypeScript));
+}
+
+#[test]
+fn map_key_membership_keeps_wrong_coordinate_boundaries() {
+    let i = Interner::new();
+    let py = "def f(lookup, other_lookup, key, other):\n    return key in lookup\n";
+    let wrong_key =
+        "def f(lookup, other_lookup, key, other):\n    return lookup.__contains__(other)\n";
+    let wrong_map =
+        "def f(lookup, other_lookup, key, other):\n    return other_lookup.__contains__(key)\n";
+    let value_membership =
+        "def f(lookup, other_lookup, key, other):\n    return key in lookup.values()\n";
+    let py_keys_wrong_key = "def f(lookup: dict[str, str], other_lookup: dict[str, str], key: str, other: str) -> bool:\n    return other in lookup.keys()\n";
+    let py_keys_wrong_map = "def f(lookup: dict[str, str], other_lookup: dict[str, str], key: str, other: str) -> bool:\n    return key in other_lookup.keys()\n";
+    let py_values_view = "def f(lookup: dict[str, str], other_lookup: dict[str, str], key: str, other: str) -> bool:\n    return key in lookup.values()\n";
+    let ts_array_from_keys_wrong_key = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return Array.from(lookup.keys()).includes(other); }";
+    let ts_array_from_keys_wrong_map = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return Array.from(other_lookup.keys()).includes(key); }";
+    let ts_array_from_values = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string): boolean { return Array.from(lookup.values()).includes(key); }";
+    let ts_array_from_shadowed_array = "function f(lookup: Map<string, string>, other_lookup: Map<string, string>, key: string, other: string, Array: any): boolean { return Array.from(lookup.keys()).includes(key); }";
+
+    let fp = value_fp(&i, py, Lang::Python);
     assert_ne!(fp, value_fp(&i, wrong_key, Lang::Python));
     assert_ne!(fp, value_fp(&i, wrong_map, Lang::Python));
     assert_ne!(fp, value_fp(&i, value_membership, Lang::Python));
@@ -4410,6 +4491,26 @@ fn literal_map_default_lookup_converges_with_go_literal_map_index_boundaries() {
     let py_int_key_literal = "def f(key, other):\n    return {0: 1, 1: 2}.get(key, 0)\n";
     let go_keyed_slice =
         "package p\n\nfunc F(key int, other int) int { return []int{0: 1, 1: 2}[key] }\n";
+    let go_string_inline =
+        "package p\n\nfunc F(key string, other string) string { return map[string]string{\"red\": \"apple\", \"blue\": \"berry\"}[key] }\n";
+
+    let fp = value_fp(&i, py_literal, Lang::Python);
+    assert_eq!(fp, value_fp(&i, ruby_literal, Lang::Ruby));
+    assert_eq!(fp, value_fp(&i, go_inline, Lang::Go));
+    assert_eq!(fp, value_fp(&i, go_local, Lang::Go));
+    assert_eq!(fp, value_fp(&i, go_var, Lang::Go));
+    assert_ne!(fp, value_fp(&i, go_wrong_key, Lang::Go));
+    assert_ne!(fp, value_fp(&i, go_wrong_map, Lang::Go));
+    assert_ne!(
+        value_fp(&i, py_int_key_literal, Lang::Python),
+        value_fp(&i, go_keyed_slice, Lang::Go)
+    );
+    assert_ne!(fp, value_fp(&i, go_string_inline, Lang::Go));
+}
+
+#[test]
+fn literal_map_default_lookup_converges_with_go_literal_string_map_boundaries() {
+    let i = Interner::new();
     let py_string_literal =
         "def f(key, other):\n    return {\"red\": \"apple\", \"blue\": \"berry\"}.get(key, \"\")\n";
     let ruby_string_literal =
@@ -4424,6 +4525,24 @@ fn literal_map_default_lookup_converges_with_go_literal_map_index_boundaries() {
         "def f(key, other):\n    return {0: \"apple\", 1: \"berry\"}.get(key, \"\")\n";
     let go_string_keyed_slice =
         "package p\n\nfunc F(key int, other int) string { return []string{0: \"apple\", 1: \"berry\"}[key] }\n";
+    let go_mixed_value =
+        "package p\n\nfunc F(key string, other string) interface{} { return map[string]interface{}{\"red\": \"apple\", \"blue\": false}[key] }\n";
+
+    let string_fp = value_fp(&i, py_string_literal, Lang::Python);
+    assert_eq!(string_fp, value_fp(&i, ruby_string_literal, Lang::Ruby));
+    assert_eq!(string_fp, value_fp(&i, go_string_inline, Lang::Go));
+    assert_eq!(string_fp, value_fp(&i, go_string_local, Lang::Go));
+    assert_ne!(string_fp, value_fp(&i, go_string_wrong_key, Lang::Go));
+    assert_ne!(string_fp, value_fp(&i, go_mixed_value, Lang::Go));
+    assert_ne!(
+        value_fp(&i, py_string_int_key_literal, Lang::Python),
+        value_fp(&i, go_string_keyed_slice, Lang::Go)
+    );
+}
+
+#[test]
+fn literal_map_default_lookup_converges_with_go_literal_scalar_map_boundaries() {
+    let i = Interner::new();
     let py_bool_literal =
         "def f(key, other):\n    return {\"red\": True, \"blue\": False}.get(key, False)\n";
     let ruby_bool_literal =
@@ -4450,32 +4569,6 @@ fn literal_map_default_lookup_converges_with_go_literal_map_index_boundaries() {
         "package p\n\ntype Item struct{}\n\nfunc F(key string, other string) *Item { return map[string]*Item{\"red\": nil, \"blue\": nil}[key] }\n";
     let go_nil_wrong_map =
         "package p\n\nfunc F(key string, other string) string { return map[string]string{\"red\": \"apple\", \"blue\": \"berry\"}[key] }\n";
-    let go_mixed_value =
-        "package p\n\nfunc F(key string, other string) interface{} { return map[string]interface{}{\"red\": \"apple\", \"blue\": false}[key] }\n";
-
-    let fp = value_fp(&i, py_literal, Lang::Python);
-    assert_eq!(fp, value_fp(&i, ruby_literal, Lang::Ruby));
-    assert_eq!(fp, value_fp(&i, go_inline, Lang::Go));
-    assert_eq!(fp, value_fp(&i, go_local, Lang::Go));
-    assert_eq!(fp, value_fp(&i, go_var, Lang::Go));
-    assert_ne!(fp, value_fp(&i, go_wrong_key, Lang::Go));
-    assert_ne!(fp, value_fp(&i, go_wrong_map, Lang::Go));
-    assert_ne!(
-        value_fp(&i, py_int_key_literal, Lang::Python),
-        value_fp(&i, go_keyed_slice, Lang::Go)
-    );
-    assert_ne!(fp, value_fp(&i, go_string_inline, Lang::Go));
-
-    let string_fp = value_fp(&i, py_string_literal, Lang::Python);
-    assert_eq!(string_fp, value_fp(&i, ruby_string_literal, Lang::Ruby));
-    assert_eq!(string_fp, value_fp(&i, go_string_inline, Lang::Go));
-    assert_eq!(string_fp, value_fp(&i, go_string_local, Lang::Go));
-    assert_ne!(string_fp, value_fp(&i, go_string_wrong_key, Lang::Go));
-    assert_ne!(string_fp, value_fp(&i, go_mixed_value, Lang::Go));
-    assert_ne!(
-        value_fp(&i, py_string_int_key_literal, Lang::Python),
-        value_fp(&i, go_string_keyed_slice, Lang::Go)
-    );
 
     let bool_fp = value_fp(&i, py_bool_literal, Lang::Python);
     assert_eq!(bool_fp, value_fp(&i, ruby_bool_literal, Lang::Ruby));
@@ -4522,72 +4615,56 @@ fn literal_map_default_lookup_converges_with_module_map_bindings() {
 
 #[test]
 fn literal_map_default_lookup_converges_with_imported_python_literal_binding() {
-    let dir =
-        std::env::temp_dir().join(format!("nose_imported_map_default_{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(
-        dir.join("local.py"),
-        "def lookup(key, other):\n    return {\"red\": 1, \"blue\": 2}.get(key, 0)\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("tables.py"),
-        "LOOKUP = {\"red\": 1, \"blue\": 2}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("imported.py"),
-        "from tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("wrong_map.py"),
-        "from tables import LOOKUP\n\ndef lookup(key, other):\n    return {\"red\": 9, \"blue\": 2}.get(key, 0)\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("mutated_tables.py"),
-        "LOOKUP = {\"red\": 1, \"blue\": 2}\nLOOKUP.clear()\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("mutated_index_tables.py"),
-        "LOOKUP = {\"red\": 1, \"blue\": 2}\nLOOKUP[\"red\"] = 9\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("escaped_tables.py"),
-        "LOOKUP = {\"red\": 1, \"blue\": 2}\nmutate(LOOKUP)\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("imported_mutated_provider.py"),
-        "from mutated_tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("imported_mutated_index_provider.py"),
-        "from mutated_index_tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("imported_escaped_provider.py"),
-        "from escaped_tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("imported_mutated_receiver.py"),
-        "from tables import LOOKUP\nLOOKUP.clear()\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("imported_mutated_index_receiver.py"),
-        "from tables import LOOKUP\nLOOKUP[\"red\"] = 9\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
-    )
-    .unwrap();
-
-    let corpus = nose_frontend::lower_corpus_many(&[dir.as_path()]);
+    let (dir, corpus) = lower_temp_corpus(
+        "nose_imported_map_default",
+        &[
+            (
+                "local.py",
+                "def lookup(key, other):\n    return {\"red\": 1, \"blue\": 2}.get(key, 0)\n",
+            ),
+            ("tables.py", "LOOKUP = {\"red\": 1, \"blue\": 2}\n"),
+            (
+                "imported.py",
+                "from tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
+            ),
+            (
+                "wrong_map.py",
+                "from tables import LOOKUP\n\ndef lookup(key, other):\n    return {\"red\": 9, \"blue\": 2}.get(key, 0)\n",
+            ),
+            (
+                "mutated_tables.py",
+                "LOOKUP = {\"red\": 1, \"blue\": 2}\nLOOKUP.clear()\n",
+            ),
+            (
+                "mutated_index_tables.py",
+                "LOOKUP = {\"red\": 1, \"blue\": 2}\nLOOKUP[\"red\"] = 9\n",
+            ),
+            (
+                "escaped_tables.py",
+                "LOOKUP = {\"red\": 1, \"blue\": 2}\nmutate(LOOKUP)\n",
+            ),
+            (
+                "imported_mutated_provider.py",
+                "from mutated_tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
+            ),
+            (
+                "imported_mutated_index_provider.py",
+                "from mutated_index_tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
+            ),
+            (
+                "imported_escaped_provider.py",
+                "from escaped_tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
+            ),
+            (
+                "imported_mutated_receiver.py",
+                "from tables import LOOKUP\nLOOKUP.clear()\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
+            ),
+            (
+                "imported_mutated_index_receiver.py",
+                "from tables import LOOKUP\nLOOKUP[\"red\"] = 9\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
+            ),
+        ],
+    );
     let local = corpus_value_fp(&corpus, "local.py", "lookup");
     assert_eq!(
         local,
@@ -4629,120 +4706,48 @@ fn literal_map_default_lookup_converges_with_imported_python_literal_binding() {
 }
 
 #[test]
-fn literal_map_default_lookup_converges_with_non_python_imported_bindings() {
-    let dir = std::env::temp_dir().join(format!(
-        "nose_imported_non_python_map_default_{}",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(
-        dir.join("local.py"),
-        "def lookup(key, other):\n    return {\"red\": 1, \"blue\": 2}.get(key, 0)\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("js_tables.js"),
-        "export const LOOKUP = new Map([[\"red\", 1], [\"blue\", 2]]);\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("js_imported.js"),
-        "import { LOOKUP } from './js_tables';\nexport function lookup(key, other) {\n  return LOOKUP.get(key) ?? 0;\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("js_mutated_tables.js"),
-        "export const LOOKUP = new Map([[\"red\", 1], [\"blue\", 2]]);\nLOOKUP.set(\"red\", 9);\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("js_imported_mutated_provider.js"),
-        "import { LOOKUP } from './js_mutated_tables';\nexport function lookup(key, other) {\n  return LOOKUP.get(key) ?? 0;\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("js_imported_mutated_receiver.js"),
-        "import { LOOKUP } from './js_tables';\nLOOKUP.set(\"red\", 9);\nexport function lookup(key, other) {\n  return LOOKUP.get(key) ?? 0;\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("js_wrong_map.js"),
-        "import { LOOKUP } from './js_tables';\nexport function lookup(key, other) {\n  return new Map([[\"red\", 9], [\"blue\", 2]]).get(key) ?? 0;\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("ts_tables.ts"),
-        "export const LOOKUP = new Map<string, number>([[\"red\", 1], [\"blue\", 2]]);\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("ts_imported.ts"),
-        "import { LOOKUP } from './ts_tables';\nexport function lookup(key: string, other: string): number {\n  return LOOKUP.get(key) ?? 0;\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("Tables.java"),
-        "import java.util.Map;\n\nclass Tables {\n  static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2);\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("JavaImported.java"),
-        "import static Tables.LOOKUP;\n\nclass JavaImported {\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("JavaImportedWithLocalMapShadow.java"),
-        "import static Tables.LOOKUP;\n\nclass JavaImportedWithLocalMapShadow {\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n\nclass Map {}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("WrongTables.java"),
-        "import java.util.Map;\n\nclass WrongTables {\n  static final Map<String, Integer> LOOKUP = Map.of(\"red\", 9, \"blue\", 2);\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("JavaImportedWrongMap.java"),
-        "import static WrongTables.LOOKUP;\n\nclass JavaImportedWrongMap {\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("MissingMapImportTables.java"),
-        "class MissingMapImportTables {\n  static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2);\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("JavaImportedMissingMapImport.java"),
-        "import static MissingMapImportTables.LOOKUP;\n\nclass JavaImportedMissingMapImport {\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("tables.rs"),
-        "pub const LOOKUP: [(&str, i32); 2] = [(\"red\", 1), (\"blue\", 2)];\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("rust_imported.rs"),
-        "use tables::LOOKUP;\n\npub fn lookup(key: &str, other: &str) -> i32 {\n    *std::collections::HashMap::from(LOOKUP).get(key).unwrap_or(&0)\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("rust_imported_shadowed_std.rs"),
-        "use tables::LOOKUP;\n\nmod std { pub mod collections { pub struct HashMap; } }\n\npub fn lookup(key: &str, other: &str) -> i32 {\n    *std::collections::HashMap::from(LOOKUP).get(key).unwrap_or(&0)\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("wrong_tables.rs"),
-        "pub const LOOKUP: [(&str, i32); 2] = [(\"red\", 9), (\"blue\", 2)];\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("rust_imported_wrong_map.rs"),
-        "use wrong_tables::LOOKUP;\n\npub fn lookup(key: &str, other: &str) -> i32 {\n    *std::collections::HashMap::from(LOOKUP).get(key).unwrap_or(&0)\n}\n",
-    )
-    .unwrap();
-
-    let corpus = nose_frontend::lower_corpus_many(&[dir.as_path()]);
+fn literal_map_default_lookup_converges_with_js_ts_imported_bindings() {
+    let (dir, corpus) = lower_temp_corpus(
+        "nose_imported_js_ts_map_default",
+        &[
+            (
+                "local.py",
+                "def lookup(key, other):\n    return {\"red\": 1, \"blue\": 2}.get(key, 0)\n",
+            ),
+            (
+                "js_tables.js",
+                "export const LOOKUP = new Map([[\"red\", 1], [\"blue\", 2]]);\n",
+            ),
+            (
+                "js_imported.js",
+                "import { LOOKUP } from './js_tables';\nexport function lookup(key, other) {\n  return LOOKUP.get(key) ?? 0;\n}\n",
+            ),
+            (
+                "js_mutated_tables.js",
+                "export const LOOKUP = new Map([[\"red\", 1], [\"blue\", 2]]);\nLOOKUP.set(\"red\", 9);\n",
+            ),
+            (
+                "js_imported_mutated_provider.js",
+                "import { LOOKUP } from './js_mutated_tables';\nexport function lookup(key, other) {\n  return LOOKUP.get(key) ?? 0;\n}\n",
+            ),
+            (
+                "js_imported_mutated_receiver.js",
+                "import { LOOKUP } from './js_tables';\nLOOKUP.set(\"red\", 9);\nexport function lookup(key, other) {\n  return LOOKUP.get(key) ?? 0;\n}\n",
+            ),
+            (
+                "js_wrong_map.js",
+                "import { LOOKUP } from './js_tables';\nexport function lookup(key, other) {\n  return new Map([[\"red\", 9], [\"blue\", 2]]).get(key) ?? 0;\n}\n",
+            ),
+            (
+                "ts_tables.ts",
+                "export const LOOKUP = new Map<string, number>([[\"red\", 1], [\"blue\", 2]]);\n",
+            ),
+            (
+                "ts_imported.ts",
+                "import { LOOKUP } from './ts_tables';\nexport function lookup(key: string, other: string): number {\n  return LOOKUP.get(key) ?? 0;\n}\n",
+            ),
+        ],
+    );
     let local = corpus_value_fp(&corpus, "local.py", "lookup");
     assert_ne!(
         local,
@@ -4753,26 +4758,6 @@ fn literal_map_default_lookup_converges_with_non_python_imported_bindings() {
         local,
         corpus_value_fp(&corpus, "ts_imported.ts", "lookup"),
         "TS imported Map bindings stay closed until constructor/provenance proof exists"
-    );
-    assert_eq!(
-        local,
-        corpus_value_fp(&corpus, "JavaImported.java", "lookup"),
-        "Java static import should prove the same literal map/default coordinates"
-    );
-    assert_eq!(
-        local,
-        corpus_value_fp(&corpus, "JavaImportedWithLocalMapShadow.java", "lookup"),
-        "provider-proven Java static import should not be invalidated by importer-local Map shadowing"
-    );
-    assert_eq!(
-        local,
-        corpus_value_fp(&corpus, "rust_imported.rs", "lookup"),
-        "Rust use-imported const entries should prove the same map/default coordinates"
-    );
-    assert_ne!(
-        local,
-        corpus_value_fp(&corpus, "rust_imported_shadowed_std.rs", "lookup"),
-        "a local Rust std module must block imported std map factory provenance"
     );
     assert_ne!(
         local,
@@ -4789,6 +4774,60 @@ fn literal_map_default_lookup_converges_with_non_python_imported_bindings() {
         corpus_value_fp(&corpus, "js_wrong_map.js", "lookup"),
         "different JS map contents must stay distinct"
     );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn literal_map_default_lookup_converges_with_java_imported_bindings() {
+    let (dir, corpus) = lower_temp_corpus(
+        "nose_imported_java_map_default",
+        &[
+            (
+                "local.py",
+                "def lookup(key, other):\n    return {\"red\": 1, \"blue\": 2}.get(key, 0)\n",
+            ),
+            (
+                "Tables.java",
+                "import java.util.Map;\n\nclass Tables {\n  static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2);\n}\n",
+            ),
+            (
+                "JavaImported.java",
+                "import static Tables.LOOKUP;\n\nclass JavaImported {\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n",
+            ),
+            (
+                "JavaImportedWithLocalMapShadow.java",
+                "import static Tables.LOOKUP;\n\nclass JavaImportedWithLocalMapShadow {\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n\nclass Map {}\n",
+            ),
+            (
+                "WrongTables.java",
+                "import java.util.Map;\n\nclass WrongTables {\n  static final Map<String, Integer> LOOKUP = Map.of(\"red\", 9, \"blue\", 2);\n}\n",
+            ),
+            (
+                "JavaImportedWrongMap.java",
+                "import static WrongTables.LOOKUP;\n\nclass JavaImportedWrongMap {\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n",
+            ),
+            (
+                "MissingMapImportTables.java",
+                "class MissingMapImportTables {\n  static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2);\n}\n",
+            ),
+            (
+                "JavaImportedMissingMapImport.java",
+                "import static MissingMapImportTables.LOOKUP;\n\nclass JavaImportedMissingMapImport {\n  static int lookup(String key, String other) {\n    return LOOKUP.getOrDefault(key, 0);\n  }\n}\n",
+            ),
+        ],
+    );
+    let local = corpus_value_fp(&corpus, "local.py", "lookup");
+    assert_eq!(
+        local,
+        corpus_value_fp(&corpus, "JavaImported.java", "lookup"),
+        "Java static import should prove the same literal map/default coordinates"
+    );
+    assert_eq!(
+        local,
+        corpus_value_fp(&corpus, "JavaImportedWithLocalMapShadow.java", "lookup"),
+        "provider-proven Java static import should not be invalidated by importer-local Map shadowing"
+    );
     assert_ne!(
         local,
         corpus_value_fp(&corpus, "JavaImportedWrongMap.java", "lookup"),
@@ -4798,6 +4837,52 @@ fn literal_map_default_lookup_converges_with_non_python_imported_bindings() {
         local,
         corpus_value_fp(&corpus, "JavaImportedMissingMapImport.java", "lookup"),
         "Java imported Map.of provider must require java.util.Map proof"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn literal_map_default_lookup_converges_with_rust_imported_bindings() {
+    let (dir, corpus) = lower_temp_corpus(
+        "nose_imported_rust_map_default",
+        &[
+            (
+                "local.py",
+                "def lookup(key, other):\n    return {\"red\": 1, \"blue\": 2}.get(key, 0)\n",
+            ),
+            (
+                "tables.rs",
+                "pub const LOOKUP: [(&str, i32); 2] = [(\"red\", 1), (\"blue\", 2)];\n",
+            ),
+            (
+                "rust_imported.rs",
+                "use tables::LOOKUP;\n\npub fn lookup(key: &str, other: &str) -> i32 {\n    *std::collections::HashMap::from(LOOKUP).get(key).unwrap_or(&0)\n}\n",
+            ),
+            (
+                "rust_imported_shadowed_std.rs",
+                "use tables::LOOKUP;\n\nmod std { pub mod collections { pub struct HashMap; } }\n\npub fn lookup(key: &str, other: &str) -> i32 {\n    *std::collections::HashMap::from(LOOKUP).get(key).unwrap_or(&0)\n}\n",
+            ),
+            (
+                "wrong_tables.rs",
+                "pub const LOOKUP: [(&str, i32); 2] = [(\"red\", 9), (\"blue\", 2)];\n",
+            ),
+            (
+                "rust_imported_wrong_map.rs",
+                "use wrong_tables::LOOKUP;\n\npub fn lookup(key: &str, other: &str) -> i32 {\n    *std::collections::HashMap::from(LOOKUP).get(key).unwrap_or(&0)\n}\n",
+            ),
+        ],
+    );
+    let local = corpus_value_fp(&corpus, "local.py", "lookup");
+    assert_eq!(
+        local,
+        corpus_value_fp(&corpus, "rust_imported.rs", "lookup"),
+        "Rust use-imported const entries should prove the same map/default coordinates"
+    );
+    assert_ne!(
+        local,
+        corpus_value_fp(&corpus, "rust_imported_shadowed_std.rs", "lookup"),
+        "a local Rust std module must block imported std map factory provenance"
     );
     assert_ne!(
         local,
@@ -4839,7 +4924,7 @@ fn literal_map_default_lookup_converges_with_js_object_own_property_boundaries()
 }
 
 #[test]
-fn map_default_lookup_converges_cross_language_with_boundaries() {
+fn map_default_lookup_converges_cross_language() {
     let i = Interner::new();
     let go = "package p\n\nfunc F(lookup map[string]int, otherLookup map[string]int, key string, otherKey string, fallback int, otherDefault int) int { value, ok := lookup[key]; if !ok { value = fallback }; return value }\n";
     let java_explicit = "import java.util.Map;\n\nclass C { static int f(Map<String, Integer> lookup, Map<String, Integer> other_lookup, String key, String other_key, int fallback, int other_default) { return lookup.containsKey(key) ? lookup.get(key) : fallback; } }\n";
@@ -4858,26 +4943,6 @@ fn map_default_lookup_converges_cross_language_with_boundaries() {
     let py_alias_mapping = "from collections.abc import Mapping as MapLike\n\ndef f(lookup: MapLike[str, int], other_lookup: MapLike[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(key, fallback)\n";
     let py_alias_mutable_mapping = "from collections.abc import MutableMapping as MapLike\n\ndef f(lookup: MapLike[str, int], other_lookup: MapLike[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(key, fallback)\n";
     let py_alias_dict = "from typing import Dict as MapLike\n\ndef f(lookup: MapLike[str, int], other_lookup: MapLike[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(key, fallback)\n";
-    let wrong_key = "import java.util.Map;\n\nclass C { static int f(Map<String, Integer> lookup, Map<String, Integer> other_lookup, String key, String other_key, int fallback, int other_default) { return lookup.getOrDefault(other_key, fallback); } }\n";
-    let wrong_default = "use std::collections::HashMap;\n\npub fn f(lookup: &HashMap<&str, i32>, other_lookup: &HashMap<&str, i32>, key: &str, other_key: &str, fallback: i32, other_default: i32) -> i32 { *lookup.get(key).unwrap_or(&other_default) }\n";
-    let wrong_map = "package p\n\nfunc F(lookup map[string]int, otherLookup map[string]int, key string, otherKey string, fallback int, otherDefault int) int { value, ok := otherLookup[key]; if !ok { value = fallback }; return value }\n";
-    let ts_wrong_key = "function f(lookup: Map<string, number>, other_lookup: Map<string, number>, key: string, other_key: string, fallback: number, other_default: number): number { return lookup.get(other_key) ?? fallback; }\n";
-    let ts_wrong_default = "function f(lookup: Map<string, number>, other_lookup: Map<string, number>, key: string, other_key: string, fallback: number, other_default: number): number { return lookup.get(key) ?? other_default; }\n";
-    let ts_wrong_map = "function f(lookup: Map<string, number>, other_lookup: Map<string, number>, key: string, other_key: string, fallback: number, other_default: number): number { return other_lookup.get(key) ?? fallback; }\n";
-    let ts_untyped = "function f(lookup, other_lookup, key, other_key, fallback, other_default) { return lookup.get(key) ?? fallback; }\n";
-    let ts_temp_shadowed_undefined = "function f(lookup: Map<string, number>, other_lookup: Map<string, number>, key: string, other_key: string, fallback: number, other_default: number, undefined: number): number { const selected = lookup.get(key); return selected === undefined ? fallback : selected; }\n";
-    let py_wrong_key = "def f(lookup: dict[str, int], other_lookup: dict[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(other_key, fallback)\n";
-    let py_wrong_default = "def f(lookup: dict[str, int], other_lookup: dict[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(key, other_default)\n";
-    let py_wrong_map = "def f(lookup: dict[str, int], other_lookup: dict[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return other_lookup.get(key, fallback)\n";
-    let py_untyped = "def f(lookup, other_lookup, key, other_key, fallback, other_default):\n    return lookup.get(key, fallback)\n";
-    let py_alias_wrong_key = "from collections.abc import Mapping as MapLike\n\ndef f(lookup: MapLike[str, int], other_lookup: MapLike[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(other_key, fallback)\n";
-    let py_alias_wrong_default = "from collections.abc import Mapping as MapLike\n\ndef f(lookup: MapLike[str, int], other_lookup: MapLike[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(key, other_default)\n";
-    let py_alias_wrong_map = "from collections.abc import Mapping as MapLike\n\ndef f(lookup: MapLike[str, int], other_lookup: MapLike[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return other_lookup.get(key, fallback)\n";
-    let py_alias_unresolved = "def f(lookup: MapLike[str, int], other_lookup: MapLike[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(key, fallback)\n";
-    let py_alias_shadowed = "from collections.abc import Mapping as MapLike\nMapLike = list\n\ndef f(lookup: MapLike[str, int], other_lookup: MapLike[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(key, fallback)\n";
-    let guard_wrong_key = "function f(lookup: Map<string, number>, other_lookup: Map<string, number>, key: string, other_key: string, fallback: number, other_default: number): number { if (lookup.has(other_key)) { return lookup.get(other_key)!; } return fallback; }\n";
-    let guard_wrong_default = "import java.util.Map;\n\nclass C { static int f(Map<String, Integer> lookup, Map<String, Integer> other_lookup, String key, String other_key, int fallback, int other_default) { if (lookup.containsKey(key)) { return lookup.get(key); } return other_default; } }\n";
-    let guard_wrong_map = "def f(lookup: dict[str, int], other_lookup: dict[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    if key in other_lookup:\n        return other_lookup[key]\n    return fallback\n";
 
     let fp = value_fp(&i, go, Lang::Go);
     assert_eq!(fp, value_fp(&i, java_explicit, Lang::Java));
@@ -4896,6 +4961,26 @@ fn map_default_lookup_converges_cross_language_with_boundaries() {
     assert_eq!(fp, value_fp(&i, py_alias_mapping, Lang::Python));
     assert_eq!(fp, value_fp(&i, py_alias_mutable_mapping, Lang::Python));
     assert_eq!(fp, value_fp(&i, py_alias_dict, Lang::Python));
+}
+
+#[test]
+fn map_default_lookup_keeps_wrong_coordinate_boundaries() {
+    let i = Interner::new();
+    let go = "package p\n\nfunc F(lookup map[string]int, otherLookup map[string]int, key string, otherKey string, fallback int, otherDefault int) int { value, ok := lookup[key]; if !ok { value = fallback }; return value }\n";
+    let wrong_key = "import java.util.Map;\n\nclass C { static int f(Map<String, Integer> lookup, Map<String, Integer> other_lookup, String key, String other_key, int fallback, int other_default) { return lookup.getOrDefault(other_key, fallback); } }\n";
+    let wrong_default = "use std::collections::HashMap;\n\npub fn f(lookup: &HashMap<&str, i32>, other_lookup: &HashMap<&str, i32>, key: &str, other_key: &str, fallback: i32, other_default: i32) -> i32 { *lookup.get(key).unwrap_or(&other_default) }\n";
+    let wrong_map = "package p\n\nfunc F(lookup map[string]int, otherLookup map[string]int, key string, otherKey string, fallback int, otherDefault int) int { value, ok := otherLookup[key]; if !ok { value = fallback }; return value }\n";
+    let ts_wrong_key = "function f(lookup: Map<string, number>, other_lookup: Map<string, number>, key: string, other_key: string, fallback: number, other_default: number): number { return lookup.get(other_key) ?? fallback; }\n";
+    let ts_wrong_default = "function f(lookup: Map<string, number>, other_lookup: Map<string, number>, key: string, other_key: string, fallback: number, other_default: number): number { return lookup.get(key) ?? other_default; }\n";
+    let ts_wrong_map = "function f(lookup: Map<string, number>, other_lookup: Map<string, number>, key: string, other_key: string, fallback: number, other_default: number): number { return other_lookup.get(key) ?? fallback; }\n";
+    let ts_untyped = "function f(lookup, other_lookup, key, other_key, fallback, other_default) { return lookup.get(key) ?? fallback; }\n";
+    let ts_temp_shadowed_undefined = "function f(lookup: Map<string, number>, other_lookup: Map<string, number>, key: string, other_key: string, fallback: number, other_default: number, undefined: number): number { const selected = lookup.get(key); return selected === undefined ? fallback : selected; }\n";
+    let py_wrong_key = "def f(lookup: dict[str, int], other_lookup: dict[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(other_key, fallback)\n";
+    let py_wrong_default = "def f(lookup: dict[str, int], other_lookup: dict[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(key, other_default)\n";
+    let py_wrong_map = "def f(lookup: dict[str, int], other_lookup: dict[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return other_lookup.get(key, fallback)\n";
+    let py_untyped = "def f(lookup, other_lookup, key, other_key, fallback, other_default):\n    return lookup.get(key, fallback)\n";
+
+    let fp = value_fp(&i, go, Lang::Go);
     assert_ne!(fp, value_fp(&i, wrong_key, Lang::Java));
     assert_ne!(fp, value_fp(&i, wrong_default, Lang::Rust));
     assert_ne!(fp, value_fp(&i, wrong_map, Lang::Go));
@@ -4911,6 +4996,22 @@ fn map_default_lookup_converges_cross_language_with_boundaries() {
     assert_ne!(fp, value_fp(&i, py_wrong_default, Lang::Python));
     assert_ne!(fp, value_fp(&i, py_wrong_map, Lang::Python));
     assert_ne!(fp, value_fp(&i, py_untyped, Lang::Python));
+}
+
+#[test]
+fn map_default_lookup_keeps_alias_and_guard_boundaries() {
+    let i = Interner::new();
+    let go = "package p\n\nfunc F(lookup map[string]int, otherLookup map[string]int, key string, otherKey string, fallback int, otherDefault int) int { value, ok := lookup[key]; if !ok { value = fallback }; return value }\n";
+    let py_alias_wrong_key = "from collections.abc import Mapping as MapLike\n\ndef f(lookup: MapLike[str, int], other_lookup: MapLike[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(other_key, fallback)\n";
+    let py_alias_wrong_default = "from collections.abc import Mapping as MapLike\n\ndef f(lookup: MapLike[str, int], other_lookup: MapLike[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(key, other_default)\n";
+    let py_alias_wrong_map = "from collections.abc import Mapping as MapLike\n\ndef f(lookup: MapLike[str, int], other_lookup: MapLike[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return other_lookup.get(key, fallback)\n";
+    let py_alias_unresolved = "def f(lookup: MapLike[str, int], other_lookup: MapLike[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(key, fallback)\n";
+    let py_alias_shadowed = "from collections.abc import Mapping as MapLike\nMapLike = list\n\ndef f(lookup: MapLike[str, int], other_lookup: MapLike[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    return lookup.get(key, fallback)\n";
+    let guard_wrong_key = "function f(lookup: Map<string, number>, other_lookup: Map<string, number>, key: string, other_key: string, fallback: number, other_default: number): number { if (lookup.has(other_key)) { return lookup.get(other_key)!; } return fallback; }\n";
+    let guard_wrong_default = "import java.util.Map;\n\nclass C { static int f(Map<String, Integer> lookup, Map<String, Integer> other_lookup, String key, String other_key, int fallback, int other_default) { if (lookup.containsKey(key)) { return lookup.get(key); } return other_default; } }\n";
+    let guard_wrong_map = "def f(lookup: dict[str, int], other_lookup: dict[str, int], key: str, other_key: str, fallback: int, other_default: int) -> int:\n    if key in other_lookup:\n        return other_lookup[key]\n    return fallback\n";
+
+    let fp = value_fp(&i, go, Lang::Go);
     assert_ne!(fp, value_fp(&i, py_alias_wrong_key, Lang::Python));
     assert_ne!(fp, value_fp(&i, py_alias_wrong_default, Lang::Python));
     assert_ne!(fp, value_fp(&i, py_alias_wrong_map, Lang::Python));

--- a/crates/nose-detect/src/fragment/recognize.rs
+++ b/crates/nose-detect/src/fragment/recognize.rs
@@ -591,8 +591,7 @@ mod tests {
         walk(il, il.root, parents, interner).expect("a contract for the migrated shape")
     }
 
-    #[test]
-    fn resolves_place_and_effect_for_write_shapes() {
+    fn assert_java_self_field_write_contract() {
         // Java `this.x = …` → FieldWrite over a proven This.field place (fail-closed safe).
         let (il, parents, interner) = norm(
             "class C { int x; void s(int v){ this.x = v + 1; } }",
@@ -610,7 +609,9 @@ mod tests {
             c.writes_proven(),
             "a proven self-field write must pass writes_proven"
         );
+    }
 
+    fn assert_java_index_write_contract() {
         // Java `a[i] = v` → IndexWrite, observable in the effect trace, so it carries no
         // receiver-identity obligation and records no place on the contract (place is reserved
         // for receiver-bearing effects like field writes).
@@ -629,7 +630,9 @@ mod tests {
         );
         assert!(!site.effect.requires_proven_place());
         assert!(c.writes_proven());
+    }
 
+    fn assert_typed_ts_push_contract() {
         // Typed TS `xs.push(v)` proves the receiver is an array, lowers to the canonical
         // append builtin, and then records an Append effect with no heap place.
         let (il, parents, interner) = norm(
@@ -641,7 +644,9 @@ mod tests {
         assert_eq!(c.effects.len(), 1);
         assert_eq!(c.effects[0].effect, Effect::Append);
         assert_eq!(c.effects[0].place, None);
+    }
 
+    fn assert_untyped_js_push_contract() {
         // The same raw selector without receiver proof is not append evidence. It may still
         // be accepted by the separate opaque-call policy as `Other`, but it must not claim
         // append semantics.
@@ -652,6 +657,14 @@ mod tests {
         assert_eq!(c.effects.len(), 1);
         assert_eq!(c.effects[0].effect, Effect::Other);
         assert_eq!(c.effects[0].place, None);
+    }
+
+    #[test]
+    fn resolves_place_and_effect_for_write_shapes() {
+        assert_java_self_field_write_contract();
+        assert_java_index_write_contract();
+        assert_typed_ts_push_contract();
+        assert_untyped_js_push_contract();
     }
 
     #[test]

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -910,28 +910,7 @@ pub fn detect_from_units(
         //    near-duplicate scans also use shape signatures so Type-3 edits that
         //    change behavior-defining values still reach the scorer. When both
         //    channels run, score the union once.
-        let mut candidates = Vec::new();
-        if opts.value_candidates {
-            candidates.extend(lsh::candidates(
-                units.len(),
-                |i| units[i].minhash.as_slice(),
-                opts.bands,
-            ));
-            candidates.extend(exact_value_candidates(&units));
-        }
-        if opts.shape_candidates {
-            candidates.extend(lsh::candidates(
-                units.len(),
-                |i| units[i].shape_minhash.as_slice(),
-                opts.bands,
-            ));
-            // Partial / sub-DAG clones: pair units that share a rare heavy anchor (an
-            // extractable common sub-computation). They share no shape band, so shape-LSH
-            // alone never proposes them — this is the candidate channel's sub-DAG path.
-            candidates.extend(anchor_candidates(&units));
-        }
-        candidates.sort_unstable();
-        candidates.dedup();
+        let candidates = structural_candidates(&units, opts);
         clk.lap("candidates");
 
         // 4. Score candidates in parallel; keep accepted pairs.
@@ -975,53 +954,7 @@ pub fn detect_from_units(
         .collect();
     duplicates.sort_by(|a, b| b.score.total_cmp(&a.score));
 
-    // Group score = mean of the accepted-pair scores within the group. Accumulate it in
-    // ONE pass over `accepted` instead of rescanning every accepted pair for every group
-    // (which was O(groups × accepted) — ~1e9 iterations / ~0.9s on guava's 17.6k groups ×
-    // 59k pairs, the detector's real hot spot). Each accepted pair was unioned, so its two
-    // endpoints share a component; index its contribution by that component's root. The
-    // per-group sum still walks `accepted` in order, so the float total — and the rounded
-    // score — is byte-identical to the per-group rescan.
-    let mut by_root: rustc_hash::FxHashMap<usize, (f64, u32)> = rustc_hash::FxHashMap::default();
-    for &(i, _j, s) in &accepted {
-        let e = by_root.entry(uf.find(i)).or_insert((0.0, 0));
-        e.0 += s;
-        e.1 += 1;
-    }
-    let groups: Vec<Group> = raw_groups
-        .iter()
-        .map(|members| {
-            let root = uf.find(members[0]);
-            let (sum, n) = by_root.get(&root).copied().unwrap_or((0.0, 0));
-            let score = if n == 0 { 0.0 } else { sum / n as f64 };
-            let mut locs: Vec<Loc> = members
-                .iter()
-                .map(|&m| loc_of(&units[m], enclosing[m].clone()))
-                .collect();
-            // If every member shares a heavy sub-DAG (a partial / sub-DAG clone), annotate each
-            // site with its OWN source range for that shared computation — so the report can point
-            // at where the shared logic lives in each copy, not just that one exists.
-            if let Some(hash) = shared_subdag_hash(members, &units) {
-                for (&m, loc) in members.iter().zip(locs.iter_mut()) {
-                    if let Some(a) = units[m].anchors.iter().find(|a| a.hash == hash) {
-                        if a.line_start > 0 || a.line_end > 0 {
-                            loc.shared_subdag = Some((a.line_start, a.line_end));
-                        }
-                    }
-                }
-            }
-            Group {
-                score: round3(score),
-                members: locs,
-                semantic_laws: semantic_laws_for_members(members, &units),
-                abstraction_witness: if opts.abstraction_witnesses {
-                    units::abstraction_family_witness(members.iter().map(|&m| &units[m]))
-                } else {
-                    None
-                },
-            }
-        })
-        .collect();
+    let groups = build_groups(&units, &accepted, &mut uf, &raw_groups, &enclosing, opts);
     clk.lap("groups");
 
     let mut report = Report {
@@ -1072,6 +1005,93 @@ pub fn detect_from_units(
     };
 
     (report, dump)
+}
+
+/// LSH candidate generation for the structural pass: the value-graph and/or shape
+/// channels per `opts`, unioned, sorted, and deduped.
+fn structural_candidates(units: &[UnitFeat], opts: &DetectOptions) -> Vec<(usize, usize)> {
+    let mut candidates = Vec::new();
+    if opts.value_candidates {
+        candidates.extend(lsh::candidates(
+            units.len(),
+            |i| units[i].minhash.as_slice(),
+            opts.bands,
+        ));
+        candidates.extend(exact_value_candidates(units));
+    }
+    if opts.shape_candidates {
+        candidates.extend(lsh::candidates(
+            units.len(),
+            |i| units[i].shape_minhash.as_slice(),
+            opts.bands,
+        ));
+        // Partial / sub-DAG clones: pair units that share a rare heavy anchor (an
+        // extractable common sub-computation). They share no shape band, so shape-LSH
+        // alone never proposes them — this is the candidate channel's sub-DAG path.
+        candidates.extend(anchor_candidates(units));
+    }
+    candidates.sort_unstable();
+    candidates.dedup();
+    candidates
+}
+
+/// Build the report's `groups` from the clustered components.
+///
+/// Group score = mean of the accepted-pair scores within the group. Accumulate it in
+/// ONE pass over `accepted` instead of rescanning every accepted pair for every group
+/// (which was O(groups × accepted) — ~1e9 iterations / ~0.9s on guava's 17.6k groups ×
+/// 59k pairs, the detector's real hot spot). Each accepted pair was unioned, so its two
+/// endpoints share a component; index its contribution by that component's root. The
+/// per-group sum still walks `accepted` in order, so the float total — and the rounded
+/// score — is byte-identical to the per-group rescan.
+fn build_groups(
+    units: &[UnitFeat],
+    accepted: &[(usize, usize, f64)],
+    uf: &mut cluster::UnionFind,
+    raw_groups: &[Vec<usize>],
+    enclosing: &[Option<EnclosingUnit>],
+    opts: &DetectOptions,
+) -> Vec<Group> {
+    let mut by_root: rustc_hash::FxHashMap<usize, (f64, u32)> = rustc_hash::FxHashMap::default();
+    for &(i, _j, s) in accepted {
+        let e = by_root.entry(uf.find(i)).or_insert((0.0, 0));
+        e.0 += s;
+        e.1 += 1;
+    }
+    raw_groups
+        .iter()
+        .map(|members| {
+            let root = uf.find(members[0]);
+            let (sum, n) = by_root.get(&root).copied().unwrap_or((0.0, 0));
+            let score = if n == 0 { 0.0 } else { sum / n as f64 };
+            let mut locs: Vec<Loc> = members
+                .iter()
+                .map(|&m| loc_of(&units[m], enclosing[m].clone()))
+                .collect();
+            // If every member shares a heavy sub-DAG (a partial / sub-DAG clone), annotate each
+            // site with its OWN source range for that shared computation — so the report can point
+            // at where the shared logic lives in each copy, not just that one exists.
+            if let Some(hash) = shared_subdag_hash(members, units) {
+                for (&m, loc) in members.iter().zip(locs.iter_mut()) {
+                    if let Some(a) = units[m].anchors.iter().find(|a| a.hash == hash) {
+                        if a.line_start > 0 || a.line_end > 0 {
+                            loc.shared_subdag = Some((a.line_start, a.line_end));
+                        }
+                    }
+                }
+            }
+            Group {
+                score: round3(score),
+                members: locs,
+                semantic_laws: semantic_laws_for_members(members, units),
+                abstraction_witness: if opts.abstraction_witnesses {
+                    units::abstraction_family_witness(members.iter().map(|&m| &units[m]))
+                } else {
+                    None
+                },
+            }
+        })
+        .collect()
 }
 
 fn semantic_laws_for_members(members: &[usize], units: &[UnitFeat]) -> Vec<ValueLaw> {

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -18,7 +18,7 @@ use crate::strict_exact::{
 use crate::strict_exact::{strict_exact_safe_tree, StrictFacts};
 #[cfg(test)]
 use nose_il::Builtin;
-use nose_il::{Il, Interner, Lang, LoopKind, NodeId, NodeKind, Payload, Symbol, UnitKind};
+use nose_il::{Il, Interner, Lang, LoopKind, NodeId, NodeKind, Payload, Span, Symbol, UnitKind};
 use nose_normalize::node_tag;
 use nose_semantics::{
     admitted_builtin_semantics_at_call, builder_append_call_args, exact_java_return_this,
@@ -393,6 +393,36 @@ pub(crate) struct ExtractFeatures {
     pub(crate) abstraction_witnesses: bool,
 }
 
+/// Per-file inputs shared by every unit extraction in [`extract`].
+struct UnitExtractCtx<'a> {
+    il: &'a Il,
+    interner: &'a Interner,
+    seeds: &'a [u64],
+    min_lines: u32,
+    min_tokens: usize,
+    features: ExtractFeatures,
+    parents: Option<&'a [Option<NodeId>]>,
+    facts: &'a StrictFacts<'a>,
+    value_context: Option<&'a nose_normalize::ValueFingerprintContext>,
+}
+
+/// A unit root that survived the size/semantic gates, with the semantic
+/// fingerprint and per-stage timings already computed.
+struct GatedUnit {
+    span: Span,
+    pre: Vec<NodeId>,
+    exact_safe: bool,
+    value: Vec<u64>,
+    lits: Vec<u64>,
+    returns: Vec<u64>,
+    anchors: Vec<nose_normalize::Anchor>,
+    semantic_laws: Vec<ValueLaw>,
+    unit_start: Option<Instant>,
+    pre_ms: Option<f64>,
+    safe_ms: Option<f64>,
+    value_ms: Option<f64>,
+}
+
 /// Extract all units of `il` passing the size gates, with features computed.
 pub(crate) fn extract(
     il: &Il,
@@ -432,223 +462,293 @@ pub(crate) fn extract(
     let facts = StrictFacts::collect(il, interner);
     let value_context =
         (roots.len() > 1).then(|| nose_normalize::ValueFingerprintContext::new(il, interner));
+    let ctx = UnitExtractCtx {
+        il,
+        interner,
+        seeds,
+        min_lines,
+        min_tokens,
+        features,
+        parents: parents.as_deref(),
+        facts: &facts,
+        value_context: value_context.as_ref(),
+    };
     let mut unit_timer = UnitTimer::new();
     let mut out = Vec::new();
-    for UnitRoot {
+    for unit_root in roots {
+        if let Some(unit) = extract_unit(&ctx, unit_root, &mut unit_timer) {
+            out.push(unit);
+        }
+    }
+    unit_timer.report_summary(&il.meta.path);
+    out
+}
+
+/// Gate one unit root: collect its pre-order, apply the container/size/dense gates
+/// (reporting skips), and compute the strict-exact verdict and value fingerprint.
+fn gate_unit(
+    ctx: &UnitExtractCtx<'_>,
+    unit_root: UnitRoot,
+    unit_timer: &mut UnitTimer,
+) -> Option<GatedUnit> {
+    let UnitRoot {
         root,
         kind,
-        name: uname,
+        name: _,
         fragment_kind,
-    } in roots
-    {
-        let exact_fragment = fragment_kind.is_some();
-        let unit_start = unit_timer.start();
-        let span = il.node(root).span;
-        let lines = span.line_count();
+    } = unit_root;
+    let exact_fragment = fragment_kind.is_some();
+    let unit_start = unit_timer.start();
+    let span = ctx.il.node(root).span;
+    let lines = span.line_count();
 
-        let pre_start = unit_timer.start();
-        let mut pre = Vec::new();
-        collect_pre(il, root, &mut pre);
-        let pre_ms = UnitTimer::elapsed(pre_start);
-
-        // Broad container units are covered by their nested primary units. Apply
-        // this cap before strict/value extraction so discarded containers never pay
-        // the dominant semantic fingerprint cost.
-        if semantic_container_token_cap(kind).is_some_and(|cap| pre.len() > cap) {
-            unit_timer.report_skip(UnitTimingSkipSample {
-                start: unit_start,
-                kind: &kind,
-                path: &il.meta.path,
-                start_line: span.start_line,
-                end_line: span.end_line,
-                tokens: pre.len(),
-                pre_ms,
-                safe_ms: None,
-                value_ms: None,
-            });
-            continue;
-        }
-
-        let syntactically_small = lines < min_lines || pre.len() < min_tokens;
-        let can_use_dense_gate =
-            matches!(kind, UnitKind::Function | UnitKind::Method) || exact_fragment;
-        if syntactically_small && !can_use_dense_gate {
-            unit_timer.report_skip(UnitTimingSkipSample {
-                start: unit_start,
-                kind: &kind,
-                path: &il.meta.path,
-                start_line: span.start_line,
-                end_line: span.end_line,
-                tokens: pre.len(),
-                pre_ms,
-                safe_ms: None,
-                value_ms: None,
-            });
-            continue;
-        }
-
-        let safe_start = unit_timer.start();
-        let strict_exact_safe = strict_exact_safe_tree(il, interner, &facts, root);
-        let exact_safe = strict_exact_safe
-            || (exact_fragment
-                && parents.as_deref().is_some_and(|parents| {
-                    strict_exact_self_field_fragment_safe(il, interner, &facts, parents, root)
-                }));
-        let safe_ms = UnitTimer::elapsed(safe_start);
-        // The value graph is the semantic fingerprint (already sorted), with the
-        // literal-only multiset for data-table detection. Computed before the size
-        // gate so the gate can consult semantic richness (below).
-        let value_start = unit_timer.start();
-        let (value, lits, returns, anchors, semantic_laws) = if let Some(context) = &value_context {
-            nose_normalize::value_fingerprint_lits_anchors_laws_with_context(
-                il, root, interner, context,
-            )
-        } else {
-            nose_normalize::value_fingerprint_lits_anchors_laws(il, root, interner)
-        };
-        let value_ms = UnitTimer::elapsed(value_start);
-
-        // Size gate. A short unit normally isn't a meaningful clone — EXCEPT a
-        // frontend-tagged function whose body is behaviorally *dense*: a functional
-        // one-liner like `return sum(v for v in xs if v>0)` is a real Type-4 clone of a
-        // multi-line loop (the value graph converges them to an *identical* fingerprint),
-        // just compressed below the line/token gate. Admit such a function when its value
-        // fingerprint is rich enough to be matched by the oracle-certified exact-match
-        // path (`value.len() >= 4`, the same floor that path uses) — this recovers the
-        // compressed functional Type-4 forms without lowering the gate for trivial units
-        // (`return x` has 1–2 atoms) or for blocks (kept strict; they are the noisy ones).
-        // Control-flow blocks keep the same syntactic min-lines/min-size gate as
-        // functions: measurement showed the real sub-function clones are small (24–40
-        // tokens), so a stricter block gate drops signal (pool-precision 0.106→0.074,
-        // AUC 0.42→0.17) faster than noise. Exact statement fragments are the narrow
-        // exception: they may pass the dense gate only after `exact_safe` and the value
-        // fingerprint floor prove that the fragment itself is a usable semantic unit.
-        let dense_exact_unit = if exact_fragment {
-            exact_safe && value.len() >= EXACT_VALUE_MIN
-        } else {
-            matches!(kind, UnitKind::Function | UnitKind::Method) && value.len() >= EXACT_VALUE_MIN
-        };
-        if (syntactically_small || exact_fragment) && !dense_exact_unit {
-            unit_timer.report_skip(UnitTimingSkipSample {
-                start: unit_start,
-                kind: &kind,
-                path: &il.meta.path,
-                start_line: span.start_line,
-                end_line: span.end_line,
-                tokens: pre.len(),
-                pre_ms,
-                safe_ms,
-                value_ms,
-            });
-            continue;
-        }
-        let feature_start = unit_timer.start();
-        let (shapes, shape_minhash, linear, abstraction_tokens) = if features.shape_features {
-            let mut shapes = Vec::with_capacity(pre.len());
-            let mut linear = Vec::with_capacity(pre.len());
-            let mut abstraction_tokens = if features.abstraction_witnesses {
-                Vec::with_capacity(pre.len())
-            } else {
-                Vec::new()
-            };
-            for &nid in &pre {
-                let n = il.node(nid);
-                let tag = node_tag(n.kind, n.payload, interner);
-                linear.push(tag);
-                if features.abstraction_witnesses {
-                    abstraction_tokens.push(abstraction::token_for(il, interner, nid, tag));
-                }
-                let mut shape = tag;
-                for &c in il.children(nid) {
-                    let cn = il.node(c);
-                    shape = combine(shape, node_tag(cn.kind, cn.payload, interner));
-                }
-                shapes.push(shape);
-            }
-            shapes.sort_unstable();
-            let mut distinct_shapes = shapes.clone();
-            distinct_shapes.dedup();
-            (
-                shapes,
-                crate::minhash::sign(&distinct_shapes, seeds),
-                linear,
-                abstraction_tokens,
-            )
-        } else if features.abstraction_witnesses {
-            let abstraction_tokens = pre
-                .iter()
-                .map(|&nid| {
-                    let n = il.node(nid);
-                    let tag = node_tag(n.kind, n.payload, interner);
-                    abstraction::token_for(il, interner, nid, tag)
-                })
-                .collect();
-            (Vec::new(), Vec::new(), Vec::new(), abstraction_tokens)
-        } else {
-            (Vec::new(), Vec::new(), Vec::new(), Vec::new())
-        };
-
-        // Candidate generation keys on the value graph when present (so clones
-        // that converge only semantically still become candidates).
-        let minhash = if value.is_empty() && !features.shape_features {
-            Vec::new()
-        } else {
-            let mut distinct = if value.is_empty() {
-                shapes.clone()
-            } else {
-                value.clone()
-            };
-            distinct.dedup();
-            crate::minhash::sign(&distinct, seeds)
-        };
-
-        let display_name = uname
-            .map(|s| interner.resolve(s).to_string())
-            .unwrap_or_else(|| "-".to_string());
-        unit_timer.report_keep(UnitTimingSample {
+    let pre_start = unit_timer.start();
+    let mut pre = Vec::new();
+    collect_pre(ctx.il, root, &mut pre);
+    let pre_ms = UnitTimer::elapsed(pre_start);
+    let skip = |unit_timer: &mut UnitTimer, safe_ms: Option<f64>, value_ms: Option<f64>| {
+        unit_timer.report_skip(UnitTimingSkipSample {
             start: unit_start,
-            feature_start,
             kind: &kind,
-            name: &display_name,
-            path: &il.meta.path,
+            path: &ctx.il.meta.path,
             start_line: span.start_line,
             end_line: span.end_line,
             tokens: pre.len(),
-            value_atoms: value.len(),
             pre_ms,
             safe_ms,
             value_ms,
         });
+    };
 
-        let proof_facts = fragment_kind.map(|fk| match fk {
-            FragmentKind::SelfFieldBody => ProofFacts::self_field_body(),
-            other => ProofFacts::context_gated(other),
-        });
-        out.push(UnitFeat {
-            path: il.meta.path.clone(),
-            lang: il.meta.lang,
-            kind,
-            name: uname.map(|s| interner.resolve(s).to_string()),
-            start_line: span.start_line,
-            end_line: span.end_line,
-            token_count: pre.len(),
+    // Broad container units are covered by their nested primary units. Apply
+    // this cap before strict/value extraction so discarded containers never pay
+    // the dominant semantic fingerprint cost.
+    if semantic_container_token_cap(kind).is_some_and(|cap| pre.len() > cap) {
+        skip(unit_timer, None, None);
+        return None;
+    }
+
+    let syntactically_small = lines < ctx.min_lines || pre.len() < ctx.min_tokens;
+    let can_use_dense_gate =
+        matches!(kind, UnitKind::Function | UnitKind::Method) || exact_fragment;
+    if syntactically_small && !can_use_dense_gate {
+        skip(unit_timer, None, None);
+        return None;
+    }
+
+    let safe_start = unit_timer.start();
+    let strict_exact_safe = strict_exact_safe_tree(ctx.il, ctx.interner, ctx.facts, root);
+    let exact_safe = strict_exact_safe
+        || (exact_fragment
+            && ctx.parents.is_some_and(|parents| {
+                strict_exact_self_field_fragment_safe(
+                    ctx.il,
+                    ctx.interner,
+                    ctx.facts,
+                    parents,
+                    root,
+                )
+            }));
+    let safe_ms = UnitTimer::elapsed(safe_start);
+    // The value graph is the semantic fingerprint (already sorted), with the
+    // literal-only multiset for data-table detection. Computed before the size
+    // gate so the gate can consult semantic richness (below).
+    let value_start = unit_timer.start();
+    let (value, lits, returns, anchors, semantic_laws) = if let Some(context) = ctx.value_context {
+        nose_normalize::value_fingerprint_lits_anchors_laws_with_context(
+            ctx.il,
+            root,
+            ctx.interner,
+            context,
+        )
+    } else {
+        nose_normalize::value_fingerprint_lits_anchors_laws(ctx.il, root, ctx.interner)
+    };
+    let value_ms = UnitTimer::elapsed(value_start);
+
+    // Size gate. A short unit normally isn't a meaningful clone — EXCEPT a
+    // frontend-tagged function whose body is behaviorally *dense*: a functional
+    // one-liner like `return sum(v for v in xs if v>0)` is a real Type-4 clone of a
+    // multi-line loop (the value graph converges them to an *identical* fingerprint),
+    // just compressed below the line/token gate. Admit such a function when its value
+    // fingerprint is rich enough to be matched by the oracle-certified exact-match
+    // path (`value.len() >= 4`, the same floor that path uses) — this recovers the
+    // compressed functional Type-4 forms without lowering the gate for trivial units
+    // (`return x` has 1–2 atoms) or for blocks (kept strict; they are the noisy ones).
+    // Control-flow blocks keep the same syntactic min-lines/min-size gate as
+    // functions: measurement showed the real sub-function clones are small (24–40
+    // tokens), so a stricter block gate drops signal (pool-precision 0.106→0.074,
+    // AUC 0.42→0.17) faster than noise. Exact statement fragments are the narrow
+    // exception: they may pass the dense gate only after `exact_safe` and the value
+    // fingerprint floor prove that the fragment itself is a usable semantic unit.
+    let dense_exact_unit = if exact_fragment {
+        exact_safe && value.len() >= EXACT_VALUE_MIN
+    } else {
+        matches!(kind, UnitKind::Function | UnitKind::Method) && value.len() >= EXACT_VALUE_MIN
+    };
+    if (syntactically_small || exact_fragment) && !dense_exact_unit {
+        skip(unit_timer, safe_ms, value_ms);
+        return None;
+    }
+    Some(GatedUnit {
+        span,
+        pre,
+        exact_safe,
+        value,
+        lits,
+        returns,
+        anchors,
+        semantic_laws,
+        unit_start,
+        pre_ms,
+        safe_ms,
+        value_ms,
+    })
+}
+
+fn extract_unit(
+    ctx: &UnitExtractCtx<'_>,
+    unit_root: UnitRoot,
+    unit_timer: &mut UnitTimer,
+) -> Option<UnitFeat> {
+    let UnitRoot {
+        root: _,
+        kind,
+        name: uname,
+        fragment_kind,
+    } = unit_root;
+    let GatedUnit {
+        span,
+        pre,
+        exact_safe,
+        value,
+        lits,
+        returns,
+        anchors,
+        semantic_laws,
+        unit_start,
+        pre_ms,
+        safe_ms,
+        value_ms,
+    } = gate_unit(ctx, unit_root, unit_timer)?;
+    let feature_start = unit_timer.start();
+    let (shapes, shape_minhash, linear, abstraction_tokens) = unit_shape_features(ctx, &pre);
+
+    // Candidate generation keys on the value graph when present (so clones
+    // that converge only semantically still become candidates).
+    let minhash = unit_minhash(&value, &shapes, ctx.features.shape_features, ctx.seeds);
+
+    let display_name = uname
+        .map(|s| ctx.interner.resolve(s).to_string())
+        .unwrap_or_else(|| "-".to_string());
+    unit_timer.report_keep(UnitTimingSample {
+        start: unit_start,
+        feature_start,
+        kind: &kind,
+        name: &display_name,
+        path: &ctx.il.meta.path,
+        start_line: span.start_line,
+        end_line: span.end_line,
+        tokens: pre.len(),
+        value_atoms: value.len(),
+        pre_ms,
+        safe_ms,
+        value_ms,
+    });
+
+    let proof_facts = fragment_kind.map(|fk| match fk {
+        FragmentKind::SelfFieldBody => ProofFacts::self_field_body(),
+        other => ProofFacts::context_gated(other),
+    });
+    Some(UnitFeat {
+        path: ctx.il.meta.path.clone(),
+        lang: ctx.il.meta.lang,
+        kind,
+        name: uname.map(|s| ctx.interner.resolve(s).to_string()),
+        start_line: span.start_line,
+        end_line: span.end_line,
+        token_count: pre.len(),
+        shapes,
+        shape_minhash,
+        value,
+        minhash,
+        linear,
+        abstraction_tokens,
+        lits,
+        returns,
+        anchors,
+        semantic_laws,
+        exact_safe,
+        fragment_kind,
+        proof_facts,
+    })
+}
+
+fn unit_shape_features(
+    ctx: &UnitExtractCtx<'_>,
+    pre: &[NodeId],
+) -> (Vec<u64>, Vec<u64>, Vec<u64>, Vec<abstraction::WitnessToken>) {
+    let il = ctx.il;
+    let interner = ctx.interner;
+    let features = ctx.features;
+    if features.shape_features {
+        let mut shapes = Vec::with_capacity(pre.len());
+        let mut linear = Vec::with_capacity(pre.len());
+        let mut abstraction_tokens = if features.abstraction_witnesses {
+            Vec::with_capacity(pre.len())
+        } else {
+            Vec::new()
+        };
+        for &nid in pre {
+            let n = il.node(nid);
+            let tag = node_tag(n.kind, n.payload, interner);
+            linear.push(tag);
+            if features.abstraction_witnesses {
+                abstraction_tokens.push(abstraction::token_for(il, interner, nid, tag));
+            }
+            let mut shape = tag;
+            for &c in il.children(nid) {
+                let cn = il.node(c);
+                shape = combine(shape, node_tag(cn.kind, cn.payload, interner));
+            }
+            shapes.push(shape);
+        }
+        shapes.sort_unstable();
+        let mut distinct_shapes = shapes.clone();
+        distinct_shapes.dedup();
+        (
             shapes,
-            shape_minhash,
-            value,
-            minhash,
+            crate::minhash::sign(&distinct_shapes, ctx.seeds),
             linear,
             abstraction_tokens,
-            lits,
-            returns,
-            anchors,
-            semantic_laws,
-            exact_safe,
-            fragment_kind,
-            proof_facts,
-        });
+        )
+    } else if features.abstraction_witnesses {
+        let abstraction_tokens = pre
+            .iter()
+            .map(|&nid| {
+                let n = il.node(nid);
+                let tag = node_tag(n.kind, n.payload, interner);
+                abstraction::token_for(il, interner, nid, tag)
+            })
+            .collect();
+        (Vec::new(), Vec::new(), Vec::new(), abstraction_tokens)
+    } else {
+        (Vec::new(), Vec::new(), Vec::new(), Vec::new())
     }
-    unit_timer.report_summary(&il.meta.path);
-    out
+}
+
+fn unit_minhash(value: &[u64], shapes: &[u64], shape_features: bool, seeds: &[u64]) -> Vec<u64> {
+    if value.is_empty() && !shape_features {
+        Vec::new()
+    } else {
+        let mut distinct = if value.is_empty() {
+            shapes.to_vec()
+        } else {
+            value.to_vec()
+        };
+        distinct.dedup();
+        crate::minhash::sign(&distinct, seeds)
+    }
 }
 
 /// Collect sub-function block roots (loops / ifs / try) as extra unit candidates.
@@ -2052,7 +2152,7 @@ pub(crate) fn build_parent_index(il: &Il) -> Vec<Option<NodeId>> {
     parents
 }
 
-pub(crate) fn subtree_spans_within(il: &Il, node: NodeId, span: nose_il::Span) -> bool {
+pub(crate) fn subtree_spans_within(il: &Il, node: NodeId, span: Span) -> bool {
     let node_span = il.node(node).span;
     if node_span.file != span.file
         || node_span.start_line < span.start_line
@@ -2153,6 +2253,31 @@ mod tests {
             arity as u16,
             dependencies,
         )
+    }
+
+    /// Push the `List.of(…)`-shaped factory contract plus the dependent `contains`
+    /// method-call evidence used by the Java collection-factory tests.
+    fn push_java_factory_contract_evidence(
+        il: &mut Il,
+        contract_id: nose_semantics::LibraryApiContractId,
+        callee: LibraryApiCalleeContract,
+    ) {
+        il.evidence.push(library_api_contract_evidence(
+            2,
+            sp(25),
+            contract_id,
+            callee,
+            2,
+            vec![EvidenceId(1)],
+        ));
+        il.evidence.push(method_call_library_api_evidence(
+            3,
+            Lang::Java,
+            "contains",
+            sp(28),
+            1,
+            vec![EvidenceId(2)],
+        ));
     }
 
     fn js_new_set_il(interner: &Interner) -> (Il, NodeId) {
@@ -2784,22 +2909,7 @@ mod tests {
         ));
         assert!(!strict_exact_safe_tree(&il, &interner, &facts, contains));
 
-        il.evidence.push(library_api_contract_evidence(
-            2,
-            sp(25),
-            contract.id,
-            contract.callee,
-            2,
-            vec![EvidenceId(1)],
-        ));
-        il.evidence.push(method_call_library_api_evidence(
-            3,
-            Lang::Java,
-            "contains",
-            sp(28),
-            1,
-            vec![EvidenceId(2)],
-        ));
+        push_java_factory_contract_evidence(&mut il, contract.id, contract.callee);
         let facts = StrictFacts::collect(&il, &interner);
         assert!(strict_exact_java_collection_factory_safe(
             &il, &interner, &facts, factory
@@ -2809,22 +2919,7 @@ mod tests {
         let wrong = library_js_like_set_constructor_contract(Lang::JavaScript, "Set").unwrap();
         il.evidence.pop();
         il.evidence.pop();
-        il.evidence.push(library_api_contract_evidence(
-            2,
-            sp(25),
-            wrong.id,
-            wrong.callee,
-            2,
-            vec![EvidenceId(1)],
-        ));
-        il.evidence.push(method_call_library_api_evidence(
-            3,
-            Lang::Java,
-            "contains",
-            sp(28),
-            1,
-            vec![EvidenceId(2)],
-        ));
+        push_java_factory_contract_evidence(&mut il, wrong.id, wrong.callee);
         let facts = StrictFacts::collect(&il, &interner);
         assert!(!strict_exact_java_collection_factory_safe(
             &il, &interner, &facts, factory

--- a/crates/nose-eval/src/lib.rs
+++ b/crates/nose-eval/src/lib.rs
@@ -265,9 +265,28 @@ pub fn evaluate(
     };
 
     // --- pool-aware precision (honest denominator on a non-exhaustive gold) ---
-    // Each prediction is matched to its best-overlapping judged pool pair (≥0.5);
-    // a matched prediction is "judged" and counts toward precision iff that pair
-    // was a true clone. Predictions overlapping no pool pair are simply unjudged.
+    let (pool_judged, pool_clone_hits) = pool_counts(&gold, &pred_pairs);
+    let pool_precision = (pool_judged > 0).then(|| pool_clone_hits as f64 / pool_judged as f64);
+
+    Ok(Report {
+        prediction_count: pred_pairs.len(),
+        gold_count: golds.len(),
+        slices,
+        macro_f1,
+        hn_fp_rate,
+        hn_matched,
+        hn_total,
+        pool_precision,
+        pool_judged,
+        pool_clone_hits,
+    })
+}
+
+/// Count judged predictions and true-clone hits against the precision pool.
+/// Each prediction is matched to its best-overlapping judged pool pair (≥0.5);
+/// a matched prediction is "judged" and counts toward precision iff that pair
+/// was a true clone. Predictions overlapping no pool pair are simply unjudged.
+fn pool_counts(gold: &Gold, pred_pairs: &[EvalPair]) -> (usize, usize) {
     let (mut pool_judged, mut pool_clone_hits) = (0usize, 0usize);
     if !gold.pool.is_empty() {
         let pool: Vec<(EvalPair, bool)> = gold
@@ -292,7 +311,7 @@ pub fn evaluate(
                 )
             })
             .collect();
-        for p in &pred_pairs {
+        for p in pred_pairs {
             let best = pool
                 .iter()
                 .map(|(pe, lbl)| (pair_overlap(p, pe), *lbl))
@@ -304,20 +323,7 @@ pub fn evaluate(
             }
         }
     }
-    let pool_precision = (pool_judged > 0).then(|| pool_clone_hits as f64 / pool_judged as f64);
-
-    Ok(Report {
-        prediction_count: pred_pairs.len(),
-        gold_count: golds.len(),
-        slices,
-        macro_f1,
-        hn_fp_rate,
-        hn_matched,
-        hn_total,
-        pool_precision,
-        pool_judged,
-        pool_clone_hits,
-    })
+    (pool_judged, pool_clone_hits)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/nose-frontend/src/c.rs
+++ b/crates/nose-frontend/src/c.rs
@@ -602,23 +602,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                 lo.var(lo.text(node), span)
             }
         }
-        "number_literal" => {
-            let t = lo.text(node);
-            let lower = t.to_ascii_lowercase();
-            // In a hex literal (`0x…`) the digits e/E are hex digits, not a float exponent;
-            // a hex float instead uses a `.` or a binary `p`/`P` exponent. A decimal literal
-            // is a float if it has a `.` or an `e`/`E` exponent.
-            let is_float = if lower.starts_with("0x") {
-                lower.contains('.') || lower.contains('p')
-            } else {
-                lower.contains('.') || lower.contains('e')
-            };
-            if is_float {
-                lo.float_lit(t, span)
-            } else {
-                lo.int_lit(t.trim_end_matches(['u', 'U', 'l', 'L']), span)
-            }
-        }
+        "number_literal" => lower_number_literal(lo, node),
         "string_literal" | "concatenated_string" | "char_literal" => {
             let t = lo.text(node);
             lo.str_lit(t, span)
@@ -627,22 +611,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         "false" => lo.add(NodeKind::Lit, Payload::LitBool(false), span, &[]),
         "null" => lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[]),
         "binary_expression" => lower_binary(lo, node),
-        "unary_expression" => {
-            let operand = node
-                .child_by_field_name("argument")
-                .map(|o| lower_expr(lo, o))
-                .unwrap_or_else(|| lo.empty_block(span));
-            // Map by the operator token, not the whole node's text: `+` is `Pos`,
-            // `-` is `Neg`, `!` is `Not`, `~` is `BitNot`. Reading only the leading
-            // byte once collapsed `+x` and `~x` onto `Neg`.
-            let op = match node.child_by_field_name("operator").map(|o| lo.text(o)) {
-                Some("+") => Op::Pos,
-                Some("!") => Op::Not,
-                Some("~") => Op::BitNot,
-                _ => Op::Neg,
-            };
-            lo.add(NodeKind::UnOp, Payload::Op(op), span, &[operand])
-        }
+        "unary_expression" => lower_unary(lo, node),
         // `*p`, `&x` pointer ops, and parentheses peel to the operand. Most casts keep
         // the historical behavior too, but explicit unsigned 32-bit casts are proof facts
         // for C byte-pack shifts such as `((u32)a[0]) << 24`.
@@ -653,81 +622,10 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             .or_else(|| node.named_child(node.named_child_count().saturating_sub(1)))
             .map(|c| lower_expr(lo, c))
             .unwrap_or_else(|| lo.empty_block(span)),
-        "assignment_expression" => {
-            let l = node
-                .child_by_field_name("left")
-                .map(|x| lower_expr(lo, x))
-                .unwrap_or_else(|| lo.empty_block(span));
-            let opt = node
-                .child_by_field_name("operator")
-                .map(|o| lo.text(o))
-                .unwrap_or("=");
-            let r = node
-                .child_by_field_name("right")
-                .map(|x| lower_expr(lo, x))
-                .unwrap_or_else(|| lo.empty_block(span));
-            if opt.len() > 1 {
-                let l2 = node
-                    .child_by_field_name("left")
-                    .map(|x| lower_expr(lo, x))
-                    .unwrap_or_else(|| lo.empty_block(span));
-                // An unmapped compound operator keeps its own raw shape —
-                // dropping the operator would merge it with `x = y`.
-                let value = match common_bin_op(opt.trim_end_matches('=')) {
-                    Some(op) => lo.add(NodeKind::BinOp, Payload::Op(op), span, &[l2, r]),
-                    None => lo.raw(&format!("compound_assignment {opt}"), span, &[l2, r]),
-                };
-                return lo.add(NodeKind::Assign, Payload::None, span, &[l, value]);
-            }
-            lo.add(NodeKind::Assign, Payload::None, span, &[l, r])
-        }
-        "update_expression" => {
-            let arg = node.child_by_field_name("argument");
-            let operand = arg
-                .map(|o| lower_expr(lo, o))
-                .unwrap_or_else(|| lo.empty_block(span));
-            let operand2 = arg
-                .map(|o| lower_expr(lo, o))
-                .unwrap_or_else(|| lo.empty_block(span));
-            let one = lo.int_lit("1", span);
-            // Decide by the operator TOKEN, scanning only this node's direct children:
-            // a substring check on the whole text misreads a nested `--`/`++` in the
-            // operand (e.g. `a[i--]++`, whose outer op is `++`).
-            let op = if crate::lower::has_direct_token(node, "--") {
-                Op::Sub
-            } else {
-                Op::Add
-            };
-            let bin = lo.add(NodeKind::BinOp, Payload::Op(op), span, &[operand2, one]);
-            lo.add(NodeKind::Assign, Payload::None, span, &[operand, bin])
-        }
-        "call_expression" => {
-            let mut kids = Vec::new();
-            if let Some(f) = node.child_by_field_name("function") {
-                kids.push(lower_expr(lo, f));
-            }
-            if let Some(args) = node.child_by_field_name("arguments") {
-                for a in Lowering::named_children(args) {
-                    kids.push(lower_expr(lo, a));
-                }
-            }
-            lo.add(NodeKind::Call, Payload::None, span, &kids)
-        }
-        "field_expression" => {
-            let base = node
-                .child_by_field_name("argument")
-                .map(|o| lower_expr(lo, o))
-                .unwrap_or_else(|| lo.empty_block(span));
-            let field = node
-                .child_by_field_name("field")
-                .map(|f| lo.sym(lo.text(f)));
-            lo.add(
-                NodeKind::Field,
-                field.map(Payload::Name).unwrap_or(Payload::None),
-                span,
-                &[base],
-            )
-        }
+        "assignment_expression" => lower_assignment(lo, node),
+        "update_expression" => lower_update(lo, node),
+        "call_expression" => lower_call(lo, node),
+        "field_expression" => lower_field_expr(lo, node),
         "subscript_expression" => {
             let kids: Vec<NodeId> = Lowering::named_children(node)
                 .into_iter()
@@ -796,6 +694,126 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             lo.raw(node.kind(), span, &kids)
         }
     }
+}
+
+fn lower_number_literal(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let t = lo.text(node);
+    let lower = t.to_ascii_lowercase();
+    // In a hex literal (`0x…`) the digits e/E are hex digits, not a float exponent;
+    // a hex float instead uses a `.` or a binary `p`/`P` exponent. A decimal literal
+    // is a float if it has a `.` or an `e`/`E` exponent.
+    let is_float = if lower.starts_with("0x") {
+        lower.contains('.') || lower.contains('p')
+    } else {
+        lower.contains('.') || lower.contains('e')
+    };
+    if is_float {
+        lo.float_lit(t, span)
+    } else {
+        lo.int_lit(t.trim_end_matches(['u', 'U', 'l', 'L']), span)
+    }
+}
+
+fn lower_unary(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let operand = node
+        .child_by_field_name("argument")
+        .map(|o| lower_expr(lo, o))
+        .unwrap_or_else(|| lo.empty_block(span));
+    // Map by the operator token, not the whole node's text: `+` is `Pos`,
+    // `-` is `Neg`, `!` is `Not`, `~` is `BitNot`. Reading only the leading
+    // byte once collapsed `+x` and `~x` onto `Neg`.
+    let op = match node.child_by_field_name("operator").map(|o| lo.text(o)) {
+        Some("+") => Op::Pos,
+        Some("!") => Op::Not,
+        Some("~") => Op::BitNot,
+        _ => Op::Neg,
+    };
+    lo.add(NodeKind::UnOp, Payload::Op(op), span, &[operand])
+}
+
+fn lower_assignment(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let l = node
+        .child_by_field_name("left")
+        .map(|x| lower_expr(lo, x))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let opt = node
+        .child_by_field_name("operator")
+        .map(|o| lo.text(o))
+        .unwrap_or("=");
+    let r = node
+        .child_by_field_name("right")
+        .map(|x| lower_expr(lo, x))
+        .unwrap_or_else(|| lo.empty_block(span));
+    if opt.len() > 1 {
+        let l2 = node
+            .child_by_field_name("left")
+            .map(|x| lower_expr(lo, x))
+            .unwrap_or_else(|| lo.empty_block(span));
+        // An unmapped compound operator keeps its own raw shape —
+        // dropping the operator would merge it with `x = y`.
+        let value = match common_bin_op(opt.trim_end_matches('=')) {
+            Some(op) => lo.add(NodeKind::BinOp, Payload::Op(op), span, &[l2, r]),
+            None => lo.raw(&format!("compound_assignment {opt}"), span, &[l2, r]),
+        };
+        return lo.add(NodeKind::Assign, Payload::None, span, &[l, value]);
+    }
+    lo.add(NodeKind::Assign, Payload::None, span, &[l, r])
+}
+
+fn lower_update(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let arg = node.child_by_field_name("argument");
+    let operand = arg
+        .map(|o| lower_expr(lo, o))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let operand2 = arg
+        .map(|o| lower_expr(lo, o))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let one = lo.int_lit("1", span);
+    // Decide by the operator TOKEN, scanning only this node's direct children:
+    // a substring check on the whole text misreads a nested `--`/`++` in the
+    // operand (e.g. `a[i--]++`, whose outer op is `++`).
+    let op = if crate::lower::has_direct_token(node, "--") {
+        Op::Sub
+    } else {
+        Op::Add
+    };
+    let bin = lo.add(NodeKind::BinOp, Payload::Op(op), span, &[operand2, one]);
+    lo.add(NodeKind::Assign, Payload::None, span, &[operand, bin])
+}
+
+fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let mut kids = Vec::new();
+    if let Some(f) = node.child_by_field_name("function") {
+        kids.push(lower_expr(lo, f));
+    }
+    if let Some(args) = node.child_by_field_name("arguments") {
+        for a in Lowering::named_children(args) {
+            kids.push(lower_expr(lo, a));
+        }
+    }
+    lo.add(NodeKind::Call, Payload::None, span, &kids)
+}
+
+fn lower_field_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let base = node
+        .child_by_field_name("argument")
+        .map(|o| lower_expr(lo, o))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let field = node
+        .child_by_field_name("field")
+        .map(|f| lo.sym(lo.text(f)));
+    lo.add(
+        NodeKind::Field,
+        field.map(Payload::Name).unwrap_or(Payload::None),
+        span,
+        &[base],
+    )
 }
 
 fn lower_cast(lo: &mut Lowering, node: TsNode) -> NodeId {

--- a/crates/nose-frontend/src/go.rs
+++ b/crates/nose-frontend/src/go.rs
@@ -293,75 +293,11 @@ fn lower_assign_like(lo: &mut Lowering, node: TsNode) -> NodeId {
     let rights: Vec<TsNode> = right.map(expr_list_items).unwrap_or_default();
 
     if !compound && lefts.len() == 2 && rights.len() == 1 {
-        if let Some(ok_rhs) = lower_map_lookup_ok(lo, rights[0]) {
-            if lo.text(lefts[1]) != "_" {
-                let mut assigns = Vec::new();
-                if lo.text(lefts[0]) != "_" {
-                    let lhs = lower_expr(lo, lefts[0]);
-                    let rhs = lower_expr(lo, rights[0]);
-                    assigns.push(lo.add(
-                        NodeKind::Assign,
-                        Payload::None,
-                        lo.span(lefts[0]),
-                        &[lhs, rhs],
-                    ));
-                }
-                let ok_lhs = lower_expr(lo, lefts[1]);
-                assigns.push(lo.add(
-                    NodeKind::Assign,
-                    Payload::None,
-                    lo.span(lefts[1]),
-                    &[ok_lhs, ok_rhs],
-                ));
-                return if assigns.len() == 1 {
-                    assigns[0]
-                } else {
-                    lo.add(NodeKind::Block, Payload::None, span, &assigns)
-                };
-            }
+        if let Some(id) = lower_two_value_map_ok(lo, span, &lefts, &rights) {
+            return id;
         }
-        if is_channel_receive_expr(lo, rights[0]) {
-            let mut assigns = Vec::new();
-            let receive_span = lo.span(rights[0]);
-            let channel = rights[0]
-                .child_by_field_name("operand")
-                .map(|operand| lower_expr(lo, operand))
-                .unwrap_or_else(|| lo.empty_block(receive_span));
-            if lo.text(lefts[0]) != "_" {
-                let lhs = lower_expr(lo, lefts[0]);
-                let value = lo.protocol_boundary(
-                    receive_span,
-                    SourceProtocolKind::ChannelReceive,
-                    "channel_receive",
-                    &[channel],
-                );
-                assigns.push(lo.add(
-                    NodeKind::Assign,
-                    Payload::None,
-                    lo.span(lefts[0]),
-                    &[lhs, value],
-                ));
-            }
-            if lo.text(lefts[1]) != "_" {
-                let ok_lhs = lower_expr(lo, lefts[1]);
-                let ok = lo.protocol_boundary(
-                    receive_span,
-                    SourceProtocolKind::ChannelReceive,
-                    "channel_receive_status",
-                    &[channel],
-                );
-                assigns.push(lo.add(
-                    NodeKind::Assign,
-                    Payload::None,
-                    lo.span(lefts[1]),
-                    &[ok_lhs, ok],
-                ));
-            }
-            return if assigns.len() == 1 {
-                assigns[0]
-            } else {
-                lo.add(NodeKind::Block, Payload::None, span, &assigns)
-            };
+        if let Some(id) = lower_two_value_channel_receive(lo, span, &lefts, &rights) {
+            return id;
         }
     }
 
@@ -398,6 +334,97 @@ fn lower_assign_like(lo: &mut Lowering, node: TsNode) -> NodeId {
     } else {
         lo.add(NodeKind::Block, Payload::None, span, &assigns)
     }
+}
+
+/// `v, ok := m[k]` — the comma-ok map lookup. The ok target becomes a
+/// `Contains(key, map)` proof; a `_` ok target falls back to the generic path.
+fn lower_two_value_map_ok(
+    lo: &mut Lowering,
+    span: Span,
+    lefts: &[TsNode],
+    rights: &[TsNode],
+) -> Option<NodeId> {
+    let ok_rhs = lower_map_lookup_ok(lo, rights[0])?;
+    if lo.text(lefts[1]) == "_" {
+        return None;
+    }
+    let mut assigns = Vec::new();
+    if lo.text(lefts[0]) != "_" {
+        let lhs = lower_expr(lo, lefts[0]);
+        let rhs = lower_expr(lo, rights[0]);
+        assigns.push(lo.add(
+            NodeKind::Assign,
+            Payload::None,
+            lo.span(lefts[0]),
+            &[lhs, rhs],
+        ));
+    }
+    let ok_lhs = lower_expr(lo, lefts[1]);
+    assigns.push(lo.add(
+        NodeKind::Assign,
+        Payload::None,
+        lo.span(lefts[1]),
+        &[ok_lhs, ok_rhs],
+    ));
+    Some(if assigns.len() == 1 {
+        assigns[0]
+    } else {
+        lo.add(NodeKind::Block, Payload::None, span, &assigns)
+    })
+}
+
+/// `v, ok := <-ch` — the comma-ok channel receive; both targets stay
+/// source-backed protocol boundaries over the same channel operand.
+fn lower_two_value_channel_receive(
+    lo: &mut Lowering,
+    span: Span,
+    lefts: &[TsNode],
+    rights: &[TsNode],
+) -> Option<NodeId> {
+    if !is_channel_receive_expr(lo, rights[0]) {
+        return None;
+    }
+    let mut assigns = Vec::new();
+    let receive_span = lo.span(rights[0]);
+    let channel = rights[0]
+        .child_by_field_name("operand")
+        .map(|operand| lower_expr(lo, operand))
+        .unwrap_or_else(|| lo.empty_block(receive_span));
+    if lo.text(lefts[0]) != "_" {
+        let lhs = lower_expr(lo, lefts[0]);
+        let value = lo.protocol_boundary(
+            receive_span,
+            SourceProtocolKind::ChannelReceive,
+            "channel_receive",
+            &[channel],
+        );
+        assigns.push(lo.add(
+            NodeKind::Assign,
+            Payload::None,
+            lo.span(lefts[0]),
+            &[lhs, value],
+        ));
+    }
+    if lo.text(lefts[1]) != "_" {
+        let ok_lhs = lower_expr(lo, lefts[1]);
+        let ok = lo.protocol_boundary(
+            receive_span,
+            SourceProtocolKind::ChannelReceive,
+            "channel_receive_status",
+            &[channel],
+        );
+        assigns.push(lo.add(
+            NodeKind::Assign,
+            Payload::None,
+            lo.span(lefts[1]),
+            &[ok_lhs, ok],
+        ));
+    }
+    Some(if assigns.len() == 1 {
+        assigns[0]
+    } else {
+        lo.add(NodeKind::Block, Payload::None, span, &assigns)
+    })
 }
 
 fn lower_map_lookup_ok(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
@@ -744,18 +771,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         "call_expression" => lower_call(lo, node),
         "binary_expression" => lower_binary(lo, node),
         "unary_expression" => lower_unary(lo, node),
-        "selector_expression" => {
-            let obj = node
-                .child_by_field_name("operand")
-                .map(|o| lower_expr(lo, o))
-                .unwrap_or_else(|| lo.empty_block(span));
-            let field = node
-                .child_by_field_name("field")
-                .map(|f| lo.text(f))
-                .unwrap_or("");
-            let sym = lo.sym(field);
-            lo.add(NodeKind::Field, Payload::Name(sym), span, &[obj])
-        }
+        "selector_expression" => lower_selector(lo, node),
         "index_expression" => {
             let base = node
                 .child_by_field_name("operand")
@@ -767,44 +783,8 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                 .unwrap_or_else(|| lo.empty_block(span));
             lo.add(NodeKind::Index, Payload::None, span, &[base, idx])
         }
-        "func_literal" => {
-            let mut kids = Vec::new();
-            if let Some(params) = node.child_by_field_name("parameters") {
-                lower_params(lo, params, &mut kids);
-            }
-            let body = node
-                .child_by_field_name("body")
-                .map(|b| lower_block(lo, b))
-                .unwrap_or_else(|| lo.empty_block(span));
-            kids.push(body);
-            lo.add(NodeKind::Lambda, Payload::None, span, &kids)
-        }
-        "composite_literal" => {
-            let body = node.child_by_field_name("body");
-            let kids: Vec<NodeId> = match body {
-                Some(b) => Lowering::named_children(b)
-                    .into_iter()
-                    .map(|c| lower_expr(lo, c))
-                    .collect(),
-                None => Vec::new(),
-            };
-            // Tag the literal by its TYPE so the kinds stay semantically distinct (the old
-            // blanket `composite_literal` tag collapsed slice ≡ map ≡ struct to one value):
-            //   • slice/array  → `array`  — an ordered sequence; converges with `[1,2]` / JS.
-            //   • map          → `composite_literal` — preserves go-map handling
-            //                    (`proven_go_literal_zero_map_seq`, which keys on this tag).
-            //   • struct/named → `go_struct` — a record, NOT a collection; a distinct value so
-            //                    `Point{1,2}` no longer value-merges with `[1,2]`.
-            // Named-type aliases default to `go_struct` (conservative: distinct, never a false
-            // sequence merge — at worst a missed convergence for a named slice alias).
-            let tag_str = match node.child_by_field_name("type").map(|t| t.kind()) {
-                Some("slice_type" | "array_type") => "array",
-                Some("map_type") => "composite_literal",
-                _ => "go_struct",
-            };
-            let tag = lo.sym(tag_str);
-            lo.add(NodeKind::Seq, Payload::Name(tag), span, &kids)
-        }
+        "func_literal" => lower_func_literal(lo, node),
+        "composite_literal" => lower_composite_literal(lo, node),
         "literal_element" | "keyed_element" => {
             let kids: Vec<NodeId> = Lowering::named_children(node)
                 .into_iter()
@@ -835,26 +815,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             lo.add(NodeKind::Seq, Payload::None, span, &kids)
         }
         // `a[lo:hi:cap]` → indexing shape: base plus whatever bounds are present.
-        "slice_expression" => {
-            let base = node
-                .child_by_field_name("operand")
-                .map(|o| lower_expr(lo, o))
-                .unwrap_or_else(|| lo.empty_block(span));
-            // Preserve slot POSITIONS: `a[1:]` (start) and `a[:1]` (end) are different
-            // slices. A missing bound emits an explicit `None` placeholder so the
-            // operands stay positional rather than both collapsing to `Index(a, 1)`.
-            let mut kids = vec![base];
-            for field in ["start", "end", "capacity"] {
-                let v = node
-                    .child_by_field_name(field)
-                    .map(|n| lower_expr(lo, n))
-                    .unwrap_or_else(|| {
-                        lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[])
-                    });
-                kids.push(v);
-            }
-            lo.add(NodeKind::Index, Payload::None, span, &kids)
-        }
+        "slice_expression" => lower_slice_expr(lo, node),
         // `x.(T)` is a type-level check; keep the operand `x`, drop the assertion.
         "type_assertion_expression" => node
             .child_by_field_name("operand")
@@ -880,6 +841,82 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             lo.raw(node.kind(), span, &kids)
         }
     }
+}
+
+fn lower_selector(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let obj = node
+        .child_by_field_name("operand")
+        .map(|o| lower_expr(lo, o))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let field = node
+        .child_by_field_name("field")
+        .map(|f| lo.text(f))
+        .unwrap_or("");
+    let sym = lo.sym(field);
+    lo.add(NodeKind::Field, Payload::Name(sym), span, &[obj])
+}
+
+fn lower_func_literal(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let mut kids = Vec::new();
+    if let Some(params) = node.child_by_field_name("parameters") {
+        lower_params(lo, params, &mut kids);
+    }
+    let body = node
+        .child_by_field_name("body")
+        .map(|b| lower_block(lo, b))
+        .unwrap_or_else(|| lo.empty_block(span));
+    kids.push(body);
+    lo.add(NodeKind::Lambda, Payload::None, span, &kids)
+}
+
+fn lower_composite_literal(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let body = node.child_by_field_name("body");
+    let kids: Vec<NodeId> = match body {
+        Some(b) => Lowering::named_children(b)
+            .into_iter()
+            .map(|c| lower_expr(lo, c))
+            .collect(),
+        None => Vec::new(),
+    };
+    // Tag the literal by its TYPE so the kinds stay semantically distinct (the old
+    // blanket `composite_literal` tag collapsed slice ≡ map ≡ struct to one value):
+    //   • slice/array  → `array`  — an ordered sequence; converges with `[1,2]` / JS.
+    //   • map          → `composite_literal` — preserves go-map handling
+    //                    (`proven_go_literal_zero_map_seq`, which keys on this tag).
+    //   • struct/named → `go_struct` — a record, NOT a collection; a distinct value so
+    //                    `Point{1,2}` no longer value-merges with `[1,2]`.
+    // Named-type aliases default to `go_struct` (conservative: distinct, never a false
+    // sequence merge — at worst a missed convergence for a named slice alias).
+    let tag_str = match node.child_by_field_name("type").map(|t| t.kind()) {
+        Some("slice_type" | "array_type") => "array",
+        Some("map_type") => "composite_literal",
+        _ => "go_struct",
+    };
+    let tag = lo.sym(tag_str);
+    lo.add(NodeKind::Seq, Payload::Name(tag), span, &kids)
+}
+
+fn lower_slice_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let base = node
+        .child_by_field_name("operand")
+        .map(|o| lower_expr(lo, o))
+        .unwrap_or_else(|| lo.empty_block(span));
+    // Preserve slot POSITIONS: `a[1:]` (start) and `a[:1]` (end) are different
+    // slices. A missing bound emits an explicit `None` placeholder so the
+    // operands stay positional rather than both collapsing to `Index(a, 1)`.
+    let mut kids = vec![base];
+    for field in ["start", "end", "capacity"] {
+        let v = node
+            .child_by_field_name(field)
+            .map(|n| lower_expr(lo, n))
+            .unwrap_or_else(|| lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[]));
+        kids.push(v);
+    }
+    lo.add(NodeKind::Index, Payload::None, span, &kids)
 }
 
 fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {

--- a/crates/nose-frontend/src/java.rs
+++ b/crates/nose-frontend/src/java.rs
@@ -468,25 +468,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         "false" => lo.add(NodeKind::Lit, Payload::LitBool(false), span, &[]),
         "null_literal" => lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[]),
         "binary_expression" => lower_binary(lo, node),
-        "unary_expression" => {
-            let operand = node
-                .child_by_field_name("operand")
-                .map(|o| lower_expr(lo, o))
-                .unwrap_or_else(|| lo.empty_block(span));
-            // Map by the operator token, not the leading byte: `+`→Pos, `-`→Neg,
-            // `~`→BitNot, `!`→Not. Reading only the first byte collapsed `+x` and `~x`
-            // onto `Neg` (same class of bug as the C/Ruby frontends).
-            // Map by the operator token, not the leading byte: `+`→Pos, `-`→Neg,
-            // `~`→BitNot, `!`→Not. Reading only the first byte collapsed `+x` and `~x`
-            // onto `Neg` (same class of bug as the C/Ruby frontends).
-            let op = match node.child_by_field_name("operator").map(|o| lo.text(o)) {
-                Some("+") => Op::Pos,
-                Some("~") => Op::BitNot,
-                Some("!") => Op::Not,
-                _ => Op::Neg,
-            };
-            lo.add(NodeKind::UnOp, Payload::Op(op), span, &[operand])
-        }
+        "unary_expression" => lower_unary(lo, node),
         "assignment_expression" => {
             let l = node
                 .child_by_field_name("left")
@@ -516,28 +498,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             }
             lo.add(NodeKind::Assign, Payload::None, span, &[l, r])
         }
-        "update_expression" => {
-            // x++ / ++x → x = x + 1
-            let operand = node
-                .named_child(0)
-                .map(|o| lower_expr(lo, o))
-                .unwrap_or_else(|| lo.empty_block(span));
-            let operand2 = node
-                .named_child(0)
-                .map(|o| lower_expr(lo, o))
-                .unwrap_or_else(|| lo.empty_block(span));
-            let one = lo.int_lit("1", span);
-            // Decide by the operator TOKEN among this node's direct children: a substring
-            // check on the whole text misreads a nested `--`/`++` in the operand (e.g.
-            // `a[i--]++`, whose outer op is `++`).
-            let op = if crate::lower::has_direct_token(node, "--") {
-                Op::Sub
-            } else {
-                Op::Add
-            };
-            let bin = lo.add(NodeKind::BinOp, Payload::Op(op), span, &[operand2, one]);
-            lo.add(NodeKind::Assign, Payload::None, span, &[operand, bin])
-        }
+        "update_expression" => lower_update(lo, node),
         "method_invocation" => lower_call(lo, node),
         "switch_expression" => lower_switch_expr(lo, node),
         "object_creation_expression" => {
@@ -575,64 +536,17 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                 .collect();
             lo.add(NodeKind::Index, Payload::None, span, &kids)
         }
-        "lambda_expression" => {
-            let mut kids = Vec::new();
-            let body_node = node.child_by_field_name("body");
-            if let Some(params) = node.child_by_field_name("parameters") {
-                for p in Lowering::named_children(params) {
-                    let psym = if p.kind() == "identifier" {
-                        Some(lo.sym(lo.text(p)))
-                    } else {
-                        p.child_by_field_name("name").map(|n| lo.sym(lo.text(n)))
-                    };
-                    let pspan = lo.span(p);
-                    kids.push(lo.add(
-                        NodeKind::Param,
-                        psym.map(Payload::Name).unwrap_or(Payload::None),
-                        pspan,
-                        &[],
-                    ));
-                }
-            } else if let Some(p) = node.child_by_field_name("parameter") {
-                let psym = if p.kind() == "identifier" {
-                    Some(lo.sym(lo.text(p)))
-                } else {
-                    p.child_by_field_name("name").map(|n| lo.sym(lo.text(n)))
-                };
-                kids.push(lo.add(
-                    NodeKind::Param,
-                    psym.map(Payload::Name).unwrap_or(Payload::None),
-                    lo.span(p),
-                    &[],
-                ));
-            } else if let Some(p) = node.named_child(0) {
-                let body_start = body_node.map(|b| b.start_byte());
-                if p.kind() == "identifier" && Some(p.start_byte()) != body_start {
-                    kids.push(lo.add(
-                        NodeKind::Param,
-                        Payload::Name(lo.sym(lo.text(p))),
-                        lo.span(p),
-                        &[],
-                    ));
-                }
-            }
-            if kids.is_empty() {
-                if let Some(name) = lambda_single_param_from_text(lo.text(node)) {
-                    kids.push(lo.add(NodeKind::Param, Payload::Name(lo.sym(name)), span, &[]));
-                }
-            }
-            let body = body_node
-                .map(|b| {
-                    if b.kind() == "block" {
-                        lower_block(lo, b)
-                    } else {
-                        lower_expr(lo, b)
-                    }
-                })
-                .unwrap_or_else(|| lo.empty_block(span));
-            kids.push(body);
-            lo.add(NodeKind::Lambda, Payload::None, span, &kids)
-        }
+        "lambda_expression" => lower_lambda(lo, node),
+        _ => lower_expr_rest(lo, node),
+    }
+}
+
+/// Tail of [`lower_expr`]'s dispatch: grouping/cast wrappers, aggregate
+/// initializers, constructor delegation, label/constant kinds, and type-level
+/// nodes that reach expression position.
+fn lower_expr_rest(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    match node.kind() {
         "parenthesized_expression" | "cast_expression" => node
             .named_child(node.named_child_count().saturating_sub(1))
             .map(|c| lower_expr(lo, c))
@@ -730,6 +644,108 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             lo.raw(node.kind(), span, &kids)
         }
     }
+}
+
+fn lower_unary(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let operand = node
+        .child_by_field_name("operand")
+        .map(|o| lower_expr(lo, o))
+        .unwrap_or_else(|| lo.empty_block(span));
+    // Map by the operator token, not the leading byte: `+`→Pos, `-`→Neg,
+    // `~`→BitNot, `!`→Not. Reading only the first byte collapsed `+x` and `~x`
+    // onto `Neg` (same class of bug as the C/Ruby frontends).
+    let op = match node.child_by_field_name("operator").map(|o| lo.text(o)) {
+        Some("+") => Op::Pos,
+        Some("~") => Op::BitNot,
+        Some("!") => Op::Not,
+        _ => Op::Neg,
+    };
+    lo.add(NodeKind::UnOp, Payload::Op(op), span, &[operand])
+}
+
+fn lower_update(lo: &mut Lowering, node: TsNode) -> NodeId {
+    // x++ / ++x → x = x + 1
+    let span = lo.span(node);
+    let operand = node
+        .named_child(0)
+        .map(|o| lower_expr(lo, o))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let operand2 = node
+        .named_child(0)
+        .map(|o| lower_expr(lo, o))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let one = lo.int_lit("1", span);
+    // Decide by the operator TOKEN among this node's direct children: a substring
+    // check on the whole text misreads a nested `--`/`++` in the operand (e.g.
+    // `a[i--]++`, whose outer op is `++`).
+    let op = if crate::lower::has_direct_token(node, "--") {
+        Op::Sub
+    } else {
+        Op::Add
+    };
+    let bin = lo.add(NodeKind::BinOp, Payload::Op(op), span, &[operand2, one]);
+    lo.add(NodeKind::Assign, Payload::None, span, &[operand, bin])
+}
+
+fn lower_lambda(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let mut kids = Vec::new();
+    let body_node = node.child_by_field_name("body");
+    if let Some(params) = node.child_by_field_name("parameters") {
+        for p in Lowering::named_children(params) {
+            let psym = if p.kind() == "identifier" {
+                Some(lo.sym(lo.text(p)))
+            } else {
+                p.child_by_field_name("name").map(|n| lo.sym(lo.text(n)))
+            };
+            let pspan = lo.span(p);
+            kids.push(lo.add(
+                NodeKind::Param,
+                psym.map(Payload::Name).unwrap_or(Payload::None),
+                pspan,
+                &[],
+            ));
+        }
+    } else if let Some(p) = node.child_by_field_name("parameter") {
+        let psym = if p.kind() == "identifier" {
+            Some(lo.sym(lo.text(p)))
+        } else {
+            p.child_by_field_name("name").map(|n| lo.sym(lo.text(n)))
+        };
+        kids.push(lo.add(
+            NodeKind::Param,
+            psym.map(Payload::Name).unwrap_or(Payload::None),
+            lo.span(p),
+            &[],
+        ));
+    } else if let Some(p) = node.named_child(0) {
+        let body_start = body_node.map(|b| b.start_byte());
+        if p.kind() == "identifier" && Some(p.start_byte()) != body_start {
+            kids.push(lo.add(
+                NodeKind::Param,
+                Payload::Name(lo.sym(lo.text(p))),
+                lo.span(p),
+                &[],
+            ));
+        }
+    }
+    if kids.is_empty() {
+        if let Some(name) = lambda_single_param_from_text(lo.text(node)) {
+            kids.push(lo.add(NodeKind::Param, Payload::Name(lo.sym(name)), span, &[]));
+        }
+    }
+    let body = body_node
+        .map(|b| {
+            if b.kind() == "block" {
+                lower_block(lo, b)
+            } else {
+                lower_expr(lo, b)
+            }
+        })
+        .unwrap_or_else(|| lo.empty_block(span));
+    kids.push(body);
+    lo.add(NodeKind::Lambda, Payload::None, span, &kids)
 }
 
 fn lower_empty_java_collection_constructor(

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -928,6 +928,15 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                 .unwrap_or_else(|| lo.empty_block(span));
             lo.await_boundary(span, value)
         }
+        _ => lower_expr_rest(lo, node),
+    }
+}
+
+/// Tail of [`lower_expr`]'s dispatch: destructuring patterns, parameters,
+/// JSX, template internals, and TS-only kinds that reach expression position.
+fn lower_expr_rest(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    match node.kind() {
         // TS-only wrappers have no runtime behavior.
         "as_expression" | "satisfies_expression" | "non_null_expression" | "type_assertion" => node
             .named_child(0)

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -1527,128 +1527,18 @@ fn record_post_lower_free_name_library_api(il: &mut Il, interner: &Interner, cal
         return false;
     };
     let arg_count = args.len();
-    let contract = (arg_count == 1)
-        .then(|| library_free_name_collection_factory_contract(il.meta.lang, callee_name))
-        .flatten()
-        .map(|contract| {
-            (
-                contract.id,
-                contract.callee,
-                "library_api_free_name_collection_factory",
-                library_collection_factory_result_domain_for_arity(contract, arg_count),
-            )
-        })
-        .or_else(|| {
-            (arg_count == 1)
-                .then(|| library_free_name_map_factory_contract(il.meta.lang, callee_name))
-                .flatten()
-                .map(|contract| {
-                    (
-                        contract.id,
-                        contract.callee,
-                        "library_api_free_name_map_factory",
-                        Some(library_map_factory_result_domain(contract)),
-                    )
-                })
-        })
-        .or_else(|| {
-            library_rust_vec_macro_factory_contract(il.meta.lang, callee_name).map(|contract| {
-                (
-                    contract.id,
-                    contract.callee,
-                    "library_api_rust_vec_macro_factory",
-                    library_collection_factory_result_domain_for_arity(contract, arg_count),
-                )
-            })
-        })
-        .or_else(|| {
-            (arg_count == 0)
-                .then(|| library_rust_vec_new_factory_contract(il.meta.lang, callee_name))
-                .flatten()
-                .map(|contract| {
-                    (
-                        contract.id,
-                        contract.callee,
-                        "library_api_rust_vec_new_factory",
-                        library_collection_factory_result_domain_for_arity(contract, arg_count),
-                    )
-                })
-        })
-        .or_else(|| {
-            library_rust_option_some_constructor_contract(il.meta.lang, callee_name, arg_count).map(
-                |contract| {
-                    (
-                        contract.id,
-                        contract.callee,
-                        "library_api_rust_option_some_constructor",
-                        Some(contract.result_domain),
-                    )
-                },
-            )
-        })
-        .or_else(|| {
-            library_free_function_builtin_contract(il.meta.lang, callee_name, arg_count).map(
-                |contract| {
-                    (
-                        contract.id,
-                        contract.callee,
-                        "library_api_free_function_builtin",
-                        None,
-                    )
-                },
-            )
-        });
+    let contract = post_lower_free_name_library_api_contract(il.meta.lang, callee_name, arg_count);
     let Some((id, callee_contract, rule, result_domain)) = contract else {
         return false;
     };
     if il.meta.lang == Lang::Python && post_lower_has_python_wildcard_import_evidence(il) {
         return false;
     }
-    let mut dependencies = Vec::new();
-    match callee_contract {
-        LibraryApiCalleeContract::FreeName { name, shadow } => {
-            if !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
-                post_lower_file_defines_name_visible_at(
-                    il,
-                    interner,
-                    candidate,
-                    il.node(callee).span,
-                )
-            }) {
-                return false;
-            }
-            let Some(dependency) = post_lower_unshadowed_symbol_evidence_id(il, callee, name)
-            else {
-                return false;
-            };
-            dependencies.push(dependency);
-        }
-        LibraryApiCalleeContract::RustMacro { name, shadow } => {
-            if !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
-                post_lower_file_defines_name_visible_at(
-                    il,
-                    interner,
-                    candidate,
-                    il.node(callee).span,
-                )
-            }) {
-                return false;
-            }
-            let Some(source_dependency) =
-                post_lower_source_call_evidence_id(il, call, SourceCallKind::MacroInvocation)
-            else {
-                return false;
-            };
-            let Some(symbol_dependency) =
-                post_lower_unshadowed_symbol_evidence_id(il, callee, name)
-            else {
-                return false;
-            };
-            dependencies.push(source_dependency);
-            dependencies.push(symbol_dependency);
-        }
-        _ => return false,
-    }
+    let Some(dependencies) =
+        post_lower_free_name_library_api_dependencies(il, interner, call, callee, callee_contract)
+    else {
+        return false;
+    };
     let api = post_lower_library_api_evidence_id(
         il,
         call,
@@ -1660,6 +1550,132 @@ fn record_post_lower_free_name_library_api(il: &mut Il, interner: &Interner, cal
     );
     post_lower_record_library_api_result_domain(il, call, result_domain, api);
     true
+}
+
+fn post_lower_free_name_library_api_contract(
+    lang: Lang,
+    callee_name: &str,
+    arg_count: usize,
+) -> Option<(
+    LibraryApiContractId,
+    LibraryApiCalleeContract,
+    &'static str,
+    Option<DomainEvidence>,
+)> {
+    (arg_count == 1)
+        .then(|| library_free_name_collection_factory_contract(lang, callee_name))
+        .flatten()
+        .map(|contract| {
+            (
+                contract.id,
+                contract.callee,
+                "library_api_free_name_collection_factory",
+                library_collection_factory_result_domain_for_arity(contract, arg_count),
+            )
+        })
+        .or_else(|| {
+            (arg_count == 1)
+                .then(|| library_free_name_map_factory_contract(lang, callee_name))
+                .flatten()
+                .map(|contract| {
+                    (
+                        contract.id,
+                        contract.callee,
+                        "library_api_free_name_map_factory",
+                        Some(library_map_factory_result_domain(contract)),
+                    )
+                })
+        })
+        .or_else(|| {
+            library_rust_vec_macro_factory_contract(lang, callee_name).map(|contract| {
+                (
+                    contract.id,
+                    contract.callee,
+                    "library_api_rust_vec_macro_factory",
+                    library_collection_factory_result_domain_for_arity(contract, arg_count),
+                )
+            })
+        })
+        .or_else(|| {
+            (arg_count == 0)
+                .then(|| library_rust_vec_new_factory_contract(lang, callee_name))
+                .flatten()
+                .map(|contract| {
+                    (
+                        contract.id,
+                        contract.callee,
+                        "library_api_rust_vec_new_factory",
+                        library_collection_factory_result_domain_for_arity(contract, arg_count),
+                    )
+                })
+        })
+        .or_else(|| {
+            library_rust_option_some_constructor_contract(lang, callee_name, arg_count).map(
+                |contract| {
+                    (
+                        contract.id,
+                        contract.callee,
+                        "library_api_rust_option_some_constructor",
+                        Some(contract.result_domain),
+                    )
+                },
+            )
+        })
+        .or_else(|| {
+            library_free_function_builtin_contract(lang, callee_name, arg_count).map(|contract| {
+                (
+                    contract.id,
+                    contract.callee,
+                    "library_api_free_function_builtin",
+                    None,
+                )
+            })
+        })
+}
+
+fn post_lower_free_name_library_api_dependencies(
+    il: &mut Il,
+    interner: &Interner,
+    call: NodeId,
+    callee: NodeId,
+    callee_contract: LibraryApiCalleeContract,
+) -> Option<Vec<EvidenceId>> {
+    let mut dependencies = Vec::new();
+    match callee_contract {
+        LibraryApiCalleeContract::FreeName { name, shadow } => {
+            if !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+                post_lower_file_defines_name_visible_at(
+                    il,
+                    interner,
+                    candidate,
+                    il.node(callee).span,
+                )
+            }) {
+                return None;
+            }
+            let dependency = post_lower_unshadowed_symbol_evidence_id(il, callee, name)?;
+            dependencies.push(dependency);
+        }
+        LibraryApiCalleeContract::RustMacro { name, shadow } => {
+            if !library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
+                post_lower_file_defines_name_visible_at(
+                    il,
+                    interner,
+                    candidate,
+                    il.node(callee).span,
+                )
+            }) {
+                return None;
+            }
+            let source_dependency =
+                post_lower_source_call_evidence_id(il, call, SourceCallKind::MacroInvocation)?;
+            let symbol_dependency = post_lower_unshadowed_symbol_evidence_id(il, callee, name)?;
+            dependencies.push(source_dependency);
+            dependencies.push(symbol_dependency);
+        }
+        _ => return None,
+    }
+    Some(dependencies)
 }
 
 fn record_post_lower_property_library_api(
@@ -2943,6 +2959,81 @@ mod tests {
             .collect()
     }
 
+    fn contract_api_count(
+        evidence: &[EvidenceRecord],
+        id: LibraryApiContractId,
+        callee: LibraryApiCalleeContract,
+    ) -> usize {
+        contract_api_ids(evidence, id, callee).len()
+    }
+
+    fn contract_api_ids(
+        evidence: &[EvidenceRecord],
+        id: LibraryApiContractId,
+        callee: LibraryApiCalleeContract,
+    ) -> Vec<EvidenceId> {
+        library_api_evidence_ids_in_records(
+            evidence,
+            library_api_contract_id_hash(id),
+            library_api_callee_contract_hash(callee),
+        )
+    }
+
+    fn lower_fixture(path: &str, src: &[u8], lang: Lang, interner: &Interner) -> Il {
+        crate::lower_source(FileId(0), path, src, lang, interner).expect("lowering should succeed")
+    }
+
+    fn array_seq(lo: &mut Lowering, interner: &Interner, sp: Span) -> NodeId {
+        lo.add(
+            NodeKind::Seq,
+            Payload::Name(interner.intern("array")),
+            sp,
+            &[],
+        )
+    }
+
+    fn field_callee(
+        lo: &mut Lowering,
+        interner: &Interner,
+        base: NodeId,
+        member: &str,
+        sp: Span,
+    ) -> NodeId {
+        lo.add(
+            NodeKind::Field,
+            Payload::Name(interner.intern(member)),
+            sp,
+            &[base],
+        )
+    }
+
+    fn named_node_span(il: &Il, interner: &Interner, kind: NodeKind, name: &str) -> Option<Span> {
+        il.nodes.iter().find_map(|node| {
+            (node.kind == kind
+                && matches!(
+                    node.payload,
+                    Payload::Name(symbol) if interner.resolve(symbol) == name
+                ))
+            .then_some(node.span)
+        })
+    }
+
+    fn call_span_with_callee_named(il: &Il, interner: &Interner, name: &str) -> Option<Span> {
+        il.nodes.iter().enumerate().find_map(|(idx, node)| {
+            (node.kind == NodeKind::Call
+                && il
+                    .children(NodeId(idx as u32))
+                    .first()
+                    .is_some_and(|&callee| {
+                        matches!(
+                            il.node(callee).payload,
+                            Payload::Name(symbol) if interner.resolve(symbol) == name
+                        )
+                    }))
+            .then_some(node.span)
+        })
+    }
+
     fn result_domain_depends_on_api(
         evidence: &[EvidenceRecord],
         span: Span,
@@ -3153,16 +3244,16 @@ mod tests {
     #[test]
     fn core_lowering_emits_result_domain_evidence_for_library_api_factories() {
         let interner = Interner::new();
+        assert_python_deque_factory_result_domain(&interner);
+        assert_java_factory_result_domains(&interner);
+        assert_js_constructor_result_domains(&interner);
+    }
 
-        let mut lo = Lowering::new(FileId(0), b"", Lang::Python, &interner);
+    fn assert_python_deque_factory_result_domain(interner: &Interner) {
+        let mut lo = Lowering::new(FileId(0), b"", Lang::Python, interner);
         import_binding(&mut lo, sp_at(1), "Values", "collections", "deque");
         let callee = lo.var("Values", sp_at(2));
-        let seq = lo.add(
-            NodeKind::Seq,
-            Payload::Name(interner.intern("array")),
-            sp_at(3),
-            &[],
-        );
+        let seq = array_seq(&mut lo, interner, sp_at(3));
         lo.add(NodeKind::Call, Payload::None, sp_at(4), &[callee, seq]);
         let deque = nose_semantics::library_imported_collection_factory_contract(
             Lang::Python,
@@ -3170,11 +3261,7 @@ mod tests {
             "deque",
         )
         .expect("deque contract");
-        let deque_api = library_api_evidence_ids_in_records(
-            &lo.evidence,
-            library_api_contract_id_hash(deque.id),
-            library_api_callee_contract_hash(deque.callee),
-        );
+        let deque_api = contract_api_ids(&lo.evidence, deque.id, deque.callee);
         assert!(
             result_domain_depends_on_api(
                 &lo.evidence,
@@ -3184,20 +3271,21 @@ mod tests {
             ),
             "collections.deque result domain should depend on the admitted LibraryApi occurrence"
         );
+    }
 
-        let mut lo = Lowering::new(FileId(0), b"", Lang::Java, &interner);
+    fn assert_java_factory_result_domains(interner: &Interner) {
+        let mut lo = Lowering::new(FileId(0), b"", Lang::Java, interner);
         import_binding(&mut lo, sp_at(10), "List", "java.util", "List");
         import_binding(&mut lo, sp_at(11), "Set", "java.util", "Set");
         import_binding(&mut lo, sp_at(12), "Map", "java.util", "Map");
         import_binding(&mut lo, sp_at(13), "Arrays", "java.util", "Arrays");
+        assert_java_of_factory_result_domains(&mut lo, interner);
+        assert_java_arrays_and_map_entry_result_domains(&mut lo, interner);
+    }
 
+    fn assert_java_of_factory_result_domains(lo: &mut Lowering, interner: &Interner) {
         let list = lo.var("List", sp_at(20));
-        let list_callee = lo.add(
-            NodeKind::Field,
-            Payload::Name(interner.intern("of")),
-            sp_at(21),
-            &[list],
-        );
+        let list_callee = field_callee(lo, interner, list, "of", sp_at(21));
         let item = lo.int_lit("1", sp_at(22));
         lo.add(
             NodeKind::Call,
@@ -3205,13 +3293,8 @@ mod tests {
             sp_at(23),
             &[list_callee, item],
         );
-        let list_contract =
-            library_java_collection_factory_contract(Lang::Java, "List", "of").unwrap();
-        let list_api = library_api_evidence_ids_in_records(
-            &lo.evidence,
-            library_api_contract_id_hash(list_contract.id),
-            library_api_callee_contract_hash(list_contract.callee),
-        );
+        let contract = library_java_collection_factory_contract(Lang::Java, "List", "of").unwrap();
+        let list_api = contract_api_ids(&lo.evidence, contract.id, contract.callee);
         assert!(result_domain_depends_on_api(
             &lo.evidence,
             sp_at(23),
@@ -3220,12 +3303,7 @@ mod tests {
         ));
 
         let set = lo.var("Set", sp_at(30));
-        let set_callee = lo.add(
-            NodeKind::Field,
-            Payload::Name(interner.intern("of")),
-            sp_at(31),
-            &[set],
-        );
+        let set_callee = field_callee(lo, interner, set, "of", sp_at(31));
         let item = lo.int_lit("1", sp_at(32));
         lo.add(
             NodeKind::Call,
@@ -3233,13 +3311,8 @@ mod tests {
             sp_at(33),
             &[set_callee, item],
         );
-        let set_contract =
-            library_java_collection_factory_contract(Lang::Java, "Set", "of").unwrap();
-        let set_api = library_api_evidence_ids_in_records(
-            &lo.evidence,
-            library_api_contract_id_hash(set_contract.id),
-            library_api_callee_contract_hash(set_contract.callee),
-        );
+        let contract = library_java_collection_factory_contract(Lang::Java, "Set", "of").unwrap();
+        let set_api = contract_api_ids(&lo.evidence, contract.id, contract.callee);
         assert!(result_domain_depends_on_api(
             &lo.evidence,
             sp_at(33),
@@ -3248,12 +3321,7 @@ mod tests {
         ));
 
         let map = lo.var("Map", sp_at(40));
-        let map_callee = lo.add(
-            NodeKind::Field,
-            Payload::Name(interner.intern("of")),
-            sp_at(41),
-            &[map],
-        );
+        let map_callee = field_callee(lo, interner, map, "of", sp_at(41));
         let key = lo.str_lit("\"red\"", sp_at(42));
         let value = lo.int_lit("1", sp_at(43));
         lo.add(
@@ -3262,26 +3330,19 @@ mod tests {
             sp_at(44),
             &[map_callee, key, value],
         );
-        let map_contract = library_java_map_factory_contract(Lang::Java, "Map", "of").unwrap();
-        let map_api = library_api_evidence_ids_in_records(
-            &lo.evidence,
-            library_api_contract_id_hash(map_contract.id),
-            library_api_callee_contract_hash(map_contract.callee),
-        );
+        let contract = library_java_map_factory_contract(Lang::Java, "Map", "of").unwrap();
+        let map_api = contract_api_ids(&lo.evidence, contract.id, contract.callee);
         assert!(result_domain_depends_on_api(
             &lo.evidence,
             sp_at(44),
             DomainEvidence::Map,
             &map_api,
         ));
+    }
 
+    fn assert_java_arrays_and_map_entry_result_domains(lo: &mut Lowering, interner: &Interner) {
         let arrays = lo.var("Arrays", sp_at(46));
-        let as_list_callee = lo.add(
-            NodeKind::Field,
-            Payload::Name(interner.intern("asList")),
-            sp_at(47),
-            &[arrays],
-        );
+        let as_list_callee = field_callee(lo, interner, arrays, "asList", sp_at(47));
         let maybe_array = lo.var("items", sp_at(48));
         lo.add(
             NodeKind::Call,
@@ -3296,12 +3357,7 @@ mod tests {
         );
 
         let arrays = lo.var("Arrays", sp_at(55));
-        let as_list_callee = lo.add(
-            NodeKind::Field,
-            Payload::Name(interner.intern("asList")),
-            sp_at(56),
-            &[arrays],
-        );
+        let as_list_callee = field_callee(lo, interner, arrays, "asList", sp_at(56));
         let red = lo.str_lit("\"red\"", sp_at(57));
         let blue = lo.str_lit("\"blue\"", sp_at(58));
         lo.add(
@@ -3327,12 +3383,7 @@ mod tests {
         ));
 
         let map = lo.var("Map", sp_at(50));
-        let entry_callee = lo.add(
-            NodeKind::Field,
-            Payload::Name(interner.intern("entry")),
-            sp_at(51),
-            &[map],
-        );
+        let entry_callee = field_callee(lo, interner, map, "entry", sp_at(51));
         let key = lo.str_lit("\"red\"", sp_at(52));
         let value = lo.int_lit("1", sp_at(53));
         lo.add(
@@ -3343,11 +3394,7 @@ mod tests {
         );
         let entry_contract = library_java_map_entry_contract(Lang::Java, "Map", "entry").unwrap();
         assert_eq!(
-            library_api_evidence_count(
-                &lo,
-                library_api_contract_id_hash(entry_contract.id),
-                library_api_callee_contract_hash(entry_contract.callee),
-            ),
+            contract_api_count(&lo.evidence, entry_contract.id, entry_contract.callee),
             1
         );
         assert_eq!(
@@ -3357,12 +3404,7 @@ mod tests {
         );
 
         let arrays = lo.var("Arrays", sp_at(60));
-        let stream_callee = lo.add(
-            NodeKind::Field,
-            Payload::Name(interner.intern("stream")),
-            sp_at(61),
-            &[arrays],
-        );
+        let stream_callee = field_callee(lo, interner, arrays, "stream", sp_at(61));
         let values = lo.var("values", sp_at(62));
         lo.add(
             NodeKind::Call,
@@ -3375,24 +3417,17 @@ mod tests {
             0,
             "Arrays.stream produces a stream/protocol surface, not any receiver-domain container"
         );
+    }
 
-        let mut lo = Lowering::new(FileId(0), b"", Lang::JavaScript, &interner);
+    fn assert_js_constructor_result_domains(interner: &Interner) {
+        let mut lo = Lowering::new(FileId(0), b"", Lang::JavaScript, interner);
         let set = lo.unshadowed_global_var("Set", sp_at(70));
-        let seq = lo.add(
-            NodeKind::Seq,
-            Payload::Name(interner.intern("array")),
-            sp_at(71),
-            &[],
-        );
+        let seq = array_seq(&mut lo, interner, sp_at(71));
         lo.record_source_fact(sp_at(72), SourceFactKind::Call(SourceCallKind::Construct));
         lo.add(NodeKind::Call, Payload::None, sp_at(72), &[set, seq]);
         let set_contract = library_js_like_set_constructor_contract(Lang::JavaScript, "Set")
             .expect("Set constructor");
-        let set_api = library_api_evidence_ids_in_records(
-            &lo.evidence,
-            library_api_contract_id_hash(set_contract.id),
-            library_api_callee_contract_hash(set_contract.callee),
-        );
+        let set_api = contract_api_ids(&lo.evidence, set_contract.id, set_contract.callee);
         assert!(result_domain_depends_on_api(
             &lo.evidence,
             sp_at(72),
@@ -3401,21 +3436,12 @@ mod tests {
         ));
 
         let map = lo.unshadowed_global_var("Map", sp_at(80));
-        let seq = lo.add(
-            NodeKind::Seq,
-            Payload::Name(interner.intern("array")),
-            sp_at(81),
-            &[],
-        );
+        let seq = array_seq(&mut lo, interner, sp_at(81));
         lo.record_source_fact(sp_at(82), SourceFactKind::Call(SourceCallKind::Construct));
         lo.add(NodeKind::Call, Payload::None, sp_at(82), &[map, seq]);
         let map_contract = library_js_like_map_constructor_contract(Lang::JavaScript, "Map")
             .expect("Map constructor");
-        let map_api = library_api_evidence_ids_in_records(
-            &lo.evidence,
-            library_api_contract_id_hash(map_contract.id),
-            library_api_callee_contract_hash(map_contract.callee),
-        );
+        let map_api = contract_api_ids(&lo.evidence, map_contract.id, map_contract.callee);
         assert!(result_domain_depends_on_api(
             &lo.evidence,
             sp_at(82),
@@ -3424,12 +3450,7 @@ mod tests {
         ));
 
         let array = lo.unshadowed_global_var("Array", sp_at(90));
-        let from_callee = lo.add(
-            NodeKind::Field,
-            Payload::Name(interner.intern("from")),
-            sp_at(91),
-            &[array],
-        );
+        let from_callee = field_callee(&mut lo, interner, array, "from", sp_at(91));
         lo.record_qualified_global_symbol(sp_at(91), NodeKind::Field, "Array.from");
         let iterable = lo.var("iterable", sp_at(92));
         lo.add(
@@ -3440,11 +3461,7 @@ mod tests {
         );
         let from_contract =
             library_map_key_view_wrapper_contract(Lang::JavaScript, "Array", "from", 1).unwrap();
-        let from_api = library_api_evidence_ids_in_records(
-            &lo.evidence,
-            library_api_contract_id_hash(from_contract.id),
-            library_api_callee_contract_hash(from_contract.callee),
-        );
+        let from_api = contract_api_ids(&lo.evidence, from_contract.id, from_contract.callee);
         assert!(result_domain_depends_on_api(
             &lo.evidence,
             sp_at(93),
@@ -3453,12 +3470,7 @@ mod tests {
         ));
 
         let promise = lo.unshadowed_global_var("Promise", sp_at(95));
-        let resolve_callee = lo.add(
-            NodeKind::Field,
-            Payload::Name(interner.intern("resolve")),
-            sp_at(96),
-            &[promise],
-        );
+        let resolve_callee = field_callee(&mut lo, interner, promise, "resolve", sp_at(96));
         lo.record_qualified_global_symbol(sp_at(96), NodeKind::Field, "Promise.resolve");
         let value = lo.int_lit("1", sp_at(97));
         lo.add(
@@ -3469,11 +3481,8 @@ mod tests {
         );
         let resolve_contract =
             library_promise_resolve_contract(Lang::JavaScript, "Promise", "resolve", 1).unwrap();
-        let resolve_api = library_api_evidence_ids_in_records(
-            &lo.evidence,
-            library_api_contract_id_hash(resolve_contract.id),
-            library_api_callee_contract_hash(resolve_contract.callee),
-        );
+        let resolve_api =
+            contract_api_ids(&lo.evidence, resolve_contract.id, resolve_contract.callee);
         assert!(result_domain_depends_on_api(
             &lo.evidence,
             sp_at(98),
@@ -3523,282 +3532,233 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
     #[test]
     fn post_lowering_emits_free_name_and_require_library_api_occurrences() {
         let interner = Interner::new();
+        assert_python_free_name_occurrences(&interner);
+        assert_go_and_rust_free_name_occurrences(&interner);
+        assert_ruby_require_occurrences(&interner);
+    }
 
-        let py = crate::lower_source(
-            FileId(0),
+    fn assert_python_free_name_occurrences(interner: &Interner) {
+        let py = lower_fixture(
             "builtin.py",
             b"def f(values):\n    return list(values)\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         let py_contract =
             library_free_name_collection_factory_contract(Lang::Python, "list").unwrap();
         assert_eq!(
-            library_api_evidence_count_in_records(
-                &py.evidence,
-                library_api_contract_id_hash(py_contract.id),
-                library_api_callee_contract_hash(py_contract.callee),
-            ),
+            contract_api_count(&py.evidence, py_contract.id, py_contract.callee),
             1
         );
 
-        let shadowed_py = crate::lower_source(
-            FileId(0),
+        let shadowed_py = lower_fixture(
             "shadowed.py",
             b"def f(list, values):\n    return list(values)\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         assert_eq!(
-            library_api_evidence_count_in_records(
-                &shadowed_py.evidence,
-                library_api_contract_id_hash(py_contract.id),
-                library_api_callee_contract_hash(py_contract.callee),
-            ),
+            contract_api_count(&shadowed_py.evidence, py_contract.id, py_contract.callee),
             0
         );
 
-        let wildcard_py = crate::lower_source(
-            FileId(0),
+        let wildcard_py = lower_fixture(
             "wildcard.py",
             b"from custom import *\n\ndef f(values):\n    return list(values)\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         assert!(wildcard_py.evidence.iter().any(|record| matches!(
             record.kind,
             EvidenceKind::Import(ImportEvidenceKind::Wildcard { module_hash })
                 if module_hash == stable_symbol_hash("custom")
         )));
         assert_eq!(
-            library_api_evidence_count_in_records(
-                &wildcard_py.evidence,
-                library_api_contract_id_hash(py_contract.id),
-                library_api_callee_contract_hash(py_contract.callee),
-            ),
+            contract_api_count(&wildcard_py.evidence, py_contract.id, py_contract.callee),
             0
         );
 
-        let py_len = crate::lower_source(
-            FileId(0),
+        let py_len = lower_fixture(
             "len.py",
             b"def f(values):\n    return len(values)\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         let py_len_contract =
             library_free_function_builtin_contract(Lang::Python, "len", 1).unwrap();
         assert_eq!(
-            library_api_evidence_count_in_records(
-                &py_len.evidence,
-                library_api_contract_id_hash(py_len_contract.id),
-                library_api_callee_contract_hash(py_len_contract.callee),
-            ),
+            contract_api_count(&py_len.evidence, py_len_contract.id, py_len_contract.callee),
             1
         );
 
-        let shadowed_py_len = crate::lower_source(
-            FileId(0),
+        let shadowed_py_len = lower_fixture(
             "shadowed_len.py",
             b"def f(len, values):\n    return len(values)\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         assert_eq!(
-            library_api_evidence_count_in_records(
+            contract_api_count(
                 &shadowed_py_len.evidence,
-                library_api_contract_id_hash(py_len_contract.id),
-                library_api_callee_contract_hash(py_len_contract.callee),
+                py_len_contract.id,
+                py_len_contract.callee
             ),
             0
         );
 
-        let wildcard_py_len = crate::lower_source(
-            FileId(0),
+        let wildcard_py_len = lower_fixture(
             "wildcard_len.py",
             b"from custom import *\n\ndef f(values):\n    return len(values)\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         assert_eq!(
-            library_api_evidence_count_in_records(
+            contract_api_count(
                 &wildcard_py_len.evidence,
-                library_api_contract_id_hash(py_len_contract.id),
-                library_api_callee_contract_hash(py_len_contract.callee),
+                py_len_contract.id,
+                py_len_contract.callee
             ),
             0
         );
+    }
 
-        let go = crate::lower_source(
-            FileId(0),
+    fn assert_go_and_rust_free_name_occurrences(interner: &Interner) {
+        let go = lower_fixture(
             "builtin.go",
             b"package p\nfunc f(xs []int, x int) int { return len(xs) }\nfunc g(xs []int, x int) []int { return append(xs, x) }\n",
             Lang::Go,
-            &interner,
-        )
-        .expect("go lowering should succeed");
+            interner,
+        );
         let go_len_contract = library_free_function_builtin_contract(Lang::Go, "len", 1).unwrap();
         assert_eq!(
-            library_api_evidence_count_in_records(
-                &go.evidence,
-                library_api_contract_id_hash(go_len_contract.id),
-                library_api_callee_contract_hash(go_len_contract.callee),
-            ),
+            contract_api_count(&go.evidence, go_len_contract.id, go_len_contract.callee),
             1
         );
         let go_append_contract =
             library_free_function_builtin_contract(Lang::Go, "append", 2).unwrap();
         assert_eq!(
-            library_api_evidence_count_in_records(
+            contract_api_count(
                 &go.evidence,
-                library_api_contract_id_hash(go_append_contract.id),
-                library_api_callee_contract_hash(go_append_contract.callee),
+                go_append_contract.id,
+                go_append_contract.callee
             ),
             1
         );
 
-        let rust = crate::lower_source(
-            FileId(0),
+        let rust = lower_fixture(
             "vec.rs",
             b"fn f() { let xs = Vec::new(); }",
             Lang::Rust,
-            &interner,
-        )
-        .expect("rust lowering should succeed");
+            interner,
+        );
         let rust_contract = library_rust_vec_new_factory_contract(Lang::Rust, "Vec::new").unwrap();
         assert_eq!(
-            library_api_evidence_count_in_records(
-                &rust.evidence,
-                library_api_contract_id_hash(rust_contract.id),
-                library_api_callee_contract_hash(rust_contract.callee),
-            ),
+            contract_api_count(&rust.evidence, rust_contract.id, rust_contract.callee),
             1
         );
 
-        let rust_macro = crate::lower_source(
-            FileId(0),
+        let rust_macro = lower_fixture(
             "vec_macro.rs",
             b"fn f() { let xs = vec![1, 2]; }",
             Lang::Rust,
-            &interner,
-        )
-        .expect("rust lowering should succeed");
+            interner,
+        );
         let rust_macro_contract =
             library_rust_vec_macro_factory_contract(Lang::Rust, "vec").unwrap();
         assert_eq!(
-            library_api_evidence_count_in_records(
+            contract_api_count(
                 &rust_macro.evidence,
-                library_api_contract_id_hash(rust_macro_contract.id),
-                library_api_callee_contract_hash(rust_macro_contract.callee),
+                rust_macro_contract.id,
+                rust_macro_contract.callee
             ),
             1
         );
 
-        let rust_function_call = crate::lower_source(
-            FileId(0),
+        let rust_function_call = lower_fixture(
             "vec_function.rs",
             b"fn f(vec: fn(i32) -> Vec<i32>) { let xs = vec(1); }",
             Lang::Rust,
-            &interner,
-        )
-        .expect("rust lowering should succeed");
+            interner,
+        );
         assert_eq!(
-            library_api_evidence_count_in_records(
+            contract_api_count(
                 &rust_function_call.evidence,
-                library_api_contract_id_hash(rust_macro_contract.id),
-                library_api_callee_contract_hash(rust_macro_contract.callee),
+                rust_macro_contract.id,
+                rust_macro_contract.callee
             ),
             0
         );
 
-        let rust_shadowed_macro = crate::lower_source(
-            FileId(0),
+        let rust_shadowed_macro = lower_fixture(
             "vec_shadowed_macro.rs",
             b"macro_rules! vec { ($($x:expr),*) => { custom_vec![$($x),*] }; }\nfn f() { let xs = vec![1, 2]; }",
             Lang::Rust,
-            &interner,
-        )
-        .expect("rust lowering should succeed");
+            interner,
+        );
         assert_eq!(
-            library_api_evidence_count_in_records(
+            contract_api_count(
                 &rust_shadowed_macro.evidence,
-                library_api_contract_id_hash(rust_macro_contract.id),
-                library_api_callee_contract_hash(rust_macro_contract.callee),
+                rust_macro_contract.id,
+                rust_macro_contract.callee
             ),
             0
         );
+    }
 
-        let ruby = crate::lower_source(
-            FileId(0),
+    fn assert_ruby_require_occurrences(interner: &Interner) {
+        let ruby = lower_fixture(
             "set.rb",
             b"require \"set\"\n\ndef f(values)\n  Set.new(values)\nend\n",
             Lang::Ruby,
-            &interner,
-        )
-        .expect("ruby lowering should succeed");
+            interner,
+        );
         let ruby_contract = library_ruby_set_factory_contract(Lang::Ruby, "Set", "new", 1).unwrap();
         assert_eq!(
-            library_api_evidence_count_in_records(
-                &ruby.evidence,
-                library_api_contract_id_hash(ruby_contract.id),
-                library_api_callee_contract_hash(ruby_contract.callee),
-            ),
+            contract_api_count(&ruby.evidence, ruby_contract.id, ruby_contract.callee),
             1
         );
 
-        let missing_require = crate::lower_source(
-            FileId(0),
+        let missing_require = lower_fixture(
             "set_missing_require.rb",
             b"def f(values)\n  Set.new(values)\nend\n",
             Lang::Ruby,
-            &interner,
-        )
-        .expect("ruby lowering should succeed");
+            interner,
+        );
         assert_eq!(
-            library_api_evidence_count_in_records(
+            contract_api_count(
                 &missing_require.evidence,
-                library_api_contract_id_hash(ruby_contract.id),
-                library_api_callee_contract_hash(ruby_contract.callee),
+                ruby_contract.id,
+                ruby_contract.callee
             ),
             0
         );
 
-        let late_require = crate::lower_source(
-            FileId(0),
+        let late_require = lower_fixture(
             "set_late_require.rb",
             b"def f(values)\n  Set.new(values)\nend\n\nrequire \"set\"\n",
             Lang::Ruby,
-            &interner,
-        )
-        .expect("ruby lowering should succeed");
+            interner,
+        );
         assert_eq!(
-            library_api_evidence_count_in_records(
+            contract_api_count(
                 &late_require.evidence,
-                library_api_contract_id_hash(ruby_contract.id),
-                library_api_callee_contract_hash(ruby_contract.callee),
+                ruby_contract.id,
+                ruby_contract.callee
             ),
             0
         );
 
-        let shadowed_require = crate::lower_source(
-            FileId(0),
+        let shadowed_require = lower_fixture(
             "set_shadowed_require.rb",
             b"def require(name)\n  name\nend\n\nrequire \"set\"\n\ndef f(values)\n  Set.new(values)\nend\n",
             Lang::Ruby,
-            &interner,
-        )
-        .expect("ruby lowering should succeed");
+            interner,
+        );
         assert_eq!(
-            library_api_evidence_count_in_records(
+            contract_api_count(
                 &shadowed_require.evidence,
-                library_api_contract_id_hash(ruby_contract.id),
-                library_api_callee_contract_hash(ruby_contract.callee),
+                ruby_contract.id,
+                ruby_contract.callee
             ),
             0
         );
@@ -3807,107 +3767,108 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
     #[test]
     fn parameter_type_domains_are_dependency_backed_and_not_substring_guesses() {
         let interner = Interner::new();
+        assert_python_typing_alias_param_domains(&interner);
+        assert_python_stdlib_pack_param_domains(&interner);
+        assert_ts_and_java_param_domains(&interner);
+    }
 
-        let py_alias = crate::lower_source(
-            FileId(0),
+    fn import_backed_param_domain_pack_hash(
+        evidence: &[EvidenceRecord],
+        exported: &str,
+        domain: DomainEvidence,
+    ) -> Option<u64> {
+        let import_ids = imported_binding_symbol_ids(evidence, "typing", exported);
+        assert_eq!(import_ids.len(), 1);
+        let py_domains = param_domain_records(evidence, domain);
+        assert_eq!(py_domains.len(), 1);
+        assert_eq!(py_domains[0].dependencies, import_ids);
+        py_domains[0].provenance.pack_hash
+    }
+
+    fn assert_python_typing_alias_param_domains(interner: &Interner) {
+        let py_alias = lower_fixture(
             "typing_alias.py",
             b"from typing import List as L\ndef f(xs: L[int]):\n    return len(xs)\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
-        let import_ids = imported_binding_symbol_ids(&py_alias.evidence, "typing", "List");
-        assert_eq!(import_ids.len(), 1);
-        let py_domains = param_domain_records(&py_alias.evidence, DomainEvidence::Collection);
-        assert_eq!(py_domains.len(), 1);
-        assert_eq!(py_domains[0].dependencies, import_ids);
+            interner,
+        );
         assert_eq!(
-            py_domains[0].provenance.pack_hash,
+            import_backed_param_domain_pack_hash(
+                &py_alias.evidence,
+                "List",
+                DomainEvidence::Collection
+            ),
             Some(stable_symbol_hash(
                 nose_semantics::PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID
             )),
             "imported Python stdlib type aliases should carry the pilot pack provenance"
         );
 
-        let py_direct_import_alias = crate::lower_source(
-            FileId(0),
+        let py_direct_import_alias = lower_fixture(
             "typing_direct_import_alias.py",
             b"from typing import List\ndef f(xs: List[int]):\n    return len(xs)\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
-        let import_ids =
-            imported_binding_symbol_ids(&py_direct_import_alias.evidence, "typing", "List");
-        assert_eq!(import_ids.len(), 1);
-        let py_domains =
-            param_domain_records(&py_direct_import_alias.evidence, DomainEvidence::Collection);
-        assert_eq!(py_domains.len(), 1);
-        assert_eq!(py_domains[0].dependencies, import_ids);
+            interner,
+        );
         assert_eq!(
-            py_domains[0].provenance.pack_hash,
+            import_backed_param_domain_pack_hash(
+                &py_direct_import_alias.evidence,
+                "List",
+                DomainEvidence::Collection
+            ),
             Some(stable_symbol_hash(
                 nose_semantics::PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID
             )),
             "a direct imported alias should not fall through to first-party text heuristics"
         );
 
-        let py_iter_alias = crate::lower_source(
-            FileId(0),
+        let py_iter_alias = lower_fixture(
             "typing_iter_alias.py",
             b"from typing import Iterable as I\ndef f(xs: I[int]):\n    return xs\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
-        let import_ids = imported_binding_symbol_ids(&py_iter_alias.evidence, "typing", "Iterable");
-        assert_eq!(import_ids.len(), 1);
-        let py_domains = param_domain_records(&py_iter_alias.evidence, DomainEvidence::Iterable);
-        assert_eq!(py_domains.len(), 1);
-        assert_eq!(py_domains[0].dependencies, import_ids);
+            interner,
+        );
         assert_eq!(
-            py_domains[0].provenance.pack_hash,
+            import_backed_param_domain_pack_hash(
+                &py_iter_alias.evidence,
+                "Iterable",
+                DomainEvidence::Iterable
+            ),
             Some(stable_symbol_hash(
                 nose_semantics::PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID
             ))
         );
 
-        let py_iter_shadowed = crate::lower_source(
-            FileId(0),
+        let py_iter_shadowed = lower_fixture(
             "typing_iter_alias_shadowed.py",
             b"from typing import Iterable as I\nI = object\ndef f(xs: I[int]):\n    return xs\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         assert_eq!(
             param_domain_record_count(&py_iter_shadowed.evidence, DomainEvidence::Iterable),
             0,
             "a rebound iterable alias must not emit parameter Domain evidence"
         );
 
-        let py_iter_class_shadowed = crate::lower_source(
-            FileId(0),
+        let py_iter_class_shadowed = lower_fixture(
             "typing_iter_alias_class_shadowed.py",
             b"from typing import Iterable as I\nclass I:\n    pass\ndef f(xs: I[int]):\n    return xs\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         assert_eq!(
             param_domain_record_count(&py_iter_class_shadowed.evidence, DomainEvidence::Iterable),
             0,
             "a class definition with the alias name must close later Domain evidence"
         );
 
-        let py_iter_function_shadowed = crate::lower_source(
-            FileId(0),
+        let py_iter_function_shadowed = lower_fixture(
             "typing_iter_alias_function_shadowed.py",
             b"from typing import Iterable as I\ndef I():\n    return None\ndef f(xs: I[int]):\n    return xs\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         assert_eq!(
             param_domain_record_count(
                 &py_iter_function_shadowed.evidence,
@@ -3916,15 +3877,15 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             0,
             "a function definition with the alias name must close later Domain evidence"
         );
+    }
 
-        let py_mapping_alias = crate::lower_source(
-            FileId(0),
+    fn assert_python_stdlib_pack_param_domains(interner: &Interner) {
+        let py_mapping_alias = lower_fixture(
             "collections_abc_mapping_alias.py",
             b"from collections.abc import Mapping as M\ndef f(xs: M[str, int]):\n    return xs\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         assert_eq!(
             param_domain_record_count_from_pack(
                 &py_mapping_alias.evidence,
@@ -3935,14 +3896,12 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             "collections.abc aliases should resolve through the same pilot pack"
         );
 
-        let py_future_alias = crate::lower_source(
-            FileId(0),
+        let py_future_alias = lower_fixture(
             "asyncio_future_alias.py",
             b"from asyncio import Future as Fut\ndef f(x: Fut[int]):\n    return x\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         assert_eq!(
             param_domain_record_count_from_pack(
                 &py_future_alias.evidence,
@@ -3953,42 +3912,38 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             "asyncio Future aliases should resolve through the same pilot pack"
         );
 
-        let py_shadowed = crate::lower_source(
-            FileId(0),
+        let py_shadowed = lower_fixture(
             "typing_alias_shadowed.py",
             b"from typing import List as L\nL = object\ndef f(xs: L[int]):\n    return xs\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         assert_eq!(
             param_domain_record_count(&py_shadowed.evidence, DomainEvidence::Collection),
             0,
             "a rebound typing alias must not emit parameter Domain evidence"
         );
 
-        let py_wrong_module_alias = crate::lower_source(
-            FileId(0),
+        let py_wrong_module_alias = lower_fixture(
             "typing_alias_wrong_module.py",
             b"from project.typing import Iterable as I\ndef f(xs: I[int]):\n    return xs\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         assert_eq!(
             param_domain_record_count(&py_wrong_module_alias.evidence, DomainEvidence::Iterable),
             0,
             "a same-named alias from another module must not satisfy the stdlib pack"
         );
+    }
 
-        let ts = crate::lower_source(
-            FileId(0),
+    fn assert_ts_and_java_param_domains(interner: &Interner) {
+        let ts = lower_fixture(
             "domain_types.ts",
             b"function f(a: Bitmap<string, number>, b: Blacklist<string>, c: string[], d: Set<string>) { return c.length; }\n",
             Lang::TypeScript,
-            &interner,
-        )
-        .expect("typescript lowering should succeed");
+            interner,
+        );
         assert_eq!(
             param_domain_record_count(&ts.evidence, DomainEvidence::Map),
             0,
@@ -4010,14 +3965,12 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             "Set<T> should still emit set domain evidence"
         );
 
-        let ts_rich = crate::lower_source(
-            FileId(0),
+        let ts_rich = lower_fixture(
             "domain_types_rich.ts",
             b"function f(a: Iterable<string>, b: Iterator<string>, c: Promise<string>, d: Record<string, number>, e: Result<string, Error>, f: boolean) { return f; }\n",
             Lang::TypeScript,
-            &interner,
-        )
-        .expect("typescript lowering should succeed");
+            interner,
+        );
         assert_eq!(
             param_domain_record_count(&ts_rich.evidence, DomainEvidence::Iterable),
             1
@@ -4043,14 +3996,12 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             1
         );
 
-        let java = crate::lower_source(
-            FileId(0),
+        let java = lower_fixture(
             "Annotated.java",
             b"class T { void f(@Ann(\"...\") String value, @Nonnull List<String> xs) {} }\n",
             Lang::Java,
-            &interner,
-        )
-        .expect("java lowering should succeed");
+            interner,
+        );
         assert_eq!(
             param_domain_record_count(&java.evidence, DomainEvidence::Array),
             0,
@@ -4069,133 +4020,105 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
     #[test]
     fn post_lowering_emits_result_domains_for_supported_factories() {
         let interner = Interner::new();
+        assert_python_factory_result_domains(&interner);
+        assert_rust_and_ruby_factory_result_domains(&interner);
+    }
 
-        let py_list = crate::lower_source(
-            FileId(0),
+    fn assert_python_factory_result_domains(interner: &Interner) {
+        let py_list = lower_fixture(
             "builtin_list.py",
             b"def f(values):\n    return list(values)\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         let list_contract =
             library_free_name_collection_factory_contract(Lang::Python, "list").unwrap();
-        let list_api = library_api_evidence_ids_in_records(
-            &py_list.evidence,
-            library_api_contract_id_hash(list_contract.id),
-            library_api_callee_contract_hash(list_contract.callee),
-        );
+        let list_api = contract_api_ids(&py_list.evidence, list_contract.id, list_contract.callee);
         assert!(result_domain_depends_on_any_api(
             &py_list.evidence,
             DomainEvidence::Collection,
             &list_api,
         ));
 
-        let py_set = crate::lower_source(
-            FileId(0),
+        let py_set = lower_fixture(
             "builtin_set.py",
             b"def f(values):\n    return set(values)\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         let set_contract =
             library_free_name_collection_factory_contract(Lang::Python, "set").unwrap();
-        let set_api = library_api_evidence_ids_in_records(
-            &py_set.evidence,
-            library_api_contract_id_hash(set_contract.id),
-            library_api_callee_contract_hash(set_contract.callee),
-        );
+        let set_api = contract_api_ids(&py_set.evidence, set_contract.id, set_contract.callee);
         assert!(result_domain_depends_on_any_api(
             &py_set.evidence,
             DomainEvidence::Set,
             &set_api,
         ));
 
-        let shadowed_py = crate::lower_source(
-            FileId(0),
+        let shadowed_py = lower_fixture(
             "shadowed.py",
             b"def f(list, values):\n    return list(values)\n",
             Lang::Python,
-            &interner,
-        )
-        .expect("python lowering should succeed");
+            interner,
+        );
         assert_eq!(
             result_domain_record_count(&shadowed_py.evidence, DomainEvidence::Collection),
             0,
             "shadowed list(...) must not emit result-domain evidence"
         );
+    }
 
-        let rust_vec = crate::lower_source(
-            FileId(0),
+    fn assert_rust_and_ruby_factory_result_domains(interner: &Interner) {
+        let rust_vec = lower_fixture(
             "vec.rs",
             b"fn f() { let xs = Vec::new(); }",
             Lang::Rust,
-            &interner,
-        )
-        .expect("rust lowering should succeed");
-        let vec_contract = library_rust_vec_new_factory_contract(Lang::Rust, "Vec::new").unwrap();
-        let vec_api = library_api_evidence_ids_in_records(
-            &rust_vec.evidence,
-            library_api_contract_id_hash(vec_contract.id),
-            library_api_callee_contract_hash(vec_contract.callee),
+            interner,
         );
+        let vec_contract = library_rust_vec_new_factory_contract(Lang::Rust, "Vec::new").unwrap();
+        let vec_api = contract_api_ids(&rust_vec.evidence, vec_contract.id, vec_contract.callee);
         assert!(result_domain_depends_on_any_api(
             &rust_vec.evidence,
             DomainEvidence::Collection,
             &vec_api,
         ));
 
-        let rust_map = crate::lower_source(
-            FileId(0),
+        let rust_map = lower_fixture(
             "hash_map.rs",
             b"fn f() { let xs = std::collections::HashMap::from([(\"red\", 1)]); }",
             Lang::Rust,
-            &interner,
-        )
-        .expect("rust lowering should succeed");
+            interner,
+        );
         let map_contract =
             library_free_name_map_factory_contract(Lang::Rust, "std::collections::HashMap::from")
                 .unwrap();
-        let map_api = library_api_evidence_ids_in_records(
-            &rust_map.evidence,
-            library_api_contract_id_hash(map_contract.id),
-            library_api_callee_contract_hash(map_contract.callee),
-        );
+        let map_api = contract_api_ids(&rust_map.evidence, map_contract.id, map_contract.callee);
         assert!(result_domain_depends_on_any_api(
             &rust_map.evidence,
             DomainEvidence::Map,
             &map_api,
         ));
 
-        let ruby = crate::lower_source(
-            FileId(0),
+        let ruby = lower_fixture(
             "set.rb",
             b"require \"set\"\n\ndef f(values)\n  Set.new(values)\nend\n",
             Lang::Ruby,
-            &interner,
-        )
-        .expect("ruby lowering should succeed");
-        let ruby_contract = library_ruby_set_factory_contract(Lang::Ruby, "Set", "new", 1).unwrap();
-        let ruby_api = library_api_evidence_ids_in_records(
-            &ruby.evidence,
-            library_api_contract_id_hash(ruby_contract.id),
-            library_api_callee_contract_hash(ruby_contract.callee),
+            interner,
         );
+        let ruby_contract = library_ruby_set_factory_contract(Lang::Ruby, "Set", "new", 1).unwrap();
+        let ruby_api = contract_api_ids(&ruby.evidence, ruby_contract.id, ruby_contract.callee);
         assert!(result_domain_depends_on_any_api(
             &ruby.evidence,
             DomainEvidence::Set,
             &ruby_api,
         ));
 
-        let missing_require = crate::lower_source(
-            FileId(0),
+        let missing_require = lower_fixture(
             "set_missing_require.rb",
             b"def f(values)\n  Set.new(values)\nend\n",
             Lang::Ruby,
-            &interner,
-        )
-        .expect("ruby lowering should succeed");
+            interner,
+        );
         assert_eq!(
             result_domain_record_count(&missing_require.evidence, DomainEvidence::Set),
             0,
@@ -4340,32 +4263,24 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
     #[test]
     fn post_lowering_emits_property_and_rust_option_occurrences() {
         let interner = Interner::new();
-        let ts = crate::lower_source(
-            FileId(0),
+        assert_ts_length_property_occurrences(&interner);
+        assert_rust_option_occurrences(&interner);
+    }
+
+    fn assert_ts_length_property_occurrences(interner: &Interner) {
+        let ts = lower_fixture(
             "t.ts",
             b"function f(xs: number[]) { return xs.length; }\n",
             Lang::TypeScript,
-            &interner,
-        )
-        .expect("typescript lowering should succeed");
+            interner,
+        );
         let property_contract =
             library_property_builtin_contract(Lang::TypeScript, "length").unwrap();
-        let length_field = ts
-            .nodes
-            .iter()
-            .enumerate()
-            .find_map(|(idx, node)| {
-                (node.kind == NodeKind::Field
-                    && matches!(
-                        node.payload,
-                        Payload::Name(symbol) if interner.resolve(symbol) == "length"
-                    ))
-                .then_some((NodeId(idx as u32), node.span))
-            })
+        let length_field = named_node_span(&ts, interner, NodeKind::Field, "length")
             .expect("length field should be lowered");
         let property_api = library_api_evidence_ids_at_node(
             &ts.evidence,
-            length_field.1,
+            length_field,
             NodeKind::Field,
             library_api_contract_id_hash(property_contract.id),
             library_api_callee_contract_hash(property_contract.callee),
@@ -4376,30 +4291,18 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             1,
             "typed exact-collection property access should carry LibraryApi occurrence evidence"
         );
-        let ts_filter_length = crate::lower_source(
-            FileId(0),
+        let ts_filter_length = lower_fixture(
             "t.ts",
             b"function f(value: string) { return [\"red\", \"blue\"].filter((item: string) => item === value).length >= 1; }\n",
             Lang::TypeScript,
-            &interner,
-        )
-        .expect("typescript lowering should succeed");
-        let filter_length_field = ts_filter_length
-            .nodes
-            .iter()
-            .enumerate()
-            .find_map(|(idx, node)| {
-                (node.kind == NodeKind::Field
-                    && matches!(
-                        node.payload,
-                        Payload::Name(symbol) if interner.resolve(symbol) == "length"
-                    ))
-                .then_some((NodeId(idx as u32), node.span))
-            })
-            .expect("filter length field should be lowered");
+            interner,
+        );
+        let filter_length_field =
+            named_node_span(&ts_filter_length, interner, NodeKind::Field, "length")
+                .expect("filter length field should be lowered");
         let filter_length_api = library_api_evidence_ids_at_node(
             &ts_filter_length.evidence,
-            filter_length_field.1,
+            filter_length_field,
             NodeKind::Field,
             library_api_contract_id_hash(property_contract.id),
             library_api_callee_contract_hash(property_contract.callee),
@@ -4410,34 +4313,18 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             1,
             "HOF result property access should carry LibraryApi occurrence evidence"
         );
+    }
 
-        let rust_some = crate::lower_source(
-            FileId(0),
+    fn assert_rust_option_occurrences(interner: &Interner) {
+        let rust_some = lower_fixture(
             "t.rs",
             b"fn f(x: i32) -> Option<i32> { Some(x) }\n",
             Lang::Rust,
-            &interner,
-        )
-        .expect("rust lowering should succeed");
+            interner,
+        );
         let some_contract =
             library_rust_option_some_constructor_contract(Lang::Rust, "Some", 1).unwrap();
-        let some_call = rust_some
-            .nodes
-            .iter()
-            .enumerate()
-            .find_map(|(idx, node)| {
-                (node.kind == NodeKind::Call
-                    && rust_some
-                        .children(NodeId(idx as u32))
-                        .first()
-                        .is_some_and(|&callee| {
-                            matches!(
-                                rust_some.node(callee).payload,
-                                Payload::Name(symbol) if interner.resolve(symbol) == "Some"
-                            )
-                        }))
-                .then_some(node.span)
-            })
+        let some_call = call_span_with_callee_named(&rust_some, interner, "Some")
             .expect("Some call should be lowered");
         let some_api = library_api_evidence_ids_at(
             &rust_some.evidence,
@@ -4454,25 +4341,13 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             &some_api,
         ));
 
-        let rust_some_pattern = crate::lower_source(
-            FileId(0),
+        let rust_some_pattern = lower_fixture(
             "t.rs",
             b"pub fn f(value: Option<i32>) -> bool { if let Some(_) = value { true } else { false } }\n",
             Lang::Rust,
-            &interner,
-        )
-        .expect("rust lowering should succeed");
-        let some_pattern_var = rust_some_pattern
-            .nodes
-            .iter()
-            .find_map(|node| {
-                (node.kind == NodeKind::Var
-                    && matches!(
-                        node.payload,
-                        Payload::Name(symbol) if interner.resolve(symbol) == "Some"
-                    ))
-                .then_some(node.span)
-            })
+            interner,
+        );
+        let some_pattern_var = named_node_span(&rust_some_pattern, interner, NodeKind::Var, "Some")
             .expect("Some pattern var should be preserved");
         let some_pattern_api = library_api_evidence_ids_at_node(
             &rust_some_pattern.evidence,
@@ -4494,26 +4369,14 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             "pattern occurrence identity must not become a constructor result domain"
         );
 
-        let rust_none = crate::lower_source(
-            FileId(0),
+        let rust_none = lower_fixture(
             "t.rs",
             b"fn f() -> Option<i32> { None }\n",
             Lang::Rust,
-            &interner,
-        )
-        .expect("rust lowering should succeed");
+            interner,
+        );
         let none_contract = library_rust_option_none_sentinel_contract(Lang::Rust, "None").unwrap();
-        let none_var = rust_none
-            .nodes
-            .iter()
-            .find_map(|node| {
-                (node.kind == NodeKind::Var
-                    && matches!(
-                        node.payload,
-                        Payload::Name(symbol) if interner.resolve(symbol) == "None"
-                    ))
-                .then_some(node.span)
-            })
+        let none_var = named_node_span(&rust_none, interner, NodeKind::Var, "None")
             .expect("None var should be lowered");
         let none_api = library_api_evidence_ids_at_node(
             &rust_none.evidence,
@@ -4532,19 +4395,17 @@ def f(value, other):\n    return Values([\"red\", \"blue\"]).__contains__(value)
             &none_api,
         ));
 
-        let shadowed_some = crate::lower_source(
-            FileId(0),
+        let shadowed_some = lower_fixture(
             "t.rs",
             b"fn Some(x: i32) -> Option<i32> { None }\nfn f(x: i32) -> Option<i32> { Some(x) }\n",
             Lang::Rust,
-            &interner,
-        )
-        .expect("rust lowering should succeed");
+            interner,
+        );
         assert_eq!(
-            library_api_evidence_count_in_records(
+            contract_api_count(
                 &shadowed_some.evidence,
-                library_api_contract_id_hash(some_contract.id),
-                library_api_callee_contract_hash(some_contract.callee),
+                some_contract.id,
+                some_contract.callee
             ),
             0,
             "local Rust Some item must close the std Option constructor occurrence"

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -1374,9 +1374,10 @@ mod tests {
         assert_eq!(importer.kind(appended.root), NodeKind::Assign);
     }
 
-    #[test]
-    fn snapshot_append_copies_relevant_evidence_with_source_origin_spans() {
-        let interner = Interner::new();
+    /// `tables.py` provider with `LOOKUP = {…}` plus the surface, export,
+    /// symbol, and (ambiguous) duplicate-surface evidence records the snapshot
+    /// copy tests filter over. Returns the provider and its assign statement.
+    fn provider_with_lookup_export_evidence(interner: &Interner) -> (Il, NodeId) {
         let mut b = IlBuilder::new(FileId(0));
         let span = Span::new(FileId(0), 4, 12, 1, 1);
         let lookup = interner.intern("LOOKUP");
@@ -1433,6 +1434,13 @@ mod tests {
             dependencies: Vec::new(),
             status: EvidenceStatus::Ambiguous,
         });
+        (provider, assign)
+    }
+
+    #[test]
+    fn snapshot_append_copies_relevant_evidence_with_source_origin_spans() {
+        let interner = Interner::new();
+        let (provider, assign) = provider_with_lookup_export_evidence(&interner);
         let snapshot = snapshot_subtree(&provider, assign);
 
         let mut b = IlBuilder::new(FileId(1));
@@ -1491,11 +1499,10 @@ mod tests {
         assert_eq!(copied_export.dependencies, vec![copied_surface.id]);
     }
 
-    #[test]
-    fn resolve_imported_literal_records_snapshot_provenance_dependencies() {
-        let interner = Interner::new();
+    /// `tables.py` provider exporting `LOOKUP = {"red": 1}` with asserted
+    /// map-surface evidence on the literal.
+    fn lookup_dict_provider(interner: &Interner, lookup: Symbol) -> Il {
         let provider_span = Span::new(FileId(0), 4, 24, 1, 1);
-        let lookup = interner.intern("LOOKUP");
         let mut b = IlBuilder::new(FileId(0));
         let lhs = b.add(NodeKind::Var, Payload::Name(lookup), provider_span, &[]);
         let key = b.add(
@@ -1531,7 +1538,12 @@ mod tests {
             dependencies: Vec::new(),
             status: EvidenceStatus::Asserted,
         });
+        provider
+    }
 
+    /// `consumer.py` importer binding `LOOKUP` from `tables` with an asserted
+    /// static-import proof. Returns the importer and its import assignment.
+    fn lookup_import_consumer(lookup: Symbol) -> (Il, NodeId) {
         let import_span = Span::new(FileId(1), 0, 24, 1, 1);
         let mut b = IlBuilder::new(FileId(1));
         let lhs = b.add(NodeKind::Var, Payload::Name(lookup), import_span, &[]);
@@ -1585,6 +1597,15 @@ mod tests {
             dependencies: Vec::new(),
             status: EvidenceStatus::Asserted,
         });
+        (importer, import_assign)
+    }
+
+    #[test]
+    fn resolve_imported_literal_records_snapshot_provenance_dependencies() {
+        let interner = Interner::new();
+        let lookup = interner.intern("LOOKUP");
+        let provider = lookup_dict_provider(&interner, lookup);
+        let (importer, import_assign) = lookup_import_consumer(lookup);
 
         let mut files = vec![provider, importer];
         resolve_imported_immutable_bindings(&mut files, &interner);

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -604,99 +604,12 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         "binary_operator" => lower_binary(lo, node),
         "boolean_operator" => lower_boolop(lo, node),
         "comparison_operator" => lower_comparison(lo, node),
-        "unary_operator" => {
-            let op = node
-                .child_by_field_name("operator")
-                .map(|o| lo.text(o))
-                .unwrap_or("-");
-            let il_op = match op {
-                "-" => Op::Neg,
-                "+" => Op::Pos,
-                "~" => Op::BitNot,
-                _ => Op::Neg,
-            };
-            let arg = node
-                .child_by_field_name("argument")
-                .map(|a| lower_expr(lo, a))
-                .unwrap_or_else(|| lo.empty_block(span));
-            lo.add(NodeKind::UnOp, Payload::Op(il_op), span, &[arg])
-        }
-        "not_operator" => {
-            let arg = node
-                .child_by_field_name("argument")
-                .map(|a| lower_expr(lo, a))
-                .unwrap_or_else(|| lo.empty_block(span));
-            lo.add(NodeKind::UnOp, Payload::Op(Op::Not), span, &[arg])
-        }
-        "attribute" => {
-            let obj = node
-                .child_by_field_name("object")
-                .map(|o| lower_expr(lo, o))
-                .unwrap_or_else(|| lo.empty_block(span));
-            let attr = node
-                .child_by_field_name("attribute")
-                .map(|a| lo.text(a))
-                .unwrap_or("");
-            let sym = lo.sym(attr);
-            lo.add(NodeKind::Field, Payload::Name(sym), span, &[obj])
-        }
-        "subscript" => {
-            let base = node
-                .child_by_field_name("value")
-                .map(|v| lower_expr(lo, v))
-                .unwrap_or_else(|| lo.empty_block(span));
-            let idx = node
-                .child_by_field_name("subscript")
-                .map(|s| lower_expr(lo, s))
-                .unwrap_or_else(|| lo.empty_block(span));
-            lo.add(NodeKind::Index, Payload::None, span, &[base, idx])
-        }
-        "lambda" => {
-            let mut kids = Vec::new();
-            if let Some(params) = node.child_by_field_name("parameters") {
-                lower_params(lo, params, &mut kids);
-            }
-            // Wrap the single-expression body in `Block(Return(expr))` so a
-            // `lambda x: e` converges with a JS arrow `x => e` (and `x => { return e }`)
-            // and a one-line function — all single-expression callables share a shape.
-            let body = match node.child_by_field_name("body") {
-                Some(b) => {
-                    let bspan = lo.span(b);
-                    let e = lower_expr(lo, b);
-                    let ret = lo.add(NodeKind::Return, Payload::None, bspan, &[e]);
-                    lo.add(NodeKind::Block, Payload::None, bspan, &[ret])
-                }
-                None => lo.empty_block(span),
-            };
-            kids.push(body);
-            lo.add(NodeKind::Lambda, Payload::None, span, &kids)
-        }
-        "slice" => {
-            // Preserve start/stop/step POSITIONS: `a[1:]` (start=1) and `a[:1]` (stop=1)
-            // are different slices and must not collapse. tree-sitter omits empty bounds
-            // and the `:` separators are anonymous, so collecting only named children
-            // loses which slot the bound occupies. Walk children in order, split on `:`,
-            // and emit an explicit `None` placeholder for each empty slot so the `Seq` is
-            // positional.
-            let mut slots: Vec<NodeId> = Vec::new();
-            let mut cur: Option<NodeId> = None;
-            let mut cursor = node.walk();
-            for child in node.children(&mut cursor) {
-                if child.kind() == ":" {
-                    slots.push(cur.take().unwrap_or_else(|| {
-                        lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[])
-                    }));
-                } else if child.is_named() {
-                    cur = Some(lower_expr(lo, child));
-                }
-            }
-            slots.push(
-                cur.take().unwrap_or_else(|| {
-                    lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[])
-                }),
-            );
-            lo.add(NodeKind::Seq, Payload::None, span, &slots)
-        }
+        "unary_operator" => lower_unary(lo, node),
+        "not_operator" => lower_not(lo, node),
+        "attribute" => lower_attribute(lo, node),
+        "subscript" => lower_subscript(lo, node),
+        "lambda" => lower_lambda(lo, node),
+        "slice" => lower_slice(lo, node),
         "list" | "tuple" | "set" => {
             let kids: Vec<NodeId> = Lowering::named_children(node)
                 .into_iter()
@@ -723,18 +636,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         // contribution `DictEntry(k, v)`. Plain dict literals use
         // `lower_dictionary_pair` instead so cross-language map literals retain a
         // language-neutral `pair` sequence tag.
-        "pair" => {
-            let kids: Vec<NodeId> = Lowering::named_children(node)
-                .into_iter()
-                .map(|c| lower_expr(lo, c))
-                .collect();
-            lo.add(
-                NodeKind::Seq,
-                Payload::Builtin(Builtin::DictEntry),
-                span,
-                &kids,
-            )
-        }
+        "pair" => lower_comprehension_pair(lo, node),
         "list_comprehension"
         | "set_comprehension"
         | "generator_expression"
@@ -751,18 +653,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                 .unwrap_or_else(|| lo.empty_block(span));
             lo.await_boundary(span, value)
         }
-        "named_expression" => {
-            // walrus `name := value` → Assign in expression position
-            let lhs = node
-                .child_by_field_name("name")
-                .map(|n| lower_expr(lo, n))
-                .unwrap_or_else(|| lo.empty_block(span));
-            let rhs = node
-                .child_by_field_name("value")
-                .map(|v| lower_expr(lo, v))
-                .unwrap_or_else(|| lo.empty_block(span));
-            lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs])
-        }
+        "named_expression" => lower_named_expr(lo, node),
         "keyword_argument" => node
             .child_by_field_name("value")
             .map(|v| lower_expr(lo, v))
@@ -791,6 +682,140 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             lo.raw(node.kind(), span, &kids)
         }
     }
+}
+
+fn lower_unary(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let op = node
+        .child_by_field_name("operator")
+        .map(|o| lo.text(o))
+        .unwrap_or("-");
+    let il_op = match op {
+        "-" => Op::Neg,
+        "+" => Op::Pos,
+        "~" => Op::BitNot,
+        _ => Op::Neg,
+    };
+    let arg = node
+        .child_by_field_name("argument")
+        .map(|a| lower_expr(lo, a))
+        .unwrap_or_else(|| lo.empty_block(span));
+    lo.add(NodeKind::UnOp, Payload::Op(il_op), span, &[arg])
+}
+
+fn lower_not(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let arg = node
+        .child_by_field_name("argument")
+        .map(|a| lower_expr(lo, a))
+        .unwrap_or_else(|| lo.empty_block(span));
+    lo.add(NodeKind::UnOp, Payload::Op(Op::Not), span, &[arg])
+}
+
+fn lower_attribute(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let obj = node
+        .child_by_field_name("object")
+        .map(|o| lower_expr(lo, o))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let attr = node
+        .child_by_field_name("attribute")
+        .map(|a| lo.text(a))
+        .unwrap_or("");
+    let sym = lo.sym(attr);
+    lo.add(NodeKind::Field, Payload::Name(sym), span, &[obj])
+}
+
+fn lower_subscript(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let base = node
+        .child_by_field_name("value")
+        .map(|v| lower_expr(lo, v))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let idx = node
+        .child_by_field_name("subscript")
+        .map(|s| lower_expr(lo, s))
+        .unwrap_or_else(|| lo.empty_block(span));
+    lo.add(NodeKind::Index, Payload::None, span, &[base, idx])
+}
+
+fn lower_lambda(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let mut kids = Vec::new();
+    if let Some(params) = node.child_by_field_name("parameters") {
+        lower_params(lo, params, &mut kids);
+    }
+    // Wrap the single-expression body in `Block(Return(expr))` so a
+    // `lambda x: e` converges with a JS arrow `x => e` (and `x => { return e }`)
+    // and a one-line function — all single-expression callables share a shape.
+    let body = match node.child_by_field_name("body") {
+        Some(b) => {
+            let bspan = lo.span(b);
+            let e = lower_expr(lo, b);
+            let ret = lo.add(NodeKind::Return, Payload::None, bspan, &[e]);
+            lo.add(NodeKind::Block, Payload::None, bspan, &[ret])
+        }
+        None => lo.empty_block(span),
+    };
+    kids.push(body);
+    lo.add(NodeKind::Lambda, Payload::None, span, &kids)
+}
+
+fn lower_slice(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    // Preserve start/stop/step POSITIONS: `a[1:]` (start=1) and `a[:1]` (stop=1)
+    // are different slices and must not collapse. tree-sitter omits empty bounds
+    // and the `:` separators are anonymous, so collecting only named children
+    // loses which slot the bound occupies. Walk children in order, split on `:`,
+    // and emit an explicit `None` placeholder for each empty slot so the `Seq` is
+    // positional.
+    let mut slots: Vec<NodeId> = Vec::new();
+    let mut cur: Option<NodeId> = None;
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == ":" {
+            slots.push(
+                cur.take().unwrap_or_else(|| {
+                    lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[])
+                }),
+            );
+        } else if child.is_named() {
+            cur = Some(lower_expr(lo, child));
+        }
+    }
+    slots.push(
+        cur.take()
+            .unwrap_or_else(|| lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[])),
+    );
+    lo.add(NodeKind::Seq, Payload::None, span, &slots)
+}
+
+fn lower_comprehension_pair(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let kids: Vec<NodeId> = Lowering::named_children(node)
+        .into_iter()
+        .map(|c| lower_expr(lo, c))
+        .collect();
+    lo.add(
+        NodeKind::Seq,
+        Payload::Builtin(Builtin::DictEntry),
+        span,
+        &kids,
+    )
+}
+
+fn lower_named_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
+    // walrus `name := value` → Assign in expression position
+    let span = lo.span(node);
+    let lhs = node
+        .child_by_field_name("name")
+        .map(|n| lower_expr(lo, n))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let rhs = node
+        .child_by_field_name("value")
+        .map(|v| lower_expr(lo, v))
+        .unwrap_or_else(|| lo.empty_block(span));
+    lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs])
 }
 
 fn lower_dotted_name(lo: &mut Lowering, node: TsNode) -> NodeId {

--- a/crates/nose-frontend/src/ruby.rs
+++ b/crates/nose-frontend/src/ruby.rs
@@ -358,36 +358,8 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         "true" => lo.add(NodeKind::Lit, Payload::LitBool(true), span, &[]),
         "false" => lo.add(NodeKind::Lit, Payload::LitBool(false), span, &[]),
         "nil" => lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[]),
-        "binary" => {
-            let l = node.child_by_field_name("left").map(|x| lower_expr(lo, x));
-            let r = node.child_by_field_name("right").map(|x| lower_expr(lo, x));
-            let op = node
-                .child_by_field_name("operator")
-                .map(|o| lo.text(o))
-                .and_then(common_bin_op);
-            match (l, r, op) {
-                (Some(l), Some(r), Some(op)) => {
-                    lo.add(NodeKind::BinOp, Payload::Op(op), span, &[l, r])
-                }
-                _ => raw_kids(lo, node),
-            }
-        }
-        "unary" => {
-            let operand = node
-                .named_child(node.named_child_count().saturating_sub(1))
-                .map(|o| lower_expr(lo, o))
-                .unwrap_or_else(|| lo.empty_block(span));
-            // Map by the operator token, not the leading byte: `+`→Pos, `-`→Neg,
-            // `~`→BitNot, `!`/`not`→Not. Reading only the first byte collapsed `+5`
-            // and `~5` onto `Neg`.
-            let op = match node.child_by_field_name("operator").map(|o| lo.text(o)) {
-                Some("+") => Op::Pos,
-                Some("~") => Op::BitNot,
-                Some("!") | Some("not") => Op::Not,
-                _ => Op::Neg,
-            };
-            lo.add(NodeKind::UnOp, Payload::Op(op), span, &[operand])
-        }
+        "binary" => lower_binary(lo, node),
+        "unary" => lower_unary(lo, node),
         "assignment" | "operator_assignment" => lower_assign(lo, node),
         "method_call" | "call" => lower_call(lo, node),
         "element_reference" => {
@@ -407,23 +379,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         }
         "hash" => lower_hash(lo, node),
         "pair" => lower_hash_pair(lo, node),
-        "block" | "do_block" => {
-            let mut kids = Vec::new();
-            if let Some(params) = node.child_by_field_name("parameters") {
-                for p in Lowering::named_children(params) {
-                    let pspan = lo.span(p);
-                    let sym = param_name(lo, p);
-                    kids.push(lo.add(
-                        NodeKind::Param,
-                        sym.map(Payload::Name).unwrap_or(Payload::None),
-                        pspan,
-                        &[],
-                    ));
-                }
-            }
-            kids.push(block_body(lo, node));
-            lo.add(NodeKind::Lambda, Payload::None, span, &kids)
-        }
+        "block" | "do_block" => lower_block_lambda(lo, node),
         "parenthesized_statements" => node
             .named_child(0)
             .map(|c| lower_expr(lo, c))
@@ -473,6 +429,57 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         "super" | "forward_argument" => lo.var(lo.text(node), span),
         _ => raw_kids(lo, node),
     }
+}
+
+fn lower_binary(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let l = node.child_by_field_name("left").map(|x| lower_expr(lo, x));
+    let r = node.child_by_field_name("right").map(|x| lower_expr(lo, x));
+    let op = node
+        .child_by_field_name("operator")
+        .map(|o| lo.text(o))
+        .and_then(common_bin_op);
+    match (l, r, op) {
+        (Some(l), Some(r), Some(op)) => lo.add(NodeKind::BinOp, Payload::Op(op), span, &[l, r]),
+        _ => raw_kids(lo, node),
+    }
+}
+
+fn lower_unary(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let operand = node
+        .named_child(node.named_child_count().saturating_sub(1))
+        .map(|o| lower_expr(lo, o))
+        .unwrap_or_else(|| lo.empty_block(span));
+    // Map by the operator token, not the leading byte: `+`→Pos, `-`→Neg,
+    // `~`→BitNot, `!`/`not`→Not. Reading only the first byte collapsed `+5`
+    // and `~5` onto `Neg`.
+    let op = match node.child_by_field_name("operator").map(|o| lo.text(o)) {
+        Some("+") => Op::Pos,
+        Some("~") => Op::BitNot,
+        Some("!") | Some("not") => Op::Not,
+        _ => Op::Neg,
+    };
+    lo.add(NodeKind::UnOp, Payload::Op(op), span, &[operand])
+}
+
+fn lower_block_lambda(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let mut kids = Vec::new();
+    if let Some(params) = node.child_by_field_name("parameters") {
+        for p in Lowering::named_children(params) {
+            let pspan = lo.span(p);
+            let sym = param_name(lo, p);
+            kids.push(lo.add(
+                NodeKind::Param,
+                sym.map(Payload::Name).unwrap_or(Payload::None),
+                pspan,
+                &[],
+            ));
+        }
+    }
+    kids.push(block_body(lo, node));
+    lo.add(NodeKind::Lambda, Payload::None, span, &kids)
 }
 
 fn lower_hash(lo: &mut Lowering, node: TsNode) -> NodeId {

--- a/crates/nose-frontend/src/rust.rs
+++ b/crates/nose-frontend/src/rust.rs
@@ -512,45 +512,22 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                 .unwrap_or_else(|| lo.empty_block(span));
             lo.await_boundary(span, value)
         }
-        "parenthesized_expression" => node
-            .named_child(0)
-            .map(|c| lower_expr(lo, c))
-            .unwrap_or_else(|| lo.empty_block(span)),
-        "reference_pattern" => node
-            .named_child(0)
-            .map(|c| lower_expr(lo, c))
-            .unwrap_or_else(|| lo.empty_block(span)),
-        // `&x` / `&mut x` → the referenced value (skip the mutable_specifier)
-        "reference_expression" => node
-            .child_by_field_name("value")
-            .map(|c| lower_expr(lo, c))
-            .unwrap_or_else(|| lo.empty_block(span)),
+        // Wrappers that peel to their single child: `(x)`, `&pat`, turbofish
+        // `foo::<T>` / `Vec::<T>::new` (drop the turbofish), and `unsafe { … }`
+        // (just its block).
+        "parenthesized_expression" | "reference_pattern" | "generic_function" | "unsafe_block" => {
+            node.named_child(0)
+                .map(|c| lower_expr(lo, c))
+                .unwrap_or_else(|| lo.empty_block(span))
+        }
+        // `&x` / `&mut x` → the referenced value (skip the mutable_specifier);
         // `x as T` → `x` (a cast is type-level; erase it, like TS `as`)
-        "type_cast_expression" => node
+        "reference_expression" | "type_cast_expression" => node
             .child_by_field_name("value")
             .map(|c| lower_expr(lo, c))
             .unwrap_or_else(|| lo.empty_block(span)),
         // `a..b` / `a..=b` / `a..` → a sequence of its endpoints
-        "range_expression" => {
-            // Preserve start/end POSITIONS and inclusivity: `1..`, `..1`, `1..2`,
-            // `1..=2` are all different. tree-sitter omits empty bounds and the
-            // `..`/`..=` operator is anonymous, so collecting named children collapsed
-            // `1..` and `..1` to `Seq(1)`. Split on the operator; emit a `None`
-            // placeholder for each empty slot and a trailing `0`/`1` inclusivity flag.
-            let (start, end, inclusive) = lower_range_bounds(lo, node);
-            let none =
-                |lo: &mut Lowering| lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[]);
-            let s = start.unwrap_or_else(|| none(lo));
-            let e = end.unwrap_or_else(|| none(lo));
-            let flag = lo.int_lit(if inclusive { "1" } else { "0" }, span);
-            let range = if inclusive {
-                SourceRangeKind::RustInclusiveRangeExpression
-            } else {
-                SourceRangeKind::RustHalfOpenRangeExpression
-            };
-            lo.record_source_fact(span, SourceFactKind::Range(range));
-            lo.add(NodeKind::Seq, Payload::None, span, &[s, e, flag])
-        }
+        "range_expression" => lower_range_expr(lo, node),
         "call_expression" => lower_call(lo, node),
         "macro_invocation" => lower_macro(lo, node),
         "method_call_expression" => lower_method_call(lo, node),
@@ -571,41 +548,12 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         }
         "break_expression" => lo.add(NodeKind::Break, Payload::None, span, &[]),
         "continue_expression" => lo.add(NodeKind::Continue, Payload::None, span, &[]),
-        "tuple_pattern" => {
-            let kids: Vec<NodeId> = Lowering::named_children(node)
-                .into_iter()
-                .map(|c| lower_expr(lo, c))
-                .collect();
-            let tag = lo.sym("tuple_expression");
-            lo.add(NodeKind::Seq, Payload::Name(tag), span, &kids)
-        }
-        "slice_pattern" => {
-            let kids: Vec<NodeId> = Lowering::named_children(node)
-                .into_iter()
-                .map(|c| lower_expr(lo, c))
-                .collect();
-            let tag = lo.sym("array_expression");
-            lo.add(NodeKind::Seq, Payload::Name(tag), span, &kids)
-        }
-        "array_expression" | "tuple_expression" => {
-            let kids: Vec<NodeId> = Lowering::named_children(node)
-                .into_iter()
-                .map(|c| lower_expr(lo, c))
-                .collect();
-            let tag = lo.sym(node.kind());
-            lo.add(NodeKind::Seq, Payload::Name(tag), span, &kids)
-        }
+        // Patterns share the tag of the expression form they destructure so
+        // `(a, b)` and `[a, b]` shapes converge across binding/value position.
+        "tuple_pattern" => lower_seq_tagged(lo, node, "tuple_expression"),
+        "slice_pattern" => lower_seq_tagged(lo, node, "array_expression"),
+        "array_expression" | "tuple_expression" => lower_seq_tagged(lo, node, node.kind()),
         "struct_expression" => lower_struct_expr(lo, node),
-        // `foo::<T>` / `Vec::<T>::new` — lower the function/value, drop the turbofish.
-        "generic_function" => node
-            .named_child(0)
-            .map(|c| lower_expr(lo, c))
-            .unwrap_or_else(|| lo.empty_block(span)),
-        // `unsafe { … }` is just its block.
-        "unsafe_block" => node
-            .named_child(0)
-            .map(|c| lower_expr(lo, c))
-            .unwrap_or_else(|| lo.empty_block(span)),
         "async_block" => {
             let body = node
                 .named_child(0)
@@ -615,26 +563,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
         }
         // Type-level nodes carry no runtime behavior — erase (don't Raw). These reach
         // expression position via turbofish, casts, and closure/fn param subtrees.
-        "type_arguments"
-        | "type_parameters"
-        | "reference_type"
-        | "primitive_type"
-        | "generic_type"
-        | "scoped_type_identifier"
-        | "array_type"
-        | "tuple_type"
-        | "pointer_type"
-        | "dynamic_type"
-        | "lifetime"
-        | "parameters"
-        | "parameter"
-        | "self_parameter"
-        | "function_signature_item"
-        | "where_clause"
-        | "type_arguments_list"
-        | "trait_bounds"
-        | "type_binding"
-        | "constrained_type_parameter" => lo.empty_block(span),
+        k if is_type_level(k) => lo.empty_block(span),
         "macro_definition" => lower_macro_definition_shadow(lo, node),
         "line_comment" | "block_comment" | "attribute_item" => lo.empty_block(span),
         _ => {
@@ -645,6 +574,63 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             lo.raw(node.kind(), span, &kids)
         }
     }
+}
+
+fn is_type_level(k: &str) -> bool {
+    matches!(
+        k,
+        "type_arguments"
+            | "type_parameters"
+            | "reference_type"
+            | "primitive_type"
+            | "generic_type"
+            | "scoped_type_identifier"
+            | "array_type"
+            | "tuple_type"
+            | "pointer_type"
+            | "dynamic_type"
+            | "lifetime"
+            | "parameters"
+            | "parameter"
+            | "self_parameter"
+            | "function_signature_item"
+            | "where_clause"
+            | "type_arguments_list"
+            | "trait_bounds"
+            | "type_binding"
+            | "constrained_type_parameter"
+    )
+}
+
+fn lower_range_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    // Preserve start/end POSITIONS and inclusivity: `1..`, `..1`, `1..2`,
+    // `1..=2` are all different. tree-sitter omits empty bounds and the
+    // `..`/`..=` operator is anonymous, so collecting named children collapsed
+    // `1..` and `..1` to `Seq(1)`. Split on the operator; emit a `None`
+    // placeholder for each empty slot and a trailing `0`/`1` inclusivity flag.
+    let (start, end, inclusive) = lower_range_bounds(lo, node);
+    let none = |lo: &mut Lowering| lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[]);
+    let s = start.unwrap_or_else(|| none(lo));
+    let e = end.unwrap_or_else(|| none(lo));
+    let flag = lo.int_lit(if inclusive { "1" } else { "0" }, span);
+    let range = if inclusive {
+        SourceRangeKind::RustInclusiveRangeExpression
+    } else {
+        SourceRangeKind::RustHalfOpenRangeExpression
+    };
+    lo.record_source_fact(span, SourceFactKind::Range(range));
+    lo.add(NodeKind::Seq, Payload::None, span, &[s, e, flag])
+}
+
+fn lower_seq_tagged(lo: &mut Lowering, node: TsNode, tag_str: &str) -> NodeId {
+    let span = lo.span(node);
+    let kids: Vec<NodeId> = Lowering::named_children(node)
+        .into_iter()
+        .map(|c| lower_expr(lo, c))
+        .collect();
+    let tag = lo.sym(tag_str);
+    lo.add(NodeKind::Seq, Payload::Name(tag), span, &kids)
 }
 
 fn lower_binary(lo: &mut Lowering, node: TsNode) -> NodeId {

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -223,21 +223,7 @@ fn apply_method_contract(
             op,
             arg_olds: vec![args[0]],
         },
-        MethodBuiltinArgs::ReceiverOnly => {
-            if let ProvenReceiver::MapGet { map, key } = receiver {
-                if op == Builtin::IsNotNull {
-                    return CallCanon::Builtin {
-                        op: Builtin::Contains,
-                        arg_olds: vec![key, map],
-                    };
-                }
-                return CallCanon::None;
-            }
-            CallCanon::Builtin {
-                op,
-                arg_olds: vec![direct.unwrap()],
-            }
-        }
+        MethodBuiltinArgs::ReceiverOnly => receiver_only_args(op, receiver, direct),
         MethodBuiltinArgs::ReceiverThenAll => {
             let Some(base) = direct else {
                 return CallCanon::None;
@@ -279,83 +265,19 @@ fn apply_method_contract(
             }
         }
         MethodBuiltinArgs::MapGetDefaultOrZeroArgLambda => {
-            let Some(base) = direct else {
-                return CallCanon::None;
-            };
-            let fallback = if old.kind(args[1]) == NodeKind::Lambda {
-                let Some(fallback) = zero_arg_lambda_body_value(old, args[1]) else {
-                    return CallCanon::None;
-                };
-                fallback
-            } else {
-                args[1]
-            };
-            CallCanon::Builtin {
-                op,
-                arg_olds: vec![base, args[0], fallback],
-            }
+            map_get_default_or_zero_arg_lambda_args(old, op, direct, args)
         }
-        MethodBuiltinArgs::RustMapGetOrOptionDefault => match receiver {
-            ProvenReceiver::MapGet { map, key } => CallCanon::Builtin {
-                op: Builtin::GetOrDefault,
-                arg_olds: vec![map, key, args[0]],
-            },
-            ProvenReceiver::Direct(base) => CallCanon::Builtin {
-                op,
-                arg_olds: vec![base, args[0]],
-            },
-        },
+        MethodBuiltinArgs::RustMapGetOrOptionDefault => {
+            rust_map_get_or_option_default_args(op, receiver, args)
+        }
         MethodBuiltinArgs::RustOptionDefaultLambda => {
-            let Some(base) = direct else {
-                return CallCanon::None;
-            };
-            if let Some(fallback) = zero_arg_lambda_body(old, args[0]) {
-                return CallCanon::Builtin {
-                    op,
-                    arg_olds: vec![base, fallback],
-                };
-            }
-            CallCanon::None
+            rust_option_default_lambda_args(old, op, direct, args)
         }
         MethodBuiltinArgs::RustOptionMapOrIdentity => {
-            let Some(base) = direct else {
-                return CallCanon::None;
-            };
-            if identity_lambda(old, args[1]) {
-                return CallCanon::Builtin {
-                    op,
-                    arg_olds: vec![base, args[0]],
-                };
-            }
-            CallCanon::None
+            rust_option_map_or_identity_args(old, op, direct, args)
         }
-        MethodBuiltinArgs::RustZip => {
-            let Some(base) = direct else {
-                return CallCanon::None;
-            };
-            CallCanon::Builtin {
-                op,
-                arg_olds: vec![
-                    unwrap_iter(old, interner, base),
-                    unwrap_iter(old, interner, args[0]),
-                ],
-            }
-        }
-        MethodBuiltinArgs::Fold => {
-            let Some(base) = direct else {
-                return CallCanon::None;
-            };
-            let (fn_old, init_old) = fold_fn_init(old, args);
-            let Some(fn_old) = fn_old else {
-                return CallCanon::None;
-            };
-            let coll = unwrap_iter(old, interner, base);
-            let mut a = vec![fn_old, coll];
-            if let Some(init) = init_old {
-                a.push(init);
-            }
-            CallCanon::Builtin { op, arg_olds: a }
-        }
+        MethodBuiltinArgs::RustZip => rust_zip_args(old, interner, op, direct, args),
+        MethodBuiltinArgs::Fold => fold_args(old, interner, op, direct, args),
         MethodBuiltinArgs::BoolReduction => {
             let Some(base) = direct else {
                 return CallCanon::None;
@@ -367,23 +289,165 @@ fn apply_method_contract(
         }
         MethodBuiltinArgs::Hof => CallCanon::None,
         MethodBuiltinArgs::CollectionReduction => {
-            let Some(base) = direct else {
-                return CallCanon::None;
-            };
-            if matches!(op, Builtin::Min | Builtin::Max) && old.kind(base) == NodeKind::Seq {
-                let items = old.children(base);
-                if items.len() == 2 {
-                    return CallCanon::Builtin {
-                        op,
-                        arg_olds: items.to_vec(),
-                    };
-                }
-            }
-            CallCanon::Builtin {
-                op,
-                arg_olds: vec![unwrap_iter(old, interner, base)],
-            }
+            collection_reduction_args(old, interner, op, direct)
         }
+    }
+}
+
+fn receiver_only_args(op: Builtin, receiver: ProvenReceiver, direct: Option<NodeId>) -> CallCanon {
+    if let ProvenReceiver::MapGet { map, key } = receiver {
+        if op == Builtin::IsNotNull {
+            return CallCanon::Builtin {
+                op: Builtin::Contains,
+                arg_olds: vec![key, map],
+            };
+        }
+        return CallCanon::None;
+    }
+    CallCanon::Builtin {
+        op,
+        arg_olds: vec![direct.unwrap()],
+    }
+}
+
+fn map_get_default_or_zero_arg_lambda_args(
+    old: &Il,
+    op: Builtin,
+    direct: Option<NodeId>,
+    args: &[NodeId],
+) -> CallCanon {
+    let Some(base) = direct else {
+        return CallCanon::None;
+    };
+    let fallback = if old.kind(args[1]) == NodeKind::Lambda {
+        let Some(fallback) = zero_arg_lambda_body_value(old, args[1]) else {
+            return CallCanon::None;
+        };
+        fallback
+    } else {
+        args[1]
+    };
+    CallCanon::Builtin {
+        op,
+        arg_olds: vec![base, args[0], fallback],
+    }
+}
+
+fn rust_map_get_or_option_default_args(
+    op: Builtin,
+    receiver: ProvenReceiver,
+    args: &[NodeId],
+) -> CallCanon {
+    match receiver {
+        ProvenReceiver::MapGet { map, key } => CallCanon::Builtin {
+            op: Builtin::GetOrDefault,
+            arg_olds: vec![map, key, args[0]],
+        },
+        ProvenReceiver::Direct(base) => CallCanon::Builtin {
+            op,
+            arg_olds: vec![base, args[0]],
+        },
+    }
+}
+
+fn rust_option_default_lambda_args(
+    old: &Il,
+    op: Builtin,
+    direct: Option<NodeId>,
+    args: &[NodeId],
+) -> CallCanon {
+    let Some(base) = direct else {
+        return CallCanon::None;
+    };
+    if let Some(fallback) = zero_arg_lambda_body(old, args[0]) {
+        return CallCanon::Builtin {
+            op,
+            arg_olds: vec![base, fallback],
+        };
+    }
+    CallCanon::None
+}
+
+fn rust_option_map_or_identity_args(
+    old: &Il,
+    op: Builtin,
+    direct: Option<NodeId>,
+    args: &[NodeId],
+) -> CallCanon {
+    let Some(base) = direct else {
+        return CallCanon::None;
+    };
+    if identity_lambda(old, args[1]) {
+        return CallCanon::Builtin {
+            op,
+            arg_olds: vec![base, args[0]],
+        };
+    }
+    CallCanon::None
+}
+
+fn rust_zip_args(
+    old: &Il,
+    interner: &Interner,
+    op: Builtin,
+    direct: Option<NodeId>,
+    args: &[NodeId],
+) -> CallCanon {
+    let Some(base) = direct else {
+        return CallCanon::None;
+    };
+    CallCanon::Builtin {
+        op,
+        arg_olds: vec![
+            unwrap_iter(old, interner, base),
+            unwrap_iter(old, interner, args[0]),
+        ],
+    }
+}
+
+fn fold_args(
+    old: &Il,
+    interner: &Interner,
+    op: Builtin,
+    direct: Option<NodeId>,
+    args: &[NodeId],
+) -> CallCanon {
+    let Some(base) = direct else {
+        return CallCanon::None;
+    };
+    let (fn_old, init_old) = fold_fn_init(old, args);
+    let Some(fn_old) = fn_old else {
+        return CallCanon::None;
+    };
+    let coll = unwrap_iter(old, interner, base);
+    let mut a = vec![fn_old, coll];
+    if let Some(init) = init_old {
+        a.push(init);
+    }
+    CallCanon::Builtin { op, arg_olds: a }
+}
+
+fn collection_reduction_args(
+    old: &Il,
+    interner: &Interner,
+    op: Builtin,
+    direct: Option<NodeId>,
+) -> CallCanon {
+    let Some(base) = direct else {
+        return CallCanon::None;
+    };
+    if matches!(op, Builtin::Min | Builtin::Max) && old.kind(base) == NodeKind::Seq {
+        let items = old.children(base);
+        if items.len() == 2 {
+            return CallCanon::Builtin {
+                op,
+                arg_olds: items.to_vec(),
+            };
+        }
+    }
+    CallCanon::Builtin {
+        op,
+        arg_olds: vec![unwrap_iter(old, interner, base)],
     }
 }
 

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -491,67 +491,13 @@ impl<'a> Interp<'a> {
                 },
                 _ => Err(Unsupported),
             },
-            NodeKind::BinOp => {
-                let kids = self.il.children(node).to_vec();
-                if kids.len() != 2 {
-                    return Err(Unsupported);
-                }
-                let op = op_of(n.payload);
-                // SHORT-CIRCUIT `and`/`or` — real Python/JS/Go/C semantics: the right
-                // operand is evaluated ONLY when the left doesn't already decide the result,
-                // and the operator yields the deciding OPERAND's value (value-and/or), not a
-                // coerced bool. So `a or b` ≡ `a if a else b` and `a and b` ≡ `b if a else a`
-                // exactly — including laziness (`x or f()` does not run `f()` when `x` is
-                // truthy) and Err-propagation only on the evaluated side. (Previously both
-                // operands were evaluated eagerly through `bin`, so `5 or (1/0)` wrongly
-                // Err'd and a value-or never converged with its ternary — an oracle bug.)
-                let a = self.eval(kids[0], env)?;
-                if matches!(op, Op::Or) {
-                    return Ok(if matches!(a, Value::Err) || truthy(&a) {
-                        a
-                    } else {
-                        self.eval(kids[1], env)?
-                    });
-                }
-                if matches!(op, Op::And) {
-                    return Ok(if matches!(a, Value::Err) || !truthy(&a) {
-                        a
-                    } else {
-                        self.eval(kids[1], env)?
-                    });
-                }
-                if matches!(a, Value::Err) {
-                    return Ok(Value::Err);
-                }
-                let b = self.eval(kids[1], env)?;
-                Ok(bin(op, &a, &b))
-            }
+            NodeKind::BinOp => self.eval_bin_op(node, n.payload, env),
             NodeKind::UnOp => {
                 let kids = self.il.children(node).to_vec();
                 let a = self.eval(*kids.first().ok_or(Unsupported)?, env)?;
                 Ok(un(op_of(n.payload), &a))
             }
-            NodeKind::Index => {
-                let kids = self.il.children(node).to_vec();
-                if kids.len() != 2 {
-                    return Err(Unsupported);
-                }
-                let base = self.eval(kids[0], env)?;
-                if matches!(base, Value::Err) {
-                    return Ok(Value::Err);
-                }
-                let idx = self.eval(kids[1], env)?;
-                if matches!(idx, Value::Err) {
-                    return Ok(Value::Err);
-                }
-                match (base, idx) {
-                    (Value::List(xs), Value::Int(i)) => {
-                        let i = if i < 0 { i + xs.len() as i64 } else { i };
-                        Ok(xs.get(i as usize).cloned().unwrap_or(Value::Err))
-                    }
-                    _ => Ok(Value::Err),
-                }
-            }
+            NodeKind::Index => self.eval_index(node, env),
             NodeKind::Seq => {
                 let mut out = Vec::new();
                 for c in self.il.children(node).to_vec() {
@@ -604,6 +550,69 @@ impl<'a> Interp<'a> {
         }
     }
 
+    fn eval_bin_op(
+        &mut self,
+        node: NodeId,
+        payload: Payload,
+        env: &mut FxHashMap<u32, Value>,
+    ) -> R<Value> {
+        let kids = self.il.children(node).to_vec();
+        if kids.len() != 2 {
+            return Err(Unsupported);
+        }
+        let op = op_of(payload);
+        // SHORT-CIRCUIT `and`/`or` — real Python/JS/Go/C semantics: the right
+        // operand is evaluated ONLY when the left doesn't already decide the result,
+        // and the operator yields the deciding OPERAND's value (value-and/or), not a
+        // coerced bool. So `a or b` ≡ `a if a else b` and `a and b` ≡ `b if a else a`
+        // exactly — including laziness (`x or f()` does not run `f()` when `x` is
+        // truthy) and Err-propagation only on the evaluated side. (Previously both
+        // operands were evaluated eagerly through `bin`, so `5 or (1/0)` wrongly
+        // Err'd and a value-or never converged with its ternary — an oracle bug.)
+        let a = self.eval(kids[0], env)?;
+        if matches!(op, Op::Or) {
+            return Ok(if matches!(a, Value::Err) || truthy(&a) {
+                a
+            } else {
+                self.eval(kids[1], env)?
+            });
+        }
+        if matches!(op, Op::And) {
+            return Ok(if matches!(a, Value::Err) || !truthy(&a) {
+                a
+            } else {
+                self.eval(kids[1], env)?
+            });
+        }
+        if matches!(a, Value::Err) {
+            return Ok(Value::Err);
+        }
+        let b = self.eval(kids[1], env)?;
+        Ok(bin(op, &a, &b))
+    }
+
+    fn eval_index(&mut self, node: NodeId, env: &mut FxHashMap<u32, Value>) -> R<Value> {
+        let kids = self.il.children(node).to_vec();
+        if kids.len() != 2 {
+            return Err(Unsupported);
+        }
+        let base = self.eval(kids[0], env)?;
+        if matches!(base, Value::Err) {
+            return Ok(Value::Err);
+        }
+        let idx = self.eval(kids[1], env)?;
+        if matches!(idx, Value::Err) {
+            return Ok(Value::Err);
+        }
+        match (base, idx) {
+            (Value::List(xs), Value::Int(i)) => {
+                let i = if i < 0 { i + xs.len() as i64 } else { i };
+                Ok(xs.get(i as usize).cloned().unwrap_or(Value::Err))
+            }
+            _ => Ok(Value::Err),
+        }
+    }
+
     fn eval_call(&mut self, node: NodeId, env: &mut FxHashMap<u32, Value>) -> R<Value> {
         let b = match self.il.node(node).payload {
             Payload::Builtin(b) => b,
@@ -638,6 +647,14 @@ impl<'a> Interp<'a> {
             }
             args.push(arg);
         }
+        self.eval_eager_builtin(eager_contract, args)
+    }
+
+    fn eval_eager_builtin(
+        &mut self,
+        eager_contract: EagerBuiltinContract,
+        args: Vec<Value>,
+    ) -> R<Value> {
         match eager_contract {
             EagerBuiltinContract::Len => match args.first() {
                 Some(Value::List(xs)) => Ok(Value::Int(xs.len() as i64)),

--- a/crates/nose-normalize/src/value_graph/canonicalize.rs
+++ b/crates/nose-normalize/src/value_graph/canonicalize.rs
@@ -9,271 +9,310 @@ use super::*;
 
 impl<'a> Builder<'a> {
     pub(super) fn mk(&mut self, mut op: ValOp, mut args: Vec<ValueId>) -> ValueId {
-        if let ValOp::Bin(opc) = op {
-            // Canonicalize comparison DIRECTION: `a > b` ≡ `b < a`, `a >= b` ≡ `b <= a`.
-            // Reduce the >/>= family to </<= with swapped operands so a guard converges
-            // however it was written or negated (`0 < v`, `v > 0`, `!(v <= 0)` all become
-            // one node). Language-agnostic and sound (total order). This is what lets a
-            // `reduce(λa,v: a+v if v>0 else a, …)` fold converge with its loop, whose
-            // guard may lower to the mirror comparison.
-            if args.len() == 2 && self.comparison_law_enabled(ComparisonLaw::DirectionCanon) {
-                if opc == Op::Gt as u32 {
-                    op = ValOp::Bin(Op::Lt as u32);
-                    args.swap(0, 1);
-                } else if opc == Op::Ge as u32 {
-                    op = ValOp::Bin(Op::Le as u32);
-                    args.swap(0, 1);
-                }
-            }
-            // Canonicalize commutative operands by structural hash. `+` commutes UNLESS an
-            // operand is PROVEN string/list — concat is non-commutative (`s + x` ≠ `x + s`)
-            // and the free-monoid oracle distinguishes the orders. Unknown operands keep
-            // commuting (optimistic, and the oracle still checks it), so the common untyped
-            // numeric case is unaffected; only known-concat is held ordered. Other
-            // commutative ops Err on non-numeric regardless of order, so stay safe.
-            if let ValOp::Bin(o) = op {
-                let concat = o == Op::Add as u32
-                    && args.len() == 2
-                    && !self.add_values_not_concat(ValueLaw::AddCommutativity, &args);
-                if is_commutative(o)
-                    && args.len() == 2
-                    && !concat
-                    && self.vhash[args[0] as usize] > self.vhash[args[1] as usize]
-                {
-                    args.swap(0, 1);
-                }
-            }
-        }
-        if let ValOp::Bin(o) = op {
-            if args.len() == 2 && (o == Op::Add as u32 || o == Op::BitOr as u32) {
-                if let Some(v) = self.c_u16_be_byte_pack_pattern(args[0], args[1]) {
-                    return v;
-                }
-            }
+        self.order_bin_operands(&mut op, &mut args);
+        if let Some(v) = self.u16_byte_pack(&op, &args) {
+            return v;
         }
         // Type-gated simplifications — now SOUND because the operand type is PROVEN (these
         // were the 17 false merges when applied untyped; they only hold on numbers/bools):
         //   -(-x) → x        when x : Num   (−(−x) = x; on a list it would Err ≠ x)
         //   x & x, x | x → x when x : Num   (idempotent integer bitwise)
         //   x && x, x || x → x when x : Bool (idempotent boolean)
-        if let ValOp::Un(o) = op {
-            // NEGATED COMPARISON: `!(a<=b) → a>b`, `!(a<b) → a>=b`, `!(a==b) → a!=b`, etc.
-            // Sound for a total order, and on non-numeric operands both sides Err
-            // (`!(Err)` propagates — see interp `un`), so the rewrite preserves behavior.
-            // This canonicalizes the residual `Not` the algebra pass leaves on a pushed
-            // double-negation (`!!(a<b)` → `!(b<=a)` → `a<b`), converging it with the bare
-            // comparison without the unsound untyped `!!x → x`.
-            if o == Op::Not as u32
-                && !args.is_empty()
-                && self.comparison_law_enabled(ComparisonLaw::Negation)
-            {
-                if let ValOp::Bin(bo) = self.nodes[args[0] as usize].op {
-                    if let Some(neg) = negate_cmp_code(self.il.meta.lang, bo) {
-                        let cargs = self.nodes[args[0] as usize].args.clone();
-                        return self.mk(ValOp::Bin(neg), cargs);
-                    }
-                }
-            }
-            if o == Op::Neg as u32 && !args.is_empty() {
-                if let ValOp::Un(io) = self.nodes[args[0] as usize].op {
-                    let inner = self.nodes[args[0] as usize].args[0];
-                    if io == Op::Neg as u32
-                        && self.value_law_satisfied(ValueLaw::NumericNegationInvolution, &[inner])
-                    {
-                        return inner;
-                    }
-                }
-                // Distribute negation over addition: `-(x + y) → (-x) + (-y)`. Sound for
-                // ALL types — `Neg` errors on non-numeric, and so does the distributed
-                // form (`-list` is Err either way). Pushing Neg inward gives a canonical
-                // form so `-(a+b)` converges with `-a - b` (= `-a + -b`).
-                if let ValOp::Bin(bo) = self.nodes[args[0] as usize].op {
-                    if bo == Op::Add as u32 {
-                        let inner = self.nodes[args[0] as usize].args.clone();
-                        let negs: Vec<ValueId> = inner
-                            .iter()
-                            .map(|&t| self.mk(ValOp::Un(Op::Neg as u32), vec![t]))
-                            .collect();
-                        let mut acc = negs[0];
-                        for &n in &negs[1..] {
-                            acc = self.mk(ValOp::Bin(Op::Add as u32), vec![acc, n]);
-                        }
-                        return acc;
-                    }
-                }
-            }
+        if let Some(v) = self.unary_canon(&op, &args) {
+            return v;
         }
-        if let ValOp::Bin(o) = op {
-            if args.len() == 2 && args[0] == args[1] {
-                let bitwise = o == Op::BitAnd as u32 || o == Op::BitOr as u32;
-                let logical = o == Op::And as u32 || o == Op::Or as u32;
-                if (bitwise
-                    && self.value_law_satisfied(ValueLaw::NumericBitwiseIdempotence, &[args[0]]))
-                    || (logical
-                        && self.value_law_satisfied(ValueLaw::BooleanIdempotence, &[args[0]]))
-                {
-                    return args[0];
-                }
-            }
-            // NOTE: arithmetic identity elimination (`x+0→x`, `x*1→x`) is deliberately NOT
-            // done — it is unsound for non-numeric `x` (`"a"+0` Errs; `self*1` on a
-            // non-number need not equal `self`), and value-domain inference is optimistic (it infers
-            // `x:Num` from `x*1` itself), so a Num gate would still merge `return self*1`
-            // with an identity `return self`. The oracle's all-types battery sees the
-            // difference. `x*1`/`x+0` keep their identity operand (algebra no longer drops
-            // it) and stay distinct from a bare `x` — a tiny convergence cost for soundness.
-
-            // DISTRIBUTION / FACTORING: `x*f + y*f → (x+y)*f`. Canonicalizes toward the
-            // factored form so `a*c + b*c` converges with `(a+b)*c`. Sound ONLY on numbers —
-            // string `*int` is repetition, where `"a"*2 + "b"*2` ("aabb") ≠ `("a"+"b")*2`
-            // ("abab") — so every leaf must be PROVEN `Num`. Lean obligation:
-            // `normalize.value_graph.factor_distribute`.
-            if o == Op::Add as u32 && args.len() == 2 {
-                if let Some(v) = rules::factor_distribute::apply(self, args[0], args[1]) {
-                    return v;
-                }
-            }
-            // DOUBLING (`x*k → x+…+x`, so `x*2` ≡ `x+x`) was TRIED and REJECTED: expansion is
-            // sound only on numbers, so it must gate on a PROVEN `Num`; but then the canonical
-            // form of `(a+b)*2` depends on whether the surrounding code happens to prove the
-            // operands numeric, splitting two behaviorally-identical functions (`a+=b; a*=2`
-            // diverged from `(a+b)*2`). It closed `x*2 vs x+x` but opened `compound assign` —
-            // net-zero, plus fragility. The gap stays open; see experiments §BA. (`x+x` in
-            // isolation cannot be proven `Num`, so the sound contraction direction never fires.)
+        if let Some(v) = self.bin_idempotence_and_factor(&op, &args) {
+            return v;
         }
-        // `and`/`or` are TYPE-GATED on commutativity, exactly like `+` is gated on concat:
-        //   • both operands PROVEN Bool → boolean-and/or, which IS commutative
-        //     (`X && Y` = `Y && X` for booleans) — sort operands so `p∧q` converges with
-        //     `q∧p` (e.g. `(a>b)∧(b>0)` vs `(0<b)∧(b<a)` after comparison-direction canon).
-        //   • otherwise → short-circuit VALUE-and/or, which is NOT commutative and yields
-        //     the deciding operand's VALUE: `a or b ≡ a if a else b`, `a and b ≡ b if a
-        //     else a`. Canonicalize to the positional `Phi` the ternary builds, so a guard
-        //     written `a or b` converges with its `a if a else b` twin — without ever
-        //     merging `a or b` with `b or a` (the value-or false merge the oracle now sees).
-        // (Idempotent `x∧x`/`x∨x` on Bool, handled just above, returns before this.)
-        if let ValOp::Bin(o) = op {
-            let is_or = o == Op::Or as u32;
-            let is_and = o == Op::And as u32;
-            if (is_or || is_and) && args.len() == 2 {
-                if self.value_law_satisfied(ValueLaw::BooleanCommutativity, &args) {
-                    if is_or {
-                        if let Some(v) = self.literal_equality_disjunction(args[0], args[1]) {
-                            return v;
-                        }
-                    }
-                    // LATTICE CANON on a total order — close the strict comparison from a
-                    // non-strict one plus an (in)equality, so a guard written as the
-                    // conjunction/disjunction converges with the strict comparison:
-                    //   (x ≤ y) ∧ (x ≠ y) → x < y     (dual of below)
-                    //   (x < y) ∨ (x = y) → x ≤ y
-                    // Sound for any total order (`normalize.value_graph.compare`); on a type
-                    // error every comparison Errs identically on both sides. It composes through
-                    // the recursive `mk` fixpoint, so `not (a>b or a==b)` reaches `a<b`.
-                    if is_and {
-                        if let Some(v) = self.lattice_strict_absorbs_nonstrict(args[0], args[1]) {
-                            return v;
-                        }
-                        if let Some(v) = self.lattice_le_ne_to_lt(args[0], args[1]) {
-                            return v;
-                        }
-                    } else if let Some(v) = self.lattice_lt_eq_to_le(args[0], args[1]) {
-                        return v;
-                    }
-                    if self.vhash[args[0] as usize] > self.vhash[args[1] as usize] {
-                        args.swap(0, 1);
-                    }
-                } else if is_or {
-                    return self.mk(ValOp::Phi, vec![args[0], args[0], args[1]]);
-                } else {
-                    return self.mk(ValOp::Phi, vec![args[0], args[1], args[0]]);
-                }
-            }
+        if let Some(v) = self.bool_and_or_canon(&op, &mut args) {
+            return v;
         }
-        // Recognize select idioms on EVERY branch merge — `Phi(cond, then, els)` is built
-        // both by a ternary (`a if c else b`) and by an if/else that assigns a variable, so
-        // doing this here (not just at the ternary) keeps the two forms convergent:
-        //   `x if x>=0 else -x` → Abs(x) ;  `x if x<y else y` → Min(x,y) / Max(x,y).
-        if let ValOp::Phi = op {
-            if args.len() == 3 {
-                if self.bool_const(args[1]) == Some(true) && self.bool_const(args[2]) == Some(false)
-                {
-                    return args[0];
-                }
-                if self.bool_const(args[1]) == Some(false) && self.bool_const(args[2]) == Some(true)
-                {
-                    return self.mk(ValOp::Un(Op::Not as u32), vec![args[0]]);
-                }
-                if let Some(v) = self.boolean_guarded_identity_phi(args[0], args[1], args[2]) {
-                    return v;
-                }
-                if let Some(v) = self.abs_pattern(args[0], args[1], args[2]) {
-                    return v;
-                }
-                if let Some(v) = self.minmax_pattern(args[0], args[1], args[2]) {
-                    return v;
-                }
-                if let Some(v) = self.clamp_ternary_pattern(args[0], args[1], args[2]) {
-                    return v;
-                }
-                if let Some(v) = self.low_bit_toggle_pattern(args[0], args[1], args[2]) {
-                    return v;
-                }
-                if let Some(v) = self.map_default_pattern(args[0], args[1], args[2]) {
-                    return v;
-                }
-                if let Some(v) = self.value_default_pattern(args[0], args[1], args[2]) {
-                    return v;
-                }
-                if let Some(v) = self.flatten_nested_guarded_identity_phi(args[0], args[1], args[2])
-                {
-                    return v;
-                }
-            }
+        if let Some(v) = self.phi_select_idioms(&op, &args) {
+            return v;
         }
-        // Boolean logical `and`/`or` is associative and commutative only when both sides are
-        // proven Bool. Flattening that narrow shape lets `guard && (p && q)` converge with
-        // `(guard && p) && q` without reviving value-short-circuit false merges for unknowns.
-        if let ValOp::Bin(o) = op {
-            if args.len() == 2 && (o == Op::And as u32 || o == Op::Or as u32) {
-                let mut leaves = Vec::new();
-                self.flatten_into(args[0], o, &mut leaves);
-                self.flatten_into(args[1], o, &mut leaves);
-                if leaves.len() > 2
-                    && self.value_law_satisfied(ValueLaw::BooleanAssociativity, &leaves)
-                {
-                    leaves.sort_unstable_by_key(|&v| self.vhash[v as usize]);
-                    return self.intern_ac_chain(o, &leaves);
-                }
-            }
+        if let Some(v) = self.bool_chain_flatten(&op, &args) {
+            return v;
         }
-
-        // Full ASSOCIATIVE-COMMUTATIVE canonicalization: flatten a `+`/`*`/`&`/`|`/`^`
-        // chain to its leaves, sort them by structural hash, and rebuild one canonical
-        // left-leaning chain — so `(a+b)+c`, `a+(b+c)`, and a factored `(a+b)+d` (from
-        // `factor_distribute`) all reach ONE node regardless of how they were grouped or
-        // built. The value graph thus canonicalizes AC chains itself, not only via the
-        // earlier `algebra` IL pass (which keyed by a different hash and did not see nodes
-        // synthesized here). Sound: any operand permutation of an AC chain is denotation-
-        // preserving (`normalize.value_graph.algebra`). String/list `+` is NOT reordered
-        // (it is ordered concat); `* & | ^` Err on non-numeric regardless of order.
-        if let ValOp::Bin(o) = op {
-            if is_assoc_comm_code(o) && args.len() == 2 {
-                let concat = o == Op::Add as u32
-                    && !self.add_values_not_concat(ValueLaw::AddAssociativity, &args);
-                if !concat {
-                    let mut leaves = Vec::new();
-                    for &a in &args {
-                        self.flatten_into(a, o, &mut leaves);
-                    }
-                    if leaves.len() > 2 {
-                        leaves.sort_unstable_by_key(|&v| self.vhash[v as usize]);
-                        return self.intern_ac_chain(o, &leaves);
-                    }
-                }
-            }
+        if let Some(v) = self.ac_chain_canon(&op, &args) {
+            return v;
         }
         let id = self.intern_node(op, args);
         rules::clamp::apply(self, id).unwrap_or(id)
+    }
+
+    fn order_bin_operands(&mut self, op: &mut ValOp, args: &mut [ValueId]) {
+        let ValOp::Bin(opc) = *op else { return };
+        // Canonicalize comparison DIRECTION: `a > b` ≡ `b < a`, `a >= b` ≡ `b <= a`.
+        // Reduce the >/>= family to </<= with swapped operands so a guard converges
+        // however it was written or negated (`0 < v`, `v > 0`, `!(v <= 0)` all become
+        // one node). Language-agnostic and sound (total order). This is what lets a
+        // `reduce(λa,v: a+v if v>0 else a, …)` fold converge with its loop, whose
+        // guard may lower to the mirror comparison.
+        if args.len() == 2 && self.comparison_law_enabled(ComparisonLaw::DirectionCanon) {
+            if opc == Op::Gt as u32 {
+                *op = ValOp::Bin(Op::Lt as u32);
+                args.swap(0, 1);
+            } else if opc == Op::Ge as u32 {
+                *op = ValOp::Bin(Op::Le as u32);
+                args.swap(0, 1);
+            }
+        }
+        // Canonicalize commutative operands by structural hash. `+` commutes UNLESS an
+        // operand is PROVEN string/list — concat is non-commutative (`s + x` ≠ `x + s`)
+        // and the free-monoid oracle distinguishes the orders. Unknown operands keep
+        // commuting (optimistic, and the oracle still checks it), so the common untyped
+        // numeric case is unaffected; only known-concat is held ordered. Other
+        // commutative ops Err on non-numeric regardless of order, so stay safe.
+        if let ValOp::Bin(o) = *op {
+            let concat = o == Op::Add as u32
+                && args.len() == 2
+                && !self.add_values_not_concat(ValueLaw::AddCommutativity, args);
+            if is_commutative(o)
+                && args.len() == 2
+                && !concat
+                && self.vhash[args[0] as usize] > self.vhash[args[1] as usize]
+            {
+                args.swap(0, 1);
+            }
+        }
+    }
+
+    fn u16_byte_pack(&mut self, op: &ValOp, args: &[ValueId]) -> Option<ValueId> {
+        let ValOp::Bin(o) = *op else { return None };
+        if args.len() == 2 && (o == Op::Add as u32 || o == Op::BitOr as u32) {
+            if let Some(v) = self.c_u16_be_byte_pack_pattern(args[0], args[1]) {
+                return Some(v);
+            }
+        }
+        None
+    }
+
+    fn unary_canon(&mut self, op: &ValOp, args: &[ValueId]) -> Option<ValueId> {
+        let ValOp::Un(o) = *op else { return None };
+        // NEGATED COMPARISON: `!(a<=b) → a>b`, `!(a<b) → a>=b`, `!(a==b) → a!=b`, etc.
+        // Sound for a total order, and on non-numeric operands both sides Err
+        // (`!(Err)` propagates — see interp `un`), so the rewrite preserves behavior.
+        // This canonicalizes the residual `Not` the algebra pass leaves on a pushed
+        // double-negation (`!!(a<b)` → `!(b<=a)` → `a<b`), converging it with the bare
+        // comparison without the unsound untyped `!!x → x`.
+        if o == Op::Not as u32
+            && !args.is_empty()
+            && self.comparison_law_enabled(ComparisonLaw::Negation)
+        {
+            if let ValOp::Bin(bo) = self.nodes[args[0] as usize].op {
+                if let Some(neg) = negate_cmp_code(self.il.meta.lang, bo) {
+                    let cargs = self.nodes[args[0] as usize].args.clone();
+                    return Some(self.mk(ValOp::Bin(neg), cargs));
+                }
+            }
+        }
+        if o == Op::Neg as u32 && !args.is_empty() {
+            if let ValOp::Un(io) = self.nodes[args[0] as usize].op {
+                let inner = self.nodes[args[0] as usize].args[0];
+                if io == Op::Neg as u32
+                    && self.value_law_satisfied(ValueLaw::NumericNegationInvolution, &[inner])
+                {
+                    return Some(inner);
+                }
+            }
+            // Distribute negation over addition: `-(x + y) → (-x) + (-y)`. Sound for
+            // ALL types — `Neg` errors on non-numeric, and so does the distributed
+            // form (`-list` is Err either way). Pushing Neg inward gives a canonical
+            // form so `-(a+b)` converges with `-a - b` (= `-a + -b`).
+            if let ValOp::Bin(bo) = self.nodes[args[0] as usize].op {
+                if bo == Op::Add as u32 {
+                    let inner = self.nodes[args[0] as usize].args.clone();
+                    let negs: Vec<ValueId> = inner
+                        .iter()
+                        .map(|&t| self.mk(ValOp::Un(Op::Neg as u32), vec![t]))
+                        .collect();
+                    let mut acc = negs[0];
+                    for &n in &negs[1..] {
+                        acc = self.mk(ValOp::Bin(Op::Add as u32), vec![acc, n]);
+                    }
+                    return Some(acc);
+                }
+            }
+        }
+        None
+    }
+
+    fn bin_idempotence_and_factor(&mut self, op: &ValOp, args: &[ValueId]) -> Option<ValueId> {
+        let ValOp::Bin(o) = *op else { return None };
+        if args.len() == 2 && args[0] == args[1] {
+            let bitwise = o == Op::BitAnd as u32 || o == Op::BitOr as u32;
+            let logical = o == Op::And as u32 || o == Op::Or as u32;
+            if (bitwise
+                && self.value_law_satisfied(ValueLaw::NumericBitwiseIdempotence, &[args[0]]))
+                || (logical && self.value_law_satisfied(ValueLaw::BooleanIdempotence, &[args[0]]))
+            {
+                return Some(args[0]);
+            }
+        }
+        // NOTE: arithmetic identity elimination (`x+0→x`, `x*1→x`) is deliberately NOT
+        // done — it is unsound for non-numeric `x` (`"a"+0` Errs; `self*1` on a
+        // non-number need not equal `self`), and value-domain inference is optimistic (it infers
+        // `x:Num` from `x*1` itself), so a Num gate would still merge `return self*1`
+        // with an identity `return self`. The oracle's all-types battery sees the
+        // difference. `x*1`/`x+0` keep their identity operand (algebra no longer drops
+        // it) and stay distinct from a bare `x` — a tiny convergence cost for soundness.
+
+        // DISTRIBUTION / FACTORING: `x*f + y*f → (x+y)*f`. Canonicalizes toward the
+        // factored form so `a*c + b*c` converges with `(a+b)*c`. Sound ONLY on numbers —
+        // string `*int` is repetition, where `"a"*2 + "b"*2` ("aabb") ≠ `("a"+"b")*2`
+        // ("abab") — so every leaf must be PROVEN `Num`. Lean obligation:
+        // `normalize.value_graph.factor_distribute`.
+        if o == Op::Add as u32 && args.len() == 2 {
+            if let Some(v) = rules::factor_distribute::apply(self, args[0], args[1]) {
+                return Some(v);
+            }
+        }
+        // DOUBLING (`x*k → x+…+x`, so `x*2` ≡ `x+x`) was TRIED and REJECTED: expansion is
+        // sound only on numbers, so it must gate on a PROVEN `Num`; but then the canonical
+        // form of `(a+b)*2` depends on whether the surrounding code happens to prove the
+        // operands numeric, splitting two behaviorally-identical functions (`a+=b; a*=2`
+        // diverged from `(a+b)*2`). It closed `x*2 vs x+x` but opened `compound assign` —
+        // net-zero, plus fragility. The gap stays open; see experiments §BA. (`x+x` in
+        // isolation cannot be proven `Num`, so the sound contraction direction never fires.)
+        None
+    }
+
+    // `and`/`or` are TYPE-GATED on commutativity, exactly like `+` is gated on concat:
+    //   • both operands PROVEN Bool → boolean-and/or, which IS commutative
+    //     (`X && Y` = `Y && X` for booleans) — sort operands so `p∧q` converges with
+    //     `q∧p` (e.g. `(a>b)∧(b>0)` vs `(0<b)∧(b<a)` after comparison-direction canon).
+    //   • otherwise → short-circuit VALUE-and/or, which is NOT commutative and yields
+    //     the deciding operand's VALUE: `a or b ≡ a if a else b`, `a and b ≡ b if a
+    //     else a`. Canonicalize to the positional `Phi` the ternary builds, so a guard
+    //     written `a or b` converges with its `a if a else b` twin — without ever
+    //     merging `a or b` with `b or a` (the value-or false merge the oracle now sees).
+    // (Idempotent `x∧x`/`x∨x` on Bool, handled just above, returns before this.)
+    fn bool_and_or_canon(&mut self, op: &ValOp, args: &mut [ValueId]) -> Option<ValueId> {
+        let ValOp::Bin(o) = *op else { return None };
+        let is_or = o == Op::Or as u32;
+        let is_and = o == Op::And as u32;
+        if (is_or || is_and) && args.len() == 2 {
+            if self.value_law_satisfied(ValueLaw::BooleanCommutativity, args) {
+                if is_or {
+                    if let Some(v) = self.literal_equality_disjunction(args[0], args[1]) {
+                        return Some(v);
+                    }
+                }
+                // LATTICE CANON on a total order — close the strict comparison from a
+                // non-strict one plus an (in)equality, so a guard written as the
+                // conjunction/disjunction converges with the strict comparison:
+                //   (x ≤ y) ∧ (x ≠ y) → x < y     (dual of below)
+                //   (x < y) ∨ (x = y) → x ≤ y
+                // Sound for any total order (`normalize.value_graph.compare`); on a type
+                // error every comparison Errs identically on both sides. It composes through
+                // the recursive `mk` fixpoint, so `not (a>b or a==b)` reaches `a<b`.
+                if is_and {
+                    if let Some(v) = self.lattice_strict_absorbs_nonstrict(args[0], args[1]) {
+                        return Some(v);
+                    }
+                    if let Some(v) = self.lattice_le_ne_to_lt(args[0], args[1]) {
+                        return Some(v);
+                    }
+                } else if let Some(v) = self.lattice_lt_eq_to_le(args[0], args[1]) {
+                    return Some(v);
+                }
+                if self.vhash[args[0] as usize] > self.vhash[args[1] as usize] {
+                    args.swap(0, 1);
+                }
+            } else if is_or {
+                return Some(self.mk(ValOp::Phi, vec![args[0], args[0], args[1]]));
+            } else {
+                return Some(self.mk(ValOp::Phi, vec![args[0], args[1], args[0]]));
+            }
+        }
+        None
+    }
+
+    // Recognize select idioms on EVERY branch merge — `Phi(cond, then, els)` is built
+    // both by a ternary (`a if c else b`) and by an if/else that assigns a variable, so
+    // doing this here (not just at the ternary) keeps the two forms convergent:
+    //   `x if x>=0 else -x` → Abs(x) ;  `x if x<y else y` → Min(x,y) / Max(x,y).
+    fn phi_select_idioms(&mut self, op: &ValOp, args: &[ValueId]) -> Option<ValueId> {
+        if !matches!(*op, ValOp::Phi) || args.len() != 3 {
+            return None;
+        }
+        if self.bool_const(args[1]) == Some(true) && self.bool_const(args[2]) == Some(false) {
+            return Some(args[0]);
+        }
+        if self.bool_const(args[1]) == Some(false) && self.bool_const(args[2]) == Some(true) {
+            return Some(self.mk(ValOp::Un(Op::Not as u32), vec![args[0]]));
+        }
+        if let Some(v) = self.boolean_guarded_identity_phi(args[0], args[1], args[2]) {
+            return Some(v);
+        }
+        if let Some(v) = self.abs_pattern(args[0], args[1], args[2]) {
+            return Some(v);
+        }
+        if let Some(v) = self.minmax_pattern(args[0], args[1], args[2]) {
+            return Some(v);
+        }
+        if let Some(v) = self.clamp_ternary_pattern(args[0], args[1], args[2]) {
+            return Some(v);
+        }
+        if let Some(v) = self.low_bit_toggle_pattern(args[0], args[1], args[2]) {
+            return Some(v);
+        }
+        if let Some(v) = self.map_default_pattern(args[0], args[1], args[2]) {
+            return Some(v);
+        }
+        if let Some(v) = self.value_default_pattern(args[0], args[1], args[2]) {
+            return Some(v);
+        }
+        if let Some(v) = self.flatten_nested_guarded_identity_phi(args[0], args[1], args[2]) {
+            return Some(v);
+        }
+        None
+    }
+
+    // Boolean logical `and`/`or` is associative and commutative only when both sides are
+    // proven Bool. Flattening that narrow shape lets `guard && (p && q)` converge with
+    // `(guard && p) && q` without reviving value-short-circuit false merges for unknowns.
+    fn bool_chain_flatten(&mut self, op: &ValOp, args: &[ValueId]) -> Option<ValueId> {
+        let ValOp::Bin(o) = *op else { return None };
+        if args.len() == 2 && (o == Op::And as u32 || o == Op::Or as u32) {
+            let mut leaves = Vec::new();
+            self.flatten_into(args[0], o, &mut leaves);
+            self.flatten_into(args[1], o, &mut leaves);
+            if leaves.len() > 2 && self.value_law_satisfied(ValueLaw::BooleanAssociativity, &leaves)
+            {
+                leaves.sort_unstable_by_key(|&v| self.vhash[v as usize]);
+                return Some(self.intern_ac_chain(o, &leaves));
+            }
+        }
+        None
+    }
+
+    // Full ASSOCIATIVE-COMMUTATIVE canonicalization: flatten a `+`/`*`/`&`/`|`/`^`
+    // chain to its leaves, sort them by structural hash, and rebuild one canonical
+    // left-leaning chain — so `(a+b)+c`, `a+(b+c)`, and a factored `(a+b)+d` (from
+    // `factor_distribute`) all reach ONE node regardless of how they were grouped or
+    // built. The value graph thus canonicalizes AC chains itself, not only via the
+    // earlier `algebra` IL pass (which keyed by a different hash and did not see nodes
+    // synthesized here). Sound: any operand permutation of an AC chain is denotation-
+    // preserving (`normalize.value_graph.algebra`). String/list `+` is NOT reordered
+    // (it is ordered concat); `* & | ^` Err on non-numeric regardless of order.
+    fn ac_chain_canon(&mut self, op: &ValOp, args: &[ValueId]) -> Option<ValueId> {
+        let ValOp::Bin(o) = *op else { return None };
+        if is_assoc_comm_code(o) && args.len() == 2 {
+            let concat = o == Op::Add as u32
+                && !self.add_values_not_concat(ValueLaw::AddAssociativity, args);
+            if !concat {
+                let mut leaves = Vec::new();
+                for &a in args {
+                    self.flatten_into(a, o, &mut leaves);
+                }
+                if leaves.len() > 2 {
+                    leaves.sort_unstable_by_key(|&v| self.vhash[v as usize]);
+                    return Some(self.intern_ac_chain(o, &leaves));
+                }
+            }
+        }
+        None
     }
 
     /// Intern a value node by `(op, args)` (hash-consing), computing its structural hash

--- a/crates/nose-normalize/src/value_graph/collections.rs
+++ b/crates/nose-normalize/src/value_graph/collections.rs
@@ -163,176 +163,205 @@ impl<'a> Builder<'a> {
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
         match reduction_builtin_contract(b)? {
-            ReductionBuiltinContract::Len => {
-                if kids.len() == 1 {
-                    if admitted_terminal_count_reduction_at_call(self.il, call) {
-                        self.eval_terminal_count_builtin(kids[0], env)
-                    } else {
-                        self.eval_len_builtin(kids[0], env)
-                    }
-                } else {
-                    None
-                }
-            }
-            ReductionBuiltinContract::Sum => {
-                if kids
-                    .first()
-                    .is_some_and(|&arg| !self.terminal_reduction_arg_admitted(arg))
-                {
-                    return None;
-                }
-                let av = self.eval(*kids.first()?, env);
-                // `sum(map)` → the mapped stream's per-element contribution; a filtered
-                // map/flat-map carries a predicate and becomes `pred ? contrib : 0`,
-                // matching a guarded loop `if pred: acc += contrib`; `sum(xs)` → the raw
-                // element.
-                let zero = self.int_const(0);
-                let (contrib, predicate) = self.collection_elem_with_pred(av);
-                let contrib = if let Some(predicate) = predicate {
-                    self.mk(ValOp::Phi, vec![predicate, contrib, zero])
-                } else {
-                    contrib
-                };
-                let init = self.int_const(0);
-                Some(self.mk(ValOp::Reduce(Op::Add as u32), vec![init, contrib]))
-            }
-            ReductionBuiltinContract::ExplicitFold => {
-                if kids.len() < 2 {
-                    return None;
-                }
-                let filtered = self.filter_parts(kids[1]);
-                let (elems, guard) = if let Some((source, predicate)) = filtered {
-                    let coll = self.eval(source, env);
-                    let elem = self.elem(coll);
-                    let guard = self.eval_lambda_body(predicate, &[elem], env)?;
-                    (vec![elem], Some(guard))
-                } else {
-                    self.elem_bindings_with_pred(kids.get(1).copied(), env)
-                };
-                let acc = self.fresh_opaque();
-                let mut params = Vec::with_capacity(elems.len() + 1);
-                params.push(acc);
-                params.extend(elems);
-                let body = self.eval_lambda_body(kids[0], &params, env)?;
-                let (op, contrib) = self.as_reduction(body, acc)?;
-                let contrib = if let Some(guard) = guard {
-                    let ident = self.int_const(identity_of(op)?);
-                    self.mk(ValOp::Phi, vec![guard, contrib, ident])
-                } else {
-                    contrib
-                };
-                // `reduce(λ, init)` carries its seed — for a selection (min/max)
-                // the seed clamps the result, so dropping it merged
-                // `reduce(max-λ, 0)` with true `max(…)`. A seedless `reduce(λ)`
-                // folds from the first element: for a selection that IS the true
-                // min/max — the same 1-arg shape the builtin builds.
-                let init = kids.get(2).map(|&i| self.eval(i, env));
-                let args = match (init, is_selection_code(op)) {
-                    (Some(init), _) => vec![init, contrib],
-                    (None, true) => vec![contrib],
-                    (None, false) => vec![self.int_const(0), contrib],
-                };
-                Some(self.mk(ValOp::Reduce(op), args))
-            }
-            ReductionBuiltinContract::Selection { max } => {
-                if kids.len() == 1 && !self.terminal_reduction_arg_admitted(kids[0]) {
-                    return None;
-                }
-                let (reduce_code, choice_code) = if max {
-                    (REDUCE_MAX, MAX_CODE)
-                } else {
-                    (REDUCE_MIN, MIN_CODE)
-                };
-                if kids.len() == 2 {
-                    let left = self.eval(kids[0], env);
-                    let right = self.eval(kids[1], env);
-                    return Some(self.mk(ValOp::Bin(choice_code), vec![left, right]));
-                }
-                let av = self.eval(*kids.first()?, env);
-                // `max(f(x) for x in xs)` → the mapped per-element value; `max(xs)` →
-                // the raw element. Seedless (1-arg) by construction: a SEEDED loop
-                // (`best = 0; …`) clamps at its seed, so it keys differently and
-                // must not merge with the true builtin selection.
-                let (op, args) = {
-                    let n = &self.nodes[av as usize];
-                    (n.op.clone(), n.args.clone())
-                };
-                let contrib = match op {
-                    ValOp::Hof(k) if k == HoFKind::Map as u32 && !args.is_empty() => args[0],
-                    _ => self.elem(av),
-                };
-                Some(self.mk(ValOp::Reduce(reduce_code), vec![contrib]))
-            }
-            ReductionBuiltinContract::Bool { all } => {
-                let code = if all { REDUCE_ALL } else { REDUCE_ANY };
-                // `xs.some(p)` / `xs.any(p)` — method form `[coll, λ]`: the per-element
-                // contribution is `p(Elem coll)`. `any(p(x) for x in xs)` — generator form
-                // `[Map]`: the mapped predicate value; a *filtered* generator carries its
-                // predicate, guarded by the OR/AND identity (false for any, true for all).
-                let contrib = if kids.len() >= 2 && self.il.kind(kids[1]) == NodeKind::Lambda {
-                    let coll = self.eval(kids[0], env);
-                    let (elem, carried_guard) = self.collection_elem_with_pred(coll);
-                    let pred = self.eval_lambda_body(kids[1], &[elem], env)?;
-                    if carried_guard.is_none()
-                        && code == REDUCE_ANY
-                        && self.is_static_non_float_collection_expr(kids[0])
-                        && self.lambda_return_source_operator_allowed(kids[1], Op::Eq)
-                    {
-                        if let Some((element, collection)) =
-                            self.static_literal_membership_predicate(pred)
-                        {
-                            return Some(
-                                self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]),
-                            );
-                        }
-                    }
-                    if carried_guard.is_none()
-                        && code == REDUCE_ALL
-                        && self.is_static_non_float_collection_expr(kids[0])
-                        && self.lambda_return_source_operator_allowed(kids[1], Op::Ne)
-                    {
-                        if let Some((element, collection)) =
-                            self.static_literal_absence_predicate(pred)
-                        {
-                            let membership =
-                                self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]);
-                            return Some(self.mk(ValOp::Un(Op::Not as u32), vec![membership]));
-                        }
-                    }
-                    if let Some(carried_guard) = carried_guard {
-                        let ident = self.mk(ValOp::Const(0x3000_0001 + code - REDUCE_ANY), vec![]);
-                        self.mk(ValOp::Phi, vec![carried_guard, pred, ident])
-                    } else {
-                        pred
-                    }
-                } else {
-                    if kids
-                        .first()
-                        .is_some_and(|&arg| !self.terminal_reduction_arg_admitted(arg))
-                    {
-                        return None;
-                    }
-                    let av = self.eval(*kids.first()?, env);
-                    let (contrib, predicate) = self.collection_elem_with_pred(av);
-                    if let Some(predicate) = predicate {
-                        let ident = self.mk(ValOp::Const(0x3000_0001 + code - REDUCE_ANY), vec![]);
-                        self.mk(ValOp::Phi, vec![predicate, contrib, ident])
-                    } else {
-                        contrib
-                    }
-                };
-                Some(self.mk(ValOp::Reduce(code), vec![contrib]))
-            }
-            ReductionBuiltinContract::Join => {
-                if kids.len() != 2 {
-                    return None;
-                }
-                let sep = self.eval(kids[0], env);
-                let coll = self.eval(kids[1], env);
-                let elem = self.elem(coll);
-                Some(self.mk(ValOp::Reduce(ORDERED_STRING_JOIN), vec![sep, elem]))
-            }
+            ReductionBuiltinContract::Len => self.reduction_len(call, kids, env),
+            ReductionBuiltinContract::Sum => self.reduction_sum(kids, env),
+            ReductionBuiltinContract::ExplicitFold => self.reduction_explicit_fold(kids, env),
+            ReductionBuiltinContract::Selection { max } => self.reduction_selection(max, kids, env),
+            ReductionBuiltinContract::Bool { all } => self.reduction_bool(all, kids, env),
+            ReductionBuiltinContract::Join => self.reduction_join(kids, env),
         }
+    }
+
+    fn reduction_len(
+        &mut self,
+        call: NodeId,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if kids.len() == 1 {
+            if admitted_terminal_count_reduction_at_call(self.il, call) {
+                self.eval_terminal_count_builtin(kids[0], env)
+            } else {
+                self.eval_len_builtin(kids[0], env)
+            }
+        } else {
+            None
+        }
+    }
+
+    fn reduction_sum(&mut self, kids: &[NodeId], env: &FxHashMap<u32, ValueId>) -> Option<ValueId> {
+        if kids
+            .first()
+            .is_some_and(|&arg| !self.terminal_reduction_arg_admitted(arg))
+        {
+            return None;
+        }
+        let av = self.eval(*kids.first()?, env);
+        // `sum(map)` → the mapped stream's per-element contribution; a filtered
+        // map/flat-map carries a predicate and becomes `pred ? contrib : 0`,
+        // matching a guarded loop `if pred: acc += contrib`; `sum(xs)` → the raw
+        // element.
+        let zero = self.int_const(0);
+        let (contrib, predicate) = self.collection_elem_with_pred(av);
+        let contrib = if let Some(predicate) = predicate {
+            self.mk(ValOp::Phi, vec![predicate, contrib, zero])
+        } else {
+            contrib
+        };
+        let init = self.int_const(0);
+        Some(self.mk(ValOp::Reduce(Op::Add as u32), vec![init, contrib]))
+    }
+
+    fn reduction_explicit_fold(
+        &mut self,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if kids.len() < 2 {
+            return None;
+        }
+        let filtered = self.filter_parts(kids[1]);
+        let (elems, guard) = if let Some((source, predicate)) = filtered {
+            let coll = self.eval(source, env);
+            let elem = self.elem(coll);
+            let guard = self.eval_lambda_body(predicate, &[elem], env)?;
+            (vec![elem], Some(guard))
+        } else {
+            self.elem_bindings_with_pred(kids.get(1).copied(), env)
+        };
+        let acc = self.fresh_opaque();
+        let mut params = Vec::with_capacity(elems.len() + 1);
+        params.push(acc);
+        params.extend(elems);
+        let body = self.eval_lambda_body(kids[0], &params, env)?;
+        let (op, contrib) = self.as_reduction(body, acc)?;
+        let contrib = if let Some(guard) = guard {
+            let ident = self.int_const(identity_of(op)?);
+            self.mk(ValOp::Phi, vec![guard, contrib, ident])
+        } else {
+            contrib
+        };
+        // `reduce(λ, init)` carries its seed — for a selection (min/max)
+        // the seed clamps the result, so dropping it merged
+        // `reduce(max-λ, 0)` with true `max(…)`. A seedless `reduce(λ)`
+        // folds from the first element: for a selection that IS the true
+        // min/max — the same 1-arg shape the builtin builds.
+        let init = kids.get(2).map(|&i| self.eval(i, env));
+        let args = match (init, is_selection_code(op)) {
+            (Some(init), _) => vec![init, contrib],
+            (None, true) => vec![contrib],
+            (None, false) => vec![self.int_const(0), contrib],
+        };
+        Some(self.mk(ValOp::Reduce(op), args))
+    }
+
+    fn reduction_selection(
+        &mut self,
+        max: bool,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if kids.len() == 1 && !self.terminal_reduction_arg_admitted(kids[0]) {
+            return None;
+        }
+        let (reduce_code, choice_code) = if max {
+            (REDUCE_MAX, MAX_CODE)
+        } else {
+            (REDUCE_MIN, MIN_CODE)
+        };
+        if kids.len() == 2 {
+            let left = self.eval(kids[0], env);
+            let right = self.eval(kids[1], env);
+            return Some(self.mk(ValOp::Bin(choice_code), vec![left, right]));
+        }
+        let av = self.eval(*kids.first()?, env);
+        // `max(f(x) for x in xs)` → the mapped per-element value; `max(xs)` →
+        // the raw element. Seedless (1-arg) by construction: a SEEDED loop
+        // (`best = 0; …`) clamps at its seed, so it keys differently and
+        // must not merge with the true builtin selection.
+        let (op, args) = {
+            let n = &self.nodes[av as usize];
+            (n.op.clone(), n.args.clone())
+        };
+        let contrib = match op {
+            ValOp::Hof(k) if k == HoFKind::Map as u32 && !args.is_empty() => args[0],
+            _ => self.elem(av),
+        };
+        Some(self.mk(ValOp::Reduce(reduce_code), vec![contrib]))
+    }
+
+    fn reduction_bool(
+        &mut self,
+        all: bool,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        let code = if all { REDUCE_ALL } else { REDUCE_ANY };
+        // `xs.some(p)` / `xs.any(p)` — method form `[coll, λ]`: the per-element
+        // contribution is `p(Elem coll)`. `any(p(x) for x in xs)` — generator form
+        // `[Map]`: the mapped predicate value; a *filtered* generator carries its
+        // predicate, guarded by the OR/AND identity (false for any, true for all).
+        let contrib = if kids.len() >= 2 && self.il.kind(kids[1]) == NodeKind::Lambda {
+            let coll = self.eval(kids[0], env);
+            let (elem, carried_guard) = self.collection_elem_with_pred(coll);
+            let pred = self.eval_lambda_body(kids[1], &[elem], env)?;
+            if carried_guard.is_none()
+                && code == REDUCE_ANY
+                && self.is_static_non_float_collection_expr(kids[0])
+                && self.lambda_return_source_operator_allowed(kids[1], Op::Eq)
+            {
+                if let Some((element, collection)) = self.static_literal_membership_predicate(pred)
+                {
+                    return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
+                }
+            }
+            if carried_guard.is_none()
+                && code == REDUCE_ALL
+                && self.is_static_non_float_collection_expr(kids[0])
+                && self.lambda_return_source_operator_allowed(kids[1], Op::Ne)
+            {
+                if let Some((element, collection)) = self.static_literal_absence_predicate(pred) {
+                    let membership = self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]);
+                    return Some(self.mk(ValOp::Un(Op::Not as u32), vec![membership]));
+                }
+            }
+            if let Some(carried_guard) = carried_guard {
+                let ident = self.mk(ValOp::Const(0x3000_0001 + code - REDUCE_ANY), vec![]);
+                self.mk(ValOp::Phi, vec![carried_guard, pred, ident])
+            } else {
+                pred
+            }
+        } else {
+            if kids
+                .first()
+                .is_some_and(|&arg| !self.terminal_reduction_arg_admitted(arg))
+            {
+                return None;
+            }
+            let av = self.eval(*kids.first()?, env);
+            let (contrib, predicate) = self.collection_elem_with_pred(av);
+            if let Some(predicate) = predicate {
+                let ident = self.mk(ValOp::Const(0x3000_0001 + code - REDUCE_ANY), vec![]);
+                self.mk(ValOp::Phi, vec![predicate, contrib, ident])
+            } else {
+                contrib
+            }
+        };
+        Some(self.mk(ValOp::Reduce(code), vec![contrib]))
+    }
+
+    fn reduction_join(
+        &mut self,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if kids.len() != 2 {
+            return None;
+        }
+        let sep = self.eval(kids[0], env);
+        let coll = self.eval(kids[1], env);
+        let elem = self.elem(coll);
+        Some(self.mk(ValOp::Reduce(ORDERED_STRING_JOIN), vec![sep, elem]))
     }
 
     pub(super) fn eval_len_builtin(

--- a/crates/nose-normalize/src/value_graph/control.rs
+++ b/crates/nose-normalize/src/value_graph/control.rs
@@ -663,15 +663,7 @@ impl<'a> Builder<'a> {
         env: &FxHashMap<u32, ValueId>,
     ) -> bool {
         if self.il.kind(expr) == NodeKind::Seq {
-            for child in self.il.children(expr).to_vec() {
-                if self.expr_is_static_runtime_err(child, env) {
-                    return crate::is_pure(self.il, child);
-                }
-                if !crate::is_pure(self.il, child) {
-                    return false;
-                }
-            }
-            return false;
+            return self.seq_is_static_runtime_err(expr, env);
         }
         if self.il.kind(expr) == NodeKind::HoF
             && matches!(
@@ -680,40 +672,10 @@ impl<'a> Builder<'a> {
                     | Payload::HoF(HoFKind::FilterMap)
             )
         {
-            let Payload::HoF(kind) = self.il.node(expr).payload else {
-                return false;
-            };
-            let demand = admitted_hof_demand_effect_profile_at_node(self.il, expr, kind);
-            let Some(demand) = demand else { return false };
-            if !demand.proves_eager_per_element_callback_demand() {
-                return false;
-            }
-            let kids = self.il.children(expr).to_vec();
-            return kids
-                .first()
-                .is_some_and(|&coll| self.expr_is_static_non_empty_seq(coll))
-                && kids
-                    .get(1)
-                    .is_some_and(|&lambda| self.lambda_body_is_static_runtime_err(lambda, env));
+            return self.hof_is_static_runtime_err(expr, env);
         }
         if self.il.kind(expr) == NodeKind::If {
-            let kids = self.il.children(expr).to_vec();
-            let Some(&cond) = kids.first() else {
-                return false;
-            };
-            if self.expr_is_static_runtime_err(cond, env) {
-                return true;
-            }
-            let cond_value = self.eval(cond, env);
-            return match self.bool_const(cond_value) {
-                Some(true) => kids
-                    .get(1)
-                    .is_some_and(|&then_expr| self.expr_is_static_runtime_err(then_expr, env)),
-                Some(false) => kids
-                    .get(2)
-                    .is_some_and(|&else_expr| self.expr_is_static_runtime_err(else_expr, env)),
-                None => false,
-            };
+            return self.if_is_static_runtime_err(expr, env);
         }
         if self.il.kind(expr) == NodeKind::Call && self.call_has_static_runtime_arg_err(expr, env) {
             return true;
@@ -746,6 +708,59 @@ impl<'a> Builder<'a> {
         if self.il.kind(expr) != NodeKind::BinOp {
             return false;
         }
+        self.binop_is_static_runtime_err(expr, env)
+    }
+
+    fn seq_is_static_runtime_err(&mut self, expr: NodeId, env: &FxHashMap<u32, ValueId>) -> bool {
+        for child in self.il.children(expr).to_vec() {
+            if self.expr_is_static_runtime_err(child, env) {
+                return crate::is_pure(self.il, child);
+            }
+            if !crate::is_pure(self.il, child) {
+                return false;
+            }
+        }
+        false
+    }
+
+    fn hof_is_static_runtime_err(&mut self, expr: NodeId, env: &FxHashMap<u32, ValueId>) -> bool {
+        let Payload::HoF(kind) = self.il.node(expr).payload else {
+            return false;
+        };
+        let demand = admitted_hof_demand_effect_profile_at_node(self.il, expr, kind);
+        let Some(demand) = demand else { return false };
+        if !demand.proves_eager_per_element_callback_demand() {
+            return false;
+        }
+        let kids = self.il.children(expr).to_vec();
+        kids.first()
+            .is_some_and(|&coll| self.expr_is_static_non_empty_seq(coll))
+            && kids
+                .get(1)
+                .is_some_and(|&lambda| self.lambda_body_is_static_runtime_err(lambda, env))
+    }
+
+    fn if_is_static_runtime_err(&mut self, expr: NodeId, env: &FxHashMap<u32, ValueId>) -> bool {
+        let kids = self.il.children(expr).to_vec();
+        let Some(&cond) = kids.first() else {
+            return false;
+        };
+        if self.expr_is_static_runtime_err(cond, env) {
+            return true;
+        }
+        let cond_value = self.eval(cond, env);
+        match self.bool_const(cond_value) {
+            Some(true) => kids
+                .get(1)
+                .is_some_and(|&then_expr| self.expr_is_static_runtime_err(then_expr, env)),
+            Some(false) => kids
+                .get(2)
+                .is_some_and(|&else_expr| self.expr_is_static_runtime_err(else_expr, env)),
+            None => false,
+        }
+    }
+
+    fn binop_is_static_runtime_err(&mut self, expr: NodeId, env: &FxHashMap<u32, ValueId>) -> bool {
         let kids = self.il.children(expr).to_vec();
         if kids.len() != 2 {
             return false;
@@ -1212,185 +1227,26 @@ impl<'a> Builder<'a> {
 
         match kind {
             LoopKind::ForEach if kids.len() >= 3 => {
-                let pat = kids[0];
-                let it = kids[1];
-                if let Some(c) = self.range_len_collection(it) {
-                    // `for i in range(len(C))`: `i` is a canonical index into `C`.
-                    let cv = self.eval(c, env);
-                    let ix = self.idx(cv);
-                    index_vals.insert(ix);
-                    for cid in self.pattern_cids(pat) {
-                        pattern_bindings.push((cid, ix));
-                    }
-                } else if self.il.kind(it) == NodeKind::Call
-                    && matches!(
-                        self.il.node(it).payload,
-                        Payload::Builtin(Builtin::Enumerate)
-                    )
-                    && self.admitted_builtin_call(it, Builtin::Enumerate)
-                {
-                    // `for i, x in enumerate(C)`: `i` is the index, `x` the element.
-                    let cids = self.pattern_cids(pat);
-                    if let Some(&cnode) = self.il.children(it).first() {
-                        let cv = self.eval(cnode, env);
-                        let ix = self.idx(cv);
-                        let el = self.elem(cv);
-                        index_vals.insert(ix);
-                        if cids.len() >= 2 {
-                            pattern_bindings.push((cids[0], ix));
-                            pattern_bindings.push((cids[1], el));
-                        } else if let Some(&only) = cids.first() {
-                            pattern_bindings.push((only, el));
-                        }
-                    }
-                } else {
-                    // Value iteration `for x in C` (or `for i in range(n)`): the
-                    // pattern var is an element of the iterable. NOTE: we do *not* treat
-                    // this element as a collection index — only a provably-*full* range
-                    // (`range_len_collection`, above) licenses `C[i] → Elem(C)`. A bare
-                    // `range(n)` or partial `range(1, len)` indexing `C[i]` must keep its
-                    // `Index(C, …)` so it stays distinct from the full-range loop (else a
-                    // subset sum merges with the full sum — a soundness bug).
-                    let iv = self.eval(it, env);
-                    let e = self.elem(iv);
-                    for cid in self.pattern_cids(pat) {
-                        pattern_bindings.push((cid, e));
-                    }
-                }
+                self.bind_foreach_loop_elements(&kids, env, &mut pattern_bindings, &mut index_vals);
             }
             _ => {
-                let cond = kids
-                    .first()
-                    .filter(|&&c| self.il.kind(c) != NodeKind::Block);
-                // A genuine loop counter both steps by a constant *and* governs the
-                // loop condition. An accumulator updated by `acc = acc + 1` (a counting
-                // reduction) matches the `i = i ± c` shape too, so `induction_vars`
-                // alone misclassifies it as iteration mechanics — which binds it to the
-                // index and destroys the reduction (it would never reach a `Reduce`).
-                // Intersect with the variables the condition actually mentions so only
-                // the real counter(s) are treated as indices; the accumulator stays an
-                // accumulator. (Sum loops were spared by luck — `sum += xs[i]` has a
-                // non-literal operand, so `is_increment` already rejected them; counting
-                // loops like `if p: count += 1` were the ones that collapsed.)
-                let cond_cids = cond
-                    .map(|&c| mentioned_cids(self.il, c))
-                    .unwrap_or_default();
-                induction = induction_vars(self.il, body)
-                    .intersection(&cond_cids)
-                    .copied()
-                    .collect();
-                let iter_node =
-                    cond.and_then(|&c| self.loop_iterable(c, &induction).map(|it| (it, None)));
-                let indexed_bound_loop = iter_node.or_else(|| {
-                    cond.and_then(|&c| {
-                        self.indexed_bound_loop_iterable(c, body, &induction)
-                            .map(|(it, bound, cmp)| (it, Some((bound, cmp))))
-                    })
-                });
-                match indexed_bound_loop {
-                    // Indexed `while i < len(C)`: the raw `i < len(C)` guard is iteration
-                    // mechanics. A counter that steps by +1 from 0 visits *every* index
-                    // in order, so `C[i]` is the canonical `Elem(C)` (converges with `for
-                    // x in C`). A non-unit stride (`i += 2`) or non-zero start (`i = 1`)
-                    // visits a SUBSET — `C[i]` is NOT `Elem(C)` — so bind `i` to a strided
-                    // index that encodes start+step (distinct strides stay distinct) and
-                    // do NOT license the `C[i] → Elem(C)` rewrite (else a strided sum
-                    // merges with the full sum — the while-loop analog of the range bug).
-                    Some((it, bound_guard)) if !induction.is_empty() => {
-                        let cv = self.eval(it, env);
-                        if let Some((bound, cmp)) = bound_guard {
-                            let bv = self.eval(bound, env);
-                            if !self.full_pointer_length_contract(cmp, cv, bv) {
-                                let gv = self.indexed_bound_guard(cmp, bv);
-                                self.sinks.push(Sink::new(SinkKind::Cond, gv));
-                            } else if let (Some(arr), Some(len)) =
-                                (self.input_key(cv), self.input_key(bv))
-                            {
-                                // The bound `n` was dropped as "length of the array" — record
-                                // (array_pos, length_pos) so the oracle interprets under n=len.
-                                self.contracts.push((arr, len));
-                            }
-                        }
-                        let zero = self.int_const(0);
-                        for &i in &induction {
-                            let step = induction_step(self.il, body, i);
-                            let start_zero = env.get(&i).is_some_and(|&s| s == zero);
-                            if step == Some(1) && start_zero {
-                                let ix = self.idx(cv);
-                                index_vals.insert(ix);
-                                pattern_bindings.push((i, ix));
-                            } else {
-                                let start_val = env.get(&i).copied().unwrap_or(zero);
-                                let step_val =
-                                    self.int_const(step.unwrap_or(0).rem_euclid(1 << 24) as u32);
-                                let base = self.idx(cv);
-                                let h = combine(
-                                    self.vhash[base as usize],
-                                    combine(
-                                        self.vhash[start_val as usize],
-                                        self.vhash[step_val as usize],
-                                    ),
-                                );
-                                let strided =
-                                    self.mk(ValOp::Idx(h), vec![base, start_val, step_val]);
-                                pattern_bindings.push((i, strided));
-                            }
-                        }
-                    }
-                    // Plain `while`/other: keep the raw condition; no element model.
-                    _ => {
-                        induction.clear();
-                        if let Some(&c) = cond {
-                            let cv = self.eval(c, env);
-                            self.sinks.push(Sink::new(SinkKind::Cond, cv));
-                        }
-                    }
-                }
+                self.bind_conditional_loop_elements(
+                    &kids,
+                    body,
+                    env,
+                    &mut pattern_bindings,
+                    &mut index_vals,
+                    &mut induction,
+                );
             }
         }
 
-        let mut assigned = FxHashSet::default();
-        collect_assigned(self.il, body, &mut assigned);
-        // List-builder vars (incl. Go's `r = append(r, …)`, which makes `r` assigned) are
-        // activated as builders, NOT seeded as numeric loop-carried recurrences — otherwise a
-        // Go builder var would be both a `Loop` placeholder and a `Map` build and collapse. The
-        // seed (empty-collection) check reads the PRE-loop `env` (the real `[]` seed; the body's
-        // reassignment would otherwise hide it). Builders are excluded from `carried`.
-        let builder_cands = self.builder_candidates(body, env);
-        let builder_set: FxHashSet<u32> = builder_cands
-            .iter()
-            .map(|candidate| candidate.cid)
-            .collect();
-        for candidate in &builder_cands {
-            self.building.insert(candidate.cid, None);
-            self.building_kind.insert(candidate.cid, candidate.kind);
-        }
-        let mut carried: Vec<u32> = assigned
-            .iter()
-            .copied()
-            .filter(|c| !builder_set.contains(c))
-            .collect();
-        carried.sort_unstable();
+        let (builder_cands, carried) = self.activate_loop_builders(body, env);
 
         // Seed each loop-carried variable with a symbolic "previous iteration" value
         // so the body expresses its update as a *recurrence* over `Loop(cid)`.
         let mut body_env = env.clone();
-        let mut loop_vals: FxHashMap<u32, ValueId> = FxHashMap::default();
-        let loop_key_base = self.next_loop_key_base;
-        let loop_key_count = u32::try_from(carried.len()).unwrap_or(u32::MAX);
-        self.next_loop_key_base = self
-            .next_loop_key_base
-            .wrapping_add(loop_key_count.saturating_add(1));
-        let mut loop_keys: FxHashMap<u32, u32> = FxHashMap::default();
-        let mut loop_key_set: FxHashSet<u32> = FxHashSet::default();
-        for (slot, &cid) in carried.iter().enumerate() {
-            let key = loop_key_base.wrapping_add(slot as u32);
-            loop_keys.insert(cid, key);
-            loop_key_set.insert(key);
-            let lv = self.mk(ValOp::Loop(key), vec![]);
-            loop_vals.insert(cid, lv);
-            body_env.insert(cid, lv);
-        }
+        let (loop_vals, loop_keys, loop_key_set) = self.seed_loop_carried(&carried, &mut body_env);
         // Pattern/index bindings override the `Loop` placeholder for iteration vars.
         let iter_vars: FxHashSet<u32> = pattern_bindings.iter().map(|&(c, _)| c).collect();
         for &(cid, v) in &pattern_bindings {
@@ -1413,24 +1269,301 @@ impl<'a> Builder<'a> {
         let pre_body_env = body_env.clone();
         self.process_stmt(body, &mut body_env);
         self.loop_recurrence = outer_recurrence;
+        self.rewrite_loop_index_sinks(sink_start, &index_vals, &carried, &mut body_env);
+        let flag_break_reduction = self.detect_flag_break_reduction(
+            body,
+            &carried,
+            env,
+            &pre_body_env,
+            &index_vals,
+            sink_start,
+        );
+        self.finalize_loop_builders(
+            &builder_cands,
+            &index_vals,
+            &body_env,
+            &pattern_bindings,
+            env,
+        );
+
+        // For each loop-carried accumulator, recognize an associative-commutative
+        // reduction `acc = acc ⊕ contrib` and canonicalize it to a `Reduce` value —
+        // so sum/product/min/max/count loops converge regardless of loop shape,
+        // accumulator name, or operand grouping (the §AH representation axis). The
+        // per-element `contrib` keys the value, so a `+`-loop and a `*`-loop (or
+        // `a[i]*b[i]` vs `a[i]+b[i]`) stay distinct (the behavior axis). When the
+        // update is not a clean reduction, thread the raw recurrence (still better
+        // than a bare opaque `Loop` value reaching the sinks).
+        let mut reduction_cache = ReductionCache::default();
+        for &cid in &carried {
+            let init = env.get(&cid).copied();
+            if let Some(v) = self.carried_special_value(
+                body,
+                cid,
+                flag_break_reduction,
+                init,
+                &pre_body_env,
+                &index_vals,
+            ) {
+                env.insert(cid, v);
+                continue;
+            }
+            if iter_vars.contains(&cid) || induction.contains(&cid) {
+                continue; // iteration mechanics, not an accumulator
+            }
+            let Some(&newv) = body_env.get(&cid) else {
+                continue;
+            };
+            let loopv = loop_vals[&cid];
+            let v = self.carried_recurrence_value(
+                init,
+                newv,
+                loopv,
+                &pattern_bindings,
+                &mut reduction_cache,
+            );
+            env.insert(cid, v);
+        }
+    }
+
+    fn activate_loop_builders(
+        &mut self,
+        body: NodeId,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> (Vec<BuilderCandidate>, Vec<u32>) {
+        let mut assigned = FxHashSet::default();
+        collect_assigned(self.il, body, &mut assigned);
+        // List-builder vars (incl. Go's `r = append(r, …)`, which makes `r` assigned) are
+        // activated as builders, NOT seeded as numeric loop-carried recurrences — otherwise a
+        // Go builder var would be both a `Loop` placeholder and a `Map` build and collapse. The
+        // seed (empty-collection) check reads the PRE-loop `env` (the real `[]` seed; the body's
+        // reassignment would otherwise hide it). Builders are excluded from `carried`.
+        let builder_cands = self.builder_candidates(body, env);
+        let builder_set: FxHashSet<u32> = builder_cands
+            .iter()
+            .map(|candidate| candidate.cid)
+            .collect();
+        for candidate in &builder_cands {
+            self.building.insert(candidate.cid, None);
+            self.building_kind.insert(candidate.cid, candidate.kind);
+        }
+        let mut carried: Vec<u32> = assigned
+            .iter()
+            .copied()
+            .filter(|c| !builder_set.contains(c))
+            .collect();
+        carried.sort_unstable();
+        (builder_cands, carried)
+    }
+
+    fn seed_loop_carried(
+        &mut self,
+        carried: &[u32],
+        body_env: &mut FxHashMap<u32, ValueId>,
+    ) -> (FxHashMap<u32, ValueId>, FxHashMap<u32, u32>, FxHashSet<u32>) {
+        let mut loop_vals: FxHashMap<u32, ValueId> = FxHashMap::default();
+        let loop_key_base = self.next_loop_key_base;
+        let loop_key_count = u32::try_from(carried.len()).unwrap_or(u32::MAX);
+        self.next_loop_key_base = self
+            .next_loop_key_base
+            .wrapping_add(loop_key_count.saturating_add(1));
+        let mut loop_keys: FxHashMap<u32, u32> = FxHashMap::default();
+        let mut loop_key_set: FxHashSet<u32> = FxHashSet::default();
+        for (slot, &cid) in carried.iter().enumerate() {
+            let key = loop_key_base.wrapping_add(slot as u32);
+            loop_keys.insert(cid, key);
+            loop_key_set.insert(key);
+            let lv = self.mk(ValOp::Loop(key), vec![]);
+            loop_vals.insert(cid, lv);
+            body_env.insert(cid, lv);
+        }
+        (loop_vals, loop_keys, loop_key_set)
+    }
+
+    fn bind_foreach_loop_elements(
+        &mut self,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+        pattern_bindings: &mut Vec<(u32, ValueId)>,
+        index_vals: &mut FxHashSet<ValueId>,
+    ) {
+        let pat = kids[0];
+        let it = kids[1];
+        if let Some(c) = self.range_len_collection(it) {
+            // `for i in range(len(C))`: `i` is a canonical index into `C`.
+            let cv = self.eval(c, env);
+            let ix = self.idx(cv);
+            index_vals.insert(ix);
+            for cid in self.pattern_cids(pat) {
+                pattern_bindings.push((cid, ix));
+            }
+        } else if self.il.kind(it) == NodeKind::Call
+            && matches!(
+                self.il.node(it).payload,
+                Payload::Builtin(Builtin::Enumerate)
+            )
+            && self.admitted_builtin_call(it, Builtin::Enumerate)
+        {
+            // `for i, x in enumerate(C)`: `i` is the index, `x` the element.
+            let cids = self.pattern_cids(pat);
+            if let Some(&cnode) = self.il.children(it).first() {
+                let cv = self.eval(cnode, env);
+                let ix = self.idx(cv);
+                let el = self.elem(cv);
+                index_vals.insert(ix);
+                if cids.len() >= 2 {
+                    pattern_bindings.push((cids[0], ix));
+                    pattern_bindings.push((cids[1], el));
+                } else if let Some(&only) = cids.first() {
+                    pattern_bindings.push((only, el));
+                }
+            }
+        } else {
+            // Value iteration `for x in C` (or `for i in range(n)`): the
+            // pattern var is an element of the iterable. NOTE: we do *not* treat
+            // this element as a collection index — only a provably-*full* range
+            // (`range_len_collection`, above) licenses `C[i] → Elem(C)`. A bare
+            // `range(n)` or partial `range(1, len)` indexing `C[i]` must keep its
+            // `Index(C, …)` so it stays distinct from the full-range loop (else a
+            // subset sum merges with the full sum — a soundness bug).
+            let iv = self.eval(it, env);
+            let e = self.elem(iv);
+            for cid in self.pattern_cids(pat) {
+                pattern_bindings.push((cid, e));
+            }
+        }
+    }
+
+    fn bind_conditional_loop_elements(
+        &mut self,
+        kids: &[NodeId],
+        body: NodeId,
+        env: &FxHashMap<u32, ValueId>,
+        pattern_bindings: &mut Vec<(u32, ValueId)>,
+        index_vals: &mut FxHashSet<ValueId>,
+        induction: &mut FxHashSet<u32>,
+    ) {
+        let cond = kids
+            .first()
+            .filter(|&&c| self.il.kind(c) != NodeKind::Block);
+        // A genuine loop counter both steps by a constant *and* governs the
+        // loop condition. An accumulator updated by `acc = acc + 1` (a counting
+        // reduction) matches the `i = i ± c` shape too, so `induction_vars`
+        // alone misclassifies it as iteration mechanics — which binds it to the
+        // index and destroys the reduction (it would never reach a `Reduce`).
+        // Intersect with the variables the condition actually mentions so only
+        // the real counter(s) are treated as indices; the accumulator stays an
+        // accumulator. (Sum loops were spared by luck — `sum += xs[i]` has a
+        // non-literal operand, so `is_increment` already rejected them; counting
+        // loops like `if p: count += 1` were the ones that collapsed.)
+        let cond_cids = cond
+            .map(|&c| mentioned_cids(self.il, c))
+            .unwrap_or_default();
+        *induction = induction_vars(self.il, body)
+            .intersection(&cond_cids)
+            .copied()
+            .collect();
+        let iter_node = cond.and_then(|&c| self.loop_iterable(c, &*induction).map(|it| (it, None)));
+        let indexed_bound_loop = iter_node.or_else(|| {
+            cond.and_then(|&c| {
+                self.indexed_bound_loop_iterable(c, body, &*induction)
+                    .map(|(it, bound, cmp)| (it, Some((bound, cmp))))
+            })
+        });
+        match indexed_bound_loop {
+            // Indexed `while i < len(C)`: the raw `i < len(C)` guard is iteration
+            // mechanics. A counter that steps by +1 from 0 visits *every* index
+            // in order, so `C[i]` is the canonical `Elem(C)` (converges with `for
+            // x in C`). A non-unit stride (`i += 2`) or non-zero start (`i = 1`)
+            // visits a SUBSET — `C[i]` is NOT `Elem(C)` — so bind `i` to a strided
+            // index that encodes start+step (distinct strides stay distinct) and
+            // do NOT license the `C[i] → Elem(C)` rewrite (else a strided sum
+            // merges with the full sum — the while-loop analog of the range bug).
+            Some((it, bound_guard)) if !induction.is_empty() => {
+                let cv = self.eval(it, env);
+                if let Some((bound, cmp)) = bound_guard {
+                    let bv = self.eval(bound, env);
+                    if !self.full_pointer_length_contract(cmp, cv, bv) {
+                        let gv = self.indexed_bound_guard(cmp, bv);
+                        self.sinks.push(Sink::new(SinkKind::Cond, gv));
+                    } else if let (Some(arr), Some(len)) = (self.input_key(cv), self.input_key(bv))
+                    {
+                        // The bound `n` was dropped as "length of the array" — record
+                        // (array_pos, length_pos) so the oracle interprets under n=len.
+                        self.contracts.push((arr, len));
+                    }
+                }
+                let zero = self.int_const(0);
+                for &i in &*induction {
+                    let step = induction_step(self.il, body, i);
+                    let start_zero = env.get(&i).is_some_and(|&s| s == zero);
+                    if step == Some(1) && start_zero {
+                        let ix = self.idx(cv);
+                        index_vals.insert(ix);
+                        pattern_bindings.push((i, ix));
+                    } else {
+                        let start_val = env.get(&i).copied().unwrap_or(zero);
+                        let step_val = self.int_const(step.unwrap_or(0).rem_euclid(1 << 24) as u32);
+                        let base = self.idx(cv);
+                        let h = combine(
+                            self.vhash[base as usize],
+                            combine(
+                                self.vhash[start_val as usize],
+                                self.vhash[step_val as usize],
+                            ),
+                        );
+                        let strided = self.mk(ValOp::Idx(h), vec![base, start_val, step_val]);
+                        pattern_bindings.push((i, strided));
+                    }
+                }
+            }
+            // Plain `while`/other: keep the raw condition; no element model.
+            _ => {
+                induction.clear();
+                if let Some(&c) = cond {
+                    let cv = self.eval(c, env);
+                    self.sinks.push(Sink::new(SinkKind::Cond, cv));
+                }
+            }
+        }
+    }
+
+    fn rewrite_loop_index_sinks(
+        &mut self,
+        sink_start: usize,
+        index_vals: &FxHashSet<ValueId>,
+        carried: &[u32],
+        body_env: &mut FxHashMap<u32, ValueId>,
+    ) {
         if !index_vals.is_empty() {
             let mut memo = FxHashMap::default();
             for idx in sink_start..self.sinks.len() {
                 let v = self.sinks[idx].value;
-                self.sinks[idx].value = self.rewrite_indices(v, &index_vals, &mut memo);
+                self.sinks[idx].value = self.rewrite_indices(v, index_vals, &mut memo);
             }
-            for &cid in &carried {
+            for &cid in carried {
                 if let Some(&v) = body_env.get(&cid) {
-                    let nv = self.rewrite_indices(v, &index_vals, &mut memo);
+                    let nv = self.rewrite_indices(v, index_vals, &mut memo);
                     body_env.insert(cid, nv);
                 }
             }
         }
+    }
+
+    fn detect_flag_break_reduction(
+        &mut self,
+        body: NodeId,
+        carried: &[u32],
+        env: &FxHashMap<u32, ValueId>,
+        pre_body_env: &FxHashMap<u32, ValueId>,
+        index_vals: &FxHashSet<ValueId>,
+        sink_start: usize,
+    ) -> Option<(u32, ValueId)> {
         let mut flag_break_reduction = None;
-        for &cid in &carried {
+        for &cid in carried {
             if let Some(&init) = env.get(&cid) {
                 if let Some(v) =
-                    self.flag_break_reduction(body, cid, init, &pre_body_env, &index_vals)
+                    self.flag_break_reduction(body, cid, init, pre_body_env, index_vals)
                 {
                     flag_break_reduction = Some((cid, v));
                     self.sinks.truncate(sink_start);
@@ -1438,21 +1571,32 @@ impl<'a> Builder<'a> {
                 }
             }
         }
+        flag_break_reduction
+    }
+
+    fn finalize_loop_builders(
+        &mut self,
+        builder_cands: &[BuilderCandidate],
+        index_vals: &FxHashSet<ValueId>,
+        body_env: &FxHashMap<u32, ValueId>,
+        pattern_bindings: &[(u32, ValueId)],
+        env: &mut FxHashMap<u32, ValueId>,
+    ) {
         // Finalize list builders: `r = []; for x: r.append(f(x))` → `r = Map(elem, f(x))`,
         // converging the loop with the comprehension `[f(x) for x in xs]` / `.map`. A
         // guarded append (`if cond: r.append(f(x))`) becomes the filtered map `Map(_, pred)`.
         // If the append happens inside a nested loop, the inner loop has already produced a
         // `Map`/`FlatMap`; wrap that per-outer-iteration collection in a `FlatMap` so
         // `for x: for y: r.append(f(x,y))` converges with `[f(x,y) for x in xs for y in ys]`.
-        for candidate in &builder_cands {
+        for candidate in builder_cands {
             let c = candidate.cid;
             if let Some(Some((mut contrib, guard))) = self.building.remove(&c) {
                 let map = if !index_vals.is_empty() {
                     let mut memo = FxHashMap::default();
-                    contrib = self.rewrite_indices(contrib, &index_vals, &mut memo);
+                    contrib = self.rewrite_indices(contrib, index_vals, &mut memo);
                     match guard {
                         Some(g) => {
-                            let g = self.rewrite_indices(g, &index_vals, &mut memo);
+                            let g = self.rewrite_indices(g, index_vals, &mut memo);
                             self.mk(ValOp::Hof(HoFKind::Map as u32), vec![contrib, g])
                         }
                         None => self.mk(ValOp::Hof(HoFKind::Map as u32), vec![contrib]),
@@ -1465,7 +1609,7 @@ impl<'a> Builder<'a> {
                 };
                 env.insert(c, map);
             } else if let Some(&nested) = body_env.get(&c) {
-                if let Some(flat) = self.flat_map_builder_value(nested, &pattern_bindings) {
+                if let Some(flat) = self.flat_map_builder_value(nested, pattern_bindings) {
                     env.insert(c, flat);
                 }
                 self.building.remove(&c);
@@ -1474,68 +1618,65 @@ impl<'a> Builder<'a> {
             }
             self.building_kind.remove(&c);
         }
+    }
 
-        // For each loop-carried accumulator, recognize an associative-commutative
-        // reduction `acc = acc ⊕ contrib` and canonicalize it to a `Reduce` value —
-        // so sum/product/min/max/count loops converge regardless of loop shape,
-        // accumulator name, or operand grouping (the §AH representation axis). The
-        // per-element `contrib` keys the value, so a `+`-loop and a `*`-loop (or
-        // `a[i]*b[i]` vs `a[i]+b[i]`) stay distinct (the behavior axis). When the
-        // update is not a clean reduction, thread the raw recurrence (still better
-        // than a bare opaque `Loop` value reaching the sinks).
-        let mut reduction_cache = ReductionCache::default();
-        for &cid in &carried {
-            if let Some((flag_cid, v)) = flag_break_reduction {
-                if flag_cid == cid {
-                    env.insert(cid, v);
-                    continue;
-                }
+    fn carried_special_value(
+        &mut self,
+        body: NodeId,
+        cid: u32,
+        flag_break_reduction: Option<(u32, ValueId)>,
+        init: Option<ValueId>,
+        pre_body_env: &FxHashMap<u32, ValueId>,
+        index_vals: &FxHashSet<ValueId>,
+    ) -> Option<ValueId> {
+        if let Some((flag_cid, v)) = flag_break_reduction {
+            if flag_cid == cid {
+                return Some(v);
             }
-            if let Some(&init) = env.get(&cid) {
-                if let Some(v) =
-                    self.ordered_string_concat_loop(body, cid, init, &pre_body_env, &index_vals)
-                {
-                    env.insert(cid, v);
-                    continue;
-                }
+        }
+        if let Some(init) = init {
+            if let Some(v) =
+                self.ordered_string_concat_loop(body, cid, init, pre_body_env, index_vals)
+            {
+                return Some(v);
             }
-            if iter_vars.contains(&cid) || induction.contains(&cid) {
-                continue; // iteration mechanics, not an accumulator
+        }
+        None
+    }
+
+    fn carried_recurrence_value(
+        &mut self,
+        init: Option<ValueId>,
+        newv: ValueId,
+        loopv: ValueId,
+        pattern_bindings: &[(u32, ValueId)],
+        reduction_cache: &mut ReductionCache,
+    ) -> ValueId {
+        let loop_context: Vec<ValueId> = pattern_bindings.iter().map(|&(_, v)| v).collect();
+        match (
+            init,
+            self.as_loop_reduction_step(newv, loopv, &loop_context, reduction_cache),
+        ) {
+            (Some(init), Some((op, contrib))) => {
+                // Every loop reduction carries its seed. For folds the seed is
+                // the init operand; for selections (min/max) the seed CLAMPS the
+                // result — `best = 0; …max…` returns 0 on all-negative input,
+                // which true `max(…)` does not — so it is behavior-defining and
+                // must reach the fingerprint. The builtins build a seedless
+                // 1-arg `Reduce`, so they can never merge with a seeded loop.
+                self.mk(ValOp::Reduce(op), vec![init, contrib])
             }
-            let Some(&newv) = body_env.get(&cid) else {
-                continue;
-            };
-            let loopv = loop_vals[&cid];
-            let loop_context: Vec<ValueId> = pattern_bindings.iter().map(|&(_, v)| v).collect();
-            match (
-                env.get(&cid).copied(),
-                self.as_loop_reduction_step(newv, loopv, &loop_context, &mut reduction_cache),
-            ) {
-                (Some(init), Some((op, contrib))) => {
-                    // Every loop reduction carries its seed. For folds the seed is
-                    // the init operand; for selections (min/max) the seed CLAMPS the
-                    // result — `best = 0; …max…` returns 0 on all-negative input,
-                    // which true `max(…)` does not — so it is behavior-defining and
-                    // must reach the fingerprint. The builtins build a seedless
-                    // 1-arg `Reduce`, so they can never merge with a seeded loop.
-                    let red = self.mk(ValOp::Reduce(op), vec![init, contrib]);
-                    env.insert(cid, red);
-                }
-                (init, _) => {
-                    // A non-reduction loop-carried value still depends on its pre-loop
-                    // SEED. The compact `Recurrence` key is the per-iteration update
-                    // expression ONLY, so `acc = a` (a parameter seed, the loop returning
-                    // `a + Σ`) collapsed onto `acc = 0` (returning `Σ`) — a false merge,
-                    // since the two differ exactly by that seed. Re-key the recurrence on
-                    // the seed as well so the seed reaches the fingerprint. (Clean
-                    // reductions above already carry their `init`.)
-                    let v = match (init, self.nodes[newv as usize].op.clone()) {
-                        (Some(init), ValOp::Recurrence(h)) => {
-                            self.mk(ValOp::Recurrence(h), vec![init])
-                        }
-                        _ => newv,
-                    };
-                    env.insert(cid, v);
+            (init, _) => {
+                // A non-reduction loop-carried value still depends on its pre-loop
+                // SEED. The compact `Recurrence` key is the per-iteration update
+                // expression ONLY, so `acc = a` (a parameter seed, the loop returning
+                // `a + Σ`) collapsed onto `acc = 0` (returning `Σ`) — a false merge,
+                // since the two differ exactly by that seed. Re-key the recurrence on
+                // the seed as well so the seed reaches the fingerprint. (Clean
+                // reductions above already carry their `init`.)
+                match (init, self.nodes[newv as usize].op.clone()) {
+                    (Some(init), ValOp::Recurrence(h)) => self.mk(ValOp::Recurrence(h), vec![init]),
+                    _ => newv,
                 }
             }
         }
@@ -1961,86 +2102,14 @@ impl<'a> Builder<'a> {
         // contrib : identity)` so a filtered loop converges with `sum(c for x if cond)`
         // and the per-element contribution becomes 0/1 (the op identity) when filtered.
         if matches!(self.nodes[val as usize].op, ValOp::Phi) {
-            let args = self.nodes[val as usize].args.clone();
-            if args.len() == 3 && args[2] == loopv {
-                // (a) guarded accumulation: `if cond { acc = acc ⊕ contrib }`.
-                if let Some((op, contrib)) = self
-                    .as_reduction_cached(args[1], loopv, cache)
-                    .or_else(|| self.nested_reduce_step(args[1], loopv, cache))
-                {
-                    if let Some(id) = identity_of(op) {
-                        let ident = self.int_const(id);
-                        let guarded = self.mk(ValOp::Phi, vec![args[0], contrib, ident]);
-                        return Some((op, guarded));
-                    }
-                }
-                // (b) selection (min/max): `if cand {>,<} acc { acc = cand }` —
-                // the new value does not reference the old accumulator and the guard
-                // compares the two. `acc = max(acc, cand)` / `min`.
-                let cand = args[1];
-                if !self.references_cached(cand, loopv, cache) {
-                    if let Some(code) = self.selection_code(args[0], cand, loopv) {
-                        return Some((code, cand));
-                    }
-                }
-            }
-            // Swapped polarity: `if cond { acc } else { acc ⊕ contrib }`. cfg_norm can
-            // flip a two-branch ternary's orientation, so the accumulator lands in the
-            // THEN branch with a negated guard — a `functools.reduce(lambda acc,v: acc+v
-            // if v>0 else acc, …)` lowers to `if v<=0 { acc } else { acc+v }`. Recognize
-            // it with the negated guard so it converges with the loop form `if v>0:
-            // acc+=v` (whose single-branch guard stays positive).
-            if args.len() == 3 && args[1] == loopv {
-                if let Some((op, contrib)) = self
-                    .as_reduction_cached(args[2], loopv, cache)
-                    .or_else(|| self.nested_reduce_step(args[2], loopv, cache))
-                {
-                    if let Some(id) = identity_of(op) {
-                        let ident = self.int_const(id);
-                        let ncond = self.negate_guard(args[0]);
-                        let guarded = self.mk(ValOp::Phi, vec![ncond, contrib, ident]);
-                        return Some((op, guarded));
-                    }
-                }
-            }
-            // Full conditional contribution: both branches update the accumulator once,
-            // e.g. `if x < 0 { total += -x } else { total += x }`. This is one reduction
-            // whose per-element contribution is itself a branch value:
-            // `Reduce(⊕, init, cond ? then_contrib : else_contrib)`. The `Phi` builder
-            // then canonicalizes idioms such as `x < 0 ? -x : x` to `Abs(x)`.
-            if args.len() == 3 {
-                if let (Some((then_op, then_contrib)), Some((else_op, else_contrib))) = (
-                    self.as_reduction_cached(args[1], loopv, cache),
-                    self.as_reduction_cached(args[2], loopv, cache),
-                ) {
-                    if then_op == else_op {
-                        let contrib =
-                            self.mk(ValOp::Phi, vec![args[0], then_contrib, else_contrib]);
-                        return Some((then_op, contrib));
-                    }
-                }
-            }
-            return None;
+            return self.phi_reduction_step(val, loopv, cache);
         }
         // A min/max accumulator written as a Min/Max node (`minmax_pattern` turned the
         // conditional update `if x>acc { acc=x }` into `Max(acc, x)`): map the idiom code
         // to the selection-reduction code so the loop converges with the `max()`/`min()`
         // builtin (both → `Reduce(REDUCE_MAX/MIN, [contrib])`).
-        if let ValOp::Bin(o) = self.nodes[val as usize].op {
-            if o == MIN_CODE || o == MAX_CODE {
-                let a = self.nodes[val as usize].args.clone();
-                let red = if o == MAX_CODE {
-                    REDUCE_MAX
-                } else {
-                    REDUCE_MIN
-                };
-                if a[0] == loopv && !self.references_cached(a[1], loopv, cache) {
-                    return Some((red, a[1]));
-                }
-                if a[1] == loopv && !self.references_cached(a[0], loopv, cache) {
-                    return Some((red, a[0]));
-                }
-            }
+        if let Some(step) = self.minmax_selection_step(val, loopv, cache) {
+            return Some(step);
         }
         let op = match self.nodes[val as usize].op {
             ValOp::Bin(o) if is_assoc_comm_code(o) => o,
@@ -2069,6 +2138,131 @@ impl<'a> Builder<'a> {
             acc = self.mk(ValOp::Bin(op), vec![acc, o]);
         }
         Some((op, acc))
+    }
+
+    fn phi_reduction_step(
+        &mut self,
+        val: ValueId,
+        loopv: ValueId,
+        cache: &mut ReductionCache,
+    ) -> Option<(u32, ValueId)> {
+        let args = self.nodes[val as usize].args.clone();
+        if let Some(step) = self.phi_guarded_reduction(&args, loopv, cache) {
+            return Some(step);
+        }
+        if let Some(step) = self.phi_swapped_guard_reduction(&args, loopv, cache) {
+            return Some(step);
+        }
+        self.phi_branch_contribution(&args, loopv, cache)
+    }
+
+    fn phi_guarded_reduction(
+        &mut self,
+        args: &[ValueId],
+        loopv: ValueId,
+        cache: &mut ReductionCache,
+    ) -> Option<(u32, ValueId)> {
+        if args.len() == 3 && args[2] == loopv {
+            // (a) guarded accumulation: `if cond { acc = acc ⊕ contrib }`.
+            if let Some((op, contrib)) = self
+                .as_reduction_cached(args[1], loopv, cache)
+                .or_else(|| self.nested_reduce_step(args[1], loopv, cache))
+            {
+                if let Some(id) = identity_of(op) {
+                    let ident = self.int_const(id);
+                    let guarded = self.mk(ValOp::Phi, vec![args[0], contrib, ident]);
+                    return Some((op, guarded));
+                }
+            }
+            // (b) selection (min/max): `if cand {>,<} acc { acc = cand }` —
+            // the new value does not reference the old accumulator and the guard
+            // compares the two. `acc = max(acc, cand)` / `min`.
+            let cand = args[1];
+            if !self.references_cached(cand, loopv, cache) {
+                if let Some(code) = self.selection_code(args[0], cand, loopv) {
+                    return Some((code, cand));
+                }
+            }
+        }
+        None
+    }
+
+    fn phi_swapped_guard_reduction(
+        &mut self,
+        args: &[ValueId],
+        loopv: ValueId,
+        cache: &mut ReductionCache,
+    ) -> Option<(u32, ValueId)> {
+        // Swapped polarity: `if cond { acc } else { acc ⊕ contrib }`. cfg_norm can
+        // flip a two-branch ternary's orientation, so the accumulator lands in the
+        // THEN branch with a negated guard — a `functools.reduce(lambda acc,v: acc+v
+        // if v>0 else acc, …)` lowers to `if v<=0 { acc } else { acc+v }`. Recognize
+        // it with the negated guard so it converges with the loop form `if v>0:
+        // acc+=v` (whose single-branch guard stays positive).
+        if args.len() == 3 && args[1] == loopv {
+            if let Some((op, contrib)) = self
+                .as_reduction_cached(args[2], loopv, cache)
+                .or_else(|| self.nested_reduce_step(args[2], loopv, cache))
+            {
+                if let Some(id) = identity_of(op) {
+                    let ident = self.int_const(id);
+                    let ncond = self.negate_guard(args[0]);
+                    let guarded = self.mk(ValOp::Phi, vec![ncond, contrib, ident]);
+                    return Some((op, guarded));
+                }
+            }
+        }
+        None
+    }
+
+    fn phi_branch_contribution(
+        &mut self,
+        args: &[ValueId],
+        loopv: ValueId,
+        cache: &mut ReductionCache,
+    ) -> Option<(u32, ValueId)> {
+        // Full conditional contribution: both branches update the accumulator once,
+        // e.g. `if x < 0 { total += -x } else { total += x }`. This is one reduction
+        // whose per-element contribution is itself a branch value:
+        // `Reduce(⊕, init, cond ? then_contrib : else_contrib)`. The `Phi` builder
+        // then canonicalizes idioms such as `x < 0 ? -x : x` to `Abs(x)`.
+        if args.len() == 3 {
+            if let (Some((then_op, then_contrib)), Some((else_op, else_contrib))) = (
+                self.as_reduction_cached(args[1], loopv, cache),
+                self.as_reduction_cached(args[2], loopv, cache),
+            ) {
+                if then_op == else_op {
+                    let contrib = self.mk(ValOp::Phi, vec![args[0], then_contrib, else_contrib]);
+                    return Some((then_op, contrib));
+                }
+            }
+        }
+        None
+    }
+
+    fn minmax_selection_step(
+        &mut self,
+        val: ValueId,
+        loopv: ValueId,
+        cache: &mut ReductionCache,
+    ) -> Option<(u32, ValueId)> {
+        if let ValOp::Bin(o) = self.nodes[val as usize].op {
+            if o == MIN_CODE || o == MAX_CODE {
+                let a = self.nodes[val as usize].args.clone();
+                let red = if o == MAX_CODE {
+                    REDUCE_MAX
+                } else {
+                    REDUCE_MIN
+                };
+                if a[0] == loopv && !self.references_cached(a[1], loopv, cache) {
+                    return Some((red, a[1]));
+                }
+                if a[1] == loopv && !self.references_cached(a[0], loopv, cache) {
+                    return Some((red, a[0]));
+                }
+            }
+        }
+        None
     }
 
     pub(super) fn nested_reduce_step(

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -108,420 +108,21 @@ impl<'a> Builder<'a> {
     pub(super) fn eval_inner(&mut self, expr: NodeId, env: &FxHashMap<u32, ValueId>) -> ValueId {
         let node = *self.il.node(expr);
         match node.kind {
-            NodeKind::Var => match node.payload {
-                Payload::Cid(c) => env
-                    .get(&c)
-                    .copied()
-                    .unwrap_or_else(|| self.mk(ValOp::Input(c), vec![])),
-                // A free variable (global / un-canonicalized callee) kept its name in
-                // alpha — give it a STABLE identity keyed by that name (high-bit range,
-                // clear of positional cids), so `foo(x)` ≠ `bar(x)` while two uses of
-                // `foo` agree. Without this, distinct globals collapsed to one cid.
-                Payload::Name(s) => {
-                    if let Some(&v) = self.global_env.get(&s) {
-                        return v;
-                    }
-                    let name = self.interner.resolve(s);
-                    if self.is_rust_option_none_node(expr) {
-                        return self.null_const();
-                    }
-                    if let Some(contract) = nullish_global_contract(self.il.meta.lang, name) {
-                        if !contract.requires_unshadowed
-                            || asserted_unshadowed_global_symbol(self.il, expr, contract.name)
-                        {
-                            return self.null_const();
-                        }
-                    }
-                    self.mk(ValOp::Input(self.free_name_key(s)), vec![])
-                }
-                _ => self.fresh_opaque(),
-            },
-            NodeKind::Lit => {
-                // Behavior-defining constants must be distinct values: `0` ≠ `1`
-                // (else `x % 2 == 0` and `x % 2 == 1` collapse). Retained small ints
-                // key by value (offset clear of the class range); others by class.
-                let key = match node.payload {
-                    Payload::LitInt(v) => 0x1000_0000u32.wrapping_add(v as u32),
-                    // strings in a separate key range from ints to avoid collision
-                    Payload::LitStr(h) => 0x2000_0000u32.wrapping_add(h as u32),
-                    // floats keyed by source-text hash, in their own range (so `3.14`≠`2.71`)
-                    Payload::LitFloat(h) => 0x4000_0000u32.wrapping_add(h as u32),
-                    // true/false are behavior-defining and must be distinct (own range)
-                    Payload::LitBool(b) => 0x3000_0001u32 + b as u32,
-                    Payload::Lit(c) => c as u32,
-                    _ => 0,
-                };
-                self.mk(ValOp::Const(key), vec![])
-            }
-            NodeKind::BinOp => {
-                let op = op_code(node.payload);
-                let kids = self.il.children(expr).to_vec();
-                if op == Op::In as u32 && kids.len() == 2 {
-                    return self.eval_membership_binop(expr, &kids, env);
-                }
-                if let Some(v) = self.eval_rust_option_some_pattern_comparison(op, &kids, env) {
-                    return v;
-                }
-                if let Some(v) = self.eval_static_filter_membership_comparison(op, &kids, env) {
-                    return v;
-                }
-                if let Some(v) = self.eval_len_zero_comparison(op, &kids, env) {
-                    return v;
-                }
-                if let Payload::Op(op_kind) = node.payload {
-                    if let Some(v) =
-                        self.eval_static_index_membership_comparison(op_kind, &kids, env)
-                    {
-                        return v;
-                    }
-                }
-                if let Some(v) = self.eval_strict_equality_comparison(expr, op, &kids, env) {
-                    return v;
-                }
-                if op == Op::Add as u32 || op == Op::Sub as u32 {
-                    let mut operands = Vec::new();
-                    self.collect_add_sub_expr_operands(expr, false, &mut operands);
-                    if operands.len() >= LARGE_AC_EXPR_OPERANDS {
-                        return self.compact_add_sub_formula(operands, env);
-                    }
-                }
-                // Canonicalize subtraction to addition-of-negation: `a - b ≡ a + (-b)`
-                // (sound for the two's-complement Int model: a.wrapping_sub(b) ==
-                // a.wrapping_add(-b)). Routing it through the AC `+` normalization unifies
-                // `a - b`, `a + (-b)`, and `-b + a` to one fingerprint — converging the
-                // many subtraction/negation algebraic variants (e.g. sympy `__sub__`
-                // `self + (-a)` with a sibling `self - a`). `verify` is the soundness gate.
-                if op == Op::Sub as u32 && kids.len() == 2 {
-                    let a = self.eval(kids[0], env);
-                    let b = self.eval(kids[1], env);
-                    let neg_b = self.mk(ValOp::Un(Op::Neg as u32), vec![b]);
-                    let mut operands = Vec::new();
-                    self.flatten_into(a, Op::Add as u32, &mut operands);
-                    self.flatten_into(neg_b, Op::Add as u32, &mut operands);
-                    // Sort unless an operand is proven concat (string/list); otherwise the
-                    // operands Err in the oracle regardless of order, so sorting is safe.
-                    if self.add_values_not_concat(ValueLaw::AddAssociativity, &operands) {
-                        operands.sort_by_key(|&v| self.vhash[v as usize]);
-                    }
-                    let mut acc = operands[0];
-                    for &o in &operands[1..] {
-                        acc = self.mk(ValOp::Bin(Op::Add as u32), vec![acc, o]);
-                    }
-                    return acc;
-                }
-                if is_assoc_comm_code(op) {
-                    // Flatten the chain (resolving temps), sort by structural hash, and
-                    // rebuild canonically — so groupings/temps converge. EXCEPT `+` is only
-                    // commutative on numeric operands; on strings/lists it is concat, which
-                    // is ordered, so we keep source order there (sorting would be unsound).
-                    //
-                    // Very large generated formulas can arrive as deeply nested binary ASTs.
-                    // For those, collect same-op source operands first so one giant expression
-                    // pays for flatten/sort/rebuild once instead of once per nested pair.
-                    let mut expr_operands = Vec::new();
-                    for &k in &kids {
-                        self.collect_ac_expr_operands(k, op, &mut expr_operands);
-                    }
-                    if expr_operands.len() >= LARGE_AC_EXPR_OPERANDS {
-                        let mut operands = Vec::new();
-                        for k in expr_operands {
-                            let v = self.eval(k, env);
-                            self.flatten_into(v, op, &mut operands);
-                        }
-                        if let Some(v) = self.c_u32_be_byte_pack_pattern(&operands) {
-                            return v;
-                        }
-                        let do_sort = op != Op::Add as u32
-                            || self.add_values_not_concat(ValueLaw::AddAssociativity, &operands);
-                        if do_sort {
-                            operands.sort_by_key(|&v| self.vhash[v as usize]);
-                        }
-                        return self.compact_formula(op, &operands);
-                    }
-
-                    let mut operands = Vec::new();
-                    for k in kids {
-                        let v = self.eval(k, env);
-                        self.flatten_into(v, op, &mut operands);
-                    }
-                    if let Some(v) = self.c_u32_be_byte_pack_pattern(&operands) {
-                        return v;
-                    }
-                    let do_sort = op != Op::Add as u32
-                        || self.add_values_not_concat(ValueLaw::AddAssociativity, &operands);
-                    if do_sort {
-                        operands.sort_by_key(|&v| self.vhash[v as usize]);
-                    }
-                    let mut acc = operands[0];
-                    for &o in &operands[1..] {
-                        acc = self.mk(ValOp::Bin(op), vec![acc, o]);
-                    }
-                    acc
-                } else {
-                    let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
-                    self.mk(ValOp::Bin(op), a)
-                }
-            }
+            NodeKind::Var => self.eval_var_expr(expr, node.payload, env),
+            NodeKind::Lit => self.eval_lit_expr(node.payload),
+            NodeKind::BinOp => self.eval_binop_expr(expr, node.payload, env),
             NodeKind::UnOp => {
                 let kids = self.il.children(expr).to_vec();
                 let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
                 let op = op_code(node.payload);
                 self.mk(ValOp::Un(op), a)
             }
-            NodeKind::Field => {
-                let kids = self.il.children(expr).to_vec();
-                let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
-                let name = match node.payload {
-                    Payload::Name(s) => self.interner.symbol_hash(s),
-                    _ => 0,
-                };
-                if a.len() == 1 {
-                    if let Some(admitted) =
-                        admitted_property_builtin_at_field(self.il, self.interner, expr)
-                    {
-                        if admitted.contract.result == Builtin::Len {
-                            if let Some(len) = self.eval_len_value(a[0]) {
-                                return len;
-                            }
-                            if self
-                                .domain_evidence_of_expr(kids[0])
-                                .is_some_and(DomainEvidence::is_array_or_collection)
-                            {
-                                return self
-                                    .mk(ValOp::Call(builtin_tag(admitted.contract.result)), a);
-                            }
-                        }
-                    }
-                    if let Payload::Name(s) = node.payload {
-                        let receiver = &self.nodes[a[0] as usize];
-                        if let ValOp::ImportNamespace { module_hash } = receiver.op {
-                            return self.mk(
-                                ValOp::ImportBinding {
-                                    module_hash,
-                                    exported_hash: stable_symbol_hash(self.interner.resolve(s)),
-                                },
-                                vec![],
-                            );
-                        }
-                    }
-                }
-                if a.len() == 1 {
-                    let Some(key) = self.exact_field_state_key(expr) else {
-                        return self.mk(ValOp::Field(name), a);
-                    };
-                    if let Some(&written) = self.field_env.get(&key) {
-                        return written;
-                    }
-                }
-                self.mk(ValOp::Field(name), a)
-            }
-            NodeKind::Index => {
-                let kids = self.il.children(expr).to_vec();
-                let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
-                if a.len() == 2 {
-                    if let Some((map, default)) = self.proven_go_literal_zero_map_value(a[0]) {
-                        return self.mk(
-                            ValOp::Call(builtin_tag(Builtin::GetOrDefault)),
-                            vec![map, a[1], default],
-                        );
-                    }
-                }
-                self.mk(ValOp::Index, a)
-            }
-            NodeKind::Call => {
-                let kids = self.il.children(expr).to_vec();
-                // Promise continuation beta-reduction is exact only when a semantic pack can
-                // prove the receiver is Promise-like; otherwise arbitrary `.then` methods stay
-                // opaque.
-                if let Some(v) = rules::promise_then::apply(self, expr, env) {
-                    return v;
-                }
-                if let Some(v) = rules::promise_then::promise_resolve_value(self, expr, env) {
-                    return v;
-                }
-                if let Payload::Builtin(builtin) = node.payload {
-                    if !self.admitted_builtin_call(expr, builtin) {
-                        return self.source_salted_opaque(expr, 0x4255_494C);
-                    }
-                }
-                // Reduction builtins fold a collection to one value — canonicalize to
-                // the same `Reduce(op, init, per-element contrib)` a loop produces, so
-                // `sum(x*x for x in xs)` / `reduce(λa,x. a+x*x, xs, 0)` converge with
-                // the explicit accumulator loop (§AI representation axis).
-                if let Payload::Builtin(Builtin::Abs) = node.payload {
-                    if let Some(&arg) = kids.first() {
-                        let v = self.eval(arg, env);
-                        return self.mk(ValOp::Un(ABS_CODE), vec![v]);
-                    }
-                }
-                if let Payload::Builtin(Builtin::IsNull | Builtin::IsNotNull) = node.payload {
-                    if let Some(&arg) = kids.first() {
-                        let v = self.eval(arg, env);
-                        let op = if matches!(node.payload, Payload::Builtin(Builtin::IsNull)) {
-                            Op::Eq
-                        } else {
-                            Op::Ne
-                        };
-                        let nil = self.null_const();
-                        return self.mk(ValOp::Bin(op as u32), vec![v, nil]);
-                    }
-                }
-                if let Payload::Builtin(Builtin::IsEmpty) = node.payload {
-                    if let Some(&arg) = kids.first() {
-                        let v = self.eval(arg, env);
-                        return self.is_empty_value(v);
-                    }
-                }
-                if let Payload::Builtin(Builtin::Contains) = node.payload {
-                    if let [element, collection] = kids.as_slice() {
-                        let element = self.eval(*element, env);
-                        if let Some(map) = self.proven_map_key_view_expr(*collection, env) {
-                            return self.mk(ValOp::Bin(Op::In as u32), vec![element, map]);
-                        }
-                        let collection = self.eval_membership_collection(*collection, env);
-                        return self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]);
-                    }
-                }
-                if let Payload::Builtin(Builtin::GetOrDefault) = node.payload {
-                    if let [map, key, default] = kids.as_slice() {
-                        let map = self.eval_map_lookup_collection(*map, env);
-                        let key = self.eval(*key, env);
-                        let default = self.eval(*default, env);
-                        return self.mk(
-                            ValOp::Call(builtin_tag(Builtin::GetOrDefault)),
-                            vec![map, key, default],
-                        );
-                    }
-                }
-                if let Payload::Builtin(Builtin::ValueOrDefault) = node.payload {
-                    if let [value, default] = kids.as_slice() {
-                        let value = self.eval(*value, env);
-                        let default = self.eval(*default, env);
-                        return self.mk_value_or_map_default(value, default);
-                    }
-                }
-                if let Payload::Builtin(b) = node.payload {
-                    if let Some(r) = self.eval_reduction_builtin(expr, b, &kids, env) {
-                        return r;
-                    }
-                }
-                if matches!(node.payload, Payload::Builtin(Builtin::UnsignedCast32))
-                    && !nose_semantics::source_fact_at_node(
-                        self.il,
-                        expr,
-                        SourceFactKind::Cast(SourceCastKind::CUnsigned32),
-                    )
-                {
-                    return self.source_salted_opaque(expr, 0x5543_3332);
-                }
-                if let Some(r) = self.eval_count_call(expr, &kids, env) {
-                    return r;
-                }
-                if let Some(r) = self.eval_product_call(expr, &kids, env) {
-                    return r;
-                }
-                if let Some(r) = self.eval_proven_integer_method_call(expr, &kids, env) {
-                    return r;
-                }
-                if let Some(r) = self.eval_rust_map_get_unwrap_or_call(expr, &kids, env) {
-                    return r;
-                }
-                if let Some(r) = self.eval_rust_map_get_is_some_call(expr, &kids, env) {
-                    return r;
-                }
-                if self.is_rust_vec_new_call(expr) {
-                    return self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), vec![]);
-                }
-                if let Some(v) = self.eval_java_collection_constructor_expr(expr, &kids) {
-                    return v;
-                }
-                if let Some(v) = self.eval_js_like_constructed_collection_or_map(expr, &kids, env) {
-                    return v;
-                }
-                if let Some(v) = self.eval_java_map_factory_expr(expr, &kids, env) {
-                    return v;
-                }
-                if let Some(v) = self.eval_iterator_identity_adapter(expr, &kids, env) {
-                    return v;
-                }
-                if let Some(v) = self.eval_proven_free_minmax_call(expr, &kids, env) {
-                    return v;
-                }
-                if let Some(r) = self.eval_proven_collection_membership_call(expr, &kids, env) {
-                    return r;
-                }
-                if let Some(r) = self.eval_proven_map_key_membership_call(expr, &kids, env) {
-                    return r;
-                }
-                if let Some(r) = self.eval_proven_map_get_default_call(expr, &kids, env) {
-                    return r;
-                }
-                if self.is_unproven_membership_like_call(expr, &kids) {
-                    let salt = self.source_salted_hash(expr, 0x4D45_4D42_4552);
-                    return self.mk(ValOp::Opaque(salt), vec![]);
-                }
-                // Interprocedural pure inline: `f(args)` to a pure file-local function ≡ its body
-                // with `args` substituted — converges with the same logic written inline / with
-                // a different extracted helper. Sound (β-reduction of an effect-free function).
-                if let Some(v) = self.eval_inlined_call(expr, &kids, env) {
-                    return v;
-                }
-                let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
-                let tag = match node.payload {
-                    Payload::Builtin(b) => builtin_tag(b),
-                    _ => 0,
-                };
-                self.mk(ValOp::Call(tag), a)
-            }
-            NodeKind::HoF => {
-                let kind = match node.payload {
-                    Payload::HoF(h) => h,
-                    _ => return self.source_salted_opaque(expr, 0x484F_465F),
-                };
-                let Some(admission) = self.hof_value_admission(expr, kind) else {
-                    return self.source_salted_opaque(expr, 0x484F_465F);
-                };
-                self.eval_hof_value(
-                    expr,
-                    kind,
-                    env,
-                    admission == HofAdmission::SourceComprehension,
-                )
-            }
-            NodeKind::Seq => {
-                if let Some(value) = self.import_fact_value(expr) {
-                    return value;
-                }
-                let kids = self.il.children(expr).to_vec();
-                let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
-                if matches!(node.payload, Payload::Builtin(Builtin::DictEntry)) {
-                    return self.dict_entry(a);
-                }
-                if let Some(map) = self.proven_go_literal_zero_map_seq(expr, &a) {
-                    return map;
-                }
-                self.mk(ValOp::Seq(self.seq_tag(expr)), a)
-            }
-            NodeKind::If => {
-                // Ternary / expression-if. Rust closures lower `if c { x } else { y }`
-                // branches as Blocks whose trailing expression is the branch value, so
-                // evaluate branches with the same implicit-return rule used for lambdas.
-                let kids = self.il.children(expr).to_vec();
-                let mut a = Vec::new();
-                if let Some(&cond) = kids.first() {
-                    a.push(self.eval(cond, env));
-                }
-                for &branch in kids.iter().skip(1).take(2) {
-                    let mut branch_env = env.clone();
-                    let value = self
-                        .eval_block_return(branch, &mut branch_env)
-                        .unwrap_or_else(|| self.eval(branch, env));
-                    a.push(value);
-                }
-                // abs/min/max idiom recognition happens in `mk(Phi, …)` so it applies to
-                // both the ternary and the equivalent if/else-assign form uniformly.
-                self.mk(ValOp::Phi, a)
-            }
+            NodeKind::Field => self.eval_field_expr(expr, node.payload, env),
+            NodeKind::Index => self.eval_index_expr(expr, env),
+            NodeKind::Call => self.eval_call_expr(expr, node.payload, env),
+            NodeKind::HoF => self.eval_hof_expr(expr, node.payload, env),
+            NodeKind::Seq => self.eval_seq_expr(expr, node.payload, env),
+            NodeKind::If => self.eval_if_expr(expr, env),
             NodeKind::Lambda => {
                 let hash = self.valued_subtree_hash(expr);
                 self.mk(ValOp::Lambda(hash), vec![])
@@ -538,5 +139,515 @@ impl<'a> Builder<'a> {
                 self.mk(ValOp::Opaque(hash), vec![])
             }
         }
+    }
+
+    fn eval_var_expr(
+        &mut self,
+        expr: NodeId,
+        payload: Payload,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> ValueId {
+        match payload {
+            Payload::Cid(c) => env
+                .get(&c)
+                .copied()
+                .unwrap_or_else(|| self.mk(ValOp::Input(c), vec![])),
+            // A free variable (global / un-canonicalized callee) kept its name in
+            // alpha — give it a STABLE identity keyed by that name (high-bit range,
+            // clear of positional cids), so `foo(x)` ≠ `bar(x)` while two uses of
+            // `foo` agree. Without this, distinct globals collapsed to one cid.
+            Payload::Name(s) => {
+                if let Some(&v) = self.global_env.get(&s) {
+                    return v;
+                }
+                let name = self.interner.resolve(s);
+                if self.is_rust_option_none_node(expr) {
+                    return self.null_const();
+                }
+                if let Some(contract) = nullish_global_contract(self.il.meta.lang, name) {
+                    if !contract.requires_unshadowed
+                        || asserted_unshadowed_global_symbol(self.il, expr, contract.name)
+                    {
+                        return self.null_const();
+                    }
+                }
+                self.mk(ValOp::Input(self.free_name_key(s)), vec![])
+            }
+            _ => self.fresh_opaque(),
+        }
+    }
+
+    fn eval_lit_expr(&mut self, payload: Payload) -> ValueId {
+        // Behavior-defining constants must be distinct values: `0` ≠ `1`
+        // (else `x % 2 == 0` and `x % 2 == 1` collapse). Retained small ints
+        // key by value (offset clear of the class range); others by class.
+        let key = match payload {
+            Payload::LitInt(v) => 0x1000_0000u32.wrapping_add(v as u32),
+            // strings in a separate key range from ints to avoid collision
+            Payload::LitStr(h) => 0x2000_0000u32.wrapping_add(h as u32),
+            // floats keyed by source-text hash, in their own range (so `3.14`≠`2.71`)
+            Payload::LitFloat(h) => 0x4000_0000u32.wrapping_add(h as u32),
+            // true/false are behavior-defining and must be distinct (own range)
+            Payload::LitBool(b) => 0x3000_0001u32 + b as u32,
+            Payload::Lit(c) => c as u32,
+            _ => 0,
+        };
+        self.mk(ValOp::Const(key), vec![])
+    }
+
+    fn eval_binop_expr(
+        &mut self,
+        expr: NodeId,
+        payload: Payload,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> ValueId {
+        let op = op_code(payload);
+        let kids = self.il.children(expr).to_vec();
+        if op == Op::In as u32 && kids.len() == 2 {
+            return self.eval_membership_binop(expr, &kids, env);
+        }
+        if let Some(v) = self.eval_rust_option_some_pattern_comparison(op, &kids, env) {
+            return v;
+        }
+        if let Some(v) = self.eval_static_filter_membership_comparison(op, &kids, env) {
+            return v;
+        }
+        if let Some(v) = self.eval_len_zero_comparison(op, &kids, env) {
+            return v;
+        }
+        if let Payload::Op(op_kind) = payload {
+            if let Some(v) = self.eval_static_index_membership_comparison(op_kind, &kids, env) {
+                return v;
+            }
+        }
+        if let Some(v) = self.eval_strict_equality_comparison(expr, op, &kids, env) {
+            return v;
+        }
+        if op == Op::Add as u32 || op == Op::Sub as u32 {
+            let mut operands = Vec::new();
+            self.collect_add_sub_expr_operands(expr, false, &mut operands);
+            if operands.len() >= LARGE_AC_EXPR_OPERANDS {
+                return self.compact_add_sub_formula(operands, env);
+            }
+        }
+        // Canonicalize subtraction to addition-of-negation: `a - b ≡ a + (-b)`
+        // (sound for the two's-complement Int model: a.wrapping_sub(b) ==
+        // a.wrapping_add(-b)). Routing it through the AC `+` normalization unifies
+        // `a - b`, `a + (-b)`, and `-b + a` to one fingerprint — converging the
+        // many subtraction/negation algebraic variants (e.g. sympy `__sub__`
+        // `self + (-a)` with a sibling `self - a`). `verify` is the soundness gate.
+        if op == Op::Sub as u32 && kids.len() == 2 {
+            return self.eval_sub_chain(&kids, env);
+        }
+        if is_assoc_comm_code(op) {
+            self.eval_assoc_comm_chain(op, &kids, env)
+        } else {
+            let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+            self.mk(ValOp::Bin(op), a)
+        }
+    }
+
+    fn eval_sub_chain(&mut self, kids: &[NodeId], env: &FxHashMap<u32, ValueId>) -> ValueId {
+        let a = self.eval(kids[0], env);
+        let b = self.eval(kids[1], env);
+        let neg_b = self.mk(ValOp::Un(Op::Neg as u32), vec![b]);
+        let mut operands = Vec::new();
+        self.flatten_into(a, Op::Add as u32, &mut operands);
+        self.flatten_into(neg_b, Op::Add as u32, &mut operands);
+        // Sort unless an operand is proven concat (string/list); otherwise the
+        // operands Err in the oracle regardless of order, so sorting is safe.
+        if self.add_values_not_concat(ValueLaw::AddAssociativity, &operands) {
+            operands.sort_by_key(|&v| self.vhash[v as usize]);
+        }
+        let mut acc = operands[0];
+        for &o in &operands[1..] {
+            acc = self.mk(ValOp::Bin(Op::Add as u32), vec![acc, o]);
+        }
+        acc
+    }
+
+    fn eval_assoc_comm_chain(
+        &mut self,
+        op: u32,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> ValueId {
+        // Flatten the chain (resolving temps), sort by structural hash, and
+        // rebuild canonically — so groupings/temps converge. EXCEPT `+` is only
+        // commutative on numeric operands; on strings/lists it is concat, which
+        // is ordered, so we keep source order there (sorting would be unsound).
+        //
+        // Very large generated formulas can arrive as deeply nested binary ASTs.
+        // For those, collect same-op source operands first so one giant expression
+        // pays for flatten/sort/rebuild once instead of once per nested pair.
+        let mut expr_operands = Vec::new();
+        for &k in kids {
+            self.collect_ac_expr_operands(k, op, &mut expr_operands);
+        }
+        if expr_operands.len() >= LARGE_AC_EXPR_OPERANDS {
+            let mut operands = Vec::new();
+            for k in expr_operands {
+                let v = self.eval(k, env);
+                self.flatten_into(v, op, &mut operands);
+            }
+            if let Some(v) = self.c_u32_be_byte_pack_pattern(&operands) {
+                return v;
+            }
+            let do_sort = op != Op::Add as u32
+                || self.add_values_not_concat(ValueLaw::AddAssociativity, &operands);
+            if do_sort {
+                operands.sort_by_key(|&v| self.vhash[v as usize]);
+            }
+            return self.compact_formula(op, &operands);
+        }
+
+        let mut operands = Vec::new();
+        for &k in kids {
+            let v = self.eval(k, env);
+            self.flatten_into(v, op, &mut operands);
+        }
+        if let Some(v) = self.c_u32_be_byte_pack_pattern(&operands) {
+            return v;
+        }
+        let do_sort = op != Op::Add as u32
+            || self.add_values_not_concat(ValueLaw::AddAssociativity, &operands);
+        if do_sort {
+            operands.sort_by_key(|&v| self.vhash[v as usize]);
+        }
+        let mut acc = operands[0];
+        for &o in &operands[1..] {
+            acc = self.mk(ValOp::Bin(op), vec![acc, o]);
+        }
+        acc
+    }
+
+    fn eval_field_expr(
+        &mut self,
+        expr: NodeId,
+        payload: Payload,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> ValueId {
+        let kids = self.il.children(expr).to_vec();
+        let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+        let name = match payload {
+            Payload::Name(s) => self.interner.symbol_hash(s),
+            _ => 0,
+        };
+        if a.len() == 1 {
+            if let Some(v) = self.eval_field_builtin_or_import(expr, payload, &kids, &a) {
+                return v;
+            }
+        }
+        if a.len() == 1 {
+            let Some(key) = self.exact_field_state_key(expr) else {
+                return self.mk(ValOp::Field(name), a);
+            };
+            if let Some(&written) = self.field_env.get(&key) {
+                return written;
+            }
+        }
+        self.mk(ValOp::Field(name), a)
+    }
+
+    fn eval_field_builtin_or_import(
+        &mut self,
+        expr: NodeId,
+        payload: Payload,
+        kids: &[NodeId],
+        a: &[ValueId],
+    ) -> Option<ValueId> {
+        if let Some(admitted) = admitted_property_builtin_at_field(self.il, self.interner, expr) {
+            if admitted.contract.result == Builtin::Len {
+                if let Some(len) = self.eval_len_value(a[0]) {
+                    return Some(len);
+                }
+                if self
+                    .domain_evidence_of_expr(kids[0])
+                    .is_some_and(DomainEvidence::is_array_or_collection)
+                {
+                    return Some(self.mk(
+                        ValOp::Call(builtin_tag(admitted.contract.result)),
+                        a.to_vec(),
+                    ));
+                }
+            }
+        }
+        if let Payload::Name(s) = payload {
+            let receiver = &self.nodes[a[0] as usize];
+            if let ValOp::ImportNamespace { module_hash } = receiver.op {
+                return Some(self.mk(
+                    ValOp::ImportBinding {
+                        module_hash,
+                        exported_hash: stable_symbol_hash(self.interner.resolve(s)),
+                    },
+                    vec![],
+                ));
+            }
+        }
+        None
+    }
+
+    fn eval_index_expr(&mut self, expr: NodeId, env: &FxHashMap<u32, ValueId>) -> ValueId {
+        let kids = self.il.children(expr).to_vec();
+        let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+        if a.len() == 2 {
+            if let Some((map, default)) = self.proven_go_literal_zero_map_value(a[0]) {
+                return self.mk(
+                    ValOp::Call(builtin_tag(Builtin::GetOrDefault)),
+                    vec![map, a[1], default],
+                );
+            }
+        }
+        self.mk(ValOp::Index, a)
+    }
+
+    fn eval_call_expr(
+        &mut self,
+        expr: NodeId,
+        payload: Payload,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> ValueId {
+        let kids = self.il.children(expr).to_vec();
+        // Promise continuation beta-reduction is exact only when a semantic pack can
+        // prove the receiver is Promise-like; otherwise arbitrary `.then` methods stay
+        // opaque.
+        if let Some(v) = rules::promise_then::apply(self, expr, env) {
+            return v;
+        }
+        if let Some(v) = rules::promise_then::promise_resolve_value(self, expr, env) {
+            return v;
+        }
+        if let Payload::Builtin(builtin) = payload {
+            if !self.admitted_builtin_call(expr, builtin) {
+                return self.source_salted_opaque(expr, 0x4255_494C);
+            }
+        }
+        if let Some(v) = self.eval_builtin_predicate_call(payload, &kids, env) {
+            return v;
+        }
+        if let Some(v) = self.eval_builtin_collection_call(expr, payload, &kids, env) {
+            return v;
+        }
+        if let Some(v) = self.eval_proven_call_pattern(expr, &kids, env) {
+            return v;
+        }
+        // Interprocedural pure inline: `f(args)` to a pure file-local function ≡ its body
+        // with `args` substituted — converges with the same logic written inline / with
+        // a different extracted helper. Sound (β-reduction of an effect-free function).
+        if let Some(v) = self.eval_inlined_call(expr, &kids, env) {
+            return v;
+        }
+        let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+        let tag = match payload {
+            Payload::Builtin(b) => builtin_tag(b),
+            _ => 0,
+        };
+        self.mk(ValOp::Call(tag), a)
+    }
+
+    fn eval_builtin_predicate_call(
+        &mut self,
+        payload: Payload,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        // Reduction builtins fold a collection to one value — canonicalize to
+        // the same `Reduce(op, init, per-element contrib)` a loop produces, so
+        // `sum(x*x for x in xs)` / `reduce(λa,x. a+x*x, xs, 0)` converge with
+        // the explicit accumulator loop (§AI representation axis).
+        if let Payload::Builtin(Builtin::Abs) = payload {
+            if let Some(&arg) = kids.first() {
+                let v = self.eval(arg, env);
+                return Some(self.mk(ValOp::Un(ABS_CODE), vec![v]));
+            }
+        }
+        if let Payload::Builtin(Builtin::IsNull | Builtin::IsNotNull) = payload {
+            if let Some(&arg) = kids.first() {
+                let v = self.eval(arg, env);
+                let op = if matches!(payload, Payload::Builtin(Builtin::IsNull)) {
+                    Op::Eq
+                } else {
+                    Op::Ne
+                };
+                let nil = self.null_const();
+                return Some(self.mk(ValOp::Bin(op as u32), vec![v, nil]));
+            }
+        }
+        if let Payload::Builtin(Builtin::IsEmpty) = payload {
+            if let Some(&arg) = kids.first() {
+                let v = self.eval(arg, env);
+                return Some(self.is_empty_value(v));
+            }
+        }
+        None
+    }
+
+    fn eval_builtin_collection_call(
+        &mut self,
+        expr: NodeId,
+        payload: Payload,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if let Payload::Builtin(Builtin::Contains) = payload {
+            if let [element, collection] = kids {
+                let element = self.eval(*element, env);
+                if let Some(map) = self.proven_map_key_view_expr(*collection, env) {
+                    return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, map]));
+                }
+                let collection = self.eval_membership_collection(*collection, env);
+                return Some(self.mk(ValOp::Bin(Op::In as u32), vec![element, collection]));
+            }
+        }
+        if let Payload::Builtin(Builtin::GetOrDefault) = payload {
+            if let [map, key, default] = kids {
+                let map = self.eval_map_lookup_collection(*map, env);
+                let key = self.eval(*key, env);
+                let default = self.eval(*default, env);
+                return Some(self.mk(
+                    ValOp::Call(builtin_tag(Builtin::GetOrDefault)),
+                    vec![map, key, default],
+                ));
+            }
+        }
+        if let Payload::Builtin(Builtin::ValueOrDefault) = payload {
+            if let [value, default] = kids {
+                let value = self.eval(*value, env);
+                let default = self.eval(*default, env);
+                return Some(self.mk_value_or_map_default(value, default));
+            }
+        }
+        if let Payload::Builtin(b) = payload {
+            if let Some(r) = self.eval_reduction_builtin(expr, b, kids, env) {
+                return Some(r);
+            }
+        }
+        if matches!(payload, Payload::Builtin(Builtin::UnsignedCast32))
+            && !nose_semantics::source_fact_at_node(
+                self.il,
+                expr,
+                SourceFactKind::Cast(SourceCastKind::CUnsigned32),
+            )
+        {
+            return Some(self.source_salted_opaque(expr, 0x5543_3332));
+        }
+        None
+    }
+
+    fn eval_proven_call_pattern(
+        &mut self,
+        expr: NodeId,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
+        if let Some(r) = self.eval_count_call(expr, kids, env) {
+            return Some(r);
+        }
+        if let Some(r) = self.eval_product_call(expr, kids, env) {
+            return Some(r);
+        }
+        if let Some(r) = self.eval_proven_integer_method_call(expr, kids, env) {
+            return Some(r);
+        }
+        if let Some(r) = self.eval_rust_map_get_unwrap_or_call(expr, kids, env) {
+            return Some(r);
+        }
+        if let Some(r) = self.eval_rust_map_get_is_some_call(expr, kids, env) {
+            return Some(r);
+        }
+        if self.is_rust_vec_new_call(expr) {
+            return Some(self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), vec![]));
+        }
+        if let Some(v) = self.eval_java_collection_constructor_expr(expr, kids) {
+            return Some(v);
+        }
+        if let Some(v) = self.eval_js_like_constructed_collection_or_map(expr, kids, env) {
+            return Some(v);
+        }
+        if let Some(v) = self.eval_java_map_factory_expr(expr, kids, env) {
+            return Some(v);
+        }
+        if let Some(v) = self.eval_iterator_identity_adapter(expr, kids, env) {
+            return Some(v);
+        }
+        if let Some(v) = self.eval_proven_free_minmax_call(expr, kids, env) {
+            return Some(v);
+        }
+        if let Some(r) = self.eval_proven_collection_membership_call(expr, kids, env) {
+            return Some(r);
+        }
+        if let Some(r) = self.eval_proven_map_key_membership_call(expr, kids, env) {
+            return Some(r);
+        }
+        if let Some(r) = self.eval_proven_map_get_default_call(expr, kids, env) {
+            return Some(r);
+        }
+        if self.is_unproven_membership_like_call(expr, kids) {
+            let salt = self.source_salted_hash(expr, 0x4D45_4D42_4552);
+            return Some(self.mk(ValOp::Opaque(salt), vec![]));
+        }
+        None
+    }
+
+    fn eval_hof_expr(
+        &mut self,
+        expr: NodeId,
+        payload: Payload,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> ValueId {
+        let kind = match payload {
+            Payload::HoF(h) => h,
+            _ => return self.source_salted_opaque(expr, 0x484F_465F),
+        };
+        let Some(admission) = self.hof_value_admission(expr, kind) else {
+            return self.source_salted_opaque(expr, 0x484F_465F);
+        };
+        self.eval_hof_value(
+            expr,
+            kind,
+            env,
+            admission == HofAdmission::SourceComprehension,
+        )
+    }
+
+    fn eval_seq_expr(
+        &mut self,
+        expr: NodeId,
+        payload: Payload,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> ValueId {
+        if let Some(value) = self.import_fact_value(expr) {
+            return value;
+        }
+        let kids = self.il.children(expr).to_vec();
+        let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+        if matches!(payload, Payload::Builtin(Builtin::DictEntry)) {
+            return self.dict_entry(a);
+        }
+        if let Some(map) = self.proven_go_literal_zero_map_seq(expr, &a) {
+            return map;
+        }
+        self.mk(ValOp::Seq(self.seq_tag(expr)), a)
+    }
+
+    fn eval_if_expr(&mut self, expr: NodeId, env: &FxHashMap<u32, ValueId>) -> ValueId {
+        // Ternary / expression-if. Rust closures lower `if c { x } else { y }`
+        // branches as Blocks whose trailing expression is the branch value, so
+        // evaluate branches with the same implicit-return rule used for lambdas.
+        let kids = self.il.children(expr).to_vec();
+        let mut a = Vec::new();
+        if let Some(&cond) = kids.first() {
+            a.push(self.eval(cond, env));
+        }
+        for &branch in kids.iter().skip(1).take(2) {
+            let mut branch_env = env.clone();
+            let value = self
+                .eval_block_return(branch, &mut branch_env)
+                .unwrap_or_else(|| self.eval(branch, env));
+            a.push(value);
+        }
+        // abs/min/max idiom recognition happens in `mk(Phi, …)` so it applies to
+        // both the ternary and the equivalent if/else-assign form uniformly.
+        self.mk(ValOp::Phi, a)
     }
 }

--- a/crates/nose-normalize/src/value_graph/tests.rs
+++ b/crates/nose-normalize/src/value_graph/tests.rs
@@ -1605,32 +1605,110 @@ fn static_index_membership_value_graph_uses_library_api_evidence() {
     ));
 }
 
+fn java_util_map_import(b: &mut IlBuilder, lhs_payload: Payload, span: Span) -> NodeId {
+    let import_lhs = b.add(NodeKind::Var, lhs_payload, span, &[]);
+    let module = b.add(
+        NodeKind::Lit,
+        Payload::LitStr(stable_symbol_hash("java.util")),
+        span,
+        &[],
+    );
+    let exported = b.add(
+        NodeKind::Lit,
+        Payload::LitStr(stable_symbol_hash("Map")),
+        span,
+        &[],
+    );
+    let import_rhs = b.add(NodeKind::Seq, Payload::None, span, &[module, exported]);
+    b.add(
+        NodeKind::Assign,
+        Payload::None,
+        span,
+        &[import_lhs, import_rhs],
+    )
+}
+
+fn java_map_of_call(b: &mut IlBuilder, callee: NodeId, base_line: u32) -> NodeId {
+    let red = b.add(
+        NodeKind::Lit,
+        Payload::LitStr(stable_symbol_hash("red")),
+        sp(base_line),
+        &[],
+    );
+    let one = b.add(NodeKind::Lit, Payload::LitInt(1), sp(base_line + 1), &[]);
+    let blue = b.add(
+        NodeKind::Lit,
+        Payload::LitStr(stable_symbol_hash("blue")),
+        sp(base_line + 2),
+        &[],
+    );
+    let two = b.add(NodeKind::Lit, Payload::LitInt(2), sp(base_line + 3), &[]);
+    b.add(
+        NodeKind::Call,
+        Payload::None,
+        sp(base_line + 4),
+        &[callee, red, one, blue, two],
+    )
+}
+
+fn push_java_map_lookup_evidence(
+    il: &mut Il,
+    import_span: Span,
+    receiver_span: Span,
+    call_span: Span,
+    binding_span: Span,
+    snapshot_module: &str,
+) {
+    let contract =
+        library_java_map_factory_contract(Lang::Java, "Map", "of").expect("Map.of contract");
+    il.evidence.push(evidence(
+        0,
+        EvidenceAnchor::sequence(import_span),
+        EvidenceKind::Import(ImportEvidenceKind::Binding {
+            module_hash: stable_symbol_hash("java.util"),
+            exported_hash: stable_symbol_hash("Map"),
+        }),
+    ));
+    push_imported_binding_use(il, 1, import_span, 2, receiver_span, "java.util", "Map");
+    il.evidence.push(library_api_contract_evidence(
+        3,
+        call_span,
+        contract.id,
+        contract.callee,
+        4,
+        vec![EvidenceId(2)],
+    ));
+    il.evidence.push(evidence_with_dependencies(
+        4,
+        EvidenceAnchor::node(call_span, NodeKind::Call),
+        EvidenceKind::Import(ImportEvidenceKind::ImportedLiteralSnapshot {
+            module_hash: stable_symbol_hash(snapshot_module),
+            exported_hash: stable_symbol_hash("LOOKUP"),
+            root_kind: NodeKind::Call,
+        }),
+        vec![EvidenceId(3)],
+    ));
+    il.evidence.push(evidence_with_dependencies(
+        5,
+        EvidenceAnchor::node(call_span, NodeKind::Call),
+        EvidenceKind::Domain(DomainEvidence::Map),
+        vec![EvidenceId(3)],
+    ));
+    il.evidence.push(evidence_with_dependencies(
+        6,
+        EvidenceAnchor::binding(binding_span, stable_symbol_hash("LOOKUP")),
+        EvidenceKind::Domain(DomainEvidence::Map),
+        vec![EvidenceId(5)],
+    ));
+}
+
 #[test]
 fn java_map_factory_value_graph_uses_library_api_after_import_seed() {
     let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));
     let map = interner.intern("Map");
     let lookup = interner.intern("LOOKUP");
-    let import_lhs = b.add(NodeKind::Var, Payload::Name(map), sp(100), &[]);
-    let module = b.add(
-        NodeKind::Lit,
-        Payload::LitStr(stable_symbol_hash("java.util")),
-        sp(100),
-        &[],
-    );
-    let exported = b.add(
-        NodeKind::Lit,
-        Payload::LitStr(stable_symbol_hash("Map")),
-        sp(100),
-        &[],
-    );
-    let import_rhs = b.add(NodeKind::Seq, Payload::None, sp(100), &[module, exported]);
-    let import = b.add(
-        NodeKind::Assign,
-        Payload::None,
-        sp(100),
-        &[import_lhs, import_rhs],
-    );
+    let import = java_util_map_import(&mut b, Payload::Name(map), sp(100));
     let receiver = b.add(NodeKind::Var, Payload::Name(map), sp(101), &[]);
     let callee = b.add(
         NodeKind::Field,
@@ -1638,26 +1716,7 @@ fn java_map_factory_value_graph_uses_library_api_after_import_seed() {
         sp(102),
         &[receiver],
     );
-    let red = b.add(
-        NodeKind::Lit,
-        Payload::LitStr(stable_symbol_hash("red")),
-        sp(103),
-        &[],
-    );
-    let one = b.add(NodeKind::Lit, Payload::LitInt(1), sp(104), &[]);
-    let blue = b.add(
-        NodeKind::Lit,
-        Payload::LitStr(stable_symbol_hash("blue")),
-        sp(105),
-        &[],
-    );
-    let two = b.add(NodeKind::Lit, Payload::LitInt(2), sp(106), &[]);
-    let call = b.add(
-        NodeKind::Call,
-        Payload::None,
-        sp(107),
-        &[callee, red, one, blue, two],
-    );
+    let call = java_map_of_call(&mut b, callee, 103);
     let lookup_lhs = b.add(NodeKind::Var, Payload::Name(lookup), sp(108), &[]);
     let lookup_assign = b.add(
         NodeKind::Assign,
@@ -1673,47 +1732,14 @@ fn java_map_factory_value_graph_uses_library_api_after_import_seed() {
         &[import, lookup_assign, lookup_ref],
     );
     let mut il = finish_test_il(b, root, Lang::Java);
-    let contract =
-        library_java_map_factory_contract(Lang::Java, "Map", "of").expect("Map.of contract");
-    il.evidence.push(evidence(
-        0,
-        EvidenceAnchor::sequence(sp(100)),
-        EvidenceKind::Import(ImportEvidenceKind::Binding {
-            module_hash: stable_symbol_hash("java.util"),
-            exported_hash: stable_symbol_hash("Map"),
-        }),
-    ));
-    push_imported_binding_use(&mut il, 1, sp(100), 2, sp(101), "java.util", "Map");
-    il.evidence.push(library_api_contract_evidence(
-        3,
+    push_java_map_lookup_evidence(
+        &mut il,
+        sp(100),
+        sp(101),
         sp(107),
-        contract.id,
-        contract.callee,
-        4,
-        vec![EvidenceId(2)],
-    ));
-    il.evidence.push(evidence_with_dependencies(
-        4,
-        EvidenceAnchor::node(sp(107), NodeKind::Call),
-        EvidenceKind::Import(ImportEvidenceKind::ImportedLiteralSnapshot {
-            module_hash: stable_symbol_hash("LookupProvider"),
-            exported_hash: stable_symbol_hash("LOOKUP"),
-            root_kind: NodeKind::Call,
-        }),
-        vec![EvidenceId(3)],
-    ));
-    il.evidence.push(evidence_with_dependencies(
-        5,
-        EvidenceAnchor::node(sp(107), NodeKind::Call),
-        EvidenceKind::Domain(DomainEvidence::Map),
-        vec![EvidenceId(3)],
-    ));
-    il.evidence.push(evidence_with_dependencies(
-        6,
-        EvidenceAnchor::binding(sp(108), stable_symbol_hash("LOOKUP")),
-        EvidenceKind::Domain(DomainEvidence::Map),
-        vec![EvidenceId(5)],
-    ));
+        sp(108),
+        "LookupProvider",
+    );
 
     let mut builder = Builder::new(&il, &interner);
     assert!(!builder.unit_defines_symbol(lookup));
@@ -1746,27 +1772,7 @@ fn normalized_java_static_import_map_binding_feeds_get_or_default() {
     let lookup = interner.intern("LOOKUP");
     let lookup_method = interner.intern("lookup");
 
-    let import_lhs = b.add(NodeKind::Var, Payload::Cid(0), sp(130), &[]);
-    let module = b.add(
-        NodeKind::Lit,
-        Payload::LitStr(stable_symbol_hash("java.util")),
-        sp(130),
-        &[],
-    );
-    let exported = b.add(
-        NodeKind::Lit,
-        Payload::LitStr(stable_symbol_hash("Map")),
-        sp(130),
-        &[],
-    );
-    let import_rhs = b.add(NodeKind::Seq, Payload::None, sp(130), &[module, exported]);
-    let import = b.add(
-        NodeKind::Assign,
-        Payload::None,
-        sp(130),
-        &[import_lhs, import_rhs],
-    );
-
+    let import = java_util_map_import(&mut b, Payload::Cid(0), sp(130));
     let receiver = b.add(NodeKind::Var, Payload::Cid(0), sp(131), &[]);
     let callee = b.add(
         NodeKind::Field,
@@ -1774,26 +1780,7 @@ fn normalized_java_static_import_map_binding_feeds_get_or_default() {
         sp(132),
         &[receiver],
     );
-    let red = b.add(
-        NodeKind::Lit,
-        Payload::LitStr(stable_symbol_hash("red")),
-        sp(133),
-        &[],
-    );
-    let one = b.add(NodeKind::Lit, Payload::LitInt(1), sp(134), &[]);
-    let blue = b.add(
-        NodeKind::Lit,
-        Payload::LitStr(stable_symbol_hash("blue")),
-        sp(135),
-        &[],
-    );
-    let two = b.add(NodeKind::Lit, Payload::LitInt(2), sp(136), &[]);
-    let map_of = b.add(
-        NodeKind::Call,
-        Payload::None,
-        sp(137),
-        &[callee, red, one, blue, two],
-    );
+    let map_of = java_map_of_call(&mut b, callee, 133);
     let lookup_lhs = b.add(NodeKind::Var, Payload::Cid(1), sp(138), &[]);
     let lookup_assign = b.add(
         NodeKind::Assign,
@@ -1846,47 +1833,7 @@ fn normalized_java_static_import_map_binding_feeds_get_or_default() {
         }],
         vec![map, lookup],
     );
-    let contract =
-        library_java_map_factory_contract(Lang::Java, "Map", "of").expect("Map.of contract");
-    il.evidence.push(evidence(
-        0,
-        EvidenceAnchor::sequence(sp(130)),
-        EvidenceKind::Import(ImportEvidenceKind::Binding {
-            module_hash: stable_symbol_hash("java.util"),
-            exported_hash: stable_symbol_hash("Map"),
-        }),
-    ));
-    push_imported_binding_use(&mut il, 1, sp(130), 2, sp(131), "java.util", "Map");
-    il.evidence.push(library_api_contract_evidence(
-        3,
-        sp(137),
-        contract.id,
-        contract.callee,
-        4,
-        vec![EvidenceId(2)],
-    ));
-    il.evidence.push(evidence_with_dependencies(
-        4,
-        EvidenceAnchor::node(sp(137), NodeKind::Call),
-        EvidenceKind::Import(ImportEvidenceKind::ImportedLiteralSnapshot {
-            module_hash: stable_symbol_hash("Tables"),
-            exported_hash: stable_symbol_hash("LOOKUP"),
-            root_kind: NodeKind::Call,
-        }),
-        vec![EvidenceId(3)],
-    ));
-    il.evidence.push(evidence_with_dependencies(
-        5,
-        EvidenceAnchor::node(sp(137), NodeKind::Call),
-        EvidenceKind::Domain(DomainEvidence::Map),
-        vec![EvidenceId(3)],
-    ));
-    il.evidence.push(evidence_with_dependencies(
-        6,
-        EvidenceAnchor::binding(sp(138), stable_symbol_hash("LOOKUP")),
-        EvidenceKind::Domain(DomainEvidence::Map),
-        vec![EvidenceId(5)],
-    ));
+    push_java_map_lookup_evidence(&mut il, sp(130), sp(131), sp(137), sp(138), "Tables");
     push_method_call_library_api_evidence(&mut il, &interner, 7, get_call, "getOrDefault", 2);
 
     let mut builder = Builder::new(&il, &interner);
@@ -2106,6 +2053,32 @@ fn record_guard_value_tag_requires_guard_evidence() {
     ));
 }
 
+fn push_own_property_guard_evidence(il: &mut Il, base_id: u32, span: Span) {
+    il.evidence.push(evidence(
+        base_id,
+        EvidenceAnchor::source_span(span),
+        EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+            name_hash: stable_symbol_hash("Object"),
+        }),
+    ));
+    il.evidence.push(evidence_with_dependencies(
+        base_id + 1,
+        EvidenceAnchor::source_span(span),
+        EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+            path_hash: stable_symbol_hash("Object.hasOwn"),
+        }),
+        vec![EvidenceId(base_id)],
+    ));
+    il.evidence.push(evidence_with_dependencies(
+        base_id + 2,
+        EvidenceAnchor::sequence(span),
+        EvidenceKind::Guard(GuardEvidenceKind::JsOwnProperty {
+            api_path_hash: stable_symbol_hash("Object.hasOwn"),
+        }),
+        vec![EvidenceId(base_id + 1)],
+    ));
+}
+
 #[test]
 fn own_property_guard_value_tag_requires_node_shape_and_guard_evidence() {
     let interner = Interner::new();
@@ -2162,52 +2135,8 @@ fn own_property_guard_value_tag_requires_node_shape_and_guard_evidence() {
             EvidenceKind::SequenceSurface(SequenceSurfaceKind::OwnPropertyGuard),
         ));
     }
-    il.evidence.push(evidence(
-        1,
-        EvidenceAnchor::source_span(sp(62)),
-        EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
-            name_hash: stable_symbol_hash("Object"),
-        }),
-    ));
-    il.evidence.push(evidence_with_dependencies(
-        2,
-        EvidenceAnchor::source_span(sp(62)),
-        EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
-            path_hash: stable_symbol_hash("Object.hasOwn"),
-        }),
-        vec![EvidenceId(1)],
-    ));
-    il.evidence.push(evidence_with_dependencies(
-        3,
-        EvidenceAnchor::sequence(sp(62)),
-        EvidenceKind::Guard(GuardEvidenceKind::JsOwnProperty {
-            api_path_hash: stable_symbol_hash("Object.hasOwn"),
-        }),
-        vec![EvidenceId(2)],
-    ));
-    il.evidence.push(evidence(
-        5,
-        EvidenceAnchor::source_span(sp(63)),
-        EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
-            name_hash: stable_symbol_hash("Object"),
-        }),
-    ));
-    il.evidence.push(evidence_with_dependencies(
-        6,
-        EvidenceAnchor::source_span(sp(63)),
-        EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
-            path_hash: stable_symbol_hash("Object.hasOwn"),
-        }),
-        vec![EvidenceId(5)],
-    ));
-    il.evidence.push(evidence_with_dependencies(
-        7,
-        EvidenceAnchor::sequence(sp(63)),
-        EvidenceKind::Guard(GuardEvidenceKind::JsOwnProperty {
-            api_path_hash: stable_symbol_hash("Object.hasOwn"),
-        }),
-        vec![EvidenceId(6)],
-    ));
+    push_own_property_guard_evidence(&mut il, 1, sp(62));
+    push_own_property_guard_evidence(&mut il, 5, sp(63));
 
     let mut builder = Builder::new(&il, &interner);
     let malformed_value = builder.eval(malformed, &FxHashMap::default());

--- a/crates/nose-normalize/src/value_graph/tests/source_evidence.rs
+++ b/crates/nose-normalize/src/value_graph/tests/source_evidence.rs
@@ -294,9 +294,7 @@ fn raw_hof_value_graph_requires_source_or_api_admission() {
     );
 }
 
-#[test]
-fn library_hof_static_callback_error_requires_explicit_eager_demand() {
-    let interner = Interner::new();
+fn div_zero_map_len_il() -> (Il, NodeId) {
     let mut b = IlBuilder::new(FileId(0));
     let item = b.add(NodeKind::Lit, Payload::LitInt(1), sp(1), &[]);
     let coll = b.add(NodeKind::Seq, Payload::None, sp(1), &[item]);
@@ -313,8 +311,11 @@ fn library_hof_static_callback_error_requires_explicit_eager_demand() {
         sp(4),
         &[hof],
     );
-    let mut il = finish_test_il(b, count, Lang::Rust);
-    let contract = library_method_call_contract(Lang::Rust, "map", 1).expect("Rust map contract");
+    (finish_test_il(b, count, Lang::Rust), hof)
+}
+
+fn push_map_contract_evidence(il: &mut Il, lang: Lang, hof: NodeId, expect_msg: &str) {
+    let contract = library_method_call_contract(lang, "map", 1).expect(expect_msg);
     il.evidence.push(library_api_contract_evidence(
         0,
         il.node(hof).span,
@@ -323,6 +324,13 @@ fn library_hof_static_callback_error_requires_explicit_eager_demand() {
         1,
         Vec::new(),
     ));
+}
+
+#[test]
+fn library_hof_static_callback_error_requires_explicit_eager_demand() {
+    let interner = Interner::new();
+    let (mut il, hof) = div_zero_map_len_il();
+    push_map_contract_evidence(&mut il, Lang::Rust, hof, "Rust map contract");
     assert!(nose_semantics::admitted_hof_api_at_node(
         &il,
         hof,
@@ -339,20 +347,14 @@ fn library_hof_static_callback_error_requires_explicit_eager_demand() {
         !builder.expr_is_static_runtime_err(hof, &FxHashMap::default()),
         "admitted library HOF payloads must not prove eager callback exception timing"
     );
+}
 
-    let mut js_il = il.clone();
+#[test]
+fn eager_js_map_demand_exposes_static_callback_error_unless_broken() {
+    let interner = Interner::new();
+    let (mut js_il, hof) = div_zero_map_len_il();
     js_il.meta.lang = Lang::JavaScript;
-    js_il.evidence.clear();
-    let contract =
-        library_method_call_contract(Lang::JavaScript, "map", 1).expect("JS map contract");
-    js_il.evidence.push(library_api_contract_evidence(
-        0,
-        js_il.node(hof).span,
-        contract.id,
-        contract.callee,
-        1,
-        Vec::new(),
-    ));
+    push_map_contract_evidence(&mut js_il, Lang::JavaScript, hof, "JS map contract");
     assert!(nose_semantics::admitted_hof_api_at_node(
         &js_il,
         hof,
@@ -381,20 +383,14 @@ fn library_hof_static_callback_error_requires_explicit_eager_demand() {
         !builder.expr_is_static_runtime_err(hof, &FxHashMap::default()),
         "broken library API evidence must keep callback exception timing closed"
     );
+}
 
-    let mut java_il = il.clone();
+#[test]
+fn pull_lazy_java_stream_map_keeps_static_callback_error_closed() {
+    let interner = Interner::new();
+    let (mut java_il, hof) = div_zero_map_len_il();
     java_il.meta.lang = Lang::Java;
-    java_il.evidence.clear();
-    let contract =
-        library_method_call_contract(Lang::Java, "map", 1).expect("Java stream map contract");
-    java_il.evidence.push(library_api_contract_evidence(
-        0,
-        java_il.node(hof).span,
-        contract.id,
-        contract.callee,
-        1,
-        Vec::new(),
-    ));
+    push_map_contract_evidence(&mut java_il, Lang::Java, hof, "Java stream map contract");
     assert!(nose_semantics::admitted_hof_api_at_node(
         &java_il,
         hof,
@@ -410,9 +406,12 @@ fn library_hof_static_callback_error_requires_explicit_eager_demand() {
         !builder.expr_is_static_runtime_err(hof, &FxHashMap::default()),
         "an admitted pull-lazy Java Stream.map profile delays callback exception timing"
     );
+}
 
-    let mut list_il = il.clone();
-    list_il.evidence.clear();
+#[test]
+fn source_comprehension_timing_controls_static_callback_error() {
+    let interner = Interner::new();
+    let (mut list_il, hof) = div_zero_map_len_il();
     list_il.meta.lang = Lang::Python;
     push_source_comprehension(
         &mut list_il,

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -1430,71 +1430,13 @@ impl OperatorSemantics {
                 }
             }
         }
-        let cid_of = |node: NodeId, il: &Il| -> Option<u32> {
-            if il.kind(node) == NodeKind::Var {
-                if let Payload::Cid(cid) = il.node(node).payload {
-                    return Some(cid);
-                }
-            }
-            None
-        };
         let mut evidence: FxHashMap<u32, ValueDomain> = FxHashMap::default();
         for _ in 0..params.len() + 1 {
             let mut next = evidence.clone();
-            let add = |cid: u32, domain: ValueDomain, ev: &mut FxHashMap<u32, ValueDomain>| {
-                ev.entry(cid)
-                    .and_modify(|existing| *existing = existing.join(domain))
-                    .or_insert(domain);
-            };
             let mut stack = vec![root];
             while let Some(node) = stack.pop() {
                 let kids = il.children(node).to_vec();
-                match il.node(node).kind {
-                    NodeKind::BinOp => {
-                        if let Payload::Op(op) = il.node(node).payload {
-                            if self.strict_operand_domain(op).is_some() && kids.len() == 2 {
-                                for &kid in &kids {
-                                    if let Some(cid) = cid_of(kid, il) {
-                                        add(cid, ValueDomain::Number, &mut next);
-                                    }
-                                }
-                            } else if op == Op::Add && kids.len() == 2 {
-                                let lookup = |cid| {
-                                    evidence.get(&cid).copied().unwrap_or(ValueDomain::Unknown)
-                                };
-                                let domains = [
-                                    self.expression_value_domain(il, kids[0], &lookup),
-                                    self.expression_value_domain(il, kids[1], &lookup),
-                                ];
-                                for i in 0..2 {
-                                    if let Some(cid) = cid_of(kids[i], il) {
-                                        if matches!(
-                                            domains[1 - i],
-                                            ValueDomain::Number | ValueDomain::String
-                                        ) {
-                                            add(cid, domains[1 - i], &mut next);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    NodeKind::UnOp => {
-                        if let Payload::Op(op) = il.node(node).payload {
-                            if self.unary_operand_domain(op).is_some() {
-                                if let Some(cid) = kids.first().and_then(|&kid| cid_of(kid, il)) {
-                                    add(cid, ValueDomain::Number, &mut next);
-                                }
-                            }
-                        }
-                    }
-                    NodeKind::Index => {
-                        if let Some(cid) = kids.get(1).and_then(|&kid| cid_of(kid, il)) {
-                            add(cid, ValueDomain::Number, &mut next);
-                        }
-                    }
-                    _ => {}
-                }
+                self.note_param_domain_evidence(il, node, &kids, &evidence, &mut next);
                 stack.extend(kids);
             }
             if next == evidence {
@@ -1506,6 +1448,74 @@ impl OperatorSemantics {
             .iter()
             .map(|cid| evidence.get(cid).copied().unwrap_or(ValueDomain::Unknown))
             .collect()
+    }
+
+    fn note_param_domain_evidence(
+        self,
+        il: &Il,
+        node: NodeId,
+        kids: &[NodeId],
+        evidence: &FxHashMap<u32, ValueDomain>,
+        next: &mut FxHashMap<u32, ValueDomain>,
+    ) {
+        let cid_of = |node: NodeId, il: &Il| -> Option<u32> {
+            if il.kind(node) == NodeKind::Var {
+                if let Payload::Cid(cid) = il.node(node).payload {
+                    return Some(cid);
+                }
+            }
+            None
+        };
+        let add = |cid: u32, domain: ValueDomain, ev: &mut FxHashMap<u32, ValueDomain>| {
+            ev.entry(cid)
+                .and_modify(|existing| *existing = existing.join(domain))
+                .or_insert(domain);
+        };
+        match il.node(node).kind {
+            NodeKind::BinOp => {
+                if let Payload::Op(op) = il.node(node).payload {
+                    if self.strict_operand_domain(op).is_some() && kids.len() == 2 {
+                        for &kid in kids {
+                            if let Some(cid) = cid_of(kid, il) {
+                                add(cid, ValueDomain::Number, next);
+                            }
+                        }
+                    } else if op == Op::Add && kids.len() == 2 {
+                        let lookup =
+                            |cid| evidence.get(&cid).copied().unwrap_or(ValueDomain::Unknown);
+                        let domains = [
+                            self.expression_value_domain(il, kids[0], &lookup),
+                            self.expression_value_domain(il, kids[1], &lookup),
+                        ];
+                        for i in 0..2 {
+                            if let Some(cid) = cid_of(kids[i], il) {
+                                if matches!(
+                                    domains[1 - i],
+                                    ValueDomain::Number | ValueDomain::String
+                                ) {
+                                    add(cid, domains[1 - i], next);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            NodeKind::UnOp => {
+                if let Payload::Op(op) = il.node(node).payload {
+                    if self.unary_operand_domain(op).is_some() {
+                        if let Some(cid) = kids.first().and_then(|&kid| cid_of(kid, il)) {
+                            add(cid, ValueDomain::Number, next);
+                        }
+                    }
+                }
+            }
+            NodeKind::Index => {
+                if let Some(cid) = kids.get(1).and_then(|&kid| cid_of(kid, il)) {
+                    add(cid, ValueDomain::Number, next);
+                }
+            }
+            _ => {}
+        }
     }
 
     pub fn comparison_law(self, law: ComparisonLaw) -> Option<OperatorLawContract> {
@@ -2137,6 +2147,8 @@ pub fn method_call_contract(
     library_method_call_contract(lang, name, arg_count).map(|contract| contract.result)
 }
 
+type MethodBuiltinShape = (Builtin, MethodReceiverContract, MethodBuiltinArgs);
+
 fn method_call_contract_shape(
     lang: Lang,
     name: &str,
@@ -2145,6 +2157,56 @@ fn method_call_contract_shape(
     use MethodBuiltinArgs as Args;
     use MethodReceiverContract as Receiver;
     use MethodSemanticContract as Semantic;
+
+    let shaped = method_append_contract_shape(lang, name, arg_count)
+        .or_else(|| method_namespace_call_contract_shape(lang, name, arg_count))
+        .or_else(|| method_cardinality_contract_shape(lang, name, arg_count))
+        .or_else(|| method_string_affix_contract_shape(lang, name, arg_count))
+        .or_else(|| method_membership_contract_shape(lang, name, arg_count))
+        .or_else(|| method_lookup_default_contract_shape(lang, name, arg_count))
+        .or_else(|| method_numeric_contract_shape(lang, name, arg_count));
+    let contract = if let Some(contract) = shaped {
+        contract
+    } else if method_fold_name(lang, name) && arg_count > 0 {
+        (Builtin::Reduce, Receiver::ExactProtocol, Args::Fold)
+    } else if method_bool_reduction_builtin(lang, name).is_some() && arg_count > 0 {
+        (
+            method_bool_reduction_builtin(lang, name).unwrap(),
+            Receiver::ExactProtocol,
+            Args::BoolReduction,
+        )
+    } else if method_collection_reduction_builtin(lang, name).is_some() && arg_count == 0 {
+        (
+            method_collection_reduction_builtin(lang, name).unwrap(),
+            Receiver::ExactProtocol,
+            Args::CollectionReduction,
+        )
+    } else if method_hof_contract(lang, name).is_some() && arg_count > 0 {
+        return Some(MethodCallContract {
+            semantic: Semantic::HoF(method_hof_contract(lang, name).unwrap()),
+            receiver: Receiver::ExactProtocol,
+            args: Args::Hof,
+        });
+    } else if matches!((lang, name, arg_count), (Lang::Rust, "abs", 0)) {
+        (Builtin::Abs, Receiver::ExactInteger, Args::ReceiverOnly)
+    } else {
+        return None;
+    };
+
+    Some(MethodCallContract {
+        semantic: Semantic::Builtin(contract.0),
+        receiver: contract.1,
+        args: contract.2,
+    })
+}
+
+fn method_append_contract_shape(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<MethodBuiltinShape> {
+    use MethodBuiltinArgs as Args;
+    use MethodReceiverContract as Receiver;
 
     let contract = match (lang, name, arg_count) {
         (Lang::Python, "append", 1) => (
@@ -2166,7 +2228,20 @@ fn method_call_contract_shape(
             Receiver::ExactCollection,
             Args::ReceiverThenAll,
         ),
+        _ => return None,
+    };
+    Some(contract)
+}
 
+fn method_namespace_call_contract_shape(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<MethodBuiltinShape> {
+    use MethodBuiltinArgs as Args;
+    use MethodReceiverContract as Receiver;
+
+    let contract = match (lang, name, arg_count) {
         (
             Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html,
             "log" | "info" | "debug",
@@ -2201,7 +2276,20 @@ fn method_call_contract_shape(
             Receiver::ImportedNamespace("slices"),
             Args::GoSliceContains,
         ),
+        _ => return None,
+    };
+    Some(contract)
+}
 
+fn method_cardinality_contract_shape(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<MethodBuiltinShape> {
+    use MethodBuiltinArgs as Args;
+    use MethodReceiverContract as Receiver;
+
+    let contract = match (lang, name, arg_count) {
         (Lang::Rust, "len", 0) | (Lang::Java, "size", 0) => {
             (Builtin::Len, Receiver::ExactCollection, Args::ReceiverOnly)
         }
@@ -2218,7 +2306,20 @@ fn method_call_contract_shape(
             Receiver::RustMapGetOrExactOption,
             Args::ReceiverOnly,
         ),
+        _ => return None,
+    };
+    Some(contract)
+}
 
+fn method_string_affix_contract_shape(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<MethodBuiltinShape> {
+    use MethodBuiltinArgs as Args;
+    use MethodReceiverContract as Receiver;
+
+    let contract = match (lang, name, arg_count) {
         (
             Lang::JavaScript
             | Lang::TypeScript
@@ -2253,7 +2354,20 @@ fn method_call_contract_shape(
             Receiver::ExactString,
             Args::ReceiverAndFirst,
         ),
+        _ => return None,
+    };
+    Some(contract)
+}
 
+fn method_membership_contract_shape(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<MethodBuiltinShape> {
+    use MethodBuiltinArgs as Args;
+    use MethodReceiverContract as Receiver;
+
+    let contract = match (lang, name, arg_count) {
         (Lang::Java, "containsKey", 1)
         | (Lang::Rust, "contains_key", 1)
         | (Lang::Ruby, "key?" | "has_key?", 1) => (
@@ -2284,7 +2398,20 @@ fn method_call_contract_shape(
                 Args::FirstThenReceiver,
             )
         }
+        _ => return None,
+    };
+    Some(contract)
+}
 
+fn method_lookup_default_contract_shape(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<MethodBuiltinShape> {
+    use MethodBuiltinArgs as Args;
+    use MethodReceiverContract as Receiver;
+
+    let contract = match (lang, name, arg_count) {
         (Lang::Python, "join", 1) => (
             Builtin::Join,
             Receiver::LiteralString,
@@ -2320,7 +2447,20 @@ fn method_call_contract_shape(
             Receiver::ExactOption,
             Args::RustOptionMapOrIdentity,
         ),
+        _ => return None,
+    };
+    Some(contract)
+}
 
+fn method_numeric_contract_shape(
+    lang: Lang,
+    name: &str,
+    arg_count: usize,
+) -> Option<MethodBuiltinShape> {
+    use MethodBuiltinArgs as Args;
+    use MethodReceiverContract as Receiver;
+
+    let contract = match (lang, name, arg_count) {
         (Lang::Python, "reduce", 2..) => (
             Builtin::Reduce,
             Receiver::ImportedNamespace("functools"),
@@ -2353,36 +2493,9 @@ fn method_call_contract_shape(
             Receiver::ExactProtocolPairArgument,
             Args::RustZip,
         ),
-
-        _ if method_fold_name(lang, name) && arg_count > 0 => {
-            (Builtin::Reduce, Receiver::ExactProtocol, Args::Fold)
-        }
-        _ if method_bool_reduction_builtin(lang, name).is_some() && arg_count > 0 => (
-            method_bool_reduction_builtin(lang, name).unwrap(),
-            Receiver::ExactProtocol,
-            Args::BoolReduction,
-        ),
-        _ if method_collection_reduction_builtin(lang, name).is_some() && arg_count == 0 => (
-            method_collection_reduction_builtin(lang, name).unwrap(),
-            Receiver::ExactProtocol,
-            Args::CollectionReduction,
-        ),
-        _ if method_hof_contract(lang, name).is_some() && arg_count > 0 => {
-            return Some(MethodCallContract {
-                semantic: Semantic::HoF(method_hof_contract(lang, name).unwrap()),
-                receiver: Receiver::ExactProtocol,
-                args: Args::Hof,
-            });
-        }
-        (Lang::Rust, "abs", 0) => (Builtin::Abs, Receiver::ExactInteger, Args::ReceiverOnly),
         _ => return None,
     };
-
-    Some(MethodCallContract {
-        semantic: Semantic::Builtin(contract.0),
-        receiver: contract.1,
-        args: contract.2,
-    })
+    Some(contract)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/crates/nose-semantics/src/library_api.rs
+++ b/crates/nose-semantics/src/library_api.rs
@@ -348,6 +348,62 @@ fn library_api_dependencies_match_callee(
         return false;
     };
     match callee {
+        LibraryApiCalleeContract::FreeName { .. }
+        | LibraryApiCalleeContract::RustMacro { .. }
+        | LibraryApiCalleeContract::JsGlobalConstructor { .. }
+        | LibraryApiCalleeContract::ImportedBinding { .. } => {
+            library_api_dependencies_match_named_callee(
+                il,
+                interner,
+                node,
+                callee_node,
+                callee,
+                record,
+            )
+        }
+        LibraryApiCalleeContract::JavaUtilStaticMember { .. }
+        | LibraryApiCalleeContract::JavaUtilConstructor { .. }
+        | LibraryApiCalleeContract::RubyRequireStaticMember { .. } => {
+            library_api_dependencies_match_static_import_callee(
+                il,
+                interner,
+                node,
+                callee_node,
+                callee,
+                record,
+            )
+        }
+        LibraryApiCalleeContract::RegexLiteralMethod { .. }
+        | LibraryApiCalleeContract::Property { .. }
+        | LibraryApiCalleeContract::StaticIndexMembershipMethod { .. }
+        | LibraryApiCalleeContract::ImportedNamespaceFunction { .. }
+        | LibraryApiCalleeContract::StaticGlobalMethod { .. }
+        | LibraryApiCalleeContract::StaticGlobalFunction { .. } => {
+            library_api_dependencies_match_static_member_callee(
+                il,
+                interner,
+                callee_node,
+                callee,
+                record,
+            )
+        }
+        LibraryApiCalleeContract::Method { .. }
+        | LibraryApiCalleeContract::IteratorAdapterMethod { .. }
+        | LibraryApiCalleeContract::AsyncMethod { .. } => {
+            library_api_dependencies_match_method_callee(il, interner, node, callee, record)
+        }
+    }
+}
+
+fn library_api_dependencies_match_named_callee(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    callee_node: NodeId,
+    callee: LibraryApiCalleeContract,
+    record: &EvidenceRecord,
+) -> bool {
+    match callee {
         LibraryApiCalleeContract::FreeName { name, shadow } => {
             dependency_has_unshadowed_global_node(il, record, callee_node, name)
                 && library_api_free_name_shadow_safe(il.meta.lang, name, shadow, |candidate| {
@@ -376,6 +432,19 @@ fn library_api_dependencies_match_callee(
         LibraryApiCalleeContract::ImportedBinding { module, exported } => {
             dependency_has_imported_member_node(il, interner, record, callee_node, module, exported)
         }
+        _ => false,
+    }
+}
+
+fn library_api_dependencies_match_static_import_callee(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    callee_node: NodeId,
+    callee: LibraryApiCalleeContract,
+    record: &EvidenceRecord,
+) -> bool {
+    match callee {
         LibraryApiCalleeContract::JavaUtilStaticMember { receiver, .. } => {
             let Some(receiver_node) = il.children(callee_node).first().copied() else {
                 return false;
@@ -439,6 +508,18 @@ fn library_api_dependencies_match_callee(
                     il.node(receiver_node).span,
                 )
         }
+        _ => false,
+    }
+}
+
+fn library_api_dependencies_match_static_member_callee(
+    il: &Il,
+    interner: &Interner,
+    callee_node: NodeId,
+    callee: LibraryApiCalleeContract,
+    record: &EvidenceRecord,
+) -> bool {
+    match callee {
         LibraryApiCalleeContract::RegexLiteralMethod {
             required_receiver_fact,
             ..
@@ -483,6 +564,18 @@ fn library_api_dependencies_match_callee(
             !requires_unshadowed_function
                 || dependency_has_unshadowed_global_node(il, record, callee_node, function)
         }
+        _ => false,
+    }
+}
+
+fn library_api_dependencies_match_method_callee(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+    callee: LibraryApiCalleeContract,
+    record: &EvidenceRecord,
+) -> bool {
+    match callee {
         LibraryApiCalleeContract::Method { .. }
         | LibraryApiCalleeContract::IteratorAdapterMethod { .. } => {
             library_api_receiver_dependencies_for_call(il, interner, node, callee)
@@ -492,6 +585,7 @@ fn library_api_dependencies_match_callee(
             library_api_receiver_dependencies_for_call(il, interner, node, callee)
                 .is_some_and(|dependencies| dependency_ids_are_present(record, &dependencies))
         }
+        _ => false,
     }
 }
 
@@ -701,6 +795,73 @@ fn library_api_dependencies_match_callee_at_span(
     record: &EvidenceRecord,
 ) -> bool {
     match callee {
+        LibraryApiCalleeContract::FreeName { .. }
+        | LibraryApiCalleeContract::RustMacro { .. }
+        | LibraryApiCalleeContract::JsGlobalConstructor { .. }
+        | LibraryApiCalleeContract::ImportedBinding { .. } => {
+            library_api_dependencies_match_named_callee_at_span(
+                il,
+                interner,
+                call_span,
+                callee_span,
+                receiver_span,
+                callee,
+                record,
+            )
+        }
+        LibraryApiCalleeContract::JavaUtilStaticMember { .. }
+        | LibraryApiCalleeContract::JavaUtilConstructor { .. }
+        | LibraryApiCalleeContract::RubyRequireStaticMember { .. } => {
+            library_api_dependencies_match_static_import_callee_at_span(
+                il,
+                interner,
+                call_span,
+                callee_span,
+                receiver_span,
+                callee,
+                record,
+            )
+        }
+        LibraryApiCalleeContract::RegexLiteralMethod { .. }
+        | LibraryApiCalleeContract::Property { .. }
+        | LibraryApiCalleeContract::StaticIndexMembershipMethod { .. }
+        | LibraryApiCalleeContract::ImportedNamespaceFunction { .. }
+        | LibraryApiCalleeContract::StaticGlobalMethod { .. }
+        | LibraryApiCalleeContract::StaticGlobalFunction { .. } => {
+            library_api_dependencies_match_static_member_callee_at_span(
+                il,
+                interner,
+                callee_span,
+                receiver_span,
+                callee,
+                record,
+            )
+        }
+        LibraryApiCalleeContract::Method { .. }
+        | LibraryApiCalleeContract::IteratorAdapterMethod { .. }
+        | LibraryApiCalleeContract::AsyncMethod { .. } => {
+            library_api_dependencies_match_method_callee_at_span(
+                il,
+                interner,
+                callee_span,
+                receiver_span,
+                callee,
+                record,
+            )
+        }
+    }
+}
+
+fn library_api_dependencies_match_named_callee_at_span(
+    il: &Il,
+    interner: &Interner,
+    call_span: Span,
+    callee_span: Option<Span>,
+    receiver_span: Option<Span>,
+    callee: LibraryApiCalleeContract,
+    record: &EvidenceRecord,
+) -> bool {
+    match callee {
         LibraryApiCalleeContract::FreeName { name, shadow } => {
             callee_span.is_some_and(|span| {
                 dependency_has_unshadowed_global_anchor(il, record, span, NodeKind::Var, name)
@@ -761,6 +922,20 @@ fn library_api_dependencies_match_callee_at_span(
                     || dependency_has_imported_namespace_dependency(il, interner, record, module)
             }
         }
+        _ => false,
+    }
+}
+
+fn library_api_dependencies_match_static_import_callee_at_span(
+    il: &Il,
+    interner: &Interner,
+    call_span: Span,
+    callee_span: Option<Span>,
+    receiver_span: Option<Span>,
+    callee: LibraryApiCalleeContract,
+    record: &EvidenceRecord,
+) -> bool {
+    match callee {
         LibraryApiCalleeContract::JavaUtilStaticMember { receiver, .. } => {
             let receiver_proven = if let Some(span) = receiver_span {
                 dependency_has_imported_binding_anchor(
@@ -828,6 +1003,19 @@ fn library_api_dependencies_match_callee_at_span(
             ) && receiver_span
                 .is_some_and(|span| !file_defines_name_visible_at(il, interner, shadow_root, span))
         }
+        _ => false,
+    }
+}
+
+fn library_api_dependencies_match_static_member_callee_at_span(
+    il: &Il,
+    interner: &Interner,
+    callee_span: Option<Span>,
+    receiver_span: Option<Span>,
+    callee: LibraryApiCalleeContract,
+    record: &EvidenceRecord,
+) -> bool {
+    match callee {
         LibraryApiCalleeContract::RegexLiteralMethod {
             required_receiver_fact,
             ..
@@ -898,6 +1086,19 @@ fn library_api_dependencies_match_callee_at_span(
                     )
                 })
         }
+        _ => false,
+    }
+}
+
+fn library_api_dependencies_match_method_callee_at_span(
+    il: &Il,
+    interner: &Interner,
+    callee_span: Option<Span>,
+    receiver_span: Option<Span>,
+    callee: LibraryApiCalleeContract,
+    record: &EvidenceRecord,
+) -> bool {
+    match callee {
         LibraryApiCalleeContract::Method { method, receiver } => {
             callee_span.is_some_and(|span| field_method_at_span(il, interner, span, method))
                 && receiver_span.is_some_and(|span| {
@@ -923,6 +1124,7 @@ fn library_api_dependencies_match_callee_at_span(
                     )
                 })
         }
+        _ => false,
     }
 }
 
@@ -1118,23 +1320,7 @@ fn receiver_dependency_ids(
             domain_or_sequence_dependency_ids(il, interner, receiver, contract, cache)
         }
         MethodReceiverContract::ExactCollection | MethodReceiverContract::ExactCollectionOrMap => {
-            if let Some(ids) =
-                domain_or_sequence_dependency_ids(il, interner, receiver, contract, cache)
-            {
-                return Some(ids);
-            }
-            if let Some(id) =
-                library_api_dependency_id_for_receiver_domain_call(il, interner, receiver, contract)
-            {
-                return Some(vec![id]);
-            }
-            library_api_dependency_id_for_map_key_view_call(
-                il,
-                interner,
-                receiver,
-                &[MapKeyViewKind::Collection],
-            )
-            .map(|id| vec![id])
+            collection_receiver_dependency_ids(il, interner, receiver, contract, cache)
         }
         MethodReceiverContract::RustMapGetOrExactOption => {
             if let Some(ids) =
@@ -1163,58 +1349,11 @@ fn receiver_dependency_ids(
                 .map(|id| vec![id])
         }
         MethodReceiverContract::ExactProtocol => {
-            if let Some(ids) =
-                domain_or_sequence_dependency_ids(il, interner, receiver, contract, cache)
-            {
-                return Some(ids);
-            }
-            if let Some(id) = library_api_dependency_id_for_map_key_view_call(
-                il,
-                interner,
-                receiver,
-                &[MapKeyViewKind::Collection, MapKeyViewKind::Iterator],
-            ) {
-                return Some(vec![id]);
-            }
-            if let Some(id) =
-                library_api_dependency_id_for_receiver_domain_call(il, interner, receiver, contract)
-            {
-                return Some(vec![id]);
-            }
-            if let Some(id) = library_api_dependency_id_for_normalized_hof(il, receiver) {
-                return Some(vec![id]);
-            }
-            library_api_dependency_id_for_protocol_call(il, interner, receiver).map(|id| vec![id])
+            exact_protocol_receiver_dependency_ids(il, interner, receiver, contract, cache)
         }
-        MethodReceiverContract::ExactProtocolPairArgument => domain_or_sequence_dependency_ids(
-            il,
-            interner,
-            receiver,
-            MethodReceiverContract::ExactProtocol,
-            cache,
-        )
-        .or_else(|| {
-            library_api_dependency_id_for_map_key_view_call(
-                il,
-                interner,
-                receiver,
-                &[MapKeyViewKind::Collection, MapKeyViewKind::Iterator],
-            )
-            .map(|id| vec![id])
-        })
-        .or_else(|| {
-            library_api_dependency_id_for_receiver_domain_call(
-                il,
-                interner,
-                receiver,
-                MethodReceiverContract::ExactProtocol,
-            )
-            .map(|id| vec![id])
-        })
-        .or_else(|| library_api_dependency_id_for_normalized_hof(il, receiver).map(|id| vec![id]))
-        .or_else(|| {
-            library_api_dependency_id_for_protocol_call(il, interner, receiver).map(|id| vec![id])
-        }),
+        MethodReceiverContract::ExactProtocolPairArgument => {
+            protocol_pair_argument_receiver_dependency_ids(il, interner, receiver, cache)
+        }
         _ => domain_or_sequence_dependency_ids(il, interner, receiver, contract, cache).or_else(
             || {
                 library_api_dependency_id_for_receiver_domain_call(il, interner, receiver, contract)
@@ -1222,6 +1361,96 @@ fn receiver_dependency_ids(
             },
         ),
     }
+}
+
+fn collection_receiver_dependency_ids(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+    contract: MethodReceiverContract,
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<Vec<EvidenceId>> {
+    if let Some(ids) = domain_or_sequence_dependency_ids(il, interner, receiver, contract, cache) {
+        return Some(ids);
+    }
+    if let Some(id) =
+        library_api_dependency_id_for_receiver_domain_call(il, interner, receiver, contract)
+    {
+        return Some(vec![id]);
+    }
+    library_api_dependency_id_for_map_key_view_call(
+        il,
+        interner,
+        receiver,
+        &[MapKeyViewKind::Collection],
+    )
+    .map(|id| vec![id])
+}
+
+fn exact_protocol_receiver_dependency_ids(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+    contract: MethodReceiverContract,
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<Vec<EvidenceId>> {
+    if let Some(ids) = domain_or_sequence_dependency_ids(il, interner, receiver, contract, cache) {
+        return Some(ids);
+    }
+    if let Some(id) = library_api_dependency_id_for_map_key_view_call(
+        il,
+        interner,
+        receiver,
+        &[MapKeyViewKind::Collection, MapKeyViewKind::Iterator],
+    ) {
+        return Some(vec![id]);
+    }
+    if let Some(id) =
+        library_api_dependency_id_for_receiver_domain_call(il, interner, receiver, contract)
+    {
+        return Some(vec![id]);
+    }
+    if let Some(id) = library_api_dependency_id_for_normalized_hof(il, receiver) {
+        return Some(vec![id]);
+    }
+    library_api_dependency_id_for_protocol_call(il, interner, receiver).map(|id| vec![id])
+}
+
+fn protocol_pair_argument_receiver_dependency_ids(
+    il: &Il,
+    interner: &Interner,
+    receiver: NodeId,
+    cache: &mut LibraryApiDependencyCache,
+) -> Option<Vec<EvidenceId>> {
+    domain_or_sequence_dependency_ids(
+        il,
+        interner,
+        receiver,
+        MethodReceiverContract::ExactProtocol,
+        cache,
+    )
+    .or_else(|| {
+        library_api_dependency_id_for_map_key_view_call(
+            il,
+            interner,
+            receiver,
+            &[MapKeyViewKind::Collection, MapKeyViewKind::Iterator],
+        )
+        .map(|id| vec![id])
+    })
+    .or_else(|| {
+        library_api_dependency_id_for_receiver_domain_call(
+            il,
+            interner,
+            receiver,
+            MethodReceiverContract::ExactProtocol,
+        )
+        .map(|id| vec![id])
+    })
+    .or_else(|| library_api_dependency_id_for_normalized_hof(il, receiver).map(|id| vec![id]))
+    .or_else(|| {
+        library_api_dependency_id_for_protocol_call(il, interner, receiver).map(|id| vec![id])
+    })
 }
 
 fn domain_or_sequence_dependency_ids(

--- a/crates/nose-semantics/src/library_api/registry.rs
+++ b/crates/nose-semantics/src/library_api/registry.rs
@@ -66,7 +66,14 @@ pub(super) fn library_api_contract_id_from_hash(hash: u64) -> Option<LibraryApiC
 }
 
 fn library_api_contract_ids() -> Vec<LibraryApiContractId> {
-    let mut ids = vec![
+    let mut ids = core_library_api_contract_ids();
+    push_keyed_library_api_contract_ids(&mut ids);
+    push_method_call_library_api_contract_ids(&mut ids);
+    ids
+}
+
+fn core_library_api_contract_ids() -> Vec<LibraryApiContractId> {
+    vec![
         LibraryApiContractId::PropertyBuiltin(Builtin::Len),
         LibraryApiContractId::PythonBuiltinCollectionFactory,
         LibraryApiContractId::PythonImportedCollectionFactory,
@@ -104,7 +111,10 @@ fn library_api_contract_ids() -> Vec<LibraryApiContractId> {
         LibraryApiContractId::PromiseThen,
         LibraryApiContractId::IteratorIdentityAdapter,
         LibraryApiContractId::StaticCollectionAdapter,
-    ];
+    ]
+}
+
+fn push_keyed_library_api_contract_ids(ids: &mut Vec<LibraryApiContractId>) {
     ids.extend(
         [
             ScalarIntegerMethod::Abs,
@@ -145,6 +155,9 @@ fn library_api_contract_ids() -> Vec<LibraryApiContractId> {
         .into_iter()
         .map(LibraryApiContractId::ImportedNamespaceFunction),
     );
+}
+
+fn push_method_call_library_api_contract_ids(ids: &mut Vec<LibraryApiContractId>) {
     ids.extend(
         [
             MethodSemanticContract::Builtin(Builtin::Append),
@@ -175,7 +188,6 @@ fn library_api_contract_ids() -> Vec<LibraryApiContractId> {
         .into_iter()
         .map(LibraryApiContractId::MethodCall),
     );
-    ids
 }
 
 pub(super) fn library_api_record_admitted_for_current_shape(
@@ -282,6 +294,15 @@ fn library_api_callee_contracts_for_id(
             .filter(|contract| contract.id == LibraryApiContractId::ScalarIntegerMethod(method))
             .map(|contract| contract.callee)
             .collect(),
+        _ => library_api_factory_callee_contracts_for_id(lang, id),
+    }
+}
+
+fn library_api_factory_callee_contracts_for_id(
+    lang: Lang,
+    id: LibraryApiContractId,
+) -> Vec<LibraryApiCalleeContract> {
+    match id {
         LibraryApiContractId::RustStdMapFactory => library_free_name_map_factory_contracts(lang)
             .filter(|contract| contract.id == id)
             .map(|contract| contract.callee)
@@ -352,6 +373,15 @@ fn library_api_callee_contracts_for_id(
                 .map(|contract| vec![contract.callee])
                 .unwrap_or_default()
         }
+        _ => library_api_member_callee_contracts_for_id(lang, id),
+    }
+}
+
+fn library_api_member_callee_contracts_for_id(
+    lang: Lang,
+    id: LibraryApiContractId,
+) -> Vec<LibraryApiCalleeContract> {
+    match id {
         LibraryApiContractId::JsLikeStaticIndexMembership(kind) => ["indexOf", "findIndex"]
             .into_iter()
             .filter_map(|method| library_static_index_membership_contract(lang, method, 1))

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -965,126 +965,10 @@ struct ManifestFixture {
 }
 
 fn validate_manifest(manifest: &SemanticPackManifest) -> Result<(), String> {
-    if manifest.api_version != SEMANTIC_PACK_API_VERSION {
-        return Err(format!(
-            "`api_version` must be {SEMANTIC_PACK_API_VERSION}, got `{}`",
-            manifest.api_version
-        ));
-    }
-    require_stable_id("pack.id", &manifest.pack.id)?;
-    require_non_empty("pack.version", &manifest.pack.version)?;
-    require_non_empty("pack.display_name", &manifest.pack.display_name)?;
-    optional_non_empty("pack.description", manifest.pack.description.as_deref())?;
-    require_non_empty(
-        "provenance.provider.name",
-        &manifest.provenance.provider.name,
-    )?;
-    optional_non_empty(
-        "provenance.provider.contact",
-        manifest.provenance.provider.contact.as_deref(),
-    )?;
-    require_non_empty("provenance.license", &manifest.provenance.license)?;
-    require_non_empty("provenance.repository", &manifest.provenance.repository)?;
-    optional_non_empty(
-        "provenance.source_revision",
-        manifest.provenance.source_revision.as_deref(),
-    )?;
-    validate_nose_version_requirement("compatibility.nose", &manifest.compatibility.nose)?;
-    optional_non_empty(
-        "compatibility.notes",
-        manifest.compatibility.notes.as_deref(),
-    )?;
-    if manifest.pack.trust != PackTrust::ExternalOptIn || manifest.pack.enabled_by_default {
-        return Err(
-            "local semantic pack manifests must be external-opt-in and disabled by default"
-                .to_string(),
-        );
-    }
-    if manifest.supported_languages.is_empty() {
-        return Err("`supported_languages` must contain at least one language".to_string());
-    }
-    for language in &manifest.supported_languages {
-        require_non_empty("supported_languages[].id", &language.id)?;
-        optional_non_empty(
-            "supported_languages[].language_version",
-            language.language_version.as_deref(),
-        )?;
-        optional_non_empty("supported_languages[].runtime", language.runtime.as_deref())?;
-        for version in &language.runtime_versions {
-            require_non_empty("supported_languages[].runtime_versions[]", version)?;
-        }
-    }
-    for package in &manifest.packages {
-        require_non_empty("packages[].ecosystem", &package.ecosystem)?;
-        require_non_empty("packages[].name", &package.name)?;
-        require_non_empty("packages[].versions", &package.versions)?;
-    }
-    for dependency in &manifest.dependencies {
-        require_stable_id("dependencies[].id", &dependency.id)?;
-        require_non_empty("dependencies[].version", &dependency.version)?;
-        let _required = dependency.required;
-    }
-
-    let mut known_refs = HashSet::new();
-    collect_unique_refs(
-        "dependencies",
-        manifest.dependencies.iter().map(|dep| &dep.id),
-        &mut known_refs,
-    )?;
-    collect_unique_refs(
-        "declares.evidence_producers",
-        manifest
-            .declares
-            .evidence_producers
-            .iter()
-            .map(|producer| &producer.id),
-        &mut known_refs,
-    )?;
-    collect_unique_refs(
-        "declares.contracts",
-        manifest
-            .declares
-            .contracts
-            .iter()
-            .map(|contract| &contract.id),
-        &mut known_refs,
-    )?;
-    collect_unique_refs(
-        "declares.value_laws",
-        manifest.declares.value_laws.iter().map(|law| &law.id),
-        &mut known_refs,
-    )?;
-
-    if manifest.conformance.positive_fixtures.is_empty() {
-        return Err("`conformance.positive_fixtures` must not be empty".to_string());
-    }
-    if manifest.conformance.hard_negatives.is_empty() {
-        return Err("`conformance.hard_negatives` must not be empty".to_string());
-    }
-    for fixture in manifest
-        .conformance
-        .positive_fixtures
-        .iter()
-        .chain(&manifest.conformance.hard_negatives)
-    {
-        require_stable_id("conformance fixture id", &fixture.id)?;
-        require_non_empty("conformance fixture description", &fixture.description)?;
-        optional_non_empty("conformance fixture path", fixture.path.as_deref())?;
-        optional_non_empty(
-            "conformance fixture expectation",
-            fixture.expectation.as_deref(),
-        )?;
-    }
-    for unsupported in &manifest.conformance.known_unsupported {
-        require_non_empty("conformance.known_unsupported[]", unsupported)?;
-    }
-    optional_non_empty(
-        "conformance.command",
-        manifest.conformance.command.as_deref(),
-    )?;
-    for proof in &manifest.conformance.proofs {
-        require_non_empty("conformance.proofs[]", proof)?;
-    }
+    validate_manifest_header(manifest)?;
+    validate_manifest_targets(manifest)?;
+    let known_refs = collect_declared_refs(manifest)?;
+    validate_manifest_conformance(manifest)?;
     let conformance_refs = collect_conformance_fixture_refs(manifest)?;
 
     for producer in &manifest.declares.evidence_producers {
@@ -1125,6 +1009,140 @@ fn validate_manifest(manifest: &SemanticPackManifest) -> Result<(), String> {
             &known_refs,
             &conformance_refs,
         )?;
+    }
+    Ok(())
+}
+
+fn validate_manifest_header(manifest: &SemanticPackManifest) -> Result<(), String> {
+    if manifest.api_version != SEMANTIC_PACK_API_VERSION {
+        return Err(format!(
+            "`api_version` must be {SEMANTIC_PACK_API_VERSION}, got `{}`",
+            manifest.api_version
+        ));
+    }
+    require_stable_id("pack.id", &manifest.pack.id)?;
+    require_non_empty("pack.version", &manifest.pack.version)?;
+    require_non_empty("pack.display_name", &manifest.pack.display_name)?;
+    optional_non_empty("pack.description", manifest.pack.description.as_deref())?;
+    require_non_empty(
+        "provenance.provider.name",
+        &manifest.provenance.provider.name,
+    )?;
+    optional_non_empty(
+        "provenance.provider.contact",
+        manifest.provenance.provider.contact.as_deref(),
+    )?;
+    require_non_empty("provenance.license", &manifest.provenance.license)?;
+    require_non_empty("provenance.repository", &manifest.provenance.repository)?;
+    optional_non_empty(
+        "provenance.source_revision",
+        manifest.provenance.source_revision.as_deref(),
+    )?;
+    validate_nose_version_requirement("compatibility.nose", &manifest.compatibility.nose)?;
+    optional_non_empty(
+        "compatibility.notes",
+        manifest.compatibility.notes.as_deref(),
+    )?;
+    if manifest.pack.trust != PackTrust::ExternalOptIn || manifest.pack.enabled_by_default {
+        return Err(
+            "local semantic pack manifests must be external-opt-in and disabled by default"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn validate_manifest_targets(manifest: &SemanticPackManifest) -> Result<(), String> {
+    if manifest.supported_languages.is_empty() {
+        return Err("`supported_languages` must contain at least one language".to_string());
+    }
+    for language in &manifest.supported_languages {
+        require_non_empty("supported_languages[].id", &language.id)?;
+        optional_non_empty(
+            "supported_languages[].language_version",
+            language.language_version.as_deref(),
+        )?;
+        optional_non_empty("supported_languages[].runtime", language.runtime.as_deref())?;
+        for version in &language.runtime_versions {
+            require_non_empty("supported_languages[].runtime_versions[]", version)?;
+        }
+    }
+    for package in &manifest.packages {
+        require_non_empty("packages[].ecosystem", &package.ecosystem)?;
+        require_non_empty("packages[].name", &package.name)?;
+        require_non_empty("packages[].versions", &package.versions)?;
+    }
+    for dependency in &manifest.dependencies {
+        require_stable_id("dependencies[].id", &dependency.id)?;
+        require_non_empty("dependencies[].version", &dependency.version)?;
+        let _required = dependency.required;
+    }
+    Ok(())
+}
+
+fn collect_declared_refs(manifest: &SemanticPackManifest) -> Result<HashSet<String>, String> {
+    let mut known_refs = HashSet::new();
+    collect_unique_refs(
+        "dependencies",
+        manifest.dependencies.iter().map(|dep| &dep.id),
+        &mut known_refs,
+    )?;
+    collect_unique_refs(
+        "declares.evidence_producers",
+        manifest
+            .declares
+            .evidence_producers
+            .iter()
+            .map(|producer| &producer.id),
+        &mut known_refs,
+    )?;
+    collect_unique_refs(
+        "declares.contracts",
+        manifest
+            .declares
+            .contracts
+            .iter()
+            .map(|contract| &contract.id),
+        &mut known_refs,
+    )?;
+    collect_unique_refs(
+        "declares.value_laws",
+        manifest.declares.value_laws.iter().map(|law| &law.id),
+        &mut known_refs,
+    )?;
+    Ok(known_refs)
+}
+
+fn validate_manifest_conformance(manifest: &SemanticPackManifest) -> Result<(), String> {
+    if manifest.conformance.positive_fixtures.is_empty() {
+        return Err("`conformance.positive_fixtures` must not be empty".to_string());
+    }
+    if manifest.conformance.hard_negatives.is_empty() {
+        return Err("`conformance.hard_negatives` must not be empty".to_string());
+    }
+    for fixture in manifest
+        .conformance
+        .positive_fixtures
+        .iter()
+        .chain(&manifest.conformance.hard_negatives)
+    {
+        require_stable_id("conformance fixture id", &fixture.id)?;
+        require_non_empty("conformance fixture description", &fixture.description)?;
+        optional_non_empty("conformance fixture path", fixture.path.as_deref())?;
+        optional_non_empty(
+            "conformance fixture expectation",
+            fixture.expectation.as_deref(),
+        )?;
+    }
+    for unsupported in &manifest.conformance.known_unsupported {
+        require_non_empty("conformance.known_unsupported[]", unsupported)?;
+    }
+    optional_non_empty(
+        "conformance.command",
+        manifest.conformance.command.as_deref(),
+    )?;
+    for proof in &manifest.conformance.proofs {
+        require_non_empty("conformance.proofs[]", proof)?;
     }
     Ok(())
 }

--- a/crates/nose-semantics/src/tests/js_symbol_guards.rs
+++ b/crates/nose-semantics/src/tests/js_symbol_guards.rs
@@ -104,6 +104,17 @@ fn record_guard_record(
     )
 }
 
+fn js_record_guard_il_with_surface(interner: &Interner, subject: &str) -> (Il, NodeId) {
+    let (mut il, guard) = js_record_guard_il(interner, subject);
+    il.evidence.push(evidence(
+        0,
+        EvidenceAnchor::sequence(sp(12)),
+        EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
+        EvidenceStatus::Asserted,
+    ));
+    (il, guard)
+}
+
 fn js_own_property_guard_il(interner: &Interner) -> (Il, NodeId) {
     let mut b = IlBuilder::new(FileId(0));
     let tag = interner.intern("own_property_guard");
@@ -395,13 +406,7 @@ fn record_shape_guard_requires_dedicated_guard_evidence() {
 fn record_shape_guard_validates_required_dependencies() {
     let interner = Interner::new();
 
-    let (mut il, guard) = js_record_guard_il(&interner, "value");
-    il.evidence.push(evidence(
-        0,
-        EvidenceAnchor::sequence(sp(12)),
-        EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
-        EvidenceStatus::Asserted,
-    ));
+    let (mut il, guard) = js_record_guard_il_with_surface(&interner, "value");
     il.evidence.push(record_guard_record(
         1,
         sp(12),
@@ -411,13 +416,7 @@ fn record_shape_guard_validates_required_dependencies() {
     ));
     assert!(!record_shape_guard_for_node(&il, &interner, guard));
 
-    let (mut il, guard) = js_record_guard_il(&interner, "value");
-    il.evidence.push(evidence(
-        0,
-        EvidenceAnchor::sequence(sp(12)),
-        EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
-        EvidenceStatus::Asserted,
-    ));
+    let (mut il, guard) = js_record_guard_il_with_surface(&interner, "value");
     il.evidence.push(evidence(
         1,
         EvidenceAnchor::source_span(sp(12)),
@@ -434,14 +433,13 @@ fn record_shape_guard_validates_required_dependencies() {
         &[1],
     ));
     assert!(!record_shape_guard_for_node(&il, &interner, guard));
+}
 
-    let (mut il, guard) = js_record_guard_il(&interner, "value");
-    il.evidence.push(evidence(
-        0,
-        EvidenceAnchor::sequence(sp(12)),
-        EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
-        EvidenceStatus::Asserted,
-    ));
+#[test]
+fn record_shape_guard_rejects_ambiguous_or_mispositioned_dependencies() {
+    let interner = Interner::new();
+
+    let (mut il, guard) = js_record_guard_il_with_surface(&interner, "value");
     il.evidence.push(array_is_array_dependency(
         1,
         sp(12),
@@ -457,13 +455,7 @@ fn record_shape_guard_validates_required_dependencies() {
     ));
     assert!(!record_shape_guard_for_node(&il, &interner, guard));
 
-    let (mut il, guard) = js_record_guard_il(&interner, "value");
-    il.evidence.push(evidence(
-        0,
-        EvidenceAnchor::sequence(sp(12)),
-        EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
-        EvidenceStatus::Asserted,
-    ));
+    let (mut il, guard) = js_record_guard_il_with_surface(&interner, "value");
     il.evidence.push(array_is_array_dependency(
         1,
         sp(14),
@@ -478,14 +470,13 @@ fn record_shape_guard_validates_required_dependencies() {
         &[1],
     ));
     assert!(!record_shape_guard_for_node(&il, &interner, guard));
+}
 
-    let (mut il, guard) = js_record_guard_il(&interner, "value");
-    il.evidence.push(evidence(
-        0,
-        EvidenceAnchor::sequence(sp(12)),
-        EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
-        EvidenceStatus::Asserted,
-    ));
+#[test]
+fn record_shape_guard_boolean_truthy_null_check_requires_full_proofs() {
+    let interner = Interner::new();
+
+    let (mut il, guard) = js_record_guard_il_with_surface(&interner, "value");
     il.evidence.push(array_is_array_dependency(
         1,
         sp(12),
@@ -512,13 +503,7 @@ fn record_shape_guard_validates_required_dependencies() {
     ));
     assert!(!record_shape_guard_for_node(&il, &interner, guard));
 
-    let (mut il, guard) = js_record_guard_il(&interner, "value");
-    il.evidence.push(evidence(
-        0,
-        EvidenceAnchor::sequence(sp(12)),
-        EvidenceKind::SequenceSurface(SequenceSurfaceKind::RecordGuard),
-        EvidenceStatus::Asserted,
-    ));
+    let (mut il, guard) = js_record_guard_il_with_surface(&interner, "value");
     il.evidence.push(array_is_array_dependency(
         1,
         sp(12),

--- a/crates/nose-semantics/src/tests/library_api_contracts.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts.rs
@@ -166,6 +166,10 @@ fn library_api_contracts_carry_identity_and_result_obligations() {
         LibraryApiShadowPolicy::RustStdRootForStdPath,
         |_| false
     ));
+}
+
+#[test]
+fn library_api_factory_contracts_cover_java_ruby_and_js_like_surfaces() {
     assert_eq!(
         library_java_collection_factory_contract(Lang::Java, "Arrays", "asList"),
         Some(LibraryCollectionFactoryContract {
@@ -324,6 +328,10 @@ fn library_api_result_domain_mapping_is_contract_scoped() {
         ),
         DomainEvidence::Set
     );
+}
+
+#[test]
+fn library_map_factory_result_domain_mapping_is_contract_scoped() {
     assert_eq!(
         library_map_factory_result_domain(
             library_free_name_map_factory_contract(Lang::Rust, "std::collections::HashMap::from",)
@@ -416,6 +424,10 @@ fn library_non_factory_api_contracts_carry_identity_and_result_obligations() {
             },
         })
     );
+}
+
+#[test]
+fn library_coercion_regex_namespace_and_promise_contracts_carry_obligations() {
     assert_eq!(
         library_js_boolean_coercion_contract(Lang::TypeScript, "Boolean", 1),
         Some(LibraryStaticGlobalFunctionContract {
@@ -501,6 +513,10 @@ fn library_non_factory_api_contracts_carry_identity_and_result_obligations() {
             },
         })
     );
+}
+
+#[test]
+fn library_iterator_adapter_and_method_call_contracts_carry_obligations() {
     assert_eq!(
         library_iterator_identity_adapter_contract(Lang::Rust, "collect", 0),
         Some(LibraryIteratorIdentityAdapterContract {
@@ -580,6 +596,10 @@ fn library_non_factory_api_contracts_reject_raw_name_only_matches() {
         library_js_boolean_coercion_contract(Lang::JavaScript, "Boolean", 2),
         None
     );
+}
+
+#[test]
+fn library_promise_adapter_and_method_contracts_reject_raw_name_only_matches() {
     assert_eq!(library_regex_test_contract(Lang::Ruby, "test", 1), None);
     assert_eq!(
         library_imported_namespace_function_contract(Lang::JavaScript, "prod", 1),
@@ -704,6 +724,10 @@ fn builtin_contracts_preserve_current_special_demand_split() {
         Some(ReductionBuiltinContract::Bool { all: false })
     );
     assert_eq!(reduction_builtin_contract(Builtin::Print), None);
+}
+
+#[test]
+fn hof_contracts_carry_callback_demand_profiles() {
     assert_eq!(
         hof_contract(HoFKind::FilterMap),
         HofContract {
@@ -773,6 +797,10 @@ fn builtin_contracts_preserve_current_special_demand_split() {
             effect_visibility: EffectVisibility::DelayedUntilPull,
         })
     );
+}
+
+#[test]
+fn hof_demand_effect_profiles_split_eager_and_pull_lazy_timing() {
     assert!(hof_demand_effect_profile(
         HoFKind::Map,
         HofDemandSource::SourceComprehension(SourceComprehensionKind::PythonGeneratorExpression)
@@ -807,6 +835,10 @@ fn builtin_contracts_preserve_current_special_demand_split() {
         library_hof_demand_effect_profile(Lang::Python, HoFKind::Map),
         None
     );
+}
+
+#[test]
+fn promise_and_protocol_demand_profiles_keep_async_boundaries() {
     assert_eq!(
         promise_then_demand_effect_profile(),
         DemandEffectProfile {
@@ -1000,6 +1032,10 @@ fn method_call_contracts_carry_receiver_and_resolution_obligations() {
             args: MethodBuiltinArgs::All,
         })
     );
+}
+
+#[test]
+fn method_call_contracts_cover_membership_and_map_default_lookups() {
     assert_eq!(
         method_call_contract(Lang::Python, "__contains__", 1),
         Some(MethodCallContract {

--- a/crates/nose-semantics/src/tests/library_api_evidence.rs
+++ b/crates/nose-semantics/src/tests/library_api_evidence.rs
@@ -60,6 +60,60 @@ fn library_api_record_with_arity(
     )
 }
 
+fn is_array_contract() -> LibraryStaticGlobalMethodContract {
+    library_js_array_is_array_contract(Lang::JavaScript, "Array", "isArray", 1)
+        .expect("test contract")
+}
+
+fn contract_status_for_call(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    id: LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+) -> LibraryApiEvidenceStatus {
+    library_api_contract_evidence_for_call(il, interner, call, id, callee, 1)
+}
+
+fn admitted_js_array_is_array_il(interner: &Interner) -> (Il, NodeId, NodeId, NodeId) {
+    let (mut il, call, callee, array) = js_array_is_array_call_il(interner);
+    let contract = is_array_contract();
+    il.evidence.push(evidence(
+        0,
+        EvidenceAnchor::node(il.node(array).span, NodeKind::Var),
+        EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+            name_hash: stable_symbol_hash("Array"),
+        }),
+        EvidenceStatus::Asserted,
+    ));
+    il.evidence.push(evidence(
+        1,
+        EvidenceAnchor::source_span(il.node(callee).span),
+        EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
+            name_hash: stable_symbol_hash("Array"),
+        }),
+        EvidenceStatus::Asserted,
+    ));
+    il.evidence.push(evidence_with_dependencies(
+        2,
+        EvidenceAnchor::node(il.node(callee).span, NodeKind::Field),
+        EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
+            path_hash: stable_symbol_hash("Array.isArray"),
+        }),
+        EvidenceStatus::Asserted,
+        vec![EvidenceId(1)],
+    ));
+    il.evidence.push(library_api_record(
+        3,
+        il.node(call).span,
+        contract.id,
+        contract.callee,
+        EvidenceStatus::Asserted,
+        &[0, 2],
+    ));
+    (il, call, callee, array)
+}
+
 fn canonical_builtin_call_il(
     lang: Lang,
     builtin: Builtin,
@@ -430,66 +484,19 @@ fn java_list_of_import_evidence_il(
 }
 
 #[test]
-fn library_api_evidence_resolution_is_dependency_backed_and_fail_closed() {
+fn library_api_evidence_resolution_is_dependency_backed() {
     let interner = Interner::new();
-    let (mut il, call, callee, array) = js_array_is_array_call_il(&interner);
-    let contract = library_js_array_is_array_contract(Lang::JavaScript, "Array", "isArray", 1)
-        .expect("test contract");
+    let (il, call, _callee, _array) = js_array_is_array_call_il(&interner);
+    let contract = is_array_contract();
 
     assert_eq!(
-        library_api_contract_evidence_for_call(
-            &il,
-            &interner,
-            call,
-            contract.id,
-            contract.callee,
-            1,
-        ),
+        contract_status_for_call(&il, &interner, call, contract.id, contract.callee),
         LibraryApiEvidenceStatus::Missing
     );
 
-    il.evidence.push(evidence(
-        0,
-        EvidenceAnchor::node(il.node(array).span, NodeKind::Var),
-        EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
-            name_hash: stable_symbol_hash("Array"),
-        }),
-        EvidenceStatus::Asserted,
-    ));
-    il.evidence.push(evidence(
-        1,
-        EvidenceAnchor::source_span(il.node(callee).span),
-        EvidenceKind::Symbol(SymbolEvidenceKind::UnshadowedGlobal {
-            name_hash: stable_symbol_hash("Array"),
-        }),
-        EvidenceStatus::Asserted,
-    ));
-    il.evidence.push(evidence_with_dependencies(
-        2,
-        EvidenceAnchor::node(il.node(callee).span, NodeKind::Field),
-        EvidenceKind::Symbol(SymbolEvidenceKind::QualifiedGlobal {
-            path_hash: stable_symbol_hash("Array.isArray"),
-        }),
-        EvidenceStatus::Asserted,
-        vec![EvidenceId(1)],
-    ));
-    il.evidence.push(library_api_record(
-        3,
-        il.node(call).span,
-        contract.id,
-        contract.callee,
-        EvidenceStatus::Asserted,
-        &[0, 2],
-    ));
+    let (il, call, callee, array) = admitted_js_array_is_array_il(&interner);
     assert_eq!(
-        library_api_contract_evidence_for_call(
-            &il,
-            &interner,
-            call,
-            contract.id,
-            contract.callee,
-            1,
-        ),
+        contract_status_for_call(&il, &interner, call, contract.id, contract.callee),
         LibraryApiEvidenceStatus::Admitted
     );
     assert_eq!(
@@ -507,6 +514,13 @@ fn library_api_evidence_resolution_is_dependency_backed_and_fail_closed() {
         ),
         LibraryApiEvidenceStatus::Admitted
     );
+}
+
+#[test]
+fn library_api_span_queries_reject_mismatched_callee_and_receiver_spans() {
+    let interner = Interner::new();
+    let (il, call, callee, array) = admitted_js_array_is_array_il(&interner);
+    let contract = is_array_contract();
     assert_eq!(
         library_api_contract_evidence_at_call_span(
             &il,
@@ -537,6 +551,12 @@ fn library_api_evidence_resolution_is_dependency_backed_and_fail_closed() {
         ),
         LibraryApiEvidenceStatus::Rejected
     );
+}
+
+#[test]
+fn library_api_evidence_resolution_rejects_missing_or_ambiguous_dependencies() {
+    let interner = Interner::new();
+    let contract = is_array_contract();
 
     let (mut missing_dep, call, _callee, _array) = js_array_is_array_call_il(&interner);
     missing_dep.evidence.push(library_api_record(
@@ -548,14 +568,7 @@ fn library_api_evidence_resolution_is_dependency_backed_and_fail_closed() {
         &[],
     ));
     assert_eq!(
-        library_api_contract_evidence_for_call(
-            &missing_dep,
-            &interner,
-            call,
-            contract.id,
-            contract.callee,
-            1,
-        ),
+        contract_status_for_call(&missing_dep, &interner, call, contract.id, contract.callee),
         LibraryApiEvidenceStatus::Rejected
     );
 
@@ -585,16 +598,21 @@ fn library_api_evidence_resolution_is_dependency_backed_and_fail_closed() {
         &[0, 1],
     ));
     assert_eq!(
-        library_api_contract_evidence_for_call(
+        contract_status_for_call(
             &ambiguous_dep,
             &interner,
             call,
             contract.id,
-            contract.callee,
-            1,
+            contract.callee
         ),
         LibraryApiEvidenceStatus::Rejected
     );
+}
+
+#[test]
+fn library_api_evidence_resolution_rejects_conflicting_or_misanchored_records() {
+    let interner = Interner::new();
+    let contract = is_array_contract();
 
     let (mut conflicting_dep, call, callee, array) = js_array_is_array_call_il(&interner);
     conflicting_dep.evidence.push(evidence(
@@ -630,17 +648,17 @@ fn library_api_evidence_resolution_is_dependency_backed_and_fail_closed() {
         &[0, 1],
     ));
     assert_eq!(
-        library_api_contract_evidence_for_call(
+        contract_status_for_call(
             &conflicting_dep,
             &interner,
             call,
             contract.id,
-            contract.callee,
-            1,
+            contract.callee
         ),
         LibraryApiEvidenceStatus::Rejected
     );
 
+    let (mut il, call, _callee, _array) = admitted_js_array_is_array_il(&interner);
     let boolean = library_js_boolean_coercion_contract(Lang::JavaScript, "Boolean", 1).unwrap();
     il.evidence.push(library_api_record(
         3,
@@ -651,14 +669,7 @@ fn library_api_evidence_resolution_is_dependency_backed_and_fail_closed() {
         &[0],
     ));
     assert_eq!(
-        library_api_contract_evidence_for_call(
-            &il,
-            &interner,
-            call,
-            contract.id,
-            contract.callee,
-            1,
-        ),
+        contract_status_for_call(&il, &interner, call, contract.id, contract.callee),
         LibraryApiEvidenceStatus::Rejected
     );
 
@@ -672,20 +683,13 @@ fn library_api_evidence_resolution_is_dependency_backed_and_fail_closed() {
         &[],
     ));
     assert_eq!(
-        library_api_contract_evidence_for_call(
-            &wrong_anchor,
-            &interner,
-            call,
-            contract.id,
-            contract.callee,
-            1,
-        ),
+        contract_status_for_call(&wrong_anchor, &interner, call, contract.id, contract.callee),
         LibraryApiEvidenceStatus::Missing
     );
 }
 
 #[test]
-fn library_api_evidence_resolution_accepts_import_and_source_backed_callees() {
+fn library_api_evidence_resolution_accepts_import_backed_callees() {
     let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));
     let local = interner.intern("Values");
@@ -731,17 +735,14 @@ fn library_api_evidence_resolution_accepts_import_and_source_backed_callees() {
         &[1],
     ));
     assert_eq!(
-        library_api_contract_evidence_for_call(
-            &il,
-            &interner,
-            call,
-            contract.id,
-            contract.callee,
-            1,
-        ),
+        contract_status_for_call(&il, &interner, call, contract.id, contract.callee),
         LibraryApiEvidenceStatus::Admitted
     );
+}
 
+#[test]
+fn library_api_evidence_resolution_accepts_source_backed_callees() {
+    let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));
     let regex = b.add(
         NodeKind::Lit,
@@ -781,20 +782,13 @@ fn library_api_evidence_resolution_accepts_import_and_source_backed_callees() {
         &[0],
     ));
     assert_eq!(
-        library_api_contract_evidence_for_call(
-            &il,
-            &interner,
-            call,
-            contract.id,
-            contract.callee,
-            1,
-        ),
+        contract_status_for_call(&il, &interner, call, contract.id, contract.callee),
         LibraryApiEvidenceStatus::Admitted
     );
 }
 
 #[test]
-fn library_api_evidence_resolution_accepts_free_name_and_require_backed_callees() {
+fn library_api_evidence_resolution_accepts_free_name_backed_callees() {
     let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));
     let callee = b.add(
@@ -831,14 +825,7 @@ fn library_api_evidence_resolution_accepts_free_name_and_require_backed_callees(
         &[0],
     ));
     assert_eq!(
-        library_api_contract_evidence_for_call(
-            &il,
-            &interner,
-            call,
-            contract.id,
-            contract.callee,
-            1,
-        ),
+        contract_status_for_call(&il, &interner, call, contract.id, contract.callee),
         LibraryApiEvidenceStatus::Admitted
     );
     assert_eq!(
@@ -856,7 +843,11 @@ fn library_api_evidence_resolution_accepts_free_name_and_require_backed_callees(
         ),
         LibraryApiEvidenceStatus::Admitted
     );
+}
 
+#[test]
+fn library_api_evidence_resolution_accepts_free_function_builtin_callees() {
+    let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));
     let callee = b.add(
         NodeKind::Var,
@@ -892,17 +883,14 @@ fn library_api_evidence_resolution_accepts_free_name_and_require_backed_callees(
         &[0],
     ));
     assert_eq!(
-        library_api_contract_evidence_for_call(
-            &il,
-            &interner,
-            call,
-            contract.id,
-            contract.callee,
-            1,
-        ),
+        contract_status_for_call(&il, &interner, call, contract.id, contract.callee),
         LibraryApiEvidenceStatus::Admitted
     );
+}
 
+#[test]
+fn library_api_evidence_resolution_accepts_require_backed_callees() {
+    let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));
     let require_callee = b.add(
         NodeKind::Var,
@@ -983,14 +971,7 @@ fn library_api_evidence_resolution_accepts_free_name_and_require_backed_callees(
         &[0, 2],
     ));
     assert_eq!(
-        library_api_contract_evidence_for_call(
-            &il,
-            &interner,
-            call,
-            contract.id,
-            contract.callee,
-            1,
-        ),
+        contract_status_for_call(&il, &interner, call, contract.id, contract.callee),
         LibraryApiEvidenceStatus::Admitted
     );
 }

--- a/crates/nose-semantics/src/tests/semantic_evidence.rs
+++ b/crates/nose-semantics/src/tests/semantic_evidence.rs
@@ -98,6 +98,10 @@ fn domain_evidence_preserves_param_semantic_boundaries() {
         domain_evidence_from_param_semantic(ParamSemantic::Result),
         DomainEvidence::Result
     );
+}
+
+#[test]
+fn domain_evidence_predicates_match_domain_families() {
     assert!(DomainEvidence::Array.is_array_collection_or_set());
     assert!(DomainEvidence::Boolean.is_boolean());
     assert!(DomainEvidence::Collection.is_array_or_collection());
@@ -116,6 +120,10 @@ fn domain_evidence_preserves_param_semantic_boundaries() {
     assert!(DomainEvidence::PromiseLike.is_promise_like());
     assert!(DomainEvidence::Record.is_record());
     assert!(DomainEvidence::Result.is_result());
+}
+
+#[test]
+fn scalar_domain_evidence_predicates_keep_numeric_axes_separate() {
     assert!(DomainEvidence::String.is_string());
     assert!(DomainEvidence::ByteArray.is_byte_array());
     assert!(DomainEvidence::Integer.is_integer());
@@ -125,6 +133,10 @@ fn domain_evidence_preserves_param_semantic_boundaries() {
     assert!(!DomainEvidence::Number.is_integer());
     assert!(!DomainEvidence::Array.is_collection_or_set());
     assert!(!DomainEvidence::Set.is_array_or_collection());
+}
+
+#[test]
+fn domain_requirements_accept_matching_evidence() {
     assert!(DomainRequirement::Boolean.accepts(DomainEvidence::Boolean));
     assert!(DomainRequirement::CollectionOrMap.accepts(DomainEvidence::Array));
     assert!(DomainRequirement::CollectionOrMap.accepts(DomainEvidence::Map));
@@ -141,6 +153,10 @@ fn domain_evidence_preserves_param_semantic_boundaries() {
     .accepts(DomainEvidence::Nominal {
         type_hash: stable_symbol_hash("pkg.Widget")
     }));
+}
+
+#[test]
+fn domain_requirements_reject_mismatches_and_map_value_domains() {
     assert!(DomainRequirement::Number.accepts(DomainEvidence::Float));
     assert!(DomainRequirement::Record.accepts(DomainEvidence::Record));
     assert!(DomainRequirement::Result.accepts(DomainEvidence::Result));
@@ -205,7 +221,10 @@ fn type_domain_contracts_are_language_scoped_and_exact_enough() {
         type_domain_from_source_text(Lang::TypeScript, "xs: Blacklist<string>"),
         None
     );
+}
 
+#[test]
+fn type_domain_contracts_cover_java_rust_c_and_go_signatures() {
     assert_eq!(
         type_domain_from_source_text(Lang::Java, "@Nonnull List<String> xs"),
         Some(DomainEvidence::Collection)
@@ -269,7 +288,10 @@ fn type_domain_contracts_are_language_scoped_and_exact_enough() {
         type_domain_from_source_text(Lang::Go, "type User struct { id int }"),
         Some(DomainEvidence::Record)
     );
+}
 
+#[test]
+fn python_stdlib_type_domain_rows_are_module_scoped() {
     let iterable = python_stdlib_type_domain_contract("typing", "Iterable")
         .expect("typing.Iterable should be a first-party pack row");
     assert_eq!(iterable.pack_id, PYTHON_STDLIB_TYPE_DOMAIN_PACK_ID);
@@ -955,7 +977,10 @@ fn sequence_surface_contracts_keep_value_and_exact_axes_separate() {
     assert!(object.exact_tree_safe);
     assert!(!object.membership_collection);
     assert!(object.imported_literal);
+}
 
+#[test]
+fn go_sequence_surface_contracts_stay_language_scoped() {
     let go_map = seq_surface_contract(Lang::Go, Some("composite_literal")).unwrap();
     assert_eq!(
         go_map.value_tag,


### PR DESCRIPTION
## Summary
- Ratchet `cognitive-complexity-threshold` from 65 to **20** (below clippy's default 25) and `too-many-lines-threshold` from 400 to **100** (clippy's default) in `clippy.toml`.
- Resolve all **105** violations at the new thresholds (22 cognitive-complexity, 83 too-many-lines) with behavior-preserving extraction — no logic changes, no public API changes (`+pub fn` count in the diff: 0).
- Production code (52 violations): the big dispatchers — `value_graph/eval.rs::eval_inner` (383 lines, cc 63), `value_graph/control.rs::process_loop` (271, cc 46), `canonicalize.rs::mk` (183, cc 44), `main.rs::cmd_verify` (333, cc 45), the per-language frontend `lower_expr` functions, the `library_api` contract matchers — are split into private per-construct helpers with verbatim bodies. Zero `#[allow]` escapes in production code.
- Test code (53 violations): 39 refactored (shared scaffolding helpers, multi-case `#[test]` splits with all fixture snippets and assertion messages byte-identical); 14 coherent broad fixture matrices keep their size with the justified `#[allow(clippy::too_many_lines)]` pattern established in #176.

## Baseline Notes
- `too_many_lines` at the default 100-line threshold reported 83 functions before this PR; now 0 (plus the 14 justified fixture-matrix allows).
- The workspace's worst function (`eval_inner`, cc 63) is now a thin dispatcher over per-node-kind helpers.
- Duplication gate (nose on itself): unchanged at 23/23 substantial families — the extractions introduced no new near-duplicate families.
- Line coverage after the change: 87.35% (floor 86) — up from 87.19%, since the test splits exercise more paths independently.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings` (clean at the new thresholds)
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace`
- `cargo build --release` + `cargo test --release` (full suite green, incl. equivalence/determinism)
- `./scripts/check-duplication.sh` → 23/23 OK
- `cargo llvm-cov --workspace --summary-only --fail-under-lines 86` → pass (87.35%)
- `python3 scripts/check-formal-obligations.py` → 21 obligations, pass (no proof-sensitive markers moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)