### PR TITLE
Close the L5/L6 collection-kind asymmetry: Ruby for-in + seed-proven shovel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ break.
 
 ## [Unreleased]
 
+### Added
+- Ruby `for x in xs … out << e` builder loops now converge with comprehensions
+  and builder loops across languages in the exact semantic channel (#247,
+  experiments §BT). The shovel is admitted as an append only through the
+  active-builder seed proof (`out = []`); an integer-seeded `<<` stays a shift,
+  a parameter receiver never builds, and `each`-block builders remain pack-gated
+  (no Enumerable inference from a method name).
+
 ### Changed
 - **`nose scan`'s default channel mix is now `syntax,semantic,near`** (#241,
   experiments §BM): omitting `--mode` also runs the fuzzy Type-3 `near` channel
@@ -36,6 +44,10 @@ break.
   `ValueFingerprintContext`.
 
 ### Fixed
+- Ruby `for x in xs` loops are no longer excluded from the exact channel:
+  tree-sitter-ruby wraps the iterable in an `in` node, which lowered to an
+  exact-unsafe `Raw("in")` and split every Ruby `for` loop from its
+  cross-language equivalents (#247).
 - `nose review --format json|sarif` now emits its machine contract (an empty
   findings envelope) instead of a human sentence when the diff has nothing
   reviewable — e.g. an adds-only change. Found by the #243 fire-precision

--- a/bench/type4/coverage_leads.md
+++ b/bench/type4/coverage_leads.md
@@ -100,29 +100,39 @@ Remaining structural axes are larger NEW MECHANISMS (not gate alignments), track
 **extract-method / interprocedural pure inlining**. These need their own design + the same
 validation discipline.
 
-## L5 — ruby `arr << x` builder (`<<` = `Shl`) — ✅ RESOLVED (scoped append)
+## L5 — ruby `arr << x` builder (`<<` = `Shl`) — ✅ RESOLVED (#247: seed-proven shovel append)
 
-ruby flat_map builder loop stays a gap: `out << y` lowers to `(binop Shl out y)` (ruby `<<` is
-overloaded shift/append). The builder loop's value graph is a shift recurrence, not an append,
-so it never matches the `flat_map`. Fix is in the ruby frontend (lower `<<` as append when the
-receiver is array-like) and is inherently ambiguous without type/context — a separate frontend
-lead, not a value-graph/gate alignment. Low-to-medium value; deferred.
+`out << y` lowers to `(binop Shl out y)` — ruby `<<` is overloaded shift/append, so the
+operator alone proves nothing. The original note proposed a frontend "lower `<<` as append
+when the receiver is array-like" and correctly deferred it as type-ambiguous. The shipped
+resolution (#247) keeps the proof where it already lives: `ruby_shovel_append_parts`
+(nose-semantics) recognizes only the *form*, and admission goes through the active-builder
+machinery — the receiver must be a local var seeded by a proven empty list literal
+(`out = []`), exactly the `MethodEffectReceiverContract::ActiveCollectionBuilder` contract.
+An integer-seeded `<<` stays a shift; a parameter receiver (no seed) never builds; the
+`each`-block form stays pack-gated (no Enumerable inference from the method name). The same
+issue fixed the prerequisite frontend bug: tree-sitter-ruby wraps the `for x in xs` iterable
+in an `in` node, which lowered to an exact-unsafe `Raw("in")` — every ruby `for` loop was
+out of the exact channel. Tests: `ruby_for_in_shovel_builder_converges_with_comprehension`
+(positive + shift/parameter/contribution hard negatives),
+`ruby_for_in_loop_converges_with_python_for`. Ruby-corpus scan diff: zero detection change
+(idiomatic ruby uses `each`, which stays closed by design) — this closes the cross-language
+evenness gap, not a corpus-recall one.
 
 ## L6 — go composite-literal disambiguation + functional-append builder — ✅ RESOLVED
 
-Cross-language builder loops (`out := []T{}; for … out = append(out, e)` in Go; `new ArrayList`
-+ `.add` in Java) do not converge with the comprehension/`.map` form. Investigation:
-- The VALUE GRAPH *can* be made to converge them. Go's functional append `r = append(r, e)`
-  (an `Assign` whose RHS is `Append(r, …)`) is recognizable as the same per-element `Map` build
-  as the effect-form `r.append(e)`; with that recognition the Go builder's value fingerprint
-  becomes byte-identical to the Python comprehension (verified end-to-end in a spike).
-- But the EXACT channel is then blocked at the gate: the Go seed `[]int{}` lowers to a
-  `Seq("composite_literal")`, which `strict_exact_safe_seq` rejects. Admitting it is NOT a clean
-  L2-style alignment: `composite_literal` is also Go's MAP and STRUCT literal syntax, and the
-  value graph already tags all three `Seq(1)` — so opening the gate would let `Point{1,2}`
-  merge with `[]int{1,2}` / `[1,2]` (a struct ≡ slice false merge). Sound admission needs Go
-  type/context info (slice vs map vs struct). Java `.add` (List vs Set) and Ruby `<<`
-  (shift vs append, L5) have the same shape of ambiguity.
-- These are therefore NOT quick gate-alignments like L1/L2; they need a typed/contextual
-  collection-kind proof to stay sound. Deferred (the spike value-graph change was reverted to
-  avoid shipping a fingerprint change with no sound exact-channel payoff).
+Originally deferred for the same ambiguity shape: the Go seed `[]int{}` lowered to the same
+`Seq("composite_literal")` as Go MAP and STRUCT literals, so opening `strict_exact_safe_seq`
+blindly would merge `Point{1,2}` with `[]int{1,2}` (a struct ≡ slice false merge). Resolved
+since by the typed/contextual collection-kind route the deferral asked for: the Go frontend
+now distinguishes the literal kinds at lowering (`array` vs `composite_literal` (map) vs
+`go_struct` — `lower_composite_literal`, keyed on the tree-sitter `type` field), the
+functional append `r = append(r, e)` is recognized as the per-element build
+(`try_record_reassign_append`), and Java `new ArrayList` + `.add` is admitted only under
+import/shadow proof (`lower_empty_java_collection_constructor` + library-API evidence).
+Locked by `go_functional_append_builder_loop_converges_with_comprehension`,
+`java_arraylist_add_builder_loop_converges_with_comprehension`, and the unimported/shadowed
+Java hard negatives. Builder-loop ≡ comprehension now converges in the exact channel for
+python/js/ts/rust/go/java, and for ruby via the `for..in` + shovel form (L5); ruby
+`each`/`map` on bare receivers remain pack-gated by design, and C has no comparable
+builder idiom (out of scope).

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -6647,3 +6647,79 @@ fn two_argument_min_max_interpret_as_two_way_selection() {
         "min(3, 1) is 1 and max(3, 1) is 3"
     );
 }
+
+/// Ruby `for x in xs … out << e` is the same list build as a Python comprehension:
+/// `for..in` is a language construct (no receiver proof needed, unlike `each`), and
+/// the shovel is admitted as an append ONLY through the active-builder seed proof
+/// (`out = []`). The shovel operator alone proves nothing — an integer-seeded `<<`
+/// stays a shift, and a parameter receiver (no seed) never becomes a builder.
+#[test]
+fn ruby_for_in_shovel_builder_converges_with_comprehension() {
+    let i = Interner::new();
+    let comp = value_fp(
+        &i,
+        "def f(xs):\n    return [x * x for x in xs]\n",
+        Lang::Python,
+    );
+    let ruby_for = value_fp(
+        &i,
+        "def f(xs)\n  out = []\n  for x in xs\n    out << x * x\n  end\n  out\nend\n",
+        Lang::Ruby,
+    );
+    assert_eq!(comp, ruby_for, "ruby for-in shovel builder ≡ comprehension");
+
+    // Adjacent hard negative: a different per-element contribution stays distinct.
+    let ruby_diff = value_fp(
+        &i,
+        "def f(xs)\n  out = []\n  for x in xs\n    out << x + 1\n  end\n  out\nend\n",
+        Lang::Ruby,
+    );
+    assert_ne!(
+        ruby_for, ruby_diff,
+        "different contribution must stay distinct"
+    );
+
+    // Hard negative: an integer-seeded `<<` is a SHIFT — must not become a builder
+    // (and must stay distinct from a doubling accumulator, which it behaviorally is not
+    // for non-trivial seeds; here the point is it must not merge with the list build).
+    let ruby_shift = value_fp(
+        &i,
+        "def f(xs)\n  acc = 1\n  for x in xs\n    acc = acc << 1\n  end\n  acc\nend\n",
+        Lang::Ruby,
+    );
+    assert_ne!(
+        ruby_for, ruby_shift,
+        "integer shovel is a shift, not an append"
+    );
+
+    // Hard negative: a parameter receiver has no empty-list seed proof, so its
+    // shovel never builds — the loop keeps its opaque per-element effect.
+    let ruby_param = value_fp(
+        &i,
+        "def f(xs, out)\n  for x in xs\n    out << x * x\n  end\n  out\nend\n",
+        Lang::Ruby,
+    );
+    assert_ne!(
+        comp, ruby_param,
+        "shovel to an unproven (parameter) receiver must stay closed"
+    );
+}
+
+/// The bare Ruby `for x in xs` loop converges with Python's: tree-sitter-ruby wraps
+/// the iterable in an `in` node, which must lower to the iterable itself, not an
+/// exact-unsafe `Raw("in")`.
+#[test]
+fn ruby_for_in_loop_converges_with_python_for() {
+    let i = Interner::new();
+    let rb = value_fp(
+        &i,
+        "def f(xs)\n  for x in xs\n    y = x\n  end\n  0\nend\n",
+        Lang::Ruby,
+    );
+    let py = value_fp(
+        &i,
+        "def f(xs):\n    for x in xs:\n        y = x\n    return 0\n",
+        Lang::Python,
+    );
+    assert_eq!(rb, py, "ruby for-in ≡ python for (no Raw iterable wrapper)");
+}

--- a/crates/nose-frontend/src/ruby.rs
+++ b/crates/nose-frontend/src/ruby.rs
@@ -202,9 +202,19 @@ fn lower_for(lo: &mut Lowering, node: TsNode) -> NodeId {
         .child_by_field_name("pattern")
         .map(|p| lower_expr(lo, p))
         .unwrap_or_else(|| lo.empty_block(span));
+    // tree-sitter-ruby wraps the iterable in an `in` node (`for x in xs` →
+    // value: (in (identifier))); lower the wrapped expression, not the wrapper,
+    // or the iterable becomes an exact-unsafe `Raw("in")`.
     let iter = node
         .child_by_field_name("value")
-        .map(|v| lower_expr(lo, v))
+        .map(|v| {
+            let target = if v.kind() == "in" {
+                Lowering::named_children(v).into_iter().next().unwrap_or(v)
+            } else {
+                v
+            };
+            lower_expr(lo, target)
+        })
         .unwrap_or_else(|| lo.empty_block(span));
     let body = node
         .child_by_field_name("body")

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -96,7 +96,7 @@ use nose_semantics::{
     imported_literal_producer_evidence_for_node, imported_namespace_symbol,
     map_builder_index_write_contract, nullish_global_contract, opaque_argument_escape_args,
     own_property_guard_for_node, receiver_mutation_call_receiver, record_shape_guard_for_node,
-    reduction_builtin_contract, semantics, seq_surface_contract_for_node,
+    reduction_builtin_contract, ruby_shovel_append_parts, semantics, seq_surface_contract_for_node,
     source_comprehension_at_node, source_operator_at_node, source_pattern_at_node,
     source_range_at_node, unproven_membership_like_method_contract, BuiltinArgContract,
     CBytePackWidth, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,

--- a/crates/nose-normalize/src/value_graph/builders.rs
+++ b/crates/nose-normalize/src/value_graph/builders.rs
@@ -84,8 +84,12 @@ impl<'a> Builder<'a> {
     /// an active-builder receiver alone does not prove that a raw method selector has
     /// builder-append semantics.
     pub(super) fn list_append_parts(&self, e: NodeId) -> Option<(u32, Vec<NodeId>)> {
+        // Ruby's shovel `out << item` is form-only recognition: it admits an append
+        // ONLY through the active-builder gates below/in the callers (the empty-list
+        // seed is the receiver proof), so an integer's `<<` stays a shift.
         let (receiver, item) = builder_append_call_args(self.il, self.interner, e)
-            .or_else(|| admitted_builder_append_method_call_args(self.il, self.interner, e))?;
+            .or_else(|| admitted_builder_append_method_call_args(self.il, self.interner, e))
+            .or_else(|| ruby_shovel_append_parts(self.il, e))?;
         let (NodeKind::Var, Payload::Cid(c)) =
             (self.il.kind(receiver), self.il.node(receiver).payload)
         else {

--- a/crates/nose-semantics/src/effects.rs
+++ b/crates/nose-semantics/src/effects.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use nose_il::{
     stable_symbol_hash, Builtin, EffectEvidenceKind, EvidenceAnchor, EvidenceKind, EvidenceStatus,
-    Il, Interner, Lang, LibraryApiEvidenceKind, NodeId, NodeKind, Payload, PlaceEvidenceKind,
+    Il, Interner, Lang, LibraryApiEvidenceKind, NodeId, NodeKind, Op, Payload, PlaceEvidenceKind,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -584,6 +584,27 @@ pub fn builder_append_call_args(
         EvidenceResolution::Found(_) | EvidenceResolution::Ambiguous => None,
         EvidenceResolution::Missing => None,
     }
+}
+
+/// `(receiver, value)` of Ruby's shovel form `recv << item`.
+///
+/// The operator alone is NOT proof — integer `<<` is a shift, and any object can
+/// overload `<<`. This recognizes only the syntactic form; admission mirrors
+/// `MethodEffectReceiverContract::ActiveCollectionBuilder`: the caller must hold an
+/// ACTIVE list builder for the receiver (seeded by a proven empty list literal),
+/// which is what makes the shovel an append rather than a shift. A receiver without
+/// that seed proof never becomes a builder, so its `<<` stays an ordinary `Shl`.
+pub fn ruby_shovel_append_parts(il: &Il, node: NodeId) -> Option<(NodeId, NodeId)> {
+    if il.meta.lang != Lang::Ruby
+        || il.kind(node) != NodeKind::BinOp
+        || !matches!(il.node(node).payload, Payload::Op(Op::Shl))
+    {
+        return None;
+    }
+    let [recv, item] = il.children(node) else {
+        return None;
+    };
+    Some((*recv, *item))
 }
 
 /// `(receiver, value)` of a source method call whose append meaning is proven by

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1534,3 +1534,42 @@ representative pair — so this measures the *oracle-visible* frontier, not the
 absolute one. The cheap re-run path when #244 widens the oracle (symbolic-
 condition path exploration raises interpretable coverage): re-run `mine` —
 the arm is corpus-pinned, deterministic, and now ~30 minutes wall.
+
+## BT. Collection-kind closure — the L5/L6 audit, and the Ruby for-in/shovel residue
+
+#247 set out to "close the L5/L6 builder-loop exact-channel asymmetry" — and the
+first finding was that **most of it had already shipped** in the semantic-kernel
+tranche, with `bench/type4/coverage_leads.md`'s body text stale against its own
+✅ headers: Go's composite-literal kinds are distinguished at lowering (`array` /
+map / `go_struct`), Go functional append and Java's import-proven
+`new ArrayList` + `.add` both converge with the comprehension form, each locked by
+equivalence tests with struct/unimported/shadowed hard negatives. Ruby `each`/`map`
+on bare receivers stay closed **by design** (no Enumerable inference from a method
+name — a pack supplies receiver proof). The audit-then-implement shape mattered:
+the issue as written would have rebuilt existing machinery.
+
+The genuine residue was Ruby's receiver-proof-free path, and it was two small
+defects deep:
+
+1. **Every Ruby `for` loop was out of the exact channel**: tree-sitter-ruby wraps
+   the iterable in an `in` node (`for x in xs` → `value: (in (identifier))`), and
+   `lower_for` lowered the wrapper — an exact-unsafe `Raw("in")` that also blocked
+   `Elem(xs)` recognition. Fixed at the frontend (lower the wrapped expression).
+2. **The shovel had no sound admission path**: `out << e` is `BinOp(Shl)` — shift
+   on integers, append on arrays, anything on objects. `ruby_shovel_append_parts`
+   (nose-semantics) now recognizes the *form only*; admission rides the existing
+   active-builder proof — the receiver must be seeded by a proven empty list
+   literal, the same `ActiveCollectionBuilder` contract the method form uses. An
+   integer-seeded `<<` stays a shift; a parameter receiver never builds.
+
+Result: Ruby `out = []; for x in xs; out << x*x; end; out` is exact-safe and
+fingerprint-identical to the Python comprehension/builder loop (and the bare
+ruby `for` ≡ python `for`). Validation per the standing discipline: equivalence
+tests + 3 adjacent hard negatives (different contribution / integer shift /
+unproven parameter receiver); `nose verify` SOUND + canon PRESERVED on
+rubocop/fastlane/sidekiq/jekyll/asciidoctor; maximal-surface scan diff across 7
+Ruby corpus repos: **zero locations lost, zero gained** — idiomatic Ruby uses
+`each`, so the axis closes the §4b cross-language `exact_safe` evenness gap, not
+a corpus-recall gap (the §BO macro-arm shape). Builder ≡ comprehension now holds
+in the exact channel for python/js/ts/rust/go/java + ruby-for-in; C has no
+comparable idiom.


### PR DESCRIPTION
Closes #247. Part of the #250 campaign (Phase 1).

## Audit first, then implement

The issue as written would have rebuilt existing machinery: the audit found Go composite-literal disambiguation (`array`/map/`go_struct` at lowering), Go functional append, and Java import-proven `ArrayList.add` **already shipped and test-locked** — `coverage_leads.md`'s L5/L6 body text was stale against its own ✅ headers. Ruby `each`/`map` on bare receivers stay closed **by design** (no Enumerable inference from a method name). Both bodies are rewritten to match reality (experiments §BT records the audit).

## The genuine residue: Ruby's receiver-proof-free path

1. **Frontend bug — every Ruby `for` loop was out of the exact channel.** tree-sitter-ruby wraps the iterable in an `in` node (`for x in xs` → `value: (in (identifier))`); `lower_for` lowered the wrapper into an exact-unsafe `Raw("in")` that also blocked `Elem(xs)` recognition. Fix: lower the wrapped expression (`crates/nose-frontend/src/ruby.rs`).
2. **The shovel had no sound admission path.** `out << e` is `BinOp(Shl)` — shift on integers, append on arrays, anything on objects. New `ruby_shovel_append_parts` (nose-semantics) recognizes the **form only**; admission rides the existing active-builder machinery — the receiver must be a local var seeded by a proven empty list literal, the same `ActiveCollectionBuilder` contract the method form uses. No new gate was opened: an integer-seeded `<<` stays a shift, a parameter receiver never becomes a builder.

Result: `def f(xs); out = []; for x in xs; out << x*x; end; out; end` is exact-safe and fingerprint-identical to the Python comprehension and builder loop. Builder ≡ comprehension now holds in the exact channel for python/js/ts/rust/go/java + ruby-for-in (C has no comparable idiom).

## Validation (the L1–L6 discipline)

- `ruby_for_in_shovel_builder_converges_with_comprehension` — positive + three adjacent hard negatives (different contribution / integer shift / unproven parameter receiver); `ruby_for_in_loop_converges_with_python_for`; the existing `each`-form negative still green.
- `nose verify`: **SOUND + canon PRESERVED** on rubocop, fastlane, sidekiq, jekyll, asciidoctor.
- Maximal-surface scan diff on 7 Ruby corpus repos (old vs new binary): **zero locations lost, zero gained** — idiomatic Ruby uses `each`, so this closes the design §4b cross-language `exact_safe` evenness gap rather than moving corpus recall (the §BO macro-arm shape).
- Fast preflight green (fmt, clippy -D warnings, full suite, awiki).

🤖 Generated with [Claude Code](https://claude.com/claude-code)