### PR TITLE
[codex] Expose scan JSON surface counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ break.
   negatives: `x ?? d` / `x == null ? d : x` stay separate from `x === null ? d :
   x`, and loose `!= null` object guards stay out of the strict non-null object
   guard family.
+- Scan JSON `ranking` now includes `surface_counts`, a pre-`--top` breakdown of
+  `default`, `review`, `hidden`, and `debug` families plus the same breakdown for
+  exact-fragment families. This makes the human-action surface explicit for
+  integrations that should filter `recommended_surface == "default"`.
 
 ### Performance
 - Minified-bundle-sized files no longer hit a quadratic cliff: `nearest_scope`

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -1007,6 +1007,63 @@ struct ScanJsonRanking {
     total_families: usize,
     shown_families: usize,
     limit: Option<usize>,
+    surface_counts: ScanJsonSurfaceCounts,
+}
+
+#[derive(Default, serde::Serialize)]
+struct ScanJsonSurfaceCounts {
+    #[serde(rename = "default")]
+    default_count: usize,
+    review: usize,
+    hidden: usize,
+    debug: usize,
+    fragments: ScanJsonFragmentSurfaceCounts,
+}
+
+#[derive(Default, serde::Serialize)]
+struct ScanJsonFragmentSurfaceCounts {
+    total: usize,
+    #[serde(rename = "default")]
+    default_count: usize,
+    review: usize,
+    hidden: usize,
+    debug: usize,
+}
+
+impl ScanJsonSurfaceCounts {
+    fn from_families(families: &[nose_detect::RefactorFamily]) -> Self {
+        let mut counts = Self::default();
+        for family in families {
+            counts.bump(family.recommended_surface());
+            if family.locations.iter().any(|loc| loc.is_fragment) {
+                counts.fragments.total += 1;
+                counts.fragments.bump(family.recommended_surface());
+            }
+        }
+        counts
+    }
+
+    fn bump(&mut self, surface: &str) {
+        match surface {
+            "default" => self.default_count += 1,
+            "review" => self.review += 1,
+            "hidden" => self.hidden += 1,
+            "debug" => self.debug += 1,
+            _ => self.debug += 1,
+        }
+    }
+}
+
+impl ScanJsonFragmentSurfaceCounts {
+    fn bump(&mut self, surface: &str) {
+        match surface {
+            "default" => self.default_count += 1,
+            "review" => self.review += 1,
+            "hidden" => self.hidden += 1,
+            "debug" => self.debug += 1,
+            _ => self.debug += 1,
+        }
+    }
 }
 
 #[derive(serde::Serialize)]
@@ -1096,6 +1153,7 @@ impl<'a> ScanJsonReport<'a> {
                 total_families: input.families.len(),
                 shown_families: input.shown.len(),
                 limit: (input.top != 0).then_some(input.top),
+                surface_counts: ScanJsonSurfaceCounts::from_families(input.families),
             },
             baseline: input.baseline.map(|b| &b.summary),
             ignore: input

--- a/crates/nose-cli/tests/cli/output_contract.rs
+++ b/crates/nose-cli/tests/cli/output_contract.rs
@@ -27,6 +27,10 @@ fn scan_json_report_has_versioned_contract() {
     assert_eq!(json["ranking"]["sort"], "extractability");
     assert_eq!(json["ranking"]["shown_families"], 1);
     assert_eq!(json["ranking"]["limit"], 1);
+    assert_eq!(json["ranking"]["surface_counts"]["default"], 1);
+    assert_eq!(json["ranking"]["surface_counts"]["review"], 0);
+    assert_eq!(json["ranking"]["surface_counts"]["hidden"], 0);
+    assert_eq!(json["ranking"]["surface_counts"]["fragments"]["total"], 0);
     let _ = fs::remove_dir_all(&dir);
 }
 
@@ -47,6 +51,10 @@ fn scan_json_exposes_exact_fragment_metadata() {
         "1",
     ]);
     let json = scan_json(&out);
+    assert_eq!(json["ranking"]["surface_counts"]["default"], 0);
+    assert_eq!(json["ranking"]["surface_counts"]["hidden"], 1);
+    assert_eq!(json["ranking"]["surface_counts"]["fragments"]["total"], 1);
+    assert_eq!(json["ranking"]["surface_counts"]["fragments"]["hidden"], 1);
     let family = scan_families(&json)
         .iter()
         .find(|family| family["recommended_surface"] == "hidden")

