### PR TITLE
Oracle completeness campaign: exclusion census + symbolic opaque-call coverage (closes #193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,15 @@ break.
   field reads as the dominant, structure-keyed coverage targets. The companion
   `--leads` merge records 179 behavior-equal fingerprint-split groups (5 with
   vj ≥ 0.7) as convergence leads (experiments §BL).
+- The interpreter oracle now models opaque calls and unproven field reads as
+  identified SYMBOLIC values (recorded in the ordered effect trace) instead of
+  bailing the whole unit: real-corpus oracle coverage rose from 4.5% to 29.4%
+  of function units, and oracle-verified fingerprint-merge pairs from 9.2% to
+  31.3%. Symbolic-trace disagreements go to a separate advisory lane — the hard
+  SOUND gate and canon-preservation stay concrete-only, and the completeness /
+  under-merge direction keeps its concrete meaning (experiments §BL.1). The
+  corpus pass also exposed a pre-existing degenerate-fingerprint false-merge
+  class, filed as #210.
 
 ### Changed
 - Tiny test-only exact-fragment scaffolding now stays on the hidden diagnostic surface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,13 @@ break.
   audited as overwhelmingly generated/scaffolding with a handful of
   worthy-shaped misses — and the audit exposed the #202 channel-merge family
   drop (experiments §BK).
+- An oracle exclusion census (`nose verify --exclusion-census`, merged by
+  `bench/labels/merge_exclusion_census.py`) now baselines real-corpus oracle
+  coverage: 4.5% of function units are interpretable and 90.8% of
+  fingerprint-equal pair mass carries no behavioral check, with opaque calls and
+  field reads as the dominant, structure-keyed coverage targets. The companion
+  `--leads` merge records 179 behavior-equal fingerprint-split groups (5 with
+  vj ≥ 0.7) as convergence leads (experiments §BL).
 
 ### Changed
 - Tiny test-only exact-fragment scaffolding now stays on the hidden diagnostic surface

--- a/bench/labels/README.md
+++ b/bench/labels/README.md
@@ -58,6 +58,13 @@ over-approximated classification of whether generalized sub-DAG matching or one-
 pure inlining could recover it. The measured verdict and method are recorded in
 [`docs/experiments.md`](../../docs/experiments.md) §BJ.
 
+`merge_exclusion_census.py` + `oracle_exclusion_census_2026_06_10.json` +
+`oracle_under_merge_leads_2026_06_10.json` are the oracle-completeness campaign's
+baseline: per-construct inventory of units the interpreter oracle cannot check (and the
+fingerprint-merge mass left unverified), plus the merged behavior-equal/fingerprint-split
+under-merge leads. Method and numbers in
+[`docs/experiments.md`](../../docs/experiments.md) §BL.
+
 ## Scoring against it
 
 `eval_by_language.py` — per-language precision@10 + worthy-recall, dev/heldout split, with

--- a/bench/labels/merge_exclusion_census.py
+++ b/bench/labels/merge_exclusion_census.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Merge per-repo `nose verify --exclusion-census` shards into one corpus inventory.
+
+The oracle-completeness campaign measures, per IL construct, how much
+fingerprint-merge mass carries no behavioral verification (see
+`crates/nose-cli/src/verify_census.rs` and experiments §BL). The corpus pass is
+run per repo — matching how the product actually scans, so fingerprint-merge
+pairs are counted within a repo, never across repos — and merged here:
+
+    ls bench/repos | grep -v '^raylib$' | xargs -P 6 -I {} sh -c \\
+      './target/release/nose verify bench/repos/{} \\
+         --exclusion-census /tmp/census_shards/{}.json \\
+         --leads /tmp/leads_shards/{}.json > /dev/null 2>&1'
+    python3 bench/labels/merge_exclusion_census.py /tmp/census_shards \\
+      bench/labels/oracle_exclusion_census_<date>.json
+
+(`raylib` is excluded until #208 — verify does not finish on it in useful time.)
+
+Deterministic: output sorted on stable keys; no timestamps.
+"""
+
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> None:
+    shard_dir = Path(sys.argv[1])
+    out_path = sys.argv[2]
+    nose_version = subprocess.run(
+        [str(ROOT / "target" / "release" / "nose"), "--version"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    units_total = interpretable = 0
+    excluded_by_reason: dict[str, int] = defaultdict(int)
+    merge = {"total": 0, "verified": 0, "unverified": 0}
+    tags: dict[str, dict] = defaultdict(
+        lambda: {
+            "interpretable_units": 0,
+            "excluded_units": 0,
+            "unverified_pairs": 0,
+            "example_excluded": [],
+        }
+    )
+    shards = sorted(shard_dir.glob("*.json"))
+    for p in shards:
+        d = json.loads(p.read_text())
+        units_total += d["units_total"]
+        interpretable += d["interpretable_units"]
+        for k, v in d["excluded_by_reason"].items():
+            excluded_by_reason[k] += v
+        for k in merge:
+            merge[k] += d["merge_pairs"][k]
+        for row in d["tags"]:
+            t = tags[row["tag"]]
+            t["interpretable_units"] += row["interpretable_units"]
+            t["excluded_units"] += row["excluded_units"]
+            t["unverified_pairs"] += row["unverified_pairs"]
+            t["example_excluded"] += [f"{p.stem}:{e}" for e in row["example_excluded"]]
+
+    rows = []
+    for tag, t in tags.items():
+        t["example_excluded"] = sorted(t["example_excluded"])[:3]
+        rows.append({"tag": tag, **t})
+    rows.sort(key=lambda r: (-r["unverified_pairs"], -r["excluded_units"], r["tag"]))
+
+    out = {
+        "schema_version": "0.1.0",
+        "nose_version": nose_version,
+        "sharding": "per-repo (merge pairs counted within repo, matching per-repo scans)",
+        "excluded_repos": ["raylib (verify does not finish, #208)"],
+        "shards": len(shards),
+        "units_total": units_total,
+        "interpretable_units": interpretable,
+        "excluded_by_reason": dict(sorted(excluded_by_reason.items())),
+        "merge_pairs": merge,
+        "tags": rows,
+    }
+    Path(out_path).write_text(json.dumps(out, indent=1, sort_keys=True) + "\n")
+
+    ex = units_total - interpretable
+    print(
+        f"units {units_total} | interpretable {interpretable} "
+        f"({100 * interpretable / units_total:.1f}%) | excluded {ex} "
+        f"{dict(sorted(excluded_by_reason.items()))}"
+    )
+    print(
+        f"merge pairs: {merge['total']} total, {merge['verified']} verified, "
+        f"{merge['unverified']} unverified "
+        f"({100 * merge['unverified'] / max(1, merge['total']):.1f}%)"
+    )
+    print("\ntop constructs by unverified merge mass:")
+    for r in rows[:14]:
+        tot_units = r["interpretable_units"] + r["excluded_units"]
+        print(
+            f"  {r['tag']:<34} unverified={r['unverified_pairs']:<8} "
+            f"excluded_units={r['excluded_units']:<7} "
+            f"(excl-share {100 * r['excluded_units'] / max(1, tot_units):.0f}%)"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/labels/oracle_exclusion_census_2026_06_10.json
+++ b/bench/labels/oracle_exclusion_census_2026_06_10.json
@@ -1,0 +1,594 @@
+{
+ "excluded_by_reason": {
+  "battery-bail": 526660,
+  "empty-fp": 38427
+ },
+ "excluded_repos": [
+  "raylib (verify does not finish, #208)"
+ ],
+ "interpretable_units": 26382,
+ "merge_pairs": {
+  "total": 3444062,
+  "unverified": 3127385,
+  "verified": 316677
+ },
+ "nose_version": "nose 0.5.0",
+ "schema_version": "0.1.0",
+ "sharding": "per-repo (merge pairs counted within repo, matching per-repo scans)",
+ "shards": 104,
+ "tags": [
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 565087,
+   "interpretable_units": 26382,
+   "tag": "kind:Block",
+   "unverified_pairs": 3127385
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 565087,
+   "interpretable_units": 26382,
+   "tag": "kind:Func",
+   "unverified_pairs": 3127385
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 384274,
+   "interpretable_units": 19776,
+   "tag": "kind:Param",
+   "unverified_pairs": 2778008
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 523232,
+   "interpretable_units": 13943,
+   "tag": "kind:Var",
+   "unverified_pairs": 1829694
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 481024,
+   "interpretable_units": 3341,
+   "tag": "call:other",
+   "unverified_pairs": 1709625
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:179",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:223"
+   ],
+   "excluded_units": 320849,
+   "interpretable_units": 2353,
+   "tag": "kind:ExprStmt",
+   "unverified_pairs": 1603950
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 419649,
+   "interpretable_units": 8058,
+   "tag": "kind:Field",
+   "unverified_pairs": 1302733
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 303488,
+   "interpretable_units": 19358,
+   "tag": "kind:Return",
+   "unverified_pairs": 1098101
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:173"
+   ],
+   "excluded_units": 296266,
+   "interpretable_units": 9195,
+   "tag": "kind:Assign",
+   "unverified_pairs": 969090
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 172356,
+   "interpretable_units": 3506,
+   "tag": "kind:If",
+   "unverified_pairs": 968553
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/bindings.rs:945",
+    "alacritty:bench/repos/alacritty/alacritty/src/display/color.rs:221",
+    "alacritty:bench/repos/alacritty/alacritty_config/src/lib.rs:84"
+   ],
+   "excluded_units": 8709,
+   "interpretable_units": 37,
+   "tag": "lit:unretained:Other",
+   "unverified_pairs": 925358
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/bindings.rs:1210",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/bindings.rs:1223",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33"
+   ],
+   "excluded_units": 126531,
+   "interpretable_units": 4021,
+   "tag": "lit:unretained:Null",
+   "unverified_pairs": 787997
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 219545,
+   "interpretable_units": 5631,
+   "tag": "kind:BinOp",
+   "unverified_pairs": 782508
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/bindings.rs:54",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/bindings.rs:65",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/mod.rs:211"
+   ],
+   "excluded_units": 73051,
+   "interpretable_units": 1467,
+   "tag": "kind:UnOp",
+   "unverified_pairs": 517597
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/migrate/mod.rs:172",
+    "alacritty:bench/repos/alacritty/alacritty_terminal/src/event_loop.rs:476",
+    "alacritty:bench/repos/alacritty/alacritty_terminal/src/term/mod.rs:2989"
+   ],
+   "excluded_units": 22602,
+   "interpretable_units": 455,
+   "tag": "kind:Throw",
+   "unverified_pairs": 478624
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 106092,
+   "interpretable_units": 3253,
+   "tag": "kind:Seq",
+   "unverified_pairs": 415050
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:148",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:93"
+   ],
+   "excluded_units": 53225,
+   "interpretable_units": 454,
+   "tag": "kind:Lambda",
+   "unverified_pairs": 263856
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:363",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:381",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:539"
+   ],
+   "excluded_units": 68476,
+   "interpretable_units": 1564,
+   "tag": "kind:Loop",
+   "unverified_pairs": 147440
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:381",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:179",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33"
+   ],
+   "excluded_units": 68501,
+   "interpretable_units": 2222,
+   "tag": "kind:Index",
+   "unverified_pairs": 128705
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:179",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:bench/repos/alacritty/alacritty/src/migrate/mod.rs:172"
+   ],
+   "excluded_units": 17429,
+   "interpretable_units": 559,
+   "tag": "builtin:Len",
+   "unverified_pairs": 117756
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/color.rs:141",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/color.rs:156",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/color.rs:179"
+   ],
+   "excluded_units": 14584,
+   "interpretable_units": 287,
+   "tag": "lit:unretained:Int",
+   "unverified_pairs": 73756
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/mod.rs:195",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:bench/repos/alacritty/alacritty/src/display/mod.rs:1382"
+   ],
+   "excluded_units": 5239,
+   "interpretable_units": 119,
+   "tag": "builtin:Append",
+   "unverified_pairs": 68002
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Go/antlr/v4/atn_config_set.go:259",
+    "antlr4:bench/repos/antlr4/runtime/Go/antlr/v4/interval_set.go:61",
+    "antlr4:bench/repos/antlr4/runtime/Go/antlr/v4/interval_set.go:91"
+   ],
+   "excluded_units": 4175,
+   "interpretable_units": 97,
+   "tag": "builtin:Enumerate",
+   "unverified_pairs": 62262
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:490",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/cursor.rs:29",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/font.rs:136"
+   ],
+   "excluded_units": 8948,
+   "interpretable_units": 60,
+   "tag": "lit:other",
+   "unverified_pairs": 27872
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/Antlr4Mojo.java:222",
+    "antlr4:bench/repos/antlr4/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/GrammarDependencies.java:281",
+    "antlr4:bench/repos/antlr4/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/GrammarDependencies.java:72"
+   ],
+   "excluded_units": 17953,
+   "interpretable_units": 94,
+   "tag": "kind:Try",
+   "unverified_pairs": 24414
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointBuffer.java:353",
+    "antlr4:bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointBuffer.java:365",
+    "antlr4:bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointBuffer.java:377"
+   ],
+   "excluded_units": 1087,
+   "interpretable_units": 64,
+   "tag": "builtin:Max",
+   "unverified_pairs": 18680
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/ANTLRInputStream.java:192",
+    "antlr4:bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointCharStream.java:152",
+    "antlr4:bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointCharStream.java:204"
+   ],
+   "excluded_units": 1049,
+   "interpretable_units": 84,
+   "tag": "builtin:Min",
+   "unverified_pairs": 16921
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 40353,
+   "interpretable_units": 243,
+   "tag": "kind:Raw",
+   "unverified_pairs": 11236
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:363",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/mod.rs:238",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/mod.rs:280"
+   ],
+   "excluded_units": 8370,
+   "interpretable_units": 152,
+   "tag": "kind:Continue",
+   "unverified_pairs": 3169
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "antlr4:bench/repos/antlr4/runtime/Go/antlr/v4/parser_atn_simulator.go:996",
+    "antlr4:bench/repos/antlr4/runtime/Go/antlr/v4/tokenstream_rewriter.go:296"
+   ],
+   "excluded_units": 2038,
+   "interpretable_units": 133,
+   "tag": "builtin:Contains",
+   "unverified_pairs": 1864
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/scripts/deploy_to_website.py:21",
+    "antlr4:bench/repos/antlr4/scripts/deploy_to_website.py:41",
+    "antlr4:bench/repos/antlr4/scripts/deploy_to_website.py:55"
+   ],
+   "excluded_units": 8522,
+   "interpretable_units": 237,
+   "tag": "lit:unretained:Str",
+   "unverified_pairs": 1512
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:bench/repos/alacritty/alacritty/src/display/content.rs:532",
+    "alacritty:bench/repos/alacritty/alacritty/src/display/damage.rs:257"
+   ],
+   "excluded_units": 13771,
+   "interpretable_units": 340,
+   "tag": "kind:Break",
+   "unverified_pairs": 664
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/InputStream.py:22",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/IntervalSet.py:89"
+   ],
+   "excluded_units": 7825,
+   "interpretable_units": 221,
+   "tag": "kind:HoF",
+   "unverified_pairs": 236
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/BufferedTokenStream.py:120",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/BufferedTokenStream.py:276",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/CommonTokenStream.py:78"
+   ],
+   "excluded_units": 2877,
+   "interpretable_units": 132,
+   "tag": "builtin:Range",
+   "unverified_pairs": 111
+  },
+  {
+   "example_excluded": [
+    "axios:bench/repos/axios/tests/browser/headers.browser.test.js:76",
+    "bat:bench/repos/bat/tests/benchmarks/highlighting-speed-src/jquery.js:3915",
+    "bat:bench/repos/bat/tests/benchmarks/highlighting-speed-src/jquery.js:4488"
+   ],
+   "excluded_units": 231,
+   "interpretable_units": 15,
+   "tag": "builtin:Keys",
+   "unverified_pairs": 105
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/atn/LexerActionExecutor.py:25",
+    "antlr4:bench/repos/antlr4/runtime/Python3/tests/xpathtest.py:30",
+    "arrow:bench/repos/arrow/arrow/arrow.py:1850"
+   ],
+   "excluded_units": 1390,
+   "interpretable_units": 53,
+   "tag": "builtin:Join",
+   "unverified_pairs": 65
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/IntervalSet.py:89",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/TokenStreamRewriter.py:140",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/atn/PredictionMode.py:212"
+   ],
+   "excluded_units": 619,
+   "interpretable_units": 25,
+   "tag": "builtin:Any",
+   "unverified_pairs": 56
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Go/antlr/v4/trace_listener.go:22",
+    "antlr4:bench/repos/antlr4/runtime/Go/antlr/v4/trace_listener.go:26",
+    "antlr4:bench/repos/antlr4/runtime/Go/antlr/v4/trace_listener.go:30"
+   ],
+   "excluded_units": 1020,
+   "interpretable_units": 209,
+   "tag": "builtin:Print",
+   "unverified_pairs": 49
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:bench/repos/alacritty/alacritty/src/renderer/mod.rs:243",
+    "antlr4:bench/repos/antlr4/tool/src/org/antlr/v4/semantics/RuleCollector.java:110"
+   ],
+   "excluded_units": 256,
+   "interpretable_units": 11,
+   "tag": "builtin:IsEmpty",
+   "unverified_pairs": 33
+  },
+  {
+   "example_excluded": [
+    "arrow:bench/repos/arrow/arrow/arrow.py:1133",
+    "arrow:bench/repos/arrow/arrow/arrow.py:1304",
+    "arrow:bench/repos/arrow/arrow/arrow.py:1344"
+   ],
+   "excluded_units": 946,
+   "interpretable_units": 60,
+   "tag": "builtin:Abs",
+   "unverified_pairs": 29
+  },
+  {
+   "example_excluded": [
+    "curl:bench/repos/curl/lib/curlx/inet_ntop.c:88",
+    "curl:bench/repos/curl/lib/socks_sspi.c:104",
+    "curl:bench/repos/curl/lib/socks_sspi.c:262"
+   ],
+   "excluded_units": 97,
+   "interpretable_units": 24,
+   "tag": "builtin:UnsignedCast32",
+   "unverified_pairs": 17
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/TokenStreamRewriter.py:108",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/TokenStreamRewriter.py:140",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/atn/SemanticContext.py:206"
+   ],
+   "excluded_units": 757,
+   "interpretable_units": 24,
+   "tag": "builtin:All",
+   "unverified_pairs": 15
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/PredictionContext.py:73",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/Recognizer.py:52",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/Recognizer.py:68"
+   ],
+   "excluded_units": 762,
+   "interpretable_units": 39,
+   "tag": "builtin:Zip",
+   "unverified_pairs": 10
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/display/color.rs:286",
+    "antlr4:bench/repos/antlr4/tool/src/org/antlr/v4/codegen/Target.java:412",
+    "antlr4:bench/repos/antlr4/tool/src/org/antlr/v4/codegen/target/GoTarget.java:70"
+   ],
+   "excluded_units": 135,
+   "interpretable_units": 41,
+   "tag": "builtin:StartsWith",
+   "unverified_pairs": 5
+  },
+  {
+   "example_excluded": [
+    "bat:bench/repos/bat/tests/benchmarks/highlighting-speed-src/numpy_test_multiarray.py:39",
+    "drizzle-orm:bench/repos/drizzle-orm/drizzle-kit/src/serializer/pgSerializer.ts:101",
+    "drizzle-orm:bench/repos/drizzle-orm/drizzle-kit/src/utils.ts:132"
+   ],
+   "excluded_units": 60,
+   "interpretable_units": 7,
+   "tag": "builtin:Reduce",
+   "unverified_pairs": 3
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/IntervalSet.py:95",
+    "antlr4:bench/repos/antlr4/scripts/deploy_to_website.py:21",
+    "antlr4:bench/repos/antlr4/scripts/update_antlr_version.py:43"
+   ],
+   "excluded_units": 362,
+   "interpretable_units": 14,
+   "tag": "builtin:Sum",
+   "unverified_pairs": 2
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/Antlr4Mojo.java:521",
+    "antlr4:bench/repos/antlr4/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java:1695",
+    "antlr4:bench/repos/antlr4/tool/src/org/antlr/v4/codegen/target/GoTarget.java:70"
+   ],
+   "excluded_units": 65,
+   "interpretable_units": 12,
+   "tag": "builtin:EndsWith",
+   "unverified_pairs": 2
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/input/keyboard.rs:378",
+    "alacritty:bench/repos/alacritty/alacritty/src/string.rs:41",
+    "clap:bench/repos/clap/clap_builder/src/output/help_template.rs:608"
+   ],
+   "excluded_units": 34,
+   "interpretable_units": 2,
+   "tag": "builtin:IsNotNull",
+   "unverified_pairs": 1
+  },
+  {
+   "example_excluded": [
+    "bat:bench/repos/bat/src/pretty_printer.rs:125",
+    "hyperfine:bench/repos/hyperfine/src/benchmark/executor.rs:133",
+    "hyperfine:bench/repos/hyperfine/src/benchmark/executor.rs:186"
+   ],
+   "excluded_units": 33,
+   "interpretable_units": 0,
+   "tag": "builtin:ValueOrDefault",
+   "unverified_pairs": 1
+  },
+  {
+   "example_excluded": [
+    "black:bench/repos/black/src/black/__init__.py:1167",
+    "flask:bench/repos/flask/src/flask/testing.py:193",
+    "graphhopper:bench/repos/graphhopper/core/src/main/java/com/graphhopper/GraphHopper.java:605"
+   ],
+   "excluded_units": 47,
+   "interpretable_units": 11,
+   "tag": "builtin:GetOrDefault",
+   "unverified_pairs": 0
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/string.rs:41",
+    "alacritty:bench/repos/alacritty/alacritty_terminal/src/term/cell.rs:180",
+    "alacritty:bench/repos/alacritty/alacritty_terminal/src/term/cell.rs:202"
+   ],
+   "excluded_units": 23,
+   "interpretable_units": 0,
+   "tag": "builtin:IsNull",
+   "unverified_pairs": 0
+  },
+  {
+   "example_excluded": [
+    "clap:bench/repos/clap/tests/derive/flags.rs:216",
+    "meilisearch:bench/repos/meilisearch/crates/meilisearch/src/lib.rs:798",
+    "meilisearch:bench/repos/meilisearch/crates/meilisearch/tests/dashboard/mod.rs:5"
+   ],
+   "excluded_units": 5,
+   "interpretable_units": 0,
+   "tag": "kind:Module",
+   "unverified_pairs": 0
+  }
+ ],
+ "units_total": 591469
+}

--- a/bench/labels/oracle_exclusion_census_post_symbolic_2026_06_10.json
+++ b/bench/labels/oracle_exclusion_census_post_symbolic_2026_06_10.json
@@ -1,0 +1,594 @@
+{
+ "excluded_by_reason": {
+  "battery-bail": 379168,
+  "empty-fp": 38427
+ },
+ "excluded_repos": [
+  "raylib (verify does not finish, #208)"
+ ],
+ "interpretable_units": 173874,
+ "merge_pairs": {
+  "total": 3444062,
+  "unverified": 2366191,
+  "verified": 1077871
+ },
+ "nose_version": "nose 0.5.0",
+ "schema_version": "0.1.0",
+ "sharding": "per-repo (merge pairs counted within repo, matching per-repo scans)",
+ "shards": 104,
+ "tags": [
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 417595,
+   "interpretable_units": 173874,
+   "tag": "kind:Block",
+   "unverified_pairs": 2366191
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 417595,
+   "interpretable_units": 173874,
+   "tag": "kind:Func",
+   "unverified_pairs": 2366191
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 285012,
+   "interpretable_units": 119038,
+   "tag": "kind:Param",
+   "unverified_pairs": 2076071
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:179",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:223"
+   ],
+   "excluded_units": 243015,
+   "interpretable_units": 80187,
+   "tag": "kind:ExprStmt",
+   "unverified_pairs": 1315208
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 338904,
+   "interpretable_units": 145461,
+   "tag": "call:other",
+   "unverified_pairs": 1196946
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 377540,
+   "interpretable_units": 159635,
+   "tag": "kind:Var",
+   "unverified_pairs": 1081993
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/bindings.rs:945",
+    "alacritty:bench/repos/alacritty/alacritty/src/display/color.rs:221",
+    "alacritty:bench/repos/alacritty/alacritty_config/src/lib.rs:84"
+   ],
+   "excluded_units": 8641,
+   "interpretable_units": 105,
+   "tag": "lit:unretained:Other",
+   "unverified_pairs": 925352
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 305637,
+   "interpretable_units": 122070,
+   "tag": "kind:Field",
+   "unverified_pairs": 803879
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 226340,
+   "interpretable_units": 96506,
+   "tag": "kind:Return",
+   "unverified_pairs": 690412
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:173"
+   ],
+   "excluded_units": 251008,
+   "interpretable_units": 54453,
+   "tag": "kind:Assign",
+   "unverified_pairs": 670179
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 162298,
+   "interpretable_units": 13564,
+   "tag": "kind:If",
+   "unverified_pairs": 656266
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/bindings.rs:54",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/bindings.rs:65",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/mod.rs:211"
+   ],
+   "excluded_units": 66784,
+   "interpretable_units": 7734,
+   "tag": "kind:UnOp",
+   "unverified_pairs": 509834
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 193684,
+   "interpretable_units": 31492,
+   "tag": "kind:BinOp",
+   "unverified_pairs": 478764
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/bindings.rs:1210",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/ui_config.rs:395"
+   ],
+   "excluded_units": 113675,
+   "interpretable_units": 16877,
+   "tag": "lit:unretained:Null",
+   "unverified_pairs": 472235
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/migrate/mod.rs:172",
+    "alacritty:bench/repos/alacritty/alacritty_terminal/src/event_loop.rs:476",
+    "alacritty:bench/repos/alacritty/alacritty_terminal/src/term/mod.rs:2989"
+   ],
+   "excluded_units": 17811,
+   "interpretable_units": 5246,
+   "tag": "kind:Throw",
+   "unverified_pairs": 405257
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 89732,
+   "interpretable_units": 19613,
+   "tag": "kind:Seq",
+   "unverified_pairs": 402193
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:148",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:93"
+   ],
+   "excluded_units": 49107,
+   "interpretable_units": 4572,
+   "tag": "kind:Lambda",
+   "unverified_pairs": 257754
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:363",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:381",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:539"
+   ],
+   "excluded_units": 61434,
+   "interpretable_units": 8606,
+   "tag": "kind:Loop",
+   "unverified_pairs": 145050
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:179",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:bench/repos/alacritty/alacritty/src/migrate/mod.rs:172"
+   ],
+   "excluded_units": 15074,
+   "interpretable_units": 2914,
+   "tag": "builtin:Len",
+   "unverified_pairs": 115030
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:381",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:179",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33"
+   ],
+   "excluded_units": 61161,
+   "interpretable_units": 9562,
+   "tag": "kind:Index",
+   "unverified_pairs": 112644
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/color.rs:141",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/color.rs:156",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/color.rs:179"
+   ],
+   "excluded_units": 14367,
+   "interpretable_units": 504,
+   "tag": "lit:unretained:Int",
+   "unverified_pairs": 73579
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/mod.rs:195",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:bench/repos/alacritty/alacritty/src/display/mod.rs:1382"
+   ],
+   "excluded_units": 4993,
+   "interpretable_units": 365,
+   "tag": "builtin:Append",
+   "unverified_pairs": 64607
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Go/antlr/v4/atn_config_set.go:259",
+    "antlr4:bench/repos/antlr4/runtime/Go/antlr/v4/interval_set.go:61",
+    "antlr4:bench/repos/antlr4/runtime/Go/antlr/v4/interval_set.go:91"
+   ],
+   "excluded_units": 3792,
+   "interpretable_units": 480,
+   "tag": "builtin:Enumerate",
+   "unverified_pairs": 62212
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:490",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/cursor.rs:29",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/font.rs:136"
+   ],
+   "excluded_units": 8692,
+   "interpretable_units": 316,
+   "tag": "lit:other",
+   "unverified_pairs": 25481
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointBuffer.java:353",
+    "antlr4:bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointBuffer.java:365",
+    "antlr4:bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointBuffer.java:377"
+   ],
+   "excluded_units": 954,
+   "interpretable_units": 197,
+   "tag": "builtin:Max",
+   "unverified_pairs": 18665
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/Antlr4Mojo.java:222",
+    "antlr4:bench/repos/antlr4/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/GrammarDependencies.java:281",
+    "antlr4:bench/repos/antlr4/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/GrammarDependencies.java:72"
+   ],
+   "excluded_units": 14752,
+   "interpretable_units": 3295,
+   "tag": "kind:Try",
+   "unverified_pairs": 17197
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/ANTLRInputStream.java:192",
+    "antlr4:bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointCharStream.java:152",
+    "antlr4:bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointCharStream.java:204"
+   ],
+   "excluded_units": 955,
+   "interpretable_units": 178,
+   "tag": "builtin:Min",
+   "unverified_pairs": 16910
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 39368,
+   "interpretable_units": 1228,
+   "tag": "kind:Raw",
+   "unverified_pairs": 9426
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/cli.rs:363",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/mod.rs:238",
+    "alacritty:bench/repos/alacritty/alacritty/src/config/mod.rs:280"
+   ],
+   "excluded_units": 7773,
+   "interpretable_units": 749,
+   "tag": "kind:Continue",
+   "unverified_pairs": 2432
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "antlr4:bench/repos/antlr4/runtime/Go/antlr/v4/parser_atn_simulator.go:996",
+    "antlr4:bench/repos/antlr4/runtime/Go/antlr/v4/tokenstream_rewriter.go:296"
+   ],
+   "excluded_units": 1942,
+   "interpretable_units": 229,
+   "tag": "builtin:Contains",
+   "unverified_pairs": 1779
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/scripts/deploy_to_website.py:21",
+    "antlr4:bench/repos/antlr4/scripts/deploy_to_website.py:41",
+    "antlr4:bench/repos/antlr4/scripts/deploy_to_website.py:55"
+   ],
+   "excluded_units": 8166,
+   "interpretable_units": 593,
+   "tag": "lit:unretained:Str",
+   "unverified_pairs": 1506
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:bench/repos/alacritty/alacritty/src/display/content.rs:532",
+    "alacritty:bench/repos/alacritty/alacritty/src/display/damage.rs:257"
+   ],
+   "excluded_units": 13347,
+   "interpretable_units": 764,
+   "tag": "kind:Break",
+   "unverified_pairs": 609
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/InputStream.py:22",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/IntervalSet.py:89"
+   ],
+   "excluded_units": 5652,
+   "interpretable_units": 2394,
+   "tag": "kind:HoF",
+   "unverified_pairs": 122
+  },
+  {
+   "example_excluded": [
+    "axios:bench/repos/axios/tests/browser/headers.browser.test.js:76",
+    "bat:bench/repos/bat/tests/benchmarks/highlighting-speed-src/jquery.js:3915",
+    "bat:bench/repos/bat/tests/benchmarks/highlighting-speed-src/jquery.js:4882"
+   ],
+   "excluded_units": 206,
+   "interpretable_units": 40,
+   "tag": "builtin:Keys",
+   "unverified_pairs": 105
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/BufferedTokenStream.py:120",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/BufferedTokenStream.py:276",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/IntervalSet.py:125"
+   ],
+   "excluded_units": 2143,
+   "interpretable_units": 866,
+   "tag": "builtin:Range",
+   "unverified_pairs": 83
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/IntervalSet.py:89",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/TokenStreamRewriter.py:140",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/atn/PredictionMode.py:212"
+   ],
+   "excluded_units": 554,
+   "interpretable_units": 90,
+   "tag": "builtin:Any",
+   "unverified_pairs": 54
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/atn/LexerActionExecutor.py:25",
+    "arrow:bench/repos/arrow/arrow/arrow.py:1850",
+    "arrow:bench/repos/arrow/arrow/locales.py:148"
+   ],
+   "excluded_units": 1007,
+   "interpretable_units": 436,
+   "tag": "builtin:Join",
+   "unverified_pairs": 36
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/JavaScript/src/antlr4/Lexer.js:192",
+    "antlr4:bench/repos/antlr4/runtime/JavaScript/src/antlr4/Lexer.js:200",
+    "antlr4:bench/repos/antlr4/runtime/JavaScript/src/antlr4/Lexer.js:91"
+   ],
+   "excluded_units": 793,
+   "interpretable_units": 436,
+   "tag": "builtin:Print",
+   "unverified_pairs": 34
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:bench/repos/alacritty/alacritty/src/renderer/mod.rs:243",
+    "antlr4:bench/repos/antlr4/tool/src/org/antlr/v4/semantics/RuleCollector.java:110"
+   ],
+   "excluded_units": 193,
+   "interpretable_units": 74,
+   "tag": "builtin:IsEmpty",
+   "unverified_pairs": 24
+  },
+  {
+   "example_excluded": [
+    "arrow:bench/repos/arrow/arrow/arrow.py:1133",
+    "arrow:bench/repos/arrow/arrow/arrow.py:1304",
+    "arrow:bench/repos/arrow/arrow/arrow.py:1344"
+   ],
+   "excluded_units": 858,
+   "interpretable_units": 148,
+   "tag": "builtin:Abs",
+   "unverified_pairs": 21
+  },
+  {
+   "example_excluded": [
+    "curl:bench/repos/curl/lib/curlx/inet_ntop.c:88",
+    "curl:bench/repos/curl/lib/socks_sspi.c:104",
+    "curl:bench/repos/curl/lib/socks_sspi.c:262"
+   ],
+   "excluded_units": 89,
+   "interpretable_units": 32,
+   "tag": "builtin:UnsignedCast32",
+   "unverified_pairs": 17
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/TokenStreamRewriter.py:108",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/TokenStreamRewriter.py:140",
+    "black:bench/repos/black/src/black/lines.py:1242"
+   ],
+   "excluded_units": 652,
+   "interpretable_units": 129,
+   "tag": "builtin:All",
+   "unverified_pairs": 7
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/Recognizer.py:52",
+    "antlr4:bench/repos/antlr4/runtime/Python3/src/antlr4/Recognizer.py:68",
+    "black:bench/repos/black/src/blib2to3/pytree.py:672"
+   ],
+   "excluded_units": 575,
+   "interpretable_units": 226,
+   "tag": "builtin:Zip",
+   "unverified_pairs": 5
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/display/color.rs:286",
+    "antlr4:bench/repos/antlr4/tool/src/org/antlr/v4/codegen/target/GoTarget.java:70",
+    "antlr4:bench/repos/antlr4/tool/src/org/antlr/v4/misc/CharSupport.java:134"
+   ],
+   "excluded_units": 114,
+   "interpretable_units": 62,
+   "tag": "builtin:StartsWith",
+   "unverified_pairs": 4
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/scripts/deploy_to_website.py:21",
+    "antlr4:bench/repos/antlr4/scripts/update_antlr_version.py:43",
+    "bat:bench/repos/bat/tests/benchmarks/highlighting-speed-src/numpy_test_multiarray.py:7074"
+   ],
+   "excluded_units": 286,
+   "interpretable_units": 90,
+   "tag": "builtin:Sum",
+   "unverified_pairs": 2
+  },
+  {
+   "example_excluded": [
+    "antlr4:bench/repos/antlr4/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/Antlr4Mojo.java:521",
+    "antlr4:bench/repos/antlr4/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java:1695",
+    "antlr4:bench/repos/antlr4/tool/src/org/antlr/v4/codegen/target/GoTarget.java:70"
+   ],
+   "excluded_units": 60,
+   "interpretable_units": 17,
+   "tag": "builtin:EndsWith",
+   "unverified_pairs": 2
+  },
+  {
+   "example_excluded": [
+    "bat:bench/repos/bat/tests/benchmarks/highlighting-speed-src/numpy_test_multiarray.py:39",
+    "drizzle-orm:bench/repos/drizzle-orm/drizzle-kit/src/serializer/pgSerializer.ts:101",
+    "drizzle-orm:bench/repos/drizzle-orm/drizzle-kit/src/utils.ts:132"
+   ],
+   "excluded_units": 50,
+   "interpretable_units": 17,
+   "tag": "builtin:Reduce",
+   "unverified_pairs": 0
+  },
+  {
+   "example_excluded": [
+    "black:bench/repos/black/src/black/__init__.py:1167",
+    "graphhopper:bench/repos/graphhopper/core/src/main/java/com/graphhopper/GraphHopper.java:605",
+    "graphhopper:bench/repos/graphhopper/core/src/main/java/com/graphhopper/GraphHopper.java:637"
+   ],
+   "excluded_units": 37,
+   "interpretable_units": 21,
+   "tag": "builtin:GetOrDefault",
+   "unverified_pairs": 0
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/input/keyboard.rs:378",
+    "alacritty:bench/repos/alacritty/alacritty/src/string.rs:41",
+    "clap:bench/repos/clap/clap_builder/src/output/help_template.rs:608"
+   ],
+   "excluded_units": 29,
+   "interpretable_units": 7,
+   "tag": "builtin:IsNotNull",
+   "unverified_pairs": 0
+  },
+  {
+   "example_excluded": [
+    "bat:bench/repos/bat/src/pretty_printer.rs:125",
+    "hyperfine:bench/repos/hyperfine/src/benchmark/executor.rs:133",
+    "hyperfine:bench/repos/hyperfine/src/benchmark/executor.rs:186"
+   ],
+   "excluded_units": 27,
+   "interpretable_units": 6,
+   "tag": "builtin:ValueOrDefault",
+   "unverified_pairs": 0
+  },
+  {
+   "example_excluded": [
+    "alacritty:bench/repos/alacritty/alacritty/src/string.rs:41",
+    "alacritty:bench/repos/alacritty/alacritty_terminal/src/term/cell.rs:180",
+    "alacritty:bench/repos/alacritty/alacritty_terminal/src/term/cell.rs:202"
+   ],
+   "excluded_units": 22,
+   "interpretable_units": 1,
+   "tag": "builtin:IsNull",
+   "unverified_pairs": 0
+  },
+  {
+   "example_excluded": [
+    "clap:bench/repos/clap/tests/derive/flags.rs:216",
+    "meilisearch:bench/repos/meilisearch/crates/meilisearch/src/lib.rs:798",
+    "meilisearch:bench/repos/meilisearch/crates/meilisearch/tests/dashboard/mod.rs:5"
+   ],
+   "excluded_units": 5,
+   "interpretable_units": 0,
+   "tag": "kind:Module",
+   "unverified_pairs": 0
+  }
+ ],
+ "units_total": 591469
+}

--- a/bench/labels/oracle_under_merge_leads_2026_06_10.json
+++ b/bench/labels/oracle_under_merge_leads_2026_06_10.json
@@ -1,0 +1,1265 @@
+{
+ "excluded_repos": [
+  "raylib (#208)"
+ ],
+ "leads": [
+  {
+   "a": "bench/repos/sympy/sympy/matrices/common.py:2372",
+   "b": "bench/repos/sympy/sympy/matrices/matrixbase.py:2646",
+   "repo": "sympy",
+   "structurally_near": true,
+   "vj": 0.8409090909090909
+  },
+  {
+   "a": "bench/repos/nginx/src/http/modules/ngx_http_geo_module.c:1670",
+   "b": "bench/repos/nginx/src/stream/ngx_stream_geo_module.c:1598",
+   "repo": "nginx",
+   "structurally_near": true,
+   "vj": 0.7674418604651163
+  },
+  {
+   "a": "bench/repos/antlr4/runtime/Go/antlr/v4/utils.go:332",
+   "b": "bench/repos/antlr4/runtime/Go/antlr/v4/utils.go:358",
+   "repo": "antlr4",
+   "structurally_near": true,
+   "vj": 0.7567567567567568
+  },
+  {
+   "a": "bench/repos/sympy/sympy/discrete/convolutions.py:382",
+   "b": "bench/repos/sympy/sympy/discrete/convolutions.py:452",
+   "repo": "sympy",
+   "structurally_near": true,
+   "vj": 0.7432432432432432
+  },
+  {
+   "a": "bench/repos/boltons/boltons/ecoutils.py:417",
+   "b": "bench/repos/boltons/boltons/strutils.py:795",
+   "repo": "boltons",
+   "structurally_near": true,
+   "vj": 0.7027027027027027
+  },
+  {
+   "a": "bench/repos/libsodium/src/libsodium/crypto_stream/chacha20/dolbeau/chacha20_dolbeau-avx2.c:123",
+   "b": "bench/repos/libsodium/src/libsodium/crypto_stream/salsa20/xmm6int/salsa20_xmm6int-avx2.c:99",
+   "repo": "libsodium",
+   "structurally_near": false,
+   "vj": 0.6923076923076923
+  },
+  {
+   "a": "bench/repos/sqlite/ext/misc/btreeinfo.c:272",
+   "b": "bench/repos/sqlite/ext/misc/tmstmpvfs.c:471",
+   "repo": "sqlite",
+   "structurally_near": false,
+   "vj": 0.6521739130434783
+  },
+  {
+   "a": "bench/repos/prettier/tests/format/flow/flow-repo/return/function_return.js:19",
+   "b": "bench/repos/prettier/tests/format/flow/flow-repo/return/function_return.js:7",
+   "repo": "prettier",
+   "structurally_near": false,
+   "vj": 0.6363636363636364
+  },
+  {
+   "a": "bench/repos/guava/android/guava/src/com/google/common/base/Preconditions.java:1357",
+   "b": "bench/repos/guava/android/guava/src/com/google/common/base/Preconditions.java:1377",
+   "repo": "guava",
+   "structurally_near": false,
+   "vj": 0.5909090909090909
+  },
+  {
+   "a": "bench/repos/delve/_fixtures/leafindrec.go:12",
+   "b": "bench/repos/delve/_fixtures/testtracefns.go:26",
+   "repo": "delve",
+   "structurally_near": false,
+   "vj": 0.5555555555555556
+  },
+  {
+   "a": "bench/repos/delve/_fixtures/leafindrec.go:5",
+   "b": "bench/repos/delve/_fixtures/testtracefns.go:19",
+   "repo": "delve",
+   "structurally_near": false,
+   "vj": 0.5555555555555556
+  },
+  {
+   "a": "bench/repos/libgdx/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/org/jbox2d/common/MathUtils.java:244",
+   "b": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/math/MathUtils.java:510",
+   "repo": "libgdx",
+   "structurally_near": false,
+   "vj": 0.5384615384615384
+  },
+  {
+   "a": "bench/repos/click/tests/test_options.py:796",
+   "b": "bench/repos/click/tests/test_options.py:814",
+   "repo": "click",
+   "structurally_near": false,
+   "vj": 0.5294117647058824
+  },
+  {
+   "a": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/Conversion.java:426",
+   "b": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/Conversion.java:456",
+   "repo": "commons-lang",
+   "structurally_near": false,
+   "vj": 0.5294117647058824
+  },
+  {
+   "a": "bench/repos/hugo/common/htime/time.go:81",
+   "b": "bench/repos/hugo/resources/page/site.go:165",
+   "repo": "hugo",
+   "structurally_near": false,
+   "vj": 0.5
+  },
+  {
+   "a": "bench/repos/libgdx/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/org/jbox2d/common/MathUtils.java:144",
+   "b": "bench/repos/libgdx/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/org/jbox2d/common/MathUtils.java:160",
+   "repo": "libgdx",
+   "structurally_near": false,
+   "vj": 0.5
+  },
+  {
+   "a": "bench/repos/netty/common/src/main/java/io/netty/util/internal/ObjectUtil.java:38",
+   "b": "bench/repos/netty/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java:1256",
+   "repo": "netty",
+   "structurally_near": false,
+   "vj": 0.5
+  },
+  {
+   "a": "bench/repos/sqlite/src/util.c:2235",
+   "b": "bench/repos/sqlite/src/util.c:2251",
+   "repo": "sqlite",
+   "structurally_near": false,
+   "vj": 0.5
+  },
+  {
+   "a": "bench/repos/prometheus/documentation/examples/remote_storage/remote_storage_adapter/graphite/client.go:40",
+   "b": "bench/repos/prometheus/storage/remote/codec.go:643",
+   "repo": "prometheus",
+   "structurally_near": false,
+   "vj": 0.47368421052631576
+  },
+  {
+   "a": "bench/repos/vim/src/cindent.c:327",
+   "b": "bench/repos/vim/src/cindent.c:336",
+   "repo": "vim",
+   "structurally_near": false,
+   "vj": 0.4666666666666667
+  },
+  {
+   "a": "bench/repos/drizzle-orm/drizzle-seed/src/index.ts:1113",
+   "b": "bench/repos/drizzle-orm/drizzle-seed/src/index.ts:1434",
+   "repo": "drizzle-orm",
+   "structurally_near": false,
+   "vj": 0.4492753623188406
+  },
+  {
+   "a": "bench/repos/jest/packages/jest-matcher-utils/src/index.ts:257",
+   "b": "bench/repos/jest/packages/jest-snapshot/src/printSnapshot.ts:148",
+   "repo": "jest",
+   "structurally_near": false,
+   "vj": 0.42857142857142855
+  },
+  {
+   "a": "bench/repos/sympy/sympy/utilities/iterables.py:1204",
+   "b": "bench/repos/sympy/sympy/utilities/iterables.py:1223",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.42857142857142855
+  },
+  {
+   "a": "bench/repos/libgdx/extensions/gdx-bullet/jni/src/bullet/BulletSoftBody/btSoftBodyInternals.h:216",
+   "b": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/math/MathUtils.java:516",
+   "repo": "libgdx",
+   "structurally_near": false,
+   "vj": 0.42105263157894735
+  },
+  {
+   "a": "bench/repos/antlr4/runtime/Go/antlr/v4/transition.go:382",
+   "b": "bench/repos/antlr4/runtime/Go/antlr/v4/transition.go:403",
+   "repo": "antlr4",
+   "structurally_near": false,
+   "vj": 0.4166666666666667
+  },
+  {
+   "a": "bench/repos/sqlalchemy/test/dialect/postgresql/test_types.py:2371",
+   "b": "bench/repos/sqlalchemy/test/dialect/postgresql/test_types.py:2376",
+   "repo": "sqlalchemy",
+   "structurally_near": false,
+   "vj": 0.4090909090909091
+  },
+  {
+   "a": "bench/repos/antlr4/runtime/Python3/src/antlr4/atn/PredictionMode.py:393",
+   "b": "bench/repos/antlr4/runtime/Python3/src/antlr4/atn/PredictionMode.py:405",
+   "repo": "antlr4",
+   "structurally_near": false,
+   "vj": 0.4
+  },
+  {
+   "a": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/Charsets.java:43",
+   "b": "bench/repos/commons-lang/src/main/java/org/apache/commons/lang3/Charsets.java:65",
+   "repo": "commons-lang",
+   "structurally_near": false,
+   "vj": 0.4
+  },
+  {
+   "a": "bench/repos/prettier/tests/format/flow/flow-repo/annot/annot.js:1",
+   "b": "bench/repos/prettier/tests/format/flow/flow-repo/modules/lib.js:7",
+   "repo": "prettier",
+   "structurally_near": false,
+   "vj": 0.4
+  },
+  {
+   "a": "bench/repos/git/git-compat-util.h:669",
+   "b": "bench/repos/git/git-compat-util.h:678",
+   "repo": "git",
+   "structurally_near": false,
+   "vj": 0.38461538461538464
+  },
+  {
+   "a": "bench/repos/sqlite/ext/fts3/fts3_expr.c:116",
+   "b": "bench/repos/sqlite/ext/fts5/fts5_expr.c:197",
+   "repo": "sqlite",
+   "structurally_near": false,
+   "vj": 0.38461538461538464
+  },
+  {
+   "a": "bench/repos/jsoup/src/main/java/org/jsoup/helper/Validate.java:53",
+   "b": "bench/repos/jsoup/src/main/java/org/jsoup/helper/Validate.java:70",
+   "repo": "jsoup",
+   "structurally_near": false,
+   "vj": 0.3684210526315789
+  },
+  {
+   "a": "bench/repos/hugo/helpers/general.go:175",
+   "b": "bench/repos/hugo/publisher/htmlElementsCollector.go:527",
+   "repo": "hugo",
+   "structurally_near": false,
+   "vj": 0.36363636363636365
+  },
+  {
+   "a": "bench/repos/nushell/crates/nu-parser/src/lex.rs:56",
+   "b": "bench/repos/nushell/crates/nu-parser/src/lex.rs:83",
+   "repo": "nushell",
+   "structurally_near": false,
+   "vj": 0.34615384615384615
+  },
+  {
+   "a": "bench/repos/curl/docs/examples/externalsocket.c:76",
+   "b": "bench/repos/curl/lib/capsule.c:45",
+   "repo": "curl",
+   "structurally_near": false,
+   "vj": 0.3333333333333333
+  },
+  {
+   "a": "bench/repos/delve/_fixtures/fncall.go:179",
+   "b": "bench/repos/delve/_fixtures/fncall.go:195",
+   "repo": "delve",
+   "structurally_near": false,
+   "vj": 0.3333333333333333
+  },
+  {
+   "a": "bench/repos/drizzle-orm/drizzle-kit/src/cli/commands/utils.ts:251",
+   "b": "bench/repos/drizzle-orm/drizzle-kit/src/cli/commands/utils.ts:262",
+   "repo": "drizzle-orm",
+   "structurally_near": false,
+   "vj": 0.3333333333333333
+  },
+  {
+   "a": "bench/repos/etcd/client/v3/mirror/syncer.go:39",
+   "b": "bench/repos/etcd/server/embed/serve.go:422",
+   "repo": "etcd",
+   "structurally_near": false,
+   "vj": 0.3333333333333333
+  },
+  {
+   "a": "bench/repos/jest/e2e/coverage-report/cached-duplicates/a/identical.js:8",
+   "b": "bench/repos/jest/packages/jest-transform/src/ScriptTransformer.ts:138",
+   "repo": "jest",
+   "structurally_near": false,
+   "vj": 0.3333333333333333
+  },
+  {
+   "a": "bench/repos/redis/deps/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_b.h:86",
+   "b": "bench/repos/redis/deps/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_b.h:91",
+   "repo": "redis",
+   "structurally_near": false,
+   "vj": 0.3333333333333333
+  },
+  {
+   "a": "bench/repos/hugo/identity/identity.go:472",
+   "b": "bench/repos/hugo/resources/resource_transformers/templates/execute_as_template.go:36",
+   "repo": "hugo",
+   "structurally_near": false,
+   "vj": 0.3157894736842105
+  },
+  {
+   "a": "bench/repos/sympy/sympy/polys/rings.py:1235",
+   "b": "bench/repos/sympy/sympy/polys/rings.py:2604",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.3125
+  },
+  {
+   "a": "bench/repos/gson/gson/src/main/java/com/google/gson/internal/NonNullElementWrapperList.java:50",
+   "b": "bench/repos/gson/gson/src/main/java/com/google/gson/internal/bind/JavaTimeTypeAdapters.java:442",
+   "repo": "gson",
+   "structurally_near": false,
+   "vj": 0.30434782608695654
+  },
+  {
+   "a": "bench/repos/rxjs/packages/rxjs/spec/operators/max-spec.ts:243",
+   "b": "bench/repos/rxjs/packages/rxjs/spec/operators/max-spec.ts:288",
+   "repo": "rxjs",
+   "structurally_near": false,
+   "vj": 0.30434782608695654
+  },
+  {
+   "a": "bench/repos/rxjs/packages/rxjs/spec/operators/every-spec.ts:20",
+   "b": "bench/repos/rxjs/packages/rxjs/spec/operators/find-spec.ts:26",
+   "repo": "rxjs",
+   "structurally_near": false,
+   "vj": 0.3
+  },
+  {
+   "a": "bench/repos/drizzle-orm/drizzle-kit/src/simulator.ts:47",
+   "b": "bench/repos/drizzle-orm/drizzle-kit/src/simulator.ts:57",
+   "repo": "drizzle-orm",
+   "structurally_near": false,
+   "vj": 0.29411764705882354
+  },
+  {
+   "a": "bench/repos/ripgrep/crates/globset/src/glob.rs:1066",
+   "b": "bench/repos/ripgrep/crates/globset/src/glob.rs:1071",
+   "repo": "ripgrep",
+   "structurally_near": false,
+   "vj": 0.2916666666666667
+  },
+  {
+   "a": "bench/repos/netty/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslEngine.java:305",
+   "b": "bench/repos/netty/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java:147",
+   "repo": "netty",
+   "structurally_near": false,
+   "vj": 0.2857142857142857
+  },
+  {
+   "a": "bench/repos/antlr4/runtime/Go/antlr/v4/diagnostic_error_listener.go:100",
+   "b": "bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/DiagnosticErrorListener.java:141",
+   "repo": "antlr4",
+   "structurally_near": false,
+   "vj": 0.27586206896551724
+  },
+  {
+   "a": "bench/repos/date-fns/pkgs/core/src/parse/_lib/parsers/Hour1To24Parser.ts:21",
+   "b": "bench/repos/date-fns/pkgs/core/src/parse/_lib/parsers/Hour1to12Parser.ts:21",
+   "repo": "date-fns",
+   "structurally_near": false,
+   "vj": 0.2727272727272727
+  },
+  {
+   "a": "bench/repos/minio/cmd/endpoint.go:934",
+   "b": "bench/repos/minio/cmd/local-locker.go:56",
+   "repo": "minio",
+   "structurally_near": false,
+   "vj": 0.2727272727272727
+  },
+  {
+   "a": "bench/repos/sqlite/src/main.c:4931",
+   "b": "bench/repos/sqlite/src/main.c:4935",
+   "repo": "sqlite",
+   "structurally_near": false,
+   "vj": 0.2727272727272727
+  },
+  {
+   "a": "bench/repos/fzf/src/algo/indexbyte2_other.go:26",
+   "b": "bench/repos/fzf/src/algo/indexbyte2_test.go:187",
+   "repo": "fzf",
+   "structurally_near": false,
+   "vj": 0.2692307692307692
+  },
+  {
+   "a": "bench/repos/sympy/sympy/polys/galoistools.py:1329",
+   "b": "bench/repos/sympy/sympy/series/formal.py:169",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.26
+  },
+  {
+   "a": "bench/repos/hugo/modules/npm/package_builder.go:388",
+   "b": "bench/repos/hugo/resources/resource_factories/create/remote.go:412",
+   "repo": "hugo",
+   "structurally_near": false,
+   "vj": 0.25
+  },
+  {
+   "a": "bench/repos/redis/deps/jemalloc/include/jemalloc/internal/fxp.h:82",
+   "b": "bench/repos/redis/deps/jemalloc/test/unit/fxp.c:5",
+   "repo": "redis",
+   "structurally_near": false,
+   "vj": 0.25
+  },
+  {
+   "a": "bench/repos/sqlalchemy/test/sql/test_types.py:719",
+   "b": "bench/repos/sqlalchemy/test/sql/test_types.py:724",
+   "repo": "sqlalchemy",
+   "structurally_near": false,
+   "vj": 0.25
+  },
+  {
+   "a": "bench/repos/sympy/sympy/assumptions/assume.py:351",
+   "b": "bench/repos/sympy/sympy/tensor/array/expressions/from_array_to_matrix.py:583",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.25
+  },
+  {
+   "a": "bench/repos/click/src/click/_compat.py:499",
+   "b": "bench/repos/click/src/click/testing.py:503",
+   "repo": "click",
+   "structurally_near": false,
+   "vj": 0.23529411764705882
+  },
+  {
+   "a": "bench/repos/antlr4/runtime/Go/antlr/v4/dfa_state.go:17",
+   "b": "bench/repos/antlr4/runtime/Go/antlr/v4/dfa_state.go:85",
+   "repo": "antlr4",
+   "structurally_near": false,
+   "vj": 0.23076923076923078
+  },
+  {
+   "a": "bench/repos/etcd/pkg/ioutil/readcloser.go:36",
+   "b": "bench/repos/etcd/server/etcdserver/api/snap/snapshotter.go:59",
+   "repo": "etcd",
+   "structurally_near": false,
+   "vj": 0.23076923076923078
+  },
+  {
+   "a": "bench/repos/sympy/sympy/core/function.py:1746",
+   "b": "bench/repos/sympy/sympy/simplify/hyperexpand.py:2254",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.21739130434782608
+  },
+  {
+   "a": "bench/repos/minio/cmd/streaming-signature-v4.go:612",
+   "b": "bench/repos/minio/cmd/utils.go:730",
+   "repo": "minio",
+   "structurally_near": false,
+   "vj": 0.21428571428571427
+  },
+  {
+   "a": "bench/repos/sqlite/autosetup/jimsh0.c:7584",
+   "b": "bench/repos/sqlite/autosetup/jimsh0.c:7608",
+   "repo": "sqlite",
+   "structurally_near": false,
+   "vj": 0.21311475409836064
+  },
+  {
+   "a": "bench/repos/drizzle-orm/drizzle-orm/src/alias.ts:15",
+   "b": "bench/repos/drizzle-orm/drizzle-orm/src/alias.ts:82",
+   "repo": "drizzle-orm",
+   "structurally_near": false,
+   "vj": 0.20833333333333334
+  },
+  {
+   "a": "bench/repos/delve/_fixtures/leaf4.go:16",
+   "b": "bench/repos/delve/_fixtures/leafregex.go:16",
+   "repo": "delve",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/etcd/pkg/pbutil/pbutil.go:67",
+   "b": "bench/repos/etcd/pkg/pbutil/pbutil.go:74",
+   "repo": "etcd",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/h2database/h2/src/main/org/h2/command/Prepared.java:331",
+   "b": "bench/repos/h2database/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java:719",
+   "repo": "h2database",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/hugo/common/hugio/readers.go:76",
+   "b": "bench/repos/hugo/hugolib/doctree/nodeshiftree_test.go:289",
+   "repo": "hugo",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/libgdx/extensions/gdx-bullet/jni/src/bullet/LinearMath/btScalar.h:552",
+   "b": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/math/MathUtils.java:648",
+   "repo": "libgdx",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/marshmallow/src/marshmallow/constants.py:12",
+   "b": "bench/repos/marshmallow/tests/test_fields.py:717",
+   "repo": "marshmallow",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/nats-server/server/accounts.go:2401",
+   "b": "bench/repos/nats-server/server/mqtt.go:5801",
+   "repo": "nats-server",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/prometheus/config/config.go:159",
+   "b": "bench/repos/prometheus/web/api/v1/translate_ast.go:181",
+   "repo": "prometheus",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/sqlalchemy/lib/sqlalchemy/dialects/mssql/base.py:2132",
+   "b": "bench/repos/sqlalchemy/lib/sqlalchemy/orm/interfaces.py:1300",
+   "repo": "sqlalchemy",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/sqlalchemy/lib/sqlalchemy/dialects/postgresql/array.py:214",
+   "b": "bench/repos/sqlalchemy/lib/sqlalchemy/sql/selectable.py:1841",
+   "repo": "sqlalchemy",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/sqlalchemy/lib/sqlalchemy/dialects/postgresql/asyncpg.py:1069",
+   "b": "bench/repos/sqlalchemy/test/orm/test_unitofworkv2.py:3595",
+   "repo": "sqlalchemy",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/sqlalchemy/lib/sqlalchemy/sql/traversals.py:394",
+   "b": "bench/repos/sqlalchemy/test/orm/test_query.py:647",
+   "repo": "sqlalchemy",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/sympy/sympy/holonomic/holonomic.py:299",
+   "b": "bench/repos/sympy/sympy/matrices/common.py:3032",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/sympy/sympy/holonomic/holonomic.py:302",
+   "b": "bench/repos/sympy/sympy/matrices/common.py:3028",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.2
+  },
+  {
+   "a": "bench/repos/sqlite/src/util.c:2087",
+   "b": "bench/repos/sqlite/tool/logest.c:42",
+   "repo": "sqlite",
+   "structurally_near": false,
+   "vj": 0.1951219512195122
+  },
+  {
+   "a": "bench/repos/sqlalchemy/lib/sqlalchemy/dialects/mysql/reflection.py:689",
+   "b": "bench/repos/sqlalchemy/test/orm/inheritance/test_single.py:307",
+   "repo": "sqlalchemy",
+   "structurally_near": false,
+   "vj": 0.19047619047619047
+  },
+  {
+   "a": "bench/repos/sqlite/ext/fts3/fts3.c:3218",
+   "b": "bench/repos/sqlite/tool/sqlite3_rsync.c:923",
+   "repo": "sqlite",
+   "structurally_near": false,
+   "vj": 0.18421052631578946
+  },
+  {
+   "a": "bench/repos/git/archive-zip.c:171",
+   "b": "bench/repos/git/ewah/ewah_bitmap.c:24",
+   "repo": "git",
+   "structurally_near": false,
+   "vj": 0.18181818181818182
+  },
+  {
+   "a": "bench/repos/netty/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java:239",
+   "b": "bench/repos/netty/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/BoringSSLCertificateCallback.java:151",
+   "repo": "netty",
+   "structurally_near": false,
+   "vj": 0.18181818181818182
+  },
+  {
+   "a": "bench/repos/prometheus/model/labels/regexp_test.go:1341",
+   "b": "bench/repos/prometheus/model/labels/regexp_test.go:151",
+   "repo": "prometheus",
+   "structurally_near": false,
+   "vj": 0.18181818181818182
+  },
+  {
+   "a": "bench/repos/sympy/sympy/core/logic.py:150",
+   "b": "bench/repos/sympy/sympy/polys/matrices/sdm.py:1361",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.18181818181818182
+  },
+  {
+   "a": "bench/repos/sympy/sympy/polys/galoistools.py:261",
+   "b": "bench/repos/sympy/sympy/polys/galoistools.py:347",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.18181818181818182
+  },
+  {
+   "a": "bench/repos/minio/internal/dsync/drwmutex.go:550",
+   "b": "bench/repos/minio/internal/dsync/drwmutex.go:576",
+   "repo": "minio",
+   "structurally_near": false,
+   "vj": 0.17857142857142858
+  },
+  {
+   "a": "bench/repos/netty/common/src/main/java/io/netty/util/internal/ConstantTimeUtils.java:36",
+   "b": "bench/repos/netty/common/src/main/java/io/netty/util/internal/ConstantTimeUtils.java:61",
+   "repo": "netty",
+   "structurally_near": false,
+   "vj": 0.17647058823529413
+  },
+  {
+   "a": "bench/repos/hugo/markup/goldmark/hugocontext/hugocontext.go:190",
+   "b": "bench/repos/hugo/tpl/internal/go_templates/texttemplate/exec.go:624",
+   "repo": "hugo",
+   "structurally_near": false,
+   "vj": 0.175
+  },
+  {
+   "a": "bench/repos/h2database/h2/src/main/org/h2/mvstore/type/ByteArrayDataType.java:24",
+   "b": "bench/repos/h2database/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java:484",
+   "repo": "h2database",
+   "structurally_near": false,
+   "vj": 0.16666666666666666
+  },
+  {
+   "a": "bench/repos/jackson-core/src/main/java/tools/jackson/core/JacksonException.java:248",
+   "b": "bench/repos/jackson-core/src/main/java/tools/jackson/core/JsonParser.java:1528",
+   "repo": "jackson-core",
+   "structurally_near": false,
+   "vj": 0.16666666666666666
+  },
+  {
+   "a": "bench/repos/redis/src/util.c:208",
+   "b": "bench/repos/redis/src/util.c:238",
+   "repo": "redis",
+   "structurally_near": false,
+   "vj": 0.16666666666666666
+  },
+  {
+   "a": "bench/repos/sqlite/test/dbfuzz2.c:248",
+   "b": "bench/repos/sqlite/tool/sqlite3_rsync.c:1972",
+   "repo": "sqlite",
+   "structurally_near": false,
+   "vj": 0.16666666666666666
+  },
+  {
+   "a": "bench/repos/netty/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java:672",
+   "b": "bench/repos/netty/microbench/src/main/java/io/netty/microbench/headers/HeadersBenchmark.java:54",
+   "repo": "netty",
+   "structurally_near": false,
+   "vj": 0.16
+  },
+  {
+   "a": "bench/repos/sympy/sympy/core/logic.py:173",
+   "b": "bench/repos/sympy/sympy/core/logic.py:201",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.15625
+  },
+  {
+   "a": "bench/repos/scrapy/scrapy/contracts/__init__.py:88",
+   "b": "bench/repos/scrapy/scrapy/spidermiddlewares/start.py:26",
+   "repo": "scrapy",
+   "structurally_near": false,
+   "vj": 0.15384615384615385
+  },
+  {
+   "a": "bench/repos/sympy/sympy/polys/densebasic.py:1381",
+   "b": "bench/repos/sympy/sympy/polys/galoistools.py:530",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.15306122448979592
+  },
+  {
+   "a": "bench/repos/git/apply.c:593",
+   "b": "bench/repos/git/xdiff/xutils.c:159",
+   "repo": "git",
+   "structurally_near": false,
+   "vj": 0.14814814814814814
+  },
+  {
+   "a": "bench/repos/guava/android/guava/src/com/google/common/collect/DiscreteDomain.java:157",
+   "b": "bench/repos/guava/android/guava/src/com/google/common/collect/DiscreteDomain.java:89",
+   "repo": "guava",
+   "structurally_near": false,
+   "vj": 0.14814814814814814
+  },
+  {
+   "a": "bench/repos/click/src/click/types.py:219",
+   "b": "bench/repos/click/tests/test_termui.py:1227",
+   "repo": "click",
+   "structurally_near": false,
+   "vj": 0.14285714285714285
+  },
+  {
+   "a": "bench/repos/esbuild/internal/css_parser/css_color_spaces.go:326",
+   "b": "bench/repos/esbuild/internal/css_parser/css_color_spaces.go:366",
+   "repo": "esbuild",
+   "structurally_near": false,
+   "vj": 0.14285714285714285
+  },
+  {
+   "a": "bench/repos/git/diff.c:2839",
+   "b": "bench/repos/git/list-objects-filter-options.c:127",
+   "repo": "git",
+   "structurally_near": false,
+   "vj": 0.14285714285714285
+  },
+  {
+   "a": "bench/repos/h2database/h2/src/main/org/h2/util/SourceCompiler.java:186",
+   "b": "bench/repos/h2database/h2/src/main/org/h2/util/SourceCompiler.java:190",
+   "repo": "h2database",
+   "structurally_near": false,
+   "vj": 0.14285714285714285
+  },
+  {
+   "a": "bench/repos/libgdx/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/org/jbox2d/particle/ParticleSystem.java:1742",
+   "b": "bench/repos/libgdx/extensions/gdx-bullet/jni/vs/Glut/EmptyGL/GL/egl_cpx.h:5",
+   "repo": "libgdx",
+   "structurally_near": false,
+   "vj": 0.14285714285714285
+  },
+  {
+   "a": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/exceptions/stacktrace/DefaultStackTraceCleaner.java:46",
+   "b": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/exceptions/stacktrace/DefaultStackTraceCleaner.java:50",
+   "repo": "mockito",
+   "structurally_near": false,
+   "vj": 0.14285714285714285
+  },
+  {
+   "a": "bench/repos/netty/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java:58",
+   "b": "bench/repos/netty/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilFuzzTest.java:113",
+   "repo": "netty",
+   "structurally_near": false,
+   "vj": 0.14285714285714285
+  },
+  {
+   "a": "bench/repos/sqlite/ext/fts5/fts5_config.c:34",
+   "b": "bench/repos/sqlite/ext/wasm/api/sqlite3-api-worker1.c-pp.js:480",
+   "repo": "sqlite",
+   "structurally_near": false,
+   "vj": 0.14285714285714285
+  },
+  {
+   "a": "bench/repos/sympy/sympy/combinatorics/fp_groups.py:612",
+   "b": "bench/repos/sympy/sympy/holonomic/holonomic.py:305",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.14285714285714285
+  },
+  {
+   "a": "bench/repos/vim/src/filepath.c:3053",
+   "b": "bench/repos/vim/src/filepath.c:3076",
+   "repo": "vim",
+   "structurally_near": false,
+   "vj": 0.14285714285714285
+  },
+  {
+   "a": "bench/repos/sqlite/ext/fts5/fts5_tokenize.c:1066",
+   "b": "bench/repos/sqlite/ext/fts5/fts5_tokenize.c:751",
+   "repo": "sqlite",
+   "structurally_near": false,
+   "vj": 0.13551401869158877
+  },
+  {
+   "a": "bench/repos/libgdx/gdx/jni/gdx2d/gdx2d.c:387",
+   "b": "bench/repos/libgdx/gdx/jni/gdx2d/gdx2d.c:402",
+   "repo": "libgdx",
+   "structurally_near": false,
+   "vj": 0.13333333333333333
+  },
+  {
+   "a": "bench/repos/zod/packages/zod/src/v4/locales/be.ts:5",
+   "b": "bench/repos/zod/packages/zod/src/v4/locales/hy.ts:5",
+   "repo": "zod",
+   "structurally_near": false,
+   "vj": 0.13333333333333333
+  },
+  {
+   "a": "bench/repos/flask/src/flask/json/tag.py:297",
+   "b": "bench/repos/flask/tests/test_json.py:235",
+   "repo": "flask",
+   "structurally_near": false,
+   "vj": 0.13157894736842105
+  },
+  {
+   "a": "bench/repos/delve/pkg/internal/gosym/additions.go:218",
+   "b": "bench/repos/delve/pkg/proc/native/proc_linux.go:222",
+   "repo": "delve",
+   "structurally_near": false,
+   "vj": 0.13043478260869565
+  },
+  {
+   "a": "bench/repos/hugo/commands/commandeer.go:705",
+   "b": "bench/repos/hugo/tpl/internal/go_templates/htmltemplate/css.go:128",
+   "repo": "hugo",
+   "structurally_near": false,
+   "vj": 0.1267605633802817
+  },
+  {
+   "a": "bench/repos/delve/_fixtures/increment.go:6",
+   "b": "bench/repos/delve/_fixtures/stepintobug.go:12",
+   "repo": "delve",
+   "structurally_near": false,
+   "vj": 0.125
+  },
+  {
+   "a": "bench/repos/graphhopper/core/src/main/java/com/graphhopper/storage/BaseGraph.java:448",
+   "b": "bench/repos/graphhopper/web-bundle/src/main/java/no/ecc/vectortile/VectorTileEncoder.java:417",
+   "repo": "graphhopper",
+   "structurally_near": false,
+   "vj": 0.125
+  },
+  {
+   "a": "bench/repos/h2database/h2/src/main/org/h2/jdbc/JdbcConnection.java:1164",
+   "b": "bench/repos/h2database/h2/src/main/org/h2/mvstore/MVMap.java:1848",
+   "repo": "h2database",
+   "structurally_near": false,
+   "vj": 0.125
+  },
+  {
+   "a": "bench/repos/httpie/httpie/internal/daemon_runner.py:37",
+   "b": "bench/repos/httpie/tests/test_update_warnings.py:29",
+   "repo": "httpie",
+   "structurally_near": false,
+   "vj": 0.125
+  },
+  {
+   "a": "bench/repos/junit5/documentation/src/tools/java/org/junit/api/tools/AbstractApiReportWriter.java:103",
+   "b": "bench/repos/junit5/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java:1931",
+   "repo": "junit5",
+   "structurally_near": false,
+   "vj": 0.125
+  },
+  {
+   "a": "bench/repos/rxjs/packages/rxjs/spec/observables/zip-spec.ts:327",
+   "b": "bench/repos/rxjs/packages/rxjs/spec/operators/scan-spec.ts:26",
+   "repo": "rxjs",
+   "structurally_near": false,
+   "vj": 0.125
+  },
+  {
+   "a": "bench/repos/sympy/sympy/plotting/pygletplot/plot_rotation.py:16",
+   "b": "bench/repos/sympy/sympy/plotting/pygletplot/util.py:179",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.12
+  },
+  {
+   "a": "bench/repos/redis/deps/lua/src/lstrlib.c:444",
+   "b": "bench/repos/redis/src/crcspeed.c:389",
+   "repo": "redis",
+   "structurally_near": false,
+   "vj": 0.11764705882352941
+  },
+  {
+   "a": "bench/repos/antlr4/runtime/Go/antlr/v4/atn_deserializer.go:30",
+   "b": "bench/repos/antlr4/runtime/Go/antlr/v4/common_token_factory.go:28",
+   "repo": "antlr4",
+   "structurally_near": false,
+   "vj": 0.1111111111111111
+  },
+  {
+   "a": "bench/repos/antlr4/runtime/Python3/src/antlr4/error/Errors.py:156",
+   "b": "bench/repos/antlr4/runtime/Python3/src/antlr4/tree/Tree.py:58",
+   "repo": "antlr4",
+   "structurally_near": false,
+   "vj": 0.1111111111111111
+  },
+  {
+   "a": "bench/repos/libgdx/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/java/lang/StrictMath.java:30",
+   "b": "bench/repos/libgdx/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/org/jbox2d/common/MathUtils.java:131",
+   "repo": "libgdx",
+   "structurally_near": false,
+   "vj": 0.1111111111111111
+  },
+  {
+   "a": "bench/repos/rubocop/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb:116",
+   "b": "bench/repos/rubocop/lib/rubocop/cop/style/format_string.rb:99",
+   "repo": "rubocop",
+   "structurally_near": false,
+   "vj": 0.1111111111111111
+  },
+  {
+   "a": "bench/repos/click/src/click/globals.py:54",
+   "b": "bench/repos/click/src/click/types.py:1177",
+   "repo": "click",
+   "structurally_near": false,
+   "vj": 0.109375
+  },
+  {
+   "a": "bench/repos/cmark/src/scanners.c:8680",
+   "b": "bench/repos/cmark/src/scanners.c:8807",
+   "repo": "cmark",
+   "structurally_near": false,
+   "vj": 0.10849909584086799
+  },
+  {
+   "a": "bench/repos/jest/packages/jest-resolve/src/resolver.ts:494",
+   "b": "bench/repos/jest/packages/jest-runtime/src/internals/EsmLoader.ts:173",
+   "repo": "jest",
+   "structurally_near": false,
+   "vj": 0.10714285714285714
+  },
+  {
+   "a": "bench/repos/sympy/sympy/plotting/pygletplot/color_scheme.py:143",
+   "b": "bench/repos/sympy/sympy/tensor/array/expressions/array_expressions.py:854",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.10204081632653061
+  },
+  {
+   "a": "bench/repos/drizzle-orm/drizzle-kit/src/cli/views.ts:83",
+   "b": "bench/repos/drizzle-orm/drizzle-orm/src/mysql2/session.ts:352",
+   "repo": "drizzle-orm",
+   "structurally_near": false,
+   "vj": 0.1
+  },
+  {
+   "a": "bench/repos/jest/packages/jest-runtime/src/internals/EsmLoader.ts:164",
+   "b": "bench/repos/jest/packages/jest-runtime/src/internals/Resolution.ts:12",
+   "repo": "jest",
+   "structurally_near": false,
+   "vj": 0.1
+  },
+  {
+   "a": "bench/repos/git/diffcore-pickaxe.c:26",
+   "b": "bench/repos/git/strbuf.c:438",
+   "repo": "git",
+   "structurally_near": false,
+   "vj": 0.09722222222222222
+  },
+  {
+   "a": "bench/repos/redis/src/geohash.c:217",
+   "b": "bench/repos/redis/src/geohash.c:224",
+   "repo": "redis",
+   "structurally_near": false,
+   "vj": 0.09523809523809523
+  },
+  {
+   "a": "bench/repos/minio/cmd/auth-handler_test.go:36",
+   "b": "bench/repos/minio/cmd/erasure-metadata-utils.go:162",
+   "repo": "minio",
+   "structurally_near": false,
+   "vj": 0.09090909090909091
+  },
+  {
+   "a": "bench/repos/minio/cmd/utils.go:234",
+   "b": "bench/repos/minio/internal/s3select/parquet/reader.go:83",
+   "repo": "minio",
+   "structurally_near": false,
+   "vj": 0.09090909090909091
+  },
+  {
+   "a": "bench/repos/esbuild/internal/resolver/resolver.go:1848",
+   "b": "bench/repos/esbuild/pkg/api/api_impl.go:504",
+   "repo": "esbuild",
+   "structurally_near": false,
+   "vj": 0.0898876404494382
+  },
+  {
+   "a": "bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/FailedPredicateException.java:67",
+   "b": "bench/repos/antlr4/runtime/JavaScript/src/antlr4/error/FailedPredicateException.js:37",
+   "repo": "antlr4",
+   "structurally_near": false,
+   "vj": 0.08695652173913043
+  },
+  {
+   "a": "bench/repos/marshmallow/src/marshmallow/fields.py:416",
+   "b": "bench/repos/marshmallow/tests/test_decorators.py:978",
+   "repo": "marshmallow",
+   "structurally_near": false,
+   "vj": 0.08695652173913043
+  },
+  {
+   "a": "bench/repos/black/src/black/nodes.py:969",
+   "b": "bench/repos/black/src/black/nodes.py:982",
+   "repo": "black",
+   "structurally_near": false,
+   "vj": 0.08571428571428572
+  },
+  {
+   "a": "bench/repos/esbuild/internal/js_parser/js_parser.go:848",
+   "b": "bench/repos/esbuild/internal/resolver/tsconfig_json.go:417",
+   "repo": "esbuild",
+   "structurally_near": false,
+   "vj": 0.08571428571428572
+  },
+  {
+   "a": "bench/repos/vim/src/regexp.c:460",
+   "b": "bench/repos/vim/src/userfunc.c:6064",
+   "repo": "vim",
+   "structurally_near": false,
+   "vj": 0.08571428571428572
+  },
+  {
+   "a": "bench/repos/git/diff-lib.c:704",
+   "b": "bench/repos/git/t/t7615/ours.c:10",
+   "repo": "git",
+   "structurally_near": false,
+   "vj": 0.08333333333333333
+  },
+  {
+   "a": "bench/repos/marked/docs/demo/demo.js:124",
+   "b": "bench/repos/marked/src/Hooks.ts:31",
+   "repo": "marked",
+   "structurally_near": false,
+   "vj": 0.08333333333333333
+  },
+  {
+   "a": "bench/repos/netty/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3CodecUtils.java:114",
+   "b": "bench/repos/netty/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java:753",
+   "repo": "netty",
+   "structurally_near": false,
+   "vj": 0.08196721311475409
+  },
+  {
+   "a": "bench/repos/sympy/sympy/parsing/mathematica.py:1008",
+   "b": "bench/repos/sympy/sympy/polys/agca/modules.py:198",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.08108108108108109
+  },
+  {
+   "a": "bench/repos/delve/_fixtures/testinline.go:24",
+   "b": "bench/repos/delve/pkg/terminal/command.go:1449",
+   "repo": "delve",
+   "structurally_near": false,
+   "vj": 0.07692307692307693
+  },
+  {
+   "a": "bench/repos/execa/lib/io/max-buffer.js:89",
+   "b": "bench/repos/execa/lib/transform/normalize.js:111",
+   "repo": "execa",
+   "structurally_near": false,
+   "vj": 0.07692307692307693
+  },
+  {
+   "a": "bench/repos/hugo/common/hashing/hashing.go:181",
+   "b": "bench/repos/hugo/common/herrors/error_locator.go:93",
+   "repo": "hugo",
+   "structurally_near": false,
+   "vj": 0.07692307692307693
+  },
+  {
+   "a": "bench/repos/rxjava/src/main/java/io/reactivex/rxjava4/internal/functions/Functions.java:668",
+   "b": "bench/repos/rxjava/src/main/java/io/reactivex/rxjava4/internal/util/ExceptionHelper.java:177",
+   "repo": "rxjava",
+   "structurally_near": false,
+   "vj": 0.07692307692307693
+  },
+  {
+   "a": "bench/repos/delve/pkg/dwarf/line/line_parser.go:278",
+   "b": "bench/repos/delve/pkg/locspec/locations.go:338",
+   "repo": "delve",
+   "structurally_near": false,
+   "vj": 0.07407407407407407
+  },
+  {
+   "a": "bench/repos/prettier/src/language-js/print/mapped-type.js:63",
+   "b": "bench/repos/prettier/tests/format/js/non-strict/argument-name-clash.js:1",
+   "repo": "prettier",
+   "structurally_near": false,
+   "vj": 0.07142857142857142
+  },
+  {
+   "a": "bench/repos/prettier/tests/format/flow/flow-repo/throw/test.js:9",
+   "b": "bench/repos/prettier/tests/format/flow/flow-repo/unary/unary.js:3",
+   "repo": "prettier",
+   "structurally_near": false,
+   "vj": 0.06666666666666667
+  },
+  {
+   "a": "bench/repos/sqlalchemy/lib/sqlalchemy/connectors/asyncio.py:305",
+   "b": "bench/repos/sqlalchemy/lib/sqlalchemy/util/langhelpers.py:1845",
+   "repo": "sqlalchemy",
+   "structurally_near": false,
+   "vj": 0.0625
+  },
+  {
+   "a": "bench/repos/esbuild/internal/css_lexer/css_lexer.go:554",
+   "b": "bench/repos/esbuild/pkg/api/api_impl.go:500",
+   "repo": "esbuild",
+   "structurally_near": false,
+   "vj": 0.06060606060606061
+  },
+  {
+   "a": "bench/repos/sympy/sympy/logic/boolalg.py:2280",
+   "b": "bench/repos/sympy/sympy/polys/densebasic.py:1031",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.05732484076433121
+  },
+  {
+   "a": "bench/repos/packaging/src/packaging/_ranges.py:261",
+   "b": "bench/repos/packaging/src/packaging/direct_url.py:83",
+   "repo": "packaging",
+   "structurally_near": false,
+   "vj": 0.05555555555555555
+  },
+  {
+   "a": "bench/repos/gin/path.go:155",
+   "b": "bench/repos/gin/utils.go:91",
+   "repo": "gin",
+   "structurally_near": false,
+   "vj": 0.05194805194805195
+  },
+  {
+   "a": "bench/repos/delve/pkg/internal/gosym/additions.go:204",
+   "b": "bench/repos/delve/pkg/logflags/logflags.go:340",
+   "repo": "delve",
+   "structurally_near": false,
+   "vj": 0.05084745762711865
+  },
+  {
+   "a": "bench/repos/gin/internal/bytesconv/bytesconv_test.go:25",
+   "b": "bench/repos/gin/utils.go:100",
+   "repo": "gin",
+   "structurally_near": false,
+   "vj": 0.05
+  },
+  {
+   "a": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/ModuleHandler.java:175",
+   "b": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/util/Checks.java:14",
+   "repo": "mockito",
+   "structurally_near": false,
+   "vj": 0.05
+  },
+  {
+   "a": "bench/repos/redis/deps/jemalloc/include/jemalloc/internal/tsd.h:281",
+   "b": "bench/repos/redis/src/util.c:1333",
+   "repo": "redis",
+   "structurally_near": false,
+   "vj": 0.05
+  },
+  {
+   "a": "bench/repos/sympy/sympy/parsing/mathematica.py:1178",
+   "b": "bench/repos/sympy/sympy/physics/quantum/qasm.py:46",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.05
+  },
+  {
+   "a": "bench/repos/delve/pkg/proc/gdbserial/gdbserver_conn.go:1555",
+   "b": "bench/repos/delve/pkg/proc/gdbserial/gdbserver_conn.go:759",
+   "repo": "delve",
+   "structurally_near": false,
+   "vj": 0.04892966360856269
+  },
+  {
+   "a": "bench/repos/minio/cmd/api-headers.go:262",
+   "b": "bench/repos/minio/cmd/generic-handlers.go:90",
+   "repo": "minio",
+   "structurally_near": false,
+   "vj": 0.04878048780487805
+  },
+  {
+   "a": "bench/repos/delve/pkg/dwarf/godwarf/sections.go:105",
+   "b": "bench/repos/delve/pkg/locspec/locations.go:231",
+   "repo": "delve",
+   "structurally_near": false,
+   "vj": 0.04819277108433735
+  },
+  {
+   "a": "bench/repos/drizzle-orm/drizzle-kit/src/cli/connections.ts:287",
+   "b": "bench/repos/drizzle-orm/drizzle-kit/src/introspect-sqlite.ts:51",
+   "repo": "drizzle-orm",
+   "structurally_near": false,
+   "vj": 0.043478260869565216
+  },
+  {
+   "a": "bench/repos/fastlane/fastlane/lib/fastlane/command_line_handler.rb:39",
+   "b": "bench/repos/fastlane/fastlane/lib/fastlane/swift_fastlane_api_generator.rb:145",
+   "repo": "fastlane",
+   "structurally_near": false,
+   "vj": 0.043478260869565216
+  },
+  {
+   "a": "bench/repos/vim/src/os_win32.c:796",
+   "b": "bench/repos/vim/src/usercmd.c:1213",
+   "repo": "vim",
+   "structurally_near": false,
+   "vj": 0.0425531914893617
+  },
+  {
+   "a": "bench/repos/jest/packages/jest-diff/src/diffLines.ts:18",
+   "b": "bench/repos/jest/packages/jest-snapshot/src/utils.ts:86",
+   "repo": "jest",
+   "structurally_near": false,
+   "vj": 0.037037037037037035
+  },
+  {
+   "a": "bench/repos/vim/src/ex_docmd.c:3579",
+   "b": "bench/repos/vim/src/regexp.c:188",
+   "repo": "vim",
+   "structurally_near": false,
+   "vj": 0.02857142857142857
+  },
+  {
+   "a": "bench/repos/sympy/sympy/physics/quantum/operator.py:314",
+   "b": "bench/repos/sympy/sympy/plotting/pygletplot/plot_axes.py:59",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.027777777777777776
+  },
+  {
+   "a": "bench/repos/delve/pkg/dwarf/godwarf/type.go:65",
+   "b": "bench/repos/delve/pkg/terminal/command.go:2292",
+   "repo": "delve",
+   "structurally_near": false,
+   "vj": 0.02702702702702703
+  },
+  {
+   "a": "bench/repos/cmark/src/scanners.c:5270",
+   "b": "bench/repos/cmark/src/scanners.c:8412",
+   "repo": "cmark",
+   "structurally_near": false,
+   "vj": 0.026168224299065422
+  },
+  {
+   "a": "bench/repos/hugo/config/allconfig/load.go:294",
+   "b": "bench/repos/hugo/config/allconfig/load.go:303",
+   "repo": "hugo",
+   "structurally_near": false,
+   "vj": 0.020833333333333332
+  },
+  {
+   "a": "bench/repos/scrapy/extras/qps-bench-server.py:21",
+   "b": "bench/repos/scrapy/scrapy/downloadermiddlewares/httpcompression.py:185",
+   "repo": "scrapy",
+   "structurally_near": false,
+   "vj": 0.02
+  },
+  {
+   "a": "bench/repos/git/diff.c:3522",
+   "b": "bench/repos/git/object-file.c:1906",
+   "repo": "git",
+   "structurally_near": false,
+   "vj": 0.017543859649122806
+  }
+ ],
+ "nose_version": "nose 0.5.0",
+ "schema_version": "0.1.0",
+ "structurally_near_vj_ge_0.7": 5,
+ "under_merged_groups": 179,
+ "what": "verify --leads merged per-repo: behavior-equal on the battery but fingerprint-split (modality A under-merge leads)"
+}

--- a/bench/labels/oracle_under_merge_leads_2026_06_10.json
+++ b/bench/labels/oracle_under_merge_leads_2026_06_10.json
@@ -81,6 +81,20 @@
    "vj": 0.5555555555555556
   },
   {
+   "a": "bench/repos/sqlite/ext/fts3/fts3_porter.c:150",
+   "b": "bench/repos/sqlite/ext/fts3/fts3_porter.c:159",
+   "repo": "sqlite",
+   "structurally_near": false,
+   "vj": 0.5510204081632653
+  },
+  {
+   "a": "bench/repos/etcd/tests/robustness/validate/patch_history.go:384",
+   "b": "bench/repos/etcd/tests/robustness/validate/patch_history.go:414",
+   "repo": "etcd",
+   "structurally_near": false,
+   "vj": 0.5384615384615384
+  },
+  {
    "a": "bench/repos/libgdx/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/org/jbox2d/common/MathUtils.java:244",
    "b": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/math/MathUtils.java:510",
    "repo": "libgdx",
@@ -284,6 +298,20 @@
    "vj": 0.3333333333333333
   },
   {
+   "a": "bench/repos/sqlalchemy/lib/sqlalchemy/dialects/mssql/base.py:2132",
+   "b": "bench/repos/sqlalchemy/test/orm/test_validators.py:97",
+   "repo": "sqlalchemy",
+   "structurally_near": false,
+   "vj": 0.3333333333333333
+  },
+  {
+   "a": "bench/repos/sympy/sympy/polys/matrices/ddm.py:1139",
+   "b": "bench/repos/sympy/sympy/polys/matrices/ddm.py:1147",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.3333333333333333
+  },
+  {
    "a": "bench/repos/hugo/identity/identity.go:472",
    "b": "bench/repos/hugo/resources/resource_transformers/templates/execute_as_template.go:36",
    "repo": "hugo",
@@ -317,6 +345,13 @@
    "repo": "rxjs",
    "structurally_near": false,
    "vj": 0.3
+  },
+  {
+   "a": "bench/repos/prometheus/web/ui/mantine-ui/src/pages/query/HistogramHelpers.ts:28",
+   "b": "bench/repos/prometheus/web/ui/mantine-ui/src/pages/query/HistogramHelpers.ts:53",
+   "repo": "prometheus",
+   "structurally_near": false,
+   "vj": 0.2962962962962963
   },
   {
    "a": "bench/repos/drizzle-orm/drizzle-kit/src/simulator.ts:47",
@@ -357,13 +392,6 @@
    "a": "bench/repos/minio/cmd/endpoint.go:934",
    "b": "bench/repos/minio/cmd/local-locker.go:56",
    "repo": "minio",
-   "structurally_near": false,
-   "vj": 0.2727272727272727
-  },
-  {
-   "a": "bench/repos/sqlite/src/main.c:4931",
-   "b": "bench/repos/sqlite/src/main.c:4935",
-   "repo": "sqlite",
    "structurally_near": false,
    "vj": 0.2727272727272727
   },
@@ -429,13 +457,6 @@
    "repo": "etcd",
    "structurally_near": false,
    "vj": 0.23076923076923078
-  },
-  {
-   "a": "bench/repos/sympy/sympy/core/function.py:1746",
-   "b": "bench/repos/sympy/sympy/simplify/hyperexpand.py:2254",
-   "repo": "sympy",
-   "structurally_near": false,
-   "vj": 0.21739130434782608
   },
   {
    "a": "bench/repos/minio/cmd/streaming-signature-v4.go:612",
@@ -511,13 +532,6 @@
    "a": "bench/repos/prometheus/config/config.go:159",
    "b": "bench/repos/prometheus/web/api/v1/translate_ast.go:181",
    "repo": "prometheus",
-   "structurally_near": false,
-   "vj": 0.2
-  },
-  {
-   "a": "bench/repos/sqlalchemy/lib/sqlalchemy/dialects/mssql/base.py:2132",
-   "b": "bench/repos/sqlalchemy/lib/sqlalchemy/orm/interfaces.py:1300",
-   "repo": "sqlalchemy",
    "structurally_near": false,
    "vj": 0.2
   },
@@ -634,6 +648,13 @@
    "vj": 0.175
   },
   {
+   "a": "bench/repos/redis/src/util.c:1254",
+   "b": "bench/repos/redis/src/util.c:342",
+   "repo": "redis",
+   "structurally_near": false,
+   "vj": 0.17142857142857143
+  },
+  {
    "a": "bench/repos/h2database/h2/src/main/org/h2/mvstore/type/ByteArrayDataType.java:24",
    "b": "bench/repos/h2database/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java:484",
    "repo": "h2database",
@@ -688,6 +709,13 @@
    "repo": "sympy",
    "structurally_near": false,
    "vj": 0.15306122448979592
+  },
+  {
+   "a": "bench/repos/tmux/tty-keys.c:1681",
+   "b": "bench/repos/tmux/tty-keys.c:1756",
+   "repo": "tmux",
+   "structurally_near": false,
+   "vj": 0.1504237288135593
   },
   {
    "a": "bench/repos/git/apply.c:593",
@@ -1068,6 +1096,13 @@
    "vj": 0.07692307692307693
   },
   {
+   "a": "bench/repos/sympy/sympy/physics/quantum/spin.py:2137",
+   "b": "bench/repos/sympy/sympy/plotting/textplot.py:41",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.07692307692307693
+  },
+  {
    "a": "bench/repos/delve/pkg/dwarf/line/line_parser.go:278",
    "b": "bench/repos/delve/pkg/locspec/locations.go:338",
    "repo": "delve",
@@ -1115,6 +1150,13 @@
    "repo": "packaging",
    "structurally_near": false,
    "vj": 0.05555555555555555
+  },
+  {
+   "a": "bench/repos/esbuild/internal/css_parser/css_parser.go:816",
+   "b": "bench/repos/esbuild/internal/css_parser/css_parser.go:928",
+   "repo": "esbuild",
+   "structurally_near": false,
+   "vj": 0.05454545454545454
   },
   {
    "a": "bench/repos/gin/path.go:155",
@@ -1201,11 +1243,25 @@
    "vj": 0.0425531914893617
   },
   {
+   "a": "bench/repos/sympy/sympy/parsing/sympy_parser.py:30",
+   "b": "bench/repos/sympy/sympy/utilities/iterables.py:2025",
+   "repo": "sympy",
+   "structurally_near": false,
+   "vj": 0.041666666666666664
+  },
+  {
    "a": "bench/repos/jest/packages/jest-diff/src/diffLines.ts:18",
    "b": "bench/repos/jest/packages/jest-snapshot/src/utils.ts:86",
    "repo": "jest",
    "structurally_near": false,
    "vj": 0.037037037037037035
+  },
+  {
+   "a": "bench/repos/prometheus/tsdb/chunks/head_chunks.go:414",
+   "b": "bench/repos/prometheus/util/documentcli/documentcli.go:208",
+   "repo": "prometheus",
+   "structurally_near": false,
+   "vj": 0.028846153846153848
   },
   {
    "a": "bench/repos/vim/src/ex_docmd.c:3579",
@@ -1260,6 +1316,6 @@
  "nose_version": "nose 0.5.0",
  "schema_version": "0.1.0",
  "structurally_near_vj_ge_0.7": 5,
- "under_merged_groups": 179,
- "what": "verify --leads merged per-repo: behavior-equal on the battery but fingerprint-split (modality A under-merge leads)"
+ "under_merged_groups": 187,
+ "what": "verify --leads merged per-repo: CONCRETE behavior-equal, fingerprint-split (modality A under-merge leads; symbolic behaviors excluded by design)"
 }

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -7,6 +7,7 @@ mod fnv;
 mod ignores;
 mod review;
 mod semantic_pack;
+mod verify_census;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -340,6 +341,12 @@ enum Cmd {
         /// (vj ≥ 0.7 are the strongest: structurally near AND behavior-equal).
         #[arg(long)]
         leads: Option<PathBuf>,
+        /// Write a JSON census of the units the oracle could NOT interpret — exclusion
+        /// reasons, the construct tags they carry, and how much fingerprint-merge mass
+        /// is unverified per construct. The instrument for ranking oracle-coverage work
+        /// by unverified-merge mass instead of by guess.
+        #[arg(long)]
+        exclusion_census: Option<PathBuf>,
     },
     /// EXPERIMENT (leaps 2+3): measure a behavioral-equivalence ACCEPTANCE gate — group
     /// interpretable units by their behavior on an input battery (two units are
@@ -1500,7 +1507,15 @@ fn run() -> Result<()> {
             json,
             max_violations,
             leads,
-        } => cmd_verify(paths, no_cfg_norm, json, max_violations, leads),
+            exclusion_census,
+        } => cmd_verify(
+            paths,
+            no_cfg_norm,
+            json,
+            max_violations,
+            leads,
+            exclusion_census,
+        ),
         Cmd::BehavioralGate {
             paths,
             manifest,
@@ -2119,6 +2134,7 @@ fn cmd_verify(
     json: bool,
     max_violations: Option<usize>,
     leads: Option<PathBuf>,
+    exclusion_census: Option<PathBuf>,
 ) -> Result<()> {
     let refs = paths_as_refs(&paths);
     let corpus = nose_frontend::lower_corpus_many(&refs);
@@ -2131,7 +2147,11 @@ fn cmd_verify(
     // battery is identical for every unit (a function uses only its first `arity`
     // inputs), so behavior vectors are always length-comparable.
     let battery = verify_battery(&verify_probes(&corpus));
-    let oracle = collect_verify_recs(&corpus, &opts, &battery);
+    let oracle = collect_verify_recs(&corpus, &opts, &battery, exclusion_census.is_some());
+    if let Some(path) = &exclusion_census {
+        verify_census::write_report(path, &oracle.census)?;
+        println!("exclusion census written to {}", path.display());
+    }
 
     if json {
         return print_verify_json(&oracle.recs);
@@ -2199,18 +2219,23 @@ struct VerifyOracle {
     total: usize,
     canon_checked: usize,
     canon_violations: Vec<String>,
+    /// Per-unit census records (outcome + construct tags), populated only when
+    /// the `--exclusion-census` instrument is requested.
+    census: Vec<verify_census::CensusUnit>,
 }
 
 fn collect_verify_recs(
     corpus: &Corpus,
     opts: &nose_normalize::NormalizeOptions,
     battery: &[Vec<nose_normalize::Value>],
+    census: bool,
 ) -> VerifyOracle {
     let mut oracle = VerifyOracle {
         recs: Vec::new(),
         total: 0,
         canon_checked: 0,
         canon_violations: Vec::new(),
+        census: Vec::new(),
     };
     let oracle_opts = nose_normalize::NormalizeOptions {
         oracle: true,
@@ -2222,9 +2247,41 @@ fn collect_verify_recs(
         // behavior-changing canon can't mask itself), matched to each fully-normalized
         // unit by source span.
         let core = nose_normalize::normalize(il, &corpus.interner, &oracle_opts);
-        collect_file_verify_recs(il, &n, &core, &corpus.interner, battery, &mut oracle);
+        collect_file_verify_recs(
+            il,
+            &n,
+            &core,
+            &corpus.interner,
+            battery,
+            &mut oracle,
+            census,
+        );
     }
     oracle
+}
+
+/// Record one unit's oracle outcome in the exclusion census (no-op unless the
+/// `--exclusion-census` instrument is on). `tag_il`/`tag_root` name the subtree
+/// the oracle would have interpreted (the core IL when span-matched, else the
+/// fully-normalized unit).
+fn push_verify_census(
+    oracle: &mut VerifyOracle,
+    enabled: bool,
+    loc: String,
+    tag_il: &nose_il::Il,
+    tag_root: nose_il::NodeId,
+    fp: &[u64],
+    reason: &'static str,
+) {
+    if !enabled {
+        return;
+    }
+    oracle.census.push(verify_census::CensusUnit {
+        loc,
+        reason,
+        fp: fp.to_vec(),
+        tags: verify_census::census_tags(tag_il, tag_root),
+    });
 }
 
 fn collect_file_verify_recs(
@@ -2234,6 +2291,7 @@ fn collect_file_verify_recs(
     interner: &Interner,
     battery: &[Vec<nose_normalize::Value>],
     oracle: &mut VerifyOracle,
+    census: bool,
 ) {
     let core_func = func_span_index(core);
     for u in &n.units {
@@ -2242,9 +2300,11 @@ fn collect_file_verify_recs(
             continue;
         }
         oracle.total += 1;
+        let loc = format!("{}:{}", il.meta.path, n.node(root).span.start_line);
         // The same function in the core IL (by span) — interpret THAT, not `n`.
         let span0 = n.node(root).span;
         let Some(&core_root) = core_func.get(&(span0.start_byte, span0.end_byte)) else {
+            push_verify_census(oracle, census, loc, n, root, &[], "no-core-span");
             continue;
         };
         // Soundness is about merges on the VALUE fingerprint. A unit whose value
@@ -2260,12 +2320,15 @@ fn collect_file_verify_recs(
         // firing, so a non-contract false merge is still exposed by the free battery.
         let (fp, contracts) = nose_normalize::value_fingerprint_and_contracts(n, root, interner);
         if fp.is_empty() {
+            push_verify_census(oracle, census, loc, n, root, &[], "empty-fp");
             continue;
         }
         // Run the battery; the unit is interpretable only if every input runs.
         let Some(beh) = run_battery(core, interner, core_root, battery, &contracts) else {
+            push_verify_census(oracle, census, loc, core, core_root, &fp, "battery-bail");
             continue;
         };
+        push_verify_census(oracle, census, loc, core, core_root, &fp, "interpretable");
         // Stricter canon check: the SAME function interpreted on the fully-normalized
         // IL must agree with the core IL on every input — else a canon pass changed
         // behavior. (Only when the full IL is itself fully interpretable on the battery.)

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -2332,13 +2332,20 @@ fn collect_file_verify_recs(
         // Stricter canon check: the SAME function interpreted on the fully-normalized
         // IL must agree with the core IL on every input — else a canon pass changed
         // behavior. (Only when the full IL is itself fully interpretable on the battery.)
+        // Canon preservation is judged on CONCRETE behaviors only: symbolic identity
+        // is keyed on syntax, and canonicalization legitimately rewrites syntax, so a
+        // Sym-bearing mismatch here is expected, not a behavior change.
         if let Some(full_beh) = run_battery(n, interner, root, battery, &contracts) {
-            oracle.canon_checked += 1;
-            if full_beh != beh && oracle.canon_violations.len() < 20 {
-                let s = n.node(root).span;
-                oracle
-                    .canon_violations
-                    .push(format!("{}:{}", il.meta.path, s.start_line));
+            let concrete = !beh.iter().any(nose_normalize::behavior_has_sym)
+                && !full_beh.iter().any(nose_normalize::behavior_has_sym);
+            if concrete {
+                oracle.canon_checked += 1;
+                if full_beh != beh && oracle.canon_violations.len() < 20 {
+                    let s = n.node(root).span;
+                    oracle
+                        .canon_violations
+                        .push(format!("{}:{}", il.meta.path, s.start_line));
+                }
             }
         }
         let span = n.node(root).span;
@@ -2393,8 +2400,13 @@ fn print_verify_json(recs: &[VerifyRec]) -> Result<()> {
 }
 
 /// Soundness: fingerprint-equal ⟹ behavior-equal. Prints the section and returns the
-/// false-merge count (the input to the `--max-violations` gate).
+/// HARD false-merge count (the input to the `--max-violations` gate). A disagreement
+/// where either behavior carries a symbolic value is reported separately as an
+/// ADVISORY lead: symbolic identity is keyed on pre-canon syntax, so a proof-backed
+/// canonicalization (AC ordering, distribution) can legitimately make two equivalent
+/// units' symbolic traces differ — those need a human look, not a red gate.
 fn report_verify_soundness(recs: &[VerifyRec]) -> usize {
+    let has_sym = |r: &VerifyRec| r.beh.iter().any(nose_normalize::behavior_has_sym);
     let mut by_fp: std::collections::HashMap<&[u64], Vec<&VerifyRec>> =
         std::collections::HashMap::new();
     for r in recs {
@@ -2402,6 +2414,7 @@ fn report_verify_soundness(recs: &[VerifyRec]) -> usize {
     }
     let mut fp_groups = 0usize;
     let mut violations: Vec<(String, String, usize)> = Vec::new();
+    let mut advisory: Vec<(String, String, usize)> = Vec::new();
     for members in by_fp.values() {
         if members.len() < 2 {
             continue;
@@ -2411,7 +2424,12 @@ fn report_verify_soundness(recs: &[VerifyRec]) -> usize {
         for r in &members[1..] {
             if r.beh != first.beh {
                 let diff = r.beh.iter().zip(&first.beh).filter(|(a, b)| a != b).count();
-                violations.push((first.loc.clone(), r.loc.clone(), diff));
+                let rec = (first.loc.clone(), r.loc.clone(), diff);
+                if has_sym(first) || has_sym(r) {
+                    advisory.push(rec);
+                } else {
+                    violations.push(rec);
+                }
             }
         }
     }
@@ -2424,6 +2442,16 @@ fn report_verify_soundness(recs: &[VerifyRec]) -> usize {
         println!("  [!] {n_violations} VIOLATION(S) (false merges):");
         for (a, b, d) in violations.iter().take(20) {
             println!("    {a}  ≡?  {b}   ({d} differing inputs)");
+        }
+    }
+    if !advisory.is_empty() {
+        advisory.sort();
+        println!(
+            "  advisory (symbolic-trace disagreements — review, not gated): {}",
+            advisory.len()
+        );
+        for (a, b, d) in advisory.iter().take(10) {
+            println!("    {a}  ≢?  {b}   ({d} differing inputs)");
         }
     }
     n_violations
@@ -2440,7 +2468,12 @@ fn report_verify_completeness(recs: &[VerifyRec], leads: Option<&std::path::Path
     let mut by_beh: std::collections::HashMap<&[nose_normalize::Behavior], Vec<&VerifyRec>> =
         std::collections::HashMap::new();
     for r in recs {
-        if !is_trivial_behavior(&r.beh) {
+        // Concrete behaviors only: symbolic equality says "same opaque operations on
+        // equal operands", which is too weak a witness for a MISSED-clone claim (two
+        // wrappers calling same-NAMED but different functions would coincide). The
+        // under-merge direction keeps its §BC meaning; symbolic coverage serves the
+        // soundness direction.
+        if !is_trivial_behavior(&r.beh) && !r.beh.iter().any(nose_normalize::behavior_has_sym) {
             by_beh.entry(&r.beh).or_default().push(r);
         }
     }

--- a/crates/nose-cli/src/verify_census.rs
+++ b/crates/nose-cli/src/verify_census.rs
@@ -1,0 +1,287 @@
+//! Research instrument for the oracle-completeness campaign: which IL constructs
+//! keep units OUT of the interpreter oracle, and how much fingerprint-merge mass
+//! is therefore unverified.
+//!
+//! `nose verify --exclusion-census <path>` records one [`CensusUnit`] per
+//! counted function unit — its oracle outcome, its value fingerprint, and the
+//! raw construct tags present in the subtree the oracle would interpret. The
+//! report then derives, per construct tag, how many units carrying it were
+//! excluded and how many fingerprint-equal pairs are unverified because at
+//! least one side was excluded.
+//!
+//! The census deliberately records raw tags (node kinds, builtin names, literal
+//! retention classes) for BOTH interpretable and excluded units rather than a
+//! hard-coded "unsupported construct" list: the interpreter's handled set
+//! drifts (experiments §BF), so the discriminating constructs are derived from
+//! the two populations at analysis time instead of asserted here.
+
+use anyhow::Result;
+use nose_il::{Il, NodeId, NodeKind, Payload};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::Path;
+
+/// One counted function unit's census record.
+pub(crate) struct CensusUnit {
+    pub(crate) loc: String,
+    /// `"interpretable"`, or the exclusion reason: `"battery-bail"`,
+    /// `"empty-fp"`, `"no-core-span"`.
+    pub(crate) reason: &'static str,
+    /// Value fingerprint (empty for `"empty-fp"` units).
+    pub(crate) fp: Vec<u64>,
+    /// Sorted construct tags present in the interpreted subtree.
+    pub(crate) tags: Vec<String>,
+}
+
+impl CensusUnit {
+    fn excluded(&self) -> bool {
+        self.reason != "interpretable"
+    }
+}
+
+/// The construct tags present in `root`'s subtree, sorted and deduplicated.
+///
+/// Tag vocabulary: `kind:<NodeKind>` for every node kind, refined for the two
+/// payload-sensitive kinds — calls become `builtin:<Builtin>` / `call:named` /
+/// `call:cid` / `call:other`, and literals tag only their *unretained* classes
+/// (`lit:unretained:<class>`), since retained literal values are interpretable.
+pub(crate) fn census_tags(il: &Il, root: NodeId) -> Vec<String> {
+    let mut tags: HashSet<String> = HashSet::new();
+    let mut stack = vec![root];
+    while let Some(x) = stack.pop() {
+        let node = il.node(x);
+        match node.kind {
+            NodeKind::Call => {
+                tags.insert(match node.payload {
+                    Payload::Builtin(b) => format!("builtin:{b:?}"),
+                    Payload::Name(_) => "call:named".to_string(),
+                    Payload::Cid(_) => "call:cid".to_string(),
+                    _ => "call:other".to_string(),
+                });
+            }
+            NodeKind::Lit => match node.payload {
+                Payload::LitInt(_) | Payload::LitBool(_) | Payload::LitStr(_) => {}
+                Payload::Lit(c) => {
+                    tags.insert(format!("lit:unretained:{c:?}"));
+                }
+                _ => {
+                    tags.insert("lit:other".to_string());
+                }
+            },
+            k => {
+                tags.insert(format!("kind:{k:?}"));
+            }
+        }
+        stack.extend(il.children(x).iter().copied());
+    }
+    let mut v: Vec<String> = tags.into_iter().collect();
+    v.sort();
+    v
+}
+
+#[derive(serde::Serialize)]
+struct TagRow {
+    tag: String,
+    interpretable_units: usize,
+    excluded_units: usize,
+    /// Fingerprint-equal pairs with ≥1 excluded side, attributed to every tag
+    /// present in an excluded member of the group (multi-attributed by design —
+    /// a pair is unverified because of *all* the constructs that kept its
+    /// members out, and the ranking question is "which construct, if covered,
+    /// touches the most unverified mass").
+    unverified_pairs: usize,
+    example_excluded: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+struct CensusReport {
+    units_total: usize,
+    interpretable_units: usize,
+    excluded_by_reason: BTreeMap<String, usize>,
+    /// Fingerprint-equal pair mass: `verified` pairs had both sides interpreted
+    /// by the oracle; `unverified` pairs carry no behavioral check at all.
+    merge_pairs: MergePairs,
+    /// Per-construct rows, sorted by unverified mass (the campaign order).
+    tags: Vec<TagRow>,
+}
+
+#[derive(serde::Serialize)]
+struct MergePairs {
+    total: usize,
+    verified: usize,
+    unverified: usize,
+}
+
+fn pairs(n: usize) -> usize {
+    n * (n - 1) / 2
+}
+
+fn build_report(units: &[CensusUnit]) -> CensusReport {
+    let mut excluded_by_reason: BTreeMap<String, usize> = BTreeMap::new();
+    let mut tag_interp: HashMap<&str, usize> = HashMap::new();
+    let mut tag_excl: HashMap<&str, usize> = HashMap::new();
+    let mut tag_examples: HashMap<&str, Vec<&str>> = HashMap::new();
+    for u in units {
+        if u.excluded() {
+            *excluded_by_reason.entry(u.reason.to_string()).or_default() += 1;
+        }
+        for t in &u.tags {
+            if u.excluded() {
+                *tag_excl.entry(t).or_default() += 1;
+                tag_examples.entry(t).or_default().push(&u.loc);
+            } else {
+                *tag_interp.entry(t).or_default() += 1;
+            }
+        }
+    }
+
+    let mut by_fp: HashMap<&[u64], Vec<&CensusUnit>> = HashMap::new();
+    for u in units {
+        if !u.fp.is_empty() {
+            by_fp.entry(&u.fp).or_default().push(u);
+        }
+    }
+    let mut merge = MergePairs {
+        total: 0,
+        verified: 0,
+        unverified: 0,
+    };
+    let mut tag_unverified: HashMap<&str, usize> = HashMap::new();
+    for group in by_fp.values() {
+        if group.len() < 2 {
+            continue;
+        }
+        let interp = group.iter().filter(|u| !u.excluded()).count();
+        let (total, verified) = (pairs(group.len()), pairs(interp));
+        merge.total += total;
+        merge.verified += verified;
+        let unverified = total - verified;
+        if unverified == 0 {
+            continue;
+        }
+        merge.unverified += unverified;
+        let mut group_tags: HashSet<&str> = HashSet::new();
+        for u in group.iter().filter(|u| u.excluded()) {
+            group_tags.extend(u.tags.iter().map(String::as_str));
+        }
+        for t in group_tags {
+            *tag_unverified.entry(t).or_default() += unverified;
+        }
+    }
+
+    let all_tags: HashSet<&str> = tag_interp.keys().chain(tag_excl.keys()).copied().collect();
+    let mut rows: Vec<TagRow> = all_tags
+        .into_iter()
+        .map(|t| {
+            let mut examples: Vec<&str> = tag_examples.get(t).cloned().unwrap_or_default();
+            examples.sort_unstable();
+            examples.truncate(3);
+            TagRow {
+                tag: t.to_string(),
+                interpretable_units: tag_interp.get(t).copied().unwrap_or(0),
+                excluded_units: tag_excl.get(t).copied().unwrap_or(0),
+                unverified_pairs: tag_unverified.get(t).copied().unwrap_or(0),
+                example_excluded: examples.into_iter().map(str::to_string).collect(),
+            }
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        b.unverified_pairs
+            .cmp(&a.unverified_pairs)
+            .then(b.excluded_units.cmp(&a.excluded_units))
+            .then(a.tag.cmp(&b.tag))
+    });
+
+    CensusReport {
+        units_total: units.len(),
+        interpretable_units: units.iter().filter(|u| !u.excluded()).count(),
+        excluded_by_reason,
+        merge_pairs: merge,
+        tags: rows,
+    }
+}
+
+/// Write the exclusion-census JSON report. Deterministic: every list is sorted
+/// on stable keys, so the file is byte-identical across runs and thread counts.
+pub(crate) fn write_report(path: &Path, units: &[CensusUnit]) -> Result<()> {
+    let report = build_report(units);
+    std::fs::write(path, serde_json::to_string_pretty(&report)?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nose_il::{Builtin, FileId, FileMeta, IlBuilder, Lang, Span};
+
+    fn unit(loc: &str, reason: &'static str, fp: Vec<u64>, tags: &[&str]) -> CensusUnit {
+        CensusUnit {
+            loc: loc.to_string(),
+            reason,
+            fp,
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn report_counts_unverified_merge_mass_per_tag() {
+        // fp group {a,b,c}: a interpretable, b/c excluded → 3 pairs, 0 verified.
+        // fp group {d,e}: both interpretable → 1 pair, verified.
+        let units = vec![
+            unit("a.py:1", "interpretable", vec![1, 2], &["kind:Loop"]),
+            unit(
+                "b.py:1",
+                "battery-bail",
+                vec![1, 2],
+                &["kind:Loop", "call:named"],
+            ),
+            unit("c.py:9", "battery-bail", vec![1, 2], &["builtin:Len"]),
+            unit("d.py:1", "interpretable", vec![3], &["kind:Loop"]),
+            unit("e.py:1", "interpretable", vec![3], &["kind:Loop"]),
+            unit("f.py:1", "empty-fp", vec![], &["kind:Raw"]),
+        ];
+        let r = build_report(&units);
+        assert_eq!(r.units_total, 6);
+        assert_eq!(r.interpretable_units, 3);
+        assert_eq!(r.excluded_by_reason["battery-bail"], 2);
+        assert_eq!(r.excluded_by_reason["empty-fp"], 1);
+        assert_eq!(r.merge_pairs.total, 4);
+        assert_eq!(r.merge_pairs.verified, 1);
+        assert_eq!(r.merge_pairs.unverified, 3);
+        let row = |tag: &str| r.tags.iter().find(|t| t.tag == tag).unwrap();
+        // All 3 unverified pairs touch an excluded member carrying each tag.
+        assert_eq!(row("call:named").unverified_pairs, 3);
+        assert_eq!(row("builtin:Len").unverified_pairs, 3);
+        assert_eq!(row("kind:Loop").unverified_pairs, 3);
+        assert_eq!(row("kind:Loop").interpretable_units, 3);
+        assert_eq!(row("kind:Loop").excluded_units, 1);
+        assert_eq!(row("kind:Raw").unverified_pairs, 0);
+        assert_eq!(row("call:named").example_excluded, vec!["b.py:1"]);
+    }
+
+    #[test]
+    fn census_tags_refine_calls_and_skip_retained_literals() {
+        let sp = Span::synthetic(FileId(0));
+        let mut b = IlBuilder::new(FileId(0));
+        let s = b.add(NodeKind::Lit, Payload::LitStr(0xABCD), sp, &[]);
+        let call = b.add(NodeKind::Call, Payload::Builtin(Builtin::Len), sp, &[s]);
+        let ret = b.add(NodeKind::Return, Payload::None, sp, &[call]);
+        let func = b.add(NodeKind::Func, Payload::None, sp, &[ret]);
+        let il = b.finish(
+            func,
+            FileMeta {
+                path: "census.rs".into(),
+                lang: Lang::Rust,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        let tags = census_tags(&il, func);
+        assert!(tags.contains(&"builtin:Len".to_string()));
+        assert!(tags.contains(&"kind:Return".to_string()));
+        assert!(tags.contains(&"kind:Func".to_string()));
+        // The retained string literal contributes no tag.
+        assert!(!tags.iter().any(|t| t.starts_with("lit:")));
+        // The call node is refined, never a bare kind tag.
+        assert!(!tags.contains(&"kind:Call".to_string()));
+    }
+}

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -45,6 +45,92 @@ pub enum Value {
     /// A runtime error (type mismatch, out-of-range, divide-by-zero). This is itself
     /// observable behavior — two equivalent programs err on the same inputs.
     Err,
+    /// A SYMBOLIC value: the result of an operation the interpreter cannot execute —
+    /// an opaque (unproven/unadmitted) call, an unproven field read, or any
+    /// composition over such a value — identified by a stable structural hash of the
+    /// operation and its operand values. This is a *differential convention*, not a
+    /// semantics claim: two runs produce the same `Sym` iff they performed the same
+    /// opaque operation on equal operands, in the same observable order (opaque calls
+    /// are also recorded in the effect trace). Control flow is never guessed:
+    /// branching on a `Sym` (truthiness, loop bounds, iteration) still bails the
+    /// unit. Because symbolic identity is keyed on pre-canonicalization syntax, a
+    /// behavior containing a `Sym` must never feed the hard SOUND gate — the verify
+    /// report routes Sym-bearing disagreements to a separate advisory lane.
+    Sym(u64),
+}
+
+/// Stable hash of a runtime value (deterministic: `FxHasher` carries no random
+/// state), used to compose symbolic identities.
+fn vhash(v: &Value) -> u64 {
+    hashed(v)
+}
+
+/// Stable structural signature of an IL subtree: pre-order over (kind, payload,
+/// child count), with `Name` symbols resolved through the interner so the signature
+/// does not depend on interner-local symbol ids. Used as the identity of an opaque
+/// callee/operation. Cids are alpha-renamed in declaration order, so fingerprint-equal
+/// units assign matching cids and their opaque signatures stay comparable.
+fn subtree_sig(il: &Il, interner: &Interner, root: NodeId) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = rustc_hash::FxHasher::default();
+    let mut stack = vec![root];
+    while let Some(x) = stack.pop() {
+        let n = il.node(x);
+        n.kind.hash(&mut h);
+        match n.payload {
+            Payload::Name(s) => {
+                0xF00Du64.hash(&mut h);
+                interner.resolve(s).hash(&mut h);
+            }
+            p => p.hash(&mut h),
+        }
+        let kids = il.children(x);
+        kids.len().hash(&mut h);
+        stack.extend(kids.iter().rev().copied());
+    }
+    h.finish()
+}
+
+/// Fold a tagged sequence of operand hashes into one symbolic identity.
+fn sym_id(tag: u64, parts: &[u64]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = rustc_hash::FxHasher::default();
+    tag.hash(&mut h);
+    for p in parts {
+        p.hash(&mut h);
+    }
+    h.finish()
+}
+
+/// Stable hash of any hashable tag (operator, builtin, contract).
+fn hashed<T: std::hash::Hash>(t: &T) -> u64 {
+    use std::hash::Hasher;
+    let mut h = rustc_hash::FxHasher::default();
+    t.hash(&mut h);
+    h.finish()
+}
+
+/// Does this behavior carry any symbolic value? Sym-bearing behaviors are
+/// comparable under the differential convention, but a disagreement involving one
+/// must never feed the hard SOUND gate: symbolic identity is keyed on pre-canon
+/// syntax, so a proof-backed canonicalization (e.g. AC ordering) can legitimately
+/// make two equivalent units' symbolic traces differ.
+pub fn behavior_has_sym(b: &Behavior) -> bool {
+    contains_sym(&b.ret)
+        || b.effects.iter().any(contains_sym)
+        || b.fields.iter().any(|(_, v)| contains_sym(v))
+}
+
+/// Does the value contain a `Sym` anywhere (including inside lists)? Concrete
+/// operations must never run over a hidden symbolic operand — `sum([f(x)])`
+/// collapsing to a concrete `Err` would launder unknownness into the hard
+/// soundness lane. Every composition guard uses this DEEP check.
+fn contains_sym(v: &Value) -> bool {
+    match v {
+        Value::Sym(_) => true,
+        Value::List(xs) => xs.iter().any(contains_sym),
+        _ => false,
+    }
 }
 
 /// A receiver identity proven by the IL shape during interpretation.
@@ -283,7 +369,7 @@ impl<'a> Interp<'a> {
                 if matches!(cond, Value::Err) {
                     return Ok(Flow::Err);
                 }
-                if truthy(&cond) {
+                if truthy(&cond).ok_or(Unsupported)? {
                     if let Some(&t) = kids.get(1) {
                         return self.exec(t, env);
                     }
@@ -317,7 +403,7 @@ impl<'a> Interp<'a> {
                     if matches!(c, Value::Err) {
                         return Ok(Flow::Err); // type error in the loop test → Err behavior
                     }
-                    if !truthy(&c) {
+                    if !truthy(&c).ok_or(Unsupported)? {
                         break;
                     }
                     match self.exec(kids[1], env)? {
@@ -365,7 +451,7 @@ impl<'a> Interp<'a> {
                     if matches!(c, Value::Err) {
                         return Ok(Flow::Err);
                     }
-                    if !truthy(&c) {
+                    if !truthy(&c).ok_or(Unsupported)? {
                         break;
                     }
                     match self.exec(kids[3], env)? {
@@ -513,18 +599,31 @@ impl<'a> Interp<'a> {
                 let Some(&receiver) = self.il.children(node).first() else {
                     return Err(Unsupported);
                 };
-                if self.field_receiver_errored(receiver, env)? {
+                // Proven self-field reads keep their concrete store semantics; an
+                // UNWRITTEN self-field reads its (symbolic) initial state.
+                if let Some(key) = self.exact_field_key(node) {
+                    if self.field_receiver_errored(receiver, env)? {
+                        return Ok(Value::Err);
+                    }
+                    return match self.fields.get(&key) {
+                        Some(v) => Ok(v.clone()),
+                        None => Ok(Value::Sym(sym_id(0x00F1_E1D0, &[key.field]))),
+                    };
+                }
+                // Any other field read is a symbolic projection keyed by the field
+                // name and the receiver VALUE (pure-read convention, applied to both
+                // sides of a merge alike).
+                let Payload::Name(field) = n.payload else {
+                    return Err(Unsupported);
+                };
+                let rv = self.eval(receiver, env)?;
+                if matches!(rv, Value::Err) {
                     return Ok(Value::Err);
                 }
-                match n.payload {
-                    Payload::Name(_) => {
-                        let Some(key) = self.exact_field_key(node) else {
-                            return Err(Unsupported);
-                        };
-                        self.fields.get(&key).cloned().ok_or(Unsupported)
-                    }
-                    _ => Err(Unsupported),
-                }
+                Ok(Value::Sym(sym_id(
+                    0x00F1_E1D1,
+                    &[hashed(&self.interner.resolve(field)), vhash(&rv)],
+                )))
             }
             NodeKind::If => {
                 // ternary expression
@@ -538,7 +637,7 @@ impl<'a> Interp<'a> {
                 if matches!(c, Value::Err) {
                     return Ok(Value::Err);
                 }
-                if truthy(&c) {
+                if truthy(&c).ok_or(Unsupported)? {
                     self.eval(kids[1], env)
                 } else {
                     self.eval(kids[2], env)
@@ -571,18 +670,22 @@ impl<'a> Interp<'a> {
         // Err'd and a value-or never converged with its ternary — an oracle bug.)
         let a = self.eval(kids[0], env)?;
         if matches!(op, Op::Or) {
-            return Ok(if matches!(a, Value::Err) || truthy(&a) {
-                a
-            } else {
-                self.eval(kids[1], env)?
-            });
+            return Ok(
+                if matches!(a, Value::Err) || truthy(&a).ok_or(Unsupported)? {
+                    a
+                } else {
+                    self.eval(kids[1], env)?
+                },
+            );
         }
         if matches!(op, Op::And) {
-            return Ok(if matches!(a, Value::Err) || !truthy(&a) {
-                a
-            } else {
-                self.eval(kids[1], env)?
-            });
+            return Ok(
+                if matches!(a, Value::Err) || !truthy(&a).ok_or(Unsupported)? {
+                    a
+                } else {
+                    self.eval(kids[1], env)?
+                },
+            );
         }
         if matches!(a, Value::Err) {
             return Ok(Value::Err);
@@ -604,6 +707,9 @@ impl<'a> Interp<'a> {
         if matches!(idx, Value::Err) {
             return Ok(Value::Err);
         }
+        if contains_sym(&base) || contains_sym(&idx) {
+            return Ok(Value::Sym(sym_id(0x1DEF_00D0, &[vhash(&base), vhash(&idx)])));
+        }
         match (base, idx) {
             (Value::List(xs), Value::Int(i)) => {
                 let i = if i < 0 { i + xs.len() as i64 } else { i };
@@ -618,10 +724,11 @@ impl<'a> Interp<'a> {
             Payload::Builtin(b) => b,
             _ => return self.eval_user_call(node, env), // self-recursion, else opaque
         };
-        if !admitted_builtin_semantics_at_call(self.il, node, b) {
-            return Err(Unsupported);
-        }
         let kids = self.il.children(node).to_vec();
+        if !admitted_builtin_semantics_at_call(self.il, node, b) {
+            // Unproven builtin spelling: an opaque, identified operation — not a bail.
+            return self.opaque_call(sym_id(0xCA11_B170, &[hashed(&b)]), &kids, env);
+        }
         let mut args = Vec::new();
         let profile = builtin_demand_profile(b);
         let demand = profile.demand_effect_profile();
@@ -638,7 +745,8 @@ impl<'a> Interp<'a> {
                 return self.eval_value_or_default_call(&kids, env);
             }
             (_, BuiltinDemandProfile::Eager { contract }) => contract,
-            _ => return Err(Unsupported),
+            // Admitted but unmodeled demand profile: opaque, identified by the builtin.
+            _ => return self.opaque_call(sym_id(0xCA11_B170, &[hashed(&b)]), &kids, env),
         };
         for &k in &kids {
             let arg = self.eval(k, env)?;
@@ -655,6 +763,14 @@ impl<'a> Interp<'a> {
         eager_contract: EagerBuiltinContract,
         args: Vec<Value>,
     ) -> R<Value> {
+        // A symbolic operand anywhere (including inside a list) makes the result
+        // symbolic — the concrete arms below must never see one, or unknownness
+        // would launder into a concrete `Err`.
+        if args.iter().any(contains_sym) {
+            let mut parts = vec![hashed(&format!("{eager_contract:?}"))];
+            parts.extend(args.iter().map(vhash));
+            return Ok(Value::Sym(sym_id(0x00EA_9E12, &parts)));
+        }
         match eager_contract {
             EagerBuiltinContract::Len => match args.first() {
                 Some(Value::List(xs)) => Ok(Value::Int(xs.len() as i64)),
@@ -746,6 +862,18 @@ impl<'a> Interp<'a> {
         if matches!(value, Value::Err) {
             return Ok(Value::Err);
         }
+        // Null-ness of a top-level Sym is unknown: compose symbolically (the default
+        // is evaluated eagerly under the same convention on both sides of a merge).
+        if matches!(value, Value::Sym(_)) {
+            let d = match kids.get(1) {
+                Some(&default) => self.eval(default, env)?,
+                None => Value::Null,
+            };
+            if matches!(d, Value::Err) {
+                return Ok(Value::Err);
+            }
+            return Ok(Value::Sym(sym_id(0x9015_4E11, &[vhash(&value), vhash(&d)])));
+        }
         if matches!(value, Value::Null) {
             return match kids.get(1) {
                 Some(&default) => self.eval(default, env),
@@ -760,10 +888,42 @@ impl<'a> Interp<'a> {
     /// caller, then bound to a fresh callee frame; effects, field state, and step budget are
     /// shared so recursion stays ordered and bounded. Every unproven or ambiguous call remains
     /// unsupported rather than guessed.
+    /// An opaque call: the callee's semantics are unknown, but its IDENTITY and its
+    /// argument values are not. Evaluate the arguments left-to-right (an `Err` argument
+    /// propagates, as for every call), produce the symbolic application value, and
+    /// RECORD it in the effect trace — an unknown callee may observably act, and call
+    /// order is behavior. Both sides of a fingerprint merge see the same convention,
+    /// so symbolic traces stay comparable; Sym-bearing disagreements are routed to the
+    /// advisory lane by the verify report, never the hard SOUND gate.
+    fn opaque_call(
+        &mut self,
+        ident: u64,
+        args: &[NodeId],
+        env: &mut FxHashMap<u32, Value>,
+    ) -> R<Value> {
+        let mut parts = vec![ident];
+        for &a in args {
+            let v = self.eval(a, env)?;
+            if matches!(v, Value::Err) {
+                return Ok(Value::Err);
+            }
+            parts.push(vhash(&v));
+        }
+        let sym = Value::Sym(sym_id(0x0CA1_1E55, &parts));
+        self.effects.push(sym.clone());
+        Ok(sym)
+    }
+
     fn eval_user_call(&mut self, node: NodeId, env: &mut FxHashMap<u32, Value>) -> R<Value> {
         let kids = self.il.children(node).to_vec();
-        kids.first().ok_or(Unsupported)?;
-        let target = self.proven_call_target(node).ok_or(Unsupported)?;
+        let &callee = kids.first().ok_or(Unsupported)?;
+        let Some(target) = self.proven_call_target(node) else {
+            // Unproven/ambiguous target: an opaque call identified by the callee's
+            // structural signature (pre-canon syntax — fingerprint-equal units have
+            // matching alpha-renamed cids, so signatures stay comparable).
+            let ident = subtree_sig(self.il, self.interner, callee);
+            return self.opaque_call(ident, &kids[1..], env);
+        };
         // Evaluate the arguments in the CURRENT frame (call-by-value), left to right.
         let mut argv = Vec::with_capacity(kids.len().saturating_sub(1));
         for &a in &kids[1..] {
@@ -822,6 +982,18 @@ impl<'a> Interp<'a> {
             Some(&t) => match self.eval(t, env)? {
                 Value::List(xs) => xs,
                 Value::Err => return Ok(Value::Err),
+                v if contains_sym(&v) => {
+                    // append over an unknown collection: compose, do not launder to Err
+                    let mut parts = vec![vhash(&v)];
+                    for &k in kids.iter().skip(1) {
+                        let item = self.eval(k, env)?;
+                        if matches!(item, Value::Err) {
+                            return Ok(Value::Err);
+                        }
+                        parts.push(vhash(&item));
+                    }
+                    return Ok(Value::Sym(sym_id(0x00A9_9E4D, &parts)));
+                }
                 _ => return Ok(Value::Err),
             },
             None => return Ok(Value::Err),
@@ -905,6 +1077,15 @@ impl<'a> Interp<'a> {
     ) -> R<Value> {
         let coll = match self.eval(*kids.first().ok_or(Unsupported)?, env)? {
             Value::List(xs) => xs,
+            v if contains_sym(&v) => {
+                let mut parts = vec![u64::from(all), vhash(&v)];
+                parts.extend(
+                    kids.iter()
+                        .skip(1)
+                        .map(|&k| subtree_sig(self.il, self.interner, k)),
+                );
+                return Ok(Value::Sym(sym_id(0x0A11_A4E0, &parts)));
+            }
             _ => return Ok(Value::Err),
         };
         let pred = kids
@@ -918,7 +1099,7 @@ impl<'a> Interp<'a> {
             if matches!(v, Value::Err) {
                 return Ok(Value::Err);
             }
-            let t = truthy(&v);
+            let t = truthy(&v).ok_or(Unsupported)?;
             // short-circuit: `any` stops at the first truthy, `all` at the first falsy.
             if all != t {
                 return Ok(Value::Bool(t));
@@ -935,6 +1116,17 @@ impl<'a> Interp<'a> {
         let lambda = kids[0];
         let seq = match self.eval(kids[1], env)? {
             Value::List(xs) => xs,
+            v if contains_sym(&v) => {
+                let mut parts = vec![subtree_sig(self.il, self.interner, lambda), vhash(&v)];
+                if let Some(&i) = kids.get(2) {
+                    let init = self.eval(i, env)?;
+                    if matches!(init, Value::Err) {
+                        return Ok(Value::Err);
+                    }
+                    parts.push(vhash(&init));
+                }
+                return Ok(Value::Sym(sym_id(0x04ED_0CE0, &parts)));
+            }
             _ => return Ok(Value::Err),
         };
         let mut it = seq.into_iter();
@@ -968,6 +1160,15 @@ impl<'a> Interp<'a> {
         }
         let coll = match self.eval(kids[0], env)? {
             Value::List(xs) => xs,
+            v if contains_sym(&v) => {
+                let mut parts = vec![hashed(&kind), vhash(&v)];
+                parts.extend(
+                    kids.iter()
+                        .skip(1)
+                        .map(|&k| subtree_sig(self.il, self.interner, k)),
+                );
+                return Ok(Value::Sym(sym_id(0x040F_5E90, &parts)));
+            }
             _ => return Ok(Value::Err),
         };
         let f = kids[1];
@@ -1012,7 +1213,7 @@ impl<'a> Interp<'a> {
                     if matches!(keep, Value::Err) {
                         return Ok(Value::Err);
                     }
-                    if truthy(&keep) {
+                    if truthy(&keep).ok_or(Unsupported)? {
                         out.push(x);
                     }
                 }
@@ -1107,14 +1308,17 @@ fn op_of(p: Payload) -> Op {
     }
 }
 
-fn truthy(v: &Value) -> bool {
-    match v {
+/// Concrete truthiness; `None` for a symbolic value. Control flow is never guessed
+/// from a `Sym` — every branching caller must bail (`Unsupported`) on `None`.
+fn truthy(v: &Value) -> Option<bool> {
+    Some(match v {
         Value::Bool(b) => *b,
         Value::Int(i) => *i != 0,
         Value::List(xs) => !xs.is_empty(),
         Value::Str(v) => !v.is_empty(),
         Value::Null | Value::Err => false,
-    }
+        Value::Sym(_) => return None,
+    })
 }
 
 fn fold_ints(v: Option<&Value>, init: i64, f: impl Fn(i64, i64) -> i64) -> Value {
@@ -1222,6 +1426,13 @@ fn range_values(args: &[Value]) -> R<Value> {
 
 fn bin(op: Op, a: &Value, b: &Value) -> Value {
     use Value::{Bool, Int};
+    // Symbolic composition: an operation over an unknown value is itself unknown,
+    // keyed by (operator, operand identities). Never collapses to Bool/Err —
+    // comparisons over `Sym` stay symbolic (`f(x) == f(x)` is NOT provably true for
+    // an impure callee), and branching on the result bails at the truthiness gate.
+    if contains_sym(a) || contains_sym(b) {
+        return Value::Sym(sym_id(0x00B1_0911, &[hashed(&op), vhash(a), vhash(b)]));
+    }
     match (a, b) {
         (Int(x), Int(y)) => match op {
             Op::Add => Int(x.wrapping_add(*y)),
@@ -1306,6 +1517,9 @@ fn bin(op: Op, a: &Value, b: &Value) -> Value {
 }
 
 fn un(op: Op, a: &Value) -> Value {
+    if contains_sym(a) {
+        return Value::Sym(sym_id(0x0004_0911, &[hashed(&op), vhash(a)]));
+    }
     match (op, a) {
         // `wrapping_neg` (not `-i`) so negating `i64::MIN` wraps to `i64::MIN` instead of
         // panicking on overflow — consistent with the wrapping binary arithmetic above.
@@ -1317,7 +1531,8 @@ fn un(op: Op, a: &Value) -> Value {
         // `Bool(true)` while the direct `a>b` gave `Err`, making the SOUND comparison-
         // negation canon (`!(a<=b) ≡ a>b`, a total order) look like a false merge.
         (Op::Not, Value::Err) => Value::Err,
-        (Op::Not, _) => Value::Bool(!truthy(a)),
+        // Operand is concrete here — the symbolic arm above intercepts `Sym`.
+        (Op::Not, _) => truthy(a).map_or(Value::Err, |b| Value::Bool(!b)),
         _ => Value::Err,
     }
 }
@@ -1628,7 +1843,7 @@ mod tests {
     }
 
     #[test]
-    fn builtin_calls_require_admission_for_oracle_execution() {
+    fn unadmitted_builtin_calls_become_identified_symbolic_effects() {
         let sp = Span::synthetic(FileId(0));
         let mut b = IlBuilder::new(FileId(0));
         let one = b.add(NodeKind::Lit, Payload::LitInt(1), sp, &[]);
@@ -1646,8 +1861,13 @@ mod tests {
             Vec::new(),
         );
 
+        // Without admission the call no longer bails the unit: it interprets to a
+        // SYMBOLIC value, recorded in the effect trace (an unknown callee may act).
         let interner = Interner::new();
-        assert!(run_unit(&il, &interner, func, &[]).is_none());
+        let beh = run_unit(&il, &interner, func, &[]).expect("symbolic run");
+        assert!(matches!(beh.ret, Value::Sym(_)));
+        assert_eq!(beh.effects, vec![beh.ret.clone()]);
+        // The admitted run keeps its CONCRETE semantics — and differs from symbolic.
         assert_eq!(
             run_admitted_unit(il, func, &[]).expect("admitted run").ret,
             Value::Int(1)
@@ -3258,7 +3478,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_same_name_self_call_without_target_evidence_is_unsupported() {
+    fn unproven_call_becomes_symbolic_application_keyed_by_callee() {
         let sp = Span::synthetic(FileId(0));
         let mut b = IlBuilder::new(FileId(0));
         let interner = Interner::new();
@@ -3282,7 +3502,126 @@ mod tests {
             Vec::new(),
         );
 
+        // No call-target evidence: the call is OPAQUE, not a bail — a symbolic
+        // application keyed by the callee's structural signature, effect-recorded.
+        let beh = run_unit(&il, &interner, func, &[]).expect("symbolic run");
+        assert!(matches!(beh.ret, Value::Sym(_)));
+        assert_eq!(beh.effects, vec![beh.ret.clone()]);
+    }
+
+    /// Build `fn() { return <name>(<litint arg>) }` with an unproven callee.
+    fn opaque_call_behavior(name: &str, arg: i64, interner: &Interner) -> Behavior {
+        let sp = Span::synthetic(FileId(0));
+        let mut b = IlBuilder::new(FileId(0));
+        let callee = b.add(NodeKind::Var, Payload::Name(interner.intern(name)), sp, &[]);
+        let a = b.add(NodeKind::Lit, Payload::LitInt(arg), sp, &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp, &[callee, a]);
+        let ret = b.add(NodeKind::Return, Payload::None, sp, &[call]);
+        let body = b.add(NodeKind::Block, Payload::None, sp, &[ret]);
+        let func = b.add(NodeKind::Func, Payload::None, sp, &[body]);
+        let il = b.finish(
+            func,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        run_unit(&il, interner, func, &[]).expect("symbolic run")
+    }
+
+    #[test]
+    fn symbolic_application_is_differential_same_call_equal_else_distinct() {
+        let interner = Interner::new();
+        // Same callee + same argument: behaviors agree (the convention is comparable).
+        assert_eq!(
+            opaque_call_behavior("f", 3, &interner),
+            opaque_call_behavior("f", 3, &interner)
+        );
+        // Different callee name or different argument: behaviors differ.
+        assert_ne!(
+            opaque_call_behavior("f", 3, &interner),
+            opaque_call_behavior("g", 3, &interner)
+        );
+        assert_ne!(
+            opaque_call_behavior("f", 3, &interner),
+            opaque_call_behavior("f", 4, &interner)
+        );
+    }
+
+    /// Two opaque calls in sequence: swapping their order swaps the effect trace —
+    /// call order stays observable behavior under the symbolic convention.
+    #[test]
+    fn opaque_call_order_is_observable() {
+        let interner = Interner::new();
+        let build = |first: &str, second: &str| {
+            let sp = Span::synthetic(FileId(0));
+            let mut b = IlBuilder::new(FileId(0));
+            let stmt = |name: &str, b: &mut IlBuilder| {
+                let callee = b.add(NodeKind::Var, Payload::Name(interner.intern(name)), sp, &[]);
+                let call = b.add(NodeKind::Call, Payload::None, sp, &[callee]);
+                b.add(NodeKind::ExprStmt, Payload::None, sp, &[call])
+            };
+            let s1 = stmt(first, &mut b);
+            let s2 = stmt(second, &mut b);
+            let body = b.add(NodeKind::Block, Payload::None, sp, &[s1, s2]);
+            let func = b.add(NodeKind::Func, Payload::None, sp, &[body]);
+            let il = b.finish(
+                func,
+                FileMeta {
+                    path: "t".into(),
+                    lang: Lang::Python,
+                },
+                Vec::new(),
+                Vec::new(),
+            );
+            run_unit(&il, &interner, func, &[]).expect("symbolic run")
+        };
+        assert_eq!(build("f", "g"), build("f", "g"));
+        assert_ne!(build("f", "g"), build("g", "f"));
+    }
+
+    /// Branching on a symbolic value still bails the unit — control flow is never guessed.
+    #[test]
+    fn branch_on_symbolic_value_bails() {
+        let interner = Interner::new();
+        let sp = Span::synthetic(FileId(0));
+        let mut b = IlBuilder::new(FileId(0));
+        let callee = b.add(NodeKind::Var, Payload::Name(interner.intern("f")), sp, &[]);
+        let call = b.add(NodeKind::Call, Payload::None, sp, &[callee]);
+        let t = b.add(NodeKind::Lit, Payload::LitInt(1), sp, &[]);
+        let e = b.add(NodeKind::Lit, Payload::LitInt(2), sp, &[]);
+        let ternary = b.add(NodeKind::If, Payload::None, sp, &[call, t, e]);
+        let ret = b.add(NodeKind::Return, Payload::None, sp, &[ternary]);
+        let body = b.add(NodeKind::Block, Payload::None, sp, &[ret]);
+        let func = b.add(NodeKind::Func, Payload::None, sp, &[body]);
+        let il = b.finish(
+            func,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
         assert!(run_unit(&il, &interner, func, &[]).is_none());
+    }
+
+    /// A symbolic operand inside a concrete operation must stay symbolic — collapsing
+    /// `len([f(x)])`-shaped compositions to a concrete `Err` would launder unknownness
+    /// into the hard soundness lane.
+    #[test]
+    fn symbolic_operand_never_launders_to_concrete_err() {
+        let s = Value::Sym(7);
+        assert!(matches!(bin(Op::Add, &Value::Int(1), &s), Value::Sym(_)));
+        assert!(matches!(bin(Op::Eq, &s, &s), Value::Sym(_)));
+        assert!(matches!(un(Op::Not, &s), Value::Sym(_)));
+        assert!(matches!(
+            un(Op::Neg, &Value::List(vec![s.clone()])),
+            Value::Sym(_)
+        ));
+        assert!(contains_sym(&Value::List(vec![Value::Int(1), s])));
     }
 
     /// `g(x) = x*x` and `f(x) = g(x) + 1` in one file — running `f(3)` must interpret the

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -708,7 +708,10 @@ impl<'a> Interp<'a> {
             return Ok(Value::Err);
         }
         if contains_sym(&base) || contains_sym(&idx) {
-            return Ok(Value::Sym(sym_id(0x1DEF_00D0, &[vhash(&base), vhash(&idx)])));
+            return Ok(Value::Sym(sym_id(
+                0x1DEF_00D0,
+                &[vhash(&base), vhash(&idx)],
+            )));
         }
         match (base, idx) {
             (Value::List(xs), Value::Int(i)) => {

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -32,7 +32,7 @@ mod recursion;
 mod value_graph;
 
 pub use commutative::{node_tag, node_tag_valued, subtree_hashes};
-pub use interp::{run_unit, Behavior, Value};
+pub use interp::{behavior_has_sym, run_unit, Behavior, Value};
 pub use value_graph::{
     value_anchors, value_fingerprint, value_fingerprint_and_contracts, value_fingerprint_contracts,
     value_fingerprint_lits, value_fingerprint_lits_anchors, value_fingerprint_lits_anchors_laws,

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1004,3 +1004,40 @@ merged into `bench/labels/oracle_under_merge_leads_2026_06_10.json` — **179
 behavior-equal fingerprint-split groups, 5 structurally near (vj ≥ 0.7)**, e.g.
 nginx's `http` vs `stream` geo modules and sympy's `matrices/common` vs `matrixbase`
 duplicates — oracle-proven missed clones, the strongest convergence leads available.
+
+### BL.1 — uninterpreted symbolic values: the census-ordered extension, measured
+
+The campaign's first move (the census's #1 and #2 targets at once): opaque calls and
+unproven field reads now interpret as **identified symbolic values** instead of bailing
+the unit. An opaque call evaluates its arguments, yields `Sym(callee-signature ⊕
+argument values)`, and records itself in the ordered effect trace; field reads become
+symbolic projections; every composition (bin/un/index/eager builtins/HoF/reduce/append/
+nullish) keeps symbolic operands symbolic via a deep `contains_sym` guard — never
+laundering unknownness into a concrete `Err` — and control flow over a `Sym` still
+bails. The convention is differential: same opaque operations on equal operands in the
+same order ⟹ equal traces. Because symbolic identity keys on pre-canon syntax, a
+Sym-bearing disagreement goes to a new **advisory lane**, never the hard SOUND gate;
+canon preservation and the completeness/leads direction stay concrete-only (a symbolic
+behavior-equality is too weak a missed-clone witness).
+
+Same sharded corpus pass (104 repos, raylib #208 excluded), before → after
+(`oracle_exclusion_census_2026_06_10.json` → `…_post_symbolic_2026_06_10.json`):
+
+| | baseline | symbolic | Δ |
+|---|---:|---:|---|
+| interpretable units | 26,382 (4.5%) | **173,874 (29.4%)** | ×6.6 |
+| oracle-verified merge pairs | 316,677 (9.2%) | **1,077,871 (31.3%)** | ×3.4 |
+| unverified merge mass | 90.8% | **68.7%** | −22.1pp |
+
+The advisory lane surfaced **1,276** symbolic-trace disagreements to review (expected:
+AC-canonicalized operand order legitimately differs pre-canon). The hard lane is *not*
+clean — and that is a pre-existing finding, not a symbolic artifact: 17 repos flag
+fingerprint-equal pairs with concretely different behavior (e.g. `black`'s
+try/import-wrapper colliding with `return self` on a degenerate 2-node fingerprint),
+reproducing identically on the pre-symbolic binary and on `origin/main` back to at
+least 517ad5c. Filed as #210 (the exact channel is protected by `exact_safe`; the
+`near` value-accept path is exposed). The remaining census leaders after this round:
+`lit:unretained:Other` stays product-irrelevant (lossy-lowered), and the residual
+battery-bail mass concentrates in branch-on-symbolic units (`kind:If` excl-share 92%) —
+i.e. the next coverage unit is symbolic-condition path exploration, a much harder,
+deliberately-not-taken step (control flow is never guessed).

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -960,3 +960,47 @@ left" verdict. Below vj 0.8 (true different-algorithm Type-4) this arm is blind 
 construction; that frontier remains unmeasured and would need a behavior- or
 embedding-based candidate source — recorded as the arm's known limit, not claimed
 covered.
+
+## BL. Oracle exclusion census — the real-corpus completeness baseline, by construct
+
+§BC measured the oracle's *behavioral recall* on a synthetic corpus (64.9%); what the
+soundness campaign actually needed was the **real-corpus inventory**: how much of the
+fingerprint-merge surface carries no behavioral verification at all, and *which IL
+constructs* keep units out of the interpreter. `nose verify --exclusion-census`
+(`crates/nose-cli/src/verify_census.rs`) records every counted function unit's oracle
+outcome, fingerprint, and raw construct tags — for excluded AND interpretable
+populations, deriving the discriminating constructs at analysis time instead of
+hard-coding an "unsupported" list that would rot when lowerings change (the §BF
+durability lesson). Run per repo (merge pairs counted within a repo, matching how scans
+run) and merged by `bench/labels/merge_exclusion_census.py`; artifact
+`bench/labels/oracle_exclusion_census_2026_06_10.json` (104 repos; `raylib` excluded —
+verify does not finish on it in useful time, #208).
+
+**Baseline.** 591,469 function units; **26,382 interpretable (4.5%)** — 526,660
+battery-bail, 38,427 empty-fingerprint. Of 3,444,062 within-repo fingerprint-equal
+pairs, **316,677 (9.2%) are oracle-verified; 3,127,385 (90.8%) carry no behavioral
+check**. (Upper bound on the product surface: the census sees verify-side units, not
+the detector's `exact_safe` gate, so some unverified mass can never reach the exact
+channel anyway — stated limitation, not a correction we can compute here.)
+
+**Discriminating constructs** (excl-share ≥ 98%, ≥ 1k excluded units, by unverified
+mass): `call:other` — calls that are neither admitted builtins nor named/cid calls —
+dominates at **481k excluded units / 1.71M unverified pairs**, followed by
+`kind:Field` reads (420k / 1.30M), statement shapes riding on them (`ExprStmt`, `If`,
+`UnOp`, `Throw`, `Lambda`, `Try`), and `lit:unretained:Other` — only 8.7k units but
+**925k unverified pairs** (the generated-twin clusters; those units are lossy-lowered
+and `exact_safe = false` product-side, so they are *low* campaign value despite the
+mass).
+
+**Campaign order this fixes:** (1) uninterpreted-function handling for opaque calls
+and field reads — evaluate them as symbolic applications/projections recorded in the
+ordered effect trace, rather than bailing the whole unit; structure-keyed, so it
+survives lowering drift (§BF). (2) Statement coverage that rides on it (Throw/Try).
+(3) Deprioritize unretained-literal units: their merges are already outside the exact
+channel.
+
+Side product (modality A for the detection campaign): the per-repo `--leads` pass
+merged into `bench/labels/oracle_under_merge_leads_2026_06_10.json` — **179
+behavior-equal fingerprint-split groups, 5 structurally near (vj ≥ 0.7)**, e.g.
+nginx's `http` vs `stream` geo modules and sympy's `matrices/common` vs `matrixbase`
+duplicates — oracle-proven missed clones, the strongest convergence leads available.


### PR DESCRIPTION
## What

The complete #193 campaign — measure first, then extend where the measurement points. Closes #193.

**Tranche 1 — instrument + baseline** (`verify --exclusion-census`, `merge_exclusion_census.py`, dated artifacts): per-construct inventory of what keeps units out of the interpreter oracle and how much fingerprint-merge mass is unverified. Real-corpus baseline (104 repos; raylib excluded → #208): **4.5% of 591,469 function units interpretable; 90.8% of 3.44M fingerprint-equal pairs carry no behavioral check**; dominant causes: opaque calls (481k excluded units), unproven field reads (420k). Context corrections recorded on the issue (the 64.9% §BC figure was synthetic-corpus; §BD already measured-and-rejected the "maps first" guess).

**Tranche 2 — uninterpreted symbolic values** (the census's #1+#2 targets): opaque calls and field reads now interpret as identified `Sym` values — argument-evaluated, effect-trace-recorded (call order stays observable) — instead of bailing the unit. Composition guards (bin/un/index/eager builtins/HoF/reduce/append/nullish) keep symbolic operands symbolic via a deep `contains_sym` check so unknownness never launders into a concrete `Err`; control flow over a `Sym` still bails. Sym-bearing disagreements route to a new **advisory lane**, never the hard SOUND gate (symbolic identity keys on pre-canon syntax, so proof-backed canons can legitimately reorder operands); canon-preservation and the completeness/leads direction stay concrete-only. Property tests pin the contract (differential equality, order observability, branch bail, no laundering).

## Result (same sharded pass, before → after)

| | baseline | symbolic |
|---|---:|---:|
| interpretable units | 26,382 (4.5%) | **173,874 (29.4%)** |
| oracle-verified merge pairs | 316,677 (9.2%) | **1,077,871 (31.3%)** |
| unverified merge mass | 90.8% | **68.7%** |

Advisory lane: 1,276 symbolic-trace disagreements to review. Modality-A side product: 187 concrete under-merge groups (5 at vj ≥ 0.7 — nginx http↔stream geo modules, sympy matrices twins).

**Found by the instrument:** the hard lane is not clean on main — 17 repos flag concrete fingerprint-equal/behavior-different pairs (degenerate 2-node fingerprints merging try/import wrappers with identity functions). Provably pre-existing (reproduces on pre-symbolic binary and origin/main back to ≥ 517ad5c); filed as **#210** with severity analysis (`exact_safe` protects the exact channel; the near value-accept path is exposed).

Workspace 914 + CLI 154 tests green, clippy clean, new unit/property tests included. Experiments §BL + §BL.1; both dated artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
