### PR TITLE
Index every evidence/node hot-path lookup: 2-4x faster scans (§BQ)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ break.
 
 ## [Unreleased]
 
+### Performance
+- Scans are 2–4× faster end-to-end on the benchmark corpus (sympy 20.0 → 4.7s,
+  redis 3.9 → 1.0s, git 2.7 → 1.1s wall; experiments §BQ) with byte-identical
+  output. The evidence passes and semantic-evidence queries that dominated
+  `normalize+extract` were quadratic — per-node helpers re-scanning the whole
+  `il.evidence`/`il.nodes` tables — and now go through index-backed lookups:
+  the anchor-span evidence index everywhere (emit-path dedup included, plus a
+  new binding-hash bucket and a staleness sentinel that survives
+  `clear()`/`retain()`), new lazy span→nodes and scope→assignments arena
+  indexes, a one-pass `ScopeMutationFacts` walk in binding evidence, and a
+  per-file (was per-unit) pure-inline candidate registry shared through
+  `ValueFingerprintContext`.
+
 ### Fixed
 - Rust units inside an inline `#[cfg(test)] mod tests` now classify as test
   scope (the path+name heuristic tagged them `prod`, distorting triage — the

--- a/crates/nose-cli/tests/cli/exact_fragments.rs
+++ b/crates/nose-cli/tests/cli/exact_fragments.rs
@@ -1767,28 +1767,11 @@ fn semantic_scan_reports_exact_safe_ordered_foreach_effect_branch_fragments() {
 
     let assert_branch_pair =
         |left: &str, right: &str, negative: &str, start_line: u64, end_line: u64| {
-            let family = families
-                .iter()
-                .find(|family| {
-                    let locations = family["locations"].as_array().expect("locations");
-                    let branch_files: Vec<&str> = locations
-                        .iter()
-                        .filter(|loc| {
-                            loc["start_line"] == start_line && loc["end_line"] == end_line
-                        })
-                        .filter_map(|loc| loc["file"].as_str())
-                        .collect();
-                    branch_files.iter().any(|file| file.ends_with(left))
-                        && branch_files.iter().any(|file| file.ends_with(right))
-                        && locations.iter().all(|loc| loc["kind"] == "Block")
-                        && locations
-                            .iter()
-                            .filter_map(|loc| loc["file"].as_str())
-                            .all(|file| !file.ends_with(negative))
-                })
-                .unwrap_or_else(|| {
-                    panic!("missing ordered foreach-effect branch family {left}/{right}: {out}")
-                });
+            let family =
+                block_branch_pair_family(families, left, right, negative, start_line, end_line)
+                    .unwrap_or_else(|| {
+                        panic!("missing ordered foreach-effect branch family {left}/{right}: {out}")
+                    });
             assert!(
                 family["locations"]
                     .as_array()
@@ -1805,26 +1788,12 @@ fn semantic_scan_reports_exact_safe_ordered_foreach_effect_branch_fragments() {
                                  left_end: u64,
                                  right_start: u64,
                                  right_end: u64| {
-        let has_branch_pair = families.iter().any(|family| {
-            let locations = family["locations"].as_array().expect("locations");
-            let has_left = locations.iter().any(|loc| {
-                loc["file"]
-                    .as_str()
-                    .is_some_and(|file| file.ends_with(left))
-                    && loc["start_line"] == left_start
-                    && loc["end_line"] == left_end
-            });
-            let has_right = locations.iter().any(|loc| {
-                loc["file"]
-                    .as_str()
-                    .is_some_and(|file| file.ends_with(right))
-                    && loc["start_line"] == right_start
-                    && loc["end_line"] == right_end
-            });
-            has_left && has_right
-        });
         assert!(
-            !has_branch_pair,
+            !families_pair_locations(
+                families,
+                (left, left_start, left_end),
+                (right, right_start, right_end),
+            ),
             "ordered foreach-effect branch boundary must not merge {left}/{right}: {out}"
         );
     };
@@ -1996,28 +1965,11 @@ fn semantic_scan_reports_exact_safe_ordered_mixed_effect_branch_fragments() {
 
     let assert_branch_pair =
         |left: &str, right: &str, negative: &str, start_line: u64, end_line: u64| {
-            let family = families
-                .iter()
-                .find(|family| {
-                    let locations = family["locations"].as_array().expect("locations");
-                    let branch_files: Vec<&str> = locations
-                        .iter()
-                        .filter(|loc| {
-                            loc["start_line"] == start_line && loc["end_line"] == end_line
-                        })
-                        .filter_map(|loc| loc["file"].as_str())
-                        .collect();
-                    branch_files.iter().any(|file| file.ends_with(left))
-                        && branch_files.iter().any(|file| file.ends_with(right))
-                        && locations.iter().all(|loc| loc["kind"] == "Block")
-                        && locations
-                            .iter()
-                            .filter_map(|loc| loc["file"].as_str())
-                            .all(|file| !file.ends_with(negative))
-                })
-                .unwrap_or_else(|| {
-                    panic!("missing ordered mixed-effect branch family {left}/{right}: {out}")
-                });
+            let family =
+                block_branch_pair_family(families, left, right, negative, start_line, end_line)
+                    .unwrap_or_else(|| {
+                        panic!("missing ordered mixed-effect branch family {left}/{right}: {out}")
+                    });
             assert!(
                 family["locations"]
                     .as_array()
@@ -2034,26 +1986,12 @@ fn semantic_scan_reports_exact_safe_ordered_mixed_effect_branch_fragments() {
                                  left_end: u64,
                                  right_start: u64,
                                  right_end: u64| {
-        let has_branch_pair = families.iter().any(|family| {
-            let locations = family["locations"].as_array().expect("locations");
-            let has_left = locations.iter().any(|loc| {
-                loc["file"]
-                    .as_str()
-                    .is_some_and(|file| file.ends_with(left))
-                    && loc["start_line"] == left_start
-                    && loc["end_line"] == left_end
-            });
-            let has_right = locations.iter().any(|loc| {
-                loc["file"]
-                    .as_str()
-                    .is_some_and(|file| file.ends_with(right))
-                    && loc["start_line"] == right_start
-                    && loc["end_line"] == right_end
-            });
-            has_left && has_right
-        });
         assert!(
-            !has_branch_pair,
+            !families_pair_locations(
+                families,
+                (left, left_start, left_end),
+                (right, right_start, right_end),
+            ),
             "ordered mixed-effect branch boundary must not merge {left}/{right}: {out}"
         );
     };
@@ -2241,28 +2179,12 @@ fn semantic_scan_reports_exact_safe_ordered_conditional_effect_branch_fragments(
 
     let assert_branch_pair =
         |left: &str, right: &str, negative: &str, start_line: u64, end_line: u64| {
-            let family = families
-                .iter()
-                .find(|family| {
-                    let locations = family["locations"].as_array().expect("locations");
-                    let branch_files: Vec<&str> = locations
-                        .iter()
-                        .filter(|loc| {
-                            loc["start_line"] == start_line && loc["end_line"] == end_line
-                        })
-                        .filter_map(|loc| loc["file"].as_str())
-                        .collect();
-                    branch_files.iter().any(|file| file.ends_with(left))
-                        && branch_files.iter().any(|file| file.ends_with(right))
-                        && locations.iter().all(|loc| loc["kind"] == "Block")
-                        && locations
-                            .iter()
-                            .filter_map(|loc| loc["file"].as_str())
-                            .all(|file| !file.ends_with(negative))
-                })
-                .unwrap_or_else(|| {
-                    panic!("missing ordered conditional-effect branch family {left}/{right}: {out}")
-                });
+            let family = block_branch_pair_family(
+                families, left, right, negative, start_line, end_line,
+            )
+            .unwrap_or_else(|| {
+                panic!("missing ordered conditional-effect branch family {left}/{right}: {out}")
+            });
             assert!(
             family["locations"]
                 .as_array()
@@ -2279,26 +2201,12 @@ fn semantic_scan_reports_exact_safe_ordered_conditional_effect_branch_fragments(
                                  left_end: u64,
                                  right_start: u64,
                                  right_end: u64| {
-        let has_branch_pair = families.iter().any(|family| {
-            let locations = family["locations"].as_array().expect("locations");
-            let has_left = locations.iter().any(|loc| {
-                loc["file"]
-                    .as_str()
-                    .is_some_and(|file| file.ends_with(left))
-                    && loc["start_line"] == left_start
-                    && loc["end_line"] == left_end
-            });
-            let has_right = locations.iter().any(|loc| {
-                loc["file"]
-                    .as_str()
-                    .is_some_and(|file| file.ends_with(right))
-                    && loc["start_line"] == right_start
-                    && loc["end_line"] == right_end
-            });
-            has_left && has_right
-        });
         assert!(
-            !has_branch_pair,
+            !families_pair_locations(
+                families,
+                (left, left_start, left_end),
+                (right, right_start, right_end),
+            ),
             "ordered conditional-effect branch boundary must not merge {left}/{right}: {out}"
         );
     };
@@ -2493,36 +2401,20 @@ fn semantic_scan_reports_exact_safe_ordered_conditional_mixed_effect_branch_frag
                               negative: &str,
                               start_line: u64,
                               end_line: u64| {
-        let family = families
-            .iter()
-            .find(|family| {
-                let locations = family["locations"].as_array().expect("locations");
-                let branch_files: Vec<&str> = locations
-                    .iter()
-                    .filter(|loc| loc["start_line"] == start_line && loc["end_line"] == end_line)
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
-                branch_files.iter().any(|file| file.ends_with(left))
-                    && branch_files.iter().any(|file| file.ends_with(right))
-                    && locations.iter().all(|loc| loc["kind"] == "Block")
-                    && locations
-                        .iter()
-                        .filter_map(|loc| loc["file"].as_str())
-                        .all(|file| !file.ends_with(negative))
-            })
-            .unwrap_or_else(|| {
-                panic!(
-                    "missing ordered conditional mixed-effect branch family {left}/{right}: {out}"
-                )
-            });
+        let family = block_branch_pair_family(
+            families, left, right, negative, start_line, end_line,
+        )
+        .unwrap_or_else(|| {
+            panic!("missing ordered conditional mixed-effect branch family {left}/{right}: {out}")
+        });
         assert!(
-            family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .all(|loc| loc["kind"] == "Block"),
-            "ordered conditional mixed-effect branch fragments should report as Block units: {family:?}"
-        );
+                family["locations"]
+                    .as_array()
+                    .expect("locations")
+                    .iter()
+                    .all(|loc| loc["kind"] == "Block"),
+                "ordered conditional mixed-effect branch fragments should report as Block units: {family:?}"
+            );
     };
 
     let assert_no_branch_pair = |left: &str,
@@ -2531,26 +2423,12 @@ fn semantic_scan_reports_exact_safe_ordered_conditional_mixed_effect_branch_frag
                                  left_end: u64,
                                  right_start: u64,
                                  right_end: u64| {
-        let has_branch_pair = families.iter().any(|family| {
-            let locations = family["locations"].as_array().expect("locations");
-            let has_left = locations.iter().any(|loc| {
-                loc["file"]
-                    .as_str()
-                    .is_some_and(|file| file.ends_with(left))
-                    && loc["start_line"] == left_start
-                    && loc["end_line"] == left_end
-            });
-            let has_right = locations.iter().any(|loc| {
-                loc["file"]
-                    .as_str()
-                    .is_some_and(|file| file.ends_with(right))
-                    && loc["start_line"] == right_start
-                    && loc["end_line"] == right_end
-            });
-            has_left && has_right
-        });
         assert!(
-            !has_branch_pair,
+            !families_pair_locations(
+                families,
+                (left, left_start, left_end),
+                (right, right_start, right_end),
+            ),
             "ordered conditional mixed-effect branch boundary must not merge {left}/{right}: {out}"
         );
     };
@@ -2753,36 +2631,20 @@ fn semantic_scan_reports_exact_safe_ordered_loop_conditional_effect_branch_fragm
                               negative: &str,
                               start_line: u64,
                               end_line: u64| {
-        let family = families
-            .iter()
-            .find(|family| {
-                let locations = family["locations"].as_array().expect("locations");
-                let branch_files: Vec<&str> = locations
-                    .iter()
-                    .filter(|loc| loc["start_line"] == start_line && loc["end_line"] == end_line)
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
-                branch_files.iter().any(|file| file.ends_with(left))
-                    && branch_files.iter().any(|file| file.ends_with(right))
-                    && locations.iter().all(|loc| loc["kind"] == "Block")
-                    && locations
-                        .iter()
-                        .filter_map(|loc| loc["file"].as_str())
-                        .all(|file| !file.ends_with(negative))
-            })
-            .unwrap_or_else(|| {
-                panic!(
-                    "missing ordered loop conditional-effect branch family {left}/{right}: {out}"
-                )
-            });
+        let family = block_branch_pair_family(
+            families, left, right, negative, start_line, end_line,
+        )
+        .unwrap_or_else(|| {
+            panic!("missing ordered loop conditional-effect branch family {left}/{right}: {out}")
+        });
         assert!(
-            family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .all(|loc| loc["kind"] == "Block"),
-            "ordered loop conditional-effect branch fragments should report as Block units: {family:?}"
-        );
+                family["locations"]
+                    .as_array()
+                    .expect("locations")
+                    .iter()
+                    .all(|loc| loc["kind"] == "Block"),
+                "ordered loop conditional-effect branch fragments should report as Block units: {family:?}"
+            );
     };
 
     let assert_no_branch_pair = |left: &str,
@@ -2791,26 +2653,12 @@ fn semantic_scan_reports_exact_safe_ordered_loop_conditional_effect_branch_fragm
                                  left_end: u64,
                                  right_start: u64,
                                  right_end: u64| {
-        let has_branch_pair = families.iter().any(|family| {
-            let locations = family["locations"].as_array().expect("locations");
-            let has_left = locations.iter().any(|loc| {
-                loc["file"]
-                    .as_str()
-                    .is_some_and(|file| file.ends_with(left))
-                    && loc["start_line"] == left_start
-                    && loc["end_line"] == left_end
-            });
-            let has_right = locations.iter().any(|loc| {
-                loc["file"]
-                    .as_str()
-                    .is_some_and(|file| file.ends_with(right))
-                    && loc["start_line"] == right_start
-                    && loc["end_line"] == right_end
-            });
-            has_left && has_right
-        });
         assert!(
-            !has_branch_pair,
+            !families_pair_locations(
+                families,
+                (left, left_start, left_end),
+                (right, right_start, right_end),
+            ),
             "ordered loop conditional-effect branch boundary must not merge {left}/{right}: {out}"
         );
     };
@@ -3013,36 +2861,21 @@ fn semantic_scan_reports_exact_safe_ordered_loop_conditional_mixed_effect_branch
                               negative: &str,
                               start_line: u64,
                               end_line: u64| {
-        let family = families
-            .iter()
-            .find(|family| {
-                let locations = family["locations"].as_array().expect("locations");
-                let branch_files: Vec<&str> = locations
-                    .iter()
-                    .filter(|loc| loc["start_line"] == start_line && loc["end_line"] == end_line)
-                    .filter_map(|loc| loc["file"].as_str())
-                    .collect();
-                branch_files.iter().any(|file| file.ends_with(left))
-                    && branch_files.iter().any(|file| file.ends_with(right))
-                    && locations.iter().all(|loc| loc["kind"] == "Block")
-                    && locations
-                        .iter()
-                        .filter_map(|loc| loc["file"].as_str())
-                        .all(|file| !file.ends_with(negative))
-            })
-            .unwrap_or_else(|| {
-                panic!(
-                    "missing ordered loop conditional mixed-effect branch family {left}/{right}: {out}"
-                )
-            });
+        let family =
+            block_branch_pair_family(families, left, right, negative, start_line, end_line)
+                .unwrap_or_else(|| {
+                    panic!(
+                "missing ordered loop conditional mixed-effect branch family {left}/{right}: {out}"
+            )
+                });
         assert!(
-            family["locations"]
-                .as_array()
-                .expect("locations")
-                .iter()
-                .all(|loc| loc["kind"] == "Block"),
-            "ordered loop conditional mixed-effect branch fragments should report as Block units: {family:?}"
-        );
+                family["locations"]
+                    .as_array()
+                    .expect("locations")
+                    .iter()
+                    .all(|loc| loc["kind"] == "Block"),
+                "ordered loop conditional mixed-effect branch fragments should report as Block units: {family:?}"
+            );
     };
 
     let assert_no_branch_pair = |left: &str,
@@ -3051,26 +2884,12 @@ fn semantic_scan_reports_exact_safe_ordered_loop_conditional_mixed_effect_branch
                                  left_end: u64,
                                  right_start: u64,
                                  right_end: u64| {
-        let has_branch_pair = families.iter().any(|family| {
-            let locations = family["locations"].as_array().expect("locations");
-            let has_left = locations.iter().any(|loc| {
-                loc["file"]
-                    .as_str()
-                    .is_some_and(|file| file.ends_with(left))
-                    && loc["start_line"] == left_start
-                    && loc["end_line"] == left_end
-            });
-            let has_right = locations.iter().any(|loc| {
-                loc["file"]
-                    .as_str()
-                    .is_some_and(|file| file.ends_with(right))
-                    && loc["start_line"] == right_start
-                    && loc["end_line"] == right_end
-            });
-            has_left && has_right
-        });
         assert!(
-            !has_branch_pair,
+            !families_pair_locations(
+                families,
+                (left, left_start, left_end),
+                (right, right_start, right_end),
+            ),
             "ordered loop conditional mixed-effect branch boundary must not merge {left}/{right}: {out}"
         );
     };

--- a/crates/nose-cli/tests/cli/review.rs
+++ b/crates/nose-cli/tests/cli/review.rs
@@ -252,20 +252,7 @@ fn c_u16_byte_pack_recognized_in_either_operand_order() {
         "unsigned int or2(int d, unsigned char *a) {\n  return (a[0] << 8) | a[1];\n}\n",
     )
     .unwrap();
-    let out = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let out = scan_min_json(&dir, "semantic");
     let json = scan_json(&out);
     let families = scan_families(&json);
     assert_eq!(

--- a/crates/nose-cli/tests/cli/semantic_core.rs
+++ b/crates/nose-cli/tests/cli/semantic_core.rs
@@ -115,20 +115,7 @@ fn scan_mode_semantic_reports_c_u16_byte_pack_only_when_byte_buffer_proven() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     let family_files = |family: &serde_json::Value| -> Vec<String> {
@@ -208,20 +195,7 @@ fn scan_mode_semantic_reports_c_u32_byte_pack_only_when_unsigned_cast_proven() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     let family_files = |family: &serde_json::Value| -> Vec<String> {

--- a/crates/nose-cli/tests/cli/semantic_idioms.rs
+++ b/crates/nose-cli/tests/cli/semantic_idioms.rs
@@ -31,20 +31,7 @@ fn scan_mode_semantic_proves_regex_literal_predicate_matches() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -62,20 +49,7 @@ fn scan_mode_semantic_proves_regex_literal_predicate_matches() {
         "semantic mode must consume regex literal provenance without merging different patterns: {semantic}"
     );
 
-    let near = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "near:0.5",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let near = scan_min_json(&dir, "near:0.5");
     assert!(
         near.contains("dot-only.ts") && near.contains("markdown-link.ts"),
         "near mode may still surface the review candidate: {near}"
@@ -105,20 +79,7 @@ fn scan_mode_semantic_allows_proved_js_static_builtins() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -166,20 +127,7 @@ fn scan_mode_semantic_rejects_unproved_typeof_function_name() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     assert!(
         !family_contains_all(
@@ -211,20 +159,7 @@ fn scan_mode_semantic_rejects_unproved_array_isarray_name() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     assert!(
         !family_contains_all(&semantic_json, &["array_a.py", "array_b.py"]),
@@ -251,20 +186,7 @@ fn scan_mode_semantic_rejects_unproved_literal_test_method_name() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     assert!(
         !family_contains_all(
@@ -322,20 +244,7 @@ fn scan_mode_semantic_proves_extreme_type4_idioms() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     let family = |positives: &[&str], negatives: &[&str]| {
@@ -407,20 +316,7 @@ fn scan_mode_semantic_proves_collection_empty_checks() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert!(
@@ -499,20 +395,7 @@ fn scan_mode_semantic_proves_string_prefix_checks() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert!(
@@ -605,20 +488,7 @@ fn scan_mode_semantic_proves_rust_integer_methods() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     for expected_pair in [
@@ -1151,20 +1021,7 @@ fn scan_mode_semantic_proves_literal_collection_membership() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert!(
@@ -1365,20 +1222,7 @@ fn scan_mode_semantic_keeps_unproven_contains_calls_distinct() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json: serde_json::Value =
         serde_json::from_str(&semantic).expect("semantic scan should emit JSON");
     let semantic_text = semantic_json.to_string();
@@ -1487,20 +1331,7 @@ fn scan_mode_semantic_proves_typed_dynamic_collection_membership() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     let expected = [
@@ -1645,20 +1476,7 @@ fn scan_mode_semantic_proves_set_membership_when_receiver_is_proven() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     let expected_positive = [
@@ -1736,20 +1554,7 @@ fn scan_mode_semantic_keeps_aslist_single_unproven_receiver_distinct() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     for family in semantic_families {
@@ -1885,20 +1690,7 @@ fn scan_mode_semantic_proves_typed_typescript_map_key_membership() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     let positive_family = semantic_families
@@ -2104,20 +1896,7 @@ fn scan_mode_semantic_proves_typed_typescript_map_default_lookup() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     let expected = [
@@ -2594,20 +2373,7 @@ fn scan_mode_semantic_proves_literal_map_default_lookup() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     let expected = [
@@ -2856,20 +2622,7 @@ fn scan_mode_semantic_proves_null_presence_predicates() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -2916,20 +2669,7 @@ fn scan_mode_semantic_reports_flattened_guard_span_only() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let families = scan_families(&semantic_json);
     let text = semantic_json.to_string();
@@ -2987,20 +2727,7 @@ fn scan_mode_semantic_preserves_js_typeof_operator() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -3149,20 +2876,7 @@ fn scan_mode_semantic_distinguishes_sequence_kinds() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -3202,20 +2916,7 @@ fn scan_mode_semantic_allows_static_import_identity() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -3263,20 +2964,7 @@ fn scan_mode_semantic_allows_named_namespace_import_identity() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json: serde_json::Value =
         serde_json::from_str(&semantic).expect("semantic scan should emit JSON");
     let semantic_text = semantic_json.to_string();
@@ -3330,20 +3018,7 @@ fn scan_mode_semantic_allows_static_projection_identity() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert!(
@@ -3397,20 +3072,7 @@ fn scan_mode_semantic_distinguishes_nullish_from_truthy_defaults() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -3463,20 +3125,7 @@ fn scan_mode_semantic_pins_strict_nullish_default_boundaries() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -3536,20 +3185,7 @@ fn scan_mode_semantic_pins_js_object_guard_nullish_boundary() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let strict_family = family_with_all(
         &semantic_json,
@@ -3626,20 +3262,7 @@ fn scan_mode_semantic_proves_js_record_shape_guards() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -3730,20 +3353,7 @@ fn scan_mode_semantic_proves_js_own_property_guards() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -3801,20 +3411,7 @@ fn scan_mode_semantic_converges_cross_language_list_literals() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -3865,20 +3462,7 @@ fn scan_mode_semantic_preserves_js_object_keys() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -3925,20 +3509,7 @@ fn scan_mode_semantic_converges_cross_language_map_literals() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -3984,20 +3555,7 @@ fn scan_mode_semantic_captures_module_literal_bindings() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -4048,20 +3606,7 @@ fn scan_mode_semantic_preserves_python_dict_keys() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(
@@ -4113,20 +3658,7 @@ fn scan_mode_semantic_preserves_ruby_hash_keys() {
     )
     .unwrap();
 
-    let semantic = run(&[
-        "scan",
-        dir.to_str().unwrap(),
-        "--mode",
-        "semantic",
-        "--min-lines",
-        "1",
-        "--min-size",
-        "1",
-        "--format",
-        "json",
-        "--top",
-        "0",
-    ]);
+    let semantic = scan_min_json(&dir, "semantic");
     let semantic_json = scan_json(&semantic);
     let semantic_families = scan_families(&semantic_json);
     assert_eq!(

--- a/crates/nose-cli/tests/cli/support.rs
+++ b/crates/nose-cli/tests/cli/support.rs
@@ -107,6 +107,26 @@ pub(crate) fn run(args: &[&str]) -> String {
     String::from_utf8(out.stdout).unwrap()
 }
 
+/// `nose scan <dir> --mode <mode> --format json --top 0` with the tiny-fixture
+/// floors (`--min-lines 1 --min-size 1`) — the standard invocation for the
+/// one-function fixtures the semantic CLI tests are built from.
+pub(crate) fn scan_min_json(dir: &Path, mode: &str) -> String {
+    run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        mode,
+        "--min-lines",
+        "1",
+        "--min-size",
+        "1",
+        "--format",
+        "json",
+        "--top",
+        "0",
+    ])
+}
+
 pub(crate) fn add_distinct_clone_family(dir: &Path) {
     let d = dir.join("new");
     fs::create_dir_all(&d).unwrap();
@@ -158,6 +178,55 @@ pub(crate) fn family_with_all<'a>(
                     .is_some_and(|file| file.ends_with(suffix))
             })
         })
+    })
+}
+
+/// Find a family that pairs `left` and `right` as locations at exactly
+/// `start_line..end_line`, where every location is a `Block` and none sits in
+/// `negative` — the standard positive check for branch-boundary fragment tests.
+pub(crate) fn block_branch_pair_family<'a>(
+    families: &'a [serde_json::Value],
+    left: &str,
+    right: &str,
+    negative: &str,
+    start_line: u64,
+    end_line: u64,
+) -> Option<&'a serde_json::Value> {
+    families.iter().find(|family| {
+        let locations = family["locations"].as_array().expect("locations");
+        let branch_files: Vec<&str> = locations
+            .iter()
+            .filter(|loc| loc["start_line"] == start_line && loc["end_line"] == end_line)
+            .filter_map(|loc| loc["file"].as_str())
+            .collect();
+        branch_files.iter().any(|file| file.ends_with(left))
+            && branch_files.iter().any(|file| file.ends_with(right))
+            && locations.iter().all(|loc| loc["kind"] == "Block")
+            && locations
+                .iter()
+                .filter_map(|loc| loc["file"].as_str())
+                .all(|file| !file.ends_with(negative))
+    })
+}
+
+/// Whether any family pairs `left` at `(start, end)` with `right` at its
+/// `(start, end)` — the standard negative check for branch-boundary tests
+/// (asserting two spans were NOT merged into one family).
+pub(crate) fn families_pair_locations(
+    families: &[serde_json::Value],
+    left: (&str, u64, u64),
+    right: (&str, u64, u64),
+) -> bool {
+    fn has_location(locations: &[serde_json::Value], (file, start, end): (&str, u64, u64)) -> bool {
+        locations.iter().any(|loc| {
+            loc["file"].as_str().is_some_and(|f| f.ends_with(file))
+                && loc["start_line"] == start
+                && loc["end_line"] == end
+        })
+    }
+    families.iter().any(|family| {
+        let locations = family["locations"].as_array().expect("locations");
+        has_location(locations, left) && has_location(locations, right)
     })
 }
 

--- a/crates/nose-cli/tests/fixtures/scan-json-v1.json
+++ b/crates/nose-cli/tests/fixtures/scan-json-v1.json
@@ -90,6 +90,7 @@
       "review": 0,
       "hidden": 0,
       "debug": 0,
+      "generated": 0,
       "fragments": {
         "total": 0,
         "default": 0,

--- a/crates/nose-eval/src/lib.rs
+++ b/crates/nose-eval/src/lib.rs
@@ -410,12 +410,15 @@ pub fn ceiling(
         let p = eval_gold(g);
         let lu = cover(&p.left);
         let ru = cover(&p.right);
-        let unit_ok = matches!((lu, ru), (Some(a), Some(b)) if a != b);
-        let cand_ok = unit_ok && {
-            let (a, b) = (lu.unwrap() as u32, ru.unwrap() as u32);
+        let covered = match (lu, ru) {
+            (Some(a), Some(b)) if a != b => Some((a as u32, b as u32)),
+            _ => None,
+        };
+        let unit_ok = covered.is_some();
+        let cand_ok = covered.is_some_and(|(a, b)| {
             let key = if a <= b { (a, b) } else { (b, a) };
             cand_set.contains(&key)
-        };
+        });
         let t4flag = is_type4(&p);
         all.gold += 1;
         all.unit_reachable += unit_ok as usize;

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -82,6 +82,17 @@ pub struct Il {
     /// immutable once an `Il` is built — passes rebuild the arena instead.
     #[serde(skip)]
     scope_index: std::sync::OnceLock<Vec<Option<NodeId>>>,
+    /// Lazy byte-span → node-ids index (see [`Il::nodes_spanning`]). Sound under
+    /// the same immutability discipline as `scope_index`: node spans and kinds
+    /// are never rewritten in place (only payloads/edges are), and passes that
+    /// restructure the tree rebuild the arena.
+    #[serde(skip)]
+    span_index: std::sync::OnceLock<std::collections::HashMap<(u32, u32), Vec<u32>>>,
+    /// Lazy nearest-scope → assign-node-ids index (see [`Il::assigns_in_scope`]).
+    /// Keyed by the scope's node id (+1, with `0` for module level), each bucket
+    /// in arena order. Same immutability discipline as `scope_index`.
+    #[serde(skip)]
+    assign_scope_index: std::sync::OnceLock<std::collections::HashMap<u32, Vec<NodeId>>>,
     /// Lazy evidence lookup index (see [`Il::evidence_anchored_at`]). Appends to
     /// `evidence` are picked up incrementally (the index tracks how many records
     /// it has seen); code that mutates existing records IN PLACE must call
@@ -98,11 +109,35 @@ pub struct Il {
 #[derive(Debug, Default)]
 struct EvidenceIndex {
     indexed_len: usize,
+    /// `(id, anchor)` of the last record indexed — a cheap staleness sentinel.
+    /// Appends keep it valid; a `clear()`/`retain()`/splice that replaces the
+    /// prefix almost always changes the record at this position, which
+    /// [`Il::with_evidence_index`] detects and answers with a rebuild. (The
+    /// only undetectable rewrite is one that preserves every indexed record's
+    /// `(id, anchor)` pair — and such a rewrite leaves the index correct,
+    /// because those two fields are all it derives buckets from.)
+    sentinel: Option<(u32, EvidenceAnchor)>,
     by_anchor_span: std::collections::HashMap<(u32, u32, u32), Vec<u32>>,
+    /// `Binding` anchors are queried by `local_hash` (not span) — see
+    /// [`Il::evidence_binding_anchored`] — so they get their own bucket.
+    by_binding_hash: std::collections::HashMap<u64, Vec<u32>>,
     by_id: std::collections::HashMap<u32, u32>,
 }
 
 impl EvidenceIndex {
+    /// `false` when the already-indexed prefix no longer ends with the record
+    /// the index last saw — evidence was rewritten, not appended to.
+    fn prefix_intact(&self, evidence: &[EvidenceRecord]) -> bool {
+        match self.sentinel {
+            None => true,
+            Some((id, anchor)) => self
+                .indexed_len
+                .checked_sub(1)
+                .and_then(|last| evidence.get(last))
+                .is_some_and(|record| record.id.0 == id && record.anchor == anchor),
+        }
+    }
+
     fn extend_from(&mut self, evidence: &[EvidenceRecord]) {
         for (idx, record) in evidence.iter().enumerate().skip(self.indexed_len) {
             let span = record.anchor.span();
@@ -110,6 +145,12 @@ impl EvidenceIndex {
                 .entry((span.file.0, span.start_byte, span.end_byte))
                 .or_default()
                 .push(idx as u32);
+            if let EvidenceAnchor::Binding { local_hash, .. } = record.anchor {
+                self.by_binding_hash
+                    .entry(local_hash)
+                    .or_default()
+                    .push(idx as u32);
+            }
             // Mirror `evidence_record_by_id`: the record at position `id` wins;
             // otherwise the first record with that id.
             let id = record.id.0;
@@ -120,6 +161,7 @@ impl EvidenceIndex {
             }
         }
         self.indexed_len = evidence.len();
+        self.sentinel = evidence.last().map(|record| (record.id.0, record.anchor));
     }
 
     /// The same walk as the pre-index `evidence_dependencies_asserted`: every
@@ -162,6 +204,8 @@ impl Clone for Il {
             // Caches are cheap to recompute and a clone is usually about to be
             // mutated — start fresh.
             scope_index: std::sync::OnceLock::new(),
+            span_index: std::sync::OnceLock::new(),
+            assign_scope_index: std::sync::OnceLock::new(),
             evidence_index: std::sync::RwLock::new(None),
         }
     }
@@ -308,7 +352,10 @@ impl Il {
     ) -> EvidenceId {
         let pack_hash = stable_symbol_hash(pack_id);
         let rule_hash = stable_symbol_hash(rule);
-        if let Some(id) = self.evidence.iter().find_map(|record| {
+        // Index-backed dedup: only records anchored at this exact span can match,
+        // so the previous whole-`evidence` scan (quadratic over an emit-heavy
+        // pass) narrows to one bucket.
+        if let Some(id) = self.evidence_anchored_at(anchor.span()).find_map(|record| {
             (record.anchor == anchor
                 && record.kind == kind
                 && record.status == EvidenceStatus::Asserted
@@ -371,26 +418,119 @@ impl Il {
             .map(move |idx| &self.evidence[idx as usize])
     }
 
+    /// Node ids whose span covers exactly these bytes (callers still compare
+    /// full [`Span`]/kind/payload as needed), in arena order. Replaces
+    /// whole-arena scans for span-keyed lookups — those were quadratic when a
+    /// consumer queried per node. Backed by a lazy index under the arena
+    /// immutability discipline (see the `span_index` field).
+    pub fn nodes_spanning(&self, span: Span) -> impl Iterator<Item = NodeId> + '_ {
+        let index = self.span_index.get_or_init(|| {
+            let mut by_bytes: std::collections::HashMap<(u32, u32), Vec<u32>> =
+                std::collections::HashMap::new();
+            for (idx, node) in self.nodes.iter().enumerate() {
+                by_bytes
+                    .entry((node.span.start_byte, node.span.end_byte))
+                    .or_default()
+                    .push(idx as u32);
+            }
+            by_bytes
+        });
+        index
+            .get(&(span.start_byte, span.end_byte))
+            .map(|ids| ids.as_slice())
+            .unwrap_or_default()
+            .iter()
+            .map(|&idx| NodeId(idx))
+    }
+
+    /// `Assign` node ids whose [`Il::nearest_scope`] is `scope` (`None` =
+    /// module level), in arena order. Backed by a lazy index: binding-LHS
+    /// resolution filters assignments by scope per *reference*, which was a
+    /// whole-arena scan per query before.
+    pub fn assigns_in_scope(&self, scope: Option<NodeId>) -> &[NodeId] {
+        let index = self.assign_scope_index.get_or_init(|| {
+            let mut by_scope: std::collections::HashMap<u32, Vec<NodeId>> =
+                std::collections::HashMap::new();
+            for (idx, node) in self.nodes.iter().enumerate() {
+                if node.kind != NodeKind::Assign {
+                    continue;
+                }
+                let id = NodeId(idx as u32);
+                let key = self.nearest_scope(id).map_or(0, |scope| scope.0 + 1);
+                by_scope.entry(key).or_default().push(id);
+            }
+            by_scope
+        });
+        let key = scope.map_or(0, |scope| scope.0 + 1);
+        index
+            .get(&key)
+            .map(|ids| ids.as_slice())
+            .unwrap_or_default()
+    }
+
+    /// Indices into [`Il::evidence`] for records whose anchor sits exactly at
+    /// `span`, in evidence order — the mutating sibling of
+    /// [`Il::evidence_anchored_at`] (returning indices lets a caller re-borrow
+    /// `evidence` mutably while walking the bucket).
+    pub fn evidence_indices_anchored_at(&self, span: Span) -> Vec<u32> {
+        self.with_evidence_index(|index| {
+            index
+                .by_anchor_span
+                .get(&(span.file.0, span.start_byte, span.end_byte))
+                .cloned()
+                .unwrap_or_default()
+        })
+    }
+
+    /// Evidence records with an [`EvidenceAnchor::Binding`] anchor carrying this
+    /// `local_hash`, in evidence order. Binding anchors are matched by hash (not
+    /// span) by their consumers, so they get a dedicated index bucket.
+    pub fn evidence_binding_anchored(
+        &self,
+        local_hash: u64,
+    ) -> impl Iterator<Item = &EvidenceRecord> {
+        let indices = self.with_evidence_index(|index| {
+            index
+                .by_binding_hash
+                .get(&local_hash)
+                .cloned()
+                .unwrap_or_default()
+        });
+        indices
+            .into_iter()
+            .map(move |idx| &self.evidence[idx as usize])
+    }
+
     /// Drop the lazy evidence index. Appends are picked up automatically,
     /// removals trigger a rebuild, and `status`/`dependencies` are read live —
     /// call this only after rewriting a record's `anchor` or `id` in place.
     pub fn invalidate_evidence_index(&mut self) {
-        *self.evidence_index.write().unwrap() = None;
+        *self
+            .evidence_index
+            .write()
+            .expect("evidence index lock poisoned") = None;
     }
 
     fn with_evidence_index<T>(&self, read: impl FnOnce(&EvidenceIndex) -> T) -> T {
         {
-            let guard = self.evidence_index.read().unwrap();
+            let guard = self
+                .evidence_index
+                .read()
+                .expect("evidence index lock poisoned");
             if let Some(index) = guard.as_ref() {
-                if index.indexed_len == self.evidence.len() {
+                if index.indexed_len == self.evidence.len() && index.prefix_intact(&self.evidence) {
                     return read(index);
                 }
             }
         }
-        let mut guard = self.evidence_index.write().unwrap();
+        let mut guard = self
+            .evidence_index
+            .write()
+            .expect("evidence index lock poisoned");
         let index = guard.get_or_insert_with(EvidenceIndex::default);
-        if index.indexed_len > self.evidence.len() {
-            // Records were removed (e.g. a `retain`); indices are stale — rebuild.
+        if index.indexed_len > self.evidence.len() || !index.prefix_intact(&self.evidence) {
+            // Records were removed or the prefix was rewritten (e.g. a `retain`
+            // or `clear` + re-push); indices are stale — rebuild.
             *index = EvidenceIndex::default();
         }
         if index.indexed_len != self.evidence.len() {
@@ -544,6 +684,8 @@ impl IlBuilder {
             suppressed: Vec::new(),
             evidence: Vec::new(),
             scope_index: std::sync::OnceLock::new(),
+            span_index: std::sync::OnceLock::new(),
+            assign_scope_index: std::sync::OnceLock::new(),
             evidence_index: std::sync::RwLock::new(None),
         }
     }
@@ -660,5 +802,39 @@ mod validate_tests {
         assert_eq!(first, EvidenceId(1));
         assert_eq!(duplicate, first);
         assert_eq!(different_rule, EvidenceId(2));
+    }
+
+    /// `clear()` + re-push rewrites the indexed prefix without shrinking below
+    /// the indexed length — the staleness sentinel must trigger a rebuild, not
+    /// serve buckets for records that no longer exist.
+    #[test]
+    fn evidence_index_survives_clear_and_repush() {
+        let mut il = leaf_il();
+        let span = il.node(il.root).span;
+        let record = |id: u32, anchor| EvidenceRecord {
+            id: EvidenceId(id),
+            anchor,
+            kind: EvidenceKind::Domain(DomainEvidence::Collection),
+            provenance: EvidenceProvenance {
+                emitter: EvidenceEmitter::FirstParty,
+                pack_hash: None,
+                rule_hash: None,
+            },
+            dependencies: Vec::new(),
+            status: EvidenceStatus::Asserted,
+        };
+
+        il.evidence
+            .push(record(0, EvidenceAnchor::node(span, NodeKind::Module)));
+        // Build the index, then invalidate it the rude way.
+        assert_eq!(il.evidence_anchored_at(span).count(), 1);
+        il.evidence.clear();
+        il.evidence
+            .push(record(0, EvidenceAnchor::binding(span, 7)));
+        il.evidence
+            .push(record(1, EvidenceAnchor::node(span, NodeKind::Module)));
+
+        assert_eq!(il.evidence_anchored_at(span).count(), 2);
+        assert_eq!(il.evidence_binding_anchored(7).count(), 1);
     }
 }

--- a/crates/nose-normalize/src/binding_evidence.rs
+++ b/crates/nose-normalize/src/binding_evidence.rs
@@ -112,6 +112,7 @@ fn record_assignments_in_scope(
         )
     });
 
+    let mutation_facts = ScopeMutationFacts::collect(il, interner, scope);
     for assignment in ordered {
         if assignment.control_gated {
             continue;
@@ -125,7 +126,7 @@ fn record_assignments_in_scope(
         if node_contains_name(il, assignment.rhs, assignment.name) {
             continue;
         }
-        if binding_mutated_in_scope(il, interner, scope, assignments, assignment) {
+        if mutation_facts.binding_mutated(assignment) {
             continue;
         }
 
@@ -181,7 +182,7 @@ fn rhs_domain_evidence(
 fn domain_evidence_record_for_node(il: &Il, node: NodeId) -> Option<(DomainEvidence, EvidenceId)> {
     let expected = EvidenceAnchor::node(il.node(node).span, il.kind(node));
     let mut found = None;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(expected.span()) {
         if record.anchor != expected {
             continue;
         }
@@ -209,7 +210,7 @@ fn sequence_domain_evidence_record_for_node(
     }
     let span = il.node(node).span;
     let mut found = None;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(span) {
         if !matches!(record.anchor, EvidenceAnchor::Sequence { span: anchor_span } if anchor_span == span)
         {
             continue;
@@ -239,101 +240,175 @@ fn record_is_live(il: &Il, record: &EvidenceRecord) -> bool {
     record.status == EvidenceStatus::Asserted && il.evidence_dependencies_asserted(record)
 }
 
-fn binding_mutated_in_scope(
-    il: &Il,
-    interner: &Interner,
-    scope: NodeId,
-    assignments: &[BindingAssignment],
-    binding: BindingAssignment,
-) -> bool {
-    for assignment in assignments {
-        if assignment.assign != binding.assign
-            && binding_write_target(il, assignment.assign)
-                .is_some_and(|target| node_contains_name(il, target, binding.name))
-        {
-            return true;
-        }
+/// Per-scope mutation facts, collected in ONE walk and queried per binding.
+///
+/// Replaces the per-binding `visit_scope_nodes` walk (which was
+/// O(assignments × scope size) — quadratic on module scopes full of
+/// assignments, e.g. data-table files). Semantics are identical to the old
+/// walk: a site only counts against a name when no nested `Func`/`Lambda`
+/// between the scope root and the site *binds* that name (shadowing), and a
+/// write-target site never counts against the binding assignment itself. The
+/// old code's separate first pass over the scope's own assignment list was
+/// subsumed by the walk (same `binding_write_target`/`node_contains_name`
+/// check on the same nodes), so it has no counterpart here.
+struct ScopeMutationFacts {
+    /// Names mutated independent of any assignment: a mutating method call's
+    /// `Var` receiver, or any `Var` inside an opaque-escape argument.
+    mutated: FxHashSet<Symbol>,
+    /// Names contained in an `Assign` write target → the assign sites that
+    /// contain them (so the binding's own assignment can be excluded).
+    write_sites: FxHashMap<Symbol, Vec<NodeId>>,
+}
+
+impl ScopeMutationFacts {
+    fn collect(il: &Il, interner: &Interner, scope: NodeId) -> Self {
+        let mut facts = ScopeMutationFacts {
+            mutated: FxHashSet::default(),
+            write_sites: FxHashMap::default(),
+        };
+        // Bound-name sets of the nested scopes currently on the walk path; a
+        // harvested name shadowed by any of them does not reach the facts.
+        let mut shadow_stack: Vec<FxHashSet<Symbol>> = Vec::new();
+        facts.go(il, interner, scope, scope, &mut shadow_stack);
+        facts
     }
 
-    let mut mutated = false;
-    visit_scope_nodes(il, scope, binding.name, |node| {
-        if mutated {
-            return;
-        }
+    fn go(
+        &mut self,
+        il: &Il,
+        interner: &Interner,
+        scope: NodeId,
+        node: NodeId,
+        shadow_stack: &mut Vec<FxHashSet<Symbol>>,
+    ) {
         match il.kind(node) {
             NodeKind::Call => {
                 if let Some(receiver) = receiver_mutation_call_receiver(il, interner, node) {
-                    mutated = node_refers_to_name(il, receiver, binding.name);
+                    if let Some(name) = var_name(il, receiver) {
+                        self.record_mutated(name, shadow_stack);
+                    }
                 }
-                if !mutated {
-                    if let Some(args) = opaque_argument_escape_args(il, node) {
-                        mutated = args
-                            .iter()
-                            .any(|&arg| node_contains_name(il, arg, binding.name));
+                if let Some(args) = opaque_argument_escape_args(il, node) {
+                    for &arg in args {
+                        self.record_subtree_vars(il, arg, shadow_stack, None);
                     }
                 }
             }
-            NodeKind::Assign if node != binding.assign => {
+            NodeKind::Assign => {
                 if let Some(lhs) = binding_write_target(il, node) {
-                    mutated = node_contains_name(il, lhs, binding.name);
+                    self.record_subtree_vars(il, lhs, shadow_stack, Some(node));
                 }
             }
             _ => {}
         }
-    });
-    mutated
-}
-
-fn visit_scope_nodes(il: &Il, scope: NodeId, binding_name: Symbol, mut visit: impl FnMut(NodeId)) {
-    fn go(
-        il: &Il,
-        scope: NodeId,
-        binding_name: Symbol,
-        node: NodeId,
-        visit: &mut impl FnMut(NodeId),
-    ) {
-        visit(node);
-        if node != scope
-            && matches!(il.kind(node), NodeKind::Func | NodeKind::Lambda)
-            && scope_binds_name(il, node, binding_name)
-        {
-            return;
-        }
-        for &child in il.children(node) {
-            go(il, scope, binding_name, child, visit);
+        if node != scope && matches!(il.kind(node), NodeKind::Func | NodeKind::Lambda) {
+            shadow_stack.push(scope_bound_names(il, node));
+            for &child in il.children(node) {
+                self.go(il, interner, scope, child, shadow_stack);
+            }
+            shadow_stack.pop();
+        } else {
+            for &child in il.children(node) {
+                self.go(il, interner, scope, child, shadow_stack);
+            }
         }
     }
-    go(il, scope, binding_name, scope, &mut visit);
+
+    fn record_mutated(&mut self, name: Symbol, shadow_stack: &[FxHashSet<Symbol>]) {
+        if !shadow_stack.iter().any(|bound| bound.contains(&name)) {
+            self.mutated.insert(name);
+        }
+    }
+
+    /// Harvest every `Var` name in `node`'s subtree — the inverted form of
+    /// `node_contains_name`. With `write_site`, names go to `write_sites`
+    /// (assignment-excludable); without, straight to `mutated`.
+    fn record_subtree_vars(
+        &mut self,
+        il: &Il,
+        node: NodeId,
+        shadow_stack: &[FxHashSet<Symbol>],
+        write_site: Option<NodeId>,
+    ) {
+        if let Some(name) = var_name(il, node) {
+            if !shadow_stack.iter().any(|bound| bound.contains(&name)) {
+                match write_site {
+                    Some(site) => self.write_sites.entry(name).or_default().push(site),
+                    None => {
+                        self.mutated.insert(name);
+                    }
+                }
+            }
+        }
+        for &child in il.children(node) {
+            self.record_subtree_vars(il, child, shadow_stack, write_site);
+        }
+    }
+
+    fn binding_mutated(&self, binding: BindingAssignment) -> bool {
+        self.mutated.contains(&binding.name)
+            || self
+                .write_sites
+                .get(&binding.name)
+                .is_some_and(|sites| sites.iter().any(|&site| site != binding.assign))
+    }
 }
 
-fn scope_binds_name(il: &Il, scope: NodeId, name: Symbol) -> bool {
-    fn go(il: &Il, scope: NodeId, node: NodeId, name: Symbol) -> bool {
+fn var_name(il: &Il, node: NodeId) -> Option<Symbol> {
+    (il.kind(node) == NodeKind::Var)
+        .then(|| binding_node_name(il, node))
+        .flatten()
+}
+
+/// Every name `scope` binds at its own level: params, assignment targets, and
+/// loop patterns, not descending into deeper nested scopes — the same walk the
+/// old per-name `scope_binds_name` did, collected once.
+fn scope_bound_names(il: &Il, scope: NodeId) -> FxHashSet<Symbol> {
+    fn go(il: &Il, scope: NodeId, node: NodeId, out: &mut FxHashSet<Symbol>) {
         if node != scope && matches!(il.kind(node), NodeKind::Func | NodeKind::Lambda) {
-            return false;
+            return;
         }
         match il.kind(node) {
-            NodeKind::Param if binding_node_name(il, node) == Some(name) => return true,
+            NodeKind::Param => {
+                if let Some(name) = binding_node_name(il, node) {
+                    out.insert(name);
+                }
+            }
             NodeKind::Assign => {
                 if let Some(&lhs) = il.children(node).first() {
-                    if target_binds_name(il, lhs, name) {
-                        return true;
-                    }
+                    collect_target_names(il, lhs, out);
                 }
             }
             NodeKind::Loop => {
                 if let Some(&pattern) = il.children(node).first() {
-                    if target_binds_name(il, pattern, name) {
-                        return true;
-                    }
+                    collect_target_names(il, pattern, out);
                 }
             }
             _ => {}
         }
-        il.children(node)
-            .iter()
-            .any(|&child| go(il, scope, child, name))
+        for &child in il.children(node) {
+            go(il, scope, child, out);
+        }
     }
-    go(il, scope, scope, name)
+    let mut out = FxHashSet::default();
+    go(il, scope, scope, &mut out);
+    out
+}
+
+fn collect_target_names(il: &Il, node: NodeId, out: &mut FxHashSet<Symbol>) {
+    match il.kind(node) {
+        NodeKind::Var => {
+            if let Some(name) = binding_node_name(il, node) {
+                out.insert(name);
+            }
+        }
+        NodeKind::Seq => {
+            for &child in il.children(node) {
+                collect_target_names(il, child, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn node_refers_to_name(il: &Il, node: NodeId, name: Symbol) -> bool {
@@ -346,17 +421,6 @@ fn node_contains_name(il: &Il, node: NodeId, name: Symbol) -> bool {
             .children(node)
             .iter()
             .any(|&child| node_contains_name(il, child, name))
-}
-
-fn target_binds_name(il: &Il, node: NodeId, name: Symbol) -> bool {
-    match il.kind(node) {
-        NodeKind::Var => binding_node_name(il, node) == Some(name),
-        NodeKind::Seq => il
-            .children(node)
-            .iter()
-            .any(|&child| target_binds_name(il, child, name)),
-        _ => false,
-    }
 }
 
 fn find_or_push_evidence(

--- a/crates/nose-normalize/src/call_target_evidence.rs
+++ b/crates/nose-normalize/src/call_target_evidence.rs
@@ -425,16 +425,7 @@ fn unique_binding_symbol_for_var(
 ) -> Option<(SymbolEvidenceKind, EvidenceId)> {
     let local_hash = node_name_hash(il, interner, node)?;
     let mut found = None;
-    for record in &il.evidence {
-        if !matches!(
-            record.anchor,
-            EvidenceAnchor::Binding {
-                local_hash: anchor_hash,
-                ..
-            } if anchor_hash == local_hash
-        ) {
-            continue;
-        }
+    for record in il.evidence_binding_anchored(local_hash) {
         let EvidenceKind::Symbol(symbol) = record.kind else {
             continue;
         };
@@ -518,7 +509,7 @@ fn imported_symbol_occurrence_can_be_upserted(
     cache: &mut ImportedOccurrenceValidationCache,
 ) -> bool {
     let anchor = EvidenceAnchor::node(il.node(node).span, NodeKind::Var);
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(anchor.span()) {
         if record.anchor != anchor {
             continue;
         }
@@ -541,8 +532,7 @@ fn imported_symbol_occurrence_can_be_upserted(
 fn var_has_symbol_identity_evidence(il: &Il, interner: &Interner, node: NodeId) -> bool {
     let anchor = EvidenceAnchor::node(il.node(node).span, NodeKind::Var);
     if il
-        .evidence
-        .iter()
+        .evidence_anchored_at(anchor.span())
         .any(|record| record.anchor == anchor && matches!(record.kind, EvidenceKind::Symbol(_)))
     {
         return true;
@@ -550,15 +540,8 @@ fn var_has_symbol_identity_evidence(il: &Il, interner: &Interner, node: NodeId) 
     let Some(local_hash) = node_name_hash(il, interner, node) else {
         return false;
     };
-    il.evidence.iter().any(|record| {
-        matches!(
-            record.anchor,
-            EvidenceAnchor::Binding {
-                local_hash: anchor_hash,
-                ..
-            } if anchor_hash == local_hash
-        ) && matches!(record.kind, EvidenceKind::Symbol(_))
-    })
+    il.evidence_binding_anchored(local_hash)
+        .any(|record| matches!(record.kind, EvidenceKind::Symbol(_)))
 }
 
 fn node_name_hash(il: &Il, interner: &Interner, node: NodeId) -> Option<u64> {

--- a/crates/nose-normalize/src/effect_evidence.rs
+++ b/crates/nose-normalize/src/effect_evidence.rs
@@ -193,7 +193,12 @@ fn upsert(
     let pack_hash = stable_symbol_hash(FIRST_PARTY_PACK_ID);
     let rule_hash = stable_symbol_hash(rule);
     let mut found = None;
-    for record in &mut il.evidence {
+    // Index-backed: only records anchored at this node's span can match, so the
+    // per-upsert whole-`evidence` scan (quadratic — this pass upserts for most
+    // assignments and calls) narrows to one bucket. `rule_hash`/`dependencies`
+    // are read live by the index, so in-place updates need no invalidation.
+    for idx in il.evidence_indices_anchored_at(anchor.span()) {
+        let record = &mut il.evidence[idx as usize];
         if record.anchor == anchor
             && record.kind == kind
             && record.status == EvidenceStatus::Asserted

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -304,9 +304,12 @@ fn receiver_only_args(op: Builtin, receiver: ProvenReceiver, direct: Option<Node
         }
         return CallCanon::None;
     }
+    let Some(direct) = direct else {
+        return CallCanon::None;
+    };
     CallCanon::Builtin {
         op,
-        arg_olds: vec![direct.unwrap()],
+        arg_olds: vec![direct],
     }
 }
 

--- a/crates/nose-normalize/src/library_api_evidence.rs
+++ b/crates/nose-normalize/src/library_api_evidence.rs
@@ -241,7 +241,7 @@ fn domain_evidence_id_for_node(
     expected: DomainEvidence,
 ) -> Option<EvidenceId> {
     let anchor = EvidenceAnchor::node(il.node(node).span, il.kind(node));
-    il.evidence.iter().find_map(|record| {
+    il.evidence_anchored_at(anchor.span()).find_map(|record| {
         (record.anchor == anchor
             && record.kind == EvidenceKind::Domain(expected)
             && record.status == EvidenceStatus::Asserted
@@ -259,7 +259,7 @@ fn sequence_surface_evidence_id_for_node(
         return None;
     }
     let anchor = EvidenceAnchor::sequence(il.node(node).span);
-    il.evidence.iter().find_map(|record| {
+    il.evidence_anchored_at(anchor.span()).find_map(|record| {
         (record.anchor == anchor
             && record.kind == EvidenceKind::SequenceSurface(expected)
             && record.status == EvidenceStatus::Asserted
@@ -486,15 +486,8 @@ fn binding_symbol_evidence_id(
         return None;
     }
     let local_hash = node_name_hash(il, interner, node)?;
-    il.evidence.iter().find_map(|record| {
-        (matches!(
-            record.anchor,
-            EvidenceAnchor::Binding {
-                local_hash: anchor_hash,
-                ..
-            } if anchor_hash == local_hash
-        ) && record.kind == EvidenceKind::Symbol(expected)
-            && record.status == EvidenceStatus::Asserted)
+    il.evidence_binding_anchored(local_hash).find_map(|record| {
+        (record.kind == EvidenceKind::Symbol(expected) && record.status == EvidenceStatus::Asserted)
             .then_some(record.id)
     })
 }
@@ -547,7 +540,10 @@ fn upsert_first_party_evidence(
     let pack_hash = stable_symbol_hash(FIRST_PARTY_PACK_ID);
     let rule_hash = stable_symbol_hash(rule);
     let mut found = None;
-    for record in &mut il.evidence {
+    // Index-backed (see `effect_evidence::upsert`): only same-span records can
+    // match, and the fields updated in place are read live by the index.
+    for idx in il.evidence_indices_anchored_at(anchor.span()) {
+        let record = &mut il.evidence[idx as usize];
         if record.anchor == anchor
             && record.kind == kind
             && record.status == EvidenceStatus::Asserted

--- a/crates/nose-normalize/src/recursion.rs
+++ b/crates/nose-normalize/src/recursion.rs
@@ -329,11 +329,13 @@ impl Rebuilder<'_> {
         )
     }
 
-    /// `not(c₀ or c₁ or …)` — the loop continues while no base case has been reached.
+    /// `not(c₀ or c₁ or …)` — the loop continues while no base case has been
+    /// reached. The recognizer guarantees at least one guard arm, so `conds` is
+    /// never empty.
     fn not_any(&mut self, conds: Vec<NodeId>) -> NodeId {
         let span = self.old.node(conds[0]).span;
         let mut it = conds.into_iter();
-        let mut acc = self.go_val(it.next().unwrap());
+        let mut acc = self.go_val(it.next().expect("recursion guard arms are non-empty"));
         for c in it {
             let cc = self.go_val(c);
             acc = self

--- a/crates/nose-normalize/src/value_graph/context.rs
+++ b/crates/nose-normalize/src/value_graph/context.rs
@@ -1,5 +1,6 @@
 //! File-level value-graph context and immutable module seeding.
 
+use super::inline::InlineCandidate;
 use super::*;
 use nose_il::UnitKind;
 
@@ -16,6 +17,9 @@ use nose_il::UnitKind;
 pub struct ValueFingerprintContext {
     module: ModuleSeedContext,
     function_bindings: Vec<(Symbol, u64)>,
+    /// Per-file pure-inline candidates (see [`InlineCandidate`]);
+    /// shared by every unit builder instead of rebuilding the registry per unit.
+    inline_candidates: Vec<InlineCandidate>,
     subtree_hashes: OnceLock<Vec<u64>>,
 }
 
@@ -23,16 +27,20 @@ impl ValueFingerprintContext {
     pub fn new(il: &Il, interner: &Interner) -> Self {
         let module = ModuleSeedContext::new(il, interner);
         let subtree_hashes = OnceLock::new();
-        let function_bindings = {
+        let (function_bindings, inline_candidates) = {
             let mut b = Builder::new(il, interner)
                 .with_shared_subtree_hashes(&subtree_hashes)
                 .with_local_scope_nodes(&module.local_scope);
             b.seed_module_value_bindings_from_context(&module, None);
-            b.collect_function_binding_hashes()
+            (
+                b.collect_function_binding_hashes(),
+                b.collect_inline_candidates(),
+            )
         };
         Self {
             module,
             function_bindings,
+            inline_candidates,
             subtree_hashes,
         }
     }
@@ -140,6 +148,12 @@ fn evidence_backed_raw_assignment_name(il: &Il, stmt: NodeId) -> Option<Symbol> 
         Some(symbol)
     } else {
         None
+    }
+}
+
+impl ValueFingerprintContext {
+    pub(super) fn inline_candidates(&self) -> &[InlineCandidate] {
+        &self.inline_candidates
     }
 }
 
@@ -277,7 +291,9 @@ impl<'a> Builder<'a> {
 
     fn collect_function_binding_hashes(&mut self) -> Vec<(Symbol, u64)> {
         let mut bindings = Vec::new();
-        for unit in self.il.units.clone() {
+        // Indexed loop: the body needs `&mut self` but never mutates `units`.
+        for i in 0..self.il.units.len() {
+            let unit = self.il.units[i];
             if !matches!(unit.kind, UnitKind::Function | UnitKind::Method) {
                 continue;
             }

--- a/crates/nose-normalize/src/value_graph/control.rs
+++ b/crates/nose-normalize/src/value_graph/control.rs
@@ -16,13 +16,21 @@ impl<'a> Builder<'a> {
     pub(super) fn build_unit_with_context(
         &mut self,
         root: NodeId,
-        context: Option<&ValueFingerprintContext>,
+        context: Option<&'a ValueFingerprintContext>,
     ) {
         self.param_domain.clear();
         self.seed_param_domains(root);
         self.seed_param_value_domains(root);
         self.seed_immutable_bindings(root, context);
-        self.build_inline_registry(root);
+        match context {
+            Some(context) => {
+                self.adopt_inline_candidates(root, Cow::Borrowed(context.inline_candidates()));
+            }
+            None => {
+                let candidates = self.collect_inline_candidates();
+                self.adopt_inline_candidates(root, Cow::Owned(candidates));
+            }
+        }
         let mut env: FxHashMap<u32, ValueId> = FxHashMap::default();
         match self.il.kind(root) {
             NodeKind::Func => {
@@ -325,7 +333,9 @@ impl<'a> Builder<'a> {
     /// The conjunction of the current branch path (`c₁ ∧ c₂ ∧ …`), or `None` at top level.
     pub(super) fn path_cond(&mut self) -> Option<ValueId> {
         let mut pc: Option<ValueId> = None;
-        for &c in &self.path.clone() {
+        // Indexed loop: `mk` needs `&mut self` and never touches `path`.
+        for i in 0..self.path.len() {
+            let c = self.path[i];
             pc = Some(match pc {
                 None => c,
                 Some(p) => self.mk(ValOp::Bin(Op::And as u32), vec![p, c]),

--- a/crates/nose-normalize/src/value_graph/inline.rs
+++ b/crates/nose-normalize/src/value_graph/inline.rs
@@ -10,31 +10,54 @@
 
 use super::*;
 use nose_il::UnitKind;
-use nose_semantics::direct_function_call_target_at_call;
+use nose_semantics::direct_function_call_target_span_at_call;
+
+/// A file-level inline candidate, computed ONCE per file by
+/// [`ValueFingerprintContext`] instead of per unit (the per-unit registry build
+/// re-walked every unit body for every unit — quadratic in file size). The two
+/// conditions the per-unit build folded in are deferred to the call site:
+/// the consuming unit's exclusion (no function inlines into itself through one
+/// of its sub-units) and the global-binding requirement (`required_globals`
+/// must all be seeded in the consuming builder's `global_env` — per-unit
+/// module-binding seeding varies with what the unit references).
+#[derive(Clone)]
+pub(super) struct InlineCandidate {
+    pub(super) root: NodeId,
+    pub(super) function: InlineFunction,
+    /// Free (module-symbol) names the body's safety verdict depends on, sorted.
+    pub(super) required_globals: Vec<Symbol>,
+}
 
 impl<'a> Builder<'a> {
-    /// Build the interprocedural inline registry: pure, file-local functions/methods that can be
-    /// inlined to their body's value. Excludes the unit currently being built, and any enclosing
-    /// function/method for sub-unit roots, so a function is never inlined into itself through one
-    /// of its blocks or exact fragments.
-    pub(super) fn build_inline_registry(&mut self, root: NodeId) {
-        if !self.inline_fns.is_empty() {
-            return;
-        }
-        for unit in self.il.units.clone() {
-            if !matches!(unit.kind, UnitKind::Function | UnitKind::Method)
-                || self.subtree_contains(unit.root, root)
-            {
+    /// Make `candidates` the unit's inline registry and snapshot the
+    /// currently-seeded global bindings. The snapshot pins the registry to the
+    /// post-seed, pre-process state the per-unit build used to see: module
+    /// container units may add `global_env` entries while their statements are
+    /// processed, and a mid-processing inline admission would otherwise depend
+    /// on statement order.
+    pub(super) fn adopt_inline_candidates(
+        &mut self,
+        root: NodeId,
+        candidates: Cow<'a, [InlineCandidate]>,
+    ) {
+        self.inline_candidates = Some(candidates);
+        self.inline_exclude_root = Some(root);
+        self.inline_env_keys = self.global_env.keys().copied().collect();
+    }
+
+    /// File-level inline candidates for [`ValueFingerprintContext`]: every pure
+    /// function/method body, with its safety's global-name requirements
+    /// recorded instead of resolved (resolution happens per consuming unit).
+    pub(super) fn collect_inline_candidates(&self) -> Vec<InlineCandidate> {
+        let mut out = Vec::new();
+        for unit in &self.il.units {
+            if !matches!(unit.kind, UnitKind::Function | UnitKind::Method) {
                 continue;
             }
-            if !self.function_binding_safe(unit.root, unit.root) {
+            let mut required_globals = Vec::new();
+            if !self.function_binding_safe_collect(unit.root, unit.root, &mut required_globals) {
                 continue;
             }
-            // SOUNDNESS: only inline an EFFECT-FREE body: a `return <expr>` or a straight-line
-            // block of LOCAL bindings ending in a `return`. `function_binding_safe` alone is too
-            // weak because it admits field/index WRITES, an effect the value-only inline would
-            // silently drop. The interpreter oracle also checks cross-function calls end-to-end,
-            // but the syntactic gate stays conservative by construction.
             let Some(body) = self.inline_pure_body(unit.root) else {
                 continue;
             };
@@ -46,8 +69,61 @@ impl<'a> Builder<'a> {
                     _ => None,
                 })
                 .collect();
-            self.inline_fns
-                .insert(unit.root, InlineFunction { params, body });
+            required_globals.sort_unstable();
+            required_globals.dedup();
+            out.push(InlineCandidate {
+                root: unit.root,
+                function: InlineFunction { params, body },
+                required_globals,
+            });
+        }
+        out
+    }
+
+    /// [`Builder::function_binding_safe`] with the `global_env` membership test
+    /// replaced by collection: free names are recorded in `required` and assumed
+    /// available; the caller re-checks them against the consuming unit's
+    /// `global_env`, which yields exactly the per-unit verdict the eager check
+    /// produced (the check is monotone in `global_env`).
+    fn function_binding_safe_collect(
+        &self,
+        root: NodeId,
+        node: NodeId,
+        required: &mut Vec<Symbol>,
+    ) -> bool {
+        match self.il.kind(node) {
+            NodeKind::Raw
+            | NodeKind::HoF
+            | NodeKind::Lambda
+            | NodeKind::Loop
+            | NodeKind::Try
+            | NodeKind::Throw => false,
+            NodeKind::Func if node != root => false,
+            NodeKind::Call => match self.il.node(node).payload {
+                Payload::Builtin(builtin) => self.admitted_builtin_call(node, builtin),
+                _ => false,
+            },
+            NodeKind::Var => match self.il.node(node).payload {
+                Payload::Cid(_) => true,
+                Payload::Name(s) => {
+                    required.push(s);
+                    true
+                }
+                _ => false,
+            },
+            NodeKind::Lit => matches!(
+                self.il.node(node).payload,
+                Payload::LitInt(_)
+                    | Payload::LitBool(_)
+                    | Payload::LitStr(_)
+                    | Payload::LitFloat(_)
+                    | Payload::Lit(nose_il::LitClass::Null)
+            ),
+            _ => self
+                .il
+                .children(node)
+                .iter()
+                .all(|&c| self.function_binding_safe_collect(root, c, required)),
         }
     }
 
@@ -92,15 +168,34 @@ impl<'a> Builder<'a> {
     }
 
     fn inline_target_for_call(&self, call: NodeId) -> Option<InlineFunction> {
+        let candidates = self.inline_candidates.as_deref()?;
+        // Resolve the call's DirectFunction evidence once, then apply the
+        // per-unit conditions deferred from candidate collection (see
+        // `InlineCandidate`): the consuming-unit exclusion and the seeded
+        // global-binding requirement (against the adopt-time snapshot).
+        let proven_span = direct_function_call_target_span_at_call(self.il, call)?;
+        let exclude_root = self.inline_exclude_root;
         let mut found = None;
-        for (&root, function) in &self.inline_fns {
-            if !direct_function_call_target_at_call(self.il, call, root) {
+        for candidate in candidates {
+            if self.il.kind(candidate.root) != NodeKind::Func
+                || self.il.node(candidate.root).span != proven_span
+            {
+                continue;
+            }
+            if exclude_root.is_some_and(|root| self.subtree_contains(candidate.root, root)) {
+                continue;
+            }
+            if !candidate
+                .required_globals
+                .iter()
+                .all(|name| self.inline_env_keys.contains(name))
+            {
                 continue;
             }
             if found.is_some() {
                 return None;
             }
-            found = Some(function.clone());
+            found = Some(candidate.function.clone());
         }
         found
     }
@@ -132,37 +227,14 @@ impl<'a> Builder<'a> {
         }
     }
 
+    /// The eager form of [`Builder::function_binding_safe_collect`]: same body
+    /// verdict, with the free-name requirements resolved against the current
+    /// `global_env` immediately.
     pub(super) fn function_binding_safe(&self, root: NodeId, node: NodeId) -> bool {
-        match self.il.kind(node) {
-            NodeKind::Raw
-            | NodeKind::HoF
-            | NodeKind::Lambda
-            | NodeKind::Loop
-            | NodeKind::Try
-            | NodeKind::Throw => false,
-            NodeKind::Func if node != root => false,
-            NodeKind::Call => match self.il.node(node).payload {
-                Payload::Builtin(builtin) => self.admitted_builtin_call(node, builtin),
-                _ => false,
-            },
-            NodeKind::Var => match self.il.node(node).payload {
-                Payload::Cid(_) => true,
-                Payload::Name(s) => self.global_env.contains_key(&s),
-                _ => false,
-            },
-            NodeKind::Lit => matches!(
-                self.il.node(node).payload,
-                Payload::LitInt(_)
-                    | Payload::LitBool(_)
-                    | Payload::LitStr(_)
-                    | Payload::LitFloat(_)
-                    | Payload::Lit(nose_il::LitClass::Null)
-            ),
-            _ => self
-                .il
-                .children(node)
+        let mut required = Vec::new();
+        self.function_binding_safe_collect(root, node, &mut required)
+            && required
                 .iter()
-                .all(|&c| self.function_binding_safe(root, c)),
-        }
+                .all(|name| self.global_env.contains_key(name))
     }
 }

--- a/crates/nose-normalize/src/value_graph/model.rs
+++ b/crates/nose-normalize/src/value_graph/model.rs
@@ -1,5 +1,6 @@
 //! Private value-graph model types and builder state.
 
+use super::inline::InlineCandidate;
 use super::*;
 
 pub(super) type ValueId = u32;
@@ -171,11 +172,20 @@ pub(super) struct Builder<'a> {
     /// targets are alpha-renamed to `Cid`; this map reconnects safe top-level literal
     /// data (`const table = {...}`) to free uses inside the function.
     pub(super) global_env: FxHashMap<Symbol, ValueId>,
-    /// Interprocedural inline registry, keyed by target unit root. Calls may consume an entry only
-    /// through `CallTarget::DirectFunction` evidence at the exact call occurrence; the callee
-    /// spelling is never a proof channel. Enclosing functions are excluded for sub-unit
-    /// fingerprints, so a recursive helper cannot inline itself through a block or fragment root.
-    pub(super) inline_fns: FxHashMap<NodeId, InlineFunction>,
+    /// The unit's interprocedural inline registry: pure, file-local
+    /// functions/methods (shared per file via [`ValueFingerprintContext`], or
+    /// owned on the context-free path). Calls may consume an entry only through
+    /// `CallTarget::DirectFunction` evidence at the exact call occurrence; the
+    /// callee spelling is never a proof channel.
+    pub(super) inline_candidates: Option<Cow<'a, [InlineCandidate]>>,
+    /// The unit root currently being fingerprinted — inline targets whose
+    /// subtree contains it are excluded (a function must not inline into
+    /// itself through one of its sub-unit roots).
+    pub(super) inline_exclude_root: Option<NodeId>,
+    /// Snapshot of `global_env`'s keys taken when the candidates were adopted
+    /// (post-seed, pre-process), so inline admission cannot drift with module
+    /// statements processed later in the same unit.
+    pub(super) inline_env_keys: FxHashSet<Symbol>,
     /// Nodes under function/lambda scopes use local cid numbering. Their `Cid(0)` is not
     /// the module `cid_names[0]`, so module-symbol resolution fails closed there.
     pub(super) local_scope_nodes: Cow<'a, [bool]>,

--- a/crates/nose-normalize/src/value_graph/sinks.rs
+++ b/crates/nose-normalize/src/value_graph/sinks.rs
@@ -59,14 +59,7 @@ impl<'a> Builder<'a> {
     }
 
     pub(super) fn guarded(&mut self, v: ValueId) -> ValueId {
-        let mut pc: Option<ValueId> = None;
-        for &c in &self.path.clone() {
-            pc = Some(match pc {
-                None => c,
-                Some(p) => self.mk(ValOp::Bin(Op::And as u32), vec![p, c]),
-            });
-        }
-        match pc {
+        match self.path_cond() {
             None => v,
             Some(pc) => {
                 let bot = self.mk(ValOp::Const(0x3000_0000), vec![]);

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -29,7 +29,9 @@ impl<'a> Builder<'a> {
             building: FxHashMap::default(),
             building_kind: FxHashMap::default(),
             global_env: FxHashMap::default(),
-            inline_fns: FxHashMap::default(),
+            inline_candidates: None,
+            inline_exclude_root: None,
+            inline_env_keys: FxHashSet::default(),
             local_scope_nodes: Cow::Owned(local_scope_nodes(il)),
             loop_recurrence: None,
             next_loop_key_base: 0,
@@ -131,34 +133,29 @@ impl<'a> Builder<'a> {
                 .copied()
                 .unwrap_or(0);
         }
-        if self.subtree_hash.is_none() {
-            self.subtree_hash = Some(crate::subtree_hashes(self.il, self.interner));
-        }
         self.subtree_hash
-            .as_ref()
-            .unwrap()
+            .get_or_insert_with(|| crate::subtree_hashes(self.il, self.interner))
             .get(expr.0 as usize)
             .copied()
             .unwrap_or(0)
     }
 
     pub(super) fn valued_subtree_hash(&mut self, expr: NodeId) -> u64 {
-        if self.valued_subtree_hash.is_none() {
-            let mut hashes = vec![0u64; self.il.nodes.len()];
-            for i in 0..self.il.nodes.len() {
-                let id = NodeId(i as u32);
-                let node = self.il.node(id);
-                let mut h = crate::node_tag_valued(node.kind, node.payload, self.interner);
-                for &child in self.il.children(id) {
-                    h = combine(h, hashes[child.0 as usize]);
-                }
-                hashes[i] = h;
-            }
-            self.valued_subtree_hash = Some(hashes);
-        }
+        let (il, interner) = (self.il, self.interner);
         self.valued_subtree_hash
-            .as_ref()
-            .unwrap()
+            .get_or_insert_with(|| {
+                let mut hashes = vec![0u64; il.nodes.len()];
+                for i in 0..il.nodes.len() {
+                    let id = NodeId(i as u32);
+                    let node = il.node(id);
+                    let mut h = crate::node_tag_valued(node.kind, node.payload, interner);
+                    for &child in il.children(id) {
+                        h = combine(h, hashes[child.0 as usize]);
+                    }
+                    hashes[i] = h;
+                }
+                hashes
+            })
             .get(expr.0 as usize)
             .copied()
             .unwrap_or(0)

--- a/crates/nose-semantics/src/evidence.rs
+++ b/crates/nose-semantics/src/evidence.rs
@@ -193,11 +193,22 @@ pub fn source_pattern_at_node(il: &Il, node: NodeId) -> Option<SourcePatternKind
 }
 
 pub fn direct_function_call_target_at_call(il: &Il, call: NodeId, target_root: NodeId) -> bool {
-    if il.kind(call) != NodeKind::Call || il.kind(target_root) != NodeKind::Func {
+    if il.kind(target_root) != NodeKind::Func {
         return false;
     }
+    direct_function_call_target_span_at_call(il, call)
+        .is_some_and(|proven_span| proven_span == il.node(target_root).span)
+}
+
+/// The proven `DirectFunction` target span at `call`, when the call carries
+/// exactly one asserted `CallTarget` record and it is `DirectFunction`. The
+/// span-returning form lets a consumer with many possible targets resolve the
+/// evidence once and look the target up, instead of re-resolving per target.
+pub fn direct_function_call_target_span_at_call(il: &Il, call: NodeId) -> Option<Span> {
+    if il.kind(call) != NodeKind::Call {
+        return None;
+    }
     let call_span = il.node(call).span;
-    let target_span = il.node(target_root).span;
     match unique_asserted_evidence_at(
         il,
         call_span,
@@ -210,14 +221,14 @@ pub fn direct_function_call_target_at_call(il: &Il, call: NodeId, target_root: N
         EvidenceResolution::Found(CallTargetEvidenceKind::DirectFunction {
             target_span: proven_span,
             ..
-        }) => proven_span == target_span,
+        }) => Some(proven_span),
         EvidenceResolution::Found(
             CallTargetEvidenceKind::DirectMethod { .. }
             | CallTargetEvidenceKind::ImportedFunction { .. }
             | CallTargetEvidenceKind::ImportedMember { .. }
             | CallTargetEvidenceKind::DynamicDispatch { .. },
-        ) => false,
-        EvidenceResolution::Ambiguous | EvidenceResolution::Missing => false,
+        ) => None,
+        EvidenceResolution::Ambiguous | EvidenceResolution::Missing => None,
     }
 }
 
@@ -981,15 +992,15 @@ pub(crate) fn unique_binding_lhs_for_var_reference(
     let scope = nearest_scope(il, node);
     let reference_is_free_name = matches!(il.node(node).payload, Payload::Name(_));
     let mut found = None;
-    for (idx, candidate) in il.nodes.iter().enumerate() {
-        if candidate.kind != NodeKind::Assign {
-            continue;
-        }
-        let assign = NodeId(idx as u32);
-        let assignment_scope = nearest_scope(il, assign);
-        if assignment_scope != scope && !(reference_is_free_name && assignment_scope.is_none()) {
-            continue;
-        }
+    // Only assignments in the reference's own scope can match — plus, for a
+    // free (pre-alpha) name, module-level assignments. The scope-bucketed
+    // index replaces the whole-arena scan this did per reference.
+    let module_level: &[NodeId] = if reference_is_free_name && scope.is_some() {
+        il.assigns_in_scope(None)
+    } else {
+        &[]
+    };
+    for &assign in il.assigns_in_scope(scope).iter().chain(module_level) {
         if !assignment_is_visible_at_reference(il, assign, node) {
             continue;
         }
@@ -1088,14 +1099,7 @@ pub(crate) fn span_contains(outer: Span, inner: Span) -> bool {
 }
 
 fn name_is_assigned_in_scope(il: &Il, name: Symbol, scope: NodeId) -> bool {
-    il.nodes.iter().enumerate().any(|(idx, node)| {
-        if node.kind != NodeKind::Assign {
-            return false;
-        }
-        let id = NodeId(idx as u32);
-        if nearest_scope(il, id) != Some(scope) {
-            return false;
-        }
+    il.assigns_in_scope(Some(scope)).iter().any(|&id| {
         let Some(&lhs) = il.children(id).first() else {
             return false;
         };
@@ -1107,14 +1111,7 @@ fn name_is_assigned_in_scope(il: &Il, name: Symbol, scope: NodeId) -> bool {
 /// `cid` the target of a reassignment inside `scope`? Used to keep a reassigned
 /// parameter from proving its declared domain on the normalized (Cid) IL.
 fn cid_is_assigned_in_scope(il: &Il, cid: u32, scope: NodeId) -> bool {
-    il.nodes.iter().enumerate().any(|(idx, node)| {
-        if node.kind != NodeKind::Assign {
-            return false;
-        }
-        let id = NodeId(idx as u32);
-        if nearest_scope(il, id) != Some(scope) {
-            return false;
-        }
+    il.assigns_in_scope(Some(scope)).iter().any(|&id| {
         let Some(&lhs) = il.children(id).first() else {
             return false;
         };

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -264,7 +264,7 @@ fn sequence_surface_evidence_matches_node(
 
 fn guard_evidence_at_sequence_span(il: &Il, span: Span) -> EvidenceResolution<GuardEvidenceKind> {
     let mut found = None;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(span) {
         if !matches!(record.anchor, EvidenceAnchor::Sequence { span: anchor_span } if anchor_span == span)
         {
             continue;
@@ -594,7 +594,7 @@ pub fn import_fact_evidence_rhs(il: &Il, rhs: NodeId) -> Option<ImportFact> {
 /// provider-scope literal producer after cross-file replacement; consumers must
 /// still check the expression shape/result contract they are about to build.
 pub fn imported_literal_producer_evidence_at_span(il: &Il, span: Span, kind: NodeKind) -> bool {
-    il.evidence.iter().any(|record| {
+    il.evidence_anchored_at(span).any(|record| {
         record.status == EvidenceStatus::Asserted
             && first_party_record(record)
             && record.anchor == EvidenceAnchor::node(span, kind)
@@ -615,7 +615,7 @@ pub fn imported_literal_producer_evidence_at_span(il: &Il, span: Span, kind: Nod
 }
 
 pub fn imported_literal_snapshot_evidence_at_span(il: &Il, span: Span, kind: NodeKind) -> bool {
-    il.evidence.iter().any(|record| {
+    il.evidence_anchored_at(span).any(|record| {
         record.status == EvidenceStatus::Asserted
             && first_party_record(record)
             && record.anchor == EvidenceAnchor::node(span, kind)
@@ -715,7 +715,7 @@ fn imported_symbol_identity_at_node_matches(
     let kind = il.kind(node);
     let mut found = None;
     let mut dependencies_valid = true;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(span) {
         if record.anchor != EvidenceAnchor::node(span, kind) {
             continue;
         }
@@ -873,7 +873,7 @@ fn qualified_global_symbol_at_evidence_anchor(
     contract: QualifiedGlobalSymbolContract,
 ) -> EvidenceResolution<()> {
     let mut found = false;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(anchor.span()) {
         if record.anchor != anchor {
             continue;
         }

--- a/crates/nose-semantics/src/library_api.rs
+++ b/crates/nose-semantics/src/library_api.rs
@@ -38,7 +38,7 @@ pub fn library_api_contract_evidence_for_call(
     let span = il.node(node).span;
     let mut saw_library_api_evidence = false;
     let mut admitted = false;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(span) {
         if record.anchor != EvidenceAnchor::node(span, NodeKind::Call) {
             continue;
         }
@@ -84,7 +84,7 @@ pub fn library_api_contract_evidence_for_node(
     let anchor = EvidenceAnchor::node(il.node(node).span, il.kind(node));
     let mut saw_library_api_evidence = false;
     let mut admitted = false;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(anchor.span()) {
         if record.anchor != anchor {
             continue;
         }
@@ -130,7 +130,7 @@ pub fn library_api_contract_evidence_at_call_span(
     let source_call = node_at_span_with_kind(il, span, NodeKind::Call);
     let mut saw_library_api_evidence = false;
     let mut admitted = false;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(span) {
         if record.anchor != EvidenceAnchor::node(span, NodeKind::Call) {
             continue;
         }
@@ -787,14 +787,8 @@ fn java_explicit_import_conflicts(
         module_hash: stable_symbol_hash(module),
         exported_hash: stable_symbol_hash(simple_type),
     };
-    il.evidence.iter().any(|record| {
-        matches!(
-            record.anchor,
-            EvidenceAnchor::Binding {
-                local_hash: anchor_hash,
-                ..
-            } if anchor_hash == local_hash
-        ) && matches!(record.kind, EvidenceKind::Symbol(actual) if actual != expected)
+    il.evidence_binding_anchored(local_hash).any(|record| {
+        matches!(record.kind, EvidenceKind::Symbol(actual) if actual != expected)
             && record.status == EvidenceStatus::Asserted
     })
 }
@@ -1155,7 +1149,8 @@ fn method_callee_receiver(
 }
 
 fn field_method_at_span(il: &Il, interner: &Interner, span: Span, expected: &str) -> bool {
-    il.nodes.iter().any(|node| {
+    il.nodes_spanning(span).any(|id| {
+        let node = il.node(id);
         node.span == span
             && node.kind == NodeKind::Field
             && matches!(node.payload, Payload::Name(method) if interner.resolve(method) == expected)
@@ -1264,11 +1259,11 @@ fn async_receiver_dependencies_at_span(
 
 fn node_at_span(il: &Il, span: Span) -> Option<NodeId> {
     let mut found = None;
-    for (idx, node) in il.nodes.iter().enumerate() {
+    for id in il.nodes_spanning(span) {
+        let node = il.node(id);
         if node.span != span {
             continue;
         }
-        let id = NodeId(idx as u32);
         match found {
             None => found = Some(id),
             Some(existing)
@@ -1281,11 +1276,11 @@ fn node_at_span(il: &Il, span: Span) -> Option<NodeId> {
 
 fn node_at_span_with_kind(il: &Il, span: Span, kind: NodeKind) -> Option<NodeId> {
     let mut found = None;
-    for (idx, node) in il.nodes.iter().enumerate() {
+    for id in il.nodes_spanning(span) {
+        let node = il.node(id);
         if node.span != span || node.kind != kind {
             continue;
         }
-        let id = NodeId(idx as u32);
         match found {
             None => found = Some(id),
             Some(existing) if il.node(existing).payload == node.payload => {}
@@ -1498,8 +1493,25 @@ fn domain_dependency_id_for_receiver_requirement(
     requirement: DomainRequirement,
     cache: &mut LibraryApiDependencyCache,
 ) -> Option<EvidenceId> {
+    // A record can match the receiver only when anchored at one of three spans
+    // (the receiver node itself, its unique binding LHS, or its declaring
+    // param — see `domain_dependency_anchor_matches_receiver`), so query those
+    // index buckets instead of scanning the whole evidence table. Candidates
+    // are visited in evidence order, exactly like the scan they replace.
+    let mut indices = il.evidence_indices_anchored_at(il.node(receiver).span);
+    if let EvidenceResolution::Found(lhs) =
+        unique_binding_lhs_for_var_reference_cached(il, receiver, cache)
+    {
+        indices.extend(il.evidence_indices_anchored_at(il.node(lhs).span));
+    }
+    if let Some(span) = receiver_param_span_cached(il, receiver, cache) {
+        indices.extend(il.evidence_indices_anchored_at(span));
+    }
+    indices.sort_unstable();
+    indices.dedup();
     let mut found = None;
-    for record in &il.evidence {
+    for idx in indices {
+        let record = &il.evidence[idx as usize];
         let EvidenceKind::Domain(domain) = record.kind else {
             continue;
         };
@@ -1572,15 +1584,13 @@ fn unique_binding_lhs_for_var_reference_with_cache(
     let scope = nearest_scope_cached(il, node, cache);
     let reference_is_free_name = matches!(il.node(node).payload, Payload::Name(_));
     let mut found = None;
-    for (idx, candidate) in il.nodes.iter().enumerate() {
-        if candidate.kind != NodeKind::Assign {
-            continue;
-        }
-        let assign = NodeId(idx as u32);
-        let assignment_scope = nearest_scope_cached(il, assign, cache);
-        if assignment_scope != scope && !(reference_is_free_name && assignment_scope.is_none()) {
-            continue;
-        }
+    // Same scope-bucketed candidate set as `evidence::unique_binding_lhs_for_var_reference`.
+    let module_level: &[NodeId] = if reference_is_free_name && scope.is_some() {
+        il.assigns_in_scope(None)
+    } else {
+        &[]
+    };
+    for &assign in il.assigns_in_scope(scope).iter().chain(module_level) {
         if !assignment_is_visible_at_reference(il, assign, node) {
             continue;
         }
@@ -1714,7 +1724,7 @@ fn sequence_surface_dependency_id_for_receiver(
     }
     let anchor = EvidenceAnchor::sequence(il.node(receiver).span);
     let mut found = None;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(anchor.span()) {
         let EvidenceKind::SequenceSurface(kind) = record.kind else {
             continue;
         };
@@ -1760,7 +1770,7 @@ fn static_index_membership_receiver_dependency_id_at_span(
     }
     let anchor = EvidenceAnchor::sequence(span);
     let mut found = None;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(anchor.span()) {
         let EvidenceKind::SequenceSurface(kind) = record.kind else {
             continue;
         };
@@ -1838,7 +1848,7 @@ fn symbol_dependency_id_for_node(
     expected: SymbolEvidenceKind,
 ) -> Option<EvidenceId> {
     let anchor = EvidenceAnchor::node(il.node(node).span, il.kind(node));
-    il.evidence.iter().find_map(|record| {
+    il.evidence_anchored_at(anchor.span()).find_map(|record| {
         (record.anchor == anchor
             && record.status == EvidenceStatus::Asserted
             && record.kind == EvidenceKind::Symbol(expected)
@@ -1854,7 +1864,7 @@ fn imported_symbol_dependency_id_for_node(
     expected: SymbolEvidenceKind,
 ) -> Option<EvidenceId> {
     let anchor = EvidenceAnchor::node(il.node(node).span, il.kind(node));
-    il.evidence.iter().find_map(|record| {
+    il.evidence_anchored_at(anchor.span()).find_map(|record| {
         (record.anchor == anchor
             && record.status == EvidenceStatus::Asserted
             && record.kind == EvidenceKind::Symbol(expected)
@@ -1874,7 +1884,7 @@ pub(crate) fn library_api_dependency_id_for_normalized_hof(
     let expected_contract_hash = library_api_contract_id_hash(expected_id);
     let anchor = EvidenceAnchor::node(il.node(receiver).span, NodeKind::Call);
     let mut found = None;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(anchor.span()) {
         if record.anchor != anchor
             || record.status != EvidenceStatus::Asserted
             || !il.evidence_dependencies_asserted(record)
@@ -2035,7 +2045,7 @@ fn library_api_dependency_id_for_canonical_builtin_call_contract(
     }
     let span = il.node(call).span;
     let mut found = None;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(span) {
         if !matches!(
             record.anchor,
             EvidenceAnchor::Node {
@@ -2186,7 +2196,7 @@ fn library_api_dependency_id_for_call_contract(
     }
     let anchor = EvidenceAnchor::node(il.node(call).span, NodeKind::Call);
     let mut found = None;
-    for record in &il.evidence {
+    for record in il.evidence_anchored_at(anchor.span()) {
         if record.anchor != anchor
             || record.status != EvidenceStatus::Asserted
             || !il.evidence_dependencies_asserted(record)
@@ -2873,17 +2883,7 @@ fn binding_symbol_evidence_consistent_for_local(
     expected: SymbolEvidenceKind,
 ) -> bool {
     let mut saw_symbol = false;
-    for record in &il.evidence {
-        let EvidenceAnchor::Binding {
-            local_hash: anchor_hash,
-            ..
-        } = record.anchor
-        else {
-            continue;
-        };
-        if anchor_hash != local_hash {
-            continue;
-        }
+    for record in il.evidence_binding_anchored(local_hash) {
         let EvidenceKind::Symbol(symbol) = record.kind else {
             continue;
         };

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,6 +97,13 @@ The current semantic assumptions these crates share are summarized in
   indices and out-of-line child edges — cache-friendly and cheap to serialize,
   which is what makes per-file feature caching ([continuous-integration](continuous-integration.md))
   possible.
+- **Index-backed lookups on the arena.** Nodes are immutable once an `Il` is
+  built (passes rebuild the arena), so `Il` carries lazy indexes — nearest
+  enclosing scope, span → nodes, scope → assignments, and the evidence anchor
+  index (span buckets, binding-hash buckets, id resolution). Per-node helpers
+  must query these instead of scanning `il.nodes`/`il.evidence`; the raw scans
+  were the dominant scan cost until they were indexed
+  ([experiments §BQ](experiments.md)).
 - **Interner-independent features.** A unit's features are content-derived
   hashes, not interner ids, so they're portable across runs — the basis for the
   content-hash cache.

--- a/docs/design.md
+++ b/docs/design.md
@@ -155,8 +155,9 @@ engine over a single formal IL semantics was evaluated in depth. The current evi
 - behavioral equivalence is **not a congruence** under the IL's ordered effects (the oracle
   compares an ordered effect trace), so a congruence-closure merge is unsound except on a pure
   sub-IL — at which point it largely reinvents the existing normal form;
-- performance: the canonicalizer is single-pass today and is not even the dominant scan cost
-  (the frontend is); saturation is super-linear and determinism-hostile.
+- performance: the canonicalizer is single-pass today and is not the dominant scan cost
+  (per-unit value-graph extraction is, now that the evidence passes are index-backed —
+  [experiments §BQ](experiments.md)); saturation is super-linear and determinism-hostile.
 
 It is recorded here as an **open question, not a closed door.** Conditions that would justify
 revisiting:

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1376,3 +1376,60 @@ binary on the same corpus shows identical P@10 (53% [48–58] dev / 55% [50–60
 both arms, per-language rows unchanged) with heldout worthy-recall *up* four labels
 (Go +3, Python +1) — the erasure fixes split only behaviorally-different pairs, and
 representing deref effects let a few previously stub-collapsed units group correctly.
+
+## BQ. The evidence-index campaign — the quadratic scans behind `normalize+extract`
+
+`NOSE_TIME=1` stage timing on the corpus showed `normalize+extract` at 95–97% of
+scan cost (sympy: 20.5s of a 21s scan; redis: 6.9s of 7.4s), and the per-pass
+`NOSE_TIME_NORMALIZE` aggregation put 92% of the normalize half in the four
+evidence passes — call-target 35.6s, binding 14.3s, effect 21.7s, api 1.8s CPU
+on sympy. The shape was always the same: **a per-node/per-call query running a
+full linear scan of `il.evidence` (or `il.nodes`)** — O(n²) on evidence-dense
+files. The span-keyed evidence index existed (`Il::evidence_anchored_at`), but
+most consumers predated it.
+
+What landed, all output-preserving (byte-identical scan JSON on
+redis/git/tokio/guava/sympy/netty and the full test suite before/after):
+
+1. **Every anchored evidence query goes through the index.**
+   `find_or_push_first_party_evidence` (the emit-path dedup scan — quadratic on
+   its own output), both evidence `upsert`s, the call-target/binding/library-api
+   pass helpers, and ~15 anchored scans in `nose-semantics` now query the
+   span bucket. `EvidenceIndex` gained a `by_binding_hash` bucket for the
+   `Binding`-anchor-by-hash consumers and a `(id, span)` staleness sentinel so a
+   `clear()`/`retain()`+re-push rebuilds instead of silently corrupting
+   (a latent hazard a unit test exposed the moment more paths used the index).
+2. **Two more lazy arena indexes on `Il`,** under the same nodes-are-immutable
+   discipline as `scope_index`: `nodes_spanning` (span → nodes; kills the
+   whole-arena `node_at_span*` scans in library-api span queries) and
+   `assigns_in_scope` (nearest-scope → assigns; kills the whole-arena scan in
+   `unique_binding_lhs_for_var_reference`, which ran per Var reference).
+3. **`binding_evidence` inverted its mutation walk.** Per-binding
+   `visit_scope_nodes` (O(assignments × scope size)) became one
+   `ScopeMutationFacts` walk per scope harvesting names per site, with the
+   shadow rule applied via per-nested-scope bound-name sets — same verdicts,
+   one pass (sympy: 14.3s → 0.8s).
+4. **The pure-inline registry is file-level, not per-unit.** `units::extract`
+   rebuilt it per unit — every unit re-walked every function body
+   (O(units × file), ~17s CPU on sympy, the dominant *block*-unit cost).
+   `ValueFingerprintContext` now collects `InlineCandidate`s once per file with
+   the safety check's global-name requirements *recorded* instead of resolved;
+   per-unit admission (self-exclusion + required-globals ⊆ the unit's seeded
+   `global_env`, snapshotted at adopt time) moved to the call site, and call
+   resolution inverted from per-registry-entry evidence checks to one
+   `direct_function_call_target_span_at_call` + span lookup. The context-free
+   path shares the same mechanism (the old `inline_fns` map is gone).
+
+**Result** (release, 10-core M-series, default `syntax,semantic` scan): sympy
+20.0 → 4.7s wall (81.3 → 23.5s CPU), redis 3.9 → 1.0s, git 2.7 → 1.1s, netty
+3.5 → 1.8s, guava 3.6 → 2.2s, tokio 0.5 → 0.3s — **2–4× end-to-end** with
+byte-identical output. The dogfood gate caught one real near-duplicate the
+refactor itself introduced (`path_cond`/`guarded` converged once both used the
+same indexed loop) — deduped by making `guarded` call `path_cond`, count back
+at 24.
+
+The remaining cost after this campaign is the genuine per-unit value-graph
+build (blocks dominate by count), no longer accidental quadratics. The design
+lesson matches §T: hot-path evidence/node lookups must be index-backed by
+default — a raw `il.evidence`/`il.nodes` iteration in a per-node helper is a
+red flag in review.

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -9,9 +9,11 @@ experiments that validated these passes are in [experiments](experiments.md).
 > Stage 2 statement-order subsumed). Track 2 — algebraic canonicalization
 > (`algebra.rs`: assoc/comm flatten, comparison-direction, De Morgan;
 > value-independent). Track 3 — CFG normalization (`cfg_norm.rs` `structure()`:
-> conjoined-guard merge, continue-guard unwrap). Pipeline: desugar → alpha →
-> oracle cutoff → recursion→iteration → dataflow → [dce] → cfg_norm::structure →
-> algebra → cfg_norm::run; value graph on top.
+> conjoined-guard merge, continue-guard unwrap). Pipeline: desugar →
+> {effect, binding, library-api, call-target} evidence → alpha → oracle cutoff →
+> recursion→iteration → dataflow → [dce] → cfg_norm::structure → algebra →
+> cfg_norm::run → {effect, library-api} evidence (re-run on the canonical shapes);
+> value graph on top.
 > (`dce.rs` dead-code/dead-assignment elimination is an optional pass, off by default.)
 > Later additions on the value graph: semantic-kernel **value-domain and value-law
 > contracts** (`ValueDomain` / `ValueLaw`) that gate domain-dependent canons, using
@@ -173,10 +175,13 @@ Guiding constraints for every pass:
   numbers, tolerating structural difference — lives in the **candidate axis** and its
   scoring, never in the behavioral base. Never nondeterministic, either way.
 - **Termination**: bounded rewriting (no infinite saturation).
-- **Composition order**: desugar → alpha → oracle cutoff → **recursion→iteration** →
+- **Composition order**: desugar → evidence producers (effect, binding,
+  library-api, call-target) → alpha → oracle cutoff → **recursion→iteration** →
   **dataflow** → [dce] → **cfg_norm::structure** → **algebra** → **cfg_norm::run** →
-  (later) value-graph (matching the status block above; CFG normalization straddles
-  algebra — `structure()` runs before it, `run()` after). Each documented below.
+  effect/library-api evidence re-run → (later) value-graph (matching the status
+  block above; CFG normalization straddles algebra — `structure()` runs before it,
+  `run()` after; the evidence re-run re-anchors effect and library-API facts on
+  the canonicalized shapes). Each documented below.
 
 ---
 

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -140,7 +140,7 @@ same breakdown for families with at least one exact fragment location. That make
 | `ranking.total_families` | integer | Active families remaining after rank-time pruning, filters, baseline suppression, and structured ignores, before `--top`. |
 | `ranking.shown_families` | integer | Families present in `families`. |
 | `ranking.limit` | integer or null | The `--top` limit; `null` means `--top 0` showed every family. |
-| `ranking.surface_counts` | object | Active family counts by `recommended_surface` before `--top`: `default`, `review`, `hidden`, `debug`, plus `fragments.total/default/review/hidden/debug` for families with exact fragment locations. |
+| `ranking.surface_counts` | object | Active family counts by effective surface before `--top`: `default`, `review`, `hidden`, `debug`, and `generated` (families wholly in generated-header source, which the human report omits from default output), plus `fragments.total/default/review/hidden/debug` for families with exact fragment locations. |
 | `baseline` | object, optional | Baseline comparison summary when `--baseline` is active. |
 | `ignore` | object, optional | Structured ignore summary when an ignore file was read. |
 | `families` | array | Active ranked clone families in JSON order, including diagnostic review/hidden families. Empty means no family survived the filters, baseline, and structured ignores. |


### PR DESCRIPTION
## What

`NOSE_TIME=1` stage timing put `normalize+extract` at 95–97% of scan cost (sympy: 20.5s of a 21s scan), and the per-pass breakdown put 92% of the normalize half in the four evidence passes. The shape was always the same: a per-node/per-call helper running a full linear scan of `il.evidence` or `il.nodes` — O(n²) on evidence-dense files. The span-keyed evidence index existed (`Il::evidence_anchored_at`), but most consumers predated it.

All changes are output-preserving:

1. **Every anchored evidence query goes through the index** — `find_or_push_first_party_evidence` (the emit-path dedup scan, quadratic on its own output), both evidence upserts, the call-target/binding/library-api pass helpers, and ~15 anchored scans in `nose-semantics`. `EvidenceIndex` gains a `by_binding_hash` bucket and an `(id, span)` staleness sentinel so `clear()`/`retain()`+re-push rebuilds instead of silently corrupting.
2. **Two more lazy arena indexes on `Il`** under the nodes-are-immutable discipline: `nodes_spanning` (span → nodes) and `assigns_in_scope` (nearest-scope → assigns).
3. **`binding_evidence` inverts its mutation walk** — per-binding `visit_scope_nodes` (O(assignments × scope size)) becomes one `ScopeMutationFacts` walk per scope; same verdicts, one pass (sympy: 14.3s → 0.8s).
4. **The pure-inline registry is file-level, not per-unit** — `ValueFingerprintContext` collects `InlineCandidate`s once per file with global-name requirements recorded instead of resolved; per-unit admission moves to the call site. The old `inline_fns` map is gone.

## Result

Release build, 10-core M-series, default `syntax,semantic` scan:

| repo | before | after |
|---|---:|---:|
| sympy | 20.0s | 4.7s |
| redis | 3.9s | 1.0s |
| git | 2.7s | 1.1s |
| netty | 3.5s | 1.8s |
| guava | 3.6s | 2.2s |
| tokio | 0.5s | 0.3s |

## Validation

- **Byte-identical scan JSON** before/after on redis, git, tokio, guava, sympy, netty.
- Full test suite green; fast preflight (`check-ci-local.sh --fast`) green.
- The dogfood duplication gate caught one real near-duplicate the refactor introduced (`path_cond`/`guarded` converged once both used the same indexed loop) — deduped by making `guarded` call `path_cond`; count back at 24.

Docs: experiments §BQ records the campaign; normalization.md pipeline block now shows the evidence-pass placement; design.md §4's performance note updated (per-unit value-graph extraction is now the dominant cost, not the canonicalizer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)