### PR TITLE
Oracle: bounded symbolic-condition path exploration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ break.
 ## [Unreleased]
 
 ### Added
+- `nose verify`'s oracle now explores BOTH arms of a symbolic If/ternary
+  condition under recorded assumptions instead of bailing the unit (#244,
+  experiments §BU): conditioned, never guessed — each path's trace carries a
+  symbolic assume marker, so explored-path disagreements can only reach the
+  advisory lane, never the hard SOUND gate. Bounded fail-closed at 3 symbolic
+  decision sites per execution (a new census-visible `path-bail` reason; 2,101
+  units corpus-wide). Interpretable units 29.2% → 31.3% on the 105-repo corpus
+  with verify SOUND everywhere; loop conditions and the strict `run_unit`
+  contract (canon validation, fragment oracle) are unchanged.
 - Ruby `for x in xs … out << e` builder loops now converge with comprehensions
   and builder loops across languages in the exact semantic channel (#247,
   experiments §BT). The shovel is admitted as an append only through the

--- a/bench/labels/oracle_exclusion_census_post_paths_2026_06_11.json
+++ b/bench/labels/oracle_exclusion_census_post_paths_2026_06_11.json
@@ -1,0 +1,595 @@
+{
+ "excluded_by_reason": {
+  "battery-bail": 371659,
+  "empty-fp": 38248,
+  "path-bail": 2101
+ },
+ "excluded_repos": [
+  "raylib (verify does not finish, #208)"
+ ],
+ "interpretable_units": 187650,
+ "merge_pairs": {
+  "total": 3410521,
+  "unverified": 2334441,
+  "verified": 1076080
+ },
+ "nose_version": "nose 0.5.0",
+ "schema_version": "0.1.0",
+ "sharding": "per-repo (merge pairs counted within repo, matching per-repo scans)",
+ "shards": 105,
+ "tags": [
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 412008,
+   "interpretable_units": 187650,
+   "tag": "kind:Block",
+   "unverified_pairs": 2334441
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 412008,
+   "interpretable_units": 187650,
+   "tag": "kind:Func",
+   "unverified_pairs": 2334441
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 280605,
+   "interpretable_units": 131599,
+   "tag": "kind:Param",
+   "unverified_pairs": 2030811
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:179",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:223"
+   ],
+   "excluded_units": 242025,
+   "interpretable_units": 86372,
+   "tag": "kind:ExprStmt",
+   "unverified_pairs": 1313086
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 332974,
+   "interpretable_units": 158464,
+   "tag": "call:other",
+   "unverified_pairs": 1185077
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 371897,
+   "interpretable_units": 173457,
+   "tag": "kind:Var",
+   "unverified_pairs": 1050257
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/bindings.rs:945",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/display/color.rs:221",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty_config/src/lib.rs:84"
+   ],
+   "excluded_units": 8883,
+   "interpretable_units": 107,
+   "tag": "lit:unretained:Other",
+   "unverified_pairs": 925340
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 299043,
+   "interpretable_units": 133573,
+   "tag": "kind:Field",
+   "unverified_pairs": 792006
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 222427,
+   "interpretable_units": 106338,
+   "tag": "kind:Return",
+   "unverified_pairs": 658576
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:134",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:173"
+   ],
+   "excluded_units": 248694,
+   "interpretable_units": 62250,
+   "tag": "kind:Assign",
+   "unverified_pairs": 654400
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 154881,
+   "interpretable_units": 26021,
+   "tag": "kind:If",
+   "unverified_pairs": 644618
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/bindings.rs:54",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/bindings.rs:65",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/mod.rs:211"
+   ],
+   "excluded_units": 65251,
+   "interpretable_units": 10975,
+   "tag": "kind:UnOp",
+   "unverified_pairs": 507371
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 191135,
+   "interpretable_units": 39584,
+   "tag": "kind:BinOp",
+   "unverified_pairs": 467382
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/bindings.rs:1210",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/ui_config.rs:395"
+   ],
+   "excluded_units": 113255,
+   "interpretable_units": 22232,
+   "tag": "lit:unretained:Null",
+   "unverified_pairs": 460963
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:113"
+   ],
+   "excluded_units": 89028,
+   "interpretable_units": 21568,
+   "tag": "kind:Seq",
+   "unverified_pairs": 402232
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/migrate/mod.rs:172",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty_terminal/src/event_loop.rs:476",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty_terminal/src/term/mod.rs:2989"
+   ],
+   "excluded_units": 16338,
+   "interpretable_units": 6724,
+   "tag": "kind:Throw",
+   "unverified_pairs": 391470
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:32",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:148",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:93"
+   ],
+   "excluded_units": 48587,
+   "interpretable_units": 5118,
+   "tag": "kind:Lambda",
+   "unverified_pairs": 255336
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:363",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:381",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:539"
+   ],
+   "excluded_units": 62709,
+   "interpretable_units": 9252,
+   "tag": "kind:Loop",
+   "unverified_pairs": 144867
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/monitor.rs:179",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/migrate/mod.rs:172"
+   ],
+   "excluded_units": 14743,
+   "interpretable_units": 3332,
+   "tag": "builtin:Len",
+   "unverified_pairs": 114726
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:381",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/mod.rs:336",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/monitor.rs:179"
+   ],
+   "excluded_units": 66307,
+   "interpretable_units": 11843,
+   "tag": "kind:Index",
+   "unverified_pairs": 107088
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/color.rs:141",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/color.rs:156",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/color.rs:179"
+   ],
+   "excluded_units": 15413,
+   "interpretable_units": 489,
+   "tag": "lit:unretained:Int",
+   "unverified_pairs": 68218
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/mod.rs:195",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/display/mod.rs:1382"
+   ],
+   "excluded_units": 4972,
+   "interpretable_units": 435,
+   "tag": "builtin:Append",
+   "unverified_pairs": 63816
+  },
+  {
+   "example_excluded": [
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Go/antlr/v4/atn_config_set.go:259",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Go/antlr/v4/interval_set.go:61",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Go/antlr/v4/interval_set.go:91"
+   ],
+   "excluded_units": 3760,
+   "interpretable_units": 563,
+   "tag": "builtin:Enumerate",
+   "unverified_pairs": 61984
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:490",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/cursor.rs:29",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/font.rs:136"
+   ],
+   "excluded_units": 9590,
+   "interpretable_units": 340,
+   "tag": "lit:other",
+   "unverified_pairs": 19739
+  },
+  {
+   "example_excluded": [
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointBuffer.java:353",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointBuffer.java:365",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointBuffer.java:377"
+   ],
+   "excluded_units": 926,
+   "interpretable_units": 226,
+   "tag": "builtin:Max",
+   "unverified_pairs": 18664
+  },
+  {
+   "example_excluded": [
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/ANTLRInputStream.java:192",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointCharStream.java:152",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Java/src/org/antlr/v4/runtime/CodePointCharStream.java:204"
+   ],
+   "excluded_units": 942,
+   "interpretable_units": 192,
+   "tag": "builtin:Min",
+   "unverified_pairs": 16944
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/build.rs:8",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:113",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:134"
+   ],
+   "excluded_units": 40468,
+   "interpretable_units": 1246,
+   "tag": "kind:Raw",
+   "unverified_pairs": 8216
+  },
+  {
+   "example_excluded": [
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/Antlr4Mojo.java:222",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/GrammarDependencies.java:281",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/GrammarDependencies.java:72"
+   ],
+   "excluded_units": 14192,
+   "interpretable_units": 3858,
+   "tag": "kind:Try",
+   "unverified_pairs": 3090
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/cli.rs:363",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/mod.rs:238",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/mod.rs:280"
+   ],
+   "excluded_units": 7860,
+   "interpretable_units": 835,
+   "tag": "kind:Continue",
+   "unverified_pairs": 2206
+  },
+  {
+   "example_excluded": [
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/scripts/deploy_to_website.py:21",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/scripts/deploy_to_website.py:41",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/scripts/deploy_to_website.py:55"
+   ],
+   "excluded_units": 8120,
+   "interpretable_units": 644,
+   "tag": "lit:unretained:Str",
+   "unverified_pairs": 1505
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Go/antlr/v4/parser_atn_simulator.go:996",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Go/antlr/v4/tokenstream_rewriter.go:296"
+   ],
+   "excluded_units": 1946,
+   "interpretable_units": 245,
+   "tag": "builtin:Contains",
+   "unverified_pairs": 1386
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/display/content.rs:532",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/display/damage.rs:257"
+   ],
+   "excluded_units": 13978,
+   "interpretable_units": 831,
+   "tag": "kind:Break",
+   "unverified_pairs": 737
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Python3/src/antlr4/InputStream.py:22",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Python3/src/antlr4/ParserInterpreter.py:41"
+   ],
+   "excluded_units": 5202,
+   "interpretable_units": 2853,
+   "tag": "kind:HoF",
+   "unverified_pairs": 114
+  },
+  {
+   "example_excluded": [
+    "axios:/Users/ak/prjs/cc/nose/bench/repos/axios/tests/browser/headers.browser.test.js:76",
+    "bat:/Users/ak/prjs/cc/nose/bench/repos/bat/tests/benchmarks/highlighting-speed-src/jquery.js:3915",
+    "bat:/Users/ak/prjs/cc/nose/bench/repos/bat/tests/benchmarks/highlighting-speed-src/jquery.js:4882"
+   ],
+   "excluded_units": 201,
+   "interpretable_units": 45,
+   "tag": "builtin:Keys",
+   "unverified_pairs": 105
+  },
+  {
+   "example_excluded": [
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Python3/src/antlr4/BufferedTokenStream.py:120",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Python3/src/antlr4/BufferedTokenStream.py:134",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Python3/src/antlr4/BufferedTokenStream.py:258"
+   ],
+   "excluded_units": 2016,
+   "interpretable_units": 993,
+   "tag": "builtin:Range",
+   "unverified_pairs": 77
+  },
+  {
+   "example_excluded": [
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Python3/src/antlr4/TokenStreamRewriter.py:140",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Python3/src/antlr4/atn/PredictionMode.py:212",
+    "arrow:/Users/ak/prjs/cc/nose/bench/repos/arrow/arrow/arrow.py:1344"
+   ],
+   "excluded_units": 512,
+   "interpretable_units": 133,
+   "tag": "builtin:Any",
+   "unverified_pairs": 54
+  },
+  {
+   "example_excluded": [
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Python3/src/antlr4/atn/LexerActionExecutor.py:25",
+    "arrow:/Users/ak/prjs/cc/nose/bench/repos/arrow/arrow/arrow.py:1850",
+    "arrow:/Users/ak/prjs/cc/nose/bench/repos/arrow/arrow/locales.py:148"
+   ],
+   "excluded_units": 892,
+   "interpretable_units": 552,
+   "tag": "builtin:Join",
+   "unverified_pairs": 33
+  },
+  {
+   "example_excluded": [
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/JavaScript/src/antlr4/Lexer.js:192",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/JavaScript/src/antlr4/Lexer.js:200",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/JavaScript/src/antlr4/Lexer.js:91"
+   ],
+   "excluded_units": 772,
+   "interpretable_units": 457,
+   "tag": "builtin:Print",
+   "unverified_pairs": 32
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/config/monitor.rs:33",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/renderer/mod.rs:243",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/tool/src/org/antlr/v4/semantics/RuleCollector.java:110"
+   ],
+   "excluded_units": 191,
+   "interpretable_units": 76,
+   "tag": "builtin:IsEmpty",
+   "unverified_pairs": 24
+  },
+  {
+   "example_excluded": [
+    "curl:/Users/ak/prjs/cc/nose/bench/repos/curl/lib/curlx/inet_ntop.c:88",
+    "curl:/Users/ak/prjs/cc/nose/bench/repos/curl/lib/socks_sspi.c:104",
+    "curl:/Users/ak/prjs/cc/nose/bench/repos/curl/lib/socks_sspi.c:262"
+   ],
+   "excluded_units": 111,
+   "interpretable_units": 45,
+   "tag": "builtin:UnsignedCast32",
+   "unverified_pairs": 24
+  },
+  {
+   "example_excluded": [
+    "arrow:/Users/ak/prjs/cc/nose/bench/repos/arrow/arrow/arrow.py:1133",
+    "arrow:/Users/ak/prjs/cc/nose/bench/repos/arrow/arrow/arrow.py:1304",
+    "arrow:/Users/ak/prjs/cc/nose/bench/repos/arrow/arrow/arrow.py:1344"
+   ],
+   "excluded_units": 841,
+   "interpretable_units": 166,
+   "tag": "builtin:Abs",
+   "unverified_pairs": 21
+  },
+  {
+   "example_excluded": [
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Python3/src/antlr4/TokenStreamRewriter.py:108",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Python3/src/antlr4/TokenStreamRewriter.py:140",
+    "black:/Users/ak/prjs/cc/nose/bench/repos/black/src/black/lines.py:1242"
+   ],
+   "excluded_units": 600,
+   "interpretable_units": 181,
+   "tag": "builtin:All",
+   "unverified_pairs": 6
+  },
+  {
+   "example_excluded": [
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/runtime/Python3/src/antlr4/Recognizer.py:52",
+    "black:/Users/ak/prjs/cc/nose/bench/repos/black/src/blib2to3/pytree.py:672",
+    "boltons:/Users/ak/prjs/cc/nose/bench/repos/boltons/boltons/fileutils.py:694"
+   ],
+   "excluded_units": 535,
+   "interpretable_units": 268,
+   "tag": "builtin:Zip",
+   "unverified_pairs": 5
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/display/color.rs:286",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/tool/src/org/antlr/v4/codegen/target/GoTarget.java:70",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/tool/src/org/antlr/v4/misc/CharSupport.java:134"
+   ],
+   "excluded_units": 102,
+   "interpretable_units": 74,
+   "tag": "builtin:StartsWith",
+   "unverified_pairs": 4
+  },
+  {
+   "example_excluded": [
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/scripts/deploy_to_website.py:21",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/scripts/update_antlr_version.py:43",
+    "bat:/Users/ak/prjs/cc/nose/bench/repos/bat/tests/benchmarks/highlighting-speed-src/numpy_test_multiarray.py:7074"
+   ],
+   "excluded_units": 264,
+   "interpretable_units": 112,
+   "tag": "builtin:Sum",
+   "unverified_pairs": 2
+  },
+  {
+   "example_excluded": [
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/Antlr4Mojo.java:521",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java:1695",
+    "antlr4:/Users/ak/prjs/cc/nose/bench/repos/antlr4/tool/src/org/antlr/v4/codegen/target/GoTarget.java:70"
+   ],
+   "excluded_units": 56,
+   "interpretable_units": 21,
+   "tag": "builtin:EndsWith",
+   "unverified_pairs": 2
+  },
+  {
+   "example_excluded": [
+    "bat:/Users/ak/prjs/cc/nose/bench/repos/bat/tests/benchmarks/highlighting-speed-src/numpy_test_multiarray.py:39",
+    "drizzle-orm:/Users/ak/prjs/cc/nose/bench/repos/drizzle-orm/drizzle-kit/src/serializer/pgSerializer.ts:101",
+    "drizzle-orm:/Users/ak/prjs/cc/nose/bench/repos/drizzle-orm/drizzle-kit/src/utils.ts:132"
+   ],
+   "excluded_units": 48,
+   "interpretable_units": 19,
+   "tag": "builtin:Reduce",
+   "unverified_pairs": 0
+  },
+  {
+   "example_excluded": [
+    "black:/Users/ak/prjs/cc/nose/bench/repos/black/src/black/__init__.py:1167",
+    "graphhopper:/Users/ak/prjs/cc/nose/bench/repos/graphhopper/core/src/main/java/com/graphhopper/GraphHopper.java:605",
+    "graphhopper:/Users/ak/prjs/cc/nose/bench/repos/graphhopper/core/src/main/java/com/graphhopper/GraphHopper.java:637"
+   ],
+   "excluded_units": 32,
+   "interpretable_units": 26,
+   "tag": "builtin:GetOrDefault",
+   "unverified_pairs": 0
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/input/keyboard.rs:378",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/string.rs:41",
+    "clap:/Users/ak/prjs/cc/nose/bench/repos/clap/clap_builder/src/output/help_template.rs:608"
+   ],
+   "excluded_units": 31,
+   "interpretable_units": 7,
+   "tag": "builtin:IsNotNull",
+   "unverified_pairs": 0
+  },
+  {
+   "example_excluded": [
+    "bat:/Users/ak/prjs/cc/nose/bench/repos/bat/src/pretty_printer.rs:125",
+    "hyperfine:/Users/ak/prjs/cc/nose/bench/repos/hyperfine/src/benchmark/executor.rs:133",
+    "hyperfine:/Users/ak/prjs/cc/nose/bench/repos/hyperfine/src/benchmark/executor.rs:186"
+   ],
+   "excluded_units": 27,
+   "interpretable_units": 6,
+   "tag": "builtin:ValueOrDefault",
+   "unverified_pairs": 0
+  },
+  {
+   "example_excluded": [
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty/src/string.rs:41",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty_terminal/src/term/cell.rs:180",
+    "alacritty:/Users/ak/prjs/cc/nose/bench/repos/alacritty/alacritty_terminal/src/term/cell.rs:202"
+   ],
+   "excluded_units": 21,
+   "interpretable_units": 3,
+   "tag": "builtin:IsNull",
+   "unverified_pairs": 0
+  },
+  {
+   "example_excluded": [
+    "clap:/Users/ak/prjs/cc/nose/bench/repos/clap/tests/derive/flags.rs:216",
+    "meilisearch:/Users/ak/prjs/cc/nose/bench/repos/meilisearch/crates/meilisearch/src/lib.rs:798",
+    "meilisearch:/Users/ak/prjs/cc/nose/bench/repos/meilisearch/crates/meilisearch/tests/dashboard/mod.rs:5"
+   ],
+   "excluded_units": 5,
+   "interpretable_units": 0,
+   "tag": "kind:Module",
+   "unverified_pairs": 0
+  }
+ ],
+ "units_total": 599658
+}

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -1866,17 +1866,24 @@ fn func_span_index(il: &nose_il::Il) -> std::collections::HashMap<(u32, u32), no
 
 /// Interpret `root` on every battery row (under the unit's pointer-length contracts);
 /// `None` when any input fails to run — the unit is not interpretable on this battery.
