### PR TITLE
[codex] Audit fragment diagnostic surface quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ break.
   `default`, `review`, `hidden`, and `debug` families plus the same breakdown for
   exact-fragment families. This makes the human-action surface explicit for
   integrations that should filter `recommended_surface == "default"`.
+- A three-reviewer fragment-quality audit artifact for Java/Python hidden/review
+  exact-fragment families now records the criteria, votes, and policy decisions
+  behind the diagnostic-surface follow-up.
+
+### Changed
+- Tiny test-only exact-fragment scaffolding now stays on the hidden diagnostic surface
+  instead of the review surface: all-test fragments with enclosing context and mean span
+  ≤3 lines, plus all-test effect/body fragments up to 4 lines. Larger test setup
+  fragments remain available for review.
 
 ### Performance
 - Minified-bundle-sized files no longer hit a quadratic cliff: `nearest_scope`

--- a/bench/labels/README.md
+++ b/bench/labels/README.md
@@ -35,6 +35,13 @@ The labelset evolved v1 (235) → v2 (576, +heldout) → v3 (3,092) → v4 (4,61
 *precision* CIs (bounded by #repos×10, not #labels). v5 (§AU) settled the anti-unification
 re-rank as small-sample overfit (+1pp dev / −1pp heldout, Rust-only — **not shipped**).
 
+## Adjacent audit artifacts
+
+`fragment_quality_audit_2026_06_10.json` is not part of the v5 product metric. It is a
+small, three-reviewer audit of Java/Python hidden/review exact-fragment families used to
+validate surface policy after the semantic corpus pass. See
+[`docs/fragment-quality-audit-2026-06-10.md`](../../docs/fragment-quality-audit-2026-06-10.md).
+
 ## Scoring against it
 
 `eval_by_language.py` — per-language precision@10 + worthy-recall, dev/heldout split, with

--- a/bench/labels/fragment_quality_audit_2026_06_10.json
+++ b/bench/labels/fragment_quality_audit_2026_06_10.json
@@ -1,0 +1,789 @@
+{
+  "schema_version": "fragment-quality-audit.v1",
+  "audit_date": "2026-06-10",
+  "issue": "https://github.com/corca-ai/nose/issues/185",
+  "source": {
+    "historical_cache": "/tmp/nose-semantic-eval-current-517ad5c",
+    "selection": "Top five hidden/review exact-fragment families from each audited repo, preserving each repo JSON order.",
+    "repos": [
+      "bench/repos/commons-lang",
+      "bench/repos/retrofit",
+      "bench/repos/poetry",
+      "bench/repos/packaging"
+    ],
+    "scan_command_template": "nose scan bench/repos/<repo> --mode semantic --format json --top 0"
+  },
+  "label_schema": {
+    "useful_diagnostic": "Correct exact fragment with meaningful synchronization, refactor, or review signal.",
+    "acceptable_low_value": "Correct or plausible diagnostic fragment but too tiny, boilerplate, test-scaffold-like, or common to be default action output.",
+    "noise": "Misleading, duplicate bookkeeping artifact, incorrect, or should be pruned rather than merely hidden/review."
+  },
+  "labelers": [
+    {
+      "id": "A",
+      "stance": "general independent reviewer"
+    },
+    {
+      "id": "B",
+      "stance": "pragmatic maintainer, conservative about actionability"
+    },
+    {
+      "id": "C",
+      "stance": "integration/product reviewer focused on output-surface policy"
+    }
+  ],
+  "policy_summary": {
+    "consensus_counts": {
+      "useful_diagnostic": 2,
+      "acceptable_low_value": 15,
+      "noise": 3
+    },
+    "by_language": {
+      "java": {
+        "useful_diagnostic": 1,
+        "acceptable_low_value": 7,
+        "noise": 2
+      },
+      "python": {
+        "useful_diagnostic": 1,
+        "acceptable_low_value": 8,
+        "noise": 1
+      }
+    },
+    "by_original_surface": {
+      "review": {
+        "useful_diagnostic": 2,
+        "acceptable_low_value": 9,
+        "noise": 0
+      },
+      "hidden": {
+        "useful_diagnostic": 0,
+        "acceptable_low_value": 6,
+        "noise": 3
+      }
+    },
+    "decision": "Keep exact fragments as diagnostic JSON substrate and out of default action output. Demote tiny test-only scaffold fragments from review to hidden. Track repeated family_id collisions and one-line direct-return over-breadth as follow-up issues rather than broad-pruning semantic fragments."
+  },
+  "items": [
+    {
+      "id": "java-01",
+      "language": "java",
+      "repo": "commons-lang",
+      "rank_in_repo": 23,
+      "family_id": "7e6f9dad0acc00b9",
+      "original_recommended_surface": "hidden",
+      "fragment_kind": "conditional-guard",
+      "reason_code": "exact-conditional-guard",
+      "members": 13,
+      "files": 4,
+      "mean_lines": 3,
+      "shared_lines": 3,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+          "start_line": 6694,
+          "end_line": 6696,
+          "enclosing": "reverse"
+        },
+        {
+          "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+          "start_line": 6736,
+          "end_line": 6738,
+          "enclosing": "reverse"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "useful_diagnostic",
+        "C": "acceptable_low_value"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Keep hidden: correct overload null-guard substrate, but too small and routine for action output."
+    },
+    {
+      "id": "java-02",
+      "language": "java",
+      "repo": "commons-lang",
+      "rank_in_repo": 27,
+      "family_id": "b85f4b4a882e594d",
+      "original_recommended_surface": "review",
+      "fragment_kind": "self-field-body",
+      "reason_code": "exact-self-field-body",
+      "members": 4,
+      "files": 2,
+      "mean_lines": 4,
+      "shared_lines": 3,
+      "params": 1,
+      "representative_locations": [
+        {
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java",
+          "start_line": 181,
+          "end_line": 184,
+          "enclosing": "TestObjectEqualsExclude"
+        },
+        {
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java",
+          "start_line": 293,
+          "end_line": 296,
+          "enclosing": "TestRecursiveObject"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "acceptable_low_value",
+        "C": "acceptable_low_value"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Demote to hidden when test-only and tiny: fixture constructor assignment boilerplate."
+    },
+    {
+      "id": "java-03",
+      "language": "java",
+      "repo": "commons-lang",
+      "rank_in_repo": 30,
+      "family_id": "11cd7d3b0f9bdf57",
+      "original_recommended_surface": "hidden",
+      "fragment_kind": "direct-return",
+      "reason_code": "exact-direct-return",
+      "members": 10,
+      "files": 7,
+      "mean_lines": 2,
+      "shared_lines": 3,
+      "params": 1,
+      "representative_locations": [
+        {
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/function/FailableTest.java",
+          "start_line": 83,
+          "end_line": 83,
+          "enclosing": "inc"
+        },
+        {
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/function/FailableTest.java",
+          "start_line": 88,
+          "end_line": 88,
+          "enclosing": "incCnfe"
+        }
+      ],
+      "votes": {
+        "A": "noise",
+        "B": "acceptable_low_value",
+        "C": "noise"
+      },
+      "consensus": "noise",
+      "policy_decision": "Keep out of visible surfaces and investigate pruning: one-line direct-return fragments can be too generic and mix awkwardly with enclosing methods."
+    },
+    {
+      "id": "java-04",
+      "language": "java",
+      "repo": "commons-lang",
+      "rank_in_repo": 33,
+      "family_id": "272926fba0300285",
+      "original_recommended_surface": "hidden",
+      "fragment_kind": "conditional-guard",
+      "reason_code": "exact-conditional-guard",
+      "members": 9,
+      "files": 1,
+      "mean_lines": 3,
+      "shared_lines": 3,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+          "start_line": 3131,
+          "end_line": 3133,
+          "enclosing": "insert"
+        },
+        {
+          "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+          "start_line": 3172,
+          "end_line": 3174,
+          "enclosing": "insert"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "noise",
+        "C": "acceptable_low_value"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Keep hidden but flag stable-id risk: correct overload guard substrate shares family_id with other ArrayUtils families."
+    },
+    {
+      "id": "java-05",
+      "language": "java",
+      "repo": "commons-lang",
+      "rank_in_repo": 34,
+      "family_id": "272926fba0300285",
+      "original_recommended_surface": "hidden",
+      "fragment_kind": "conditional-guard",
+      "reason_code": "exact-conditional-guard",
+      "members": 9,
+      "files": 1,
+      "mean_lines": 3,
+      "shared_lines": 3,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+          "start_line": 7144,
+          "end_line": 7146,
+          "enclosing": "shift"
+        },
+        {
+          "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+          "start_line": 7214,
+          "end_line": 7216,
+          "enclosing": "shift"
+        }
+      ],
+      "votes": {
+        "A": "useful_diagnostic",
+        "B": "noise",
+        "C": "noise"
+      },
+      "consensus": "noise",
+      "policy_decision": "Track as stable-id collision before relying on JSON identity: distinct shift guard family shares java-04's family_id."
+    },
+    {
+      "id": "java-06",
+      "language": "java",
+      "repo": "retrofit",
+      "rank_in_repo": 1,
+      "family_id": "42196bd5241b8168",
+      "original_recommended_surface": "review",
+      "fragment_kind": "self-field-body",
+      "reason_code": "exact-self-field-body",
+      "members": 3,
+      "files": 3,
+      "mean_lines": 4,
+      "shared_lines": 4,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/retrofit/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/Result.java",
+          "start_line": 39,
+          "end_line": 42,
+          "enclosing": "Result"
+        },
+        {
+          "file": "bench/repos/retrofit/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/Result.java",
+          "start_line": 39,
+          "end_line": 42,
+          "enclosing": "Result"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "acceptable_low_value",
+        "C": "useful_diagnostic"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Keep review, not default: product-code module parity is plausible, but the fragment is mostly constructor assignment."
+    },
+    {
+      "id": "java-07",
+      "language": "java",
+      "repo": "retrofit",
+      "rank_in_repo": 2,
+      "family_id": "4beffc785dfefe42",
+      "original_recommended_surface": "review",
+      "fragment_kind": "self-field-body",
+      "reason_code": "exact-self-field-body",
+      "members": 2,
+      "files": 2,
+      "mean_lines": 11,
+      "shared_lines": 11,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/retrofit/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapter.java",
+          "start_line": 48,
+          "end_line": 58,
+          "enclosing": "RxJava2CallAdapter"
+        },
+        {
+          "file": "bench/repos/retrofit/retrofit-adapters/rxjava3/src/main/java/retrofit2/adapter/rxjava3/RxJava3CallAdapter.java",
+          "start_line": 48,
+          "end_line": 58,
+          "enclosing": "RxJava3CallAdapter"
+        }
+      ],
+      "votes": {
+        "A": "useful_diagnostic",
+        "B": "useful_diagnostic",
+        "C": "useful_diagnostic"
+      },
+      "consensus": "useful_diagnostic",
+      "policy_decision": "Keep review: long cross-module state initialization is a concrete synchronization signal."
+    },
+    {
+      "id": "java-08",
+      "language": "java",
+      "repo": "retrofit",
+      "rank_in_repo": 4,
+      "family_id": "117a00db8e54ad37",
+      "original_recommended_surface": "review",
+      "fragment_kind": "self-field-body",
+      "reason_code": "exact-self-field-body",
+      "members": 3,
+      "files": 3,
+      "mean_lines": 4,
+      "shared_lines": 3,
+      "params": 1,
+      "representative_locations": [
+        {
+          "file": "bench/repos/retrofit/retrofit-adapters/rxjava/src/main/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactory.java",
+          "start_line": 90,
+          "end_line": 93,
+          "enclosing": "RxJavaCallAdapterFactory"
+        },
+        {
+          "file": "bench/repos/retrofit/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/RxJava2CallAdapterFactory.java",
+          "start_line": 88,
+          "end_line": 91,
+          "enclosing": "RxJava2CallAdapterFactory"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "acceptable_low_value",
+        "C": "useful_diagnostic"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Keep review, not default: small product-code adapter parity signal."
+    },
+    {
+      "id": "java-09",
+      "language": "java",
+      "repo": "retrofit",
+      "rank_in_repo": 5,
+      "family_id": "21e2c006ddc7e7b3",
+      "original_recommended_surface": "review",
+      "fragment_kind": "self-field-body",
+      "reason_code": "exact-self-field-body",
+      "members": 2,
+      "files": 2,
+      "mean_lines": 4,
+      "shared_lines": 4,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/retrofit/retrofit-adapters/rxjava2/src/main/java/retrofit2/adapter/rxjava2/CallEnqueueObservable.java",
+          "start_line": 52,
+          "end_line": 55,
+          "enclosing": "CallCallback"
+        },
+        {
+          "file": "bench/repos/retrofit/retrofit-adapters/rxjava3/src/main/java/retrofit2/adapter/rxjava3/CallEnqueueObservable.java",
+          "start_line": 52,
+          "end_line": 55,
+          "enclosing": "CallCallback"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "acceptable_low_value",
+        "C": "acceptable_low_value"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Keep review-only: exact but mechanical product-code constructor assignment."
+    },
+    {
+      "id": "java-10",
+      "language": "java",
+      "repo": "retrofit",
+      "rank_in_repo": 6,
+      "family_id": "dcce50a0c18b3117",
+      "original_recommended_surface": "review",
+      "fragment_kind": "self-field-body",
+      "reason_code": "exact-self-field-body",
+      "members": 2,
+      "files": 2,
+      "mean_lines": 4,
+      "shared_lines": 4,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/retrofit/retrofit-converters/jaxb/src/main/java/retrofit2/converter/jaxb/JaxbRequestConverter.java",
+          "start_line": 34,
+          "end_line": 37,
+          "enclosing": "JaxbRequestConverter"
+        },
+        {
+          "file": "bench/repos/retrofit/retrofit-converters/jaxb3/src/main/java/retrofit2/converter/jaxb3/JaxbRequestConverter.java",
+          "start_line": 34,
+          "end_line": 37,
+          "enclosing": "JaxbRequestConverter"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "acceptable_low_value",
+        "C": "acceptable_low_value"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Keep review-only: exact converter parity, too mechanical for default action output."
+    },
+    {
+      "id": "python-01",
+      "language": "python",
+      "repo": "poetry",
+      "rank_in_repo": 9,
+      "family_id": "b5fb42404e0cef48",
+      "original_recommended_surface": "review",
+      "fragment_kind": "expr-effect",
+      "reason_code": "exact-expr-effect",
+      "members": 5,
+      "files": 1,
+      "mean_lines": 3,
+      "shared_lines": 3,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/poetry/tests/puzzle/test_solver.py",
+          "start_line": 2727,
+          "end_line": 2729,
+          "enclosing": "test_solver_git_dependencies_update"
+        },
+        {
+          "file": "bench/repos/poetry/tests/puzzle/test_solver.py",
+          "start_line": 2770,
+          "end_line": 2772,
+          "enclosing": "test_solver_git_dependencies_update_skipped"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "acceptable_low_value",
+        "C": "acceptable_low_value"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Demote to hidden: tiny test dependency setup scaffold."
+    },
+    {
+      "id": "python-02",
+      "language": "python",
+      "repo": "poetry",
+      "rank_in_repo": 12,
+      "family_id": "12eaefcda17d1095",
+      "original_recommended_surface": "review",
+      "fragment_kind": "expr-effect",
+      "reason_code": "exact-expr-effect",
+      "members": 3,
+      "files": 2,
+      "mean_lines": 3,
+      "shared_lines": 3,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/poetry/tests/installation/test_installer.py",
+          "start_line": 2964,
+          "end_line": 2966,
+          "enclosing": "test_installer_should_use_the_locked_version_of_git_dependencies_without_reference"
+        },
+        {
+          "file": "bench/repos/poetry/tests/puzzle/test_solver.py",
+          "start_line": 2341,
+          "end_line": 2343,
+          "enclosing": "test_solver_can_resolve_git_dependencies"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "acceptable_low_value",
+        "C": "acceptable_low_value"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Demote to hidden: tiny test arrange scaffold, even across files."
+    },
+    {
+      "id": "python-03",
+      "language": "python",
+      "repo": "poetry",
+      "rank_in_repo": 16,
+      "family_id": "8eebac82de5ac9ed",
+      "original_recommended_surface": "review",
+      "fragment_kind": "expr-effect",
+      "reason_code": "exact-expr-effect",
+      "members": 2,
+      "files": 1,
+      "mean_lines": 8,
+      "shared_lines": 7,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/poetry/tests/utils/test_authenticator.py",
+          "start_line": 518,
+          "end_line": 525,
+          "enclosing": "test_authenticator_falls_back_to_keyring_url_matched_by_path"
+        },
+        {
+          "file": "bench/repos/poetry/tests/utils/test_authenticator.py",
+          "start_line": 563,
+          "end_line": 570,
+          "enclosing": "test_authenticator_uses_env_provided_credentials_matched_by_url_path"
+        }
+      ],
+      "votes": {
+        "A": "useful_diagnostic",
+        "B": "acceptable_low_value",
+        "C": "useful_diagnostic"
+      },
+      "consensus": "useful_diagnostic",
+      "policy_decision": "Keep review: larger shared authenticator setup is meaningful synchronization context."
+    },
+    {
+      "id": "python-04",
+      "language": "python",
+      "repo": "poetry",
+      "rank_in_repo": 17,
+      "family_id": "2026b8257713aa10",
+      "original_recommended_surface": "review",
+      "fragment_kind": "expr-effect",
+      "reason_code": "exact-expr-effect",
+      "members": 3,
+      "files": 1,
+      "mean_lines": 3,
+      "shared_lines": 3,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/poetry/tests/console/commands/test_run.py",
+          "start_line": 106,
+          "end_line": 108,
+          "enclosing": "test_run_keeps_options_passed_before_command_args_combined_short_opts"
+        },
+        {
+          "file": "bench/repos/poetry/tests/console/commands/test_run.py",
+          "start_line": 118,
+          "end_line": 120,
+          "enclosing": "test_run_keeps_options_passed_before_command_args"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "acceptable_low_value",
+        "C": "acceptable_low_value"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Demote to hidden: tiny repeated assertion scaffold."
+    },
+    {
+      "id": "python-05",
+      "language": "python",
+      "repo": "poetry",
+      "rank_in_repo": 18,
+      "family_id": "e2d12762f3788c9d",
+      "original_recommended_surface": "review",
+      "fragment_kind": "expr-effect",
+      "reason_code": "exact-expr-effect",
+      "members": 2,
+      "files": 1,
+      "mean_lines": 6,
+      "shared_lines": 6,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/poetry/tests/utils/env/test_env.py",
+          "start_line": 165,
+          "end_line": 170,
+          "enclosing": "test_run_with_called_process_error"
+        },
+        {
+          "file": "bench/repos/poetry/tests/utils/env/test_env.py",
+          "start_line": 198,
+          "end_line": 203,
+          "enclosing": "test_check_output_with_called_process_error"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "acceptable_low_value",
+        "C": "acceptable_low_value"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Keep review-only: plausible test helper opportunity, but still scaffold-like."
+    },
+    {
+      "id": "python-06",
+      "language": "python",
+      "repo": "packaging",
+      "rank_in_repo": 6,
+      "family_id": "003bc790327ebd05",
+      "original_recommended_surface": "hidden",
+      "fragment_kind": "conditional-guard",
+      "reason_code": "exact-conditional-guard",
+      "members": 4,
+      "files": 1,
+      "mean_lines": 2,
+      "shared_lines": 2,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/packaging/src/packaging/version.py",
+          "start_line": 286,
+          "end_line": 287,
+          "enclosing": "_validate_pre"
+        },
+        {
+          "file": "bench/repos/packaging/src/packaging/version.py",
+          "start_line": 299,
+          "end_line": 300,
+          "enclosing": "_validate_post"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "acceptable_low_value",
+        "C": "acceptable_low_value"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Keep hidden: correct None guard, too small/common for review."
+    },
+    {
+      "id": "python-07",
+      "language": "python",
+      "repo": "packaging",
+      "rank_in_repo": 7,
+      "family_id": "dec180d30fb91a88",
+      "original_recommended_surface": "hidden",
+      "fragment_kind": "conditional-guard",
+      "reason_code": "exact-conditional-guard",
+      "members": 2,
+      "files": 2,
+      "mean_lines": 2,
+      "shared_lines": 2,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/packaging/src/packaging/direct_url.py",
+          "start_line": 48,
+          "end_line": 49,
+          "enclosing": "_get"
+        },
+        {
+          "file": "bench/repos/packaging/src/packaging/pylock.py",
+          "start_line": 106,
+          "end_line": 107,
+          "enclosing": "_get"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "useful_diagnostic",
+        "C": "acceptable_low_value"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Keep hidden: points at helper parity, but fragment alone is too tiny."
+    },
+    {
+      "id": "python-08",
+      "language": "python",
+      "repo": "packaging",
+      "rank_in_repo": 9,
+      "family_id": "a64ff675e0f9f3ed",
+      "original_recommended_surface": "hidden",
+      "fragment_kind": "conditional-guard",
+      "reason_code": "exact-conditional-guard",
+      "members": 2,
+      "files": 1,
+      "mean_lines": 2,
+      "shared_lines": 2,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/packaging/src/packaging/metadata.py",
+          "start_line": 603,
+          "end_line": 604,
+          "enclosing": "_process_name"
+        },
+        {
+          "file": "bench/repos/packaging/src/packaging/metadata.py",
+          "start_line": 616,
+          "end_line": 617,
+          "enclosing": "_process_version"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "useful_diagnostic",
+        "C": "acceptable_low_value"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Keep hidden: validation consistency is real but too small for review output."
+    },
+    {
+      "id": "python-09",
+      "language": "python",
+      "repo": "packaging",
+      "rank_in_repo": 10,
+      "family_id": "a80e66532f54ba2d",
+      "original_recommended_surface": "hidden",
+      "fragment_kind": "conditional-guard",
+      "reason_code": "exact-conditional-guard",
+      "members": 2,
+      "files": 1,
+      "mean_lines": 2,
+      "shared_lines": 2,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/packaging/src/packaging/specifiers.py",
+          "start_line": 420,
+          "end_line": 421,
+          "enclosing": "_to_ranges"
+        },
+        {
+          "file": "bench/repos/packaging/src/packaging/specifiers.py",
+          "start_line": 1051,
+          "end_line": 1052,
+          "enclosing": "_get_ranges"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "noise",
+        "C": "acceptable_low_value"
+      },
+      "consensus": "acceptable_low_value",
+      "policy_decision": "Keep hidden but flag stable-id risk: tiny cache guard shares family_id with python-10."
+    },
+    {
+      "id": "python-10",
+      "language": "python",
+      "repo": "packaging",
+      "rank_in_repo": 11,
+      "family_id": "a80e66532f54ba2d",
+      "original_recommended_surface": "hidden",
+      "fragment_kind": "conditional-guard",
+      "reason_code": "exact-conditional-guard",
+      "members": 2,
+      "files": 1,
+      "mean_lines": 2,
+      "shared_lines": 2,
+      "params": 0,
+      "representative_locations": [
+        {
+          "file": "bench/repos/packaging/src/packaging/specifiers.py",
+          "start_line": 443,
+          "end_line": 444,
+          "enclosing": "prereleases"
+        },
+        {
+          "file": "bench/repos/packaging/src/packaging/specifiers.py",
+          "start_line": 852,
+          "end_line": 853,
+          "enclosing": "prereleases"
+        }
+      ],
+      "votes": {
+        "A": "acceptable_low_value",
+        "B": "noise",
+        "C": "noise"
+      },
+      "consensus": "noise",
+      "policy_decision": "Track as stable-id collision before relying on JSON identity: distinct prerelease cache guard shares python-09's family_id."
+    }
+  ]
+}

