### PR TITLE
Record LawPack provenance audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ break.
 - A three-reviewer fragment-quality audit artifact for Java/Python hidden/review
   exact-fragment families now records the criteria, votes, and policy decisions
   behind the diagnostic-surface follow-up.
+- A LawPack provenance audit artifact now records the 105-repo and targeted
+  real-corpus pass for `nose.value_graph.laws`: the pack is active in scan JSON,
+  but the current two proof-backed laws produced no real clone families with
+  `semantic_laws` provenance.
 
 ### Changed
 - Tiny test-only exact-fragment scaffolding now stays on the hidden diagnostic surface

--- a/bench/labels/README.md
+++ b/bench/labels/README.md
@@ -42,6 +42,11 @@ small, three-reviewer audit of Java/Python hidden/review exact-fragment families
 validate surface policy after the semantic corpus pass. See
 [`docs/fragment-quality-audit-2026-06-10.md`](../../docs/fragment-quality-audit-2026-06-10.md).
 
+`lawpack_provenance_audit_2026_06_10.json` is also adjacent evidence, not part of
+the v5 metric. It records the full-corpus and targeted real-repo pass for the
+first-party `nose.value_graph.laws` LawPack pilot. See
+[`docs/lawpack-provenance-audit-2026-06-10.md`](../../docs/lawpack-provenance-audit-2026-06-10.md).
+
 ## Scoring against it
 
 `eval_by_language.py` — per-language precision@10 + worthy-recall, dev/heldout split, with

