### PR TITLE
[codex] Record near default-surface experiment

### DIFF
--- a/bench/labels/README.md
+++ b/bench/labels/README.md
@@ -58,6 +58,13 @@ over-approximated classification of whether generalized sub-DAG matching or one-
 pure inlining could recover it. The measured verdict and method are recorded in
 [`docs/experiments.md`](../../docs/experiments.md) §BJ.
 
+`near_default_surface_experiment.py` +
+`near_default_surface_2026_06_10.json` price the product decision of adding the
+`near` channel to the default scan surface. The script compares default,
+`syntax,semantic,near`, and two thresholded `near` arms on v5 P@10, worthy-recall,
+and default-surface family-count deltas. The decision record is in
+[`docs/experiments.md`](../../docs/experiments.md) §BM.
+
 `merge_exclusion_census.py` + `oracle_exclusion_census_2026_06_10.json` +
 `oracle_under_merge_leads_2026_06_10.json` are the oracle-completeness campaign's
 baseline: per-construct inventory of units the interpreter oracle cannot check (and the
@@ -73,4 +80,10 @@ essential: they tell you whether a per-language difference is real or noise.
 
 ```sh
 python3 bench/labels/eval_by_language.py
+```
+
+Pass `--mode` to compare a non-default channel mix without editing the script:
+
+```sh
+python3 bench/labels/eval_by_language.py --mode syntax,semantic,near
 ```

--- a/bench/labels/eval_by_language.py
+++ b/bench/labels/eval_by_language.py
@@ -9,7 +9,9 @@ infrastructure that tells us whether a per-language number is trustworthy at the
 current label count.
 
 Usage: python3 bench/labels/eval_by_language.py
+       python3 bench/labels/eval_by_language.py --mode syntax,semantic,near
 """
+import argparse
 import importlib.util
 import json
 import random
@@ -64,6 +66,25 @@ def scan_families(stdout):
     return payload
 
 
+def split_modes(raw_modes):
+    modes = []
+    for raw in raw_modes or []:
+        modes.extend(part.strip() for part in raw.split(",") if part.strip())
+    return modes
+
+
+def scan_repo(repo, *, mode=None, cache_dir=None, top=1000000, timeout=300):
+    cmd = [str(NOSE), "scan", str(repo), "--format", "json", "--top", str(top)]
+    modes = split_modes([mode] if mode else [])
+    if modes:
+        cmd += ["--mode", ",".join(modes)]
+    if cache_dir:
+        cmd += ["--cache-dir", str(cache_dir)]
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True, timeout=timeout)
+    r.check_returncode()
+    return scan_families(r.stdout)
+
+
 def ci(flags, b=2000):
     """95% bootstrap CI for the mean of a 0/1 list; returns (lo, hi) in %."""
     if not flags:
@@ -77,7 +98,41 @@ def ci(flags, b=2000):
     return (means[int(0.025 * b)] * 100, means[int(0.975 * b)] * 100)
 
 
-def main():
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--mode",
+        action="append",
+        help=(
+            "nose scan channel list. Omit for the CLI default; repeat or pass a "
+            "comma-list, e.g. --mode syntax,semantic,near"
+        ),
+    )
+    p.add_argument(
+        "--repos-root",
+        type=Path,
+        default=ROOT / "bench" / "repos",
+        help="checkout root containing one directory per corpus repo",
+    )
+    p.add_argument("--cache-dir", type=Path, help="forwarded to nose scan --cache-dir")
+    p.add_argument("--top", type=int, default=1000000, help="forwarded to nose scan --top")
+    p.add_argument("--timeout", type=int, default=300, help="per-repo scan timeout in seconds")
+    p.add_argument("--bootstrap", type=int, default=2000, help="bootstrap resamples per CI")
+    p.add_argument(
+        "--rank",
+        choices=("value", "extractability"),
+        default="value",
+        help=(
+            "base P@10 order. 'value' preserves the historical report; "
+            "'extractability' uses nose's native JSON order."
+        ),
+    )
+    return p.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    mode = ",".join(split_modes(args.mode))
     labels = json.loads((ROOT / "bench/labels/refactoring_families.v5.json").read_text())["families"]
     corpus = {r["id"]: r for r in json.loads((ROOT / "bench/goldens/corpus.json").read_text())["repositories"]}
     by_repo = defaultdict(list)
@@ -88,17 +143,25 @@ def main():
     acc = defaultdict(lambda: {"base": [], "rr": [], "rec": [0, 0], "n": 0, "worthy": 0})
 
     for rid, labs in by_repo.items():
-        repo = ROOT / "bench" / "repos" / rid
+        repo = args.repos_root / rid
         if not repo.is_dir():
             continue
         lang, split = corpus[rid]["primary_language"], corpus[rid]["split"]
         a = acc[(lang, split)]
         a["n"] += len(labs)
         a["worthy"] += sum(x["worthy"] for x in labs)
-        r = subprocess.run([str(NOSE), "scan", str(repo), "--format", "json", "--top", "1000000"],
-                           cwd=ROOT, capture_output=True, text=True, timeout=300)
-        r.check_returncode()
-        fams = sorted(scan_families(r.stdout), key=lambda f: -f["value"])
+        native = scan_repo(
+            repo,
+            mode=mode or None,
+            cache_dir=args.cache_dir,
+            top=args.top,
+            timeout=args.timeout,
+        )
+        fams = (
+            sorted(native, key=lambda f: -f["value"])
+            if args.rank == "value"
+            else list(native)
+        )
         top = fams[:40]
         for f in top:
             f["rv"] = f["value"] * refactorability(f)
@@ -127,12 +190,13 @@ def main():
         if not flags:
             return "    -        "
         m = sum(flags) / len(flags) * 100
-        lo, hi = ci(flags)
+        lo, hi = ci(flags, args.bootstrap)
         return f"{m:>3.0f}% [{lo:>3.0f}-{hi:>3.0f}] n={len(flags)}"
 
+    base_label = f"P@10 {args.rank}"
     for split in ("dev", "heldout"):
         print(f"\n=== {split} ===")
-        print(f"{'lang':<11}{'worthy':>7}  {'P@10 base':<18}{'P@10 re-rank':<18}{'recall':>8}")
+        print(f"{'lang':<11}{'worthy':>7}  {base_label:<18}{'P@10 re-rank':<18}{'recall':>8}")
         for lang in sorted({l for (l, s) in acc if s == split}):
             a = acc[(lang, split)]
             rec = f"{a['rec'][0]}/{a['rec'][1]}" if a["rec"][1] else "-"

--- a/bench/labels/near_default_surface_2026_06_10.json
+++ b/bench/labels/near_default_surface_2026_06_10.json
@@ -1,0 +1,1561 @@
+{
+  "arms": [
+    {
+      "mode": "(CLI default syntax,semantic)",
+      "name": "default"
+    },
+    {
+      "mode": "syntax,semantic,near",
+      "name": "near"
+    },
+    {
+      "mode": "syntax,semantic,near:0.8",
+      "name": "near:0.80"
+    },
+    {
+      "mode": "syntax,semantic,near:0.85",
+      "name": "near:0.85"
+    }
+  ],
+  "generated_by": "bench/labels/near_default_surface_experiment.py",
+  "labelset": "refactoring_families.v5.json",
+  "metrics": {
+    "default": {
+      "dev": {
+        "C": {
+          "labels": 1004,
+          "p_at_10": {
+            "ci95": [
+              43.08,
+              67.69
+            ],
+            "hits": 36,
+            "n": 65,
+            "pct": 55.38
+          },
+          "worthy_labels": 450,
+          "worthy_recall": {
+            "ci95": [
+              89.11,
+              94.22
+            ],
+            "hits": 413,
+            "n": 450,
+            "pct": 91.78
+          }
+        },
+        "Go": {
+          "labels": 799,
+          "p_at_10": {
+            "ci95": [
+              51.92,
+              76.92
+            ],
+            "hits": 34,
+            "n": 52,
+            "pct": 65.38
+          },
+          "worthy_labels": 475,
+          "worthy_recall": {
+            "ci95": [
+              87.58,
+              93.05
+            ],
+            "hits": 430,
+            "n": 475,
+            "pct": 90.53
+          }
+        },
+        "Java": {
+          "labels": 1169,
+          "p_at_10": {
+            "ci95": [
+              23.44,
+              45.31
+            ],
+            "hits": 22,
+            "n": 64,
+            "pct": 34.38
+          },
+          "worthy_labels": 535,
+          "worthy_recall": {
+            "ci95": [
+              87.85,
+              92.71
+            ],
+            "hits": 483,
+            "n": 535,
+            "pct": 90.28
+          }
+        },
+        "OVERALL": {
+          "labels": 5445,
+          "p_at_10": {
+            "ci95": [
+              58.07,
+              67.71
+            ],
+            "hits": 222,
+            "n": 353,
+            "pct": 62.89
+          },
+          "worthy_labels": 2849,
+          "worthy_recall": {
+            "ci95": [
+              84.94,
+              87.5
+            ],
+            "hits": 2457,
+            "n": 2849,
+            "pct": 86.24
+          }
+        },
+        "Python": {
+          "labels": 596,
+          "p_at_10": {
+            "ci95": [
+              70.73,
+              92.68
+            ],
+            "hits": 34,
+            "n": 41,
+            "pct": 82.93
+          },
+          "worthy_labels": 299,
+          "worthy_recall": {
+            "ci95": [
+              79.6,
+              87.96
+            ],
+            "hits": 251,
+            "n": 299,
+            "pct": 83.95
+          }
+        },
+        "Ruby": {
+          "labels": 478,
+          "p_at_10": {
+            "ci95": [
+              72.97,
+              94.59
+            ],
+            "hits": 31,
+            "n": 37,
+            "pct": 83.78
+          },
+          "worthy_labels": 380,
+          "worthy_recall": {
+            "ci95": [
+              73.16,
+              81.58
+            ],
+            "hits": 294,
+            "n": 380,
+            "pct": 77.37
+          }
+        },
+        "Rust": {
+          "labels": 689,
+          "p_at_10": {
+            "ci95": [
+              64.91,
+              87.72
+            ],
+            "hits": 44,
+            "n": 57,
+            "pct": 77.19
+          },
+          "worthy_labels": 411,
+          "worthy_recall": {
+            "ci95": [
+              73.48,
+              81.51
+            ],
+            "hits": 318,
+            "n": 411,
+            "pct": 77.37
+          }
+        },
+        "TypeScript": {
+          "labels": 710,
+          "p_at_10": {
+            "ci95": [
+              40.54,
+              72.97
+            ],
+            "hits": 21,
+            "n": 37,
+            "pct": 56.76
+          },
+          "worthy_labels": 299,
+          "worthy_recall": {
+            "ci95": [
+              85.95,
+              92.98
+            ],
+            "hits": 268,
+            "n": 299,
+            "pct": 89.63
+          }
+        }
+      },
+      "heldout": {
+        "C": {
+          "labels": 534,
+          "p_at_10": {
+            "ci95": [
+              19.44,
+              50.0
+            ],
+            "hits": 12,
+            "n": 36,
+            "pct": 33.33
+          },
+          "worthy_labels": 231,
+          "worthy_recall": {
+            "ci95": [
+              87.88,
+              94.81
+            ],
+            "hits": 211,
+            "n": 231,
+            "pct": 91.34
+          }
+        },
+        "Go": {
+          "labels": 715,
+          "p_at_10": {
+            "ci95": [
+              69.09,
+              90.91
+            ],
+            "hits": 44,
+            "n": 55,
+            "pct": 80.0
+          },
+          "worthy_labels": 426,
+          "worthy_recall": {
+            "ci95": [
+              84.74,
+              91.08
+            ],
+            "hits": 375,
+            "n": 426,
+            "pct": 88.03
+          }
+        },
+        "Java": {
+          "labels": 737,
+          "p_at_10": {
+            "ci95": [
+              25.71,
+              60.0
+            ],
+            "hits": 15,
+            "n": 35,
+            "pct": 42.86
+          },
+          "worthy_labels": 457,
+          "worthy_recall": {
+            "ci95": [
+              91.47,
+              95.84
+            ],
+            "hits": 428,
+            "n": 457,
+            "pct": 93.65
+          }
+        },
+        "OVERALL": {
+          "labels": 4016,
+          "p_at_10": {
+            "ci95": [
+              50.0,
+              60.71
+            ],
+            "hits": 171,
+            "n": 308,
+            "pct": 55.52
+          },
+          "worthy_labels": 2091,
+          "worthy_recall": {
+            "ci95": [
+              87.14,
+              89.86
+            ],
+            "hits": 1851,
+            "n": 2091,
+            "pct": 88.52
+          }
+        },
+        "Python": {
+          "labels": 500,
+          "p_at_10": {
+            "ci95": [
+              28.85,
+              53.85
+            ],
+            "hits": 21,
+            "n": 52,
+            "pct": 40.38
+          },
+          "worthy_labels": 225,
+          "worthy_recall": {
+            "ci95": [
+              88.44,
+              95.11
+            ],
+            "hits": 207,
+            "n": 225,
+            "pct": 92.0
+          }
+        },
+        "Ruby": {
+          "labels": 310,
+          "p_at_10": {
+            "ci95": [
+              68.0,
+              96.0
+            ],
+            "hits": 21,
+            "n": 25,
+            "pct": 84.0
+          },
+          "worthy_labels": 250,
+          "worthy_recall": {
+            "ci95": [
+              66.4,
+              77.2
+            ],
+            "hits": 180,
+            "n": 250,
+            "pct": 72.0
+          }
+        },
+        "Rust": {
+          "labels": 572,
+          "p_at_10": {
+            "ci95": [
+              48.28,
+              74.14
+            ],
+            "hits": 36,
+            "n": 58,
+            "pct": 62.07
+          },
+          "worthy_labels": 255,
+          "worthy_recall": {
+            "ci95": [
+              85.1,
+              92.55
+            ],
+            "hits": 227,
+            "n": 255,
+            "pct": 89.02
+          }
+        },
+        "TypeScript": {
+          "labels": 648,
+          "p_at_10": {
+            "ci95": [
+              31.91,
+              61.7
+            ],
+            "hits": 22,
+            "n": 47,
+            "pct": 46.81
+          },
+          "worthy_labels": 247,
+          "worthy_recall": {
+            "ci95": [
+              86.64,
+              93.52
+            ],
+            "hits": 223,
+            "n": 247,
+            "pct": 90.28
+          }
+        }
+      }
+    },
+    "near": {
+      "dev": {
+        "C": {
+          "labels": 1004,
+          "p_at_10": {
+            "ci95": [
+              40.0,
+              62.86
+            ],
+            "hits": 36,
+            "n": 70,
+            "pct": 51.43
+          },
+          "worthy_labels": 450,
+          "worthy_recall": {
+            "ci95": [
+              96.22,
+              99.11
+            ],
+            "hits": 440,
+            "n": 450,
+            "pct": 97.78
+          }
+        },
+        "Go": {
+          "labels": 799,
+          "p_at_10": {
+            "ci95": [
+              61.22,
+              85.71
+            ],
+            "hits": 36,
+            "n": 49,
+            "pct": 73.47
+          },
+          "worthy_labels": 475,
+          "worthy_recall": {
+            "ci95": [
+              93.68,
+              97.47
+            ],
+            "hits": 454,
+            "n": 475,
+            "pct": 95.58
+          }
+        },
+        "Java": {
+          "labels": 1169,
+          "p_at_10": {
+            "ci95": [
+              28.57,
+              51.43
+            ],
+            "hits": 28,
+            "n": 70,
+            "pct": 40.0
+          },
+          "worthy_labels": 535,
+          "worthy_recall": {
+            "ci95": [
+              93.27,
+              96.82
+            ],
+            "hits": 509,
+            "n": 535,
+            "pct": 95.14
+          }
+        },
+        "OVERALL": {
+          "labels": 5445,
+          "p_at_10": {
+            "ci95": [
+              57.26,
+              67.6
+            ],
+            "hits": 223,
+            "n": 358,
+            "pct": 62.29
+          },
+          "worthy_labels": 2849,
+          "worthy_recall": {
+            "ci95": [
+              93.79,
+              95.47
+            ],
+            "hits": 2696,
+            "n": 2849,
+            "pct": 94.63
+          }
+        },
+        "Python": {
+          "labels": 596,
+          "p_at_10": {
+            "ci95": [
+              72.09,
+              93.02
+            ],
+            "hits": 36,
+            "n": 43,
+            "pct": 83.72
+          },
+          "worthy_labels": 299,
+          "worthy_recall": {
+            "ci95": [
+              94.98,
+              98.66
+            ],
+            "hits": 290,
+            "n": 299,
+            "pct": 96.99
+          }
+        },
+        "Ruby": {
+          "labels": 478,
+          "p_at_10": {
+            "ci95": [
+              58.33,
+              86.11
+            ],
+            "hits": 26,
+            "n": 36,
+            "pct": 72.22
+          },
+          "worthy_labels": 380,
+          "worthy_recall": {
+            "ci95": [
+              87.37,
+              93.42
+            ],
+            "hits": 344,
+            "n": 380,
+            "pct": 90.53
+          }
+        },
+        "Rust": {
+          "labels": 689,
+          "p_at_10": {
+            "ci95": [
+              51.92,
+              76.92
+            ],
+            "hits": 34,
+            "n": 52,
+            "pct": 65.38
+          },
+          "worthy_labels": 411,
+          "worthy_recall": {
+            "ci95": [
+              85.89,
+              91.73
+            ],
+            "hits": 365,
+            "n": 411,
+            "pct": 88.81
+          }
+        },
+        "TypeScript": {
+          "labels": 710,
+          "p_at_10": {
+            "ci95": [
+              57.89,
+              84.21
+            ],
+            "hits": 27,
+            "n": 38,
+            "pct": 71.05
+          },
+          "worthy_labels": 299,
+          "worthy_recall": {
+            "ci95": [
+              96.66,
+              99.67
+            ],
+            "hits": 294,
+            "n": 299,
+            "pct": 98.33
+          }
+        }
+      },
+      "heldout": {
+        "C": {
+          "labels": 534,
+          "p_at_10": {
+            "ci95": [
+              26.67,
+              55.56
+            ],
+            "hits": 19,
+            "n": 45,
+            "pct": 42.22
+          },
+          "worthy_labels": 231,
+          "worthy_recall": {
+            "ci95": [
+              95.67,
+              99.57
+            ],
+            "hits": 226,
+            "n": 231,
+            "pct": 97.84
+          }
+        },
+        "Go": {
+          "labels": 715,
+          "p_at_10": {
+            "ci95": [
+              74.55,
+              92.73
+            ],
+            "hits": 46,
+            "n": 55,
+            "pct": 83.64
+          },
+          "worthy_labels": 426,
+          "worthy_recall": {
+            "ci95": [
+              94.37,
+              97.89
+            ],
+            "hits": 410,
+            "n": 426,
+            "pct": 96.24
+          }
+        },
+        "Java": {
+          "labels": 737,
+          "p_at_10": {
+            "ci95": [
+              40.91,
+              68.18
+            ],
+            "hits": 24,
+            "n": 44,
+            "pct": 54.55
+          },
+          "worthy_labels": 457,
+          "worthy_recall": {
+            "ci95": [
+              96.28,
+              99.12
+            ],
+            "hits": 447,
+            "n": 457,
+            "pct": 97.81
+          }
+        },
+        "OVERALL": {
+          "labels": 4016,
+          "p_at_10": {
+            "ci95": [
+              53.09,
+              63.89
+            ],
+            "hits": 190,
+            "n": 324,
+            "pct": 58.64
+          },
+          "worthy_labels": 2091,
+          "worthy_recall": {
+            "ci95": [
+              95.89,
+              97.47
+            ],
+            "hits": 2022,
+            "n": 2091,
+            "pct": 96.7
+          }
+        },
+        "Python": {
+          "labels": 500,
+          "p_at_10": {
+            "ci95": [
+              36.96,
+              65.22
+            ],
+            "hits": 24,
+            "n": 46,
+            "pct": 52.17
+          },
+          "worthy_labels": 225,
+          "worthy_recall": {
+            "ci95": [
+              95.11,
+              99.11
+            ],
+            "hits": 219,
+            "n": 225,
+            "pct": 97.33
+          }
+        },
+        "Ruby": {
+          "labels": 310,
+          "p_at_10": {
+            "ci95": [
+              64.29,
+              92.86
+            ],
+            "hits": 22,
+            "n": 28,
+            "pct": 78.57
+          },
+          "worthy_labels": 250,
+          "worthy_recall": {
+            "ci95": [
+              91.2,
+              97.2
+            ],
+            "hits": 236,
+            "n": 250,
+            "pct": 94.4
+          }
+        },
+        "Rust": {
+          "labels": 572,
+          "p_at_10": {
+            "ci95": [
+              46.43,
+              71.43
+            ],
+            "hits": 33,
+            "n": 56,
+            "pct": 58.93
+          },
+          "worthy_labels": 255,
+          "worthy_recall": {
+            "ci95": [
+              93.73,
+              98.43
+            ],
+            "hits": 245,
+            "n": 255,
+            "pct": 96.08
+          }
+        },
+        "TypeScript": {
+          "labels": 648,
+          "p_at_10": {
+            "ci95": [
+              30.0,
+              58.0
+            ],
+            "hits": 22,
+            "n": 50,
+            "pct": 44.0
+          },
+          "worthy_labels": 247,
+          "worthy_recall": {
+            "ci95": [
+              94.33,
+              98.79
+            ],
+            "hits": 239,
+            "n": 247,
+            "pct": 96.76
+          }
+        }
+      }
+    },
+    "near:0.80": {
+      "dev": {
+        "C": {
+          "labels": 1004,
+          "p_at_10": {
+            "ci95": [
+              39.71,
+              63.24
+            ],
+            "hits": 35,
+            "n": 68,
+            "pct": 51.47
+          },
+          "worthy_labels": 450,
+          "worthy_recall": {
+            "ci95": [
+              92.44,
+              96.44
+            ],
+            "hits": 425,
+            "n": 450,
+            "pct": 94.44
+          }
+        },
+        "Go": {
+          "labels": 799,
+          "p_at_10": {
+            "ci95": [
+              60.0,
+              84.0
+            ],
+            "hits": 36,
+            "n": 50,
+            "pct": 72.0
+          },
+          "worthy_labels": 475,
+          "worthy_recall": {
+            "ci95": [
+              90.32,
+              94.95
+            ],
+            "hits": 441,
+            "n": 475,
+            "pct": 92.84
+          }
+        },
+        "Java": {
+          "labels": 1169,
+          "p_at_10": {
+            "ci95": [
+              30.0,
+              52.86
+            ],
+            "hits": 29,
+            "n": 70,
+            "pct": 41.43
+          },
+          "worthy_labels": 535,
+          "worthy_recall": {
+            "ci95": [
+              91.96,
+              96.07
+            ],
+            "hits": 503,
+            "n": 535,
+            "pct": 94.02
+          }
+        },
+        "OVERALL": {
+          "labels": 5445,
+          "p_at_10": {
+            "ci95": [
+              56.39,
+              66.67
+            ],
+            "hits": 221,
+            "n": 360,
+            "pct": 61.39
+          },
+          "worthy_labels": 2849,
+          "worthy_recall": {
+            "ci95": [
+              90.38,
+              92.42
+            ],
+            "hits": 2604,
+            "n": 2849,
+            "pct": 91.4
+          }
+        },
+        "Python": {
+          "labels": 596,
+          "p_at_10": {
+            "ci95": [
+              72.73,
+              93.18
+            ],
+            "hits": 37,
+            "n": 44,
+            "pct": 84.09
+          },
+          "worthy_labels": 299,
+          "worthy_recall": {
+            "ci95": [
+              87.63,
+              93.98
+            ],
+            "hits": 272,
+            "n": 299,
+            "pct": 90.97
+          }
+        },
+        "Ruby": {
+          "labels": 478,
+          "p_at_10": {
+            "ci95": [
+              51.28,
+              82.05
+            ],
+            "hits": 26,
+            "n": 39,
+            "pct": 66.67
+          },
+          "worthy_labels": 380,
+          "worthy_recall": {
+            "ci95": [
+              83.68,
+              90.0
+            ],
+            "hits": 330,
+            "n": 380,
+            "pct": 86.84
+          }
+        },
+        "Rust": {
+          "labels": 689,
+          "p_at_10": {
+            "ci95": [
+              49.02,
+              76.47
+            ],
+            "hits": 32,
+            "n": 51,
+            "pct": 62.75
+          },
+          "worthy_labels": 411,
+          "worthy_recall": {
+            "ci95": [
+              82.0,
+              88.81
+            ],
+            "hits": 351,
+            "n": 411,
+            "pct": 85.4
+          }
+        },
+        "TypeScript": {
+          "labels": 710,
+          "p_at_10": {
+            "ci95": [
+              52.63,
+              81.58
+            ],
+            "hits": 26,
+            "n": 38,
+            "pct": 68.42
+          },
+          "worthy_labels": 299,
+          "worthy_recall": {
+            "ci95": [
+              91.64,
+              96.99
+            ],
+            "hits": 282,
+            "n": 299,
+            "pct": 94.31
+          }
+        }
+      },
+      "heldout": {
+        "C": {
+          "labels": 534,
+          "p_at_10": {
+            "ci95": [
+              24.39,
+              53.66
+            ],
+            "hits": 16,
+            "n": 41,
+            "pct": 39.02
+          },
+          "worthy_labels": 231,
+          "worthy_recall": {
+            "ci95": [
+              90.04,
+              96.54
+            ],
+            "hits": 216,
+            "n": 231,
+            "pct": 93.51
+          }
+        },
+        "Go": {
+          "labels": 715,
+          "p_at_10": {
+            "ci95": [
+              70.69,
+              91.38
+            ],
+            "hits": 47,
+            "n": 58,
+            "pct": 81.03
+          },
+          "worthy_labels": 426,
+          "worthy_recall": {
+            "ci95": [
+              91.31,
+              95.77
+            ],
+            "hits": 399,
+            "n": 426,
+            "pct": 93.66
+          }
+        },
+        "Java": {
+          "labels": 737,
+          "p_at_10": {
+            "ci95": [
+              35.0,
+              65.0
+            ],
+            "hits": 20,
+            "n": 40,
+            "pct": 50.0
+          },
+          "worthy_labels": 457,
+          "worthy_recall": {
+            "ci95": [
+              94.75,
+              98.03
+            ],
+            "hits": 441,
+            "n": 457,
+            "pct": 96.5
+          }
+        },
+        "OVERALL": {
+          "labels": 4016,
+          "p_at_10": {
+            "ci95": [
+              50.61,
+              61.52
+            ],
+            "hits": 185,
+            "n": 330,
+            "pct": 56.06
+          },
+          "worthy_labels": 2091,
+          "worthy_recall": {
+            "ci95": [
+              92.44,
+              94.64
+            ],
+            "hits": 1957,
+            "n": 2091,
+            "pct": 93.59
+          }
+        },
+        "Python": {
+          "labels": 500,
+          "p_at_10": {
+            "ci95": [
+              32.69,
+              59.62
+            ],
+            "hits": 24,
+            "n": 52,
+            "pct": 46.15
+          },
+          "worthy_labels": 225,
+          "worthy_recall": {
+            "ci95": [
+              91.11,
+              97.33
+            ],
+            "hits": 212,
+            "n": 225,
+            "pct": 94.22
+          }
+        },
+        "Ruby": {
+          "labels": 310,
+          "p_at_10": {
+            "ci95": [
+              58.06,
+              87.1
+            ],
+            "hits": 23,
+            "n": 31,
+            "pct": 74.19
+          },
+          "worthy_labels": 250,
+          "worthy_recall": {
+            "ci95": [
+              82.0,
+              90.4
+            ],
+            "hits": 216,
+            "n": 250,
+            "pct": 86.4
+          }
+        },
+        "Rust": {
+          "labels": 572,
+          "p_at_10": {
+            "ci95": [
+              48.28,
+              72.41
+            ],
+            "hits": 35,
+            "n": 58,
+            "pct": 60.34
+          },
+          "worthy_labels": 255,
+          "worthy_recall": {
+            "ci95": [
+              90.59,
+              96.47
+            ],
+            "hits": 239,
+            "n": 255,
+            "pct": 93.73
+          }
+        },
+        "TypeScript": {
+          "labels": 648,
+          "p_at_10": {
+            "ci95": [
+              28.0,
+              54.0
+            ],
+            "hits": 20,
+            "n": 50,
+            "pct": 40.0
+          },
+          "worthy_labels": 247,
+          "worthy_recall": {
+            "ci95": [
+              91.5,
+              97.17
+            ],
+            "hits": 234,
+            "n": 247,
+            "pct": 94.74
+          }
+        }
+      }
+    },
+    "near:0.85": {
+      "dev": {
+        "C": {
+          "labels": 1004,
+          "p_at_10": {
+            "ci95": [
+              41.43,
+              64.29
+            ],
+            "hits": 37,
+            "n": 70,
+            "pct": 52.86
+          },
+          "worthy_labels": 450,
+          "worthy_recall": {
+            "ci95": [
+              90.89,
+              95.56
+            ],
+            "hits": 420,
+            "n": 450,
+            "pct": 93.33
+          }
+        },
+        "Go": {
+          "labels": 799,
+          "p_at_10": {
+            "ci95": [
+              54.9,
+              80.39
+            ],
+            "hits": 35,
+            "n": 51,
+            "pct": 68.63
+          },
+          "worthy_labels": 475,
+          "worthy_recall": {
+            "ci95": [
+              89.68,
+              94.53
+            ],
+            "hits": 438,
+            "n": 475,
+            "pct": 92.21
+          }
+        },
+        "Java": {
+          "labels": 1169,
+          "p_at_10": {
+            "ci95": [
+              26.47,
+              50.0
+            ],
+            "hits": 26,
+            "n": 68,
+            "pct": 38.24
+          },
+          "worthy_labels": 535,
+          "worthy_recall": {
+            "ci95": [
+              90.47,
+              94.95
+            ],
+            "hits": 496,
+            "n": 535,
+            "pct": 92.71
+          }
+        },
+        "OVERALL": {
+          "labels": 5445,
+          "p_at_10": {
+            "ci95": [
+              56.11,
+              66.11
+            ],
+            "hits": 220,
+            "n": 360,
+            "pct": 61.11
+          },
+          "worthy_labels": 2849,
+          "worthy_recall": {
+            "ci95": [
+              88.45,
+              90.8
+            ],
+            "hits": 2555,
+            "n": 2849,
+            "pct": 89.68
+          }
+        },
+        "Python": {
+          "labels": 596,
+          "p_at_10": {
+            "ci95": [
+              72.09,
+              93.02
+            ],
+            "hits": 36,
+            "n": 43,
+            "pct": 83.72
+          },
+          "worthy_labels": 299,
+          "worthy_recall": {
+            "ci95": [
+              84.95,
+              91.97
+            ],
+            "hits": 265,
+            "n": 299,
+            "pct": 88.63
+          }
+        },
+        "Ruby": {
+          "labels": 478,
+          "p_at_10": {
+            "ci95": [
+              51.28,
+              79.49
+            ],
+            "hits": 26,
+            "n": 39,
+            "pct": 66.67
+          },
+          "worthy_labels": 380,
+          "worthy_recall": {
+            "ci95": [
+              79.21,
+              86.84
+            ],
+            "hits": 315,
+            "n": 380,
+            "pct": 82.89
+          }
+        },
+        "Rust": {
+          "labels": 689,
+          "p_at_10": {
+            "ci95": [
+              50.0,
+              78.0
+            ],
+            "hits": 32,
+            "n": 50,
+            "pct": 64.0
+          },
+          "worthy_labels": 411,
+          "worthy_recall": {
+            "ci95": [
+              79.32,
+              86.86
+            ],
+            "hits": 342,
+            "n": 411,
+            "pct": 83.21
+          }
+        },
+        "TypeScript": {
+          "labels": 710,
+          "p_at_10": {
+            "ci95": [
+              56.41,
+              84.62
+            ],
+            "hits": 28,
+            "n": 39,
+            "pct": 71.79
+          },
+          "worthy_labels": 299,
+          "worthy_recall": {
+            "ci95": [
+              90.3,
+              95.99
+            ],
+            "hits": 279,
+            "n": 299,
+            "pct": 93.31
+          }
+        }
+      },
+      "heldout": {
+        "C": {
+          "labels": 534,
+          "p_at_10": {
+            "ci95": [
+              20.51,
+              48.72
+            ],
+            "hits": 13,
+            "n": 39,
+            "pct": 33.33
+          },
+          "worthy_labels": 231,
+          "worthy_recall": {
+            "ci95": [
+              89.61,
+              96.1
+            ],
+            "hits": 215,
+            "n": 231,
+            "pct": 93.07
+          }
+        },
+        "Go": {
+          "labels": 715,
+          "p_at_10": {
+            "ci95": [
+              57.14,
+              82.14
+            ],
+            "hits": 39,
+            "n": 56,
+            "pct": 69.64
+          },
+          "worthy_labels": 426,
+          "worthy_recall": {
+            "ci95": [
+              89.44,
+              94.6
+            ],
+            "hits": 392,
+            "n": 426,
+            "pct": 92.02
+          }
+        },
+        "Java": {
+          "labels": 737,
+          "p_at_10": {
+            "ci95": [
+              40.48,
+              69.05
+            ],
+            "hits": 23,
+            "n": 42,
+            "pct": 54.76
+          },
+          "worthy_labels": 457,
+          "worthy_recall": {
+            "ci95": [
+              93.87,
+              97.59
+            ],
+            "hits": 437,
+            "n": 457,
+            "pct": 95.62
+          }
+        },
+        "OVERALL": {
+          "labels": 4016,
+          "p_at_10": {
+            "ci95": [
+              48.62,
+              59.94
+            ],
+            "hits": 177,
+            "n": 327,
+            "pct": 54.13
+          },
+          "worthy_labels": 2091,
+          "worthy_recall": {
+            "ci95": [
+              91.1,
+              93.4
+            ],
+            "hits": 1929,
+            "n": 2091,
+            "pct": 92.25
+          }
+        },
+        "Python": {
+          "labels": 500,
+          "p_at_10": {
+            "ci95": [
+              33.33,
+              60.78
+            ],
+            "hits": 24,
+            "n": 51,
+            "pct": 47.06
+          },
+          "worthy_labels": 225,
+          "worthy_recall": {
+            "ci95": [
+              90.22,
+              96.44
+            ],
+            "hits": 211,
+            "n": 225,
+            "pct": 93.78
+          }
+        },
+        "Ruby": {
+          "labels": 310,
+          "p_at_10": {
+            "ci95": [
+              56.67,
+              86.67
+            ],
+            "hits": 22,
+            "n": 30,
+            "pct": 73.33
+          },
+          "worthy_labels": 250,
+          "worthy_recall": {
+            "ci95": [
+              76.0,
+              86.0
+            ],
+            "hits": 203,
+            "n": 250,
+            "pct": 81.2
+          }
+        },
+        "Rust": {
+          "labels": 572,
+          "p_at_10": {
+            "ci95": [
+              46.55,
+              72.41
+            ],
+            "hits": 35,
+            "n": 58,
+            "pct": 60.34
+          },
+          "worthy_labels": 255,
+          "worthy_recall": {
+            "ci95": [
+              90.2,
+              96.47
+            ],
+            "hits": 238,
+            "n": 255,
+            "pct": 93.33
+          }
+        },
+        "TypeScript": {
+          "labels": 648,
+          "p_at_10": {
+            "ci95": [
+              27.45,
+              54.9
+            ],
+            "hits": 21,
+            "n": 51,
+            "pct": 41.18
+          },
+          "worthy_labels": 247,
+          "worthy_recall": {
+            "ci95": [
+              91.09,
+              97.17
+            ],
+            "hits": 233,
+            "n": 247,
+            "pct": 94.33
+          }
+        }
+      }
+    }
+  },
+  "missing_repos": [],
+  "noise": {
+    "default": {
+      "default_surface_by_scope": {
+        "mixed": 833,
+        "prod": 29081,
+        "test": 37005
+      },
+      "default_surface_delta_by_scope": {
+        "mixed": 0,
+        "prod": 0,
+        "test": 0
+      },
+      "repos": 105,
+      "surface_delta_vs_default": {
+        "debug": 0,
+        "default": 0,
+        "hidden": 0,
+        "review": 0
+      },
+      "surfaces": {
+        "debug": 0,
+        "default": 66919,
+        "hidden": 4626,
+        "review": 209
+      }
+    },
+    "near": {
+      "default_surface_by_scope": {
+        "mixed": 1576,
+        "prod": 39849,
+        "test": 40300
+      },
+      "default_surface_delta_by_scope": {
+        "mixed": 743,
+        "prod": 10768,
+        "test": 3295
+      },
+      "repos": 105,
+      "surface_delta_vs_default": {
+        "debug": 0,
+        "default": 14806,
+        "hidden": -206,
+        "review": -121
+      },
+      "surfaces": {
+        "debug": 0,
+        "default": 81725,
+        "hidden": 4420,
+        "review": 88
+      }
+    },
+    "near:0.80": {
+      "default_surface_by_scope": {
+        "mixed": 1388,
+        "prod": 38566,
+        "test": 41569
+      },
+      "default_surface_delta_by_scope": {
+        "mixed": 555,
+        "prod": 9485,
+        "test": 4564
+      },
+      "repos": 105,
+      "surface_delta_vs_default": {
+        "debug": 0,
+        "default": 14604,
+        "hidden": -294,
+        "review": -125
+      },
+      "surfaces": {
+        "debug": 0,
+        "default": 81523,
+        "hidden": 4332,
+        "review": 84
+      }
+    },
+    "near:0.85": {
+      "default_surface_by_scope": {
+        "mixed": 1348,
+        "prod": 37566,
+        "test": 40442
+      },
+      "default_surface_delta_by_scope": {
+        "mixed": 515,
+        "prod": 8485,
+        "test": 3437
+      },
+      "repos": 105,
+      "surface_delta_vs_default": {
+        "debug": 0,
+        "default": 12437,
+        "hidden": -463,
+        "review": -158
+      },
+      "surfaces": {
+        "debug": 0,
+        "default": 79356,
+        "hidden": 4163,
+        "review": 51
+      }
+    }
+  },
+  "repos_root": "bench/repos",
+  "schema_version": 1
+}

--- a/bench/labels/near_default_surface_experiment.py
+++ b/bench/labels/near_default_surface_experiment.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Price putting the near channel on the default scan surface.
+
+The experiment compares the current CLI default (`syntax,semantic`) with opt-in
+`near` arms on the frozen v5 refactoring-family labelset. It reports:
+
+* P@10 in nose's native JSON order (`extractability`)
+* worthy-label recall
+* default-surface family-count deltas by family `scope`
+
+Example:
+
+    python3 bench/labels/near_default_surface_experiment.py \
+      --repos-root /Users/ak/prjs/cc/nose/bench/repos \
+      --cache-dir /tmp/nose-near-default-cache \
+      --output bench/labels/near_default_surface_2026_06_10.json
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import random
+import subprocess
+from collections import Counter, defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+NOSE = ROOT / "target" / "release" / "nose"
+SURFACES = ("default", "review", "hidden", "debug")
+SCOPES = ("prod", "test", "mixed", "unknown")
+ARMS = (
+    ("default", None),
+    ("near", "syntax,semantic,near"),
+    ("near:0.80", "syntax,semantic,near:0.8"),
+    ("near:0.85", "syntax,semantic,near:0.85"),
+)
+
+spec = importlib.util.spec_from_file_location("ev", ROOT / "bench/labels/eval_by_language.py")
+ev = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ev)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--repos-root",
+        type=Path,
+        default=ROOT / "bench" / "repos",
+        help="checkout root containing one directory per corpus repo",
+    )
+    p.add_argument("--cache-dir", type=Path, help="forwarded to nose scan --cache-dir")
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=ROOT / "bench/labels/near_default_surface_2026_06_10.json",
+        help="aggregate JSON result path",
+    )
+    p.add_argument("--bootstrap", type=int, default=2000, help="bootstrap resamples per CI")
+    p.add_argument("--timeout", type=int, default=300, help="per-repo scan timeout in seconds")
+    p.add_argument("--limit-repos", type=int, help="smoke-test with the first N labeled repos")
+    return p.parse_args()
+
+
+def load_inputs() -> tuple[list[dict], dict[str, dict], dict[str, list[dict]]]:
+    labels = json.loads((ROOT / "bench/labels/refactoring_families.v5.json").read_text())["families"]
+    corpus = {
+        r["id"]: r
+        for r in json.loads((ROOT / "bench/goldens/corpus.json").read_text())["repositories"]
+    }
+    by_repo: dict[str, list[dict]] = defaultdict(list)
+    for label in labels:
+        by_repo[label["repo"]].append(label)
+    return labels, corpus, by_repo
+
+
+def scan(repo: Path, mode: str | None, cache_dir: Path | None, timeout: int) -> dict:
+    cmd = [str(NOSE), "scan", str(repo), "--format", "json", "--top", "0"]
+    if mode:
+        cmd += ["--mode", mode]
+    if cache_dir:
+        cmd += ["--cache-dir", str(cache_dir)]
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True, timeout=timeout)
+    r.check_returncode()
+    payload = json.loads(r.stdout or "{}")
+    if isinstance(payload, list):
+        return {"ranking": {}, "families": payload}
+    return payload
+
+
+def overlap_count(family: dict, label: dict) -> int:
+    return sum(
+        1
+        for site in ev.mlocs(family)
+        for member in label["members"]
+        if ev.ov(site, member)
+    )
+
+
+def p10_flags(families: list[dict], labels: list[dict]) -> list[int]:
+    out = []
+    for family in families[:10]:
+        best = None
+        best_overlap = 0
+        for label in labels:
+            overlap = overlap_count(family, label)
+            if overlap > best_overlap:
+                best = label
+                best_overlap = overlap
+        if best:
+            out.append(1 if best["worthy"] else 0)
+    return out
+
+
+def recall_flags(families: list[dict], labels: list[dict]) -> list[int]:
+    out = []
+    for label in labels:
+        if not label["worthy"]:
+            continue
+        hit = any(overlap_count(family, label) > 0 for family in families)
+        out.append(1 if hit else 0)
+    return out
+
+
+def surface_counter(payload: dict) -> Counter:
+    counts = Counter()
+    reported = payload.get("ranking", {}).get("surface_counts") or {}
+    for surface in SURFACES:
+        counts[surface] = int(reported.get(surface, 0) or 0)
+    return counts
+
+
+def surface_scope_counter(families: list[dict]) -> Counter:
+    counts = Counter()
+    for family in families:
+        surface = family.get("recommended_surface") or "unknown"
+        scope = family.get("scope") or "unknown"
+        counts[(surface, scope)] += 1
+    return counts
+
+
+def display_path(path: Path) -> str:
+    text = str(path)
+    marker = "bench/repos"
+    idx = text.find(marker)
+    return text[idx:] if idx >= 0 else text
+
+
+def ci(flags: list[int], bootstrap: int, rng: random.Random) -> tuple[float, float]:
+    if not flags:
+        return (0.0, 0.0)
+    n = len(flags)
+    samples = []
+    for _ in range(bootstrap):
+        samples.append(sum(flags[rng.randrange(n)] for _ in range(n)) / n)
+    samples.sort()
+    return (samples[int(0.025 * bootstrap)] * 100, samples[int(0.975 * bootstrap)] * 100)
+
+
+def metric(flags: list[int], bootstrap: int, rng: random.Random) -> dict:
+    pct = (sum(flags) / len(flags) * 100) if flags else 0.0
+    lo, hi = ci(flags, bootstrap, rng)
+    return {
+        "pct": round(pct, 2),
+        "ci95": [round(lo, 2), round(hi, 2)],
+        "n": len(flags),
+        "hits": sum(flags),
+    }
+
+
+def evaluate(args: argparse.Namespace) -> dict:
+    _labels, corpus, by_repo = load_inputs()
+    repo_ids = sorted(by_repo)
+    if args.limit_repos:
+        repo_ids = repo_ids[: args.limit_repos]
+
+    acc = {
+        arm: defaultdict(lambda: {"p10": [], "recall": [], "worthy": 0, "labels": 0})
+        for arm, _mode in ARMS
+    }
+    noise = {
+        arm: {"surfaces": Counter(), "surface_scope": Counter(), "repos": 0}
+        for arm, _mode in ARMS
+    }
+    missing = []
+
+    for rid in repo_ids:
+        repo = args.repos_root / rid
+        if not repo.is_dir():
+            missing.append(rid)
+            continue
+        labs = by_repo[rid]
+        meta = corpus[rid]
+        keys = [(meta["primary_language"], meta["split"]), ("OVERALL", meta["split"])]
+        for arm, mode in ARMS:
+            payload = scan(repo, mode, args.cache_dir, args.timeout)
+            families = payload.get("families", [])
+            for key in keys:
+                acc[arm][key]["p10"].extend(p10_flags(families, labs))
+                acc[arm][key]["recall"].extend(recall_flags(families, labs))
+                acc[arm][key]["worthy"] += sum(1 for label in labs if label["worthy"])
+                acc[arm][key]["labels"] += len(labs)
+            noise[arm]["surfaces"].update(surface_counter(payload))
+            noise[arm]["surface_scope"].update(surface_scope_counter(families))
+            noise[arm]["repos"] += 1
+
+    rng = random.Random(1)
+    metrics = {}
+    for arm, values in acc.items():
+        metrics[arm] = {}
+        for (lang, split), data in sorted(values.items()):
+            metrics[arm].setdefault(split, {})[lang] = {
+                "labels": data["labels"],
+                "worthy_labels": data["worthy"],
+                "p_at_10": metric(data["p10"], args.bootstrap, rng),
+                "worthy_recall": metric(data["recall"], args.bootstrap, rng),
+            }
+
+    noise_out = {}
+    baseline_scope = noise["default"]["surface_scope"]
+    baseline_surfaces = noise["default"]["surfaces"]
+    for arm, data in noise.items():
+        surface_scope = data["surface_scope"]
+        default_by_scope = {
+            scope: int(surface_scope[("default", scope)])
+            for scope in SCOPES
+            if surface_scope[("default", scope)] or scope != "unknown"
+        }
+        delta_default_by_scope = {
+            scope: int(surface_scope[("default", scope)] - baseline_scope[("default", scope)])
+            for scope in SCOPES
+            if surface_scope[("default", scope)] or baseline_scope[("default", scope)] or scope != "unknown"
+        }
+        surfaces = {surface: int(data["surfaces"][surface]) for surface in SURFACES}
+        noise_out[arm] = {
+            "repos": data["repos"],
+            "surfaces": surfaces,
+            "surface_delta_vs_default": {
+                surface: int(data["surfaces"][surface] - baseline_surfaces[surface])
+                for surface in SURFACES
+            },
+            "default_surface_by_scope": default_by_scope,
+            "default_surface_delta_by_scope": delta_default_by_scope,
+        }
+
+    return {
+        "schema_version": 1,
+        "generated_by": "bench/labels/near_default_surface_experiment.py",
+        "labelset": "refactoring_families.v5.json",
+        "arms": [{"name": name, "mode": mode or "(CLI default syntax,semantic)"} for name, mode in ARMS],
+        "repos_root": display_path(args.repos_root),
+        "missing_repos": missing,
+        "metrics": metrics,
+        "noise": noise_out,
+    }
+
+
+def fmt_metric(data: dict) -> str:
+    lo, hi = data["ci95"]
+    return f'{data["pct"]:.1f}% [{lo:.1f}-{hi:.1f}] n={data["n"]}'
+
+
+def markdown(result: dict) -> str:
+    lines = []
+    lines.append("## Near default-surface experiment")
+    lines.append("")
+    lines.append("P@10 uses nose's native JSON order (`extractability`); worthy-recall is over worthy v5 labels.")
+    for split in ("dev", "heldout"):
+        lines.append("")
+        lines.append(f"### {split}")
+        lines.append("")
+        lines.append("| arm | language | worthy labels | P@10 | worthy recall |")
+        lines.append("|---|---:|---:|---:|---:|")
+        for arm, split_map in result["metrics"].items():
+            for lang in sorted(split_map.get(split, {}), key=lambda x: (x != "OVERALL", x)):
+                data = split_map[split][lang]
+                lines.append(
+                    f"| {arm} | {lang} | {data['worthy_labels']}/{data['labels']} | "
+                    f"{fmt_metric(data['p_at_10'])} | {fmt_metric(data['worthy_recall'])} |"
+                )
+    lines.append("")
+    lines.append("### default-surface family deltas")
+    lines.append("")
+    lines.append("| arm | default | delta | prod delta | test delta | mixed delta | review delta | hidden delta |")
+    lines.append("|---|---:|---:|---:|---:|---:|---:|---:|")
+    for arm, data in result["noise"].items():
+        lines.append(
+            f"| {arm} | {data['surfaces']['default']} | {data['surface_delta_vs_default']['default']:+d} | "
+            f"{data['default_surface_delta_by_scope'].get('prod', 0):+d} | "
+            f"{data['default_surface_delta_by_scope'].get('test', 0):+d} | "
+            f"{data['default_surface_delta_by_scope'].get('mixed', 0):+d} | "
+            f"{data['surface_delta_vs_default']['review']:+d} | "
+            f"{data['surface_delta_vs_default']['hidden']:+d} |"
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    args = parse_args()
+    result = evaluate(args)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print(markdown(result))
+    print(f"\nwrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1066,3 +1066,119 @@ pre-existing value-fingerprint false-merge leads and one
 canon-preservation lead in raylib; #208 intentionally does not mask them with exclusions because
 the product semantic scan did not report those targeted pairs, and the point of `verify` is to
 make such soundness leads visible once the oracle is tractable.
+
+## BM. Near on the default scan surface — price the locked +8pp recall
+
+§BJ measured the biggest proven recall gap in today's product: the shipped but opt-in
+`near` channel lifts worthy-recall by about eight points. This experiment prices the
+product decision rather than assuming the answer: keep the current CLI default
+(`syntax,semantic`), add unthresholded `near`, or adopt a thresholded middle.
+
+**Method.** `bench/labels/near_default_surface_experiment.py` scans all 105 v5 repos
+with four arms: default, `syntax,semantic,near`, `syntax,semantic,near:0.8`, and
+`syntax,semantic,near:0.85`. P@10 uses the native `nose scan --format json` order
+(`extractability`); worthy-recall is over worthy v5 labels; noise is the
+`ranking.surface_counts.default` delta plus family `scope` splits from full `--top 0`
+JSON. Artifact: `bench/labels/near_default_surface_2026_06_10.json`. Held-out was
+not tuned; the threshold arms are reported as candidate policies, not selected by
+fitting held-out.
+
+### BM.1 — dev split
+
+| arm | language | worthy labels | P@10 | worthy recall |
+|---|---:|---:|---:|---:|
+| default | OVERALL | 2849/5445 | 62.9% [58.1-67.7] n=353 | 86.2% [84.9-87.5] n=2849 |
+| default | C | 450/1004 | 55.4% [43.1-67.7] n=65 | 91.8% [89.1-94.2] n=450 |
+| default | Go | 475/799 | 65.4% [51.9-76.9] n=52 | 90.5% [87.6-93.0] n=475 |
+| default | Java | 535/1169 | 34.4% [23.4-45.3] n=64 | 90.3% [87.8-92.7] n=535 |
+| default | Python | 299/596 | 82.9% [70.7-92.7] n=41 | 84.0% [79.6-88.0] n=299 |
+| default | Ruby | 380/478 | 83.8% [73.0-94.6] n=37 | 77.4% [73.2-81.6] n=380 |
+| default | Rust | 411/689 | 77.2% [64.9-87.7] n=57 | 77.4% [73.5-81.5] n=411 |
+| default | TypeScript | 299/710 | 56.8% [40.5-73.0] n=37 | 89.6% [86.0-93.0] n=299 |
+| near | OVERALL | 2849/5445 | 62.3% [57.3-67.6] n=358 | 94.6% [93.8-95.5] n=2849 |
+| near | C | 450/1004 | 51.4% [40.0-62.9] n=70 | 97.8% [96.2-99.1] n=450 |
+| near | Go | 475/799 | 73.5% [61.2-85.7] n=49 | 95.6% [93.7-97.5] n=475 |
+| near | Java | 535/1169 | 40.0% [28.6-51.4] n=70 | 95.1% [93.3-96.8] n=535 |
+| near | Python | 299/596 | 83.7% [72.1-93.0] n=43 | 97.0% [95.0-98.7] n=299 |
+| near | Ruby | 380/478 | 72.2% [58.3-86.1] n=36 | 90.5% [87.4-93.4] n=380 |
+| near | Rust | 411/689 | 65.4% [51.9-76.9] n=52 | 88.8% [85.9-91.7] n=411 |
+| near | TypeScript | 299/710 | 71.0% [57.9-84.2] n=38 | 98.3% [96.7-99.7] n=299 |
+| near:0.80 | OVERALL | 2849/5445 | 61.4% [56.4-66.7] n=360 | 91.4% [90.4-92.4] n=2849 |
+| near:0.80 | C | 450/1004 | 51.5% [39.7-63.2] n=68 | 94.4% [92.4-96.4] n=450 |
+| near:0.80 | Go | 475/799 | 72.0% [60.0-84.0] n=50 | 92.8% [90.3-95.0] n=475 |
+| near:0.80 | Java | 535/1169 | 41.4% [30.0-52.9] n=70 | 94.0% [92.0-96.1] n=535 |
+| near:0.80 | Python | 299/596 | 84.1% [72.7-93.2] n=44 | 91.0% [87.6-94.0] n=299 |
+| near:0.80 | Ruby | 380/478 | 66.7% [51.3-82.0] n=39 | 86.8% [83.7-90.0] n=380 |
+| near:0.80 | Rust | 411/689 | 62.8% [49.0-76.5] n=51 | 85.4% [82.0-88.8] n=411 |
+| near:0.80 | TypeScript | 299/710 | 68.4% [52.6-81.6] n=38 | 94.3% [91.6-97.0] n=299 |
+| near:0.85 | OVERALL | 2849/5445 | 61.1% [56.1-66.1] n=360 | 89.7% [88.5-90.8] n=2849 |
+| near:0.85 | C | 450/1004 | 52.9% [41.4-64.3] n=70 | 93.3% [90.9-95.6] n=450 |
+| near:0.85 | Go | 475/799 | 68.6% [54.9-80.4] n=51 | 92.2% [89.7-94.5] n=475 |
+| near:0.85 | Java | 535/1169 | 38.2% [26.5-50.0] n=68 | 92.7% [90.5-95.0] n=535 |
+| near:0.85 | Python | 299/596 | 83.7% [72.1-93.0] n=43 | 88.6% [85.0-92.0] n=299 |
+| near:0.85 | Ruby | 380/478 | 66.7% [51.3-79.5] n=39 | 82.9% [79.2-86.8] n=380 |
+| near:0.85 | Rust | 411/689 | 64.0% [50.0-78.0] n=50 | 83.2% [79.3-86.9] n=411 |
+| near:0.85 | TypeScript | 299/710 | 71.8% [56.4-84.6] n=39 | 93.3% [90.3-96.0] n=299 |
+
+### BM.2 — held-out split
+
+| arm | language | worthy labels | P@10 | worthy recall |
+|---|---:|---:|---:|---:|
+| default | OVERALL | 2091/4016 | 55.5% [50.0-60.7] n=308 | 88.5% [87.1-89.9] n=2091 |
+| default | C | 231/534 | 33.3% [19.4-50.0] n=36 | 91.3% [87.9-94.8] n=231 |
+| default | Go | 426/715 | 80.0% [69.1-90.9] n=55 | 88.0% [84.7-91.1] n=426 |
+| default | Java | 457/737 | 42.9% [25.7-60.0] n=35 | 93.7% [91.5-95.8] n=457 |
+| default | Python | 225/500 | 40.4% [28.9-53.9] n=52 | 92.0% [88.4-95.1] n=225 |
+| default | Ruby | 250/310 | 84.0% [68.0-96.0] n=25 | 72.0% [66.4-77.2] n=250 |
+| default | Rust | 255/572 | 62.1% [48.3-74.1] n=58 | 89.0% [85.1-92.5] n=255 |
+| default | TypeScript | 247/648 | 46.8% [31.9-61.7] n=47 | 90.3% [86.6-93.5] n=247 |
+| near | OVERALL | 2091/4016 | 58.6% [53.1-63.9] n=324 | 96.7% [95.9-97.5] n=2091 |
+| near | C | 231/534 | 42.2% [26.7-55.6] n=45 | 97.8% [95.7-99.6] n=231 |
+| near | Go | 426/715 | 83.6% [74.5-92.7] n=55 | 96.2% [94.4-97.9] n=426 |
+| near | Java | 457/737 | 54.5% [40.9-68.2] n=44 | 97.8% [96.3-99.1] n=457 |
+| near | Python | 225/500 | 52.2% [37.0-65.2] n=46 | 97.3% [95.1-99.1] n=225 |
+| near | Ruby | 250/310 | 78.6% [64.3-92.9] n=28 | 94.4% [91.2-97.2] n=250 |
+| near | Rust | 255/572 | 58.9% [46.4-71.4] n=56 | 96.1% [93.7-98.4] n=255 |
+| near | TypeScript | 247/648 | 44.0% [30.0-58.0] n=50 | 96.8% [94.3-98.8] n=247 |
+| near:0.80 | OVERALL | 2091/4016 | 56.1% [50.6-61.5] n=330 | 93.6% [92.4-94.6] n=2091 |
+| near:0.80 | C | 231/534 | 39.0% [24.4-53.7] n=41 | 93.5% [90.0-96.5] n=231 |
+| near:0.80 | Go | 426/715 | 81.0% [70.7-91.4] n=58 | 93.7% [91.3-95.8] n=426 |
+| near:0.80 | Java | 457/737 | 50.0% [35.0-65.0] n=40 | 96.5% [94.8-98.0] n=457 |
+| near:0.80 | Python | 225/500 | 46.1% [32.7-59.6] n=52 | 94.2% [91.1-97.3] n=225 |
+| near:0.80 | Ruby | 250/310 | 74.2% [58.1-87.1] n=31 | 86.4% [82.0-90.4] n=250 |
+| near:0.80 | Rust | 255/572 | 60.3% [48.3-72.4] n=58 | 93.7% [90.6-96.5] n=255 |
+| near:0.80 | TypeScript | 247/648 | 40.0% [28.0-54.0] n=50 | 94.7% [91.5-97.2] n=247 |
+| near:0.85 | OVERALL | 2091/4016 | 54.1% [48.6-59.9] n=327 | 92.2% [91.1-93.4] n=2091 |
+| near:0.85 | C | 231/534 | 33.3% [20.5-48.7] n=39 | 93.1% [89.6-96.1] n=231 |
+| near:0.85 | Go | 426/715 | 69.6% [57.1-82.1] n=56 | 92.0% [89.4-94.6] n=426 |
+| near:0.85 | Java | 457/737 | 54.8% [40.5-69.0] n=42 | 95.6% [93.9-97.6] n=457 |
+| near:0.85 | Python | 225/500 | 47.1% [33.3-60.8] n=51 | 93.8% [90.2-96.4] n=225 |
+| near:0.85 | Ruby | 250/310 | 73.3% [56.7-86.7] n=30 | 81.2% [76.0-86.0] n=250 |
+| near:0.85 | Rust | 255/572 | 60.3% [46.5-72.4] n=58 | 93.3% [90.2-96.5] n=255 |
+| near:0.85 | TypeScript | 247/648 | 41.2% [27.4-54.9] n=51 | 94.3% [91.1-97.2] n=247 |
+
+### BM.3 — reviewer-burden proxy
+
+| arm | default-surface families | delta | prod delta | test delta | mixed delta | review delta | hidden delta |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| default | 66919 | +0 | +0 | +0 | +0 | +0 | +0 |
+| near | 81725 | +14806 | +10768 | +3295 | +743 | -121 | -206 |
+| near:0.80 | 81523 | +14604 | +9485 | +4564 | +555 | -125 | -294 |
+| near:0.85 | 79356 | +12437 | +8485 | +3437 | +515 | -158 | -463 |
+
+**Verdict: flip the default channel mix to include unthresholded `near`, but do it as a
+separate product change with release/docs migration notes.** The held-out gate does
+not show a material P@10 drop; it improves from 55.5% to 58.6% while worthy-recall
+jumps from 88.5% to 96.7%. The thresholded middle is not a good trade: `near:0.80`
+keeps almost all the default-surface burden (+14.6k vs +14.8k) while giving back
+three points of held-out recall, and `near:0.85` saves only another ~2.2k default
+families while giving back more than half the recall gain.
+
+The cost is real: unthresholded `near` adds 14,806 default-surface families across the
+corpus (+22.1%), mostly production-scope (+10,768) with a large test-scope tail
+(+3,295). That argues for making the flip explicit rather than silent. But
+[design](design.md) §2's primary consumer is an LLM agent that wants high recall and
+can filter/rerank; perfect worthiness separation in the scanner is lower leverage for
+that consumer. With no held-out precision hit and a measured +8.2pp held-out
+worthy-recall gain, keeping `near` opt-in would leave proven useful candidates behind
+the flag that the primary consumer is least likely to remember.


### PR DESCRIPTION
## Summary

Closes #213.

This records the decisive near/default-surface experiment on the frozen v5 labelset:

- adds `bench/labels/near_default_surface_experiment.py` for default, `near`, `near:0.80`, and `near:0.85` arms
- checks in `bench/labels/near_default_surface_2026_06_10.json` with aggregate metrics and surface deltas
- updates `eval_by_language.py` with `--mode`, `--repos-root`, `--cache-dir`, `--top`, `--timeout`, `--bootstrap`, and native `extractability` ranking support
- records the verdict in `docs/experiments.md` §BM and links the artifact from `bench/labels/README.md`

Key result: unthresholded `near` raises held-out worthy-recall from 88.5% to 96.7% while P@10 moves from 55.5% to 58.6%; thresholded arms give back too much recall for too little default-surface reduction.

## Validation

- `python3 bench/labels/near_default_surface_experiment.py --repos-root /Users/ak/prjs/cc/nose/bench/repos --cache-dir /tmp/nose-213-near-cache --output bench/labels/near_default_surface_2026_06_10.json`
- `python3 -m py_compile bench/labels/eval_by_language.py bench/labels/near_default_surface_experiment.py`
- `python3 bench/labels/near_default_surface_experiment.py --repos-root /Users/ak/prjs/cc/nose/bench/repos --cache-dir /tmp/nose-213-near-cache --output /tmp/nose-213-smoke3.json --limit-repos 1 --bootstrap 20`
- `awiki lint --root docs`
- `cargo fmt --all --check`
- `cargo test -p nose-cli`
- `./scripts/check-ci-local.sh`