--- a/crates/nose-detect/src/report.rs
+++ b/crates/nose-detect/src/report.rs
@@ -174,8 +174,15 @@ impl RefactorFamily {
                 )
             )
         });
+        let tiny_test_scaffold = all_test
+            && all_have_enclosing
+            && (self.mean_lines <= 3 || (has_effect_or_body && self.mean_lines <= 4));
 
-        if high_fanout && self.mean_lines <= 3 {
+        if tiny_test_scaffold {
+            // The fragment-quality audit found these are usually correct but too often
+            // test arrange/assert or fixture-constructor substrate to be review items.
+            "hidden"
+        } else if high_fanout && self.mean_lines <= 3 {
             "hidden"
         } else if has_effect_or_body {
             // Receiver/effect-bearing fragments are usually synchronization hazards first.
@@ -595,7 +602,7 @@ fn subsumes(outer: &RefactorFamily, inner: &RefactorFamily) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{LineSpan, LocInit, Metrics, Report};
+    use crate::{EnclosingUnit, LineSpan, LocInit, Metrics, Report};
     use nose_il::UnitKind::{Class, Function};
 
     fn loc(file: &str, s: u32, e: u32, lang: &str) -> Loc {
@@ -642,6 +649,24 @@ mod tests {
             })
         }
     }
