### PR TITLE
review: emit the JSON/SARIF contract when there is nothing to review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ break.
   `ValueFingerprintContext`.
 
 ### Fixed
+- `nose review --format json|sarif` now emits its machine contract (an empty
+  findings envelope) instead of a human sentence when the diff has nothing
+  reviewable — e.g. an adds-only change. Found by the #243 fire-precision
+  replay: a JSON consumer parsing review stdout broke on exactly those PRs.
 - Rust units inside an inline `#[cfg(test)] mod tests` now classify as test
   scope (the path+name heuristic tagged them `prod`, distorting triage — the
   #216 audit's alacritty family). Locations carry `in_test_module` in scan

--- a/crates/nose-cli/src/review.rs
+++ b/crates/nose-cli/src/review.rs
@@ -71,7 +71,13 @@ pub(crate) fn cmd_review(args: ReviewArgs) -> Result<()> {
     )?;
     let changed = git_changed_ranges(&root, &args.base, &args.paths)?;
     if changed.is_empty() {
-        println!("no changes vs `{}` — nothing to review.", args.base);
+        // Nothing reviewable (e.g. an adds-only diff), but the machine formats
+        // must still emit their contract — a JSON consumer parses stdout.
+        match args.format {
+            ReportFormat::Json => println!("{}", review_json(&[], &args.base, 0)?),
+            ReportFormat::Sarif => println!("{}", review_sarif(&[])?),
+            _ => println!("no changes vs `{}` — nothing to review.", args.base),
+        }
         return Ok(());
     }
 

--- a/crates/nose-cli/tests/cli/review.rs
+++ b/crates/nose-cli/tests/cli/review.rs
@@ -262,3 +262,25 @@ fn c_u16_byte_pack_recognized_in_either_operand_order() {
     );
     let _ = fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn review_machine_formats_emit_json_when_nothing_to_review() {
+    let dir = make_project("review_empty_json");
+    init_git_repo(&dir);
+    // No working-tree changes vs HEAD: review has nothing to flag, but the
+    // machine formats must still print their contract, not a human sentence.
+    let out = nose_review(&dir, &["--format", "json"]);
+    assert!(out.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .expect("--format json must emit JSON even with no reviewable changes");
+    assert_eq!(json["inconsistent_families"], 0);
+    assert_eq!(json["findings"].as_array().map(Vec::len), Some(0));
+    assert_eq!(json["changed_files"], 0);
+
+    let sarif = nose_review(&dir, &["--format", "sarif"]);
+    assert!(sarif.status.success());
+    let doc: serde_json::Value = serde_json::from_slice(&sarif.stdout)
+        .expect("--format sarif must emit JSON even with no reviewable changes");
+    assert!(doc["runs"].is_array(), "sarif keeps its runs envelope");
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Small contract fix found while building the #243 fire-precision replay (part of #250).

`nose review --format json|sarif` printed the human sentence `no changes vs ... — nothing to review.` whenever the reviewable diff was empty — which happens on real PRs (adds-only changes have no base-side spans to review). Any tool parsing review stdout breaks on exactly those PRs; the replay harness hit it on 3 of 350 sampled corpus commits (sidekiq adds-only test commits, rxjava).

Now `--format json` emits the normal envelope with `findings: []` / `changed_files: 0`, and `--format sarif` emits its empty `runs` document. Human/markdown output keeps the sentence. Locked by `review_machine_formats_emit_json_when_nothing_to_review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)