### PR TITLE
Recover enclosing unit names for Block locations (closes #225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@ break.
   `default` — the #216 audit's gap #3), and `surface_counts` gains a
   `generated` bucket. Partly-generated families stay on their ranked surface
   with generated members flagged.
+- Block locations now carry `enclosing_unit` (the host function/method) in
+  scan JSON — structural blocks via the fragment recovery path, copy-paste-run
+  blocks via a new span lookup over the unit set, and same-span method/body
+  pairs resolve to the method. Every sampled #216 audit block had `name: null`
+  with nothing to anchor a discussion to.
 - Scan JSON families now carry `varying_spots` difference evidence: per varying
   spot, both representative copies' absolute line ranges and trimmed text —
   consistent with `params` by construction. With the witness's shape-vs-value

--- a/crates/nose-cli/tests/cli/output_contract.rs
+++ b/crates/nose-cli/tests/cli/output_contract.rs
@@ -324,3 +324,54 @@ fn scan_surfaces_generated_families_off_default_and_flags_partial_ones() {
         "surface_counts accounts the generated family: {out}"
     );
 }
+
+/// #225: plain Block locations carry their enclosing function/method, so an
+/// agent can NAME the region a block family lives in without opening files.
+#[test]
+fn scan_json_block_locations_carry_enclosing_unit() {
+    let dir = std::env::temp_dir().join(format!("nose_encl_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    // Two DIFFERENT functions sharing one identical inner block: the whole
+    // functions must not merge (different surrounding statements), so the
+    // family's reported members are the Block units — which must name their
+    // host functions.
+    let block = "    for x in items:\n        if x > 100:\n            out.append(x * 2 + 7)\n        elif x > 50:\n            out.append(x * 3 + 11)\n        elif x > 10:\n            out.append(x * 5 + 13)\n        else:\n            out.append(x - 17)\n";
+    fs::write(
+        dir.join("a.py"),
+        format!("def host_one(items, label):\n    out = []\n    print(\"first\" + label)\n{block}    return out\n"),
+    )
+    .unwrap();
+    fs::write(
+        dir.join("b.py"),
+        format!("def host_two(items, n):\n    out = []\n    total = n * 3\n{block}    return (out, total)\n"),
+    )
+    .unwrap();
+
+    let out = run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--min-lines",
+        "1",
+        "--format",
+        "json",
+        "--top",
+        "0",
+    ]);
+    let json = scan_json(&out);
+    let fams = scan_families(&json);
+    let mut named = 0;
+    for f in fams {
+        for l in f["locations"].as_array().unwrap() {
+            if l["kind"] == "Block" {
+                let host = l["enclosing_unit"]["name"].as_str().unwrap_or("");
+                assert!(
+                    host.starts_with("host_"),
+                    "block location must name its enclosing function: {out}"
+                );
+                named += 1;
+            }
+        }
+    }
+    assert!(named >= 2, "expected named block locations: {out}");
+}

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -754,7 +754,13 @@ fn contains_span(parent: &UnitFeat, child: &UnitFeat) -> bool {
     parent.path == child.path
         && parent.start_line <= child.start_line
         && parent.end_line >= child.end_line
-        && (parent.start_line < child.start_line || parent.end_line > child.end_line)
+        // Strict containment, except that a DIFFERENT-kind parent may share the
+        // exact span: a method and its whole-body block are one region in two
+        // unit kinds, and the method IS the block's enclosing context (#225).
+        // Same-kind twins still never enclose each other.
+        && (parent.start_line < child.start_line
+            || parent.end_line > child.end_line
+            || parent.kind != child.kind)
 }
 
 fn enclosing_unit_of(parent: &UnitFeat) -> EnclosingUnit {
@@ -768,6 +774,45 @@ fn enclosing_unit_of(parent: &UnitFeat) -> EnclosingUnit {
     };
     unit.refresh_unit_key();
     unit
+}
+
+/// Attach enclosing function/method names to copy-paste-run members. Contiguous
+/// groups are built from token streams, not from the unit set, so they never
+/// passed through `enclosing_units` — and the #216 audit's sampled block
+/// locations (all contiguous) carried `name: null` with nothing to anchor a
+/// discussion to (#225). A run that crosses unit boundaries keeps `None`.
+fn attach_enclosing_units(groups: &mut [Group], units: &[UnitFeat]) {
+    let mut by_file: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (idx, unit) in units.iter().enumerate() {
+        if can_enclose_fragment(unit) {
+            by_file.entry(unit.path.as_str()).or_default().push(idx);
+        }
+    }
+    for parents in by_file.values_mut() {
+        parents.sort_by_key(|&idx| {
+            (
+                LineSpan::new(units[idx].start_line, units[idx].end_line).line_count(),
+                units[idx].start_line,
+            )
+        });
+    }
+    for group in groups {
+        for loc in &mut group.members {
+            if loc.enclosing_unit.is_some() {
+                continue;
+            }
+            let Some(parents) = by_file.get(loc.file.as_str()) else {
+                continue;
+            };
+            let parent = parents.iter().copied().find(|&idx| {
+                let u = &units[idx];
+                u.start_line <= loc.start_line && u.end_line >= loc.end_line
+            });
+            if let Some(idx) = parent {
+                loc.enclosing_unit = Some(enclosing_unit_of(&units[idx]));
+            }
+        }
+    }
 }
 
 fn enclosing_units(units: &[UnitFeat]) -> Vec<Option<EnclosingUnit>> {
@@ -792,7 +837,11 @@ fn enclosing_units(units: &[UnitFeat]) -> Vec<Option<EnclosingUnit>> {
         });
 
         for &idx in indices {
-            if units[idx].fragment_kind.is_none() {
+            // Fragments AND plain Block units get their enclosing
+            // function/method recovered — an agent cannot even NAME the region
+            // of a block family without it (#225: every sampled block location
+            // had `name: null`). Whole function/method/class units need none.
+            if units[idx].fragment_kind.is_none() && units[idx].kind != nose_il::UnitKind::Block {
                 continue;
             }
             if let Some(parent) = parents
@@ -1060,11 +1109,12 @@ pub fn detect_from_units(
     // the same families — the cache supplies cached streams, otherwise this would
     // silently omit every contiguous clone.
     if opts.contiguous {
-        let extra = contiguous::detect(
+        let mut extra = contiguous::detect(
             streams,
             opts.contiguous_min_tokens,
             opts.contiguous_min_lines,
         );
+        attach_enclosing_units(&mut extra, &units);
         report.metrics.groups += extra.len();
         report.groups.extend(extra);
     }

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -264,7 +264,7 @@ Each `locations[]` item has:
 | `is_fragment` | boolean | `true` when this location is an exact sub-function fragment; `false` for whole units and syntax-channel copy-paste spans. |
 | `fragment_kind` | string, optional | Exact fragment proof shape, present only when `is_fragment` is `true`; examples include `direct-return`, `conditional-guard`, and `self-field-body`. |
 | `reason_code` | string, optional | Stable exact-fragment proof reason derived from `fragment_kind`, present only when `is_fragment` is `true`; examples include `exact-direct-return` and `exact-conditional-guard`. |
-| `enclosing_unit` | object, optional | Exact enclosing function/method/class recovered from the same extracted unit set when available. |
+| `enclosing_unit` | object, optional | Enclosing function/method/class recovered from the extracted unit set when available — for exact fragments AND plain `Block` locations (structural and copy-paste alike), so a block family names its host. Absent when a copy-paste run crosses unit boundaries, and in syntax-only scans (no unit set is extracted). |
 
 ### Fragment metadata
 


### PR DESCRIPTION
## What

Closes #225 (gap #4 of the #216 audit; tranche #228). Every sampled audit block had `name: null` — nothing to anchor a discussion to. Two missing recovery paths:

- **Structural blocks**: `enclosing_units` only filled fragments; plain Block units now recover their host the same way, and a *different-kind* parent may share the exact span — a method IS its whole-body block's context (rxjava's constructor blocks now read `EqualSubscriber · Method`).
- **Copy-paste runs**: contiguous groups are built from token streams and never saw the unit set; a post-pass attaches the smallest containing function/method/class per member (cmark's scanner runs read `_scan_html_block_start`). A run crossing unit boundaries stays `None`; syntax-only scans have no unit set — both documented.

## Validation

Contract test pins block families naming their hosts under the default scan mode; corpus spot checks on the audit families (cmark, rxjava). Workspace 927/0, clippy 0, dup-gate OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)