+
+    fn test_fragment_loc_k(file: &str, s: u32, e: u32, fragment_kind: crate::FragmentKind) -> Loc {
+        let mut loc = fragment_loc_k(file, s, e, fragment_kind);
+        loc.enclosing_unit = Some(EnclosingUnit {
+            file: file.into(),
+            start_line: s.saturating_sub(5).max(1),
+            end_line: e + 5,
+            kind: Function,
+            name: Some("test_scaffold".into()),
+            unit_key: format!(
+                "{file}:Function:{}-{}:test_scaffold",
+                s.saturating_sub(5).max(1),
+                e + 5
+            ),
+        });
+        loc
+    }
+
     /// A family with the given locations and metrics, other fields at neutral values.
     fn fam(
         value: f64,
@@ -1248,6 +1273,54 @@ mod tests {
             review_effect.recommended_surface(),
             "review",
             "medium effect fragments are synchronization hazards before default refactors"
+        );
+
+        let tiny_test_expr = fam(
+            10.0,
+            3,
+            3,
+            0,
+            vec![
+                test_fragment_loc_k("tests/a.py", 1, 3, crate::FragmentKind::ExprEffect),
+                test_fragment_loc_k("tests/b.py", 1, 3, crate::FragmentKind::ExprEffect),
+            ],
+        );
+        assert_eq!(
+            tiny_test_expr.recommended_surface(),
+            "hidden",
+            "tiny test-only expression-effect scaffolding stays diagnostic-only"
+        );
+
+        let tiny_test_self_field = fam(
+            10.0,
+            4,
+            3,
+            1,
+            vec![
+                test_fragment_loc_k("tests/A.java", 10, 13, crate::FragmentKind::SelfFieldBody),
+                test_fragment_loc_k("tests/B.java", 20, 23, crate::FragmentKind::SelfFieldBody),
+            ],
+        );
+        assert_eq!(
+            tiny_test_self_field.recommended_surface(),
+            "hidden",
+            "small test fixture constructor bodies stay out of review output"
+        );
+
+        let medium_test_expr = fam(
+            10.0,
+            8,
+            7,
+            0,
+            vec![
+                test_fragment_loc_k("tests/a.py", 10, 17, crate::FragmentKind::ExprEffect),
+                test_fragment_loc_k("tests/b.py", 20, 27, crate::FragmentKind::ExprEffect),
+            ],
+        );
+        assert_eq!(
+            medium_test_expr.recommended_surface(),
+            "review",
+            "larger test setup fragments can still be useful review context"
         );
 
         let default_guard = fam(

--- a/docs/field-evaluation.md
+++ b/docs/field-evaluation.md
@@ -218,3 +218,21 @@ integration contract now makes that explicit by documenting
 `recommended_surface == "default"` as the human-action filter and by emitting
 `ranking.surface_counts`, including a nested exact-fragment breakdown, before
 `--top` truncation.
+
+## Fourth pass follow-up — fragment quality audit
+
+The Java/Python hidden/review volume was sampled rather than tuned by guesswork. A
+three-reviewer audit of 20 exact-fragment candidates is recorded in
+[fragment-quality-audit-2026-06-10](fragment-quality-audit-2026-06-10.md), with the
+machine-readable votes in
+[bench/labels/fragment_quality_audit_2026_06_10.json](../bench/labels/fragment_quality_audit_2026_06_10.json).
+
+The result was mostly validating for the semantic kernel: 17/20 candidates were
+consensus correct diagnostic substrate, but 15/20 were too small or scaffold-like to be
+action output. The `review` surface had no consensus noise and kept the two useful
+signals in the sample: a long RxJava2/RxJava3 adapter constructor parity fragment and a
+larger Poetry authenticator test setup fragment. The policy change from the audit is
+narrow: tiny test-only exact fragments with enclosing-unit context now stay hidden
+instead of review-visible. Broader pruning is deferred; the real follow-ups are stable
+`family_id` collisions in hidden JSON output and overly generic one-line direct-return
+fragments.

--- a/docs/fragment-quality-audit-2026-06-10.md
+++ b/docs/fragment-quality-audit-2026-06-10.md
@@ -1,0 +1,85 @@
+# Fragment quality audit, 2026-06-10
+
+This audit closes the follow-up from the 18-repo semantic corpus pass in
+[field evaluation](field-evaluation.md). That pass showed Java and Python had many
+hidden/review exact-fragment families. The question was whether those fragments were
+useful diagnostic substrate, acceptable low-value noise for the default surface, or
+detector output that should be pruned.
+
+The checked-in data artifact is
+[bench/labels/fragment_quality_audit_2026_06_10.json](../bench/labels/fragment_quality_audit_2026_06_10.json).
+
+## Sample
+
+The sample takes the top five hidden/review exact-fragment families, in scan JSON order,
+from each of four audited repositories:
+
+| language | repos | candidates |
+|---|---|---:|
+| Java | `commons-lang`, `retrofit` | 10 |
+| Python | `poetry`, `packaging` | 10 |
+
+The source scan cache was `/tmp/nose-semantic-eval-current-517ad5c`, produced with:
+
+```sh
+nose scan bench/repos/<repo> --mode semantic --format json --top 0
+```
+
+Each candidate was labeled independently by three reviewers using this schema:
+
+| label | meaning |
+|---|---|
+| `useful_diagnostic` | correct exact fragment with meaningful synchronization, refactor, or review signal |
+| `acceptable_low_value` | correct or plausible diagnostic fragment, but too tiny, boilerplate, test-scaffold-like, or common for default action output |
+| `noise` | misleading, duplicate bookkeeping artifact, incorrect, or should be pruned rather than merely hidden/review |
+
+## Results
+
+Consensus labels:
+
+| slice | useful diagnostic | acceptable low value | noise |
+|---|---:|---:|---:|
+| all 20 | 2 | 15 | 3 |
+| Java | 1 | 7 | 2 |
+| Python | 1 | 8 | 1 |
+| original `review` surface | 2 | 9 | 0 |
+| original `hidden` surface | 0 | 6 | 3 |
+
+The main read is positive for the semantic kernel: most fragment families were exact and
+explainable. They were just not refactoring recommendations. The `review` surface had no
+consensus noise in this sample, and the two useful items were exactly the kind of
+synchronization signal review output should preserve:
+
+| candidate | label | why it matters |
+|---|---|---|
+| `java-07` | `useful_diagnostic` | 11-line RxJava2/RxJava3 constructor state initialization mirrors many behavioral flags across adapter modules. |
+| `python-03` | `useful_diagnostic` | 8-line Poetry authenticator repository config ties two credential-path tests that should stay aligned. |
+| `java-02` | `acceptable_low_value` | test fixture constructor self-field assignments are correct but boilerplate. |
+| `python-01`, `python-02`, `python-04` | `acceptable_low_value` | 3-line test setup/assertion `expr-effect` fragments are real but too small for review output. |
+| `java-05`, `python-10` | `noise` | both expose stable `family_id` collisions with different nearby hidden families. |
+| `java-03` | `noise` | one-line direct-return fragments are too generic and can group awkwardly with enclosing methods. |
+
+## Policy
+
+The audit supports the current separation between exactness and product placement:
+
+- Keep exact fragments in full scan JSON. They are useful proof/review substrate for
+  integrations, audits, and changed-line review workflows.
+- Keep `recommended_surface == "default"` as the human-action filter. Hidden/review
+  fragments should not become default findings merely because they are exact.
+- Do not broad-prune Java/Python fragments. The dominant class is "correct but low-value",
+  not "incorrect".
+- Demote tiny test-only scaffold fragments from `review` to `hidden`: all-test exact
+  fragments with an enclosing unit and mean span <= 3 lines, plus all-test
+  effect/body fragments up to 4 lines. This keeps 3-line arrange/assert snippets and
+  fixture constructors diagnostic-only while leaving larger test setup blocks available for
+  review.
+
+Two follow-ups remain outside this narrow policy change:
+
+- **Stable family identity:** repeated `family_id` values appeared for distinct hidden
+  families (`272926fba0300285` in `commons-lang`, `a80e66532f54ba2d` in `packaging`).
+  That is a JSON integration risk even when the families are hidden.
+- **One-line direct returns:** `exact-direct-return` one-liners are correct too often to
+  drop blindly, but the sample shows they need a stricter low-context pruning pass or a
+  stronger enclosing/effect boundary before they become useful diagnostics.

--- a/docs/home.md
+++ b/docs/home.md
@@ -73,6 +73,7 @@ You want to *change* nose or understand how it works inside.
 - [type4-adversarial-coverage](type4-adversarial-coverage.md) — focused Type-4 cases, target-packet task cards, and verifier-lead draft workflow.
 - [frontier-platform](frontier-platform.md) — corpus-balanced evidence platform that ranks the next Type-4 axis by presence breadth (not raw count) and separates the queue signal from human-verified evidence.
 - [field-evaluation](field-evaluation.md) — qualitative results from running nose on real third-party projects.
+- [fragment-quality-audit-2026-06-10](fragment-quality-audit-2026-06-10.md) — labeled Java/Python hidden/review exact-fragment sample and the resulting surface policy.
 - [dogfooding](dogfooding.md) — nose run on its own source, and what its findings taught us.
 
 The contributor workflow and quality gates live in


### PR DESCRIPTION
Fixes #185

## Summary
- add a checked-in three-labeler audit artifact for 20 Java/Python hidden/review exact-fragment families
- document the audit conclusion: most fragments are exact diagnostic substrate, not default action output; review had no consensus noise in this sample
- demote tiny test-only exact-fragment scaffolding from review to hidden while keeping larger test setup fragments review-visible

## Validation
- jq empty bench/labels/fragment_quality_audit_2026_06_10.json
- cargo test -p nose-detect fragment_surface_uses_kind_scope_and_spread -- --nocapture
- cargo test -p nose-cli --test cli output_contract -- --nocapture
- ./scripts/check-docs.sh
- cargo fmt --all --check
- ./scripts/check-ci-local.sh --fast