--- a/crates/nose-cli/tests/cli/support.rs
+++ b/crates/nose-cli/tests/cli/support.rs
@@ -217,9 +217,16 @@ pub(crate) fn assert_scan_json_v1_contract(json: &serde_json::Value) {
     }
 
     let ranking = json["ranking"].as_object().expect("ranking object");
-    for key in ["sort", "total_families", "shown_families", "limit"] {
+    for key in [
+        "sort",
+        "total_families",
+        "shown_families",
+        "limit",
+        "surface_counts",
+    ] {
         assert!(ranking.contains_key(key), "ranking.{key} missing: {json}");
     }
+    assert_scan_json_surface_counts_contract(json, ranking);
 
     let family = scan_families(json)
         .first()
@@ -264,5 +271,29 @@ pub(crate) fn assert_scan_json_v1_contract(json: &serde_json::Value) {
         "is_fragment",
     ] {
         assert!(loc.contains_key(key), "location.{key} missing: {json}");
+    }
+}
+
+fn assert_scan_json_surface_counts_contract(
+    json: &serde_json::Value,
+    ranking: &serde_json::Map<String, serde_json::Value>,
+) {
+    let surface_counts = ranking["surface_counts"]
+        .as_object()
+        .expect("ranking.surface_counts object");
+    for key in ["default", "review", "hidden", "debug", "fragments"] {
+        assert!(
+            surface_counts.contains_key(key),
+            "ranking.surface_counts.{key} missing: {json}"
+        );
+    }
+    let fragment_counts = surface_counts["fragments"]
+        .as_object()
+        .expect("ranking.surface_counts.fragments object");
+    for key in ["total", "default", "review", "hidden", "debug"] {
+        assert!(
+            fragment_counts.contains_key(key),
+            "ranking.surface_counts.fragments.{key} missing: {json}"
+        );
     }
 }

--- a/crates/nose-cli/tests/fixtures/scan-json-v1.json
+++ b/crates/nose-cli/tests/fixtures/scan-json-v1.json
@@ -84,7 +84,20 @@
     "sort": "extractability",
     "total_families": 1,
     "shown_families": 1,
