### PR TITLE
[codex] Prevent rxjs recursive callback inlining overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ break.
 ## [Unreleased]
 
 ### Fixed
+- Semantic scans no longer stack-overflow when a recursive helper is referenced
+  from inside one of its own callback bodies while extracting a block or exact
+  fragment. The value graph now excludes the enclosing function/method from the
+  per-unit inline registry, preserving bounded inlining for sub-unit
+  fingerprints. This fixes the `rxjs` corpus crash and keeps the 105-repo bench
+  corpus green in semantic JSON mode.
 - **Soundness:** a seeded selection loop (`best = 0; … if v > best: best = v`) no
   longer merges with the true builtin selection (`max(…)`) — the seed clamps the
   result (empty or all-negative input returns the seed), so it is

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1608,6 +1608,34 @@ fn deeply_nested_file_does_not_overflow() {
 }
 
 #[test]
+fn recursive_hof_callback_fragment_does_not_overflow() {
+    // Regression for the rxjs scanner abort: when extracting sub-function units inside a
+    // recursive helper, the value graph must not register the enclosing function as a pure inline
+    // target and inline the helper through its own reduce callback forever.
+    let dir = std::env::temp_dir().join(format!("nose_recursive_hof_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("recursive.ts"),
+        "export function recInLambda(xs: any[]): number {\n  return xs.reduce((acc, x) => recInLambda(x), 0);\n}\n",
+    )
+    .unwrap();
+    let out = run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--format",
+        "json",
+        "--top",
+        "0",
+    ]);
+    let json = scan_json(&out);
+    assert_eq!(json["scope"]["files"], 1);
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn proposal_shows_shared_skeleton_and_parameters() {
     // Two near-identical functions differing in one line → an extraction proposal:
     // the shared skeleton plus a ⟨param⟩ for the varying spot.

--- a/crates/nose-normalize/src/value_graph/inline.rs
+++ b/crates/nose-normalize/src/value_graph/inline.rs
@@ -14,14 +14,17 @@ use nose_semantics::direct_function_call_target_at_call;
 
 impl<'a> Builder<'a> {
     /// Build the interprocedural inline registry: pure, file-local functions/methods that can be
-    /// inlined to their body's value. Excludes the unit currently being built (`root`) so a
-    /// function is never inlined into itself.
+    /// inlined to their body's value. Excludes the unit currently being built, and any enclosing
+    /// function/method for sub-unit roots, so a function is never inlined into itself through one
+    /// of its blocks or exact fragments.
     pub(super) fn build_inline_registry(&mut self, root: NodeId) {
         if !self.inline_fns.is_empty() {
             return;
         }
         for unit in self.il.units.clone() {
-            if !matches!(unit.kind, UnitKind::Function | UnitKind::Method) || unit.root == root {
+            if !matches!(unit.kind, UnitKind::Function | UnitKind::Method)
+                || self.subtree_contains(unit.root, root)
+            {
                 continue;
             }
             if !self.function_binding_safe(unit.root, unit.root) {
@@ -46,6 +49,20 @@ impl<'a> Builder<'a> {
             self.inline_fns
                 .insert(unit.root, InlineFunction { params, body });
         }
+    }
+
+    fn subtree_contains(&self, root: NodeId, needle: NodeId) -> bool {
+        let mut stack = vec![root];
+        let mut seen = FxHashSet::default();
+        while let Some(node) = stack.pop() {
+            if node == needle {
+                return true;
+            }
+            if seen.insert(node) {
+                stack.extend(self.il.children(node).iter().copied());
+            }
+        }
+        false
     }
 
     /// Inline a call to a PURE registered function: bind its parameters to the caller-evaluated

--- a/crates/nose-normalize/src/value_graph/model.rs
+++ b/crates/nose-normalize/src/value_graph/model.rs
@@ -173,8 +173,8 @@ pub(super) struct Builder<'a> {
     pub(super) global_env: FxHashMap<Symbol, ValueId>,
     /// Interprocedural inline registry, keyed by target unit root. Calls may consume an entry only
     /// through `CallTarget::DirectFunction` evidence at the exact call occurrence; the callee
-    /// spelling is never a proof channel. Pure bodies have no user calls, so an inlined body never
-    /// triggers further inlining -- single-level, no cycles, no depth bound.
+    /// spelling is never a proof channel. Enclosing functions are excluded for sub-unit
+    /// fingerprints, so a recursive helper cannot inline itself through a block or fragment root.
     pub(super) inline_fns: FxHashMap<NodeId, InlineFunction>,
     /// Nodes under function/lambda scopes use local cid numbering. Their `Cid(0)` is not
     /// the module `cid_names[0]`, so module-symbol resolution fails closed there.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -871,8 +871,9 @@ one same-file sibling unit's multiset added to either side lifts the mass over 2
 shape), **no-overlapping-unit** if a member has no unit at all, else **unrecovered**.
 Multiset intersection ignores connectivity and single-file `features` lacks whole-repo
 import resolution, so the sub-DAG/inline classes **over-approximate** — a ceiling, not a
-forecast. Caveats: `rxjs` excluded (scanner stack overflow, #198); corpus was dir-pruned
-but not file-pruned (`prune_corpus.py` missing, #200).
+forecast. Caveats: the original run excluded `rxjs` for a scanner stack overflow later
+fixed by #198; corpus was dir-pruned but not file-pruned (`prune_corpus.py` missing,
+#200).
 
 **Result** (4,921 worthy labels; dev / heldout):
 
@@ -926,7 +927,7 @@ discipline): every record carries `evidence_tier: detector-suggested`, annotated
 textually-dissimilar tail (the jscpd-shaped blind spot) is sliceable. The complementary
 modality A — behavior-equal fingerprint-split pairs — is the existing
 `nose verify --leads`. Artifact: `bench/type4/miss_mining_2026_06_10.json`
-(104 repos; `rxjs` excluded, #198).
+(104 repos; original run excluded `rxjs` for the stack overflow later fixed by #198).
 
 **Result: 593 candidates corpus-wide, and the audit says the residual is structured,
 small, and mostly *not* detector-recall.**

--- a/docs/field-evaluation.md
+++ b/docs/field-evaluation.md
@@ -83,8 +83,10 @@ compiled first-party `nose.value_graph.laws` pack across the 105-repo
 `bench/repos` corpus, plus a targeted 10-repo subset selected for clamp/min-max
 and arithmetic-law surfaces. The pack was active in all 104 successful full-corpus
 scans, covering 59,865 source files and 10,967 reported families, but no family
-contained `semantic_laws` provenance. `rxjs` failed with a stack overflow and is
-recorded separately.
+contained `semantic_laws` provenance. The checked-in audit recorded `rxjs`
+separately because it hit a scanner stack overflow at the time; follow-up #198
+fixed that crash, and the current semantic JSON corpus loop completes 105/105
+repos.
 
 The qualitative read is a negative field result, not a pack-loading failure:
 real code contains many clamp-shaped idioms (`fzf` generic `Constrain`,

--- a/docs/lawpack-provenance-audit-2026-06-10.md
+++ b/docs/lawpack-provenance-audit-2026-06-10.md
@@ -40,6 +40,11 @@ families:
 | repos with `semantic_laws` families | 0 |
 | `semantic_laws` families | 0 |
 
+Follow-up: #198 fixed the `rxjs` scanner crash by preventing sub-unit value
+fingerprints from inlining their own enclosing recursive helper. This document
+keeps the original 104/105 audit result because it describes the checked-in
+artifact above.
+
 Language coverage in the successful scans:
 
 | language | files | repos |


### PR DESCRIPTION
Fixes #198.

## Summary
- exclude the enclosing function/method from sub-unit value-graph inline registries
- add a CLI regression for a recursive helper referenced from inside its own reduce callback
- update field-evaluation, experiment, audit, and changelog notes for the rxjs corpus crash follow-up

## Validation
- cargo fmt --all --check
- cargo test -p nose-cli --test cli recursive_hof_callback_fragment_does_not_overflow -- --nocapture
- cargo build -p nose-cli --release
- target/release/nose scan /Users/ak/prjs/cc/nose/bench/repos/rxjs --mode semantic --format json --top 0
- 105/105 bench/repos semantic JSON scan loop passed; artifact dir: /tmp/nose-198-full-1781079268
- ./scripts/check-docs.sh
- awiki lint --root docs
- ./scripts/check-ci-local.sh --fast