### PR TITLE
Fix duplicate scan family IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ break.
 ## [Unreleased]
 
 ### Fixed
+- Scan JSON `family_id` values are now unique for distinct reported families that
+  share the same files and symbol names but point at different spans, especially
+  hidden exact-fragment families. The ID now includes each member's displayed
+  path, language, span, unit kind, symbol name, and fragment proof metadata; old
+  baselines can still classify re-keyed overlapping families as `changed`, but
+  structured ignores by `family_id` may need a one-time refresh.
 - Fresh benchmark-corpus reconstruction works again: `bench/setup_repos.sh`
   now has its missing file-level prune helper checked in, guards that the helper
   exists before cloning, and writes a deterministic

--- a/bench/labels/fragment_quality_audit_2026_06_10.json
+++ b/bench/labels/fragment_quality_audit_2026_06_10.json
@@ -62,7 +62,7 @@
         "noise": 3
       }
     },
-    "decision": "Keep exact fragments as diagnostic JSON substrate and out of default action output. Demote tiny test-only scaffold fragments from review to hidden. Track repeated family_id collisions and one-line direct-return over-breadth as follow-up issues rather than broad-pruning semantic fragments."
+    "decision": "Keep exact fragments as diagnostic JSON substrate and out of default action output. Demote tiny test-only scaffold fragments from review to hidden. Track repeated family_id collisions (#199, resolved by span-aware IDs) and one-line direct-return over-breadth as follow-up issues rather than broad-pruning semantic fragments."
   },
   "items": [
     {

--- a/bench/type4/scan_regression/README.md
+++ b/bench/type4/scan_regression/README.md
@@ -85,9 +85,9 @@ main worktree or any other path you pass to `--repos-root`. Per repo we record a
 - `recommended_surface_counts` — family product placement counts for `default`,
   `review`, `hidden`, and reserved `debug`
 - `family_shape_counts` — whole-only, all-fragment, and mixed family counts
-- per family — **keyed by the normalized location set, not `family_id`** (the product
-  `family_id` is not unique; distinct families can share one id, so keying on it would
-  silently drop a family): `family_id` (kept as an attribute and a drift signal),
+- per family — **keyed by the normalized location set, not `family_id`** (so deliberate
+  `family_id` scheme migrations and accidental ID regressions stay reviewable):
+  `family_id` (kept as an attribute and a drift signal),
   `members`, `location_count`, `mean_lines`, `recommended_surface`, family shape,
   fragment count, per-kind counts, family-local fragment kind/reason-code counts,
   family-local kind/reason-by-surface counts, fragment-only span buckets,

--- a/bench/type4/scan_regression/scan_regression.py
+++ b/bench/type4/scan_regression/scan_regression.py
@@ -30,9 +30,9 @@ Why this exists, and the rules it follows (from the issue #37 decision):
 
 5. Output drift is compared on the `--top 0` full JSON, canonicalized: family order
    and ranking tie-breaks are ignored. Families are keyed by their normalized
-   (repo-relative) location set, because the product `family_id` is NOT unique (distinct
-   families can share one id); family_id is compared as an attribute and is itself a
-   drift signal. We also compare unit kind, mean_lines / span size, location count,
+   (repo-relative) location set so the harness remains robust to deliberate
+   `family_id` scheme migrations; family_id is compared as an attribute and is itself
+   a drift signal. We also compare unit kind, mean_lines / span size, location count,
    product JSON byte size, fragment product-surface placement, all-fragment vs mixed
    family shape, fragment span buckets, enclosing-unit recovery, and family-local
    `fragment_kind` / `reason_code` summaries. `fragment_kind` / `reason_code` are
@@ -518,12 +518,10 @@ def canonicalize(scan_json: dict, repo: Path) -> dict:
     fragment_line_span_buckets: dict[str, int] = {}
     fragment_token_span_buckets: dict[str, int] = {}
     enclosing_unit_recovery_counts: dict[str, int] = {"recovered": 0, "missing": 0}
-    # NOTE: the product `family_id` is NOT unique — distinct families can share one id
-    # (observed in chi: two Block families both keyed `c55b843732270ba0`). Keying by
-    # family_id would silently drop a family, so families are keyed by their normalized
-    # location set (the true identity per the #37 decision), with family_id kept as an
-    # attribute (and itself a drift signal). The location-set key also keeps the diff
-    # robust to family_id scheme changes.
+    # Families are keyed by their normalized location set (the true identity per the
+    # #37 decision), with family_id kept as an attribute and drift signal. That keeps
+    # the diff robust to deliberate family_id scheme migrations and prevents any
+    # accidental ID regression from hiding a reported family.
     families: dict[str, dict] = {}
 
     for fam in families_in:
@@ -767,8 +765,9 @@ def compare_repo(repo_id: str, base: dict, cur: dict) -> dict:
     bo, co = base["output"], cur["output"]
     triggers: list[str] = []
 
-    # Family set drift (rule 5). Families are keyed by their normalized location set,
-    # not the non-unique family_id; we report each by family_id + a location for humans.
+    # Family set drift (rule 5). Families are keyed by their normalized location set
+    # rather than family_id so ID migrations remain reviewable instead of reshaping the
+    # dictionary; we report each by family_id + a location for humans.
     bfam, cfam = bo["families"], co["families"]
     base_keys, cur_keys = set(bfam), set(cfam)
 

--- a/crates/nose-cli/src/baseline.rs
+++ b/crates/nose-cli/src/baseline.rs
@@ -1,13 +1,14 @@
 //! Baseline support for incremental adoption: record the duplication a codebase
 //! already has, so later runs (and the `--fail-on` gate) flag only *new* families.
 //!
-//! A family's identity must survive ordinary edits. Line numbers shift constantly,
-//! so the key is a hash over the family's members' `(file, symbol-name)` pairs,
-//! sorted — invariant to line moves and member order, but sensitive to *which*
-//! sites form the family (adding/removing a copy is legitimately a new family).
+//! A family's identity is the sorted set of its reported locations. Fragment families
+//! can repeat in the same file and enclosing symbol, so the key includes the displayed
+//! path, language, source span, syntactic kind, symbol name, and fragment proof metadata.
+//! Baseline files also keep those member identities for changed-family matching; older
+//! member-only baselines are still accepted as coarse `(file, name)` overlap hints.
 
 use anyhow::{Context, Result};
-use nose_detect::RefactorFamily;
+use nose_detect::{Loc, RefactorFamily};
 use std::collections::HashSet;
 use std::path::Path;
 
@@ -22,9 +23,8 @@ pub(crate) fn family_key(f: &RefactorFamily) -> u64 {
         }
         h = crate::fnv::mix(h, 0xff); // field separator
     };
-    for MemberKey { file, name } in members {
-        mix(file.as_bytes());
-        mix(name.as_bytes());
+    for member in members {
+        member.mix_into(&mut mix);
     }
     h
 }
@@ -51,24 +51,107 @@ pub(crate) fn parse_key(s: &str) -> Option<u64> {
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) struct MemberKey {
     pub file: String,
+    pub lang: Option<String>,
+    pub start_line: Option<u32>,
+    pub end_line: Option<u32>,
+    pub kind: Option<String>,
     pub name: String,
+    pub is_fragment: Option<bool>,
+    pub fragment_kind: Option<String>,
+    pub reason_code: Option<String>,
 }
 
-/// Build a [`MemberKey`] from a `(file, optional name)` pair, applying the canonical
-/// missing-name default (`""`). The single place that decides how an absent member name
-/// maps into a key, shared by `member_keys` and baseline loading.
-pub(crate) fn member_key(file: &str, name: &Option<String>) -> MemberKey {
+impl MemberKey {
+    fn mix_into(&self, mix: &mut impl FnMut(&[u8])) {
+        mix(self.file.as_bytes());
+        mix_opt_str(mix, self.lang.as_deref());
+        mix_opt_u32(mix, self.start_line);
+        mix_opt_u32(mix, self.end_line);
+        mix_opt_str(mix, self.kind.as_deref());
+        mix(self.name.as_bytes());
+        mix_opt_bool(mix, self.is_fragment);
+        mix_opt_str(mix, self.fragment_kind.as_deref());
+        mix_opt_str(mix, self.reason_code.as_deref());
+    }
+
+    fn has_location_identity(&self) -> bool {
+        self.lang.is_some()
+            && self.start_line.is_some()
+            && self.end_line.is_some()
+            && self.kind.is_some()
+            && self.is_fragment.is_some()
+    }
+
+    fn overlaps(&self, other: &Self) -> bool {
+        if self.file != other.file || self.name != other.name {
+            return false;
+        }
+        if self.has_location_identity() && other.has_location_identity() {
+            return self == other;
+        }
+        true
+    }
+}
+
+fn mix_opt_str(mix: &mut impl FnMut(&[u8]), value: Option<&str>) {
+    match value {
+        Some(value) => {
+            mix(b"some");
+            mix(value.as_bytes());
+        }
+        None => mix(b"none"),
+    }
+}
+
+fn mix_opt_u32(mix: &mut impl FnMut(&[u8]), value: Option<u32>) {
+    match value {
+        Some(value) => {
+            mix(b"some");
+            mix(&value.to_le_bytes());
+        }
+        None => mix(b"none"),
+    }
+}
+
+fn mix_opt_bool(mix: &mut impl FnMut(&[u8]), value: Option<bool>) {
+    match value {
+        Some(true) => mix(b"true"),
+        Some(false) => mix(b"false"),
+        None => mix(b"none"),
+    }
+}
+
+fn serialized_name<T>(value: T) -> String
+where
+    T: serde::Serialize + std::fmt::Debug,
+{
+    serde_json::to_value(&value)
+        .ok()
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .unwrap_or_else(|| format!("{value:?}"))
+}
+
+fn member_key_from_location(loc: &Loc) -> MemberKey {
     MemberKey {
-        file: file.to_owned(),
-        name: name.clone().unwrap_or_default(),
+        file: loc.file.clone(),
+        lang: Some(loc.lang.clone()),
+        start_line: Some(loc.start_line),
+        end_line: Some(loc.end_line),
+        kind: Some(serialized_name(loc.kind)),
+        name: loc.name.clone().unwrap_or_default(),
+        is_fragment: Some(loc.is_fragment),
+        fragment_kind: loc.fragment_kind.map(serialized_name),
+        reason_code: loc.reason_code.map(ToOwned::to_owned),
     }
 }
 
 pub(crate) fn member_keys(f: &RefactorFamily) -> Vec<MemberKey> {
-    f.locations
-        .iter()
-        .map(|l| member_key(&l.file, &l.name))
-        .collect()
+    f.locations.iter().map(member_key_from_location).collect()
+}
+
+pub(crate) fn member_sets_overlap(left: &[MemberKey], right: &[MemberKey]) -> bool {
+    left.iter()
+        .any(|left| right.iter().any(|right| left.overlaps(right)))
 }
 
 pub(crate) struct Baseline {
@@ -91,11 +174,55 @@ struct Entry {
     members: Vec<MemberEntry>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 struct MemberEntry {
     file: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    lang: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    start_line: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    end_line: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    is_fragment: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    fragment_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reason_code: Option<String>,
+}
+
+impl MemberEntry {
+    fn into_member_key(self) -> MemberKey {
+        MemberKey {
+            file: self.file,
+            lang: self.lang,
+            start_line: self.start_line,
+            end_line: self.end_line,
+            kind: self.kind,
+            name: self.name.unwrap_or_default(),
+            is_fragment: self.is_fragment,
+            fragment_kind: self.fragment_kind,
+            reason_code: self.reason_code,
+        }
+    }
+
+    fn from_member_key(member: MemberKey) -> Self {
+        Self {
+            file: member.file,
+            lang: member.lang,
+            start_line: member.start_line,
+            end_line: member.end_line,
+            kind: member.kind,
+            name: (!member.name.is_empty()).then_some(member.name),
+            is_fragment: member.is_fragment,
+            fragment_kind: member.fragment_kind,
+            reason_code: member.reason_code,
+        }
+    }
 }
 
 /// Load the set of accepted family keys. A missing or malformed baseline is a hard
@@ -118,7 +245,8 @@ pub(crate) fn load(path: &Path) -> Result<Baseline> {
             let members = e
                 .members
                 .iter()
-                .map(|m| member_key(&m.file, &m.name))
+                .cloned()
+                .map(MemberEntry::into_member_key)
                 .collect();
             Ok(BaselineEntry { key, members })
         })
@@ -140,10 +268,7 @@ pub(crate) fn write(
             note: note_of(f),
             members: member_keys(f)
                 .into_iter()
-                .map(|m| MemberEntry {
-                    file: m.file,
-                    name: (!m.name.is_empty()).then_some(m.name),
-                })
+                .map(MemberEntry::from_member_key)
                 .collect(),
         })
         .collect();
@@ -151,4 +276,85 @@ pub(crate) fn write(
     let mut json = serde_json::to_string_pretty(&entries).unwrap_or_default();
     json.push('\n');
     std::fs::write(path, json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nose_detect::{FragmentKind, Loc};
+    use nose_il::UnitKind;
+
+    fn fragment_family(starts: &[u32]) -> RefactorFamily {
+        RefactorFamily {
+            value: 1.0,
+            members: starts.len(),
+            files: 1,
+            modules: 1,
+            languages: 1,
+            mean_score: 1.0,
+            mean_lines: 1,
+            dup_lines: starts.len().saturating_sub(1) as u32,
+            shared_lines: 1,
+            params: 0,
+            shared_weight: 1.0,
+            locations: starts.iter().copied().map(fragment_loc).collect(),
+            mean_sem: 1.0,
+            scope: "prod",
+            discount: 1.0,
+            abstraction_witness: None,
+            semantic_laws: Vec::new(),
+        }
+    }
+
+    fn fragment_loc(start_line: u32) -> Loc {
+        Loc {
+            file: "src/main/java/example/DateUtils.java".to_owned(),
+            start_line,
+            end_line: start_line,
+            lang: "java".to_owned(),
+            kind: UnitKind::Block,
+            name: None,
+            sem: 1,
+            span_lines: 1,
+            span_tokens: 4,
+            is_fragment: true,
+            fragment_kind: Some(FragmentKind::ExprEffect),
+            reason_code: Some(FragmentKind::ExprEffect.reason_code()),
+            enclosing_unit: None,
+            shared_subdag: None,
+        }
+    }
+
+    #[test]
+    fn family_key_distinguishes_same_file_fragment_families_by_span() {
+        let first = fragment_family(&[866, 902, 937]);
+        let second = fragment_family(&[867, 903, 938]);
+
+        assert_ne!(
+            family_id(&first),
+            family_id(&second),
+            "families with the same file/name members but different reported spans need unique ids"
+        );
+    }
+
+    #[test]
+    fn legacy_member_keys_overlap_location_identities_by_file_and_name() {
+        let current = member_keys(&fragment_family(&[866, 902, 937]));
+        let legacy = vec![MemberKey {
+            file: "src/main/java/example/DateUtils.java".to_owned(),
+            lang: None,
+            start_line: None,
+            end_line: None,
+            kind: None,
+            name: String::new(),
+            is_fragment: None,
+            fragment_kind: None,
+            reason_code: None,
+        }];
+
+        assert!(
+            member_sets_overlap(&legacy, &current),
+            "member-only baselines should still classify re-keyed families as changed"
+        );
+    }
 }

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -1253,15 +1253,14 @@ impl BaselineComparison {
             if baseline.keys.contains(&key) {
                 continue;
             }
-            let current_members: std::collections::HashSet<_> =
-                baseline::member_keys(family).into_iter().collect();
+            let current_members = baseline::member_keys(family);
             if baseline
                 .entries
                 .iter()
                 .filter(|entry| !current_keys.contains(&entry.key))
                 .any(|entry| {
                     !entry.members.is_empty()
-                        && entry.members.iter().any(|m| current_members.contains(m))
+                        && baseline::member_sets_overlap(&entry.members, &current_members)
                 })
             {
                 changed_current.insert(key);
@@ -1271,7 +1270,7 @@ impl BaselineComparison {
                     .filter(|entry| !current_keys.contains(&entry.key))
                 {
                     if !entry.members.is_empty()
-                        && entry.members.iter().any(|m| current_members.contains(m))
+                        && baseline::member_sets_overlap(&entry.members, &current_members)
                     {
                         changed_baseline.insert(entry.key);
                     }

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -358,6 +358,10 @@ fn baseline_hides_accepted_families() {
         baseline_text.contains("\"members\""),
         "baseline should record member identities for changed/resolved comparison: {baseline_text}"
     );
+    assert!(
+        baseline_text.contains("\"start_line\"") && baseline_text.contains("\"kind\""),
+        "baseline member identities should include location fields for unique family ids: {baseline_text}"
+    );
 
     // …then a re-run shows no *new* families.
     let after = run(&["scan", p, "--min-size", "12", "--baseline", bls]);

--- a/crates/nose-cli/tests/cli/support.rs
+++ b/crates/nose-cli/tests/cli/support.rs
@@ -231,6 +231,7 @@ pub(crate) fn assert_scan_json_v1_contract(json: &serde_json::Value) {
     let family = scan_families(json)
         .first()
         .expect("fixture should include a family");
+    assert_scan_json_family_ids_unique(json);
     let family = family.as_object().expect("family object");
     for key in [
         "family_id",
@@ -271,6 +272,19 @@ pub(crate) fn assert_scan_json_v1_contract(json: &serde_json::Value) {
         "is_fragment",
     ] {
         assert!(loc.contains_key(key), "location.{key} missing: {json}");
+    }
+}
+
+fn assert_scan_json_family_ids_unique(json: &serde_json::Value) {
+    let mut family_ids = std::collections::BTreeSet::new();
+    for family in scan_families(json) {
+        let id = family["family_id"]
+            .as_str()
+            .unwrap_or_else(|| panic!("family.family_id should be a string: {json}"));
+        assert!(
+            family_ids.insert(id),
+            "family_id values must be unique within families[]: {json}"
+        );
     }
 }
 

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -119,13 +119,14 @@ accepted by the baseline (the default whenever `--baseline` is present). Use
 non-zero for new or changed clone families. Plain `--fail-on any` still means "fail if
 anything is reported after the active filters."
 
-Commit `.nose-baseline.json`. Families are keyed by their members' (file, name),
-so the baseline is stable across line moves. New baselines also record the member
-list next to the reviewable note, which lets later scans classify exact matches as
-`unchanged`, overlapping but re-keyed families as `changed`, missing accepted
-families as `resolved`, and unmatched current families as `new`. Regenerate the
-baseline deliberately (re-run `--write-baseline`) when you've paid down duplication
-and want the lower bar locked in — it's a ratchet.
+Commit `.nose-baseline.json`. Families are keyed by their sorted reported member
+locations: displayed path, language, span, unit kind, symbol name, and fragment
+metadata. New baselines also record those member identities next to the reviewable
+note, which lets later scans classify exact matches as `unchanged`, overlapping
+but re-keyed families as `changed`, missing accepted families as `resolved`, and
+unmatched current families as `new`. Regenerate the baseline deliberately (re-run
+`--write-baseline`) when you've paid down duplication and want the lower bar
+locked in — it's a ratchet.
 
 When `--baseline` is present, the file must exist and parse as a valid baseline.
 Missing or malformed baselines are hard errors; otherwise a CI ratchet could

--- a/docs/field-evaluation.md
+++ b/docs/field-evaluation.md
@@ -252,6 +252,7 @@ action output. The `review` surface had no consensus noise and kept the two usef
 signals in the sample: a long RxJava2/RxJava3 adapter constructor parity fragment and a
 larger Poetry authenticator test setup fragment. The policy change from the audit is
 narrow: tiny test-only exact fragments with enclosing-unit context now stay hidden
-instead of review-visible. Broader pruning is deferred; the real follow-ups are stable
-`family_id` collisions in hidden JSON output and overly generic one-line direct-return
+instead of review-visible. Broader pruning is deferred; #199 closed the stable
+`family_id` collision follow-up by including location spans and fragment metadata in
+scan JSON IDs. The remaining follow-up is overly generic one-line direct-return
 fragments.

--- a/docs/fragment-quality-audit-2026-06-10.md
+++ b/docs/fragment-quality-audit-2026-06-10.md
@@ -56,7 +56,7 @@ synchronization signal review output should preserve:
 | `python-03` | `useful_diagnostic` | 8-line Poetry authenticator repository config ties two credential-path tests that should stay aligned. |
 | `java-02` | `acceptable_low_value` | test fixture constructor self-field assignments are correct but boilerplate. |
 | `python-01`, `python-02`, `python-04` | `acceptable_low_value` | 3-line test setup/assertion `expr-effect` fragments are real but too small for review output. |
-| `java-05`, `python-10` | `noise` | both expose stable `family_id` collisions with different nearby hidden families. |
+| `java-05`, `python-10` | `noise` | both exposed pre-#199 `family_id` collisions with different nearby hidden families. |
 | `java-03` | `noise` | one-line direct-return fragments are too generic and can group awkwardly with enclosing methods. |
 
 ## Policy
@@ -75,11 +75,10 @@ The audit supports the current separation between exactness and product placemen
   fixture constructors diagnostic-only while leaving larger test setup blocks available for
   review.
 
-Two follow-ups remain outside this narrow policy change:
+One follow-up remains outside this narrow policy change. The stable family identity
+follow-up was closed by #199: scan JSON IDs now include span and fragment metadata
+so distinct hidden fragment families do not share one `family_id`.
 
-- **Stable family identity:** repeated `family_id` values appeared for distinct hidden
-  families (`272926fba0300285` in `commons-lang`, `a80e66532f54ba2d` in `packaging`).
-  That is a JSON integration risk even when the families are hidden.
 - **One-line direct returns:** `exact-direct-return` one-liners are correct too often to
   drop blindly, but the sample shows they need a stricter low-context pruning pass or a
   stronger enclosing/effect boundary before they become useful diagnostics.

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -223,7 +223,7 @@ schema version 1:
 
 | field | type | meaning |
 |---|---|---|
-| `family_id` | string | Stable family key used by baselines and structured ignores. |
+| `family_id` | string | Stable family key used by baselines and structured ignores. Unique for distinct reported families in one scan; derived from each member's displayed path, language, source span, unit kind, symbol name, and fragment proof metadata. The ID is stable across run order and thread count, but changes when the reported locations or spans change. |
 | `value` | number | Raw refactoring value: duplicated volume scaled by similarity and spread. |
 | `members` | integer | Number of duplicated sites. |
 | `files` | integer | Distinct files spanned by the family. |

--- a/docs/structured-ignores.md
+++ b/docs/structured-ignores.md
@@ -97,10 +97,20 @@ family, the first active entry supplies the metadata.
 
 ## Family IDs
 
-`family_id` is the same stable key used by baselines. It is derived from the
-family members' displayed file paths and symbol names, not line numbers. That
-makes it stable across ordinary line movement, but intentionally changes when a
-copy is added, removed, renamed, or moved to another displayed path.
+`family_id` is the same key used by baselines. It is derived from the sorted
+reported location identities: displayed file path, language, start/end line span,
+unit kind, symbol name, and fragment proof metadata. That makes IDs unique for
+distinct reported families in one scan, including hidden exact fragments that
+share the same file and enclosing symbol but live on nearby lines. It also means
+IDs intentionally change when a copy is added, removed, renamed, moved, or when
+the reported span changes.
+
+Baseline comparison records member identities and can classify overlapping
+re-keyed families as `changed`. Structured ignores that select by `family_id` are
+more exact: refresh them after large code motion or after upgrading from older
+nose versions whose IDs omitted span and fragment metadata. Use `paths` and
+`languages` selectors when the review decision should survive routine movement
+inside a file.
 
 Human output includes the ID on each family:
 


### PR DESCRIPTION
## Summary
- make scan/baseline family IDs span-aware by hashing each reported member location, including path, language, span, unit kind, symbol name, and fragment proof metadata
- keep legacy member-only baselines useful as coarse overlap hints for changed-family classification
- document the family_id migration and update scan-regression comments/audit follow-up state

Fixes #199.

## Verification
- ./scripts/check-ci-local.sh
- target/release/nose scan /Users/ak/prjs/cc/nose/bench/repos/commons-lang --mode semantic --format json --top 0 -> 183 families, 183 unique IDs, 0 duplicate IDs
- target/release/nose scan /Users/ak/prjs/cc/nose/bench/repos/packaging --mode semantic --format json --top 0 -> 31 families, 31 unique IDs, 0 duplicate IDs
- RAYON_NUM_THREADS=1 and 8 commons-lang JSON sha256 both 0948ba47daef8974fb21cca2e6433ed68fa1f49ce00575df3f7f40ad2cf13214