-    "limit": 30
+    "limit": 30,
+    "surface_counts": {
+      "default": 1,
+      "review": 0,
+      "hidden": 0,
+      "debug": 0,
+      "fragments": {
+        "total": 0,
+        "default": 0,
+        "review": 0,
+        "hidden": 0,
+        "debug": 0
+      }
+    }
   },
   "families": [
     {

--- a/docs/field-evaluation.md
+++ b/docs/field-evaluation.md
@@ -199,3 +199,22 @@ third-party repositories. The fixtures run `nose scan --mode semantic` over smal
 JavaScript projects and assert that the exact semantic channel keeps
 loose-nullish and strict-null families separate while preserving the positive
 families on each side.
+
+## Fourth pass follow-up — diagnostic surface volume
+
+The 18-repo semantic sample intentionally used `--format json --top 0`, so it
+captured diagnostic families as well as the default human action surface. The
+current output shape was:
+
+- 940 semantic families total;
+- 277 `recommended_surface = "default"` families;
+- 48 `review` families;
+- 615 `hidden` families;
+- 657 families with at least one exact fragment location.
+
+That hidden/review volume is expected: exact fragments are proof and review
+substrate, not automatically top-level refactoring recommendations. The
+integration contract now makes that explicit by documenting
+`recommended_surface == "default"` as the human-action filter and by emitting
+`ranking.surface_counts`, including a nested exact-fragment breakdown, before
+`--top` truncation.

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -72,7 +72,20 @@ The top-level value is always an object:
     "sort": "extractability",
     "total_families": 12,
     "shown_families": 10,
-    "limit": 10
+    "limit": 10,
+    "surface_counts": {
+      "default": 4,
+      "review": 1,
+      "hidden": 7,
+      "debug": 0,
+      "fragments": {
+        "total": 8,
+        "default": 1,
+        "review": 1,
+        "hidden": 6,
+        "debug": 0
+      }
+    }
   },
   "ignore": {
     "path": "nose.ignore.json",
@@ -102,9 +115,17 @@ omitted from the default human, Markdown, SARIF, and `--fail-on` surfaces: hidde
 proof-only fragments, review-surface fragments, and families wholly inside files with
 generated-code headers. It is not raw detector output: families wholly in
 vendored/generated-looking paths may already have been pruned before serialization.
-Consumers that want the same first-screen surface as humans should filter for
-`recommended_surface == "default"` and drop generated-header files according to their own
-source metadata.
+
+**Consumer rule:** integrations that want the same first-screen human action surface should
+filter `families[]` to `recommended_surface == "default"` and drop generated-header files
+according to their own source metadata. Treat `review` and `hidden` as diagnostic surfaces:
+useful for audits, review-hazard tooling, and regression checks, but not default
+refactoring recommendations.
+
+`ranking.surface_counts` gives the active post-filter family counts by
+`recommended_surface` before `--top` truncation. The nested `fragments` object repeats the
+same breakdown for families with at least one exact fragment location. That makes a
+`--top 0` diagnostic run easy to summarize without scanning every location first.
 
 ## Top-level fields
 
@@ -119,6 +140,7 @@ source metadata.
 | `ranking.total_families` | integer | Active families remaining after rank-time pruning, filters, baseline suppression, and structured ignores, before `--top`. |
 | `ranking.shown_families` | integer | Families present in `families`. |
 | `ranking.limit` | integer or null | The `--top` limit; `null` means `--top 0` showed every family. |
+| `ranking.surface_counts` | object | Active family counts by `recommended_surface` before `--top`: `default`, `review`, `hidden`, `debug`, plus `fragments.total/default/review/hidden/debug` for families with exact fragment locations. |
 | `baseline` | object, optional | Baseline comparison summary when `--baseline` is active. |
 | `ignore` | object, optional | Structured ignore summary when an ignore file was read. |
 | `families` | array | Active ranked clone families in JSON order, including diagnostic review/hidden families. Empty means no family survived the filters, baseline, and structured ignores. |
@@ -217,7 +239,7 @@ schema version 1:
 | `mean_sem` | number | Mean value-graph size across members. |
 | `scope` | string | `prod`, `test`, or `mixed` test/production classification. |
 | `discount` | number | Refactor-worthiness discount for generated or type-heavy families. |
-| `recommended_surface` | string | Product placement hint. Current detector output uses `default`, `review`, or `hidden`; `debug` is reserved for diagnostics/regression tooling. This is ranking/presentation policy, not detector exactness. |
+| `recommended_surface` | string | Product placement hint. Current detector output uses `default`, `review`, or `hidden`; `debug` is reserved for diagnostics/regression tooling. Human-action integrations should keep `default` and treat the others as diagnostic/review surfaces. This is ranking/presentation policy, not detector exactness. |
 | `baseline_status` | string, optional | `new` or `changed` when this family is shown because of `--baseline`. |
 | `abstraction_witness` | object, optional | Experimental weak-claim witness emitted only for `--mode abstraction` families that share a normalized template with one supported literal leaf hole. |
 | `semantic_laws` | array, optional | Deduped pack-facing law provenance for value-graph laws that actually rewrote or bridged this family. Current first-party rows include `pack_id`, `pack_hash`, `law_id`, `channel`, `proof_status`, and `proof_obligation_id`. External local LawPack manifests are `metadata-only` today and do not appear here unless future producer execution admits them through the kernel. |


### PR DESCRIPTION
Closes #184.

## Summary
- Add `ranking.surface_counts` to scan JSON with pre-`--top` counts for `default`, `review`, `hidden`, and `debug` families.
- Include a nested `fragments` breakdown so diagnostic exact-fragment volume is visible without walking every location.
- Update the v1 fixture and JSON contract tests to require the new additive field.
- Document the consumer rule: integrations that want the human action surface should filter `recommended_surface == "default"`; `review` and `hidden` remain diagnostic/review surfaces.
- Record the 18-repo audit counts in field-evaluation docs: 940 semantic families, 277 default, 48 review, 615 hidden, 657 fragment families.

## Validation
- `cargo test -p nose-cli --test cli output_contract -- --nocapture`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `./scripts/check-ci-local.sh --fast`