### PR TITLE
[codex] Bound raylib verify oracle work

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -12,6 +12,7 @@ mod verify_census;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use nose_il::{Corpus, FileId, Interner, Lang};
+use rayon::prelude::*;
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -324,8 +325,9 @@ enum Cmd {
         #[arg(long)]
         no_cfg_norm: bool,
         /// Emit interpretable units as JSON `{units:[{file,start_line,end_line,
-        /// behavior,trivial}]}` (the oracle's behavioral ground truth) instead of the
-        /// soundness/completeness report. Used by the value-add evaluator.
+        /// behavior,trivial}], exclusions:{...}}` (the oracle's behavioral ground truth
+        /// plus fail-closed exclusion counts) instead of the soundness/completeness report.
+        /// Used by the value-add evaluator.
         #[arg(long)]
         json: bool,
         /// CI soundness gate: exit non-zero if the false-merge count EXCEEDS this budget.
@@ -1659,6 +1661,14 @@ fn run_review_cmd(cmd: Cmd) -> Result<()> {
 /// number of rows (the behavior-vector length must be arity-independent — two
 /// fingerprint-equal units can differ in arity, e.g. constant functions).
 const VERIFY_WIDTH: usize = 4;
+/// Verify is a bounded oracle, not a stress test for every generated/parser-vendored
+/// mega-function. Cap per-unit battery work before building the value fingerprint or
+/// interpreting rows; units above the cap are reported as `battery-bail` and excluded.
+const VERIFY_BATTERY_NODE_ROW_BUDGET: usize = 384_000; // 2k IL nodes * 192 standard rows.
+
+fn verify_battery_over_budget(tokens: usize, battery_rows: usize) -> bool {
+    tokens.saturating_mul(battery_rows) > VERIFY_BATTERY_NODE_ROW_BUDGET
+}
 
 fn verify_battery(probes: &[nose_normalize::Value]) -> Vec<Vec<nose_normalize::Value>> {
     use nose_normalize::Value;
@@ -2154,7 +2164,7 @@ fn cmd_verify(
     }
 
     if json {
-        return print_verify_json(&oracle.recs);
+        return print_verify_json(&oracle);
     }
 
     println!("=== value-graph oracle (soundness + completeness) ===");
@@ -2164,6 +2174,7 @@ fn cmd_verify(
         oracle.recs.len(),
         oracle.total - oracle.recs.len()
     );
+    print_verify_exclusions(&oracle.exclusions);
 
     // --- Canon preservation: full-normalize behavior must equal pre-canon core behavior. ---
     println!("\nCANON PRESERVATION — normalization preserves behavior:");
@@ -2210,6 +2221,78 @@ struct VerifyRec {
     loc: String,
 }
 
+#[derive(Clone, Copy)]
+enum VerifyExclusionReason {
+    CoreMissing,
+    BatteryBail,
+    EmptyFingerprint,
+    Uninterpretable,
+}
+
+impl VerifyExclusionReason {
+    fn label(self) -> &'static str {
+        match self {
+            VerifyExclusionReason::CoreMissing => "core-missing",
+            VerifyExclusionReason::BatteryBail => "battery-bail",
+            VerifyExclusionReason::EmptyFingerprint => "empty-fingerprint",
+            VerifyExclusionReason::Uninterpretable => "uninterpretable",
+        }
+    }
+}
+
+struct VerifyExcludedUnit {
+    reason: VerifyExclusionReason,
+    file: String,
+    start: u32,
+    end: u32,
+    tokens: usize,
+}
+
+#[derive(Default)]
+struct VerifyExclusions {
+    core_missing: usize,
+    battery_bail: usize,
+    empty_fingerprint: usize,
+    uninterpretable: usize,
+    units: Vec<VerifyExcludedUnit>,
+}
+
+impl VerifyExclusions {
+    fn record(
+        &mut self,
+        reason: VerifyExclusionReason,
+        file: &str,
+        span: nose_il::Span,
+        tokens: usize,
+    ) {
+        match reason {
+            VerifyExclusionReason::CoreMissing => self.core_missing += 1,
+            VerifyExclusionReason::BatteryBail => self.battery_bail += 1,
+            VerifyExclusionReason::EmptyFingerprint => self.empty_fingerprint += 1,
+            VerifyExclusionReason::Uninterpretable => self.uninterpretable += 1,
+        }
+        self.units.push(VerifyExcludedUnit {
+            reason,
+            file: file.to_string(),
+            start: span.start_line,
+            end: span.end_line,
+            tokens,
+        });
+    }
+
+    fn append(&mut self, other: VerifyExclusions) {
+        self.core_missing += other.core_missing;
+        self.battery_bail += other.battery_bail;
+        self.empty_fingerprint += other.empty_fingerprint;
+        self.uninterpretable += other.uninterpretable;
+        self.units.extend(other.units);
+    }
+
+    fn total(&self) -> usize {
+        self.core_missing + self.battery_bail + self.empty_fingerprint + self.uninterpretable
+    }
+}
+
 /// The oracle's interpretation pass: every interpretable unit's record, plus the
 /// CANON PRESERVATION tallies — a stricter, pair-free soundness check: does the full
 /// normalization pipeline preserve each unit's behavior vs the pre-canon core IL? A
@@ -2222,6 +2305,7 @@ struct VerifyOracle {
     /// Per-unit census records (outcome + construct tags), populated only when
     /// the `--exclusion-census` instrument is requested.
     census: Vec<verify_census::CensusUnit>,
+    exclusions: VerifyExclusions,
 }
 
 fn collect_verify_recs(
@@ -2230,32 +2314,67 @@ fn collect_verify_recs(
     battery: &[Vec<nose_normalize::Value>],
     census: bool,
 ) -> VerifyOracle {
+    let oracle_opts = nose_normalize::NormalizeOptions {
+        oracle: true,
+        ..*opts
+    };
+    let per_file: Vec<_> = corpus
+        .files
+        .par_iter()
+        .map(|il| {
+            let n = nose_normalize::normalize(il, &corpus.interner, opts);
+            // The behavioral ground truth comes from the pre-canonicalization core IL (so a
+            // behavior-changing canon can't mask itself), matched to each fully-normalized
+            // unit by source span.
+            let core = nose_normalize::normalize(il, &corpus.interner, &oracle_opts);
+            let mut oracle = VerifyOracle {
+                recs: Vec::new(),
+                total: 0,
+                canon_checked: 0,
+                canon_violations: Vec::new(),
+                census: Vec::new(),
+                exclusions: VerifyExclusions::default(),
+            };
+            let func_count = n
+                .units
+                .iter()
+                .filter(|u| n.kind(u.root) == nose_il::NodeKind::Func)
+                .count();
+            let value_context = (func_count > 1)
+                .then(|| nose_normalize::ValueFingerprintContext::new(&n, &corpus.interner));
+            collect_file_verify_recs(
+                &n,
+                &core,
+                value_context.as_ref(),
+                &corpus.interner,
+                battery,
+                &mut oracle,
+                census,
+            );
+            oracle
+        })
+        .collect();
+
     let mut oracle = VerifyOracle {
         recs: Vec::new(),
         total: 0,
         canon_checked: 0,
         canon_violations: Vec::new(),
         census: Vec::new(),
+        exclusions: VerifyExclusions::default(),
     };
-    let oracle_opts = nose_normalize::NormalizeOptions {
-        oracle: true,
-        ..*opts
-    };
-    for il in &corpus.files {
-        let n = nose_normalize::normalize(il, &corpus.interner, opts);
-        // The behavioral ground truth comes from the pre-canonicalization core IL (so a
-        // behavior-changing canon can't mask itself), matched to each fully-normalized
-        // unit by source span.
-        let core = nose_normalize::normalize(il, &corpus.interner, &oracle_opts);
-        collect_file_verify_recs(
-            il,
-            &n,
-            &core,
-            &corpus.interner,
-            battery,
-            &mut oracle,
-            census,
-        );
+    for mut file_oracle in per_file {
+        oracle.total += file_oracle.total;
+        oracle.canon_checked += file_oracle.canon_checked;
+        oracle.recs.append(&mut file_oracle.recs);
+        oracle.census.append(&mut file_oracle.census);
+        oracle
+            .canon_violations
+            .append(&mut file_oracle.canon_violations);
+        if oracle.canon_violations.len() > 20 {
+            oracle.canon_violations.truncate(20);
+        }
+        oracle.exclusions.append(file_oracle.exclusions);
     }
     oracle
 }
@@ -2285,14 +2404,15 @@ fn push_verify_census(
 }
 
 fn collect_file_verify_recs(
-    il: &nose_il::Il,
     n: &nose_il::Il,
     core: &nose_il::Il,
+    value_context: Option<&nose_normalize::ValueFingerprintContext>,
     interner: &Interner,
     battery: &[Vec<nose_normalize::Value>],
     oracle: &mut VerifyOracle,
     census: bool,
 ) {
+    let file_path = &n.meta.path;
     let core_func = func_span_index(core);
     for u in &n.units {
         let root = u.root;
@@ -2300,13 +2420,24 @@ fn collect_file_verify_recs(
             continue;
         }
         oracle.total += 1;
-        let loc = format!("{}:{}", il.meta.path, n.node(root).span.start_line);
+        let loc = format!("{}:{}", file_path, n.node(root).span.start_line);
         // The same function in the core IL (by span) — interpret THAT, not `n`.
         let span0 = n.node(root).span;
+        let tokens = subtree_node_count(n, root);
         let Some(&core_root) = core_func.get(&(span0.start_byte, span0.end_byte)) else {
             push_verify_census(oracle, census, loc, n, root, &[], "no-core-span");
+            oracle
+                .exclusions
+                .record(VerifyExclusionReason::CoreMissing, file_path, span0, tokens);
             continue;
         };
+        if verify_battery_over_budget(tokens, battery.len()) {
+            oracle
+                .exclusions
+                .record(VerifyExclusionReason::BatteryBail, file_path, span0, tokens);
+            push_verify_census(oracle, census, loc, core, core_root, &[], "battery-bail");
+            continue;
+        }
         // Soundness is about merges on the VALUE fingerprint. A unit whose value
         // graph is EMPTY (`fn resumed() {}`, or a body the graph captures nothing of)
         // has no value fingerprint to merge on — the detector keys candidates on
@@ -2318,14 +2449,31 @@ fn collect_file_verify_recs(
         // binds n = len(array) so the oracle interprets `f(xs,n)` under the same
         // convention the value graph used to merge it; gated on the contract actually
         // firing, so a non-contract false merge is still exposed by the free battery.
-        let (fp, contracts) = nose_normalize::value_fingerprint_and_contracts(n, root, interner);
+        let (fp, contracts) = match value_context {
+            Some(context) => nose_normalize::value_fingerprint_and_contracts_with_context(
+                n, root, interner, context,
+            ),
+            None => nose_normalize::value_fingerprint_and_contracts(n, root, interner),
+        };
         if fp.is_empty() {
             push_verify_census(oracle, census, loc, n, root, &[], "empty-fp");
+            oracle.exclusions.record(
+                VerifyExclusionReason::EmptyFingerprint,
+                file_path,
+                span0,
+                tokens,
+            );
             continue;
         }
         // Run the battery; the unit is interpretable only if every input runs.
         let Some(beh) = run_battery(core, interner, core_root, battery, &contracts) else {
             push_verify_census(oracle, census, loc, core, core_root, &fp, "battery-bail");
+            oracle.exclusions.record(
+                VerifyExclusionReason::Uninterpretable,
+                file_path,
+                span0,
+                tokens,
+            );
             continue;
         };
         push_verify_census(oracle, census, loc, core, core_root, &fp, "interpretable");
@@ -2344,7 +2492,7 @@ fn collect_file_verify_recs(
                     let s = n.node(root).span;
                     oracle
                         .canon_violations
-                        .push(format!("{}:{}", il.meta.path, s.start_line));
+                        .push(format!("{}:{}", file_path, s.start_line));
                 }
             }
         }
@@ -2352,11 +2500,11 @@ fn collect_file_verify_recs(
         oracle.recs.push(VerifyRec {
             fp,
             beh,
-            file: il.meta.path.clone(),
+            file: file_path.to_string(),
             start: span.start_line,
             end: span.end_line,
-            tokens: subtree_node_count(n, root),
-            loc: format!("{}:{}", il.meta.path, span.start_line),
+            tokens,
+            loc: format!("{}:{}", file_path, span.start_line),
         });
     }
 }
@@ -2378,8 +2526,9 @@ fn subtree_node_count(il: &nose_il::Il, root: nose_il::NodeId) -> usize {
 /// battery) and whether that behavior is trivial (constant / all-Err — coincidental,
 /// not evidence of a real clone). The evaluator groups by behavior to form gold clone
 /// pairs, then scores jscpd and nose against them on equal footing.
-fn print_verify_json(recs: &[VerifyRec]) -> Result<()> {
-    let recs_json: Vec<_> = recs
+fn print_verify_json(oracle: &VerifyOracle) -> Result<()> {
+    let recs_json: Vec<_> = oracle
+        .recs
         .iter()
         .map(|r| {
             serde_json::json!({
@@ -2392,11 +2541,48 @@ fn print_verify_json(recs: &[VerifyRec]) -> Result<()> {
             })
         })
         .collect();
+    let excluded_json: Vec<_> = oracle
+        .exclusions
+        .units
+        .iter()
+        .map(|u| {
+            serde_json::json!({
+                "file": u.file,
+                "start_line": u.start,
+                "end_line": u.end,
+                "tokens": u.tokens,
+                "reason": u.reason.label(),
+            })
+        })
+        .collect();
     println!(
         "{}",
-        serde_json::to_string(&serde_json::json!({ "units": recs_json }))?
+        serde_json::to_string(&serde_json::json!({
+            "units": recs_json,
+            "exclusions": {
+                "core-missing": oracle.exclusions.core_missing,
+                "battery-bail": oracle.exclusions.battery_bail,
+                "empty-fingerprint": oracle.exclusions.empty_fingerprint,
+                "uninterpretable": oracle.exclusions.uninterpretable,
+            },
+            "excluded_units": excluded_json,
+        }))?
     );
     Ok(())
+}
+
+fn print_verify_exclusions(exclusions: &VerifyExclusions) {
+    if exclusions.total() == 0 {
+        return;
+    }
+    println!("\nEXCLUSIONS — fail-closed units by reason:");
+    println!("  core-missing: {}", exclusions.core_missing);
+    println!(
+        "  battery-bail: {} (>{} node-rows)",
+        exclusions.battery_bail, VERIFY_BATTERY_NODE_ROW_BUDGET
+    );
+    println!("  empty-fingerprint: {}", exclusions.empty_fingerprint);
+    println!("  uninterpretable: {}", exclusions.uninterpretable);
 }
 
 /// Soundness: fingerprint-equal ⟹ behavior-equal. Prints the section and returns the
@@ -4427,6 +4613,22 @@ mod tests {
             abstraction_witness: None,
             semantic_laws: Vec::new(),
         }
+    }
+
+    #[test]
+    fn verify_battery_budget_is_node_row_bounded() {
+        assert!(
+            !verify_battery_over_budget(2_000, 192),
+            "the documented 2k x 192-row boundary stays inside the verify budget"
+        );
+        assert!(
+            verify_battery_over_budget(2_001, 192),
+            "one node beyond the boundary fails closed as battery-bail"
+        );
+        assert!(
+            !verify_battery_over_budget(6_000, 1),
+            "large units are allowed when the battery is tiny"
+        );
     }
 
     #[test]

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -108,6 +108,48 @@ fn invalid_exclude_glob_fails_clearly() {
 }
 
 #[test]
+fn verify_json_reports_battery_bail_exclusions() {
+    let dir = std::env::temp_dir().join(format!("nose_verify_bail_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    let mut src = String::from("int huge(int x) {\n  int s = 0;\n");
+    for i in 0..700 {
+        src.push_str(&format!("  s = s + x + {i};\n"));
+    }
+    src.push_str("  return s;\n}\n\nint tiny(int x) {\n  return x + 1;\n}\n");
+    fs::write(dir.join("huge.c"), src).unwrap();
+
+    let out = run(&["verify", dir.to_str().unwrap(), "--json"]);
+    let json: serde_json::Value = serde_json::from_str(&out).expect("verify JSON");
+    assert_eq!(
+        json["exclusions"]["battery-bail"], 1,
+        "oversized unit should fail closed into battery-bail: {out}"
+    );
+    assert!(
+        json["excluded_units"]
+            .as_array()
+            .expect("excluded_units")
+            .iter()
+            .any(|unit| unit["reason"] == "battery-bail"
+                && unit["file"]
+                    .as_str()
+                    .is_some_and(|file| file.ends_with("huge.c"))),
+        "battery-bail unit should be named in excluded_units: {out}"
+    );
+    assert!(
+        json["units"]
+            .as_array()
+            .expect("units")
+            .iter()
+            .any(|unit| unit["file"]
+                .as_str()
+                .is_some_and(|file| file.ends_with("huge.c"))),
+        "small sibling function in the same file should still be verified: {out}"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn min_value_filters_low_value_families() {
     let dir = make_project("minval");
     let p = dir.to_str().unwrap();

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -34,7 +34,8 @@ mod value_graph;
 pub use commutative::{node_tag, node_tag_valued, subtree_hashes};
 pub use interp::{behavior_has_sym, run_unit, Behavior, Value};
 pub use value_graph::{
-    value_anchors, value_fingerprint, value_fingerprint_and_contracts, value_fingerprint_contracts,
+    value_anchors, value_fingerprint, value_fingerprint_and_contracts,
+    value_fingerprint_and_contracts_with_context, value_fingerprint_contracts,
     value_fingerprint_lits, value_fingerprint_lits_anchors, value_fingerprint_lits_anchors_laws,
     value_fingerprint_lits_anchors_laws_with_context, value_fingerprint_lits_anchors_with_context,
     value_fingerprint_lits_with_context, Anchor, Anchors, FingerprintBundle, FingerprintLawBundle,

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -43,7 +43,8 @@ mod state;
 mod stdlib;
 
 pub use api::{
-    value_anchors, value_fingerprint, value_fingerprint_and_contracts, value_fingerprint_contracts,
+    value_anchors, value_fingerprint, value_fingerprint_and_contracts,
+    value_fingerprint_and_contracts_with_context, value_fingerprint_contracts,
     value_fingerprint_lits, value_fingerprint_lits_anchors, value_fingerprint_lits_anchors_laws,
     value_fingerprint_lits_anchors_laws_with_context, value_fingerprint_lits_anchors_with_context,
     value_fingerprint_lits_with_context, Anchor, Anchors, FingerprintBundle, FingerprintLawBundle,

--- a/crates/nose-normalize/src/value_graph/api.rs
+++ b/crates/nose-normalize/src/value_graph/api.rs
@@ -136,6 +136,22 @@ pub fn value_fingerprint_and_contracts(
 ) -> (Vec<u64>, Vec<(u32, u32)>) {
     let mut b = Builder::new(il, interner);
     b.build_unit(root);
+    finish_fingerprint_contracts(b)
+}
+
+/// Context-shared variant of [`value_fingerprint_and_contracts`].
+pub fn value_fingerprint_and_contracts_with_context(
+    il: &Il,
+    root: NodeId,
+    interner: &Interner,
+    context: &ValueFingerprintContext,
+) -> (Vec<u64>, Vec<(u32, u32)>) {
+    let mut b = Builder::new(il, interner).with_context(context);
+    b.build_unit_with_context(root, Some(context));
+    finish_fingerprint_contracts(b)
+}
+
+fn finish_fingerprint_contracts(mut b: Builder<'_>) -> (Vec<u64>, Vec<(u32, u32)>) {
     let fp = b.fingerprint_lits().0;
     b.contracts.sort_unstable();
     b.contracts.dedup();

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -51,7 +51,9 @@ an input battery and flags any fingerprint-equal pair whose behavior differs. It
 the *pre-canonicalization* IL (so a behavior-changing canon can't mask itself), and a
 **canon-preservation** check requires each unit's core-IL behavior to equal its full-IL
 behavior. The core canonicalizations are additionally machine-checked in Lean (`formal/`).
-Both currently report **zero** violations.
+Both currently report **zero** violations on the characterized gates. `verify` is bounded:
+units whose estimated work (`IL nodes × battery rows`) exceeds the oracle budget fail closed as
+`battery-bail` and appear in the exclusion census instead of monopolizing the run.
 
 ```sh
 nose verify bench/repos   # SOUND / canon PRESERVED, + a completeness ratio

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1041,3 +1041,28 @@ least 517ad5c. Filed as #210 (the exact channel is protected by `exact_safe`; th
 battery-bail mass concentrates in branch-on-symbolic units (`kind:If` excl-share 92%) —
 i.e. the next coverage unit is symbolic-condition path exploration, a much harder,
 deliberately-not-taken step (control flow is never guessed).
+
+### BL.2 — raylib verify budget: bound the oracle, don't hang it
+
+Issue #208 exposed a verify-only performance path: `nose verify bench/repos/raylib` exceeded a
+120s local timeout even though normal scanning completed. Sampling showed two costs compounding:
+the oracle rebuilt file-level value-graph context for every unit, then ran the full input battery
+against large C functions.
+
+The fix mirrors detector extraction by sharing one `ValueFingerprintContext` per file and adds a
+unit work cap before value fingerprinting or interpretation. A unit whose
+`IL node count × battery rows > 384000` is excluded as `battery-bail`; this is a fail-closed
+coverage loss, not a guessed equivalence.
+
+Measured on 2026-06-10 against local raylib:
+
+| command | before | after |
+|---|---:|---:|
+| `nose verify bench/repos/raylib` | >120s timeout | 62.8s |
+
+The after run on top of the symbolic-oracle baseline reported 8182 total units, 1735
+interpretable units, and 18 oversized `battery-bail` exclusions. It also surfaced two
+pre-existing value-fingerprint false-merge leads and one
+canon-preservation lead in raylib; #208 intentionally does not mask them with exclusions because
+the product semantic scan did not report those targeted pairs, and the point of `verify` is to
+make such soundness leads visible once the oracle is tractable.


### PR DESCRIPTION
## Summary

- share `ValueFingerprintContext` across `nose verify` units in the same file
- add a bounded per-unit verify work cap and report oversized units as `battery-bail`
- expose verify exclusion counts in human and JSON output, while preserving `--exclusion-census`
- document the raylib measurement and bounded-oracle policy

## Root Cause

`nose verify` rebuilt file-level value-graph context for every unit and then attempted the full behavior battery on very large C functions. On raylib that turned the oracle into a long-running path before it could produce any exclusion census.

## Validation

- `cargo test -p nose-normalize`
- `cargo test -p nose-cli`
- `./scripts/check-ci-local.sh`
- `target/release/nose verify /Users/ak/prjs/cc/nose/bench/repos/raylib` completes in 62.8s locally on top of the symbolic-oracle baseline, reporting `battery-bail: 18`

Note: now that raylib verify completes, it exposes two existing value-fingerprint false-merge leads and one canon-preservation lead in raylib. This PR does not mask those as exclusions; targeted product semantic scans do not report the two false-merge pairs.

Fixes #208