--- a/bench/labels/lawpack_provenance_audit_2026_06_10.json
+++ b/bench/labels/lawpack_provenance_audit_2026_06_10.json
@@ -1,0 +1,284 @@
+{
+  "schema_version": "lawpack-provenance-audit.v1",
+  "audit_date": "2026-06-10",
+  "issue": "https://github.com/corca-ai/nose/issues/186",
+  "git_revision": "1b83307085171ca6a6f61efaaa2480fdaead463c",
+  "binary": {
+    "build_command": "cargo build -p nose-cli --release",
+    "scan_command_template": "target/release/nose scan bench/repos/<repo> --mode semantic --format json --top 0"
+  },
+  "pack_under_test": {
+    "id": "nose.value_graph.laws",
+    "kind": "LawPack",
+    "value_law_count": 2,
+    "value_laws": [
+      {
+        "law_id": "value-graph.factor-distribute.numeric-common-factor",
+        "proof_obligation_id": "normalize.value_graph.factor_distribute"
+      },
+      {
+        "law_id": "value-graph.clamp.integer-ordered-minmax",
+        "proof_obligation_id": "normalize.value_graph.clamp"
+      }
+    ]
+  },
+  "full_corpus_scan": {
+    "repos_root": "bench/repos",
+    "output_cache": "/tmp/nose-lawpack-eval-full-1781066700",
+    "successful_repos": 104,
+    "failed_repos": [
+      {
+        "repo": "rxjs",
+        "failure": "scan aborted with stack overflow"
+      }
+    ],
+    "source_files": 59865,
+    "families": 10967,
+    "pack_active_repos": 104,
+    "law_bearing_repos": 0,
+    "law_bearing_families": 0,
+    "languages": [
+      {
+        "language": "java",
+        "files": 18837,
+        "repos": 21
+      },
+      {
+        "language": "javascript",
+        "files": 8386,
+        "repos": 59
+      },
+      {
+        "language": "typescript",
+        "files": 7562,
+        "repos": 21
+      },
+      {
+        "language": "c",
+        "files": 6143,
+        "repos": 28
+      },
+      {
+        "language": "go",
+        "files": 5138,
+        "repos": 18
+      },
+      {
+        "language": "ruby",
+        "files": 4864,
+        "repos": 22
+      },
+      {
+        "language": "python",
+        "files": 4475,
+        "repos": 34
+      },
+      {
+        "language": "rust",
+        "files": 4460,
+        "repos": 16
+      }
+    ],
+    "largest_family_repos": [
+      {
+        "repo": "guava",
+        "files": 3228,
+        "families": 1795,
+        "law_bearing_families": 0
+      },
+      {
+        "repo": "libgdx",
+        "files": 2100,
+        "families": 931,
+        "law_bearing_families": 0
+      },
+      {
+        "repo": "netty",
+        "files": 3556,
+        "families": 912,
+        "law_bearing_families": 0
+      },
+      {
+        "repo": "sympy",
+        "files": 1582,
+        "families": 902,
+        "law_bearing_families": 0
+      },
+      {
+        "repo": "sqlalchemy",
+        "files": 667,
+        "families": 736,
+        "law_bearing_families": 0
+      }
+    ]
+  },
+  "targeted_subset_scan": {
+    "selection": "Repos were selected from the frontier numeric-clamp signal plus targeted grep for clamp/min-max and common-factor arithmetic surfaces.",
+    "output_cache": "/tmp/nose-lawpack-eval-1781066520",
+    "repos": [
+      {
+        "repo": "fzf",
+        "selection_reason": "Go custom clamp helper and many call sites",
+        "languages": {
+          "go": 78,
+          "ruby": 10
+        },
+        "files": 88,
+        "families": 4,
+        "law_bearing_families": 0
+      },
+      {
+        "repo": "pixijs",
+        "selection_reason": "TypeScript nested Math.min/Math.max clamp idioms",
+        "languages": {
+          "typescript": 1468,
+          "javascript": 15
+        },
+        "files": 1483,
+        "families": 38,
+        "law_bearing_families": 0
+      },
+      {
+        "repo": "alacritty",
+        "selection_reason": "Rust min/max clamp-shaped viewport arithmetic",
+        "languages": {
+          "rust": 88
+        },
+        "files": 88,
+        "families": 1,
+        "law_bearing_families": 0
+      },
+      {
+        "repo": "meilisearch",
+        "selection_reason": "Rust .clamp plus adjacent min/max bound normalization",
+        "languages": {
+          "rust": 690
+        },
+        "files": 690,
+        "families": 8,
+        "law_bearing_families": 0
+      },
+      {
+        "repo": "h2database",
+        "selection_reason": "Java Math.min/Math.max-heavy corpus",
+        "languages": {
+          "java": 1253,
+          "javascript": 39
+        },
+        "files": 1292,
+        "families": 496,
+        "law_bearing_families": 0
+      },
+      {
+        "repo": "netty",
+        "selection_reason": "Large Java network corpus with min/max candidates",
+        "languages": {
+          "java": 3515,
+          "c": 37,
+          "javascript": 4
+        },
+        "files": 3556,
+        "families": 912,
+        "law_bearing_families": 0
+      },
+      {
+        "repo": "marked",
+        "selection_reason": "Small JavaScript/TypeScript parser with arithmetic guards",
+        "languages": {
+          "javascript": 200,
+          "typescript": 15
+        },
+        "files": 215,
+        "families": 1,
+        "law_bearing_families": 0
+      },
+      {
+        "repo": "libgdx",
+        "selection_reason": "Large Java/C game corpus with arithmetic helper duplication",
+        "languages": {
+          "java": 1767,
+          "c": 324,
+          "typescript": 8,
+          "javascript": 1
+        },
+        "files": 2100,
+        "families": 931,
+        "law_bearing_families": 0
+      },
+      {
+        "repo": "libsodium",
+        "selection_reason": "C arithmetic-heavy corpus",
+        "languages": {
+          "c": 417,
+          "python": 1
+        },
+        "files": 418,
+        "families": 21,
+        "law_bearing_families": 0
+      },
+      {
+        "repo": "nushell",
+        "selection_reason": "Rust corpus with numeric min/max and clamp-like guards",
+        "languages": {
+          "rust": 1710,
+          "javascript": 1,
+          "python": 1
+        },
+        "files": 1712,
+        "families": 44,
+        "law_bearing_families": 0
+      }
+    ]
+  },
+  "qualitative_examples": [
+    {
+      "id": "fzf-constrain",
+      "repo": "fzf",
+      "location": "bench/repos/fzf/src/util/util.go:63",
+      "surface": "return max(min(val, maximum), minimum)",
+      "law": "value-graph.clamp.integer-ordered-minmax",
+      "assessment": "Real clamp helper, but generic Ordered operands and parameter names do not prove integer domain or minimum <= maximum. The scan also found no equivalent family member that would require pack-facing law provenance."
+    },
+    {
+      "id": "pixijs-color-clamp",
+      "repo": "pixijs",
+      "location": "bench/repos/pixijs/src/color/Color.ts:1095",
+      "surface": "Math.min(Math.max(value, min), max)",
+      "law": "value-graph.clamp.integer-ordered-minmax",
+      "assessment": "Actionable-looking clamp idiom, but TypeScript number is not an integer-only domain and the bound order is not proven. It is a good candidate for future diagnostic miss-mining, not for current exact LawPack provenance."
+    },
+    {
+      "id": "pixijs-render-target-clamps",
+      "repo": "pixijs",
+      "location": "bench/repos/pixijs/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts:409",
+      "surface": "Math.min(Math.max(x, 0), pixelWidth - 1)",
+      "law": "value-graph.clamp.integer-ordered-minmax",
+      "assessment": "The expression is likely integer-shaped after bitwise rounding, but the current proof boundary does not connect that evidence to the Math.min/Math.max pair or prove the upper bound order."
+    },
+    {
+      "id": "meilisearch-facet-clamp",
+      "repo": "meilisearch",
+      "location": "bench/repos/meilisearch/crates/milli/src/update/facet/mod.rs:413",
+      "surface": "group_size.clamp(2, 127) and min(max(...)) nearby",
+      "law": "value-graph.clamp.integer-ordered-minmax",
+      "assessment": "Rust .clamp can be exact in isolation, but this scan did not produce a duplicate family that bridged .clamp to an equivalent min/max or ternary member with law provenance."
+    },
+    {
+      "id": "alacritty-scroll-clamp",
+      "repo": "alacritty",
+      "location": "bench/repos/alacritty/alacritty_terminal/src/grid/mod.rs:166",
+      "surface": "min(max((display_offset as i32) + count, 0) as usize, history_size())",
+      "law": "value-graph.clamp.integer-ordered-minmax",
+      "assessment": "Clamp-shaped viewport code, but the mixed casts/newtypes and dynamic bounds keep this outside the current small exact ordered-integer law surface."
+    }
+  ],
+  "conclusion": {
+    "verdict": "negative-real-corpus-yield",
+    "summary": "The first-party LawPack pilot is wired into scan JSON across the successful corpus, but this 105-repo pass found no real clone family with semantic_laws provenance. The result is a useful boundary finding rather than a safety regression: current law provenance fires only when a proven value-graph law participates in a reported family.",
+    "next_work": [
+      "Add a dedicated law-provenance corpus fixture or focused benchmark so the JSON contract stays pinned outside unit tests.",
+      "Build a miss-mining arm that records singleton law-shaped candidates and proof blockers separately from clone families.",
+      "Expand LawPack-facing law ids beyond the two pilot laws once proof obligations and hard negatives exist."
+    ]
+  }
+}

