### PR TITLE
Keep semantic families when channels combine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ break.
 ## [Unreleased]
 
 ### Fixed
+- Combining `--mode syntax,semantic` no longer drops an exact semantic family when
+  the syntax channel also creates a same-file window that collapses to one reported
+  site. Such single-site windows are not clone families and no longer participate
+  in rank-time overlap subsumption, so adding the syntax channel cannot erase an
+  otherwise reported semantic region.
 - Scan JSON `family_id` values are now unique for distinct reported families that
   share the same files and symbol names but point at different spans, especially
   hidden exact-fragment families. The ID now includes each member's displayed

--- a/crates/nose-detect/src/report.rs
+++ b/crates/nose-detect/src/report.rs
@@ -518,6 +518,10 @@ pub fn rank_families(report: &Report) -> Vec<RefactorFamily> {
         // refactor code a tool regenerates. A *partly*-generated family is kept — that's
         // a real leak of hand-written logic into generated output.
         .filter(|f| !f.locations.iter().all(is_generated_loc))
+        // A raw group can collapse to one reported site when all of its matches are
+        // overlapping windows in the same file. That is not a clone family, and it must
+        // not subsume a real multi-site family before the CLI's min-member gate drops it.
+        .filter(|f| f.members >= 2)
         .collect();
     // Dedup overlapping families by total span, LARGEST FIRST, so the most complete
     // family of a region is the one kept and the sub-blocks inside it are dropped. (A
@@ -953,6 +957,42 @@ mod tests {
             fams[0].mean_lines, 31,
             "the surviving family is the outer one"
         );
+    }
+
+    #[test]
+    fn single_site_family_does_not_subsume_reportable_family() {
+        // A contiguous-channel group can be one long same-file window after
+        // `family_of` coalesces overlapping matches. It is not itself reportable, so
+        // it must not hide the exact semantic method family it covers.
+        let syntax_window = Group {
+            score: 1.0,
+            members: vec![loc("Param.java", 1589, 1611, "java")],
+            semantic_laws: Vec::new(),
+            abstraction_witness: None,
+        };
+        let semantic_methods = Group {
+            score: 1.0,
+            members: vec![
+                loc("Param.java", 1589, 1593, "java"),
+                loc("Param.java", 1595, 1599, "java"),
+                loc("Param.java", 1601, 1605, "java"),
+                loc("Param.java", 1607, 1611, "java"),
+            ],
+            semantic_laws: Vec::new(),
+            abstraction_witness: None,
+        };
+
+        let fams = rank_families(&report(vec![syntax_window, semantic_methods]));
+
+        assert_eq!(fams.len(), 1);
+        assert_eq!(
+            fams[0].members, 4,
+            "the reportable semantic family should survive"
+        );
+        assert!(fams[0]
+            .locations
+            .iter()
+            .any(|loc| loc.start_line <= 1592 && loc.end_line >= 1592));
     }
 
     #[test]

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -946,7 +946,9 @@ fires) — among stub/parallel-by-design neighbours (curl no-op callbacks, sympy
 type-defs). The deeper catch was mechanical: chasing *why* fp-equal `exact_safe` pairs
 (`junit5` annotation-varying `fail(...)` methods) never surface exposed that **adding
 the syntax channel can drop an exact semantic family the semantic channel reports
-alone** — a channel-merge reporting bug, filed with a single-file reproducer as #202.
+alone** — a channel-merge reporting bug, closed by #202. The fix drops
+single-site windows after same-file coalescing before they can subsume reportable
+multi-site semantic families.
 That is the arm working as designed: candidates are cheap, and each audited one either
 dies as scaffolding/generated (raising confidence in the policy layers) or names a
 precise defect.


### PR DESCRIPTION
## Summary
- drop rank-time families that collapse to a single reported site before overlap dedup
- prevent syntax-channel same-file windows from subsuming exact semantic families and then disappearing behind the CLI min-members filter
- document the #202 miss-mining follow-up as closed

Fixes #202.

## Verification
- ./scripts/check-ci-local.sh
- cargo test -p nose-detect single_site_family_does_not_subsume_reportable_family
- cargo test -p nose-detect subsumes
- target/release/nose scan /Users/ak/prjs/cc/nose/bench/repos/junit5/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java --format json --top 0 --min-value 0 --mode syntax,semantic -> 34 families, line 1592 covered by the 4-member exact semantic family
- semantic-only vs combined representation check: 17 semantic-only families, 34 combined families, 0 unrepresented semantic-only families