+/// A row whose execution forks on symbolic If/ternary conditions contributes one
+/// behavior per explored path (#244, deterministic order, assumptions recorded in
+/// each trace); `path_cap` reports a fail-closed bail on the per-execution
+/// symbolic-site cap so the census can distinguish it from other bails.
 fn run_battery(
     il: &nose_il::Il,
     interner: &Interner,
     root: nose_il::NodeId,
     battery: &[Vec<nose_normalize::Value>],
     contracts: &[(u32, u32)],
+    path_cap: &mut bool,
 ) -> Option<Vec<nose_normalize::Behavior>> {
     let mut beh = Vec::with_capacity(battery.len());
     for inputs in battery {
         let row = apply_contracts(inputs, contracts);
-        beh.push(nose_normalize::run_unit(il, interner, root, &row)?);
+        beh.extend(nose_normalize::run_unit_paths(
+            il, interner, root, &row, path_cap,
+        )?);
     }
     Some(beh)
 }
@@ -1936,8 +1943,15 @@ fn gate_units(
             if fp.is_empty() {
                 continue;
             }
-            let Some(beh) = run_battery(&core, &corpus.interner, core_root, battery, &contracts)
-            else {
+            let mut path_cap = false;
+            let Some(beh) = run_battery(
+                &core,
+                &corpus.interner,
+                core_root,
+                battery,
+                &contracts,
+                &mut path_cap,
+            ) else {
                 continue;
             };
             let trivial = is_trivial_behavior(&beh);
@@ -2266,6 +2280,9 @@ enum VerifyExclusionReason {
     BatteryBail,
     EmptyFingerprint,
     Uninterpretable,
+    /// #244 fail-closed: the unit forked on more symbolic If/ternary sites than
+    /// the per-execution exploration cap allows.
+    PathBail,
 }
 
 impl VerifyExclusionReason {
@@ -2275,6 +2292,7 @@ impl VerifyExclusionReason {
             VerifyExclusionReason::BatteryBail => "battery-bail",
             VerifyExclusionReason::EmptyFingerprint => "empty-fingerprint",
             VerifyExclusionReason::Uninterpretable => "uninterpretable",
+            VerifyExclusionReason::PathBail => "path-bail",
         }
     }
 }
@@ -2293,6 +2311,7 @@ struct VerifyExclusions {
     battery_bail: usize,
     empty_fingerprint: usize,
     uninterpretable: usize,
+    path_bail: usize,
     units: Vec<VerifyExcludedUnit>,
 }
 
@@ -2309,6 +2328,7 @@ impl VerifyExclusions {
             VerifyExclusionReason::BatteryBail => self.battery_bail += 1,
             VerifyExclusionReason::EmptyFingerprint => self.empty_fingerprint += 1,
             VerifyExclusionReason::Uninterpretable => self.uninterpretable += 1,
+            VerifyExclusionReason::PathBail => self.path_bail += 1,
         }
         self.units.push(VerifyExcludedUnit {
             reason,
@@ -2324,11 +2344,16 @@ impl VerifyExclusions {
         self.battery_bail += other.battery_bail;
         self.empty_fingerprint += other.empty_fingerprint;
         self.uninterpretable += other.uninterpretable;
+        self.path_bail += other.path_bail;
         self.units.extend(other.units);
     }
 
     fn total(&self) -> usize {
-        self.core_missing + self.battery_bail + self.empty_fingerprint + self.uninterpretable
+        self.core_missing
+            + self.battery_bail
+            + self.empty_fingerprint
+            + self.uninterpretable
+            + self.path_bail
     }
 }
 
@@ -2525,14 +2550,22 @@ fn collect_file_verify_recs(
             continue;
         }
         // Run the battery; the unit is interpretable only if every input runs.
-        let Some(beh) = run_battery(core, interner, core_root, battery, &contracts) else {
-            push_verify_census(oracle, loc, core, core_root, &fp, "battery-bail");
-            oracle.exclusions.record(
-                VerifyExclusionReason::Uninterpretable,
-                file_path,
-                span0,
-                tokens,
-            );
+        let mut path_cap = false;
+        let Some(beh) = run_battery(
+            core,
+            interner,
+            core_root,
+            battery,
+            &contracts,
+            &mut path_cap,
+        ) else {
+            let (census_reason, reason) = if path_cap {
+                ("path-bail", VerifyExclusionReason::PathBail)
+            } else {
+                ("battery-bail", VerifyExclusionReason::Uninterpretable)
+            };
+            push_verify_census(oracle, loc, core, core_root, &fp, census_reason);
+            oracle.exclusions.record(reason, file_path, span0, tokens);
             continue;
         };
         push_verify_census(oracle, loc, core, core_root, &fp, "interpretable");
@@ -2542,7 +2575,14 @@ fn collect_file_verify_recs(
         // Canon preservation is judged on CONCRETE behaviors only: symbolic identity
         // is keyed on syntax, and canonicalization legitimately rewrites syntax, so a
         // Sym-bearing mismatch here is expected, not a behavior change.
-        if let Some(full_beh) = run_battery(n, interner, root, battery, &contracts) {
+        let mut full_path_cap = false;
+        if let Some(full_beh) =
+            run_battery(n, interner, root, battery, &contracts, &mut full_path_cap)
+        {
+            // Path-explored behaviors always carry the Sym assume markers, so the
+            // concrete-only filter below also keeps canon preservation away from
+            // path alignment questions (canonicalization may merge or split the
+            // very branches exploration forks on).
             let concrete = !beh.iter().any(nose_normalize::behavior_has_sym)
                 && !full_beh.iter().any(nose_normalize::behavior_has_sym);
             if concrete {
@@ -2645,6 +2685,7 @@ fn print_verify_json(oracle: &VerifyOracle) -> Result<()> {
                 "battery-bail": oracle.exclusions.battery_bail,
                 "empty-fingerprint": oracle.exclusions.empty_fingerprint,
                 "uninterpretable": oracle.exclusions.uninterpretable,
+                "path-bail": oracle.exclusions.path_bail,
             },
             "excluded_units": excluded_json,
         }))?
@@ -2664,6 +2705,11 @@ fn print_verify_exclusions(exclusions: &VerifyExclusions) {
     );
     println!("  empty-fingerprint: {}", exclusions.empty_fingerprint);
     println!("  uninterpretable: {}", exclusions.uninterpretable);
+    println!(
+        "  path-bail: {} (> {} symbolic branch sites)",
+        exclusions.path_bail,
+        nose_normalize::MAX_SYM_BRANCH_SITES
+    );
 }
 
 /// Soundness: fingerprint-equal ⟹ behavior-equal. Prints the section and returns the

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -6723,3 +6723,109 @@ fn ruby_for_in_loop_converges_with_python_for() {
     );
     assert_eq!(rb, py, "ruby for-in ≡ python for (no Raw iterable wrapper)");
 }
+
+/// #244 — bounded symbolic-condition path exploration. Branching on an opaque
+/// call's symbolic result no longer bails the unit under `run_unit_paths`: both
+/// arms run, each path's trace records its assumption as a Sym marker (so the
+/// behaviors stay symbolic → advisory lane), and the strict `run_unit` contract
+/// is unchanged (still bails).
+#[test]
+fn symbolic_condition_paths_explore_both_arms() {
+    use nose_normalize::{run_unit, Value};
+    let i = Interner::new();
+    let src = "def f(x):\n    if g(x):\n        return 1\n    return 2\n";
+    let il = nose_frontend::lower_source(FileId(0), "t", src.as_bytes(), Lang::Python, &i).unwrap();
+    let oracle = normalize(
+        &il,
+        &i,
+        &NormalizeOptions {
+            oracle: true,
+            ..NormalizeOptions::default()
+        },
+    );
+    let root = first_func(&oracle);
+
+    // Strict contract unchanged: a symbolic condition bails run_unit.
+    assert!(
+        run_unit(&oracle, &i, root, &[Value::Int(3)]).is_none(),
+        "strict run_unit must still bail on a symbolic condition"
+    );
+
+    let mut cap = false;
+    let paths = nose_normalize::run_unit_paths(&oracle, &i, root, &[Value::Int(3)], &mut cap)
+        .expect("two-arm exploration interprets the unit");
+    assert!(!cap, "one site is within the exploration cap");
+    assert_eq!(paths.len(), 2, "one symbolic site forks exactly two paths");
+    assert_eq!(
+        paths[0].ret,
+        Value::Int(1),
+        "true arm first (deterministic)"
+    );
+    assert_eq!(paths[1].ret, Value::Int(2), "false arm second");
+    for p in &paths {
+        assert!(
+            nose_normalize::behavior_has_sym(p),
+            "every explored path carries its Sym assumption marker: {p:?}"
+        );
+    }
+    assert_ne!(
+        paths[0].effects, paths[1].effects,
+        "the two arms record different assumptions"
+    );
+
+    // Differential alignment: the SAME shape over the same opaque call agrees…
+    let twin = nose_normalize::run_unit_paths(&oracle, &i, root, &[Value::Int(3)], &mut cap)
+        .expect("twin run");
+    assert_eq!(paths, twin, "deterministic across runs");
+    // …while branching on a DIFFERENT opaque call yields different assumptions.
+    let src_other = "def f(x):\n    if h(x):\n        return 1\n    return 2\n";
+    let il2 = nose_frontend::lower_source(FileId(0), "t", src_other.as_bytes(), Lang::Python, &i)
+        .unwrap();
+    let oracle2 = normalize(
+        &il2,
+        &i,
+        &NormalizeOptions {
+            oracle: true,
+            ..NormalizeOptions::default()
+        },
+    );
+    let other = nose_normalize::run_unit_paths(
+        &oracle2,
+        &i,
+        first_func(&oracle2),
+        &[Value::Int(3)],
+        &mut cap,
+    )
+    .expect("other unit");
+    assert_ne!(
+        paths, other,
+        "a different opaque condition must not align (different assumption markers)"
+    );
+}
+
+/// #244 fail-closed: more symbolic decision sites than the cap → path-bail,
+/// reported via the out-flag, never guessed.
+#[test]
+fn symbolic_condition_paths_fail_closed_past_the_cap() {
+    use nose_normalize::Value;
+    let i = Interner::new();
+    // 4 sequential symbolic decisions > MAX_SYM_BRANCH_SITES (3).
+    let src = "def f(x):\n    a = 1 if g(x) else 2\n    b = 1 if h(x) else 2\n    c = 1 if p(x) else 2\n    d = 1 if q(x) else 2\n    return a + b + c + d\n";
+    let il = nose_frontend::lower_source(FileId(0), "t", src.as_bytes(), Lang::Python, &i).unwrap();
+    let oracle = normalize(
+        &il,
+        &i,
+        &NormalizeOptions {
+            oracle: true,
+            ..NormalizeOptions::default()
+        },
+    );
+    let root = first_func(&oracle);
+    let mut cap = false;
+    let out = nose_normalize::run_unit_paths(&oracle, &i, root, &[Value::Int(3)], &mut cap);
+    assert!(out.is_none(), "past the site cap the unit fails closed");
+    assert!(
+        cap,
+        "the bail is reported as a path-cap bail for the census"
+    );
+}

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -208,6 +208,27 @@ enum Flow {
 
 const STEP_BUDGET: u64 = 200_000;
 
+/// Symbolic-condition path exploration cap (#244): at most this many symbolic
+/// If/ternary decision SITES per execution, so a row explores ≤ 2^cap paths.
+/// Beyond it the unit fails closed (path-bail), never guessed.
+pub const MAX_SYM_BRANCH_SITES: usize = 3;
+
+/// Effect-trace marker for an assumed symbolic condition: `Sym(assume ⊕ cond ⊕ arm)`.
+/// Because the marker is symbolic, every path-explored behavior carries `Sym`, which
+/// routes any cross-unit disagreement to verify's ADVISORY lane by construction —
+/// path exploration can never create a hard SOUND violation.
+const SYM_ASSUME: u64 = 0xA55E_0011;
+
+/// State for bounded symbolic-condition path exploration. `prescribed` replays
+/// decisions for sites already enumerated (depth-first, true-arm first); past its
+/// end a new site assumes `true` and appends to `taken`.
+#[derive(Default)]
+struct Explore {
+    prescribed: Vec<bool>,
+    taken: Vec<bool>,
+    cap_hit: bool,
+}
+
 struct Interp<'a> {
     il: &'a Il,
     interner: &'a Interner,
@@ -221,16 +242,14 @@ struct Interp<'a> {
     /// evidence record admits the exact call occurrence. This lets the oracle interpret proven
     /// recursive and interprocedural calls without treating raw callee spelling as proof.
     callable_roots: Vec<NodeId>,
+    /// `None` = strict (a symbolic condition bails the unit — `run_unit`'s contract,
+    /// kept for canon validation and the fragment oracle). `Some` = #244 bounded
+    /// two-arm exploration with each assumption recorded in the effect trace.
+    explore: Option<Explore>,
 }
 
-/// Run the `Func` unit at `root` with `args` bound to its parameters (in order).
-/// Returns its [`Behavior`], or `None` if the unit is uninterpretable.
-pub fn run_unit(il: &Il, interner: &Interner, root: NodeId, args: &[Value]) -> Option<Behavior> {
-    if il.kind(root) != NodeKind::Func {
-        return None;
-    }
-    let callable_roots = il
-        .units
+fn callable_roots(il: &Il) -> Vec<NodeId> {
+    il.units
         .iter()
         .filter(|u| {
             matches!(
@@ -239,7 +258,72 @@ pub fn run_unit(il: &Il, interner: &Interner, root: NodeId, args: &[Value]) -> O
             )
         })
         .map(|u| u.root)
-        .collect();
+        .collect()
+}
+
+/// Run the `Func` unit at `root` with `args` bound to its parameters (in order).
+/// Returns its [`Behavior`], or `None` if the unit is uninterpretable. A symbolic
+/// branch condition bails (strict contract; see [`run_unit_paths`] for the
+/// exploring variant).
+pub fn run_unit(il: &Il, interner: &Interner, root: NodeId, args: &[Value]) -> Option<Behavior> {
+    run_unit_once(il, interner, root, args, callable_roots(il), None).0
+}
+
+/// Every behavior of the unit on `args`, one per explored symbolic-condition path
+/// (deterministic depth-first order, true-arm first; a unit with no symbolic
+/// conditions yields exactly one). Each path's effect trace records its assumed
+/// conditions as `Sym` markers, so two units compare equal only when their
+/// assumptions AND outcomes align. Returns `None` when any path is
+/// uninterpretable or the per-execution symbolic-site cap is exceeded
+/// (fail-closed); `path_cap` reports the cap case for the exclusion census.
+pub fn run_unit_paths(
+    il: &Il,
+    interner: &Interner,
+    root: NodeId,
+    args: &[Value],
+    path_cap: &mut bool,
+) -> Option<Vec<Behavior>> {
+    let roots = callable_roots(il);
+    let mut out = Vec::new();
+    let mut prescribed: Vec<bool> = Vec::new();
+    loop {
+        let explore = Explore {
+            prescribed: prescribed.clone(),
+            ..Explore::default()
+        };
+        let (beh, ex) = run_unit_once(il, interner, root, args, roots.clone(), Some(explore));
+        let ex = ex.expect("explore state survives the run");
+        if ex.cap_hit {
+            *path_cap = true;
+            return None;
+        }
+        out.push(beh?);
+        // Advance depth-first: flip the deepest `true` decision to `false`,
+        // dropping exhausted (`false`) tails — a binary counter over sites.
+        let mut next = ex.taken;
+        while next.last() == Some(&false) {
+            next.pop();
+        }
+        match next.last_mut() {
+            Some(last) => *last = false,
+            None => break,
+        }
+        prescribed = next;
+    }
+    Some(out)
+}
+
+fn run_unit_once(
+    il: &Il,
+    interner: &Interner,
+    root: NodeId,
+    args: &[Value],
+    callable_roots: Vec<NodeId>,
+    explore: Option<Explore>,
+) -> (Option<Behavior>, Option<Explore>) {
+    if il.kind(root) != NodeKind::Func {
+        return (None, explore);
+    }
     let mut it = Interp {
         il,
         interner,
@@ -248,6 +332,7 @@ pub fn run_unit(il: &Il, interner: &Interner, root: NodeId, args: &[Value]) -> O
         fields: FxHashMap::default(),
         params: FxHashSet::default(),
         callable_roots,
+        explore,
     };
     let mut env: FxHashMap<u32, Value> = FxHashMap::default();
     let kids = il.children(root).to_vec();
@@ -273,20 +358,23 @@ pub fn run_unit(il: &Il, interner: &Interner, root: NodeId, args: &[Value]) -> O
             }
         }
     }
-    let body = *kids.last()?;
+    let Some(&body) = kids.last() else {
+        return (None, it.explore);
+    };
     let ret = match it.exec(body, &mut env) {
         Ok(Flow::Ret(v)) => v,
         Ok(Flow::Err) => Value::Err,
         Ok(_) => Value::Null,
-        Err(_) => return None,
+        Err(_) => return (None, it.explore),
     };
     let mut fields: Vec<(FieldKey, Value)> = it.fields.into_iter().collect();
     fields.sort_by(|(left, _), (right, _)| left.cmp(right));
-    Some(Behavior {
+    let behavior = Behavior {
         ret,
         effects: it.effects,
         fields,
-    })
+    };
+    (Some(behavior), it.explore)
 }
 
 impl<'a> Interp<'a> {
@@ -297,6 +385,36 @@ impl<'a> Interp<'a> {
         } else {
             Ok(())
         }
+    }
+
+    /// Truthiness of an If/ternary condition. A concrete value decides as usual.
+    /// A symbolic condition bails in strict mode; under #244 exploration it takes
+    /// the prescribed arm (or assumes `true` at a new site, depth-first) and
+    /// RECORDS the assumption as a `Sym` effect marker — so the decision is
+    /// conditioned, never guessed, and any cross-unit disagreement involving an
+    /// explored path stays in the advisory lane (the marker keeps the behavior
+    /// symbolic). Loop conditions deliberately stay strict: an assumption per
+    /// iteration is an unbounded chain, not a bounded fork.
+    fn cond_truthy(&mut self, v: &Value) -> R<bool> {
+        if let Some(t) = truthy(v) {
+            return Ok(t);
+        }
+        let Value::Sym(h) = v else {
+            return Err(Unsupported);
+        };
+        let h = *h;
+        let Some(ex) = self.explore.as_mut() else {
+            return Err(Unsupported);
+        };
+        if ex.taken.len() >= MAX_SYM_BRANCH_SITES {
+            ex.cap_hit = true;
+            return Err(Unsupported);
+        }
+        let taken = ex.prescribed.get(ex.taken.len()).copied().unwrap_or(true);
+        ex.taken.push(taken);
+        self.effects
+            .push(Value::Sym(sym_id(SYM_ASSUME, &[h, u64::from(taken)])));
+        Ok(taken)
     }
 
     fn exact_field_place(&self, node: NodeId) -> Option<FieldPlace> {
@@ -407,7 +525,7 @@ impl<'a> Interp<'a> {
                 if matches!(cond, Value::Err) {
                     return Ok(Flow::Err);
                 }
-                if truthy(&cond).ok_or(Unsupported)? {
+                if self.cond_truthy(&cond)? {
                     if let Some(&t) = kids.get(1) {
                         return self.exec(t, env);
                     }
@@ -675,7 +793,7 @@ impl<'a> Interp<'a> {
                 if matches!(c, Value::Err) {
                     return Ok(Value::Err);
                 }
-                if truthy(&c).ok_or(Unsupported)? {
+                if self.cond_truthy(&c)? {
                     self.eval(kids[1], env)
                 } else {
                     self.eval(kids[2], env)

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -32,7 +32,9 @@ mod recursion;
 mod value_graph;
 
 pub use commutative::{node_tag, node_tag_valued, subtree_hashes};
-pub use interp::{behavior_has_sym, run_unit, Behavior, Value};
+pub use interp::{
+    behavior_has_sym, run_unit, run_unit_paths, Behavior, Value, MAX_SYM_BRANCH_SITES,
+};
 pub use value_graph::{
     value_anchors, value_fingerprint, value_fingerprint_and_contracts,
     value_fingerprint_and_contracts_with_context, value_fingerprint_contracts,

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1039,8 +1039,10 @@ least 517ad5c. Filed as #210 (the exact channel is protected by `exact_safe`; th
 `near` value-accept path is exposed). The remaining census leaders after this round:
 `lit:unretained:Other` stays product-irrelevant (lossy-lowered), and the residual
 battery-bail mass concentrates in branch-on-symbolic units (`kind:If` excl-share 92%) —
-i.e. the next coverage unit is symbolic-condition path exploration, a much harder,
-deliberately-not-taken step (control flow is never guessed).
+i.e. the next coverage unit is symbolic-condition path exploration, a much harder
+step deliberately not taken at the time (control flow is never guessed). *Taken,
+boundedly, in §BU (#244): both arms explored under recorded assumptions — conditioned,
+not guessed — with a fail-closed site cap.*
 
 ### BL.2 — raylib verify budget: bound the oracle, don't hang it
 
@@ -1573,3 +1575,49 @@ Ruby corpus repos: **zero locations lost, zero gained** — idiomatic Ruby uses
 a corpus-recall gap (the §BO macro-arm shape). Builder ≡ comprehension now holds
 in the exact channel for python/js/ts/rust/go/java + ruby-for-in; C has no
 comparable idiom.
+
+## BU. Bounded symbolic-condition path exploration — conditioned, never guessed
+
+The §BL census's top residual — branch-on-symbolic units (`kind:If` excl-share
+92%) — named a step deliberately not taken: control flow is never guessed. #244
+takes it without guessing: when an If/ternary condition evaluates to a symbolic
+value, the oracle now explores BOTH arms (depth-first, true-arm first,
+deterministic), recording each assumption in the effect trace as a `Sym` marker
+(`assume ⊕ cond ⊕ arm`). The decision is *conditioned*, not guessed: two units
+compare equal only when their assumptions AND outcomes align. Three design locks:
+
+- **advisory by construction** — the assume marker keeps every explored path's
+  behavior symbolic, so a cross-unit disagreement involving an explored path can
+  only ever reach the advisory lane (`has_sym`), never the hard SOUND gate; canon
+  preservation likewise stays concrete-only (canonicalization may merge the very
+  branches exploration forks on);
+- **fail-closed cap** — at most 3 symbolic decision sites per execution (≤ 8
+  paths per battery row); past it the unit bails as a new, census-visible
+  `path-bail` (2,101 units corpus-wide). While/ForEach conditions stay strict —
+  an assumption per iteration is an unbounded chain, not a bounded fork;
+- **the strict contract is untouched** — `run_unit` (canon validation, the
+  fragment oracle) still bails on a symbolic condition; only `nose verify`'s
+  battery uses the exploring `run_unit_paths`.
+
+**Result** (105-repo census, both binaries, same corpus:
+`oracle_exclusion_census_post_paths_2026_06_11.json`; verify **SOUND on all
+105 repos**, canon PRESERVED, raylib within its §BL.2 budget):
+
+| | pre-#244 | post-#244 | Δ |
+|---|---:|---:|---|
+| interpretable units | 174,881 (29.2%) | 187,650 (31.3%) | **+12,769 (+2.1pp)** |
+| verified merge pairs | 1,073,454 (31.5%) | 1,076,080 (31.6%) | +2,626 (+0.1pp) |
+| path-bail (fail-closed, visible) | — | 2,101 | |
+
+**The honest read is double-edged.** The instrument gain is real — ~12.8k units
+that bailed on a symbolic branch now interpret, and the behavior-keyed mining arm
+(§BS) gets a wider candidate source for its cheap re-runs. But the *pair-mass*
+needle barely moves: the unverified 68.5% → 68.4%. The §BL attribution listed
+`kind:If` at 92% excl-share, yet conditioning on branches recovers only 0.1pp of
+pair mass — i.e. the units behind the unverified bulk are excluded for SEVERAL
+reasons at once (opaque statements, unsupported shapes, sheer size), and no single
+construct unlock will move it. That refines the campaign order the census set in
+§BL: the remaining oracle-completeness work is broad-spectrum statement coverage,
+not another control-flow mechanism — and given §BS measured the frontier this
+instrument feeds at one worthy pair per 105 repos, further oracle-completeness
+investment should wait for a consumer that needs it.


### PR DESCRIPTION
Closes #244. Part of the #250 campaign (Phase 1 — the last implementation item).

## What

When an If/ternary condition evaluates to a symbolic value, `nose verify`'s oracle now explores **both arms** instead of bailing the unit — depth-first, true-arm first, deterministic — with each assumption recorded in the effect trace as a `Sym` marker (`assume ⊕ cond ⊕ arm`). The decision is *conditioned, never guessed*: two units compare equal only when their assumptions AND outcomes align (the §BL.1 differential convention extended to control flow).

## Design locks

- **Advisory by construction.** The assume marker keeps every explored path's behavior symbolic, so a cross-unit disagreement involving an explored path can only reach the advisory lane (`has_sym`), never the hard SOUND gate. Canon preservation stays concrete-only (canonicalization may merge the very branches exploration forks on).
- **Fail-closed cap.** At most `MAX_SYM_BRANCH_SITES = 3` symbolic decision sites per execution (≤ 8 paths per battery row); past it the unit bails as a new census-visible **`path-bail`** reason (2,101 units corpus-wide). While/ForEach conditions stay strict — an assumption per iteration is an unbounded chain, not a bounded fork.
- **The strict contract is untouched.** `run_unit` (canon validation, the fragment oracle) still bails on symbolic conditions; only verify's battery uses the new `run_unit_paths`.

## Measured (105-repo census, both binaries; artifact `bench/labels/oracle_exclusion_census_post_paths_2026_06_11.json`)

| | pre | post | Δ |
|---|---:|---:|---|
| interpretable units | 174,881 (29.2%) | 187,650 (31.3%) | **+12,769 (+2.1pp)** |
| verified merge pairs | 1,073,454 (31.5%) | 1,076,080 (31.6%) | +2,626 (+0.1pp) |

`nose verify` **SOUND on all 105 repos**, canon PRESERVED, raylib within its §BL.2 budget.

**Honest read (experiments §BU):** the instrument gain is real (+12.8k units; the §BS behavior-keyed mining arm gets a wider candidate source), but the pair-mass needle barely moves — the units behind the unverified bulk are excluded for several reasons at once, so no single construct unlock will move it. This refines the §BL campaign order: the remaining completeness work is broad-spectrum statement coverage, and per §BS's one-worthy-pair-per-105-repos frontier, further investment should wait for a consumer that needs it.

## Tests

- `symbolic_condition_paths_explore_both_arms` — strict `run_unit` still bails; `run_unit_paths` forks exactly 2 paths (true arm first), every path carries its Sym marker, deterministic across runs, and a *different* opaque condition does not align.
- `symbolic_condition_paths_fail_closed_past_the_cap` — 4 sites > cap → `None` + the path-cap flag for the census.

Fast preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)