--- a/docs/field-evaluation.md
+++ b/docs/field-evaluation.md
@@ -76,6 +76,23 @@ maintainer would plausibly act on, across multiple languages and frontend
 containers. The gap to adoption is mostly workflow and ranking ergonomics rather
 than basic parsing or detection.
 
+## LawPack provenance audit -- 2026-06-10
+
+The [LawPack provenance audit](lawpack-provenance-audit-2026-06-10.md) ran the
+compiled first-party `nose.value_graph.laws` pack across the 105-repo
+`bench/repos` corpus, plus a targeted 10-repo subset selected for clamp/min-max
+and arithmetic-law surfaces. The pack was active in all 104 successful full-corpus
+scans, covering 59,865 source files and 10,967 reported families, but no family
+contained `semantic_laws` provenance. `rxjs` failed with a stack overflow and is
+recorded separately.
+
+The qualitative read is a negative field result, not a pack-loading failure:
+real code contains many clamp-shaped idioms (`fzf` generic `Constrain`,
+`pixijs` `Math.min(Math.max(...))`, Rust `.clamp`), but current provenance only
+appears when a proof-backed law actually participates in a reported clone
+family. The next useful layer is miss-mining for singleton law-shaped candidates
+and proof blockers, not merely another broad clone scan.
+
 ## Update -- backlog addressed
 
 Most workflow items above have since landed:

--- a/docs/home.md
+++ b/docs/home.md
@@ -62,6 +62,7 @@ You want to *change* nose or understand how it works inside.
 - [semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md) — post-PR #147 audit of remaining raw/local semantic pockets and follow-up owners.
 - [semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md) — closeout for the #109 semantic-kernel foundation and follow-up tranche.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.
+- [lawpack-provenance-audit-2026-06-10](lawpack-provenance-audit-2026-06-10.md) — full-corpus and targeted real-repo audit of `nose.value_graph.laws` provenance.
 - [fragment-contracts](fragment-contracts.md) — how exact sub-function fragments are modeled: classification, contract, the wrapper-synthesis behavior oracle, the effect algebra, and fail-closed receiver identity.
 - [formal-soundness](formal-soundness.md) — Lean 4 proof-obligation registry for proof-sensitive IL, normalization, fragment, and oracle contracts.
 - [hazard-ranking](hazard-ranking.md) — the evidence base for the experimental `--sort hazard` (a divergence-*propensity* signal; **not** a validated harm ranker — it ranks actual harm near chance) and the honest evaluation trail.

--- a/docs/lawpack-provenance-audit-2026-06-10.md
+++ b/docs/lawpack-provenance-audit-2026-06-10.md
@@ -1,0 +1,107 @@
+# LawPack provenance audit, 2026-06-10
+
+This audit closes [#186](https://github.com/corca-ai/nose/issues/186): run
+targeted real-corpus scans for the first-party LawPack pilot and decide whether
+`semantic_laws` provenance is showing up as actionable signal.
+
+The checked-in data artifact is
+[bench/labels/lawpack_provenance_audit_2026_06_10.json](../bench/labels/lawpack_provenance_audit_2026_06_10.json).
+
+## What Was Tested
+
+The pack under test was the compiled first-party LawPack,
+`nose.value_graph.laws`, which currently exposes two proof-backed value laws:
+
+| law id | proof obligation |
+|---|---|
+| `value-graph.factor-distribute.numeric-common-factor` | `normalize.value_graph.factor_distribute` |
+| `value-graph.clamp.integer-ordered-minmax` | `normalize.value_graph.clamp` |
+
+The scan command was:
+
+```sh
+target/release/nose scan bench/repos/<repo> --mode semantic --format json --top 0
+```
+
+The release binary was built from `1b83307085171ca6a6f61efaaa2480fdaead463c`.
+
+## Corpus Result
+
+The full `bench/repos` pass had one scanner failure and zero law-bearing
+families:
+
+| measure | value |
+|---|---:|
+| successful repos | 104 |
+| failed repos | 1 (`rxjs`, stack overflow) |
+| scanned files | 59,865 |
+| reported families | 10,967 |
+| repos with active `nose.value_graph.laws` | 104 |
+| repos with `semantic_laws` families | 0 |
+| `semantic_laws` families | 0 |
+
+Language coverage in the successful scans:
+
+| language | files | repos |
+|---|---:|---:|
+| Java | 18,837 | 21 |
+| JavaScript | 8,386 | 59 |
+| TypeScript | 7,562 | 21 |
+| C | 6,143 | 28 |
+| Go | 5,138 | 18 |
+| Ruby | 4,864 | 22 |
+| Python | 4,475 | 34 |
+| Rust | 4,460 | 16 |
+
+The five largest family-producing repos in this pass were `guava` (1,795),
+`libgdx` (931), `netty` (912), `sympy` (902), and `sqlalchemy` (736). None had
+law-bearing families.
+
+## Targeted Subset
+
+A second pass selected likely LawPack candidates from the frontier numeric-clamp
+signal and targeted source search for clamp/min-max and common-factor arithmetic
+surfaces.
+
+| repo | why selected | files | families | law families |
+|---|---|---:|---:|---:|
+| `fzf` | Go custom clamp helper and many call sites | 88 | 4 | 0 |
+| `pixijs` | TypeScript nested `Math.min`/`Math.max` clamp idioms | 1,483 | 38 | 0 |
+| `alacritty` | Rust min/max viewport clamps | 88 | 1 | 0 |
+| `meilisearch` | Rust `.clamp` plus adjacent min/max bound normalization | 690 | 8 | 0 |
+| `h2database` | Java `Math.min`/`Math.max`-heavy corpus | 1,292 | 496 | 0 |
+| `netty` | Large Java network corpus with min/max candidates | 3,556 | 912 | 0 |
+| `marked` | Small JS/TS parser with arithmetic guards | 215 | 1 | 0 |
+| `libgdx` | Large Java/C game corpus with arithmetic helpers | 2,100 | 931 | 0 |
+| `libsodium` | C arithmetic-heavy corpus | 418 | 21 | 0 |
+| `nushell` | Rust numeric min/max and clamp-like guards | 1,712 | 44 | 0 |
+
+## Qualitative Read
+
+The negative result is not evidence that the pack is disconnected. Every
+successful scan reported `nose.value_graph.laws` in `semantic_packs` with two
+value laws. `semantic_laws` is deliberately narrower: it appears only when a
+proven value-graph law actually participates in a reported family.
+
+The targeted search found real law-shaped code, but not law-bearing families:
+
+| example | location | read |
+|---|---|---|
+| `fzf` generic clamp helper | `bench/repos/fzf/src/util/util.go:63` | `return max(min(val, maximum), minimum)` is a real clamp helper, but generic `cmp.Ordered` operands and parameter names do not prove integer domain or `minimum <= maximum`. |
+| `pixijs` color clamp | `bench/repos/pixijs/src/color/Color.ts:1095` | `Math.min(Math.max(value, min), max)` is a useful idiom candidate, but TypeScript `number` is not integer-only and bound order is not proven. |
+| `pixijs` render target clamp | `bench/repos/pixijs/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts:409` | Bitwise-rounded dimensions are probably integer-shaped, but the current proof boundary does not connect that evidence to the min/max pair. |
+| `meilisearch` facet clamp | `bench/repos/meilisearch/crates/milli/src/update/facet/mod.rs:413` | Rust `.clamp(2, 127)` is exact in isolation, but this scan did not report a duplicate family bridging it to an equivalent min/max or ternary member. |
+| `alacritty` scroll clamp | `bench/repos/alacritty/alacritty_terminal/src/grid/mod.rs:166` | The expression is clamp-shaped, but mixed casts/newtypes and dynamic bounds keep it outside the small ordered-integer law surface. |
+
+## Conclusion
+
+This is a useful negative field result. The LawPack pilot is present and
+serialized in scan metadata, but the current two laws did not surface in the
+real-corpus family layer. The main gap is not pack loading; it is that the
+current exact law surface is too narrow for common real-code clamp forms, and
+clone-family output is the wrong instrument for singleton law-shaped misses.
+
+Next work should add a small law-provenance corpus fixture, introduce a
+miss-mining arm for singleton law candidates and proof blockers, and expand
+LawPack-facing laws only where proof obligations and hard negatives are already
+clear.


### PR DESCRIPTION
## Summary
- add a checked-in LawPack provenance audit artifact for issue #186
- document the full 105-repo pass and targeted clamp/arithmetic subset
- record the negative field result: `nose.value_graph.laws` was active in every successful scan, but no real clone family emitted `semantic_laws` provenance

## Validation
- `/usr/bin/jq empty bench/labels/lawpack_provenance_audit_2026_06_10.json`
- `awiki lint --root docs`
- `./scripts/check-docs.sh`
- `cargo fmt --all --check`
- `./scripts/check-ci-local.sh --fast`

Fixes #186
