### PR TITLE
[codex] Extract Rust macro_rules arms as units

### DIFF
--- a/bench/labels/README.md
+++ b/bench/labels/README.md
@@ -71,6 +71,12 @@ allowlisted Ruby test blocks became `Block` units, records the remaining Ruby
 misses, and captures the Ruby unit-count extraction delta. The decision record is
 in [`docs/experiments.md`](../../docs/experiments.md) §BN.
 
+`rust_macro_rules_recovery_2026_06_10.json` is the #215 recovery artifact for
+Rust `macro_rules!` arm extraction. It records the feasibility spike conclusion,
+the Rust recall-ceiling probe before/after, remaining Rust no-overlapping-unit
+records, default P@10, and Rust corpus surface/raw-ratio deltas. The decision
+record is in [`docs/experiments.md`](../../docs/experiments.md) §BO.
+
 `merge_exclusion_census.py` + `oracle_exclusion_census_2026_06_10.json` +
 `oracle_under_merge_leads_2026_06_10.json` are the oracle-completeness campaign's
 baseline: per-construct inventory of units the interpreter oracle cannot check (and the

--- a/bench/labels/rust_macro_rules_recovery_2026_06_10.json
+++ b/bench/labels/rust_macro_rules_recovery_2026_06_10.json
@@ -1,0 +1,335 @@
+{
+  "default_eval_after_extractability": {
+    "dev": {
+      "overall_p10": "63% [58-68] n=353",
+      "rust_p10": "77% [65-88] n=57",
+      "rust_recall": "318/411"
+    },
+    "heldout": {
+      "overall_p10": "56% [50-61] n=308",
+      "rust_p10": "62% [50-74] n=58",
+      "rust_recall": "227/255"
+    }
+  },
+  "generated_by": "manual #215 measurement using recall_ceiling_probe.py, eval_by_language.py, and before/after nose binaries",
+  "remaining_rust_no_overlapping_after": [
+    {
+      "channel": "contiguous",
+      "family_id": "46fd2ef00c8d9e98",
+      "members": [
+        {
+          "end_line": 321,
+          "file": "bench/repos/nushell/crates/nu-plugin-core/src/serializers/tests.rs",
+          "start_line": 307
+        },
+        {
+          "end_line": 257,
+          "file": "bench/repos/nushell/crates/nu-plugin-core/src/serializers/tests.rs",
+          "start_line": 243
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "nushell",
+      "split": "dev"
+    },
+    {
+      "channel": "contiguous",
+      "family_id": "5e0a811d5b711a35",
+      "members": [
+        {
+          "end_line": 151,
+          "file": "bench/repos/nushell/crates/nu-plugin-core/src/serializers/tests.rs",
+          "start_line": 138
+        },
+        {
+          "end_line": 101,
+          "file": "bench/repos/nushell/crates/nu-plugin-core/src/serializers/tests.rs",
+          "start_line": 88
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "nushell",
+      "split": "dev"
+    },
+    {
+      "channel": "contiguous",
+      "family_id": "b950a3c8f074b925",
+      "members": [
+        {
+          "end_line": 13,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/selector/selector_signed_integer.rs",
+          "start_line": 1
+        },
+        {
+          "end_line": 13,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/selector/selector_unsigned_integer.rs",
+          "start_line": 1
+        }
+      ],
+      "reason": "extract-base",
+      "repo": "nushell",
+      "split": "dev"
+    },
+    {
+      "channel": "contiguous",
+      "family_id": "1f02b28389d3dd36",
+      "members": [
+        {
+          "end_line": 514,
+          "file": "bench/repos/regex/regex-capi/src/rure.rs",
+          "start_line": 500
+        },
+        {
+          "end_line": 128,
+          "file": "bench/repos/regex/regex-capi/src/rure.rs",
+          "start_line": 114
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "regex",
+      "split": "heldout"
+    },
+    {
+      "channel": "contiguous",
+      "family_id": "fc8646004b5ef173",
+      "members": [
+        {
+          "end_line": 390,
+          "file": "bench/repos/regex/regex-capi/src/rure.rs",
+          "start_line": 378
+        },
+        {
+          "end_line": 348,
+          "file": "bench/repos/regex/regex-capi/src/rure.rs",
+          "start_line": 336
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "regex",
+      "split": "heldout"
+    },
+    {
+      "channel": "contiguous",
+      "family_id": "70daf912736d8c82",
+      "members": [
+        {
+          "end_line": 8,
+          "file": "bench/repos/ripgrep/tests/hay.rs",
+          "start_line": 1
+        },
+        {
+          "end_line": 209,
+          "file": "bench/repos/ripgrep/crates/searcher/src/lines.rs",
+          "start_line": 203
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "ripgrep",
+      "split": "dev"
+    },
+    {
+      "channel": "contiguous",
+      "family_id": "8172f2a4057bdd27",
+      "members": [
+        {
+          "end_line": 241,
+          "file": "bench/repos/ripgrep/tests/json.rs",
+          "start_line": 207
+        },
+        {
+          "end_line": 190,
+          "file": "bench/repos/ripgrep/tests/json.rs",
+          "start_line": 157
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "ripgrep",
+      "split": "dev"
+    },
+    {
+      "channel": "contiguous",
+      "family_id": "6189ced49439fb29",
+      "members": [
+        {
+          "end_line": 265,
+          "file": "bench/repos/tokio/tokio/src/io/poll_evented.rs",
+          "start_line": 238
+        },
+        {
+          "end_line": 211,
+          "file": "bench/repos/tokio/tokio/src/io/poll_evented.rs",
+          "start_line": 180
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "tokio",
+      "split": "heldout"
+    },
+    {
+      "channel": "contiguous",
+      "family_id": "af17a49f38c801e2",
+      "members": [
+        {
+          "end_line": 467,
+          "file": "bench/repos/tokio/tokio/tests/rt_handle_block_on.rs",
+          "start_line": 457
+        },
+        {
+          "end_line": 401,
+          "file": "bench/repos/tokio/tokio/tests/rt_handle_block_on.rs",
+          "start_line": 370
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "tokio",
+      "split": "heldout"
+    }
+  ],
+  "rust_probe": {
+    "after": {
+      "missed_classes": {
+        "inline-ceiling": 5,
+        "no-overlapping-unit": 9,
+        "same-unit-window": 3,
+        "subdag-ceiling": 22,
+        "unrecovered": 13
+      },
+      "missed_count": 52,
+      "no_overlapping_unit_count": 9,
+      "summary": {
+        "Rust/dev": {
+          "hit_arm0": 318,
+          "hit_arm1": 369,
+          "inline-ceiling": 4,
+          "no-overlapping-unit": 5,
+          "same-unit-window": 2,
+          "subdag-ceiling": 19,
+          "unrecovered": 12,
+          "worthy": 411
+        },
+        "Rust/heldout": {
+          "hit_arm0": 227,
+          "hit_arm1": 245,
+          "inline-ceiling": 1,
+          "no-overlapping-unit": 4,
+          "same-unit-window": 1,
+          "subdag-ceiling": 3,
+          "unrecovered": 1,
+          "worthy": 255
+        }
+      }
+    },
+    "before": {
+      "missed_classes": {
+        "inline-ceiling": 4,
+        "no-overlapping-unit": 14,
+        "same-unit-window": 3,
+        "subdag-ceiling": 23,
+        "unrecovered": 13
+      },
+      "missed_count": 57,
+      "no_overlapping_unit_count": 14,
+      "summary": {
+        "Rust/dev": {
+          "hit_arm0": 318,
+          "hit_arm1": 364,
+          "inline-ceiling": 3,
+          "no-overlapping-unit": 10,
+          "same-unit-window": 2,
+          "subdag-ceiling": 20,
+          "unrecovered": 12,
+          "worthy": 411
+        },
+        "Rust/heldout": {
+          "hit_arm0": 226,
+          "hit_arm1": 245,
+          "inline-ceiling": 1,
+          "no-overlapping-unit": 4,
+          "same-unit-window": 1,
+          "subdag-ceiling": 3,
+          "unrecovered": 1,
+          "worthy": 255
+        }
+      }
+    }
+  },
+  "rust_surface_delta": {
+    "after": {
+      "default_surface": 4789,
+      "families": 4826,
+      "macro_arm_units": 356,
+      "units": 94507
+    },
+    "after_macro_raw_ratio": {
+      "count": 356,
+      "max": 0.125,
+      "mean": 0.0634,
+      "median": 0.0667,
+      "token_count_max": 145,
+      "token_count_median": 15.0,
+      "token_count_min": 8
+    },
+    "before": {
+      "default_surface": 4782,
+      "families": 4819,
+      "macro_arm_units": 0,
+      "units": 93948
+    },
+    "delta": {
+      "default_surface": 7,
+      "families": 7,
+      "macro_arm_units": 356,
+      "units": 559
+    },
+    "macro_arm_units_by_repo_after": {
+      "alacritty": 10,
+      "bat": 2,
+      "clap": 31,
+      "fd": 6,
+      "image": 13,
+      "meilisearch": 50,
+      "nushell": 30,
+      "regex": 14,
+      "ripgrep": 19,
+      "rustls": 8,
+      "serde_json": 27,
+      "sled": 3,
+      "tokei": 10,
+      "tokio": 133
+    },
+    "repos": [
+      "alacritty",
+      "bat",
+      "clap",
+      "fd",
+      "hyperfine",
+      "image",
+      "meilisearch",
+      "nushell",
+      "regex",
+      "ripgrep",
+      "rustls",
+      "serde_json",
+      "sled",
+      "tokei",
+      "tokio"
+    ],
+    "timing": {
+      "after": {
+        "feature_sec_sum": 17.759,
+        "scan_sec_sum": 5.86
+      },
+      "before": {
+        "feature_sec_sum": 17.482,
+        "scan_sec_sum": 5.808
+      }
+    }
+  },
+  "schema_version": 1,
+  "source_commands": {
+    "after_probe": "python3 bench/labels/recall_ceiling_probe.py --repos-root /Users/ak/prjs/cc/nose/bench/repos --json-out <tmp-after-probe.json>",
+    "default_eval_after": "python3 bench/labels/eval_by_language.py --repos-root /Users/ak/prjs/cc/nose/bench/repos --rank extractability --top 0 --bootstrap 2000 --cache-dir <tmp-cache>",
+    "rust_delta": "<before-or-after-nose> scan/features over the 15 Rust corpus repos from bench/goldens/corpus.json"
+  },
+  "spike_conclusion": "tree-sitter-rust exposes macro_rules! arms as macro_rule nodes with token_tree RHS, not full Rust statement AST. The implementation extracts each RHS as a named Block unit with one Raw macro_rule_body boundary plus identifier/literal atoms, so it is matchable by syntax/near but not exact_safe semantic proof."
+}

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -24,6 +24,18 @@ fn first_func(il: &nose_il::Il) -> NodeId {
         .expect("expected a function unit")
 }
 
+fn count_nodes(il: &nose_il::Il, root: NodeId, kind: Option<nose_il::NodeKind>) -> usize {
+    let own = match kind {
+        Some(kind) => usize::from(il.node(root).kind == kind),
+        None => 1,
+    };
+    own + il
+        .children(root)
+        .iter()
+        .map(|child| count_nodes(il, *child, kind))
+        .sum::<usize>()
+}
+
 #[test]
 fn foreach_accumulator_is_interpretable_iterating_a_nonlist_is_err_not_unsupported() {
     // The headline foreach-accumulator: iterating a LIST computes; iterating a non-iterable
@@ -2071,6 +2083,92 @@ fn ruby_test_dsl_block_units_converge_and_keep_literal_boundaries() {
         value_fp_named(&i, expected_one, Lang::Ruby, "it:expects one"),
         value_fp_named(&i, expected_two, Lang::Ruby, "it:expects two"),
         "different assertion literals must keep Ruby test DSL block units split"
+    );
+}
+
+#[test]
+fn rust_macro_rules_arm_units_survive_feature_extraction() {
+    let i = Interner::new();
+    let src = r#"
+macro_rules! sample {
+    ($arg:expr) => {{
+        let value = $arg;
+        if value > 0 {
+            panic!("bad");
+        }
+        value
+    }};
+    ($other:expr) => {{
+        let value = $other;
+        if value > 1 {
+            panic!("worse");
+        }
+        value
+    }};
+}
+"#;
+    let il = nose_frontend::lower_source(FileId(0), "sample.rs", src.as_bytes(), Lang::Rust, &i)
+        .expect("lower");
+    let lowered_names: Vec<_> = il
+        .units
+        .iter()
+        .map(|unit| {
+            let span = il.node(unit.root).span;
+            (
+                unit.kind,
+                unit.name.map(|name| i.resolve(name).to_string()),
+                span.start_line,
+                span.end_line,
+                count_nodes(&il, unit.root, None),
+                count_nodes(&il, unit.root, Some(nose_il::NodeKind::Raw)),
+            )
+        })
+        .collect();
+    let normalized = normalize(&il, &i, &NormalizeOptions::default());
+    let normalized_names: Vec<_> = normalized
+        .units
+        .iter()
+        .map(|unit| {
+            let span = normalized.node(unit.root).span;
+            (
+                unit.kind,
+                unit.name.map(|name| i.resolve(name).to_string()),
+                span.start_line,
+                span.end_line,
+                count_nodes(&normalized, unit.root, None),
+                count_nodes(&normalized, unit.root, Some(nose_il::NodeKind::Raw)),
+            )
+        })
+        .collect();
+    let opts = DetectOptions {
+        min_lines: 1,
+        min_tokens: 1,
+        ..Default::default()
+    };
+    let units = nose_detect::units_of_file(&il, &i, &opts);
+    let names: Vec<_> = units
+        .iter()
+        .filter_map(|unit| unit.name.as_deref())
+        .collect();
+    assert!(
+        names.contains(&"sample:arm0") && names.contains(&"sample:arm1"),
+        "macro_rules! arm units should survive feature extraction: lowered={lowered_names:?} normalized={normalized_names:?} kept={names:?}"
+    );
+    let arm_summaries: Vec<_> = units
+        .iter()
+        .filter(|unit| {
+            unit.name
+                .as_deref()
+                .is_some_and(|name| name.starts_with("sample:arm"))
+        })
+        .map(|unit| (unit.name.as_deref(), unit.token_count, unit.exact_safe))
+        .collect();
+    assert!(
+        units
+            .iter()
+            .filter(|unit| unit.name.as_deref().is_some_and(|name| name.starts_with("sample:arm")))
+            .all(|unit| !unit.exact_safe && unit.token_count > 1),
+        "macro_rules! arm units should be matchable but not exact-safe semantic proofs: {arm_summaries:?}"
     );
 }
 

--- a/crates/nose-frontend/src/rust.rs
+++ b/crates/nose-frontend/src/rust.rs
@@ -733,13 +733,43 @@ fn lower_macro(lo: &mut Lowering, node: TsNode) -> NodeId {
 
 fn lower_macro_definition_shadow(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
-    let name = rust_macro_definition_name(lo, node).map(|name| lo.sym(name));
+    let macro_name = rust_macro_definition_name(lo, node).map(str::to_string);
+    let name = macro_name.as_deref().map(|name| lo.sym(name));
+    let kids: Vec<NodeId> = Lowering::named_children(node)
+        .into_iter()
+        .filter(|child| child.kind() == "macro_rule")
+        .enumerate()
+        .map(|(idx, rule)| {
+            lower_macro_rule_body_unit(lo, rule, macro_name.as_deref().unwrap_or("macro"), idx)
+        })
+        .collect();
     lo.add(
         NodeKind::Block,
         name.map(Payload::Name).unwrap_or(Payload::None),
         span,
-        &[],
+        &kids,
     )
+}
+
+fn lower_macro_rule_body_unit(
+    lo: &mut Lowering,
+    rule: TsNode,
+    macro_name: &str,
+    arm_index: usize,
+) -> NodeId {
+    let right = rule.child_by_field_name("right").unwrap_or(rule);
+    let span = lo.span(right);
+    let mut atoms = Vec::new();
+    collect_macro_atoms(lo, right, &mut atoms);
+    // A macro_rules! RHS is still token-tree syntax, not normal Rust statements.
+    // Keep a Raw boundary so strict semantic reporting cannot treat the atom
+    // sequence as an exact runtime proof, while still giving syntax/near channels
+    // a matchable unit instead of an invisible macro arm.
+    let body = lo.raw("macro_rule_body", span, &atoms);
+    let block = lo.add(NodeKind::Block, Payload::None, span, &[body]);
+    let unit_name = lo.sym(&format!("{macro_name}:arm{arm_index}"));
+    lo.push_unit(block, UnitKind::Block, Some(unit_name));
+    block
 }
 
 fn rust_macro_definition_name<'a>(lo: &Lowering<'a>, node: TsNode<'a>) -> Option<&'a str> {
@@ -761,7 +791,7 @@ fn rust_macro_definition_name<'a>(lo: &Lowering<'a>, node: TsNode<'a>) -> Option
 /// never leaves `Raw` token_tree nodes that would corrupt the value graph.
 fn collect_macro_atoms(lo: &mut Lowering, tt: TsNode, kids: &mut Vec<NodeId>) {
     for t in Lowering::named_children(tt) {
-        if t.kind() == "token_tree" {
+        if is_macro_token_container(t.kind()) {
             collect_macro_atoms(lo, t, kids);
         } else if is_macro_atom(t.kind()) {
             kids.push(lower_expr(lo, t));
@@ -770,20 +800,29 @@ fn collect_macro_atoms(lo: &mut Lowering, tt: TsNode, kids: &mut Vec<NodeId>) {
     }
 }
 
-fn is_macro_atom(k: &str) -> bool {
+fn is_macro_token_container(k: &str) -> bool {
     matches!(
         k,
-        "identifier"
-            | "scoped_identifier"
-            | "field_identifier"
-            | "self"
-            | "integer_literal"
-            | "float_literal"
-            | "string_literal"
-            | "raw_string_literal"
-            | "char_literal"
-            | "boolean_literal"
+        "token_tree" | "token_repetition" | "token_tree_pattern" | "token_repetition_pattern"
     )
+}
+
+fn is_macro_atom(k: &str) -> bool {
+    const ATOMS: &[&str] = &[
+        "identifier",
+        "scoped_identifier",
+        "field_identifier",
+        "self",
+        "crate",
+        "super",
+        "integer_literal",
+        "float_literal",
+        "string_literal",
+        "raw_string_literal",
+        "char_literal",
+        "boolean_literal",
+    ];
+    ATOMS.contains(&k)
 }
 
 fn lower_field(lo: &mut Lowering, node: TsNode) -> NodeId {
@@ -1273,6 +1312,21 @@ mod tests {
             .collect()
     }
 
+    fn unit_names(src: &str) -> Vec<(UnitKind, String)> {
+        let (interner, il) = lower_rust(src);
+        il.units
+            .iter()
+            .map(|unit| {
+                (
+                    unit.kind,
+                    unit.name
+                        .map(|name| interner.resolve(name).to_string())
+                        .unwrap_or_else(|| "-".to_string()),
+                )
+            })
+            .collect()
+    }
+
     fn binop_ops(il: &Il) -> Vec<Op> {
         il.nodes
             .iter()
@@ -1361,6 +1415,44 @@ mod tests {
             "if let Some(_) = value { true } else { false }",
             "Some"
         ));
+    }
+
+    #[test]
+    fn macro_rules_arm_bodies_become_block_units_without_raw_token_trees() {
+        let src = r#"
+macro_rules! sample {
+    ($arg:expr) => {{
+        let value = $arg;
+        if value > 0 {
+            panic!("bad");
+        }
+        value
+    }};
+    ($other:expr) => {{
+        let value = $other;
+        if value > 1 {
+            panic!("worse");
+        }
+        value
+    }};
+}
+"#;
+        let units = unit_names(src);
+        assert!(
+            units.contains(&(UnitKind::Block, "sample:arm0".to_string())),
+            "first macro_rules! arm should be a block unit: {units:?}"
+        );
+        assert!(
+            units.contains(&(UnitKind::Block, "sample:arm1".to_string())),
+            "second macro_rules! arm should be a block unit: {units:?}"
+        );
+
+        let (interner, il) = lower_rust(src);
+        let raw = raw_names(&il, &interner);
+        assert!(
+            !raw.iter().any(|name| name == "token_tree"),
+            "macro_rules! arm extraction should not emit Raw token_tree nodes: {raw:?}"
+        );
     }
 
     #[test]

--- a/crates/nose-normalize/src/desugar.rs
+++ b/crates/nose-normalize/src/desugar.rs
@@ -85,6 +85,7 @@ impl Rebuilder<'_> {
         let kind = self.old.kind(old_id);
         match kind {
             // Flatten statement-position blocks; drop empties.
+            NodeKind::Block if self.unit_root_set.contains(&old_id.0) => out.push(self.go(old_id)),
             NodeKind::Block => {
                 let child_count = self.old.children(old_id).len();
                 for idx in 0..child_count {

--- a/docs/design.md
+++ b/docs/design.md
@@ -215,8 +215,10 @@ Cheap experiments that turn direction into data:
   consumer 1.)* **Ran 2026-06-10 — answer: small.** [experiments §BJ](experiments.md):
   worthy-recall at the maximal current surface is 94.3% dev / 96.4% heldout; the
   generalized sub-DAG ceiling is 2.0% (0.6% at the shipped anchor weight), inlining 0.3%,
-  and the remaining misses are unit-extraction gaps (Ruby DSL blocks, Rust macro bodies),
-  statement-window fragments, and zero-shared-mass judgment cases.
+  and the remaining misses are unit-extraction gaps, statement-window fragments, and
+  zero-shared-mass judgment cases. Follow-up experiments closed most Ruby test-DSL block
+  misses and part of the Rust `macro_rules!` arm gap; see [experiments §BN](experiments.md)
+  and [§BO](experiments.md).
 - **Byte-determinism stress** — diff `nose scan --format json` across thread counts on a large
   repo. Any difference is a hard-invariant violation. *(Protects both consumers.)*
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1256,3 +1256,72 @@ regression. The stable cost signal is extraction work: about 247ms extra over th
 Ruby corpus, with no candidate-family or default-surface expansion. Verdict: keep
 the allowlisted Ruby test-DSL block units. They remove the dominant Ruby unit-blind
 spot from the recall-ceiling probe without harming the default product metric.
+
+## BO. Rust `macro_rules!` arms — expose token-tree bodies without semantic overclaiming
+
+Issue #215 tested the second named unit-extraction gap from §BJ: Rust macro bodies,
+especially `clap`'s `clap_builder/src/macros.rs`, where duplicated `macro_rules!`
+arms were invisible because macro definitions only contributed a shadowing marker.
+
+The feasibility answer is mixed but useful. `tree-sitter-rust` exposes each
+`macro_rules!` arm as a `macro_rule` with `left` and `right` fields, but the RHS is
+a `token_tree`, not a parsed Rust statement/expression tree. The implementation
+therefore extracts each RHS as a named `Block` unit (`macro_name:armN`) containing
+one `Raw("macro_rule_body")` boundary plus identifier/literal atoms. That keeps the
+unit matchable by syntax/near, while `exact_safe=false` prevents the semantic exact
+channel from claiming runtime equivalence for token soup.
+
+### BO.1 — recall-ceiling probe
+
+Artifact: `bench/labels/rust_macro_rules_recovery_2026_06_10.json`.
+
+| metric | before | after | delta |
+|---|---:|---:|---:|
+| Rust `no-overlapping-unit` misses | 14 | 9 | -5 |
+| Rust arm1 missed worthy labels | 57 | 52 | -5 |
+| Rust arm1 recall, dev | 364/411 (88.6%) | 369/411 (89.8%) | +1.2pp |
+| Rust arm1 recall, held-out | 245/255 (96.1%) | 245/255 (96.1%) | +0.0pp |
+| Overall arm1 recall, dev | 94.9% | 95.1% | +0.2pp |
+| Overall arm1 recall, held-out | 96.7% | 96.7% | +0.0pp |
+
+The recovered labels are the `macro_rules!` arm-definition shape, led by the
+`clap` `arg_impl!` arms. The remaining Rust `no-overlapping-unit` records are
+not all the same shape: large single-arm macro definitions (`nushell`), macro
+invocation bodies (`regex` `ffi_fn!`, `ripgrep` `rgtest!`, Tokio test macros),
+top-level constant/import spans, and ordinary unit-size/window gaps remain.
+Those need separate, more conservative decisions.
+
+### BO.2 — default product metric
+
+Full default `eval_by_language.py --rank extractability --top 0` after the change
+did not move the product P@10 gate:
+
+| split | overall P@10 | Rust P@10 | Rust worthy recall |
+|---|---:|---:|---:|
+| dev | 63% [58-68] n=353 | 77% [65-88] n=57 | 318/411 |
+| held-out | 56% [50-61] n=308 | 62% [50-74] n=58 | 227/255 |
+
+Default worthy recall is essentially unchanged because these units are exact-unsafe
+token-tree units. They mainly help the maximal/near recall probe and make macro-arm
+duplication visible for review.
+
+### BO.3 — Rust extraction surface
+
+Measured across the 15 Rust corpus repos:
+
+| Rust corpus scan metric | before | after | delta |
+|---|---:|---:|---:|
+| units kept | 93948 | 94507 | +559 |
+| macro-arm units kept | 0 | 356 | +356 |
+| candidate families | 4819 | 4826 | +7 |
+| default-surface families | 4782 | 4789 | +7 |
+| scan wall time sum | 5.808s | 5.860s | +0.052s |
+| features wall time sum | 17.482s | 17.759s | +0.277s |
+
+The new macro-arm units have exactly one raw boundary each. Their measured raw ratio
+is not "mostly Raw": median 0.0667, mean 0.0634, max 0.125, with median token count
+15 and range 8-145. The cost is small but nonzero: +7 default-surface families over
+the Rust corpus. Verdict: keep `macro_rules!` arm units, but do not generalize to all
+macro invocation bodies in this issue. The remaining Rust no-overlap records should
+be handled as separate coverage questions because their blast radius is broader than
+arm definitions.


### PR DESCRIPTION
## Summary
- extract Rust `macro_rules!` RHS token trees as named `Block` units (`macro_name:armN`)
- keep one `Raw("macro_rule_body")` boundary so macro-arm units are matchable by syntax/near but not `exact_safe` semantic proofs
- preserve frontend Block unit roots through desugar normalization so named block units survive feature extraction
- record #215 spike measurements and remaining Rust no-overlap cases

## Measurement
- Rust `no-overlapping-unit` probe misses: 14 -> 9
- Rust arm1 missed worthy labels: 57 -> 52
- Rust arm1 recall: dev 364/411 -> 369/411; held-out unchanged at 245/255
- Default eval after: overall P@10 63% dev / 56% held-out; Rust P@10 77% dev / 62% held-out
- Rust corpus surface delta: +356 macro-arm units, +559 units total, +7 candidate/default-surface families
- Macro-arm raw ratio: median 0.0667, mean 0.0634, max 0.125; all new macro-arm units are exact-unsafe

## Validation
- `awiki lint --root docs`
- `jq empty bench/labels/rust_macro_rules_recovery_2026_06_10.json`
- `python3 -m py_compile bench/labels/recall_ceiling_probe.py bench/labels/eval_by_language.py`
- `cargo fmt --all --check`
- `cargo test -p nose-frontend`
- `cargo test -p nose-cli`
- `./scripts/check-ci-local.sh`
- full recall-ceiling probe with shared corpus root
- full `eval_by_language.py --rank extractability --top 0`

Closes #215