### PR TITLE
[codex] Cache imported occurrence validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ break.
   nodes/records and are now lazy per-file indexes. A 246 KB minified JS file
   went from 227 s to ≈ 2 s in normalize+extract (~118×), and ordinary repos get
   ~3× faster normalize+extract. Profiler-driven (`sample` + `NOSE_TIME=1`).
+- Large Java test files with many imported API occurrences no longer spend
+  minutes revalidating the same import-shadow proof. Imported occurrence
+  validation now reuses a per-file function/local-shadow cache; the
+  `commons-lang` semantic scan outlier went from ≈119 s to <1 s in
+  normalize+extract, with identical family ids.
 
 ### Removed
 - Pre-release compat shims: `seq_surface_contract_evidence_for_node`,

--- a/crates/nose-normalize/src/call_target_evidence.rs
+++ b/crates/nose-normalize/src/call_target_evidence.rs
@@ -9,7 +9,10 @@ use nose_il::{
     EvidenceProvenance, EvidenceRecord, EvidenceStatus, Il, Interner, LoopKind, NodeId, NodeKind,
     Payload, Symbol, SymbolEvidenceKind, UnitKind,
 };
-use nose_semantics::{imported_occurrence_symbol_dependencies_valid, FIRST_PARTY_PACK_ID};
+use nose_semantics::{
+    imported_occurrence_symbol_dependencies_valid_with_cache, ImportedOccurrenceValidationCache,
+    FIRST_PARTY_PACK_ID,
+};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 const DIRECT_FUNCTION_RULE: &str = "normalize.call_target.direct_function";
@@ -80,8 +83,9 @@ pub(crate) fn run(il: &mut Il, interner: &Interner) {
             Vec::new(),
         );
     }
+    let mut imported_occurrence_cache = ImportedOccurrenceValidationCache::default();
     for call in calls {
-        record_imported_call_target(il, interner, call);
+        record_imported_call_target(il, interner, call, &mut imported_occurrence_cache);
     }
 }
 
@@ -290,7 +294,12 @@ fn collect_call_nodes(il: &Il, node: NodeId, out: &mut Vec<NodeId>) {
     }
 }
 
