### PR TITLE
Build the independent miss-mining arm: measure in-the-wild unreported pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ break.
   anchor weight), answering the recall-mechanism gate no-go and routing the
   residual to unit-extraction coverage and the fragment statement-window axis
   (experiments §BJ).
+- An independent miss-mining arm (`bench/type4/miss_mining.py` plus its dated
+  artifact) now measures in-the-wild unreported same-computation pairs beyond
+  the nose ∪ jscpd label pool: 593 detector-suggested candidates corpus-wide,
+  audited as overwhelmingly generated/scaffolding with a handful of
+  worthy-shaped misses — and the audit exposed the #202 channel-merge family
+  drop (experiments §BK).
 
 ### Changed
 - Tiny test-only exact-fragment scaffolding now stays on the hidden diagnostic surface

--- a/bench/type4/miss_mining.py
+++ b/bench/type4/miss_mining.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Independent miss-mining arm: same-computation candidate pairs nose does NOT report.
+
+The v5 gold-set pool is nose ∪ jscpd, and a token detector cannot contribute
+semantic misses — so in-the-wild Type-4 recall has no measurement
+(experiments §BJ closed the *mechanism* question; this tool addresses the
+*measurement* one, #194). It mines, per pinned-corpus repo:
+
+- modality B (structure): unit pairs whose exact value-multiset Jaccard is high
+  (>= --vj, default 0.80) yet no reported family on the MAXIMAL current surface
+  (`--mode syntax,semantic,near --min-value 0`) contains both — i.e. the
+  detector's own value evidence says "same computation" while every product
+  channel stays silent. Candidates come from LSH banding over the detection
+  minhash (32 bands x 4 rows), so the pass is near-linear, then exact vj
+  confirms. Each candidate is annotated with a source text-similarity ratio so
+  analysis can slice off the textually-obvious ones (the jscpd-shaped blind
+  spot is the LOW-text-similarity tail).
+
+(Modality A — behavior-equal fingerprint-split pairs from the interpreter
+oracle — is `nose verify --leads`; run it alongside.)
+
+Output is a QUEUE SIGNAL only (issue #36 discipline): every record carries
+`evidence_tier: detector-suggested` and nothing here writes frontier status.
+A confirmed miss graduates by hand into `real_frontier.v1.json` via the audit
+template in docs/frontier-platform.md.
+
+Usage:
+  python3 bench/type4/miss_mining.py [--repos-root bench/repos] [--vj 0.8]
+    [--limit-repos N] [--per-repo 30] [--json-out bench/type4/miss_mining_<date>.json]
+
+Deterministic given pinned inputs: no timestamps; candidates sorted on stable keys.
+"""
+
+import argparse
+import difflib
+import hashlib
+import json
+import subprocess
+from collections import Counter, defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+NOSE = ROOT / "target" / "release" / "nose"
+
+BANDS, ROWS = 32, 4  # over the 128-slot detection minhash
+MIN_LINES, MIN_TOKENS = 5, 40  # meaningful-size floor for mined units
+SCAN_TIMEOUT = 900
+
+
+def rel(p: str) -> str:
+    p = p.replace(str(ROOT) + "/", "")
+    i = p.find("bench/repos/")
+    return p[i:] if i >= 0 else p
+
+
+def run_json(cmd):
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True, timeout=SCAN_TIMEOUT)
+    if r.returncode != 0:
+        return None
+    return json.loads(r.stdout)
+
+
+def reported_groups(repo_dir):
+    """Family id per (file,line) span on the maximal current surface."""
+    payload = run_json([
+        str(NOSE), "scan", str(repo_dir), "--format", "json", "--top", "0",
+        "--mode", "syntax,semantic,near", "--min-value", "0", "--min-members", "2",
+    ])
+    if payload is None:
+        return None
+    fams = payload.get("families", []) if isinstance(payload, dict) else payload
+    spans = defaultdict(list)  # file -> [(start, end, fam_idx)]
+    for i, f in enumerate(fams):
+        for loc in f["locations"]:
+            spans[rel(loc["file"])].append((loc["start_line"], loc["end_line"], i))
+    return spans
+
+
+def fams_covering(spans, file, start, end):
+    return {
+        fi for (s, e, fi) in spans.get(file, [])
+        if not (e < start or end < s)
+    }
+
+
+def vj(a, b) -> float:
+    ca, cb = Counter(a), Counter(b)
+    inter = sum((ca & cb).values())
+    union = sum((ca | cb).values())
+    return inter / union if union else 0.0
+
+
+def text_ratio(ua, ub) -> float:
+    def slice_of(u):
+        try:
+            lines = (ROOT / rel(u["path"])).read_text(errors="replace").splitlines()
+        except OSError:
+            return ""
+        return "\n".join(lines[u["start_line"] - 1 : u["end_line"]])[:4000]
+
+    return round(
+        difflib.SequenceMatcher(None, slice_of(ua), slice_of(ub), autojunk=False).ratio(), 3
+    )
+
+
+def overlapping(ua, ub) -> bool:
+    return rel(ua["path"]) == rel(ub["path"]) and not (
+        ua["end_line"] < ub["start_line"] or ub["end_line"] < ua["start_line"]
+    )
+
+
+def mine_repo(repo_dir, vj_floor, per_repo):
+    spans = reported_groups(repo_dir)
+    if spans is None:
+        return None, "scan-failed"
+    feats = run_json([
+        str(NOSE), "features", str(repo_dir),
+        "--min-lines", str(MIN_LINES), "--min-tokens", str(MIN_TOKENS),
+    ])
+    if feats is None:
+        return None, "features-failed"
+    units = [u for u in feats["units"] if len(u["value"]) >= 8]
+
+    buckets = defaultdict(list)
+    for i, u in enumerate(units):
+        mh = u["minhash"]
+        for b in range(BANDS):
+            key = (b, tuple(mh[b * ROWS : (b + 1) * ROWS]))
+            buckets[key].append(i)
+
+    seen = set()
+    found = []
+    for members in buckets.values():
+        if len(members) < 2 or len(members) > 50:  # giant buckets are boilerplate
+            continue
+        for x in range(len(members)):
+            for y in range(x + 1, len(members)):
+                i, j = members[x], members[y]
+                if (i, j) in seen:
+                    continue
+                seen.add((i, j))
+                ua, ub = units[i], units[j]
+                if overlapping(ua, ub):
+                    continue
+                score = vj(ua["value"], ub["value"])
+                if score < vj_floor:
+                    continue
+                fa = fams_covering(spans, rel(ua["path"]), ua["start_line"], ua["end_line"])
+                fb = fams_covering(spans, rel(ub["path"]), ub["start_line"], ub["end_line"])
+                if fa & fb:
+                    continue  # already reported together somewhere
+                found.append({
+                    "vj": round(score, 3),
+                    "fp_equal": ua["value"] == ub["value"],
+                    "exact_safe": [ua["exact_safe"], ub["exact_safe"]],
+                    "kinds": [ua["kind"], ub["kind"]],
+                    "text_similarity": text_ratio(ua, ub),
+                    "members": [
+                        {"file": rel(u["path"]), "start_line": u["start_line"],
+                         "end_line": u["end_line"], "name": u.get("name")}
+                        for u in (ua, ub)
+                    ],
+                    "evidence_tier": "detector-suggested",
+                })
+    found.sort(key=lambda r: (-r["vj"], r["members"][0]["file"],
+                              r["members"][0]["start_line"],
+                              r["members"][1]["file"], r["members"][1]["start_line"]))
+    return found[:per_repo], None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repos-root", default=str(ROOT / "bench" / "repos"))
+    ap.add_argument("--vj", type=float, default=0.80)
+    ap.add_argument("--per-repo", type=int, default=30)
+    ap.add_argument("--limit-repos", type=int, default=None)
+    ap.add_argument("--json-out", default=None)
+    args = ap.parse_args()
+
+    corpus = json.loads((ROOT / "bench/goldens/corpus.json").read_text())["repositories"]
+    digest = hashlib.sha256()
+    for r in sorted(corpus, key=lambda r: r["id"]):
+        digest.update(
+            f"{r['id']}\t{r['split']}\t{r['primary_language']}\t{r['commit']}\n".encode()
+        )
+    repos = sorted(corpus, key=lambda r: r["id"])
+    if args.limit_repos:
+        repos = repos[: args.limit_repos]
+
+    out_repos, failures = {}, []
+    totals = Counter()
+    for r in repos:
+        repo_dir = Path(args.repos_root) / r["id"]
+        if not repo_dir.is_dir():
+            continue
+        cands, err = mine_repo(repo_dir, args.vj, args.per_repo)
+        if err:
+            failures.append({"repo": r["id"], "error": err})
+            continue
+        if cands:
+            out_repos[r["id"]] = {
+                "split": r["split"], "language": r["primary_language"], "candidates": cands,
+            }
+        totals[(r["primary_language"], r["split"])] += len(cands or [])
+        low_text = sum(1 for c in cands or [] if c["text_similarity"] < 0.5)
+        print(f"{r['id']}: {len(cands or [])} candidates ({low_text} low-text)", flush=True)
+
+    nose_ver = subprocess.run([str(NOSE), "--version"], capture_output=True, text=True).stdout.strip()
+    print("\nper (language, split):")
+    for (lang, split), n in sorted(totals.items()):
+        print(f"  {lang}/{split}: {n}")
+    if failures:
+        print("failures:", ", ".join(f"{f['repo']}({f['error']})" for f in failures))
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps({
+            "schema_version": "0.1.0",
+            "discipline": "queue-signal-only; see docs/frontier-platform.md (#36)",
+            "corpus_commit_digest": digest.hexdigest(),
+            "nose_version": nose_ver,
+            "vj_floor": args.vj,
+            "min_unit": {"lines": MIN_LINES, "tokens": MIN_TOKENS, "value_nodes": 8},
+            "scan_failures": sorted(f["repo"] for f in failures),
+            "repos": dict(sorted(out_repos.items())),
+        }, indent=1, sort_keys=True) + "\n")
+        print(f"wrote {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/type4/miss_mining_2026_06_10.json
+++ b/bench/type4/miss_mining_2026_06_10.json
@@ -1,0 +1,16945 @@
+{
+ "corpus_commit_digest": "27572e8d375650ea537c548fdcaec1184b0e9ebb645361b8f40f002ce2be5cba",
+ "discipline": "queue-signal-only; see docs/frontier-platform.md (#36)",
+ "min_unit": {
+  "lines": 5,
+  "tokens": 40,
+  "value_nodes": 8
+ },
+ "nose_version": "nose 0.5.0",
+ "repos": {
+  "alacritty": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 76,
+       "file": "bench/repos/alacritty/alacritty_terminal/src/tty/windows/mod.rs",
+       "name": "register",
+       "start_line": 65
+      },
+      {
+       "end_line": 90,
+       "file": "bench/repos/alacritty/alacritty_terminal/src/tty/windows/mod.rs",
+       "name": "reregister",
+       "start_line": 79
+      }
+     ],
+     "text_similarity": 0.99,
+     "vj": 1.0
+    }
+   ],
+   "language": "Rust",
+   "split": "dev"
+  },
+  "antlr4": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 125,
+       "file": "bench/repos/antlr4/runtime/Go/antlr/v4/parser_rule_context.go",
+       "name": "addTerminalNodeChild",
+       "start_line": 116
+      },
+      {
+       "end_line": 136,
+       "file": "bench/repos/antlr4/runtime/Go/antlr/v4/parser_rule_context.go",
+       "name": "AddChild",
+       "start_line": 127
+      }
+     ],
+     "text_similarity": 0.907,
+     "vj": 1.0
+    }
+   ],
+   "language": "Java",
+   "split": "dev"
+  },
+  "asciidoctor": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 230,
+       "file": "bench/repos/asciidoctor/test/options_test.rb",
+       "name": null,
+       "start_line": 221
+      },
+      {
+       "end_line": 245,
+       "file": "bench/repos/asciidoctor/test/options_test.rb",
+       "name": null,
+       "start_line": 236
+      }
+     ],
+     "text_similarity": 0.966,
+     "vj": 0.83
+    }
+   ],
+   "language": "Ruby",
+   "split": "heldout"
+  },
+  "badger": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 53,
+       "file": "bench/repos/badger/pb/badgerpb4.pb.go",
+       "name": "String",
+       "start_line": 51
+      },
+      {
+       "end_line": 99,
+       "file": "bench/repos/badger/pb/badgerpb4.pb.go",
+       "name": "String",
+       "start_line": 97
+      }
+     ],
+     "text_similarity": 0.896,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 53,
+       "file": "bench/repos/badger/pb/badgerpb4.pb.go",
+       "name": "String",
+       "start_line": 51
+      },
+      {
+       "end_line": 145,
+       "file": "bench/repos/badger/pb/badgerpb4.pb.go",
+       "name": "String",
+       "start_line": 143
+      }
+     ],
+     "text_similarity": 0.91,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 99,
+       "file": "bench/repos/badger/pb/badgerpb4.pb.go",
+       "name": "String",
+       "start_line": 97
+      },
+      {
+       "end_line": 145,
+       "file": "bench/repos/badger/pb/badgerpb4.pb.go",
+       "name": "String",
+       "start_line": 143
+      }
+     ],
+     "text_similarity": 0.874,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 444,
+       "file": "bench/repos/badger/pb/badgerpb4.pb.go",
+       "name": "GetKeyId",
+       "start_line": 439
+      },
+      {
+       "end_line": 563,
+       "file": "bench/repos/badger/pb/badgerpb4.pb.go",
+       "name": "GetKeyId",
+       "start_line": 558
+      }
+     ],
+     "text_similarity": 0.903,
+     "vj": 1.0
+    }
+   ],
+   "language": "Go",
+   "split": "heldout"
+  },
+  "bat": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 3976,
+       "file": "bench/repos/bat/tests/benchmarks/highlighting-speed-src/numpy_test_multiarray.py",
+       "name": "test_list",
+       "start_line": 3969
+      },
+      {
+       "end_line": 3984,
+       "file": "bench/repos/bat/tests/benchmarks/highlighting-speed-src/numpy_test_multiarray.py",
+       "name": "test_tuple",
+       "start_line": 3978
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    }
+   ],
+   "language": "Rust",
+   "split": "dev"
+  },
+  "black": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 598,
+       "file": "bench/repos/black/src/black/linegen.py",
+       "name": "visit_fstring",
+       "start_line": 579
+      },
+      {
+       "end_line": 651,
+       "file": "bench/repos/black/src/black/linegen.py",
+       "name": "visit_tstring",
+       "start_line": 600
+      }
+     ],
+     "text_similarity": 0.619,
+     "vj": 1.0
+    }
+   ],
+   "language": "Python",
+   "split": "dev"
+  },
+  "clap": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 52,
+       "file": "bench/repos/clap/clap_builder/src/mkeymap.rs",
+       "name": "eq",
+       "start_line": 47
+      },
+      {
+       "end_line": 61,
+       "file": "bench/repos/clap/clap_builder/src/mkeymap.rs",
+       "name": "eq",
+       "start_line": 56
+      }
+     ],
+     "text_similarity": 0.996,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 52,
+       "file": "bench/repos/clap/clap_builder/src/mkeymap.rs",
+       "name": "eq",
+       "start_line": 47
+      },
+      {
+       "end_line": 70,
+       "file": "bench/repos/clap/clap_builder/src/mkeymap.rs",
+       "name": "eq",
+       "start_line": 65
+      }
+     ],
+     "text_similarity": 0.989,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 61,
+       "file": "bench/repos/clap/clap_builder/src/mkeymap.rs",
+       "name": "eq",
+       "start_line": 56
+      },
+      {
+       "end_line": 70,
+       "file": "bench/repos/clap/clap_builder/src/mkeymap.rs",
+       "name": "eq",
+       "start_line": 65
+      }
+     ],
+     "text_similarity": 0.993,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 103,
+       "file": "bench/repos/clap/clap_builder/src/util/flat_map.rs",
+       "name": "get",
+       "start_line": 92
+      },
+      {
+       "end_line": 116,
+       "file": "bench/repos/clap/clap_builder/src/util/flat_map.rs",
+       "name": "get_mut",
+       "start_line": 105
+      }
+     ],
+     "text_similarity": 0.975,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 165,
+       "file": "bench/repos/clap/clap_builder/src/util/flat_map.rs",
+       "name": "or_insert",
+       "start_line": 156
+      },
+      {
+       "end_line": 176,
+       "file": "bench/repos/clap/clap_builder/src/util/flat_map.rs",
+       "name": "or_insert_with",
+       "start_line": 167
+      }
+     ],
+     "text_similarity": 0.964,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 51,
+       "file": "bench/repos/clap/tests/derive/basic.rs",
+       "name": "update_basic",
+       "start_line": 31
+      },
+      {
+       "end_line": 74,
+       "file": "bench/repos/clap/tests/derive/basic.rs",
+       "name": "update_explicit_required",
+       "start_line": 54
+      }
+     ],
+     "text_similarity": 0.94,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 22,
+       "file": "bench/repos/clap/tests/derive/generic.rs",
+       "name": "generic_struct_flatten",
+       "start_line": 4
+      },
+      {
+       "end_line": 46,
+       "file": "bench/repos/clap/tests/derive/generic.rs",
+       "name": "generic_struct_flatten_w_where_clause",
+       "start_line": 25
+      }
+     ],
+     "text_similarity": 0.95,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 422,
+       "file": "bench/repos/clap/tests/derive/value_enum.rs",
+       "name": "skip_variant",
+       "start_line": 394
+      },
+      {
+       "end_line": 453,
+       "file": "bench/repos/clap/tests/derive/value_enum.rs",
+       "name": "skip_non_unit_variant",
+       "start_line": 425
+      }
+     ],
+     "text_similarity": 0.99,
+     "vj": 1.0
+    }
+   ],
+   "language": "Rust",
+   "split": "dev"
+  },
+  "commons-lang": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1208,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1206
+      },
+      {
+       "end_line": 1234,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1232
+      }
+     ],
+     "text_similarity": 0.937,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1208,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1206
+      },
+      {
+       "end_line": 1260,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1258
+      }
+     ],
+     "text_similarity": 0.918,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1208,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1206
+      },
+      {
+       "end_line": 1286,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1284
+      }
+     ],
+     "text_similarity": 0.938,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1208,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1206
+      },
+      {
+       "end_line": 1312,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1310
+      }
+     ],
+     "text_similarity": 0.928,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1208,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1206
+      },
+      {
+       "end_line": 1338,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1336
+      }
+     ],
+     "text_similarity": 0.927,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1208,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1206
+      },
+      {
+       "end_line": 1364,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1362
+      }
+     ],
+     "text_similarity": 0.937,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1208,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1206
+      },
+      {
+       "end_line": 1390,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1388
+      }
+     ],
+     "text_similarity": 0.91,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1208,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1206
+      },
+      {
+       "end_line": 1421,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1419
+      }
+     ],
+     "text_similarity": 0.914,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1234,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1232
+      },
+      {
+       "end_line": 1260,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1258
+      }
+     ],
+     "text_similarity": 0.925,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1234,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1232
+      },
+      {
+       "end_line": 1286,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1284
+      }
+     ],
+     "text_similarity": 0.945,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1234,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1232
+      },
+      {
+       "end_line": 1312,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1310
+      }
+     ],
+     "text_similarity": 0.935,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1234,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1232
+      },
+      {
+       "end_line": 1338,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1336
+      }
+     ],
+     "text_similarity": 0.953,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1234,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1232
+      },
+      {
+       "end_line": 1364,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1362
+      }
+     ],
+     "text_similarity": 0.925,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1234,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1232
+      },
+      {
+       "end_line": 1390,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1388
+      }
+     ],
+     "text_similarity": 0.935,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1234,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1232
+      },
+      {
+       "end_line": 1421,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1419
+      }
+     ],
+     "text_similarity": 0.94,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1260,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1258
+      },
+      {
+       "end_line": 1286,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1284
+      }
+     ],
+     "text_similarity": 0.909,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1260,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1258
+      },
+      {
+       "end_line": 1312,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1310
+      }
+     ],
+     "text_similarity": 0.935,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1260,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1258
+      },
+      {
+       "end_line": 1338,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1336
+      }
+     ],
+     "text_similarity": 0.934,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1260,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1258
+      },
+      {
+       "end_line": 1364,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1362
+      }
+     ],
+     "text_similarity": 0.925,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1260,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1258
+      },
+      {
+       "end_line": 1390,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1388
+      }
+     ],
+     "text_similarity": 0.954,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1260,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1258
+      },
+      {
+       "end_line": 1421,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1419
+      }
+     ],
+     "text_similarity": 0.94,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1286,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1284
+      },
+      {
+       "end_line": 1312,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1310
+      }
+     ],
+     "text_similarity": 0.918,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1286,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1284
+      },
+      {
+       "end_line": 1338,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1336
+      }
+     ],
+     "text_similarity": 0.917,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1286,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1284
+      },
+      {
+       "end_line": 1364,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1362
+      }
+     ],
+     "text_similarity": 0.927,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1286,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1284
+      },
+      {
+       "end_line": 1390,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1388
+      }
+     ],
+     "text_similarity": 0.918,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1286,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1284
+      },
+      {
+       "end_line": 1421,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1419
+      }
+     ],
+     "text_similarity": 0.923,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1312,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1310
+      },
+      {
+       "end_line": 1338,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1336
+      }
+     ],
+     "text_similarity": 0.944,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1312,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1310
+      },
+      {
+       "end_line": 1364,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1362
+      }
+     ],
+     "text_similarity": 0.954,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1312,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1310
+      },
+      {
+       "end_line": 1390,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1388
+      }
+     ],
+     "text_similarity": 0.945,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1312,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1310
+      },
+      {
+       "end_line": 1421,
+       "file": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+       "name": "addFirst",
+       "start_line": 1419
+      }
+     ],
+     "text_similarity": 0.931,
+     "vj": 1.0
+    }
+   ],
+   "language": "Java",
+   "split": "dev"
+  },
+  "curl": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 322,
+       "file": "bench/repos/curl/tests/http/testenv/certs.py",
+       "name": "get_cert_file",
+       "start_line": 320
+      },
+      {
+       "end_line": 326,
+       "file": "bench/repos/curl/tests/http/testenv/certs.py",
+       "name": "get_pkey_file",
+       "start_line": 324
+      }
+     ],
+     "text_similarity": 0.972,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 985,
+       "file": "bench/repos/curl/lib/cfilters.c",
+       "name": "Curl_cf_def_cntrl",
+       "start_line": 975
+      },
+      {
+       "end_line": 1249,
+       "file": "bench/repos/curl/lib/sendf.c",
+       "name": "cr_null_read",
+       "start_line": 1237
+      }
+     ],
+     "text_similarity": 0.503,
+     "vj": 0.833
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 36,
+       "file": "bench/repos/curl/tests/libtest/lib1518.c",
+       "name": "t1518_write_cb",
+       "start_line": 28
+      },
+      {
+       "end_line": 37,
+       "file": "bench/repos/curl/tests/libtest/lib1523.c",
+       "name": "dload_progress_cb",
+       "start_line": 28
+      }
+     ],
+     "text_similarity": 0.646,
+     "vj": 0.833
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 37,
+       "file": "bench/repos/curl/tests/libtest/lib1523.c",
+       "name": "dload_progress_cb",
+       "start_line": 28
+      },
+      {
+       "end_line": 33,
+       "file": "bench/repos/curl/tests/libtest/lib1971.c",
+       "name": "t1971_read_cb",
+       "start_line": 26
+      }
+     ],
+     "text_similarity": 0.474,
+     "vj": 0.833
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 37,
+       "file": "bench/repos/curl/tests/libtest/lib1523.c",
+       "name": "dload_progress_cb",
+       "start_line": 28
+      },
+      {
+       "end_line": 33,
+       "file": "bench/repos/curl/tests/libtest/lib1975.c",
+       "name": "t1975_read_cb",
+       "start_line": 26
+      }
+     ],
+     "text_similarity": 0.474,
+     "vj": 0.833
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 65,
+       "file": "bench/repos/curl/lib/cfilters.c",
+       "name": "Curl_cf_def_adjust_pollset",
+       "start_line": 56
+      },
+      {
+       "end_line": 1249,
+       "file": "bench/repos/curl/lib/sendf.c",
+       "name": "cr_null_read",
+       "start_line": 1237
+      }
+     ],
+     "text_similarity": 0.458,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 367,
+       "file": "bench/repos/curl/lib/http2.c",
+       "name": "cf_h2_update_local_win",
+       "start_line": 359
+      },
+      {
+       "end_line": 1249,
+       "file": "bench/repos/curl/lib/sendf.c",
+       "name": "cr_null_read",
+       "start_line": 1237
+      }
+     ],
+     "text_similarity": 0.494,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 598,
+       "file": "bench/repos/curl/lib/sendf.c",
+       "name": "Curl_creader_def_cntrl",
+       "start_line": 590
+      },
+      {
+       "end_line": 1249,
+       "file": "bench/repos/curl/lib/sendf.c",
+       "name": "cr_null_read",
+       "start_line": 1237
+      }
+     ],
+     "text_similarity": 0.717,
+     "vj": 0.8
+    }
+   ],
+   "language": "C",
+   "split": "dev"
+  },
+  "delve": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 209,
+       "file": "bench/repos/delve/pkg/proc/core/linux_core.go",
+       "name": "Registers",
+       "start_line": 204
+      },
+      {
+       "end_line": 216,
+       "file": "bench/repos/delve/pkg/proc/core/linux_core.go",
+       "name": "Registers",
+       "start_line": 211
+      }
+     ],
+     "text_similarity": 0.988,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 209,
+       "file": "bench/repos/delve/pkg/proc/core/linux_core.go",
+       "name": "Registers",
+       "start_line": 204
+      },
+      {
+       "end_line": 223,
+       "file": "bench/repos/delve/pkg/proc/core/linux_core.go",
+       "name": "Registers",
+       "start_line": 218
+      }
+     ],
+     "text_similarity": 0.951,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 209,
+       "file": "bench/repos/delve/pkg/proc/core/linux_core.go",
+       "name": "Registers",
+       "start_line": 204
+      },
+      {
+       "end_line": 230,
+       "file": "bench/repos/delve/pkg/proc/core/linux_core.go",
+       "name": "Registers",
+       "start_line": 225
+      }
+     ],
+     "text_similarity": 0.951,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 216,
+       "file": "bench/repos/delve/pkg/proc/core/linux_core.go",
+       "name": "Registers",
+       "start_line": 211
+      },
+      {
+       "end_line": 223,
+       "file": "bench/repos/delve/pkg/proc/core/linux_core.go",
+       "name": "Registers",
+       "start_line": 218
+      }
+     ],
+     "text_similarity": 0.963,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 216,
+       "file": "bench/repos/delve/pkg/proc/core/linux_core.go",
+       "name": "Registers",
+       "start_line": 211
+      },
+      {
+       "end_line": 230,
+       "file": "bench/repos/delve/pkg/proc/core/linux_core.go",
+       "name": "Registers",
+       "start_line": 225
+      }
+     ],
+     "text_similarity": 0.951,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 223,
+       "file": "bench/repos/delve/pkg/proc/core/linux_core.go",
+       "name": "Registers",
+       "start_line": 218
+      },
+      {
+       "end_line": 230,
+       "file": "bench/repos/delve/pkg/proc/core/linux_core.go",
+       "name": "Registers",
+       "start_line": 225
+      }
+     ],
+     "text_similarity": 0.939,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 70,
+       "file": "bench/repos/delve/pkg/terminal/command_test.go",
+       "name": "Exec",
+       "start_line": 57
+      },
+      {
+       "end_line": 83,
+       "file": "bench/repos/delve/pkg/terminal/command_test.go",
+       "name": "ExecStarlark",
+       "start_line": 72
+      }
+     ],
+     "text_similarity": 0.795,
+     "vj": 0.871
+    }
+   ],
+   "language": "Go",
+   "split": "dev"
+  },
+  "esbuild": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 530,
+       "file": "bench/repos/esbuild/internal/css_parser/css_decls_color.go",
+       "name": null,
+       "start_line": 508
+      },
+      {
+       "end_line": 568,
+       "file": "bench/repos/esbuild/internal/css_parser/css_decls_color.go",
+       "name": null,
+       "start_line": 546
+      }
+     ],
+     "text_similarity": 0.961,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 530,
+       "file": "bench/repos/esbuild/internal/css_parser/css_decls_color.go",
+       "name": null,
+       "start_line": 508
+      },
+      {
+       "end_line": 568,
+       "file": "bench/repos/esbuild/internal/css_parser/css_decls_color.go",
+       "name": null,
+       "start_line": 546
+      }
+     ],
+     "text_similarity": 0.961,
+     "vj": 1.0
+    }
+   ],
+   "language": "Go",
+   "split": "heldout"
+  },
+  "etcd": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 55,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "String",
+       "start_line": 53
+      },
+      {
+       "end_line": 60,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "String",
+       "start_line": 58
+      }
+     ],
+     "text_similarity": 0.949,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 55,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "String",
+       "start_line": 53
+      },
+      {
+       "end_line": 109,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "String",
+       "start_line": 107
+      }
+     ],
+     "text_similarity": 0.867,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 55,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "String",
+       "start_line": 53
+      },
+      {
+       "end_line": 164,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "String",
+       "start_line": 162
+      }
+     ],
+     "text_similarity": 0.88,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 55,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "String",
+       "start_line": 53
+      },
+      {
+       "end_line": 216,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "String",
+       "start_line": 214
+      }
+     ],
+     "text_similarity": 0.879,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 55,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "String",
+       "start_line": 53
+      },
+      {
+       "end_line": 271,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "String",
+       "start_line": 269
+      }
+     ],
+     "text_similarity": 0.887,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 55,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "String",
+       "start_line": 53
+      },
+      {
+       "end_line": 319,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "String",
+       "start_line": 317
+      }
+     ],
+     "text_similarity": 0.875,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 55,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "String",
+       "start_line": 53
+      },
+      {
+       "end_line": 368,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "String",
+       "start_line": 366
+      }
+     ],
+     "text_similarity": 0.892,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 55,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "String",
+       "start_line": 53
+      },
+      {
+       "end_line": 417,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "String",
+       "start_line": 415
+      }
+     ],
+     "text_similarity": 0.857,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 55,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "String",
+       "start_line": 53
+      },
+      {
+       "end_line": 52,
+       "file": "bench/repos/etcd/api/mvccpb/kv.pb.go",
+       "name": "String",
+       "start_line": 50
+      }
+     ],
+     "text_similarity": 0.934,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 164,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetName",
+       "start_line": 159
+      },
+      {
+       "end_line": 292,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetName",
+       "start_line": 287
+      }
+     ],
+     "text_similarity": 0.963,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 164,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetName",
+       "start_line": 159
+      },
+      {
+       "end_line": 78,
+       "file": "bench/repos/etcd/server/etcdserver/api/v3election/v3electionpb/v3election.pb.go",
+       "name": "GetName",
+       "start_line": 73
+      }
+     ],
+     "text_similarity": 0.902,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 164,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetName",
+       "start_line": 159
+      },
+      {
+       "end_line": 199,
+       "file": "bench/repos/etcd/server/etcdserver/api/v3election/v3electionpb/v3election.pb.go",
+       "name": "GetName",
+       "start_line": 194
+      }
+     ],
+     "text_similarity": 0.946,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 164,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetName",
+       "start_line": 159
+      },
+      {
+       "end_line": 265,
+       "file": "bench/repos/etcd/server/etcdserver/api/v3election/v3electionpb/v3election.pb.go",
+       "name": "GetName",
+       "start_line": 260
+      }
+     ],
+     "text_similarity": 0.924,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 164,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetName",
+       "start_line": 159
+      },
+      {
+       "end_line": 76,
+       "file": "bench/repos/etcd/server/etcdserver/api/v3lock/v3lockpb/v3lock.pb.go",
+       "name": "GetName",
+       "start_line": 71
+      }
+     ],
+     "text_similarity": 0.923,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 178,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetRoles",
+       "start_line": 173
+      },
+      {
+       "end_line": 5587,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "GetRoles",
+       "start_line": 5582
+      }
+     ],
+     "text_similarity": 0.919,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 178,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetRoles",
+       "start_line": 173
+      },
+      {
+       "end_line": 5911,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "GetRoles",
+       "start_line": 5906
+      }
+     ],
+     "text_similarity": 0.892,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 185,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetOptions",
+       "start_line": 180
+      },
+      {
+       "end_line": 4705,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "GetOptions",
+       "start_line": 4700
+      }
+     ],
+     "text_similarity": 0.901,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 239,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetKey",
+       "start_line": 234
+      },
+      {
+       "end_line": 595,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "GetKey",
+       "start_line": 590
+      }
+     ],
+     "text_similarity": 0.895,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 239,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetKey",
+       "start_line": 234
+      },
+      {
+       "end_line": 812,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "GetKey",
+       "start_line": 807
+      }
+     ],
+     "text_similarity": 0.918,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 239,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetKey",
+       "start_line": 234
+      },
+      {
+       "end_line": 954,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "GetKey",
+       "start_line": 949
+      }
+     ],
+     "text_similarity": 0.865,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 239,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetKey",
+       "start_line": 234
+      },
+      {
+       "end_line": 1336,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "GetKey",
+       "start_line": 1331
+      }
+     ],
+     "text_similarity": 0.91,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 239,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetKey",
+       "start_line": 234
+      },
+      {
+       "end_line": 2168,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "GetKey",
+       "start_line": 2163
+      }
+     ],
+     "text_similarity": 0.865,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 239,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetKey",
+       "start_line": 234
+      },
+      {
+       "end_line": 5282,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "GetKey",
+       "start_line": 5277
+      }
+     ],
+     "text_similarity": 0.89,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 239,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetKey",
+       "start_line": 234
+      },
+      {
+       "end_line": 128,
+       "file": "bench/repos/etcd/api/mvccpb/kv.pb.go",
+       "name": "GetKey",
+       "start_line": 123
+      }
+     ],
+     "text_similarity": 0.905,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 239,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetKey",
+       "start_line": 234
+      },
+      {
+       "end_line": 206,
+       "file": "bench/repos/etcd/server/etcdserver/api/v3election/v3electionpb/v3election.pb.go",
+       "name": "GetKey",
+       "start_line": 201
+      }
+     ],
+     "text_similarity": 0.911,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 239,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetKey",
+       "start_line": 234
+      },
+      {
+       "end_line": 138,
+       "file": "bench/repos/etcd/server/etcdserver/api/v3lock/v3lockpb/v3lock.pb.go",
+       "name": "GetKey",
+       "start_line": 133
+      }
+     ],
+     "text_similarity": 0.919,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 239,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetKey",
+       "start_line": 234
+      },
+      {
+       "end_line": 183,
+       "file": "bench/repos/etcd/server/etcdserver/api/v3lock/v3lockpb/v3lock.pb.go",
+       "name": "GetKey",
+       "start_line": 178
+      }
+     ],
+     "text_similarity": 0.89,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 246,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetRangeEnd",
+       "start_line": 241
+      },
+      {
+       "end_line": 602,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "GetRangeEnd",
+       "start_line": 597
+      }
+     ],
+     "text_similarity": 0.906,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 246,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetRangeEnd",
+       "start_line": 241
+      },
+      {
+       "end_line": 961,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "GetRangeEnd",
+       "start_line": 956
+      }
+     ],
+     "text_similarity": 0.879,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 246,
+       "file": "bench/repos/etcd/api/authpb/auth.pb.go",
+       "name": "GetRangeEnd",
+       "start_line": 241
+      },
+      {
+       "end_line": 1395,
+       "file": "bench/repos/etcd/api/etcdserverpb/rpc.pb.go",
+       "name": "GetRangeEnd",
+       "start_line": 1390
+      }
+     ],
+     "text_similarity": 0.92,
+     "vj": 1.0
+    }
+   ],
+   "language": "Go",
+   "split": "heldout"
+  },
+  "fastlane": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 98,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_category=",
+       "start_line": 94
+      },
+      {
+       "end_line": 104,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_first_sub_category=",
+       "start_line": 100
+      }
+     ],
+     "text_similarity": 0.965,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 98,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_category=",
+       "start_line": 94
+      },
+      {
+       "end_line": 110,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_second_sub_category=",
+       "start_line": 106
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 98,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_category=",
+       "start_line": 94
+      },
+      {
+       "end_line": 116,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_category=",
+       "start_line": 112
+      }
+     ],
+     "text_similarity": 0.964,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 98,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_category=",
+       "start_line": 94
+      },
+      {
+       "end_line": 122,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_first_sub_category=",
+       "start_line": 118
+      }
+     ],
+     "text_similarity": 0.931,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 98,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_category=",
+       "start_line": 94
+      },
+      {
+       "end_line": 128,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_second_sub_category=",
+       "start_line": 124
+      }
+     ],
+     "text_similarity": 0.927,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 104,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_first_sub_category=",
+       "start_line": 100
+      },
+      {
+       "end_line": 110,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_second_sub_category=",
+       "start_line": 106
+      }
+     ],
+     "text_similarity": 0.97,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 104,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_first_sub_category=",
+       "start_line": 100
+      },
+      {
+       "end_line": 116,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_category=",
+       "start_line": 112
+      }
+     ],
+     "text_similarity": 0.931,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 104,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_first_sub_category=",
+       "start_line": 100
+      },
+      {
+       "end_line": 122,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_first_sub_category=",
+       "start_line": 118
+      }
+     ],
+     "text_similarity": 0.966,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 104,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_first_sub_category=",
+       "start_line": 100
+      },
+      {
+       "end_line": 128,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_second_sub_category=",
+       "start_line": 124
+      }
+     ],
+     "text_similarity": 0.936,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 110,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_second_sub_category=",
+       "start_line": 106
+      },
+      {
+       "end_line": 116,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_category=",
+       "start_line": 112
+      }
+     ],
+     "text_similarity": 0.948,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 110,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_second_sub_category=",
+       "start_line": 106
+      },
+      {
+       "end_line": 122,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_first_sub_category=",
+       "start_line": 118
+      }
+     ],
+     "text_similarity": 0.943,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 110,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "primary_second_sub_category=",
+       "start_line": 106
+      },
+      {
+       "end_line": 128,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_second_sub_category=",
+       "start_line": 124
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 116,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_category=",
+       "start_line": 112
+      },
+      {
+       "end_line": 122,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_first_sub_category=",
+       "start_line": 118
+      }
+     ],
+     "text_similarity": 0.966,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 116,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_category=",
+       "start_line": 112
+      },
+      {
+       "end_line": 128,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_second_sub_category=",
+       "start_line": 124
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 122,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_first_sub_category=",
+       "start_line": 118
+      },
+      {
+       "end_line": 128,
+       "file": "bench/repos/fastlane/spaceship/lib/spaceship/tunes/app_details.rb",
+       "name": "secondary_second_sub_category=",
+       "start_line": 124
+      }
+     ],
+     "text_similarity": 0.97,
+     "vj": 1.0
+    }
+   ],
+   "language": "Ruby",
+   "split": "dev"
+  },
+  "git": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 983,
+       "file": "bench/repos/git/t/unit-tests/clar/clar.c",
+       "name": "clar__assert_compare_i",
+       "start_line": 942
+      },
+      {
+       "end_line": 1026,
+       "file": "bench/repos/git/t/unit-tests/clar/clar.c",
+       "name": "clar__assert_compare_u",
+       "start_line": 985
+      }
+     ],
+     "text_similarity": 0.997,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 856,
+       "file": "bench/repos/git/builtin/update-index.c",
+       "name": "stdin_cacheinfo_callback",
+       "start_line": 842
+      },
+      {
+       "end_line": 871,
+       "file": "bench/repos/git/builtin/update-index.c",
+       "name": "stdin_callback",
+       "start_line": 858
+      }
+     ],
+     "text_similarity": 0.854,
+     "vj": 0.828
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 58,
+       "file": "bench/repos/git/builtin/merge-file.c",
+       "name": "diff_algorithm_cb",
+       "start_line": 46
+      },
+      {
+       "end_line": 5683,
+       "file": "bench/repos/git/diff.c",
+       "name": "diff_opt_diff_algorithm",
+       "start_line": 5669
+      }
+     ],
+     "text_similarity": 0.863,
+     "vj": 0.808
+    }
+   ],
+   "language": "C",
+   "split": "dev"
+  },
+  "gorm": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 918,
+       "file": "bench/repos/gorm/schema/field.go",
+       "name": null,
+       "start_line": 899
+      },
+      {
+       "end_line": 939,
+       "file": "bench/repos/gorm/schema/field.go",
+       "name": null,
+       "start_line": 925
+      }
+     ],
+     "text_similarity": 0.866,
+     "vj": 0.818
+    }
+   ],
+   "language": "Go",
+   "split": "dev"
+  },
+  "graphhopper": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 95,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "internalGetFieldAccessorTable",
+       "start_line": 89
+      },
+      {
+       "end_line": 5037,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "internalGetFieldAccessorTable",
+       "start_line": 5031
+      }
+     ],
+     "text_similarity": 0.981,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 366,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "internalGetFieldAccessorTable",
+       "start_line": 360
+      },
+      {
+       "end_line": 845,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "internalGetFieldAccessorTable",
+       "start_line": 839
+      }
+     ],
+     "text_similarity": 0.983,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 406,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "getStringValue",
+       "start_line": 392
+      },
+      {
+       "end_line": 2939,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "getName",
+       "start_line": 2925
+      }
+     ],
+     "text_similarity": 0.97,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 428,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "getStringValueBytes",
+       "start_line": 415
+      },
+      {
+       "end_line": 1127,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "getStringValueBytes",
+       "start_line": 1115
+      }
+     ],
+     "text_similarity": 0.939,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 428,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "getStringValueBytes",
+       "start_line": 415
+      },
+      {
+       "end_line": 2957,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "getNameBytes",
+       "start_line": 2944
+      }
+     ],
+     "text_similarity": 0.969,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 428,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "getStringValueBytes",
+       "start_line": 415
+      },
+      {
+       "end_line": 3881,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "getNameBytes",
+       "start_line": 3869
+      }
+     ],
+     "text_similarity": 0.907,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 765,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 761
+      },
+      {
+       "end_line": 792,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 787
+      }
+     ],
+     "text_similarity": 0.925,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 765,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 761
+      },
+      {
+       "end_line": 1941,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 1937
+      }
+     ],
+     "text_similarity": 0.988,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 765,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 761
+      },
+      {
+       "end_line": 1968,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 1963
+      }
+     ],
+     "text_similarity": 0.913,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 765,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 761
+      },
+      {
+       "end_line": 3369,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 3365
+      }
+     ],
+     "text_similarity": 0.987,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 765,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 761
+      },
+      {
+       "end_line": 3396,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 3391
+      }
+     ],
+     "text_similarity": 0.913,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 765,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 761
+      },
+      {
+       "end_line": 4962,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 4958
+      }
+     ],
+     "text_similarity": 0.965,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 765,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 761
+      },
+      {
+       "end_line": 4989,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 4984
+      }
+     ],
+     "text_similarity": 0.893,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 772,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 766
+      },
+      {
+       "end_line": 799,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 793
+      }
+     ],
+     "text_similarity": 0.961,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 772,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 766
+      },
+      {
+       "end_line": 1948,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 1942
+      }
+     ],
+     "text_similarity": 0.991,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 772,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 766
+      },
+      {
+       "end_line": 1975,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 1969
+      }
+     ],
+     "text_similarity": 0.953,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 772,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 766
+      },
+      {
+       "end_line": 3376,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 3370
+      }
+     ],
+     "text_similarity": 0.991,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 772,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 766
+      },
+      {
+       "end_line": 3403,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 3397
+      }
+     ],
+     "text_similarity": 0.953,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 772,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 766
+      },
+      {
+       "end_line": 4969,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 4963
+      }
+     ],
+     "text_similarity": 0.97,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 772,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 766
+      },
+      {
+       "end_line": 4996,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 4990
+      }
+     ],
+     "text_similarity": 0.931,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 778,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseDelimitedFrom",
+       "start_line": 774
+      },
+      {
+       "end_line": 1954,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseDelimitedFrom",
+       "start_line": 1950
+      }
+     ],
+     "text_similarity": 0.988,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 778,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseDelimitedFrom",
+       "start_line": 774
+      },
+      {
+       "end_line": 3382,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseDelimitedFrom",
+       "start_line": 3378
+      }
+     ],
+     "text_similarity": 0.988,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 778,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseDelimitedFrom",
+       "start_line": 774
+      },
+      {
+       "end_line": 4975,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseDelimitedFrom",
+       "start_line": 4971
+      }
+     ],
+     "text_similarity": 0.968,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 786,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseDelimitedFrom",
+       "start_line": 780
+      },
+      {
+       "end_line": 1962,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseDelimitedFrom",
+       "start_line": 1956
+      }
+     ],
+     "text_similarity": 0.992,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 786,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseDelimitedFrom",
+       "start_line": 780
+      },
+      {
+       "end_line": 3390,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseDelimitedFrom",
+       "start_line": 3384
+      }
+     ],
+     "text_similarity": 0.992,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 786,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseDelimitedFrom",
+       "start_line": 780
+      },
+      {
+       "end_line": 4983,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseDelimitedFrom",
+       "start_line": 4977
+      }
+     ],
+     "text_similarity": 0.971,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 792,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 787
+      },
+      {
+       "end_line": 1941,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 1937
+      }
+     ],
+     "text_similarity": 0.909,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 792,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 787
+      },
+      {
+       "end_line": 1968,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 1963
+      }
+     ],
+     "text_similarity": 0.989,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 792,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 787
+      },
+      {
+       "end_line": 3369,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 3365
+      }
+     ],
+     "text_similarity": 0.909,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 792,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 787
+      },
+      {
+       "end_line": 3396,
+       "file": "bench/repos/graphhopper/web-bundle/src/main/java/vector_tile/VectorTile.java",
+       "name": "parseFrom",
+       "start_line": 3391
+      }
+     ],
+     "text_similarity": 0.989,
+     "vj": 1.0
+    }
+   ],
+   "language": "Java",
+   "split": "dev"
+  },
+  "gson": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 95,
+       "file": "bench/repos/gson/gson/src/main/java/com/google/gson/JsonObject.java",
+       "name": "addProperty",
+       "start_line": 93
+      },
+      {
+       "end_line": 106,
+       "file": "bench/repos/gson/gson/src/main/java/com/google/gson/JsonObject.java",
+       "name": "addProperty",
+       "start_line": 104
+      }
+     ],
+     "text_similarity": 0.965,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 95,
+       "file": "bench/repos/gson/gson/src/main/java/com/google/gson/JsonObject.java",
+       "name": "addProperty",
+       "start_line": 93
+      },
+      {
+       "end_line": 117,
+       "file": "bench/repos/gson/gson/src/main/java/com/google/gson/JsonObject.java",
+       "name": "addProperty",
+       "start_line": 115
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 95,
+       "file": "bench/repos/gson/gson/src/main/java/com/google/gson/JsonObject.java",
+       "name": "addProperty",
+       "start_line": 93
+      },
+      {
+       "end_line": 128,
+       "file": "bench/repos/gson/gson/src/main/java/com/google/gson/JsonObject.java",
+       "name": "addProperty",
+       "start_line": 126
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 106,
+       "file": "bench/repos/gson/gson/src/main/java/com/google/gson/JsonObject.java",
+       "name": "addProperty",
+       "start_line": 104
+      },
+      {
+       "end_line": 117,
+       "file": "bench/repos/gson/gson/src/main/java/com/google/gson/JsonObject.java",
+       "name": "addProperty",
+       "start_line": 115
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 106,
+       "file": "bench/repos/gson/gson/src/main/java/com/google/gson/JsonObject.java",
+       "name": "addProperty",
+       "start_line": 104
+      },
+      {
+       "end_line": 128,
+       "file": "bench/repos/gson/gson/src/main/java/com/google/gson/JsonObject.java",
+       "name": "addProperty",
+       "start_line": 126
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 117,
+       "file": "bench/repos/gson/gson/src/main/java/com/google/gson/JsonObject.java",
+       "name": "addProperty",
+       "start_line": 115
+      },
+      {
+       "end_line": 128,
+       "file": "bench/repos/gson/gson/src/main/java/com/google/gson/JsonObject.java",
+       "name": "addProperty",
+       "start_line": 126
+      }
+     ],
+     "text_similarity": 0.952,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 235,
+       "file": "bench/repos/gson/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java",
+       "name": "testStrictNansAndInfinities",
+       "start_line": 224
+      },
+      {
+       "end_line": 254,
+       "file": "bench/repos/gson/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java",
+       "name": "testStrictBoxedNansAndInfinities",
+       "start_line": 238
+      }
+     ],
+     "text_similarity": 0.914,
+     "vj": 1.0
+    }
+   ],
+   "language": "Java",
+   "split": "dev"
+  },
+  "guava": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 813,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 805
+      },
+      {
+       "end_line": 836,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 828
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 813,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 805
+      },
+      {
+       "end_line": 859,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 851
+      }
+     ],
+     "text_similarity": 0.953,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 813,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 805
+      },
+      {
+       "end_line": 882,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 874
+      }
+     ],
+     "text_similarity": 0.949,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 813,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 805
+      },
+      {
+       "end_line": 905,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 897
+      }
+     ],
+     "text_similarity": 0.953,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 813,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 805
+      },
+      {
+       "end_line": 928,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 920
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 813,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 805
+      },
+      {
+       "end_line": 951,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 943
+      }
+     ],
+     "text_similarity": 0.923,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 813,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 805
+      },
+      {
+       "end_line": 974,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 966
+      }
+     ],
+     "text_similarity": 0.913,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 836,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 828
+      },
+      {
+       "end_line": 859,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 851
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 836,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 828
+      },
+      {
+       "end_line": 882,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 874
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 836,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 828
+      },
+      {
+       "end_line": 905,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 897
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 836,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 828
+      },
+      {
+       "end_line": 928,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 920
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 836,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 828
+      },
+      {
+       "end_line": 951,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 943
+      }
+     ],
+     "text_similarity": 0.908,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 836,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 828
+      },
+      {
+       "end_line": 974,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 966
+      }
+     ],
+     "text_similarity": 0.936,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 859,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 851
+      },
+      {
+       "end_line": 882,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 874
+      }
+     ],
+     "text_similarity": 0.958,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 859,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 851
+      },
+      {
+       "end_line": 905,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 897
+      }
+     ],
+     "text_similarity": 0.972,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 859,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 851
+      },
+      {
+       "end_line": 928,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 920
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 859,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 851
+      },
+      {
+       "end_line": 951,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 943
+      }
+     ],
+     "text_similarity": 0.922,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 859,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 851
+      },
+      {
+       "end_line": 974,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 966
+      }
+     ],
+     "text_similarity": 0.931,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 882,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 874
+      },
+      {
+       "end_line": 905,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 897
+      }
+     ],
+     "text_similarity": 0.958,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 882,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 874
+      },
+      {
+       "end_line": 928,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 920
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 882,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 874
+      },
+      {
+       "end_line": 951,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 943
+      }
+     ],
+     "text_similarity": 0.909,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 882,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 874
+      },
+      {
+       "end_line": 974,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 966
+      }
+     ],
+     "text_similarity": 0.936,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 905,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 897
+      },
+      {
+       "end_line": 928,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 920
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 905,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 897
+      },
+      {
+       "end_line": 951,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 943
+      }
+     ],
+     "text_similarity": 0.932,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 905,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 897
+      },
+      {
+       "end_line": 974,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 966
+      }
+     ],
+     "text_similarity": 0.922,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 928,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 920
+      },
+      {
+       "end_line": 951,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 943
+      }
+     ],
+     "text_similarity": 0.927,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 928,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 920
+      },
+      {
+       "end_line": 974,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 966
+      }
+     ],
+     "text_similarity": 0.936,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 951,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 943
+      },
+      {
+       "end_line": 974,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java",
+       "name": "equals",
+       "start_line": 966
+      }
+     ],
+     "text_similarity": 0.932,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1100,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/NullPointerTesterTest.java",
+       "name": "check",
+       "start_line": 1096
+      },
+      {
+       "end_line": 1118,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/NullPointerTesterTest.java",
+       "name": "check",
+       "start_line": 1114
+      }
+     ],
+     "text_similarity": 0.935,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1100,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/NullPointerTesterTest.java",
+       "name": "check",
+       "start_line": 1096
+      },
+      {
+       "end_line": 1136,
+       "file": "bench/repos/guava/guava-testlib/test/com/google/common/testing/NullPointerTesterTest.java",
+       "name": "check",
+       "start_line": 1132
+      }
+     ],
+     "text_similarity": 0.954,
+     "vj": 1.0
+    }
+   ],
+   "language": "Java",
+   "split": "dev"
+  },
+  "h2database": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 738,
+       "file": "bench/repos/h2database/h2/src/main/org/h2/message/DbException.java",
+       "name": "printNextExceptions",
+       "start_line": 727
+      },
+      {
+       "end_line": 757,
+       "file": "bench/repos/h2database/h2/src/main/org/h2/message/DbException.java",
+       "name": "printNextExceptions",
+       "start_line": 746
+      }
+     ],
+     "text_similarity": 0.99,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 74,
+       "file": "bench/repos/h2database/h2/src/main/org/h2/util/OsgiDataSourceFactory.java",
+       "name": "createDataSource",
+       "start_line": 54
+      },
+      {
+       "end_line": 104,
+       "file": "bench/repos/h2database/h2/src/main/org/h2/util/OsgiDataSourceFactory.java",
+       "name": "createConnectionPoolDataSource",
+       "start_line": 84
+      }
+     ],
+     "text_similarity": 0.916,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 74,
+       "file": "bench/repos/h2database/h2/src/main/org/h2/util/OsgiDataSourceFactory.java",
+       "name": "createDataSource",
+       "start_line": 54
+      },
+      {
+       "end_line": 134,
+       "file": "bench/repos/h2database/h2/src/main/org/h2/util/OsgiDataSourceFactory.java",
+       "name": "createXADataSource",
+       "start_line": 114
+      }
+     ],
+     "text_similarity": 0.951,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 104,
+       "file": "bench/repos/h2database/h2/src/main/org/h2/util/OsgiDataSourceFactory.java",
+       "name": "createConnectionPoolDataSource",
+       "start_line": 84
+      },
+      {
+       "end_line": 134,
+       "file": "bench/repos/h2database/h2/src/main/org/h2/util/OsgiDataSourceFactory.java",
+       "name": "createXADataSource",
+       "start_line": 114
+      }
+     ],
+     "text_similarity": 0.958,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/h2database/h2/src/tools/org/h2/build/indexer/HtmlConverter.java",
+       "name": null,
+       "start_line": 98
+      },
+      {
+       "end_line": 135,
+       "file": "bench/repos/h2database/h2/src/tools/org/h2/build/indexer/HtmlConverter.java",
+       "name": null,
+       "start_line": 133
+      }
+     ],
+     "text_similarity": 0.923,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 545,
+       "file": "bench/repos/h2database/h2/src/main/org/h2/table/Table.java",
+       "name": null,
+       "start_line": 530
+      },
+      {
+       "end_line": 562,
+       "file": "bench/repos/h2database/h2/src/main/org/h2/table/Table.java",
+       "name": null,
+       "start_line": 548
+      }
+     ],
+     "text_similarity": 0.858,
+     "vj": 0.821
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 116,
+       "file": "bench/repos/h2database/h2/src/test/org/h2/test/bench/BenchA.java",
+       "name": "runTest",
+       "start_line": 108
+      },
+      {
+       "end_line": 219,
+       "file": "bench/repos/h2database/h2/src/test/org/h2/test/bench/BenchB.java",
+       "name": "runTest",
+       "start_line": 209
+      }
+     ],
+     "text_similarity": 0.872,
+     "vj": 0.808
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 48,
+       "file": "bench/repos/h2database/h2/src/main/org/h2/expression/OperationN.java",
+       "name": "addParameter",
+       "start_line": 41
+      },
+      {
+       "end_line": 103,
+       "file": "bench/repos/h2database/h2/src/tools/org/h2/build/doc/XMLParser.java",
+       "name": "addAttributeName",
+       "start_line": 97
+      }
+     ],
+     "text_similarity": 0.526,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 38,
+       "file": "bench/repos/h2database/h2/src/main/org/h2/expression/function/table/TableFunction.java",
+       "name": "addParameter",
+       "start_line": 31
+      },
+      {
+       "end_line": 103,
+       "file": "bench/repos/h2database/h2/src/tools/org/h2/build/doc/XMLParser.java",
+       "name": "addAttributeName",
+       "start_line": 97
+      }
+     ],
+     "text_similarity": 0.526,
+     "vj": 0.8
+    }
+   ],
+   "language": "Java",
+   "split": "heldout"
+  },
+  "hugo": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1704,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderLink",
+       "start_line": 1702
+      },
+      {
+       "end_line": 1708,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderHeading",
+       "start_line": 1706
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1704,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderLink",
+       "start_line": 1702
+      },
+      {
+       "end_line": 1712,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderCodeblock",
+       "start_line": 1710
+      }
+     ],
+     "text_similarity": 0.92,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1704,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderLink",
+       "start_line": 1702
+      },
+      {
+       "end_line": 1716,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderPassthrough",
+       "start_line": 1714
+      }
+     ],
+     "text_similarity": 0.919,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1704,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderLink",
+       "start_line": 1702
+      },
+      {
+       "end_line": 1720,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderBlockquote",
+       "start_line": 1718
+      }
+     ],
+     "text_similarity": 0.915,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1704,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderLink",
+       "start_line": 1702
+      },
+      {
+       "end_line": 1724,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderTable",
+       "start_line": 1722
+      }
+     ],
+     "text_similarity": 0.929,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1708,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderHeading",
+       "start_line": 1706
+      },
+      {
+       "end_line": 1712,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderCodeblock",
+       "start_line": 1710
+      }
+     ],
+     "text_similarity": 0.906,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1708,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderHeading",
+       "start_line": 1706
+      },
+      {
+       "end_line": 1716,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderPassthrough",
+       "start_line": 1714
+      }
+     ],
+     "text_similarity": 0.926,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1708,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderHeading",
+       "start_line": 1706
+      },
+      {
+       "end_line": 1720,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderBlockquote",
+       "start_line": 1718
+      }
+     ],
+     "text_similarity": 0.901,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1708,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderHeading",
+       "start_line": 1706
+      },
+      {
+       "end_line": 1724,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderTable",
+       "start_line": 1722
+      }
+     ],
+     "text_similarity": 0.925,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1712,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderCodeblock",
+       "start_line": 1710
+      },
+      {
+       "end_line": 1716,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderPassthrough",
+       "start_line": 1714
+      }
+     ],
+     "text_similarity": 0.887,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1712,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderCodeblock",
+       "start_line": 1710
+      },
+      {
+       "end_line": 1720,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderBlockquote",
+       "start_line": 1718
+      }
+     ],
+     "text_similarity": 0.944,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1712,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderCodeblock",
+       "start_line": 1710
+      },
+      {
+       "end_line": 1724,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderTable",
+       "start_line": 1722
+      }
+     ],
+     "text_similarity": 0.948,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1716,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderPassthrough",
+       "start_line": 1714
+      },
+      {
+       "end_line": 1720,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderBlockquote",
+       "start_line": 1718
+      }
+     ],
+     "text_similarity": 0.883,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1716,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderPassthrough",
+       "start_line": 1714
+      },
+      {
+       "end_line": 1724,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderTable",
+       "start_line": 1722
+      }
+     ],
+     "text_similarity": 0.906,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1720,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderBlockquote",
+       "start_line": 1718
+      },
+      {
+       "end_line": 1724,
+       "file": "bench/repos/hugo/hugolib/site.go",
+       "name": "RenderTable",
+       "start_line": 1722
+      }
+     ],
+     "text_similarity": 0.943,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 1477,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": "json_object_get_count",
+       "start_line": 1475
+      },
+      {
+       "end_line": 1552,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": "json_array_get_count",
+       "start_line": 1550
+      }
+     ],
+     "text_similarity": 0.712,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1477,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": "json_object_get_count",
+       "start_line": 1475
+      },
+      {
+       "end_line": 1551,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": null,
+       "start_line": 1551
+      }
+     ],
+     "text_similarity": 0.388,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1476,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": null,
+       "start_line": 1476
+      },
+      {
+       "end_line": 1551,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": null,
+       "start_line": 1551
+      }
+     ],
+     "text_similarity": 0.703,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1482,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": null,
+       "start_line": 1480
+      },
+      {
+       "end_line": 1489,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": null,
+       "start_line": 1487
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1482,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": null,
+       "start_line": 1480
+      },
+      {
+       "end_line": 1522,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": null,
+       "start_line": 1520
+      }
+     ],
+     "text_similarity": 0.822,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1489,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": null,
+       "start_line": 1487
+      },
+      {
+       "end_line": 1522,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": null,
+       "start_line": 1520
+      }
+     ],
+     "text_similarity": 0.822,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 1498,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": "json_object_get_wrapping_value",
+       "start_line": 1493
+      },
+      {
+       "end_line": 1559,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": "json_array_get_wrapping_value",
+       "start_line": 1554
+      }
+     ],
+     "text_similarity": 0.816,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1552,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": "json_array_get_count",
+       "start_line": 1550
+      },
+      {
+       "end_line": 1476,
+       "file": "bench/repos/hugo/internal/warpc/deps/parson/parson.c",
+       "name": null,
+       "start_line": 1476
+      }
+     ],
+     "text_similarity": 0.397,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 139,
+       "file": "bench/repos/hugo/transform/urlreplacers/absurlreplacer_test.go",
+       "name": "BenchmarkAbsURLSrcset",
+       "start_line": 133
+      },
+      {
+       "end_line": 180,
+       "file": "bench/repos/hugo/transform/urlreplacers/absurlreplacer_test.go",
+       "name": "TestAbsURLSrcSet",
+       "start_line": 176
+      }
+     ],
+     "text_similarity": 0.863,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 147,
+       "file": "bench/repos/hugo/transform/urlreplacers/absurlreplacer_test.go",
+       "name": "BenchmarkXMLAbsURLSrcset",
+       "start_line": 141
+      },
+      {
+       "end_line": 186,
+       "file": "bench/repos/hugo/transform/urlreplacers/absurlreplacer_test.go",
+       "name": "TestAbsXMLURLSrcSet",
+       "start_line": 182
+      }
+     ],
+     "text_similarity": 0.853,
+     "vj": 0.8
+    }
+   ],
+   "language": "Go",
+   "split": "dev"
+  },
+  "image": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 400,
+       "file": "bench/repos/image/src/imageops/filter_1d.rs",
+       "name": "transform",
+       "start_line": 397
+      },
+      {
+       "end_line": 407,
+       "file": "bench/repos/image/src/imageops/filter_1d.rs",
+       "name": "transform",
+       "start_line": 404
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 62,
+       "file": "bench/repos/image/tests/conversions.rs",
+       "name": "test_decode_8bit_jpeg_ycbcr",
+       "start_line": 44
+      },
+      {
+       "end_line": 84,
+       "file": "bench/repos/image/tests/conversions.rs",
+       "name": "test_decode_8bit_ycbcr_lzw_bt709",
+       "start_line": 66
+      }
+     ],
+     "text_similarity": 0.981,
+     "vj": 1.0
+    }
+   ],
+   "language": "Rust",
+   "split": "dev"
+  },
+  "jackson-core": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 229,
+       "file": "bench/repos/jackson-core/src/main/java/tools/jackson/core/base/DecorableTSFactory.java",
+       "name": "_decorate",
+       "start_line": 220
+      },
+      {
+       "end_line": 240,
+       "file": "bench/repos/jackson-core/src/main/java/tools/jackson/core/base/DecorableTSFactory.java",
+       "name": "_decorate",
+       "start_line": 231
+      }
+     ],
+     "text_similarity": 0.934,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 359,
+       "file": "bench/repos/jackson-core/src/main/java/tools/jackson/core/json/JsonFactory.java",
+       "name": "createNonBlockingByteArrayParser",
+       "start_line": 350
+      },
+      {
+       "end_line": 370,
+       "file": "bench/repos/jackson-core/src/main/java/tools/jackson/core/json/JsonFactory.java",
+       "name": "createNonBlockingByteBufferParser",
+       "start_line": 361
+      }
+     ],
+     "text_similarity": 0.982,
+     "vj": 1.0
+    }
+   ],
+   "language": "Java",
+   "split": "heldout"
+  },
+  "jedis": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 519,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/ClusterCommandObjects.java",
+       "name": "msetMultiShard",
+       "start_line": 513
+      },
+      {
+       "end_line": 535,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/ClusterCommandObjects.java",
+       "name": "msetMultiShard",
+       "start_line": 529
+      }
+     ],
+     "text_similarity": 0.987,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 196,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "expire",
+       "start_line": 193
+      },
+      {
+       "end_line": 201,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "expire",
+       "start_line": 198
+      }
+     ],
+     "text_similarity": 0.978,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 214,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "pexpire",
+       "start_line": 211
+      },
+      {
+       "end_line": 219,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "pexpire",
+       "start_line": 216
+      }
+     ],
+     "text_similarity": 0.979,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 247,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "expireAt",
+       "start_line": 245
+      },
+      {
+       "end_line": 251,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "expireAt",
+       "start_line": 249
+      }
+     ],
+     "text_similarity": 0.978,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 264,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "pexpireAt",
+       "start_line": 261
+      },
+      {
+       "end_line": 269,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "pexpireAt",
+       "start_line": 266
+      }
+     ],
+     "text_similarity": 0.981,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 399,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "copy",
+       "start_line": 393
+      },
+      {
+       "end_line": 407,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "copy",
+       "start_line": 401
+      }
+     ],
+     "text_similarity": 0.966,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 632,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "msetex",
+       "start_line": 627
+      },
+      {
+       "end_line": 639,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "msetex",
+       "start_line": 634
+      }
+     ],
+     "text_similarity": 0.984,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 869,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "lset",
+       "start_line": 867
+      },
+      {
+       "end_line": 873,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "lset",
+       "start_line": 871
+      }
+     ],
+     "text_similarity": 0.949,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 944,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "linsert",
+       "start_line": 941
+      },
+      {
+       "end_line": 949,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "linsert",
+       "start_line": 946
+      }
+     ],
+     "text_similarity": 0.937,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1585,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "smove",
+       "start_line": 1583
+      },
+      {
+       "end_line": 1589,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "smove",
+       "start_line": 1587
+      }
+     ],
+     "text_similarity": 0.927,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1795,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "zcount",
+       "start_line": 1793
+      },
+      {
+       "end_line": 1799,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "zcount",
+       "start_line": 1797
+      }
+     ],
+     "text_similarity": 0.937,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1795,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "zcount",
+       "start_line": 1793
+      },
+      {
+       "end_line": 1803,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "zcount",
+       "start_line": 1801
+      }
+     ],
+     "text_similarity": 0.974,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1795,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "zcount",
+       "start_line": 1793
+      },
+      {
+       "end_line": 1807,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "zcount",
+       "start_line": 1805
+      }
+     ],
+     "text_similarity": 0.931,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1799,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "zcount",
+       "start_line": 1797
+      },
+      {
+       "end_line": 1803,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "zcount",
+       "start_line": 1801
+      }
+     ],
+     "text_similarity": 0.91,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1799,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "zcount",
+       "start_line": 1797
+      },
+      {
+       "end_line": 1807,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "zcount",
+       "start_line": 1805
+      }
+     ],
+     "text_similarity": 0.921,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1803,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "zcount",
+       "start_line": 1801
+      },
+      {
+       "end_line": 1807,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "zcount",
+       "start_line": 1805
+      }
+     ],
+     "text_similarity": 0.958,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 2652,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "ardel",
+       "start_line": 2646
+      },
+      {
+       "end_line": 2660,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "ardel",
+       "start_line": 2654
+      }
+     ],
+     "text_similarity": 0.98,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 2812,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "armset",
+       "start_line": 2806
+      },
+      {
+       "end_line": 2820,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "armset",
+       "start_line": 2814
+      }
+     ],
+     "text_similarity": 0.955,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 2883,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "arring",
+       "start_line": 2880
+      },
+      {
+       "end_line": 2888,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "arring",
+       "start_line": 2885
+      }
+     ],
+     "text_similarity": 0.95,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 2921,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "arset",
+       "start_line": 2918
+      },
+      {
+       "end_line": 2926,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "arset",
+       "start_line": 2923
+      }
+     ],
+     "text_similarity": 0.955,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 3775,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "copy",
+       "start_line": 3771
+      },
+      {
+       "end_line": 3781,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "copy",
+       "start_line": 3777
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 3877,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "waitReplicas",
+       "start_line": 3875
+      },
+      {
+       "end_line": 3881,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "waitReplicas",
+       "start_line": 3879
+      }
+     ],
+     "text_similarity": 0.978,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 3889,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "waitAOF",
+       "start_line": 3887
+      },
+      {
+       "end_line": 3893,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "waitAOF",
+       "start_line": 3891
+      }
+     ],
+     "text_similarity": 0.982,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 5513,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "vsetattr",
+       "start_line": 5511
+      },
+      {
+       "end_line": 5517,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/CommandObjects.java",
+       "name": "vsetattr",
+       "start_line": 5515
+      }
+     ],
+     "text_similarity": 0.934,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 138,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/Pipeline.java",
+       "name": "move",
+       "start_line": 134
+      },
+      {
+       "end_line": 144,
+       "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/Pipeline.java",
+       "name": "move",
+       "start_line": 140
+      }
+     ],
+     "text_similarity": 0.957,
+     "vj": 1.0
+    }
+   ],
+   "language": "Java",
+   "split": "heldout"
+  },
+  "junit5": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 34,
+       "file": "bench/repos/junit5/documentation/src/test/java/example/ParameterizedMigrationDemo.java",
+       "name": "data",
+       "start_line": 31
+      },
+      {
+       "end_line": 73,
+       "file": "bench/repos/junit5/documentation/src/test/java/example/ParameterizedMigrationDemo.java",
+       "name": "data",
+       "start_line": 71
+      }
+     ],
+     "text_similarity": 0.865,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 692,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java",
+       "name": "provideTestTemplateInvocationContexts",
+       "start_line": 689
+      },
+      {
+       "end_line": 734,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java",
+       "name": "provideTestTemplateInvocationContexts",
+       "start_line": 731
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 692,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java",
+       "name": "provideTestTemplateInvocationContexts",
+       "start_line": 689
+      },
+      {
+       "end_line": 767,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java",
+       "name": "provideTestTemplateInvocationContexts",
+       "start_line": 764
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 734,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java",
+       "name": "provideTestTemplateInvocationContexts",
+       "start_line": 731
+      },
+      {
+       "end_line": 767,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java",
+       "name": "provideTestTemplateInvocationContexts",
+       "start_line": 764
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1795,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedClassIntegrationTests.java",
+       "name": "setOrCheckWrapper",
+       "start_line": 1788
+      },
+      {
+       "end_line": 1832,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedClassIntegrationTests.java",
+       "name": "setOrCheckWrapper",
+       "start_line": 1825
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 352,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatterTests.java",
+       "name": "quotedStrings",
+       "start_line": 333
+      },
+      {
+       "end_line": 374,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatterTests.java",
+       "name": "quotedCharacters",
+       "start_line": 354
+      }
+     ],
+     "text_similarity": 0.8,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1593,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToFalseForCsvSource",
+       "start_line": 1589
+      },
+      {
+       "end_line": 1599,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToTrueForCsvSource",
+       "start_line": 1595
+      }
+     ],
+     "text_similarity": 0.978,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1593,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToFalseForCsvSource",
+       "start_line": 1589
+      },
+      {
+       "end_line": 1598,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1598
+      }
+     ],
+     "text_similarity": 0.332,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1593,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToFalseForCsvSource",
+       "start_line": 1589
+      },
+      {
+       "end_line": 1605,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToFalseForCsvFileSource",
+       "start_line": 1601
+      }
+     ],
+     "text_similarity": 0.891,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1593,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToFalseForCsvSource",
+       "start_line": 1589
+      },
+      {
+       "end_line": 1604,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1604
+      }
+     ],
+     "text_similarity": 0.332,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1593,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToFalseForCsvSource",
+       "start_line": 1589
+      },
+      {
+       "end_line": 1611,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToTrueForCsvFileSource",
+       "start_line": 1607
+      }
+     ],
+     "text_similarity": 0.869,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1593,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToFalseForCsvSource",
+       "start_line": 1589
+      },
+      {
+       "end_line": 1610,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1610
+      }
+     ],
+     "text_similarity": 0.332,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1592,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1592
+      },
+      {
+       "end_line": 1598,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1598
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1592,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1592
+      },
+      {
+       "end_line": 1604,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1604
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1592,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1592
+      },
+      {
+       "end_line": 1610,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1610
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1599,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToTrueForCsvSource",
+       "start_line": 1595
+      },
+      {
+       "end_line": 1592,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1592
+      }
+     ],
+     "text_similarity": 0.333,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1599,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToTrueForCsvSource",
+       "start_line": 1595
+      },
+      {
+       "end_line": 1605,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToFalseForCsvFileSource",
+       "start_line": 1601
+      }
+     ],
+     "text_similarity": 0.869,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1599,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToTrueForCsvSource",
+       "start_line": 1595
+      },
+      {
+       "end_line": 1604,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1604
+      }
+     ],
+     "text_similarity": 0.333,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1599,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToTrueForCsvSource",
+       "start_line": 1595
+      },
+      {
+       "end_line": 1611,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToTrueForCsvFileSource",
+       "start_line": 1607
+      }
+     ],
+     "text_similarity": 0.89,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1599,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToTrueForCsvSource",
+       "start_line": 1595
+      },
+      {
+       "end_line": 1610,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1610
+      }
+     ],
+     "text_similarity": 0.333,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1598,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1598
+      },
+      {
+       "end_line": 1604,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1604
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1598,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1598
+      },
+      {
+       "end_line": 1610,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1610
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1605,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToFalseForCsvFileSource",
+       "start_line": 1601
+      },
+      {
+       "end_line": 1592,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1592
+      }
+     ],
+     "text_similarity": 0.31,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1605,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToFalseForCsvFileSource",
+       "start_line": 1601
+      },
+      {
+       "end_line": 1598,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1598
+      }
+     ],
+     "text_similarity": 0.31,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1605,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToFalseForCsvFileSource",
+       "start_line": 1601
+      },
+      {
+       "end_line": 1611,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToTrueForCsvFileSource",
+       "start_line": 1607
+      }
+     ],
+     "text_similarity": 0.98,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1605,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToFalseForCsvFileSource",
+       "start_line": 1601
+      },
+      {
+       "end_line": 1610,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1610
+      }
+     ],
+     "text_similarity": 0.31,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1604,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1604
+      },
+      {
+       "end_line": 1610,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1610
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1611,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToTrueForCsvFileSource",
+       "start_line": 1607
+      },
+      {
+       "end_line": 1592,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1592
+      }
+     ],
+     "text_similarity": 0.312,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1611,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToTrueForCsvFileSource",
+       "start_line": 1607
+      },
+      {
+       "end_line": 1598,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1598
+      }
+     ],
+     "text_similarity": 0.312,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1611,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": "testWithIgnoreLeadingAndTrailingWhitespaceSetToTrueForCsvFileSource",
+       "start_line": 1607
+      },
+      {
+       "end_line": 1604,
+       "file": "bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java",
+       "name": null,
+       "start_line": 1604
+      }
+     ],
+     "text_similarity": 0.312,
+     "vj": 1.0
+    }
+   ],
+   "language": "Java",
+   "split": "dev"
+  },
+  "ky": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 1131,
+       "file": "bench/repos/ky/test/retry.ts",
+       "name": "customFetch",
+       "start_line": 1127
+      },
+      {
+       "end_line": 1858,
+       "file": "bench/repos/ky/test/retry.ts",
+       "name": "customFetch",
+       "start_line": 1855
+      }
+     ],
+     "text_similarity": 0.918,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 1661,
+       "file": "bench/repos/ky/test/retry.ts",
+       "name": "customFetch",
+       "start_line": 1657
+      },
+      {
+       "end_line": 1858,
+       "file": "bench/repos/ky/test/retry.ts",
+       "name": "customFetch",
+       "start_line": 1855
+      }
+     ],
+     "text_similarity": 0.918,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 1858,
+       "file": "bench/repos/ky/test/retry.ts",
+       "name": "customFetch",
+       "start_line": 1855
+      },
+      {
+       "end_line": 1887,
+       "file": "bench/repos/ky/test/retry.ts",
+       "name": "customFetch",
+       "start_line": 1882
+      }
+     ],
+     "text_similarity": 0.725,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 1858,
+       "file": "bench/repos/ky/test/retry.ts",
+       "name": "customFetch",
+       "start_line": 1855
+      },
+      {
+       "end_line": 1915,
+       "file": "bench/repos/ky/test/retry.ts",
+       "name": "customFetch",
+       "start_line": 1911
+      }
+     ],
+     "text_similarity": 0.918,
+     "vj": 0.8
+    }
+   ],
+   "language": "TypeScript",
+   "split": "heldout"
+  },
+  "libgdx": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 66,
+       "file": "bench/repos/libgdx/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplet.java",
+       "name": "LwjglApplet",
+       "start_line": 48
+      },
+      {
+       "end_line": 86,
+       "file": "bench/repos/libgdx/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplet.java",
+       "name": "LwjglApplet",
+       "start_line": 68
+      }
+     ],
+     "text_similarity": 0.947,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1537,
+       "file": "bench/repos/libgdx/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/org/jbox2d/particle/ParticleSystem.java",
+       "name": "setParticleBuffer",
+       "start_line": 1530
+      },
+      {
+       "end_line": 1546,
+       "file": "bench/repos/libgdx/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/org/jbox2d/particle/ParticleSystem.java",
+       "name": "setParticleBuffer",
+       "start_line": 1539
+      }
+     ],
+     "text_similarity": 0.982,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 3296,
+       "file": "bench/repos/libgdx/gdx/jni/gdx2d/stb_image.h",
+       "name": null,
+       "start_line": 3291
+      },
+      {
+       "end_line": 3412,
+       "file": "bench/repos/libgdx/gdx/jni/gdx2d/stb_image.h",
+       "name": null,
+       "start_line": 3407
+      }
+     ],
+     "text_similarity": 0.989,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 86,
+       "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParallelArray.java",
+       "name": "FloatChannel",
+       "start_line": 83
+      },
+      {
+       "end_line": 121,
+       "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParallelArray.java",
+       "name": "IntChannel",
+       "start_line": 118
+      }
+     ],
+     "text_similarity": 0.94,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 112,
+       "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParallelArray.java",
+       "name": "setCapacity",
+       "start_line": 107
+      },
+      {
+       "end_line": 147,
+       "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParallelArray.java",
+       "name": "setCapacity",
+       "start_line": 142
+      }
+     ],
+     "text_similarity": 0.975,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 696,
+       "file": "bench/repos/libgdx/extensions/gdx-bullet/jni/src/bullet/LinearMath/btScalar.h",
+       "name": "btSwapEndianDouble",
+       "start_line": 684
+      },
+      {
+       "end_line": 1259,
+       "file": "bench/repos/libgdx/extensions/gdx-bullet/jni/src/bullet/LinearMath/btVector3.h",
+       "name": "btSwapScalarEndian",
+       "start_line": 1238
+      }
+     ],
+     "text_similarity": 0.507,
+     "vj": 0.84
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 175,
+       "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java",
+       "name": "unbind",
+       "start_line": 161
+      },
+      {
+       "end_line": 240,
+       "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObject.java",
+       "name": "unbind",
+       "start_line": 224
+      }
+     ],
+     "text_similarity": 0.914,
+     "vj": 0.811
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 175,
+       "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java",
+       "name": "unbind",
+       "start_line": 161
+      },
+      {
+       "end_line": 224,
+       "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectSubData.java",
+       "name": "unbind",
+       "start_line": 208
+      }
+     ],
+     "text_similarity": 0.914,
+     "vj": 0.811
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 114,
+       "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Widget.java",
+       "name": "pack",
+       "start_line": 111
+      },
+      {
+       "end_line": 148,
+       "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/WidgetGroup.java",
+       "name": "pack",
+       "start_line": 141
+      }
+     ],
+     "text_similarity": 0.382,
+     "vj": 0.8
+    }
+   ],
+   "language": "Java",
+   "split": "heldout"
+  },
+  "libuv": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 235,
+       "file": "bench/repos/libuv/src/unix/ibmi.c",
+       "name": "uv_get_free_memory",
+       "start_line": 228
+      },
+      {
+       "end_line": 245,
+       "file": "bench/repos/libuv/src/unix/ibmi.c",
+       "name": "uv_get_total_memory",
+       "start_line": 238
+      }
+     ],
+     "text_similarity": 0.972,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 958,
+       "file": "bench/repos/libuv/test/test-spawn.c",
+       "name": "spawn_and_ping",
+       "start_line": 914
+      },
+      {
+       "end_line": 1005,
+       "file": "bench/repos/libuv/test/test-spawn.c",
+       "name": "spawn_same_stdout_stderr",
+       "start_line": 961
+      }
+     ],
+     "text_similarity": 0.991,
+     "vj": 1.0
+    }
+   ],
+   "language": "C",
+   "split": "heldout"
+  },
+  "meilisearch": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 246,
+       "file": "bench/repos/meilisearch/crates/milli/src/update/new/extract/geo/mod.rs",
+       "name": null,
+       "start_line": 240
+      },
+      {
+       "end_line": 274,
+       "file": "bench/repos/meilisearch/crates/milli/src/update/new/extract/geo/mod.rs",
+       "name": null,
+       "start_line": 268
+      }
+     ],
+     "text_similarity": 0.966,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 60,
+       "file": "bench/repos/meilisearch/crates/milli/src/update/new/indexer/document_operation.rs",
+       "name": "replace_documents",
+       "start_line": 51
+      },
+      {
+       "end_line": 74,
+       "file": "bench/repos/meilisearch/crates/milli/src/update/new/indexer/document_operation.rs",
+       "name": "update_documents",
+       "start_line": 65
+      }
+     ],
+     "text_similarity": 0.979,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 179,
+       "file": "bench/repos/meilisearch/crates/dump/src/writer.rs",
+       "name": "new",
+       "start_line": 171
+      },
+      {
+       "end_line": 205,
+       "file": "bench/repos/meilisearch/crates/dump/src/writer.rs",
+       "name": "new",
+       "start_line": 201
+      }
+     ],
+     "text_similarity": 0.776,
+     "vj": 0.818
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 205,
+       "file": "bench/repos/meilisearch/crates/dump/src/writer.rs",
+       "name": "new",
+       "start_line": 201
+      },
+      {
+       "end_line": 266,
+       "file": "bench/repos/meilisearch/crates/dump/src/writer.rs",
+       "name": "new",
+       "start_line": 256
+      }
+     ],
+     "text_similarity": 0.578,
+     "vj": 0.818
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 54,
+       "file": "bench/repos/meilisearch/crates/meilisearch/tests/index/update_index.rs",
+       "name": "create_and_update_with_different_encoding",
+       "start_line": 42
+      },
+      {
+       "end_line": 71,
+       "file": "bench/repos/meilisearch/crates/meilisearch/tests/index/update_index.rs",
+       "name": "update_nothing",
+       "start_line": 57
+      }
+     ],
+     "text_similarity": 0.788,
+     "vj": 0.8
+    }
+   ],
+   "language": "Rust",
+   "split": "heldout"
+  },
+  "minio": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 241,
+       "file": "bench/repos/minio/internal/s3select/sql/aggregation.go",
+       "name": "aggregateRow",
+       "start_line": 229
+      },
+      {
+       "end_line": 255,
+       "file": "bench/repos/minio/internal/s3select/sql/aggregation.go",
+       "name": "aggregateRow",
+       "start_line": 243
+      }
+     ],
+     "text_similarity": 0.983,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 345,
+       "file": "bench/repos/minio/internal/s3select/sql/evaluate.go",
+       "name": "evalNode",
+       "start_line": 324
+      },
+      {
+       "end_line": 368,
+       "file": "bench/repos/minio/internal/s3select/sql/evaluate.go",
+       "name": "evalNode",
+       "start_line": 347
+      }
+     ],
+     "text_similarity": 0.963,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 343,
+       "file": "bench/repos/minio/internal/s3select/sql/evaluate.go",
+       "name": null,
+       "start_line": 333
+      },
+      {
+       "end_line": 366,
+       "file": "bench/repos/minio/internal/s3select/sql/evaluate.go",
+       "name": null,
+       "start_line": 355
+      }
+     ],
+     "text_similarity": 0.998,
+     "vj": 1.0
+    }
+   ],
+   "language": "Go",
+   "split": "heldout"
+  },
+  "mockito": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 205,
+       "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/invocation/InvocationsFinderTest.java",
+       "name": "shouldReturnAllChunksWhenModeIsAtLeastOnce",
+       "start_line": 192
+      },
+      {
+       "end_line": 220,
+       "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/invocation/InvocationsFinderTest.java",
+       "name": "shouldReturnAllChunksWhenWantedCountDoesntMatch",
+       "start_line": 207
+      }
+     ],
+     "text_similarity": 0.975,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 126,
+       "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/verification/NoMoreInteractionsVerificationTest.java",
+       "name": "shouldVerifyOneMockButFailOnOther",
+       "start_line": 108
+      },
+      {
+       "end_line": 146,
+       "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/verification/NoMoreInteractionsVerificationTest.java",
+       "name": "shouldVerifyOneMockButFailOnOtherVerifyNoInteractions",
+       "start_line": 128
+      }
+     ],
+     "text_similarity": 0.979,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 45,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs",
+       "start_line": 42
+      },
+      {
+       "end_line": 89,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_in_a_nested_class",
+       "start_line": 86
+      }
+     ],
+     "text_similarity": 0.896,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 45,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs",
+       "start_line": 42
+      },
+      {
+       "end_line": 112,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_in_a_nested_class",
+       "start_line": 109
+      }
+     ],
+     "text_similarity": 0.896,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 45,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs",
+       "start_line": 42
+      },
+      {
+       "end_line": 132,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_configured_by_default",
+       "start_line": 129
+      }
+     ],
+     "text_similarity": 0.93,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 45,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs",
+       "start_line": 42
+      },
+      {
+       "end_line": 153,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_execute_successfully_on_warn_stubs_inherited_from_base_class",
+       "start_line": 150
+      }
+     ],
+     "text_similarity": 0.799,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 89,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_in_a_nested_class",
+       "start_line": 86
+      },
+      {
+       "end_line": 112,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_in_a_nested_class",
+       "start_line": 109
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 89,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_in_a_nested_class",
+       "start_line": 86
+      },
+      {
+       "end_line": 132,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_configured_by_default",
+       "start_line": 129
+      }
+     ],
+     "text_similarity": 0.874,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 89,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_in_a_nested_class",
+       "start_line": 86
+      },
+      {
+       "end_line": 153,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_execute_successfully_on_warn_stubs_inherited_from_base_class",
+       "start_line": 150
+      }
+     ],
+     "text_similarity": 0.795,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 112,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_in_a_nested_class",
+       "start_line": 109
+      },
+      {
+       "end_line": 132,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_configured_by_default",
+       "start_line": 129
+      }
+     ],
+     "text_similarity": 0.874,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 112,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_in_a_nested_class",
+       "start_line": 109
+      },
+      {
+       "end_line": 153,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_execute_successfully_on_warn_stubs_inherited_from_base_class",
+       "start_line": 150
+      }
+     ],
+     "text_similarity": 0.795,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 132,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_configured_by_default",
+       "start_line": 129
+      },
+      {
+       "end_line": 153,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_execute_successfully_on_warn_stubs_inherited_from_base_class",
+       "start_line": 150
+      }
+     ],
+     "text_similarity": 0.8,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 45,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs",
+       "start_line": 42
+      },
+      {
+       "end_line": 66,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_not_throw_exception_on_strict_stubs_because_of_test_failure",
+       "start_line": 62
+      }
+     ],
+     "text_similarity": 0.797,
+     "vj": 0.846
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 66,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_not_throw_exception_on_strict_stubs_because_of_test_failure",
+       "start_line": 62
+      },
+      {
+       "end_line": 89,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_in_a_nested_class",
+       "start_line": 86
+      }
+     ],
+     "text_similarity": 0.789,
+     "vj": 0.846
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 66,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_not_throw_exception_on_strict_stubs_because_of_test_failure",
+       "start_line": 62
+      },
+      {
+       "end_line": 112,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_in_a_nested_class",
+       "start_line": 109
+      }
+     ],
+     "text_similarity": 0.789,
+     "vj": 0.846
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 66,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_not_throw_exception_on_strict_stubs_because_of_test_failure",
+       "start_line": 62
+      },
+      {
+       "end_line": 132,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_throw_an_exception_on_strict_stubs_configured_by_default",
+       "start_line": 129
+      }
+     ],
+     "text_similarity": 0.793,
+     "vj": 0.846
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 66,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_not_throw_exception_on_strict_stubs_because_of_test_failure",
+       "start_line": 62
+      },
+      {
+       "end_line": 153,
+       "file": "bench/repos/mockito/mockito-extensions/mockito-junit-jupiter/src/test/java/org/mockitousage/StrictnessTest.java",
+       "name": "should_execute_successfully_on_warn_stubs_inherited_from_base_class",
+       "start_line": 150
+      }
+     ],
+     "text_similarity": 0.696,
+     "vj": 0.846
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 123,
+       "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/stubbing/DeepStubbingTest.java",
+       "name": "oneLevelDeep",
+       "start_line": 115
+      },
+      {
+       "end_line": 141,
+       "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/stubbing/DeepStubbingTest.java",
+       "name": "interactions",
+       "start_line": 128
+      }
+     ],
+     "text_similarity": 0.671,
+     "vj": 0.81
+    }
+   ],
+   "language": "Java",
+   "split": "dev"
+  },
+  "nats-server": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1691,
+       "file": "bench/repos/nats-server/server/gateway.go",
+       "name": "getGatewayURL",
+       "start_line": 1686
+      },
+      {
+       "end_line": 1757,
+       "file": "bench/repos/nats-server/server/gateway.go",
+       "name": "getOutboundGatewayConnections",
+       "start_line": 1751
+      }
+     ],
+     "text_similarity": 0.59,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1691,
+       "file": "bench/repos/nats-server/server/gateway.go",
+       "name": "getGatewayURL",
+       "start_line": 1686
+      },
+      {
+       "end_line": 1782,
+       "file": "bench/repos/nats-server/server/gateway.go",
+       "name": "getInboundGatewayConnections",
+       "start_line": 1776
+      }
+     ],
+     "text_similarity": 0.638,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Block",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 570,
+       "file": "bench/repos/nats-server/server/jetstream_cluster_long_test.go",
+       "name": null,
+       "start_line": 535
+      },
+      {
+       "end_line": 104,
+       "file": "bench/repos/nats-server/server/jetstream_tpm_test.go",
+       "name": "checkSendMessage",
+       "start_line": 92
+      }
+     ],
+     "text_similarity": 0.342,
+     "vj": 0.8
+    }
+   ],
+   "language": "Go",
+   "split": "dev"
+  },
+  "netty": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 60,
+       "file": "bench/repos/netty/codec-base/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java",
+       "name": "weakCachingResolver",
+       "start_line": 56
+      },
+      {
+       "end_line": 73,
+       "file": "bench/repos/netty/codec-base/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java",
+       "name": "softCachingResolver",
+       "start_line": 69
+      }
+     ],
+     "text_similarity": 0.974,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 60,
+       "file": "bench/repos/netty/codec-base/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java",
+       "name": "weakCachingResolver",
+       "start_line": 56
+      },
+      {
+       "end_line": 86,
+       "file": "bench/repos/netty/codec-base/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java",
+       "name": "weakCachingConcurrentResolver",
+       "start_line": 82
+      }
+     ],
+     "text_similarity": 0.922,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 60,
+       "file": "bench/repos/netty/codec-base/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java",
+       "name": "weakCachingResolver",
+       "start_line": 56
+      },
+      {
+       "end_line": 99,
+       "file": "bench/repos/netty/codec-base/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java",
+       "name": "softCachingConcurrentResolver",
+       "start_line": 95
+      }
+     ],
+     "text_similarity": 0.896,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 73,
+       "file": "bench/repos/netty/codec-base/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java",
+       "name": "softCachingResolver",
+       "start_line": 69
+      },
+      {
+       "end_line": 86,
+       "file": "bench/repos/netty/codec-base/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java",
+       "name": "weakCachingConcurrentResolver",
+       "start_line": 82
+      }
+     ],
+     "text_similarity": 0.896,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 73,
+       "file": "bench/repos/netty/codec-base/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java",
+       "name": "softCachingResolver",
+       "start_line": 69
+      },
+      {
+       "end_line": 99,
+       "file": "bench/repos/netty/codec-base/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java",
+       "name": "softCachingConcurrentResolver",
+       "start_line": 95
+      }
+     ],
+     "text_similarity": 0.922,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 86,
+       "file": "bench/repos/netty/codec-base/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java",
+       "name": "weakCachingConcurrentResolver",
+       "start_line": 82
+      },
+      {
+       "end_line": 99,
+       "file": "bench/repos/netty/codec-base/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java",
+       "name": "softCachingConcurrentResolver",
+       "start_line": 95
+      }
+     ],
+     "text_similarity": 0.973,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 268,
+       "file": "bench/repos/netty/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyCodecUtil.java",
+       "name": "getUnsignedInt",
+       "start_line": 263
+      },
+      {
+       "end_line": 278,
+       "file": "bench/repos/netty/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyCodecUtil.java",
+       "name": "getSignedInt",
+       "start_line": 273
+      }
+     ],
+     "text_similarity": 0.989,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 77,
+       "file": "bench/repos/netty/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorTest.java",
+       "name": "testAggregationBinary",
+       "start_line": 44
+      },
+      {
+       "end_line": 112,
+       "file": "bench/repos/netty/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorTest.java",
+       "name": "testAggregationText",
+       "start_line": 79
+      }
+     ],
+     "text_similarity": 0.985,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 238,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/ObjectUtil.java",
+       "name": "checkNonEmpty",
+       "start_line": 232
+      },
+      {
+       "end_line": 251,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/ObjectUtil.java",
+       "name": "checkNonEmpty",
+       "start_line": 245
+      }
+     ],
+     "text_similarity": 0.976,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 238,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/ObjectUtil.java",
+       "name": "checkNonEmpty",
+       "start_line": 232
+      },
+      {
+       "end_line": 264,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/ObjectUtil.java",
+       "name": "checkNonEmpty",
+       "start_line": 258
+      }
+     ],
+     "text_similarity": 0.976,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 251,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/ObjectUtil.java",
+       "name": "checkNonEmpty",
+       "start_line": 245
+      },
+      {
+       "end_line": 264,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/ObjectUtil.java",
+       "name": "checkNonEmpty",
+       "start_line": 258
+      }
+     ],
+     "text_similarity": 0.973,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 71,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/SWARUtil.java",
+       "name": "applyUpperCasePattern",
+       "start_line": 62
+      },
+      {
+       "end_line": 84,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/SWARUtil.java",
+       "name": "applyUpperCasePattern",
+       "start_line": 76
+      }
+     ],
+     "text_similarity": 0.757,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 71,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/SWARUtil.java",
+       "name": "applyUpperCasePattern",
+       "start_line": 62
+      },
+      {
+       "end_line": 97,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/SWARUtil.java",
+       "name": "applyLowerCasePattern",
+       "start_line": 89
+      }
+     ],
+     "text_similarity": 0.818,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 71,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/SWARUtil.java",
+       "name": "applyUpperCasePattern",
+       "start_line": 62
+      },
+      {
+       "end_line": 110,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/SWARUtil.java",
+       "name": "applyLowerCasePattern",
+       "start_line": 102
+      }
+     ],
+     "text_similarity": 0.738,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 84,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/SWARUtil.java",
+       "name": "applyUpperCasePattern",
+       "start_line": 76
+      },
+      {
+       "end_line": 97,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/SWARUtil.java",
+       "name": "applyLowerCasePattern",
+       "start_line": 89
+      }
+     ],
+     "text_similarity": 0.879,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 84,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/SWARUtil.java",
+       "name": "applyUpperCasePattern",
+       "start_line": 76
+      },
+      {
+       "end_line": 110,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/SWARUtil.java",
+       "name": "applyLowerCasePattern",
+       "start_line": 102
+      }
+     ],
+     "text_similarity": 0.975,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 97,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/SWARUtil.java",
+       "name": "applyLowerCasePattern",
+       "start_line": 89
+      },
+      {
+       "end_line": 110,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/SWARUtil.java",
+       "name": "applyLowerCasePattern",
+       "start_line": 102
+      }
+     ],
+     "text_similarity": 0.902,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 112,
+       "file": "bench/repos/netty/common/src/test/java/io/netty/util/concurrent/PromiseCombinerTest.java",
+       "name": "testAddAfterFinish",
+       "start_line": 103
+      },
+      {
+       "end_line": 124,
+       "file": "bench/repos/netty/common/src/test/java/io/netty/util/concurrent/PromiseCombinerTest.java",
+       "name": "testAddAllAfterFinish",
+       "start_line": 114
+      }
+     ],
+     "text_similarity": 0.929,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 112,
+       "file": "bench/repos/netty/common/src/test/java/io/netty/util/concurrent/PromiseCombinerTest.java",
+       "name": "testAddAfterFinish",
+       "start_line": 103
+      },
+      {
+       "end_line": 136,
+       "file": "bench/repos/netty/common/src/test/java/io/netty/util/concurrent/PromiseCombinerTest.java",
+       "name": "testFinishCalledTwiceThrows",
+       "start_line": 126
+      }
+     ],
+     "text_similarity": 0.879,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 124,
+       "file": "bench/repos/netty/common/src/test/java/io/netty/util/concurrent/PromiseCombinerTest.java",
+       "name": "testAddAllAfterFinish",
+       "start_line": 114
+      },
+      {
+       "end_line": 136,
+       "file": "bench/repos/netty/common/src/test/java/io/netty/util/concurrent/PromiseCombinerTest.java",
+       "name": "testFinishCalledTwiceThrows",
+       "start_line": 126
+      }
+     ],
+     "text_similarity": 0.933,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 465,
+       "file": "bench/repos/netty/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java",
+       "name": "isAcceptMultishotSupported",
+       "start_line": 462
+      },
+      {
+       "end_line": 470,
+       "file": "bench/repos/netty/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java",
+       "name": "isCqeFSockNonEmptySupported",
+       "start_line": 467
+      }
+     ],
+     "text_similarity": 0.942,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 192,
+       "file": "bench/repos/netty/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java",
+       "name": "testBindDeadLock",
+       "start_line": 157
+      },
+      {
+       "end_line": 229,
+       "file": "bench/repos/netty/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java",
+       "name": "testConnectDeadLock",
+       "start_line": 194
+      }
+     ],
+     "text_similarity": 0.984,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 233,
+       "file": "bench/repos/netty/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java",
+       "name": "current",
+       "start_line": 226
+      },
+      {
+       "end_line": 272,
+       "file": "bench/repos/netty/transport/src/main/java/io/netty/channel/PendingWriteQueue.java",
+       "name": "current",
+       "start_line": 265
+      }
+     ],
+     "text_similarity": 0.765,
+     "vj": 0.818
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 584,
+       "file": "bench/repos/netty/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java",
+       "name": "get",
+       "start_line": 578
+      },
+      {
+       "end_line": 594,
+       "file": "bench/repos/netty/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java",
+       "name": "remove",
+       "start_line": 586
+      }
+     ],
+     "text_similarity": 0.768,
+     "vj": 0.812
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 47,
+       "file": "bench/repos/netty/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicConnectionAddressTest.java",
+       "name": "testByteArrayIsCloned",
+       "start_line": 39
+      },
+      {
+       "end_line": 58,
+       "file": "bench/repos/netty/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicConnectionAddressTest.java",
+       "name": "tesByteBufferIsDuplicated",
+       "start_line": 49
+      }
+     ],
+     "text_similarity": 0.798,
+     "vj": 0.808
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 320,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java",
+       "name": "indexedVariable",
+       "start_line": 317
+      },
+      {
+       "end_line": 374,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java",
+       "name": "removeIndexedVariable",
+       "start_line": 365
+      }
+     ],
+     "text_similarity": 0.667,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 149,
+       "file": "bench/repos/netty/common/src/main/java/io/netty/util/internal/RecyclableArrayList.java",
+       "name": "recycle",
+       "start_line": 144
+      },
+      {
+       "end_line": 282,
+       "file": "bench/repos/netty/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java",
+       "name": "recycle",
+       "start_line": 279
+      }
+     ],
+     "text_similarity": 0.717,
+     "vj": 0.8
+    }
+   ],
+   "language": "Java",
+   "split": "dev"
+  },
+  "nushell": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 128,
+       "file": "bench/repos/nushell/crates/nu-cmd-base/src/hook.rs",
+       "name": null,
+       "start_line": 121
+      },
+      {
+       "end_line": 248,
+       "file": "bench/repos/nushell/crates/nu-cmd-base/src/hook.rs",
+       "name": null,
+       "start_line": 239
+      }
+     ],
+     "text_similarity": 0.818,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 291,
+       "file": "bench/repos/nushell/crates/nu-explore/src/explore/views/binary/binary_widget.rs",
+       "name": "get_ascii_char",
+       "start_line": 285
+      },
+      {
+       "end_line": 299,
+       "file": "bench/repos/nushell/crates/nu-explore/src/explore/views/binary/binary_widget.rs",
+       "name": "get_segment_char",
+       "start_line": 293
+      }
+     ],
+     "text_similarity": 0.98,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 99,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i8",
+       "start_line": 96
+      },
+      {
+       "end_line": 105,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i16",
+       "start_line": 102
+      }
+     ],
+     "text_similarity": 0.983,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 99,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i8",
+       "start_line": 96
+      },
+      {
+       "end_line": 111,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i32",
+       "start_line": 108
+      }
+     ],
+     "text_similarity": 0.983,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 99,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i8",
+       "start_line": 96
+      },
+      {
+       "end_line": 117,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i64",
+       "start_line": 114
+      }
+     ],
+     "text_similarity": 0.983,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 99,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i8",
+       "start_line": 96
+      },
+      {
+       "end_line": 123,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u8",
+       "start_line": 120
+      }
+     ],
+     "text_similarity": 0.989,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 99,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i8",
+       "start_line": 96
+      },
+      {
+       "end_line": 129,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u16",
+       "start_line": 126
+      }
+     ],
+     "text_similarity": 0.972,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 99,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i8",
+       "start_line": 96
+      },
+      {
+       "end_line": 135,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u32",
+       "start_line": 132
+      }
+     ],
+     "text_similarity": 0.972,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 99,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i8",
+       "start_line": 96
+      },
+      {
+       "end_line": 141,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u64",
+       "start_line": 138
+      }
+     ],
+     "text_similarity": 0.972,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 105,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i16",
+       "start_line": 102
+      },
+      {
+       "end_line": 111,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i32",
+       "start_line": 108
+      }
+     ],
+     "text_similarity": 0.978,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 105,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i16",
+       "start_line": 102
+      },
+      {
+       "end_line": 117,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i64",
+       "start_line": 114
+      }
+     ],
+     "text_similarity": 0.989,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 105,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i16",
+       "start_line": 102
+      },
+      {
+       "end_line": 123,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u8",
+       "start_line": 120
+      }
+     ],
+     "text_similarity": 0.972,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 105,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i16",
+       "start_line": 102
+      },
+      {
+       "end_line": 129,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u16",
+       "start_line": 126
+      }
+     ],
+     "text_similarity": 0.989,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 105,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i16",
+       "start_line": 102
+      },
+      {
+       "end_line": 135,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u32",
+       "start_line": 132
+      }
+     ],
+     "text_similarity": 0.966,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 105,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i16",
+       "start_line": 102
+      },
+      {
+       "end_line": 141,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u64",
+       "start_line": 138
+      }
+     ],
+     "text_similarity": 0.978,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 111,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i32",
+       "start_line": 108
+      },
+      {
+       "end_line": 117,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i64",
+       "start_line": 114
+      }
+     ],
+     "text_similarity": 0.978,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 111,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i32",
+       "start_line": 108
+      },
+      {
+       "end_line": 123,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u8",
+       "start_line": 120
+      }
+     ],
+     "text_similarity": 0.972,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 111,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i32",
+       "start_line": 108
+      },
+      {
+       "end_line": 129,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u16",
+       "start_line": 126
+      }
+     ],
+     "text_similarity": 0.966,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 111,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i32",
+       "start_line": 108
+      },
+      {
+       "end_line": 135,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u32",
+       "start_line": 132
+      }
+     ],
+     "text_similarity": 0.989,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 111,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i32",
+       "start_line": 108
+      },
+      {
+       "end_line": 141,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u64",
+       "start_line": 138
+      }
+     ],
+     "text_similarity": 0.966,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 117,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i64",
+       "start_line": 114
+      },
+      {
+       "end_line": 123,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u8",
+       "start_line": 120
+      }
+     ],
+     "text_similarity": 0.972,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 117,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i64",
+       "start_line": 114
+      },
+      {
+       "end_line": 129,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u16",
+       "start_line": 126
+      }
+     ],
+     "text_similarity": 0.978,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 117,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i64",
+       "start_line": 114
+      },
+      {
+       "end_line": 135,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u32",
+       "start_line": 132
+      }
+     ],
+     "text_similarity": 0.966,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 117,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_i64",
+       "start_line": 114
+      },
+      {
+       "end_line": 141,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u64",
+       "start_line": 138
+      }
+     ],
+     "text_similarity": 0.989,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 123,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u8",
+       "start_line": 120
+      },
+      {
+       "end_line": 129,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u16",
+       "start_line": 126
+      }
+     ],
+     "text_similarity": 0.983,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 123,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u8",
+       "start_line": 120
+      },
+      {
+       "end_line": 135,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u32",
+       "start_line": 132
+      }
+     ],
+     "text_similarity": 0.983,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 123,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u8",
+       "start_line": 120
+      },
+      {
+       "end_line": 141,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u64",
+       "start_line": 138
+      }
+     ],
+     "text_similarity": 0.983,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 129,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u16",
+       "start_line": 126
+      },
+      {
+       "end_line": 135,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u32",
+       "start_line": 132
+      }
+     ],
+     "text_similarity": 0.978,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 129,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u16",
+       "start_line": 126
+      },
+      {
+       "end_line": 141,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u64",
+       "start_line": 138
+      }
+     ],
+     "text_similarity": 0.989,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 135,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u32",
+       "start_line": 132
+      },
+      {
+       "end_line": 141,
+       "file": "bench/repos/nushell/crates/nu-json/src/ser.rs",
+       "name": "serialize_u64",
+       "start_line": 138
+      }
+     ],
+     "text_similarity": 0.978,
+     "vj": 1.0
+    }
+   ],
+   "language": "Rust",
+   "split": "dev"
+  },
+  "prettier": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 105,
+       "file": "bench/repos/prettier/scripts/release/utilities.js",
+       "name": "writeJson",
+       "start_line": 103
+      },
+      {
+       "end_line": 15,
+       "file": "bench/repos/prettier/scripts/utilities/index.js",
+       "name": "writeJson",
+       "start_line": 12
+      }
+     ],
+     "text_similarity": 0.757,
+     "vj": 0.846
+    }
+   ],
+   "language": "TypeScript",
+   "split": "dev"
+  },
+  "prometheus": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 125,
+       "file": "bench/repos/prometheus/discovery/xds/kuma_mads.pb.go",
+       "name": "GetLabels",
+       "start_line": 120
+      },
+      {
+       "end_line": 218,
+       "file": "bench/repos/prometheus/discovery/xds/kuma_mads.pb.go",
+       "name": "GetLabels",
+       "start_line": 213
+      }
+     ],
+     "text_similarity": 0.97,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 154,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 143
+      }
+     ],
+     "text_similarity": 0.966,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 203,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 192
+      }
+     ],
+     "text_similarity": 0.959,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 265,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 254
+      }
+     ],
+     "text_similarity": 0.956,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 322,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 311
+      }
+     ],
+     "text_similarity": 0.959,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 390,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 379
+      }
+     ],
+     "text_similarity": 0.952,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 470,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 459
+      }
+     ],
+     "text_similarity": 0.946,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 625,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 614
+      }
+     ],
+     "text_similarity": 0.955,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 700,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 689
+      }
+     ],
+     "text_similarity": 0.942,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 756,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 745
+      }
+     ],
+     "text_similarity": 0.956,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 823,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 812
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 916,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 905
+      }
+     ],
+     "text_similarity": 0.943,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 151,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/write/v2/types.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 140
+      }
+     ],
+     "text_similarity": 0.952,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 224,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/write/v2/types.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 213
+      }
+     ],
+     "text_similarity": 0.949,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 314,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/write/v2/types.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 303
+      }
+     ],
+     "text_similarity": 0.956,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 402,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/write/v2/types.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 391
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 472,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/write/v2/types.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 461
+      }
+     ],
+     "text_similarity": 0.956,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 631,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/write/v2/types.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 620
+      }
+     ],
+     "text_similarity": 0.946,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 848,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/write/v2/types.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 837
+      }
+     ],
+     "text_similarity": 0.942,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 94,
+       "file": "bench/repos/prometheus/prompb/remote.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 83
+      }
+     ],
+     "text_similarity": 0.936,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 155,
+       "file": "bench/repos/prometheus/prompb/remote.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 144
+      }
+     ],
+     "text_similarity": 0.946,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 211,
+       "file": "bench/repos/prometheus/prompb/remote.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 200
+      }
+     ],
+     "text_similarity": 0.943,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 261,
+       "file": "bench/repos/prometheus/prompb/remote.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 250
+      }
+     ],
+     "text_similarity": 0.966,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 330,
+       "file": "bench/repos/prometheus/prompb/remote.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 319
+      }
+     ],
+     "text_similarity": 0.946,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 383,
+       "file": "bench/repos/prometheus/prompb/remote.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 372
+      }
+     ],
+     "text_similarity": 0.921,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 197,
+       "file": "bench/repos/prometheus/prompb/types.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 186
+      }
+     ],
+     "text_similarity": 0.936,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 268,
+       "file": "bench/repos/prometheus/prompb/types.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 257
+      }
+     ],
+     "text_similarity": 0.962,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 327,
+       "file": "bench/repos/prometheus/prompb/types.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 316
+      }
+     ],
+     "text_similarity": 0.956,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 434,
+       "file": "bench/repos/prometheus/prompb/types.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 423
+      }
+     ],
+     "text_similarity": 0.946,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 100,
+       "file": "bench/repos/prometheus/prompb/io/prometheus/client/metrics.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 89
+      },
+      {
+       "end_line": 644,
+       "file": "bench/repos/prometheus/prompb/types.pb.go",
+       "name": "XXX_Marshal",
+       "start_line": 633
+      }
+     ],
+     "text_similarity": 0.942,
+     "vj": 1.0
+    }
+   ],
+   "language": "Go",
+   "split": "dev"
+  },
+  "puma": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 538,
+       "file": "bench/repos/puma/test/test_integration_cluster.rb",
+       "name": "test_application_is_loaded_exactly_once_if_using_fork_worker",
+       "start_line": 525
+      },
+      {
+       "end_line": 553,
+       "file": "bench/repos/puma/test/test_integration_cluster.rb",
+       "name": "test_application_is_loaded_exactly_once_if_using_preload_app_with_fork_worker",
+       "start_line": 540
+      }
+     ],
+     "text_similarity": 0.963,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 223,
+       "file": "bench/repos/puma/ext/puma_http11/org/jruby/puma/Http11.java",
+       "name": "finish",
+       "start_line": 218
+      },
+      {
+       "end_line": 259,
+       "file": "bench/repos/puma/ext/puma_http11/org/jruby/puma/Http11.java",
+       "name": "is_finished",
+       "start_line": 256
+      }
+     ],
+     "text_similarity": 0.764,
+     "vj": 0.812
+    }
+   ],
+   "language": "Ruby",
+   "split": "heldout"
+  },
+  "raylib": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 3521,
+       "file": "bench/repos/raylib/src/external/stb_image.h",
+       "name": null,
+       "start_line": 3516
+      },
+      {
+       "end_line": 3637,
+       "file": "bench/repos/raylib/src/external/stb_image.h",
+       "name": null,
+       "start_line": 3632
+      }
+     ],
+     "text_similarity": 0.989,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 48368,
+       "file": "bench/repos/raylib/src/external/miniaudio.h",
+       "name": "ma_hpf1_config_init",
+       "start_line": 48357
+      },
+      {
+       "end_line": 51277,
+       "file": "bench/repos/raylib/src/external/miniaudio.h",
+       "name": "ma_fader_config_init",
+       "start_line": 51267
+      }
+     ],
+     "text_similarity": 0.847,
+     "vj": 0.81
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 13113,
+       "file": "bench/repos/raylib/src/external/RGFW/RGFW.h",
+       "name": "RGFW__osxUpdateLayer",
+       "start_line": 13107
+      },
+      {
+       "end_line": 13122,
+       "file": "bench/repos/raylib/src/external/RGFW/RGFW.h",
+       "name": "RGFW__osxDrawRect",
+       "start_line": 13115
+      }
+     ],
+     "text_similarity": 0.93,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 2696,
+       "file": "bench/repos/raylib/src/external/rlsw.h",
+       "name": null,
+       "start_line": 2686
+      },
+      {
+       "end_line": 2707,
+       "file": "bench/repos/raylib/src/external/rlsw.h",
+       "name": null,
+       "start_line": 2698
+      }
+     ],
+     "text_similarity": 0.944,
+     "vj": 0.8
+    }
+   ],
+   "language": "C",
+   "split": "dev"
+  },
+  "redis": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 78,
+       "file": "bench/repos/redis/deps/hiredis/adapters/glib.h",
+       "name": "redis_source_prepare",
+       "start_line": 71
+      },
+      {
+       "end_line": 85,
+       "file": "bench/repos/redis/deps/hiredis/adapters/glib.h",
+       "name": "redis_source_check",
+       "start_line": 80
+      }
+     ],
+     "text_similarity": 0.821,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 20,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ae.c",
+       "name": "getCallback",
+       "start_line": 13
+      },
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "getCallback",
+       "start_line": 10
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 20,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ae.c",
+       "name": "getCallback",
+       "start_line": 13
+      },
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libev.c",
+       "name": "getCallback",
+       "start_line": 10
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 20,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ae.c",
+       "name": "getCallback",
+       "start_line": 13
+      },
+      {
+       "end_line": 18,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libevent-ssl.c",
+       "name": "getCallback",
+       "start_line": 11
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 20,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ae.c",
+       "name": "getCallback",
+       "start_line": 13
+      },
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libhv.c",
+       "name": "getCallback",
+       "start_line": 10
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 20,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ae.c",
+       "name": "getCallback",
+       "start_line": 13
+      },
+      {
+       "end_line": 19,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-macosx.c",
+       "name": "getCallback",
+       "start_line": 12
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 20,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ae.c",
+       "name": "getCallback",
+       "start_line": 13
+      },
+      {
+       "end_line": 20,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-poll.c",
+       "name": "getCallback",
+       "start_line": 13
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "getCallback",
+       "start_line": 10
+      },
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libev.c",
+       "name": "getCallback",
+       "start_line": 10
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "getCallback",
+       "start_line": 10
+      },
+      {
+       "end_line": 18,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libevent-ssl.c",
+       "name": "getCallback",
+       "start_line": 11
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "getCallback",
+       "start_line": 10
+      },
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libhv.c",
+       "name": "getCallback",
+       "start_line": 10
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "getCallback",
+       "start_line": 10
+      },
+      {
+       "end_line": 19,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-macosx.c",
+       "name": "getCallback",
+       "start_line": 12
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "getCallback",
+       "start_line": 10
+      },
+      {
+       "end_line": 20,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-poll.c",
+       "name": "getCallback",
+       "start_line": 13
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 25,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "connectCallback",
+       "start_line": 19
+      },
+      {
+       "end_line": 25,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libev.c",
+       "name": "connectCallback",
+       "start_line": 19
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 25,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "connectCallback",
+       "start_line": 19
+      },
+      {
+       "end_line": 26,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libevent-ssl.c",
+       "name": "connectCallback",
+       "start_line": 20
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 25,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "connectCallback",
+       "start_line": 19
+      },
+      {
+       "end_line": 30,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libevent.c",
+       "name": "connectCallback",
+       "start_line": 24
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 25,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "connectCallback",
+       "start_line": 19
+      },
+      {
+       "end_line": 37,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libhv.c",
+       "name": "connectCallback",
+       "start_line": 31
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 25,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "connectCallback",
+       "start_line": 19
+      },
+      {
+       "end_line": 27,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-macosx.c",
+       "name": "connectCallback",
+       "start_line": 21
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 25,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "connectCallback",
+       "start_line": 19
+      },
+      {
+       "end_line": 30,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-poll.c",
+       "name": "connectCallback",
+       "start_line": 22
+      }
+     ],
+     "text_similarity": 0.94,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 25,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "connectCallback",
+       "start_line": 19
+      },
+      {
+       "end_line": 42,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-redismoduleapi.c",
+       "name": "connectCallback",
+       "start_line": 36
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 33,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "disconnectCallback",
+       "start_line": 27
+      },
+      {
+       "end_line": 33,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libev.c",
+       "name": "disconnectCallback",
+       "start_line": 27
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 33,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "disconnectCallback",
+       "start_line": 27
+      },
+      {
+       "end_line": 34,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libevent-ssl.c",
+       "name": "disconnectCallback",
+       "start_line": 28
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 33,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "disconnectCallback",
+       "start_line": 27
+      },
+      {
+       "end_line": 38,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libevent.c",
+       "name": "disconnectCallback",
+       "start_line": 32
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 33,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "disconnectCallback",
+       "start_line": 27
+      },
+      {
+       "end_line": 45,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libhv.c",
+       "name": "disconnectCallback",
+       "start_line": 39
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 33,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "disconnectCallback",
+       "start_line": 27
+      },
+      {
+       "end_line": 40,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-poll.c",
+       "name": "disconnectCallback",
+       "start_line": 32
+      }
+     ],
+     "text_similarity": 0.951,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 33,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-ivykis.c",
+       "name": "disconnectCallback",
+       "start_line": 27
+      },
+      {
+       "end_line": 50,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-redismoduleapi.c",
+       "name": "disconnectCallback",
+       "start_line": 44
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libev.c",
+       "name": "getCallback",
+       "start_line": 10
+      },
+      {
+       "end_line": 18,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libevent-ssl.c",
+       "name": "getCallback",
+       "start_line": 11
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libev.c",
+       "name": "getCallback",
+       "start_line": 10
+      },
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libhv.c",
+       "name": "getCallback",
+       "start_line": 10
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libev.c",
+       "name": "getCallback",
+       "start_line": 10
+      },
+      {
+       "end_line": 19,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-macosx.c",
+       "name": "getCallback",
+       "start_line": 12
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 17,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libev.c",
+       "name": "getCallback",
+       "start_line": 10
+      },
+      {
+       "end_line": 20,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-poll.c",
+       "name": "getCallback",
+       "start_line": 13
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 25,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libev.c",
+       "name": "connectCallback",
+       "start_line": 19
+      },
+      {
+       "end_line": 26,
+       "file": "bench/repos/redis/deps/hiredis/examples/example-libevent-ssl.c",
+       "name": "connectCallback",
+       "start_line": 20
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    }
+   ],
+   "language": "C",
+   "split": "heldout"
+  },
+  "regex": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 22,
+       "file": "bench/repos/regex/regex-automata/tests/gen/dense/mod.rs",
+       "name": "multi_pattern_v2",
+       "start_line": 6
+      },
+      {
+       "end_line": 22,
+       "file": "bench/repos/regex/regex-automata/tests/gen/sparse/mod.rs",
+       "name": "multi_pattern_v2",
+       "start_line": 6
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 2279,
+       "file": "bench/repos/regex/regex-automata/src/dfa/onepass.rs",
+       "name": "transition",
+       "start_line": 2275
+      },
+      {
+       "end_line": 2287,
+       "file": "bench/repos/regex/regex-automata/src/dfa/onepass.rs",
+       "name": "set_transition",
+       "start_line": 2283
+      }
+     ],
+     "text_similarity": 0.951,
+     "vj": 0.8
+    }
+   ],
+   "language": "Rust",
+   "split": "heldout"
+  },
+  "retrofit": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 163,
+       "file": "bench/repos/retrofit/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactoryTest.java",
+       "name": "rawResponseTypeThrows",
+       "start_line": 142
+      },
+      {
+       "end_line": 107,
+       "file": "bench/repos/retrofit/retrofit/java-test/src/test/java/retrofit2/CompletableFutureCallAdapterFactoryTest.java",
+       "name": "rawResponseTypeThrows",
+       "start_line": 96
+      }
+     ],
+     "text_similarity": 0.689,
+     "vj": 0.875
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 77,
+       "file": "bench/repos/retrofit/retrofit-adapters/guava/src/test/java/retrofit2/adapter/guava/GuavaCallAdapterFactoryTest.java",
+       "name": "responseType",
+       "start_line": 52
+      },
+      {
+       "end_line": 62,
+       "file": "bench/repos/retrofit/retrofit/java-test/src/test/java/retrofit2/DefaultCallAdapterFactoryTest.java",
+       "name": "responseType",
+       "start_line": 51
+      }
+     ],
+     "text_similarity": 0.548,
+     "vj": 0.833
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 77,
+       "file": "bench/repos/retrofit/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/Java8CallAdapterFactoryTest.java",
+       "name": "responseType",
+       "start_line": 52
+      },
+      {
+       "end_line": 62,
+       "file": "bench/repos/retrofit/retrofit/java-test/src/test/java/retrofit2/DefaultCallAdapterFactoryTest.java",
+       "name": "responseType",
+       "start_line": 51
+      }
+     ],
+     "text_similarity": 0.549,
+     "vj": 0.833
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 75,
+       "file": "bench/repos/retrofit/retrofit-adapters/scala/src/test/java/retrofit2/adapter/scala/ScalaCallAdapterFactoryTest.java",
+       "name": "responseType",
+       "start_line": 52
+      },
+      {
+       "end_line": 62,
+       "file": "bench/repos/retrofit/retrofit/java-test/src/test/java/retrofit2/DefaultCallAdapterFactoryTest.java",
+       "name": "responseType",
+       "start_line": 51
+      }
+     ],
+     "text_similarity": 0.564,
+     "vj": 0.833
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 74,
+       "file": "bench/repos/retrofit/retrofit/java-test/src/test/java/retrofit2/CompletableFutureCallAdapterFactoryTest.java",
+       "name": "responseType",
+       "start_line": 49
+      },
+      {
+       "end_line": 62,
+       "file": "bench/repos/retrofit/retrofit/java-test/src/test/java/retrofit2/DefaultCallAdapterFactoryTest.java",
+       "name": "responseType",
+       "start_line": 51
+      }
+     ],
+     "text_similarity": 0.549,
+     "vj": 0.833
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 163,
+       "file": "bench/repos/retrofit/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactoryTest.java",
+       "name": "rawResponseTypeThrows",
+       "start_line": 142
+      },
+      {
+       "end_line": 250,
+       "file": "bench/repos/retrofit/retrofit-adapters/rxjava3/src/test/java/retrofit2/adapter/rxjava3/RxJava3CallAdapterFactoryTest.java",
+       "name": "rawResponseTypeThrows",
+       "start_line": 209
+      }
+     ],
+     "text_similarity": 0.685,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 186,
+       "file": "bench/repos/retrofit/retrofit-adapters/rxjava/src/test/java/retrofit2/adapter/rxjava/RxJavaCallAdapterFactoryTest.java",
+       "name": "rawResultTypeThrows",
+       "start_line": 165
+      },
+      {
+       "end_line": 293,
+       "file": "bench/repos/retrofit/retrofit-adapters/rxjava3/src/test/java/retrofit2/adapter/rxjava3/RxJava3CallAdapterFactoryTest.java",
+       "name": "rawResultTypeThrows",
+       "start_line": 252
+      }
+     ],
+     "text_similarity": 0.684,
+     "vj": 0.8
+    }
+   ],
+   "language": "Java",
+   "split": "dev"
+  },
+  "rich": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1400,
+       "file": "bench/repos/rich/rich/progress.py",
+       "name": "start_task",
+       "start_line": 1388
+      },
+      {
+       "end_line": 1415,
+       "file": "bench/repos/rich/rich/progress.py",
+       "name": "stop_task",
+       "start_line": 1402
+      }
+     ],
+     "text_similarity": 0.734,
+     "vj": 0.812
+    }
+   ],
+   "language": "Python",
+   "split": "dev"
+  },
+  "ripgrep": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 344,
+       "file": "bench/repos/ripgrep/crates/globset/src/glob.rs",
+       "name": "literal",
+       "start_line": 334
+      },
+      {
+       "end_line": 448,
+       "file": "bench/repos/ripgrep/crates/globset/src/glob.rs",
+       "name": "prefix",
+       "start_line": 419
+      }
+     ],
+     "text_similarity": 0.436,
+     "vj": 0.812
+    }
+   ],
+   "language": "Rust",
+   "split": "dev"
+  },
+  "rspec-core": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 68,
+       "file": "bench/repos/rspec-core/lib/rspec/core/formatters/bisect_progress_formatter.rb",
+       "name": "bisect_round_detected_multiple_culprits",
+       "start_line": 65
+      },
+      {
+       "end_line": 120,
+       "file": "bench/repos/rspec-core/lib/rspec/core/formatters/bisect_progress_formatter.rb",
+       "name": "bisect_individual_run_complete",
+       "start_line": 118
+      }
+     ],
+     "text_similarity": 0.69,
+     "vj": 0.8
+    }
+   ],
+   "language": "Ruby",
+   "split": "dev"
+  },
+  "rxjava": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 490,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java",
+       "name": "onStartRequestsAreAdditive",
+       "start_line": 464
+      },
+      {
+       "end_line": 517,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java",
+       "name": "onStartRequestsAreAdditiveAndOverflowBecomesMaxValue",
+       "start_line": 492
+      }
+     ],
+     "text_similarity": 0.959,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 104,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction2",
+       "start_line": 96
+      },
+      {
+       "end_line": 114,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction3",
+       "start_line": 106
+      }
+     ],
+     "text_similarity": 0.965,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 104,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction2",
+       "start_line": 96
+      },
+      {
+       "end_line": 124,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction4",
+       "start_line": 116
+      }
+     ],
+     "text_similarity": 0.938,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 104,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction2",
+       "start_line": 96
+      },
+      {
+       "end_line": 134,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction5",
+       "start_line": 126
+      }
+     ],
+     "text_similarity": 0.912,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 104,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction2",
+       "start_line": 96
+      },
+      {
+       "end_line": 144,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction6",
+       "start_line": 136
+      }
+     ],
+     "text_similarity": 0.888,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 104,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction2",
+       "start_line": 96
+      },
+      {
+       "end_line": 154,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction7",
+       "start_line": 146
+      }
+     ],
+     "text_similarity": 0.866,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 104,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction2",
+       "start_line": 96
+      },
+      {
+       "end_line": 164,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction8",
+       "start_line": 156
+      }
+     ],
+     "text_similarity": 0.844,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 104,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction2",
+       "start_line": 96
+      },
+      {
+       "end_line": 174,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction9",
+       "start_line": 166
+      }
+     ],
+     "text_similarity": 0.823,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 114,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction3",
+       "start_line": 106
+      },
+      {
+       "end_line": 124,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction4",
+       "start_line": 116
+      }
+     ],
+     "text_similarity": 0.968,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 114,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction3",
+       "start_line": 106
+      },
+      {
+       "end_line": 134,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction5",
+       "start_line": 126
+      }
+     ],
+     "text_similarity": 0.942,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 114,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction3",
+       "start_line": 106
+      },
+      {
+       "end_line": 144,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction6",
+       "start_line": 136
+      }
+     ],
+     "text_similarity": 0.918,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 114,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction3",
+       "start_line": 106
+      },
+      {
+       "end_line": 154,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction7",
+       "start_line": 146
+      }
+     ],
+     "text_similarity": 0.895,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 114,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction3",
+       "start_line": 106
+      },
+      {
+       "end_line": 164,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction8",
+       "start_line": 156
+      }
+     ],
+     "text_similarity": 0.873,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 114,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction3",
+       "start_line": 106
+      },
+      {
+       "end_line": 174,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction9",
+       "start_line": 166
+      }
+     ],
+     "text_similarity": 0.852,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 124,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction4",
+       "start_line": 116
+      },
+      {
+       "end_line": 134,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction5",
+       "start_line": 126
+      }
+     ],
+     "text_similarity": 0.969,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 124,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction4",
+       "start_line": 116
+      },
+      {
+       "end_line": 144,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction6",
+       "start_line": 136
+      }
+     ],
+     "text_similarity": 0.945,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 124,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction4",
+       "start_line": 116
+      },
+      {
+       "end_line": 154,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction7",
+       "start_line": 146
+      }
+     ],
+     "text_similarity": 0.922,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 124,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction4",
+       "start_line": 116
+      },
+      {
+       "end_line": 164,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction8",
+       "start_line": 156
+      }
+     ],
+     "text_similarity": 0.9,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 124,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction4",
+       "start_line": 116
+      },
+      {
+       "end_line": 174,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction9",
+       "start_line": 166
+      }
+     ],
+     "text_similarity": 0.879,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 134,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction5",
+       "start_line": 126
+      },
+      {
+       "end_line": 144,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction6",
+       "start_line": 136
+      }
+     ],
+     "text_similarity": 0.971,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 134,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction5",
+       "start_line": 126
+      },
+      {
+       "end_line": 154,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction7",
+       "start_line": 146
+      }
+     ],
+     "text_similarity": 0.948,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 134,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction5",
+       "start_line": 126
+      },
+      {
+       "end_line": 164,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction8",
+       "start_line": 156
+      }
+     ],
+     "text_similarity": 0.926,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 134,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction5",
+       "start_line": 126
+      },
+      {
+       "end_line": 174,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction9",
+       "start_line": 166
+      }
+     ],
+     "text_similarity": 0.905,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 144,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction6",
+       "start_line": 136
+      },
+      {
+       "end_line": 154,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction7",
+       "start_line": 146
+      }
+     ],
+     "text_similarity": 0.972,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 144,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction6",
+       "start_line": 136
+      },
+      {
+       "end_line": 164,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction8",
+       "start_line": 156
+      }
+     ],
+     "text_similarity": 0.95,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 144,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction6",
+       "start_line": 136
+      },
+      {
+       "end_line": 174,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction9",
+       "start_line": 166
+      }
+     ],
+     "text_similarity": 0.929,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 154,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction7",
+       "start_line": 146
+      },
+      {
+       "end_line": 164,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction8",
+       "start_line": 156
+      }
+     ],
+     "text_similarity": 0.973,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 154,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction7",
+       "start_line": 146
+      },
+      {
+       "end_line": 174,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction9",
+       "start_line": 166
+      }
+     ],
+     "text_similarity": 0.952,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 164,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction8",
+       "start_line": 156
+      },
+      {
+       "end_line": 174,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/functions/FunctionsTest.java",
+       "name": "toFunction9",
+       "start_line": 166
+      }
+     ],
+     "text_similarity": 0.975,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1016,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCreateTest.java",
+       "name": "tryOnError",
+       "start_line": 991
+      },
+      {
+       "end_line": 1044,
+       "file": "bench/repos/rxjava/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCreateTest.java",
+       "name": "tryOnErrorSerialized",
+       "start_line": 1018
+      }
+     ],
+     "text_similarity": 0.973,
+     "vj": 1.0
+    }
+   ],
+   "language": "Java",
+   "split": "heldout"
+  },
+  "scrapy": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 225,
+       "file": "bench/repos/scrapy/scrapy/spidermiddlewares/referer.py",
+       "name": "referrer",
+       "start_line": 221
+      },
+      {
+       "end_line": 162,
+       "file": "bench/repos/scrapy/scrapy/spidermiddlewares/referer.py",
+       "name": null,
+       "start_line": 161
+      }
+     ],
+     "text_similarity": 0.661,
+     "vj": 0.8
+    }
+   ],
+   "language": "Python",
+   "split": "dev"
+  },
+  "sidekiq": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 80,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 77
+      },
+      {
+       "end_line": 89,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 86
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 80,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 77
+      },
+      {
+       "end_line": 98,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 95
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 80,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 77
+      },
+      {
+       "end_line": 107,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 104
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 80,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 77
+      },
+      {
+       "end_line": 116,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 113
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 89,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 86
+      },
+      {
+       "end_line": 98,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 95
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 89,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 86
+      },
+      {
+       "end_line": 107,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 104
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 89,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 86
+      },
+      {
+       "end_line": 116,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 113
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 98,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 95
+      },
+      {
+       "end_line": 107,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 104
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 98,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 95
+      },
+      {
+       "end_line": 116,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 113
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 107,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 104
+      },
+      {
+       "end_line": 116,
+       "file": "bench/repos/sidekiq/myapp/config/initializers/sidekiq.rb",
+       "name": "perform",
+       "start_line": 113
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    }
+   ],
+   "language": "Ruby",
+   "split": "heldout"
+  },
+  "sqlalchemy": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 264,
+       "file": "bench/repos/sqlalchemy/lib/sqlalchemy/sql/traversals.py",
+       "name": "visit_clauseelement_tuple",
+       "start_line": 261
+      },
+      {
+       "end_line": 269,
+       "file": "bench/repos/sqlalchemy/lib/sqlalchemy/sql/traversals.py",
+       "name": "visit_executable_options",
+       "start_line": 266
+      }
+     ],
+     "text_similarity": 0.919,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 728,
+       "file": "bench/repos/sqlalchemy/test/engine/test_logging.py",
+       "name": "plain_assert_buf",
+       "start_line": 709
+      },
+      {
+       "end_line": 750,
+       "file": "bench/repos/sqlalchemy/test/engine/test_logging.py",
+       "name": "assert_buf",
+       "start_line": 731
+      }
+     ],
+     "text_similarity": 0.989,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 722,
+       "file": "bench/repos/sqlalchemy/test/engine/test_logging.py",
+       "name": "go",
+       "start_line": 716
+      },
+      {
+       "end_line": 744,
+       "file": "bench/repos/sqlalchemy/test/engine/test_logging.py",
+       "name": "go",
+       "start_line": 738
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 156,
+       "file": "bench/repos/sqlalchemy/test/orm/declarative/test_tm_future_annotations.py",
+       "name": "test_fully_qualified_mapped_name",
+       "start_line": 137
+      },
+      {
+       "end_line": 201,
+       "file": "bench/repos/sqlalchemy/test/orm/declarative/test_tm_future_annotations.py",
+       "name": "test_indirect_mapped_name_module_level",
+       "start_line": 158
+      }
+     ],
+     "text_similarity": 0.511,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1116,
+       "file": "bench/repos/sqlalchemy/test/orm/test_options.py",
+       "name": "_assert_loader_strategy_exception",
+       "start_line": 1106
+      },
+      {
+       "end_line": 1130,
+       "file": "bench/repos/sqlalchemy/test/orm/test_options.py",
+       "name": "_assert_eager_with_entity_exception",
+       "start_line": 1118
+      }
+     ],
+     "text_similarity": 0.933,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 5048,
+       "file": "bench/repos/sqlalchemy/test/sql/test_metadata.py",
+       "name": "test_server_default_onupdate_positional",
+       "start_line": 5044
+      },
+      {
+       "end_line": 5054,
+       "file": "bench/repos/sqlalchemy/test/sql/test_metadata.py",
+       "name": "test_server_default_onupdate_keyword_as_schemaitem",
+       "start_line": 5050
+      }
+     ],
+     "text_similarity": 0.918,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 5066,
+       "file": "bench/repos/sqlalchemy/test/sql/test_metadata.py",
+       "name": "test_column_default_positional",
+       "start_line": 5062
+      },
+      {
+       "end_line": 5072,
+       "file": "bench/repos/sqlalchemy/test/sql/test_metadata.py",
+       "name": "test_column_default_keyword_as_schemaitem",
+       "start_line": 5068
+      }
+     ],
+     "text_similarity": 0.923,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 437,
+       "file": "bench/repos/sqlalchemy/test/sql/test_typed_froms.py",
+       "name": "test_invalid_non_typed_columns",
+       "start_line": 423
+      },
+      {
+       "end_line": 455,
+       "file": "bench/repos/sqlalchemy/test/sql/test_typed_froms.py",
+       "name": "test_no_kw_args",
+       "start_line": 439
+      }
+     ],
+     "text_similarity": 0.84,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 864,
+       "file": "bench/repos/sqlalchemy/lib/sqlalchemy/sql/base.py",
+       "name": "_generate",
+       "start_line": 859
+      },
+      {
+       "end_line": 1289,
+       "file": "bench/repos/sqlalchemy/lib/sqlalchemy/util/langhelpers.py",
+       "name": "_reset_memoizations",
+       "start_line": 1287
+      }
+     ],
+     "text_similarity": 0.555,
+     "vj": 0.889
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 179,
+       "file": "bench/repos/sqlalchemy/lib/sqlalchemy/orm/identity.py",
+       "name": "replace",
+       "start_line": 159
+      },
+      {
+       "end_line": 205,
+       "file": "bench/repos/sqlalchemy/lib/sqlalchemy/orm/identity.py",
+       "name": "add",
+       "start_line": 181
+      }
+     ],
+     "text_similarity": 0.628,
+     "vj": 0.812
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1475,
+       "file": "bench/repos/sqlalchemy/test/orm/test_froms.py",
+       "name": "test_contains_eager_aliased",
+       "start_line": 1458
+      },
+      {
+       "end_line": 4109,
+       "file": "bench/repos/sqlalchemy/test/orm/test_query.py",
+       "name": "test_eager_load",
+       "start_line": 4087
+      }
+     ],
+     "text_similarity": 0.565,
+     "vj": 0.81
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1475,
+       "file": "bench/repos/sqlalchemy/test/orm/test_froms.py",
+       "name": "test_contains_eager_aliased",
+       "start_line": 1458
+      },
+      {
+       "end_line": 4816,
+       "file": "bench/repos/sqlalchemy/test/orm/test_query.py",
+       "name": "test_columns_augmented_roundtrip_two",
+       "start_line": 4789
+      }
+     ],
+     "text_similarity": 0.542,
+     "vj": 0.81
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 4109,
+       "file": "bench/repos/sqlalchemy/test/orm/test_query.py",
+       "name": "test_eager_load",
+       "start_line": 4087
+      },
+      {
+       "end_line": 4816,
+       "file": "bench/repos/sqlalchemy/test/orm/test_query.py",
+       "name": "test_columns_augmented_roundtrip_two",
+       "start_line": 4789
+      }
+     ],
+     "text_similarity": 0.598,
+     "vj": 0.81
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1185,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_query",
+       "start_line": 1175
+      },
+      {
+       "end_line": 1225,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_session_execute_orm",
+       "start_line": 1214
+      }
+     ],
+     "text_similarity": 0.872,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1185,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_query",
+       "start_line": 1175
+      },
+      {
+       "end_line": 1236,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_cache_key",
+       "start_line": 1227
+      }
+     ],
+     "text_similarity": 0.797,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1185,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_query",
+       "start_line": 1175
+      },
+      {
+       "end_line": 1275,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_query_alias",
+       "start_line": 1263
+      }
+     ],
+     "text_similarity": 0.906,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1185,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_query",
+       "start_line": 1175
+      },
+      {
+       "end_line": 1286,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_entity_path_w_aliased",
+       "start_line": 1277
+      }
+     ],
+     "text_similarity": 0.722,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1185,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_query",
+       "start_line": 1175
+      },
+      {
+       "end_line": 1500,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_result_fetchone",
+       "start_line": 1482
+      }
+     ],
+     "text_similarity": 0.613,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1185,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_query",
+       "start_line": 1175
+      },
+      {
+       "end_line": 1515,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_result_fetchall",
+       "start_line": 1502
+      }
+     ],
+     "text_similarity": 0.763,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1185,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_query",
+       "start_line": 1175
+      },
+      {
+       "end_line": 1531,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_result_fetchmany",
+       "start_line": 1517
+      }
+     ],
+     "text_similarity": 0.712,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1185,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_query",
+       "start_line": 1175
+      },
+      {
+       "end_line": 1547,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_result_fetchmany_unique",
+       "start_line": 1533
+      }
+     ],
+     "text_similarity": 0.707,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1185,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_query",
+       "start_line": 1175
+      },
+      {
+       "end_line": 1564,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_core_select_from_orm_query",
+       "start_line": 1549
+      }
+     ],
+     "text_similarity": 0.618,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1225,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_session_execute_orm",
+       "start_line": 1214
+      },
+      {
+       "end_line": 1236,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_cache_key",
+       "start_line": 1227
+      }
+     ],
+     "text_similarity": 0.837,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1225,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_session_execute_orm",
+       "start_line": 1214
+      },
+      {
+       "end_line": 1275,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_query_alias",
+       "start_line": 1263
+      }
+     ],
+     "text_similarity": 0.801,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1225,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_session_execute_orm",
+       "start_line": 1214
+      },
+      {
+       "end_line": 1480,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_join_via_query_to_entity",
+       "start_line": 1470
+      }
+     ],
+     "text_similarity": 0.843,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1225,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_session_execute_orm",
+       "start_line": 1214
+      },
+      {
+       "end_line": 1500,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_result_fetchone",
+       "start_line": 1482
+      }
+     ],
+     "text_similarity": 0.634,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1225,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_session_execute_orm",
+       "start_line": 1214
+      },
+      {
+       "end_line": 1515,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_result_fetchall",
+       "start_line": 1502
+      }
+     ],
+     "text_similarity": 0.739,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1225,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_session_execute_orm",
+       "start_line": 1214
+      },
+      {
+       "end_line": 1531,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_result_fetchmany",
+       "start_line": 1517
+      }
+     ],
+     "text_similarity": 0.701,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1225,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_session_execute_orm",
+       "start_line": 1214
+      },
+      {
+       "end_line": 1547,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_result_fetchmany_unique",
+       "start_line": 1533
+      }
+     ],
+     "text_similarity": 0.688,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 1225,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_session_execute_orm",
+       "start_line": 1214
+      },
+      {
+       "end_line": 1564,
+       "file": "bench/repos/sqlalchemy/test/aaa_profiling/test_memusage.py",
+       "name": "test_core_select_from_orm_query",
+       "start_line": 1549
+      }
+     ],
+     "text_similarity": 0.622,
+     "vj": 0.8
+    }
+   ],
+   "language": "Python",
+   "split": "heldout"
+  },
+  "sqlite": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 721,
+       "file": "bench/repos/sqlite/ext/jni/src/org/sqlite/jni/wrapper1/Sqlite.java",
+       "name": "createFunction",
+       "start_line": 717
+      },
+      {
+       "end_line": 731,
+       "file": "bench/repos/sqlite/ext/jni/src/org/sqlite/jni/wrapper1/Sqlite.java",
+       "name": "createFunction",
+       "start_line": 727
+      }
+     ],
+     "text_similarity": 0.955,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 721,
+       "file": "bench/repos/sqlite/ext/jni/src/org/sqlite/jni/wrapper1/Sqlite.java",
+       "name": "createFunction",
+       "start_line": 717
+      },
+      {
+       "end_line": 741,
+       "file": "bench/repos/sqlite/ext/jni/src/org/sqlite/jni/wrapper1/Sqlite.java",
+       "name": "createFunction",
+       "start_line": 737
+      }
+     ],
+     "text_similarity": 0.956,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 731,
+       "file": "bench/repos/sqlite/ext/jni/src/org/sqlite/jni/wrapper1/Sqlite.java",
+       "name": "createFunction",
+       "start_line": 727
+      },
+      {
+       "end_line": 741,
+       "file": "bench/repos/sqlite/ext/jni/src/org/sqlite/jni/wrapper1/Sqlite.java",
+       "name": "createFunction",
+       "start_line": 737
+      }
+     ],
+     "text_similarity": 0.946,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 230,
+       "file": "bench/repos/sqlite/ext/fts3/fts3_aux.c",
+       "name": "fts3auxOpenMethod",
+       "start_line": 219
+      },
+      {
+       "end_line": 372,
+       "file": "bench/repos/sqlite/ext/fts3/fts3_test.c",
+       "name": "testTokenizerCreate",
+       "start_line": 358
+      }
+     ],
+     "text_similarity": 0.596,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 186,
+       "file": "bench/repos/sqlite/ext/fts3/fts3_term.c",
+       "name": "fts3termOpenMethod",
+       "start_line": 175
+      },
+      {
+       "end_line": 372,
+       "file": "bench/repos/sqlite/ext/fts3/fts3_test.c",
+       "name": "testTokenizerCreate",
+       "start_line": 358
+      }
+     ],
+     "text_similarity": 0.6,
+     "vj": 0.8
+    }
+   ],
+   "language": "C",
+   "split": "dev"
+  },
+  "sympy": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 200,
+       "file": "bench/repos/sympy/doc/generate_logos.py",
+       "name": null,
+       "start_line": 194
+      },
+      {
+       "end_line": 258,
+       "file": "bench/repos/sympy/doc/generate_logos.py",
+       "name": null,
+       "start_line": 252
+      }
+     ],
+     "text_similarity": 0.957,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 246,
+       "file": "bench/repos/sympy/sympy/assumptions/handlers/ntheory.py",
+       "name": "_",
+       "start_line": 244
+      },
+      {
+       "end_line": 251,
+       "file": "bench/repos/sympy/sympy/assumptions/handlers/ntheory.py",
+       "name": "_",
+       "start_line": 249
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 246,
+       "file": "bench/repos/sympy/sympy/assumptions/handlers/ntheory.py",
+       "name": "_",
+       "start_line": 244
+      },
+      {
+       "end_line": 251,
+       "file": "bench/repos/sympy/sympy/assumptions/handlers/ntheory.py",
+       "name": null,
+       "start_line": 250
+      }
+     ],
+     "text_similarity": 0.885,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 246,
+       "file": "bench/repos/sympy/sympy/assumptions/handlers/ntheory.py",
+       "name": null,
+       "start_line": 245
+      },
+      {
+       "end_line": 251,
+       "file": "bench/repos/sympy/sympy/assumptions/handlers/ntheory.py",
+       "name": null,
+       "start_line": 250
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 251,
+       "file": "bench/repos/sympy/sympy/assumptions/handlers/ntheory.py",
+       "name": "_",
+       "start_line": 249
+      },
+      {
+       "end_line": 246,
+       "file": "bench/repos/sympy/sympy/assumptions/handlers/ntheory.py",
+       "name": null,
+       "start_line": 245
+      }
+     ],
+     "text_similarity": 0.885,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 775,
+       "file": "bench/repos/sympy/sympy/physics/biomechanics/activation.py",
+       "name": "constants",
+       "start_line": 756
+      },
+      {
+       "end_line": 797,
+       "file": "bench/repos/sympy/sympy/physics/biomechanics/activation.py",
+       "name": "p",
+       "start_line": 778
+      }
+     ],
+     "text_similarity": 0.942,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 319,
+       "file": "bench/repos/sympy/sympy/polys/agca/extensions.py",
+       "name": "convert",
+       "start_line": 317
+      },
+      {
+       "end_line": 323,
+       "file": "bench/repos/sympy/sympy/polys/agca/extensions.py",
+       "name": "convert_from",
+       "start_line": 321
+      }
+     ],
+     "text_similarity": 0.959,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 236,
+       "file": "bench/repos/sympy/sympy/printing/lambdarepr.py",
+       "name": "_print_Rational",
+       "start_line": 235
+      },
+      {
+       "end_line": 239,
+       "file": "bench/repos/sympy/sympy/printing/lambdarepr.py",
+       "name": "_print_Half",
+       "start_line": 238
+      }
+     ],
+     "text_similarity": 0.966,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 289,
+       "file": "bench/repos/sympy/sympy/printing/pretty/tests/test_pretty.py",
+       "name": "test_pretty_ascii_str",
+       "start_line": 279
+      },
+      {
+       "end_line": 302,
+       "file": "bench/repos/sympy/sympy/printing/pretty/tests/test_pretty.py",
+       "name": "test_pretty_unicode_str",
+       "start_line": 292
+      }
+     ],
+     "text_similarity": 0.985,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Class",
+      "Class"
+     ],
+     "members": [
+      {
+       "end_line": 71,
+       "file": "bench/repos/sympy/sympy/polys/domains/powerseriesring.py",
+       "name": "SeriesRingProto",
+       "start_line": 27
+      },
+      {
+       "end_line": 272,
+       "file": "bench/repos/sympy/sympy/polys/series/base.py",
+       "name": "PowerSeriesRingFieldProto",
+       "start_line": 198
+      }
+     ],
+     "text_similarity": 0.238,
+     "vj": 0.81
+    }
+   ],
+   "language": "Python",
+   "split": "heldout"
+  },
+  "tokio": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 596,
+       "file": "bench/repos/tokio/tokio/src/io/async_fd.rs",
+       "name": "ready",
+       "start_line": 589
+      },
+      {
+       "end_line": 695,
+       "file": "bench/repos/tokio/tokio/src/io/async_fd.rs",
+       "name": "ready_mut",
+       "start_line": 685
+      }
+     ],
+     "text_similarity": 0.935,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 688,
+       "file": "bench/repos/tokio/tokio/src/sync/watch.rs",
+       "name": "borrow_and_update",
+       "start_line": 676
+      },
+      {
+       "end_line": 771,
+       "file": "bench/repos/tokio/tokio/src/sync/watch.rs",
+       "name": "mark_unchanged",
+       "start_line": 768
+      }
+     ],
+     "text_similarity": 0.41,
+     "vj": 0.833
+    }
+   ],
+   "language": "Rust",
+   "split": "heldout"
+  },
+  "trpc": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 28,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 25
+      },
+      {
+       "end_line": 57,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 54
+      }
+     ],
+     "text_similarity": 0.971,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 28,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 25
+      },
+      {
+       "end_line": 91,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 88
+      }
+     ],
+     "text_similarity": 0.971,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 28,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 25
+      },
+      {
+       "end_line": 125,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 122
+      }
+     ],
+     "text_similarity": 0.971,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 28,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 25
+      },
+      {
+       "end_line": 159,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 156
+      }
+     ],
+     "text_similarity": 0.971,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 28,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 25
+      },
+      {
+       "end_line": 190,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 187
+      }
+     ],
+     "text_similarity": 0.971,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 28,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 25
+      },
+      {
+       "end_line": 267,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 264
+      }
+     ],
+     "text_similarity": 0.971,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 28,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 25
+      },
+      {
+       "end_line": 401,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 398
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 28,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 25
+      },
+      {
+       "end_line": 806,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 803
+      }
+     ],
+     "text_similarity": 0.936,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 28,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 25
+      },
+      {
+       "end_line": 833,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 830
+      }
+     ],
+     "text_similarity": 0.936,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 57,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 54
+      },
+      {
+       "end_line": 91,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 88
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 57,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 54
+      },
+      {
+       "end_line": 125,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 122
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 57,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 54
+      },
+      {
+       "end_line": 159,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 156
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 57,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 54
+      },
+      {
+       "end_line": 190,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 187
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 57,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 54
+      },
+      {
+       "end_line": 267,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 264
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 57,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 54
+      },
+      {
+       "end_line": 401,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 398
+      }
+     ],
+     "text_similarity": 0.971,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 57,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 54
+      },
+      {
+       "end_line": 806,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 803
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 57,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 54
+      },
+      {
+       "end_line": 833,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 830
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 91,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 88
+      },
+      {
+       "end_line": 125,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 122
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 91,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 88
+      },
+      {
+       "end_line": 159,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 156
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 91,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 88
+      },
+      {
+       "end_line": 190,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 187
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 91,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 88
+      },
+      {
+       "end_line": 267,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 264
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 91,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 88
+      },
+      {
+       "end_line": 401,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 398
+      }
+     ],
+     "text_similarity": 0.971,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 91,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 88
+      },
+      {
+       "end_line": 806,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 803
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 91,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 88
+      },
+      {
+       "end_line": 833,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 830
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 125,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 122
+      },
+      {
+       "end_line": 159,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 156
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 125,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 122
+      },
+      {
+       "end_line": 190,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 187
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 125,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 122
+      },
+      {
+       "end_line": 267,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 264
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 125,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 122
+      },
+      {
+       "end_line": 401,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 398
+      }
+     ],
+     "text_similarity": 0.971,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 125,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 122
+      },
+      {
+       "end_line": 806,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 803
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 125,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 122
+      },
+      {
+       "end_line": 833,
+       "file": "bench/repos/trpc/packages/react-query/test/withTRPC.test.tsx",
+       "name": "App",
+       "start_line": 830
+      }
+     ],
+     "text_similarity": 0.967,
+     "vj": 1.0
+    }
+   ],
+   "language": "TypeScript",
+   "split": "heldout"
+  },
+  "vim": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Block",
+      "Block"
+     ],
+     "members": [
+      {
+       "end_line": 1109,
+       "file": "bench/repos/vim/src/gui_w32.c",
+       "name": null,
+       "start_line": 1098
+      },
+      {
+       "end_line": 1171,
+       "file": "bench/repos/vim/src/gui_w32.c",
+       "name": null,
+       "start_line": 1160
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    }
+   ],
+   "language": "C",
+   "split": "heldout"
+  },
+  "zap": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 327,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint",
+       "start_line": 327
+      },
+      {
+       "end_line": 328,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint32",
+       "start_line": 328
+      }
+     ],
+     "text_similarity": 0.954,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 327,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint",
+       "start_line": 327
+      },
+      {
+       "end_line": 329,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint16",
+       "start_line": 329
+      }
+     ],
+     "text_similarity": 0.954,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 327,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint",
+       "start_line": 327
+      },
+      {
+       "end_line": 330,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint8",
+       "start_line": 330
+      }
+     ],
+     "text_similarity": 0.977,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 327,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint",
+       "start_line": 327
+      },
+      {
+       "end_line": 331,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUintptr",
+       "start_line": 331
+      }
+     ],
+     "text_similarity": 0.931,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 328,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint32",
+       "start_line": 328
+      },
+      {
+       "end_line": 329,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint16",
+       "start_line": 329
+      }
+     ],
+     "text_similarity": 0.954,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 328,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint32",
+       "start_line": 328
+      },
+      {
+       "end_line": 330,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint8",
+       "start_line": 330
+      }
+     ],
+     "text_similarity": 0.954,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 328,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint32",
+       "start_line": 328
+      },
+      {
+       "end_line": 331,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUintptr",
+       "start_line": 331
+      }
+     ],
+     "text_similarity": 0.931,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 329,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint16",
+       "start_line": 329
+      },
+      {
+       "end_line": 330,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint8",
+       "start_line": 330
+      }
+     ],
+     "text_similarity": 0.954,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 329,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint16",
+       "start_line": 329
+      },
+      {
+       "end_line": 331,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUintptr",
+       "start_line": 331
+      }
+     ],
+     "text_similarity": 0.931,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Method",
+      "Method"
+     ],
+     "members": [
+      {
+       "end_line": 330,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUint8",
+       "start_line": 330
+      },
+      {
+       "end_line": 331,
+       "file": "bench/repos/zap/zapcore/json_encoder.go",
+       "name": "AddUintptr",
+       "start_line": 331
+      }
+     ],
+     "text_similarity": 0.931,
+     "vj": 1.0
+    }
+   ],
+   "language": "Go",
+   "split": "dev"
+  },
+  "zstd": {
+   "candidates": [
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": true,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 50,
+       "file": "bench/repos/zstd/build/single_file_libs/examples/roundtrip.c",
+       "name": "ZSTD_decompress",
+       "start_line": 48
+      },
+      {
+       "end_line": 53,
+       "file": "bench/repos/zstd/build/single_file_libs/examples/simple.c",
+       "name": "ZSTD_decompress",
+       "start_line": 51
+      }
+     ],
+     "text_similarity": 1.0,
+     "vj": 1.0
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 538,
+       "file": "bench/repos/zstd/lib/common/fse.h",
+       "name": "FSE_updateState",
+       "start_line": 532
+      },
+      {
+       "end_line": 549,
+       "file": "bench/repos/zstd/lib/common/fse.h",
+       "name": "FSE_decodeSymbol",
+       "start_line": 540
+      }
+     ],
+     "text_similarity": 0.879,
+     "vj": 0.857
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 538,
+       "file": "bench/repos/zstd/lib/common/fse.h",
+       "name": "FSE_updateState",
+       "start_line": 532
+      },
+      {
+       "end_line": 668,
+       "file": "bench/repos/zstd/lib/legacy/zstd_v02.c",
+       "name": "FSE_decodeSymbol",
+       "start_line": 659
+      }
+     ],
+     "text_similarity": 0.846,
+     "vj": 0.857
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 538,
+       "file": "bench/repos/zstd/lib/common/fse.h",
+       "name": "FSE_updateState",
+       "start_line": 532
+      },
+      {
+       "end_line": 669,
+       "file": "bench/repos/zstd/lib/legacy/zstd_v03.c",
+       "name": "FSE_decodeSymbol",
+       "start_line": 660
+      }
+     ],
+     "text_similarity": 0.846,
+     "vj": 0.857
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      true
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 538,
+       "file": "bench/repos/zstd/lib/common/fse.h",
+       "name": "FSE_updateState",
+       "start_line": 532
+      },
+      {
+       "end_line": 848,
+       "file": "bench/repos/zstd/lib/legacy/zstd_v04.c",
+       "name": "FSE_decodeSymbol",
+       "start_line": 839
+      }
+     ],
+     "text_similarity": 0.846,
+     "vj": 0.857
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 1073,
+       "file": "bench/repos/zstd/lib/legacy/zstd_v06.c",
+       "name": "FSEv06_updateState",
+       "start_line": 1067
+      },
+      {
+       "end_line": 1084,
+       "file": "bench/repos/zstd/lib/legacy/zstd_v06.c",
+       "name": "FSEv06_decodeSymbol",
+       "start_line": 1075
+      }
+     ],
+     "text_similarity": 0.885,
+     "vj": 0.857
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      true,
+      true
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 838,
+       "file": "bench/repos/zstd/lib/legacy/zstd_v07.c",
+       "name": "FSEv07_updateState",
+       "start_line": 832
+      },
+      {
+       "end_line": 849,
+       "file": "bench/repos/zstd/lib/legacy/zstd_v07.c",
+       "name": "FSEv07_decodeSymbol",
+       "start_line": 840
+      }
+     ],
+     "text_similarity": 0.885,
+     "vj": 0.857
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 596,
+       "file": "bench/repos/zstd/lib/decompress/huf_decompress.c",
+       "name": "HUF_decompress1X1_usingDTable_internal_body",
+       "start_line": 575
+      },
+      {
+       "end_line": 1378,
+       "file": "bench/repos/zstd/lib/decompress/huf_decompress.c",
+       "name": "HUF_decompress1X2_usingDTable_internal_body",
+       "start_line": 1353
+      }
+     ],
+     "text_similarity": 0.539,
+     "vj": 0.833
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 1834,
+       "file": "bench/repos/zstd/lib/legacy/zstd_v07.c",
+       "name": "HUFv07_decompress1X2_usingDTable_internal",
+       "start_line": 1812
+      },
+      {
+       "end_line": 2246,
+       "file": "bench/repos/zstd/lib/legacy/zstd_v07.c",
+       "name": "HUFv07_decompress1X4_usingDTable_internal",
+       "start_line": 2220
+      }
+     ],
+     "text_similarity": 0.61,
+     "vj": 0.805
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 1129,
+       "file": "bench/repos/zstd/lib/compress/huf_compress.c",
+       "name": "HUF_compress1X_usingCTable_internal_bmi2",
+       "start_line": 1123
+      },
+      {
+       "end_line": 1159,
+       "file": "bench/repos/zstd/lib/compress/huf_compress.c",
+       "name": "HUF_compress1X_usingCTable_internal",
+       "start_line": 1152
+      }
+     ],
+     "text_similarity": 0.89,
+     "vj": 0.8
+    },
+    {
+     "evidence_tier": "detector-suggested",
+     "exact_safe": [
+      false,
+      false
+     ],
+     "fp_equal": false,
+     "kinds": [
+      "Function",
+      "Function"
+     ],
+     "members": [
+      {
+       "end_line": 1137,
+       "file": "bench/repos/zstd/lib/compress/huf_compress.c",
+       "name": "HUF_compress1X_usingCTable_internal_default",
+       "start_line": 1131
+      },
+      {
+       "end_line": 1159,
+       "file": "bench/repos/zstd/lib/compress/huf_compress.c",
+       "name": "HUF_compress1X_usingCTable_internal",
+       "start_line": 1152
+      }
+     ],
+     "text_similarity": 0.908,
+     "vj": 0.8
+    }
+   ],
+   "language": "C",
+   "split": "heldout"
+  }
+ },
+ "scan_failures": [
+  "rxjs"
+ ],
+ "schema_version": "0.1.0",
+ "vj_floor": 0.8
+}

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -912,3 +912,48 @@ lower anchor weight floor, but those small shared chunks are weak refactor targe
 the band is an over-approximation — worth at most a knob experiment
 (`NOSE_ANCHOR_*`), not a mechanism. The honest headline for further worthy-recall is
 **unit extraction coverage and the fragment axis, not more matching**.
+
+## BK. The independent miss-mining arm — measuring in-the-wild misses (modality B)
+
+The §BJ probe answered the *mechanism* question; this answers the *measurement* one
+(#194): the v5 pool is nose ∪ jscpd, so semantic clones missed by **both** can't appear
+in any recall denominator. `bench/type4/miss_mining.py` is the independent arm: per
+pinned repo, LSH-band the detection minhash over all ≥ 5-line/≥ 40-token units, confirm
+candidate pairs by exact value-multiset Jaccard (≥ 0.80), and keep pairs **no family on
+the maximal current surface co-reports**. Output is a queue signal only (#36 two-layer
+discipline): every record carries `evidence_tier: detector-suggested`, annotated with
+`fp_equal`, `exact_safe`, and a source `text_similarity` ratio so the
+textually-dissimilar tail (the jscpd-shaped blind spot) is sliceable. The complementary
+modality A — behavior-equal fingerprint-split pairs — is the existing
+`nose verify --leads`. Artifact: `bench/type4/miss_mining_2026_06_10.json`
+(104 repos; `rxjs` excluded, #198).
+
+**Result: 593 candidates corpus-wide, and the audit says the residual is structured,
+small, and mostly *not* detector-recall.**
+
+| class | n | read |
+|---|---:|---|
+| fp-equal, same-file, not exact-safe | 375 | parameterized-test / scaffolding bodies, annotation-varying twins |
+| fp-equal, cross-file | 78 | dominated by generated code (`etcd` protobuf `*.pb.go`) — correctly excluded from ranking by the generated-file policy |
+| fp-equal, same-file, exact-safe | 44 | small proven twins, mostly test scaffolds |
+| vj ∈ [0.8, 1.0), mixed | 96 | the only class with worthy-shaped finds |
+
+Spot-audit of the non-fp-equal cross-file slice found one clearly worthy-shaped miss —
+`libgdx` `Widget.pack()` ≡ `WidgetGroup.pack()` (identical method duplicated across
+sibling classes; impure, vj 0.80 < the 0.90 value-accept, shapes split, so no channel
+fires) — among stub/parallel-by-design neighbours (curl no-op callbacks, sympy protocol
+type-defs). The deeper catch was mechanical: chasing *why* fp-equal `exact_safe` pairs
+(`junit5` annotation-varying `fail(...)` methods) never surface exposed that **adding
+the syntax channel can drop an exact semantic family the semantic channel reports
+alone** — a channel-merge reporting bug, filed with a single-file reproducer as #202.
+That is the arm working as designed: candidates are cheap, and each audited one either
+dies as scaffolding/generated (raising confidence in the policy layers) or names a
+precise defect.
+
+Honest bottom line for the in-the-wild recall question: at vj ≥ 0.8 the unreported mass
+is ~600 pairs across 59k files, overwhelmingly generated/scaffolding; the worthy-shaped
+tail is a handful per corpus — consistent with §BJ's "no headline recall mechanism
+left" verdict. Below vj 0.8 (true different-algorithm Type-4) this arm is blind by
+construction; that frontier remains unmeasured and would need a behavior- or
+embedding-based candidate source — recorded as the arm's known limit, not claimed
+covered.

--- a/docs/frontier-platform.md
+++ b/docs/frontier-platform.md
@@ -90,6 +90,19 @@ established by literal bounds or an exiting inverse guard. The surface bridge al
 two-comparison ternary clamps and proven numeric Rust `.clamp` forms while keeping unproven
 bounds, custom method names, and float domains outside the shared Clamp value.
 
+## The miss-mining arm (`miss_mining.py`)
+
+`bench/type4/miss_mining.py` is a corpus-wide **queue-signal** source on the same
+two-layer discipline: it LSH-bands the detection minhash over every meaningful-size
+unit per repo and emits unit pairs with high exact value-Jaccard that **no family on
+the maximal current scan surface co-reports** — same-computation evidence the product
+stays silent on, annotated with `fp_equal`, `exact_safe`, and a source
+`text_similarity` ratio (the low-text tail is what a token-based pool can never
+contribute). Every record carries `evidence_tier: detector-suggested` and nothing is
+auto-elevated; a confirmed miss graduates by hand into `real_frontier.v1.json` via the
+audit template below. Method, the dated artifact, and the first audit's findings are
+recorded in [experiments §BK](experiments.md).
+
 ## Target packets (`frontier_target_packets.v1.json`)
 
 An *implementation-ready* candidate becomes a **target packet** in a separate artifact —


### PR DESCRIPTION
## What

Builds the **independent miss-mining arm** (#194): a measurement for in-the-wild same-computation pairs that nose does not report — the recall blind spot the v5 gold-set pool (nose ∪ jscpd) can't contain by construction. Closes #194.

- `bench/type4/miss_mining.py` — per pinned repo: LSH-band the detection minhash over all ≥5-line/≥40-token units, confirm pairs by exact value-multiset Jaccard (≥ 0.80), keep pairs no family on the **maximal current surface** (`syntax,semantic,near --min-value 0`) co-reports. Strict #36 two-layer discipline: every record is `evidence_tier: detector-suggested`, nothing auto-elevates; `fp_equal` / `exact_safe` / source `text_similarity` annotations make the textually-dissimilar tail (the jscpd-shaped blind spot) sliceable. Modality A (behavior-equal, fingerprint-split) remains the existing `nose verify --leads`.
- `bench/type4/miss_mining_2026_06_10.json` — first full-corpus artifact (104 repos; rxjs excluded, #198).
- `docs/experiments.md` §BK — method, class table, audit, limits; `docs/frontier-platform.md` — queue-signal pointer; CHANGELOG.

## Result

**593 candidates corpus-wide; the audited residual is structured, small, and mostly not detector-recall:** 375 fp-equal same-file scaffolding twins, 78 cross-file fp-equal dominated by generated protobuf (`etcd *.pb.go` — correctly excluded from ranking), 44 small proven test twins, and a 96-pair mixed slice holding the only worthy-shaped finds (e.g. `libgdx` `Widget.pack()` ≡ `WidgetGroup.pack()` across sibling classes — impure, vj 0.80 below the 0.90 value-accept, shape-split, so no channel fires).

Two concrete products of the first audit:

1. **Bug found:** chasing why fp-equal `exact_safe` pairs never surface exposed that *adding the syntax channel drops an exact semantic family the semantic channel reports alone* — filed as #202 with a single-file reproducer.
2. **Honest limit recorded:** below vj 0.8 (true different-algorithm Type-4) this arm is blind by construction; that frontier stays unmeasured and is stated as such, not claimed covered.

Consistent with the §BJ probe verdict: no headline recall mechanism is hiding in the unreported mass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