-fn record_imported_call_target(il: &mut Il, interner: &Interner, call: NodeId) {
+fn record_imported_call_target(
+    il: &mut Il,
+    interner: &Interner,
+    call: NodeId,
+    cache: &mut ImportedOccurrenceValidationCache,
+) {
     if il.kind(call) != NodeKind::Call || !matches!(il.node(call).payload, Payload::None) {
         return;
     }
@@ -299,7 +308,7 @@ fn record_imported_call_target(il: &mut Il, interner: &Interner, call: NodeId) {
     };
     match il.kind(callee) {
         NodeKind::Var => {
-            if let Some(target) = imported_function_target(il, interner, callee) {
+            if let Some(target) = imported_function_target(il, interner, callee, cache) {
                 il.find_or_push_first_party_evidence(
                     EvidenceAnchor::node(il.node(call).span, NodeKind::Call),
                     EvidenceKind::CallTarget(CallTargetEvidenceKind::ImportedFunction {
@@ -314,7 +323,7 @@ fn record_imported_call_target(il: &mut Il, interner: &Interner, call: NodeId) {
             }
         }
         NodeKind::Field => {
-            if let Some(target) = imported_member_target(il, interner, callee) {
+            if let Some(target) = imported_member_target(il, interner, callee, cache) {
                 il.find_or_push_first_party_evidence(
                     EvidenceAnchor::node(il.node(call).span, NodeKind::Call),
                     EvidenceKind::CallTarget(CallTargetEvidenceKind::ImportedMember {
@@ -336,6 +345,7 @@ fn imported_function_target(
     il: &mut Il,
     interner: &Interner,
     callee: NodeId,
+    cache: &mut ImportedOccurrenceValidationCache,
 ) -> Option<ImportedFunctionTarget> {
     let local_hash = node_name_hash(il, interner, callee)?;
     let (symbol, binding_dependency) =
@@ -347,8 +357,14 @@ fn imported_function_target(
     else {
         return None;
     };
-    let dependency =
-        upsert_valid_imported_symbol_occurrence(il, interner, callee, symbol, binding_dependency)?;
+    let dependency = upsert_valid_imported_symbol_occurrence(
+        il,
+        interner,
+        callee,
+        symbol,
+        binding_dependency,
+        cache,
+    )?;
     Some(ImportedFunctionTarget {
         module_hash,
         exported_hash,
@@ -361,6 +377,7 @@ fn imported_member_target(
     il: &mut Il,
     interner: &Interner,
     callee: NodeId,
+    cache: &mut ImportedOccurrenceValidationCache,
 ) -> Option<ImportedMemberTarget> {
     let Payload::Name(member) = il.node(callee).payload else {
         return None;
@@ -378,6 +395,7 @@ fn imported_member_target(
         receiver,
         symbol,
         binding_dependency,
+        cache,
     )?;
     match symbol {
         SymbolEvidenceKind::ImportedBinding {
@@ -457,8 +475,9 @@ fn upsert_valid_imported_symbol_occurrence(
     node: NodeId,
     symbol: SymbolEvidenceKind,
     binding_dependency: EvidenceId,
+    cache: &mut ImportedOccurrenceValidationCache,
 ) -> Option<EvidenceId> {
-    if !imported_symbol_occurrence_can_be_upserted(il, interner, node, symbol) {
+    if !imported_symbol_occurrence_can_be_upserted(il, interner, node, symbol, cache) {
         return None;
     }
     let rule = match symbol {
@@ -481,7 +500,9 @@ fn upsert_valid_imported_symbol_occurrence(
         dependencies: dependencies.clone(),
         status: EvidenceStatus::Asserted,
     };
-    if !imported_occurrence_symbol_dependencies_valid(il, interner, &candidate, symbol) {
+    if !imported_occurrence_symbol_dependencies_valid_with_cache(
+        il, interner, &candidate, symbol, cache,
+    ) {
         return None;
     }
     let id =
@@ -494,6 +515,7 @@ fn imported_symbol_occurrence_can_be_upserted(
     interner: &Interner,
     node: NodeId,
     expected: SymbolEvidenceKind,
+    cache: &mut ImportedOccurrenceValidationCache,
 ) -> bool {
     let anchor = EvidenceAnchor::node(il.node(node).span, NodeKind::Var);
     for record in &il.evidence {
@@ -506,7 +528,9 @@ fn imported_symbol_occurrence_can_be_upserted(
         if record.status != EvidenceStatus::Asserted
             || actual != expected
             || !il.evidence_dependencies_asserted(record)
-            || !imported_occurrence_symbol_dependencies_valid(il, interner, record, expected)
+            || !imported_occurrence_symbol_dependencies_valid_with_cache(
+                il, interner, record, expected, cache,
+            )
         {
             return false;
         }
@@ -1030,6 +1054,53 @@ mod tests {
             Vec::new(),
             Vec::new(),
         );
+        il.evidence.push(binding_symbol(
+            0,
+            sp(1),
+            "p",
+            SymbolEvidenceKind::ImportedBinding {
+                module_hash: stable_symbol_hash("math"),
+                exported_hash: stable_symbol_hash("prod"),
+            },
+            EvidenceStatus::Asserted,
+        ));
+
+        run(&mut il, &interner);
+
+        assert_eq!(call_target_evidence_at_call(&il, &interner, call), None);
+        assert!(!il.evidence.iter().any(|record| {
+            record.anchor == EvidenceAnchor::node(wide_sp(30, 31), NodeKind::Var)
+                && matches!(record.kind, EvidenceKind::Symbol(_))
+        }));
+    }
+
+    #[test]
+    fn does_not_emit_imported_function_target_when_parameter_shadows_alias() {
+        let interner = Interner::new();
+        let p = interner.intern("p");
+        let mut b = IlBuilder::new(FileId(0));
+        let param = b.add(NodeKind::Param, Payload::Cid(0), wide_sp(10, 11), &[]);
+        let callee = b.add(NodeKind::Var, Payload::Cid(0), wide_sp(30, 31), &[]);
+        let call = b.add(NodeKind::Call, Payload::None, wide_sp(31, 32), &[callee]);
+        let ret = b.add(NodeKind::Return, Payload::None, wide_sp(31, 33), &[call]);
+        let body = b.add(NodeKind::Block, Payload::None, wide_sp(20, 40), &[ret]);
+        let func = b.add(
+            NodeKind::Func,
+            Payload::None,
+            wide_sp(8, 50),
+            &[param, body],
+        );
+        let module = b.add(NodeKind::Module, Payload::None, wide_sp(0, 60), &[func]);
+        let mut il = b.finish(
+            module,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        il.cid_names = vec![p];
         il.evidence.push(binding_symbol(
             0,
             sp(1),

--- a/crates/nose-semantics/src/library_api.rs
+++ b/crates/nose-semantics/src/library_api.rs
@@ -214,6 +214,20 @@ pub struct LibraryApiDependencyCache {
     name_assigned_in_scope: FxHashMap<(NodeId, Symbol), bool>,
 }
 
+#[derive(Default)]
+pub struct ImportedOccurrenceValidationCache {
+    function_spans: Option<Vec<Span>>,
+    function_span_by_span: FxHashMap<Span, Option<Span>>,
+    var_cid_by_span: FxHashMap<Span, Option<u32>>,
+    local_shadows_by_function: Option<FxHashMap<Span, LocalShadowIndex>>,
+}
+
+#[derive(Default)]
+struct LocalShadowIndex {
+    by_cid: FxHashMap<u32, Vec<Span>>,
+    raw_assign_by_hash: FxHashMap<u64, Vec<Span>>,
+}
+
 pub fn library_api_receiver_dependencies_for_call_with_cache(
     il: &Il,
     interner: &Interner,
@@ -2627,6 +2641,23 @@ pub fn imported_occurrence_symbol_dependencies_valid(
     symbol_record: &EvidenceRecord,
     expected: SymbolEvidenceKind,
 ) -> bool {
+    let mut cache = ImportedOccurrenceValidationCache::default();
+    imported_occurrence_symbol_dependencies_valid_with_cache(
+        il,
+        interner,
+        symbol_record,
+        expected,
+        &mut cache,
+    )
+}
+
+pub fn imported_occurrence_symbol_dependencies_valid_with_cache(
+    il: &Il,
+    interner: &Interner,
+    symbol_record: &EvidenceRecord,
+    expected: SymbolEvidenceKind,
+    cache: &mut ImportedOccurrenceValidationCache,
+) -> bool {
     let EvidenceAnchor::Node {
         span: occurrence_span,
         kind: NodeKind::Var,
@@ -2662,8 +2693,14 @@ pub fn imported_occurrence_symbol_dependencies_valid(
     if !binding_has_no_visible_conflicting_assignment(il, interner, local_hash, binding_span) {
         return false;
     }
-    if !binding_has_no_visible_local_shadow(il, interner, local_hash, binding_span, occurrence_span)
-    {
+    if !binding_has_no_visible_local_shadow_with_cache(
+        il,
+        interner,
+        local_hash,
+        binding_span,
+        occurrence_span,
+        cache,
+    ) {
         return false;
     }
     binding_symbol_evidence_consistent_for_local(il, local_hash, expected)
@@ -2681,48 +2718,121 @@ fn binding_has_no_visible_conflicting_assignment(
         .all(|stmt| il.node(stmt).span == binding_span)
 }
 
-fn binding_has_no_visible_local_shadow(
+fn binding_has_no_visible_local_shadow_with_cache(
     il: &Il,
     interner: &Interner,
     local_hash: u64,
     binding_span: Span,
     occurrence_span: Span,
+    cache: &mut ImportedOccurrenceValidationCache,
 ) -> bool {
-    let Some(function_span) = innermost_enclosing_function_span(il, occurrence_span) else {
+    let Some(function_span) =
+        innermost_enclosing_function_span_with_cache(il, occurrence_span, cache)
+    else {
         return true;
     };
-    let occurrence_cid = var_cid_at_span(il, occurrence_span);
-    !il.nodes.iter().enumerate().any(|(idx, node)| {
-        let node_id = NodeId(idx as u32);
-        if !span_contains(function_span, node.span)
-            || node.span == binding_span
-            || node.span.start_byte > occurrence_span.start_byte
-            || innermost_enclosing_function_span(il, node.span) != Some(function_span)
-        {
-            return false;
-        }
-        match node.kind {
-            NodeKind::Param => node_cid(il, node_id)
-                .zip(occurrence_cid)
-                .is_some_and(|(param_cid, occurrence_cid)| param_cid == occurrence_cid),
-            NodeKind::Assign => {
-                assignment_lhs_cid(il, node_id)
-                    .zip(occurrence_cid)
-                    .is_some_and(|(lhs_cid, occurrence_cid)| lhs_cid == occurrence_cid)
-                    || assignment_lhs_raw_name_hash(il, interner, node_id) == Some(local_hash)
-            }
-            _ => false,
-        }
-    })
+    let occurrence_cid = var_cid_at_span_with_cache(il, occurrence_span, cache);
+    let indexes = local_shadow_indexes(il, interner, cache);
+    let Some(index) = indexes.get(&function_span) else {
+        return true;
+    };
+    let visible_before_occurrence =
+        |span: &Span| *span != binding_span && span.start_byte <= occurrence_span.start_byte;
+    if occurrence_cid.is_some_and(|cid| {
+        index
+            .by_cid
+            .get(&cid)
+            .is_some_and(|spans| spans.iter().any(visible_before_occurrence))
+    }) {
+        return false;
+    }
+    !index
+        .raw_assign_by_hash
+        .get(&local_hash)
+        .is_some_and(|spans| spans.iter().any(visible_before_occurrence))
 }
 
-fn innermost_enclosing_function_span(il: &Il, span: Span) -> Option<Span> {
-    il.nodes
+fn innermost_enclosing_function_span_with_cache(
+    il: &Il,
+    span: Span,
+    cache: &mut ImportedOccurrenceValidationCache,
+) -> Option<Span> {
+    if let Some(cached) = cache.function_span_by_span.get(&span) {
+        return *cached;
+    }
+    let function_spans = cache.function_spans.get_or_insert_with(|| {
+        il.nodes
+            .iter()
+            .filter_map(|node| (node.kind == NodeKind::Func).then_some(node.span))
+            .collect()
+    });
+    let result = function_spans
         .iter()
-        .filter_map(|node| {
-            (node.kind == NodeKind::Func && span_contains(node.span, span)).then_some(node.span)
-        })
-        .min_by_key(|span| span.end_byte.saturating_sub(span.start_byte))
+        .copied()
+        .filter(|function_span| span_contains(*function_span, span))
+        .min_by_key(|span| span.end_byte.saturating_sub(span.start_byte));
+    cache.function_span_by_span.insert(span, result);
+    result
+}
+
+fn var_cid_at_span_with_cache(
+    il: &Il,
+    span: Span,
+    cache: &mut ImportedOccurrenceValidationCache,
+) -> Option<u32> {
+    if let Some(cached) = cache.var_cid_by_span.get(&span) {
+        return *cached;
+    }
+    let result = var_cid_at_span(il, span);
+    cache.var_cid_by_span.insert(span, result);
+    result
+}
+
+fn local_shadow_indexes<'a>(
+    il: &Il,
+    interner: &Interner,
+    cache: &'a mut ImportedOccurrenceValidationCache,
+) -> &'a FxHashMap<Span, LocalShadowIndex> {
+    if cache.local_shadows_by_function.is_none() {
+        let mut indexes: FxHashMap<Span, LocalShadowIndex> = FxHashMap::default();
+        for (idx, node) in il.nodes.iter().enumerate() {
+            if !matches!(node.kind, NodeKind::Param | NodeKind::Assign) {
+                continue;
+            }
+            let node_id = NodeId(idx as u32);
+            let Some(function_span) =
+                innermost_enclosing_function_span_with_cache(il, node.span, cache)
+            else {
+                continue;
+            };
+            let index = indexes.entry(function_span).or_default();
+            match node.kind {
+                NodeKind::Param => {
+                    if let Some(cid) = node_cid(il, node_id) {
+                        index.by_cid.entry(cid).or_default().push(node.span);
+                    }
+                }
+                NodeKind::Assign => {
+                    if let Some(cid) = assignment_lhs_cid(il, node_id) {
+                        index.by_cid.entry(cid).or_default().push(node.span);
+                    }
+                    if let Some(hash) = assignment_lhs_raw_name_hash(il, interner, node_id) {
+                        index
+                            .raw_assign_by_hash
+                            .entry(hash)
+                            .or_default()
+                            .push(node.span);
+                    }
+                }
+                _ => {}
+            }
+        }
+        cache.local_shadows_by_function = Some(indexes);
+    }
+    cache
+        .local_shadows_by_function
+        .as_ref()
+        .expect("local shadow indexes initialized")
 }
 
 fn var_cid_at_span(il: &Il, span: Span) -> Option<u32> {

--- a/docs/field-evaluation.md
+++ b/docs/field-evaluation.md
@@ -169,3 +169,19 @@ Two substantive findings came out of this pass:
 
 The practical advice stands: scan source roots, not build output — but a
 committed bundle must degrade gracefully, and now it does.
+
+## Fourth pass follow-up — imported call-target proof cache
+
+The 105-repo bench corpus pass exposed a second real-world performance cliff:
+`commons-lang` scanned 620 files, but one large Java test file
+(`ArrayUtilsTest.java`) made `normalize+extract` take **≈119 s** while
+parse/lower and detector clustering stayed below 0.1 s and 0.02 s respectively.
+Sampler output showed almost all CPU under imported call-target occurrence
+validation, repeatedly proving that the same imported binding was still visible
+and not locally shadowed.
+
+Imported occurrence validation now reuses a per-file function/local-shadow cache.
+The same `commons-lang` semantic scan runs `normalize+extract` in **<1 s** with
+identical family ids; the single pathological `ArrayUtilsTest.java` scan dropped
+from **≈119 s** to **≈0.8 s**. This keeps the semantic-kernel fail-closed proof
+policy intact while removing the quadratic proof-validation shape.


### PR DESCRIPTION
Closes #183.

## Summary
- Reuse a per-file imported occurrence validation cache for function-span and local-shadow checks.
- Thread that cache through imported call-target evidence extraction while preserving the fail-closed one-shot API.
- Add a regression test for a function parameter shadowing an imported alias, and document the field-evaluation result.

## Root cause
`commons-lang` was dominated by repeated imported call-target occurrence validation. The pathological file was `ArrayUtilsTest.java`: parse/lower and clustering were small, but `normalize+extract` spent about 119s repeatedly proving the same imported binding visibility and local-shadow facts.

## Result
- `ArrayUtilsTest.java`: `normalize+extract` 118.8s before -> 768.6ms after.
- Full `commons-lang` corpus, 620 files: `normalize+extract` about 119s before -> 840.8ms after.
- Family ids and `semantic_packs` are unchanged versus the pre-fix JSON baseline.

## Validation
- `./scripts/check-ci-local.sh --fast`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --quiet`
- `cargo test --release`
- `./scripts/check-duplication.sh`
- `NOSE_TIME=1 target/release/nose scan /Users/ak/prjs/cc/nose/bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java --mode semantic --format json --top 0`
- `NOSE_TIME=1 target/release/nose scan /Users/ak/prjs/cc/nose/bench/repos/commons-lang --mode semantic --format json --top 0`
- `jq`/`diff` comparison of family ids and `semantic_packs` against `/tmp/nose-semantic-eval-current-517ad5c/commons-lang.json`