### PR TITLE
review: conservative --fail fire policy, measured on the §BR labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ break.
 
 ## [Unreleased]
 
+### Changed
+- **`nose review --fail` now fires on the conservative gate tier by default**
+  (#245, experiments §BV): only findings where the diff provably touches lines
+  the changed copy shares with its un-updated sibling (by the family's own
+  proof for exact-value-graph families; by varying-spot subtraction for
+  token/fuzzy families), excluding all-test scaffolding. Measured on the §BR
+  judge-labeled replay: every genuine missed propagation kept, 73% fewer fires,
+  3.7× precision. **Migration:** `--fail-on any` restores the old
+  fire-on-anything behavior. Review JSON findings gain `fire_eligible`,
+  `witness_kind`, `scope`, and per-changed-site `touches_shared`; human output
+  marks gate-firing findings with `[gate: touches shared lines]`.
+
+- **`nose scan`'s default channel mix is now `syntax,semantic,near`** (#241,
+  experiments §BM): omitting `--mode` also runs the fuzzy Type-3 `near` channel
+  at its standard `0.70` acceptance floor. Measured on the 105-repo corpus,
+  the flip lifts held-out worthy-recall 88.5% → 96.7% with held-out P@10
+  *improving* 55.5% → 58.6%; the cost is a larger default report
+  (+22% default-surface families corpus-wide, mostly production scope).
+  **Migration:** an explicit `--mode` (or config `mode`) is unaffected — it
+  replaces the default exactly as before. CI gates and baseline users should
+  pin `--mode` (e.g. `--mode syntax,semantic` for the old mix) or re-baseline
+  with `--write-baseline`, since a default-mode scan now reports more families
+  and `--fail-on any` can newly fail. `nose review`'s default is **unchanged**
+  (`syntax,semantic`): review feeds a gate, where false fires cost more than
+  missed candidates, and the §BM pricing covered the scan surface only.
+  `nose capabilities` advertises the new `scan.default_modes` truthfully.
+
 ### Added
 - `nose verify`'s oracle now explores BOTH arms of a symbolic If/ternary
   condition under recorded assumptions instead of bailing the unit (#244,
@@ -22,22 +49,6 @@ break.
   active-builder seed proof (`out = []`); an integer-seeded `<<` stays a shift,
   a parameter receiver never builds, and `each`-block builders remain pack-gated
   (no Enumerable inference from a method name).
-
-### Changed
-- **`nose scan`'s default channel mix is now `syntax,semantic,near`** (#241,
-  experiments §BM): omitting `--mode` also runs the fuzzy Type-3 `near` channel
-  at its standard `0.70` acceptance floor. Measured on the 105-repo corpus,
-  the flip lifts held-out worthy-recall 88.5% → 96.7% with held-out P@10
-  *improving* 55.5% → 58.6%; the cost is a larger default report
-  (+22% default-surface families corpus-wide, mostly production scope).
-  **Migration:** an explicit `--mode` (or config `mode`) is unaffected — it
-  replaces the default exactly as before. CI gates and baseline users should
-  pin `--mode` (e.g. `--mode syntax,semantic` for the old mix) or re-baseline
-  with `--write-baseline`, since a default-mode scan now reports more families
-  and `--fail-on any` can newly fail. `nose review`'s default is **unchanged**
-  (`syntax,semantic`): review feeds a gate, where false fires cost more than
-  missed candidates, and the §BM pricing covered the scan surface only.
-  `nose capabilities` advertises the new `scan.default_modes` truthfully.
 
 ### Performance
 - Scans are 2–4× faster end-to-end on the benchmark corpus (sympy 20.0 → 4.7s,

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -246,9 +246,16 @@ enum Cmd {
         /// Show at most N findings (0 = all). [default: 30]
         #[arg(long)]
         top: Option<usize>,
-        /// Exit non-zero if any family changed inconsistently (CI gate).
+        /// Exit non-zero when the gate fires (CI gate). What fires is governed
+        /// by --fail-on (default: only findings whose change provably touches
+        /// lines shared with the un-updated sibling).
         #[arg(long)]
         fail: bool,
+        /// Gate tier for --fail: `shared-logic` (default — fire only when the
+        /// diff provably touches lines a changed copy shares with its
+        /// un-updated sibling) or `any` (fire on every flagged finding).
+        #[arg(long, value_enum, default_value_t = review::ReviewFailOn::SharedLogic)]
+        fail_on: review::ReviewFailOn,
     },
     /// Recall-ceiling diagnostic: split gold recall across unit-extraction /
     /// candidate-generation stages. (Hidden — benchmark/research tooling.)
@@ -1648,6 +1655,7 @@ fn run_review_cmd(cmd: Cmd) -> Result<()> {
         format,
         top,
         fail,
+        fail_on,
     } = cmd
     else {
         unreachable!("run_review_cmd requires Cmd::Review")
@@ -1669,6 +1677,7 @@ fn run_review_cmd(cmd: Cmd) -> Result<()> {
         format,
         top,
         fail,
+        fail_on,
     })
 }
 
@@ -4291,7 +4300,7 @@ fn shared_lines_of(
 /// source-line ranges and trimmed, length-capped text — so an agent can see WHAT
 /// an extracted helper would parameterize (e.g. "every spot is a data literal")
 /// without opening files. Same diff the `params` count walks.
-fn varying_spots_of(
+pub(crate) fn varying_spots_of(
     a: &nose_detect::Loc,
     b: &nose_detect::Loc,
     cache: &mut FileLineCache,
@@ -4460,7 +4469,7 @@ fn family_anchor(f: &nose_detect::RefactorFamily) -> (String, u32) {
 /// Memoizes file contents (split into lines) so ranking many families that touch the
 /// same files reads each file at most once. `None` for files that fail to read.
 #[derive(Default)]
-struct FileLineCache(std::collections::HashMap<String, Option<Vec<String>>>);
+pub(crate) struct FileLineCache(std::collections::HashMap<String, Option<Vec<String>>>);
 
 impl FileLineCache {
     /// All lines of `file`, reading and caching on first touch. `None` if unreadable.

--- a/crates/nose-cli/src/review.rs
+++ b/crates/nose-cli/src/review.rs
@@ -33,6 +33,20 @@ pub(crate) struct ReviewArgs {
     pub format: ReportFormat,
     pub top: Option<usize>,
     pub fail: bool,
+    pub fail_on: ReviewFailOn,
+}
+
+/// What `--fail` fires on. The default is the #245 conservative tier: only
+/// findings where the diff PROVABLY touches lines a changed member shares with
+/// its un-updated sibling (§BR measured span-overlap firing at 33% of merged
+/// PRs with ~4% top-1 precision — a gate that cries wolf gets disabled).
+#[derive(Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+pub(crate) enum ReviewFailOn {
+    /// Fire only on shared-logic-touching findings (the conservative gate).
+    #[default]
+    SharedLogic,
+    /// Fire on any flagged finding (the pre-#245 span-overlap behavior).
+    Any,
 }
 
 /// A flagged family: a clone whose copies were edited apart in this change set. Locations
@@ -43,6 +57,15 @@ struct Divergence {
     hazard: f64,
     review_priority: u8,
     complexity: usize,
+    /// Family scope: `prod` / `test` / `mixed` (test scaffolding fires differently).
+    scope: &'static str,
+    /// The family's equivalence-witness kind (`exact-value-graph`,
+    /// `copy-paste-run`, `shared-sub-dag`, `structural-similarity`).
+    witness_kind: Option<&'static str>,
+    /// The #245 conservative gate verdict: some changed member PROVABLY touches
+    /// lines it shares with an un-updated sibling. `--fail` fires only on these;
+    /// `--fail-on any` restores span-overlap firing.
+    fire_eligible: bool,
     /// Members whose base span was changed by the diff (the edit landed here).
     changed: Vec<Site>,
     /// Sibling members the change did *not* touch (where it may be missing).
@@ -63,6 +86,11 @@ struct Site {
     fragment_kind: Option<FragmentKind>,
     reason_code: Option<&'static str>,
     enclosing_unit: Option<EnclosingUnit>,
+    /// For CHANGED sites: does the diff touch lines this member shares with an
+    /// un-updated sibling? `Some(false)` = the edit stayed inside this member's
+    /// varying spots; `None` = unprovable (unreadable source / capped diff) or a
+    /// not-updated site.
+    touches_shared: Option<bool>,
 }
 
 pub(crate) fn cmd_review(args: ReviewArgs) -> Result<()> {
@@ -110,6 +138,7 @@ pub(crate) fn cmd_review(args: ReviewArgs) -> Result<()> {
     // normalized to repo-relative first, so the family_id is stable across runs (the base
     // worktree lives at a per-run temp path) and matches what `scan` and the ignore file use.
     let prefix = canonical(&base_tree.path);
+    let mut lines = crate::FileLineCache::default();
     let mut flagged: Vec<Divergence> = Vec::new();
     for fam in &families {
         let fam = repo_relative(fam, &prefix);
@@ -124,6 +153,28 @@ pub(crate) fn cmd_review(args: ReviewArgs) -> Result<()> {
             .iter()
             .partition(|loc| site_touched_loc(loc, &changed));
         if !changed_members.is_empty() && !untouched.is_empty() {
+            // The #245 fire policy input: does the diff touch lines this changed
+            // member SHARES with an un-updated sibling (its span minus the
+            // varying spots)? §BR measured 51% of review false-fires as
+            // span-overlap-but-not-shared-logic; a gate fires only on proof.
+            let witness_kind = fam.witness.as_ref().map(|w| w.kind);
+            let touches: Vec<Option<bool>> = changed_members
+                .iter()
+                .map(|c| {
+                    touches_shared_lines(
+                        c,
+                        &untouched,
+                        witness_kind,
+                        &base_tree.path,
+                        &mut lines,
+                        &changed,
+                    )
+                })
+                .collect();
+            // All-test families are review context, not gate material: §BG-audit
+            // found test variants legitimately diverge, and on the §BR labels the
+            // scope term doubled gate precision at zero true-positive cost.
+            let fire_eligible = touches.iter().any(|t| *t == Some(true)) && fam.scope != "test";
             flagged.push(Divergence {
                 family_id: crate::baseline::family_id(&fam),
                 similarity: fam.mean_score,
@@ -134,7 +185,14 @@ pub(crate) fn cmd_review(args: ReviewArgs) -> Result<()> {
                 // profile (the most likely un-propagated fix); an edit in a trivial clone is
                 // likely benign.
                 complexity: changed_members.iter().map(|l| l.sem).max().unwrap_or(0),
-                changed: changed_members.iter().map(|l| to_site(l)).collect(),
+                scope: fam.scope,
+                witness_kind,
+                fire_eligible,
+                changed: changed_members
+                    .iter()
+                    .zip(&touches)
+                    .map(|(l, t)| to_site_touch(l, *t))
+                    .collect(),
                 not_updated: untouched.iter().map(|l| to_site(l)).collect(),
             });
         }
@@ -158,8 +216,14 @@ pub(crate) fn cmd_review(args: ReviewArgs) -> Result<()> {
         _ => print_review_human(&flagged, &args.base, changed_files, args.top.unwrap_or(30)),
     }
 
-    if args.fail && !flagged.is_empty() {
-        std::process::exit(1);
+    if args.fail {
+        let fires = match args.fail_on {
+            ReviewFailOn::SharedLogic => flagged.iter().any(|d| d.fire_eligible),
+            ReviewFailOn::Any => !flagged.is_empty(),
+        };
+        if fires {
+            std::process::exit(1);
+        }
     }
     Ok(())
 }
@@ -203,7 +267,79 @@ fn to_site(loc: &Loc) -> Site {
         fragment_kind: loc.fragment_kind,
         reason_code: loc.reason_code,
         enclosing_unit: loc.enclosing_unit.clone(),
+        touches_shared: None,
     }
+}
+
+fn to_site_touch(loc: &Loc, touches_shared: Option<bool>) -> Site {
+    Site {
+        touches_shared,
+        ..to_site(loc)
+    }
+}
+
+/// Does the diff PROVABLY touch lines `member` shares with an un-updated sibling?
+///
+/// Two proof shapes, by the family's equivalence witness:
+///
+/// - `exact-value-graph`: the WHOLE span is shared logic by the channel's own
+///   proof — equal value fingerprints retain literal VALUES, so the copies
+///   compute identically down to constants, and the typical exact clone is a
+///   *renamed* twin whose every line differs textually while all of the logic
+///   is shared (a line diff would under-fire exactly on the strongest
+///   families). Any in-span change qualifies.
+/// - everything else (`copy-paste-run`, `structural-similarity`,
+///   `shared-sub-dag`): shared lines = the member's span minus its side of the
+///   varying spots vs the first sibling whose source diffs cleanly. The token
+///   channel abstracts identifiers/literals, so a `copy-paste-run` member may
+///   legitimately vary in exactly those spots — and the §BR 51% bucket (span
+///   overlap without shared-logic contact) lives in the fuzzy families. `None`
+///   (unknown) when no sibling pair diffs — unreadable source, or the spot list
+///   hit its cap (a truncated list under-counts variance, which would
+///   over-claim shared lines). The gate treats unknown as not-eligible: it
+///   fires on proof, never on absence of one.
+fn touches_shared_lines(
+    member: &Loc,
+    siblings: &[&Loc],
+    witness_kind: Option<&'static str>,
+    base_root: &Path,
+    lines: &mut crate::FileLineCache,
+    changed: &HashMap<String, Vec<(u32, u32)>>,
+) -> Option<bool> {
+    const SPOT_CAP: usize = 16; // mirrors varying_spots_of's cap
+    let changed_ranges = changed.get(&member.file)?;
+    if witness_kind == Some("exact-value-graph") {
+        return Some(true);
+    }
+    let abs = |loc: &Loc| {
+        let mut l = loc.clone();
+        l.file = base_root.join(&loc.file).to_string_lossy().into_owned();
+        l
+    };
+    let a = abs(member);
+    let spots = siblings.iter().find_map(|s| {
+        // Same-language siblings only: a cross-language "diff" is all-varying noise.
+        (s.lang == member.lang).then(|| crate::varying_spots_of(&a, &abs(s), lines))?
+    })?;
+    if spots.len() >= SPOT_CAP {
+        return None;
+    }
+    let varying: Vec<(u32, u32)> = spots.iter().filter_map(|s| s.a_lines).collect();
+    let shared_touched = changed_ranges.iter().any(|&(cs, ce)| {
+        // Walk the member's span; a changed line inside the span that is not in
+        // any varying range is a shared-line hit. (Pure insertions are encoded
+        // as empty ranges between lines and count as touching the gap they sit in.)
+        let lo = cs.max(member.start_line);
+        let hi = ce.min(member.end_line);
+        if lo > hi {
+            // Empty/insertion range: touches shared logic when it falls inside
+            // the span but not strictly inside a varying range.
+            let inside = cs > member.start_line && ce < member.end_line;
+            return inside && !varying.iter().any(|&(vs, ve)| ce >= vs && cs <= ve);
+        }
+        (lo..=hi).any(|line| !varying.iter().any(|&(vs, ve)| line >= vs && line <= ve))
+    });
+    Some(shared_touched)
 }
 
 fn review_priority(fam: &RefactorFamily, changed: &[&Loc], untouched: &[&Loc]) -> u8 {
@@ -496,14 +632,19 @@ fn print_review_human(flagged: &[Divergence], base: &str, changed_files: usize, 
             break;
         }
         println!(
-            "#{}  changed: {}  (sim {:.2})",
+            "#{}  changed: {}  (sim {:.2}){}",
             i + 1,
             d.changed
                 .iter()
                 .map(site_label)
                 .collect::<Vec<_>>()
                 .join(", "),
-            d.similarity
+            d.similarity,
+            if d.fire_eligible {
+                "  [gate: touches shared lines]"
+            } else {
+                ""
+            }
         );
         for s in &d.changed {
             if let Some(context) = fragment_context(s) {
@@ -536,6 +677,7 @@ fn review_json(flagged: &[Divergence], base: &str, changed_files: usize) -> Resu
             "fragment_kind": s.fragment_kind,
             "reason_code": s.reason_code,
             "enclosing_unit": s.enclosing_unit,
+            "touches_shared": s.touches_shared,
         })
     };
     let items: Vec<_> = flagged
@@ -545,6 +687,9 @@ fn review_json(flagged: &[Divergence], base: &str, changed_files: usize) -> Resu
                 "family_id": d.family_id,
                 "similarity": d.similarity,
                 "complexity": d.complexity,
+                "scope": d.scope,
+                "witness_kind": d.witness_kind,
+                "fire_eligible": d.fire_eligible,
                 "changed": d.changed.iter().map(&site).collect::<Vec<_>>(),
                 "not_updated": d.not_updated.iter().map(&site).collect::<Vec<_>>(),
             })

--- a/crates/nose-cli/tests/cli/review.rs
+++ b/crates/nose-cli/tests/cli/review.rs
@@ -284,3 +284,96 @@ fn review_machine_formats_emit_json_when_nothing_to_review() {
     assert!(doc["runs"].is_array(), "sarif keeps its runs envelope");
     let _ = fs::remove_dir_all(&dir);
 }
+
+/// #245 — the conservative `--fail` gate: a change INSIDE a member's varying
+/// spot (the part that already differed from the sibling) is not a propagation
+/// hazard and must not fire; a change to SHARED lines must. `--fail-on any`
+/// restores span-overlap firing.
+#[test]
+fn review_fail_fires_on_shared_logic_only() {
+    let body = |tag: &str| {
+        format!(
+            "def process(items, flag):\n    out = []\n    for item in items:\n        if item > 0:\n            out.append(item * 2 + 1)\n    log_result(out, \"{tag}\")\n    return out\n"
+        )
+    };
+    let dir = std::env::temp_dir().join(format!("nose_fire_policy_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("a")).unwrap();
+    fs::create_dir_all(dir.join("b")).unwrap();
+    fs::write(dir.join("a/f.py"), body("alpha")).unwrap();
+    fs::write(dir.join("b/f.py"), body("beta")).unwrap();
+    init_git_repo(&dir);
+
+    let review = |dir: &Path, extra: &[&str]| {
+        let mut args = vec![
+            "review",
+            ".",
+            "--min-size",
+            "8",
+            "--mode",
+            "syntax,semantic,near",
+        ];
+        args.extend_from_slice(extra);
+        Command::new(bin())
+            .current_dir(dir)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_OBJECT_DIRECTORY")
+            .env_remove("GIT_COMMON_DIR")
+            .args(&args)
+            .output()
+            .expect("run nose review")
+    };
+
+    // Scenario 1: edit only the varying spot ("alpha" → "gamma") — the line that
+    // already differed from the sibling. Flagged for review, but the gate stays quiet.
+    fs::write(dir.join("a/f.py"), body("gamma")).unwrap();
+    let out = review(&dir, &["--format", "json"]);
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("review JSON");
+    let finding = json["findings"]
+        .as_array()
+        .and_then(|f| f.first())
+        .expect("the divergence is still flagged for review");
+    assert_eq!(
+        finding["fire_eligible"], false,
+        "a varying-spot-only change must not be gate-eligible: {json}"
+    );
+    let gated = review(&dir, &["--fail"]);
+    assert!(
+        gated.status.success(),
+        "--fail must not fire on a varying-spot-only change"
+    );
+    let any = review(&dir, &["--fail", "--fail-on", "any"]);
+    assert!(
+        !any.status.success(),
+        "--fail-on any restores span-overlap firing"
+    );
+
+    // Scenario 2: edit a SHARED line (the computation both copies carry).
+    fs::write(
+        dir.join("a/f.py"),
+        body("alpha").replace("item * 2 + 1", "item * 2 + 3"),
+    )
+    .unwrap();
+    let out = review(&dir, &["--format", "json"]);
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("review JSON");
+    let finding = json["findings"]
+        .as_array()
+        .and_then(|f| f.first())
+        .expect("the shared-line divergence is flagged");
+    assert_eq!(
+        finding["fire_eligible"], true,
+        "a shared-line change is gate-eligible: {json}"
+    );
+    assert_eq!(
+        finding["changed"][0]["touches_shared"], true,
+        "the changed site carries the per-site verdict: {json}"
+    );
+    let gated = review(&dir, &["--fail"]);
+    assert!(
+        !gated.status.success(),
+        "--fail fires when the change touches shared lines"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1621,3 +1621,49 @@ construct unlock will move it. That refines the campaign order the census set in
 not another control-flow mechanism — and given §BS measured the frontier this
 instrument feeds at one worthy pair per 105 repos, further oracle-completeness
 investment should wait for a consumer that needs it.
+
+## BV. The conservative review fire policy — measured, shipped as the `--fail` default
+
+§BR gave the gate its labelset (120 refuter-confirmed top-1 findings; 5 genuine
+should-propagate) and its gap list (51% of false fires = span overlap without
+shared-logic contact). #245 turns that into the `--fail` policy. Review now
+computes, per changed member, whether the diff PROVABLY touches lines the member
+shares with an un-updated sibling — two proof shapes keyed on the family's
+equivalence witness: an `exact-value-graph` family's whole span is shared by the
+channel's own proof (equal value fingerprints retain literal values; the typical
+exact clone is a renamed twin whose every line differs textually — a line diff
+would under-fire exactly on the strongest families), while fuzzy and token
+families subtract the member's varying spots (the token channel abstracts
+identifiers/literals, so a `copy-paste-run` member may legitimately vary in
+exactly those spots). Unknown (unreadable source, capped spot list) is
+not-eligible: the gate fires on proof, never on absence of one. Scan JSON gains
+`fire_eligible` / `witness_kind` / `scope` per finding and `touches_shared` per
+changed site.
+
+**Measured on the §BR labels** (re-replay with policy fields, joined 120/120 by
+changed-site span; `eval/review_fire/policy_eval_2026_06_11.json`):
+
+| policy | fires (n=120) | true positives kept | precision |
+|---|---:|---:|---:|
+| any (pre-#245 `--fail`) | 120 | 5/5 | 4.2% |
+| touches-shared (line proof) | 64 | **5/5** | 7.8% |
+| exact-witness only | 4 | 0/5 | 0% |
+| **shipped: (line ∨ exact-witness) ∧ scope ≠ test** | **32** | **5/5** | **15.6%** |
+
+Every true positive survives every tier — a real propagation hazard by
+definition touches shared logic — so the policy is pure noise reduction: 73%
+fewer fires at 3.7× the precision. Change-level, the gate now fires on 15% of
+replayed merged changes (was 33%) on review's default mix. The exact-witness
+fast path is measured-neutral on this sample (its 4 fires were all judged
+intentional/no-propagation) but stays for correctness on renamed twins, locked
+by the `review_flags_a_clone_changed_in_one_copy_only` fixture. `--fail-on any`
+restores span-overlap firing for ratchet-style use.
+
+Honest limits: 16% precision is a measured floor on THIS labelset (top-1
+findings only, 14 repos, no held-out split), not a precision claim; the
+remaining false fires are §BR's judgment classes (intentional variants,
+not-a-clone grouping artifacts) where structured ignores and family-quality
+work are the levers, not more gate logic. The §BG-gold3 ordering result also
+closes here: all 5 positives sat at rank 0 under review's existing
+priority/complexity ordering on this labelset — the post-divergence ordering
+already works; the gate needed precision, not better ranking (#23's answer).

--- a/docs/review.md
+++ b/docs/review.md
@@ -52,11 +52,28 @@ decide whether the edit belongs there too, or whether the divergence is intentio
 
 This is a **candidate surfacer, not a proof**: nose tells you a sibling exists and wasn't
 touched, not that the change definitely belongs there. Review each flagged sibling.
-Measured on replayed merged PRs ([experiments §BR](experiments.md)), review fires on
-roughly a third of real changes and the top finding is a genuine missed propagation in
-~4% of fires — real catches exist (including one later fixed upstream for exactly the
-flagged reason), but treat `--fail` as an explicitly-opted, policy-tuned gate, not a
-default-on blocker, until the conservative fire policy lands.
+
+## The gate (`--fail`)
+
+The report and the gate are deliberately different surfaces. The report shows every
+inconsistently-changed family; **`--fail` fires only on findings that pass the
+conservative fire policy** ([experiments §BV](experiments.md)):
+
+- the diff **provably touches lines the changed copy shares with its un-updated
+  sibling** — by the family's own equivalence proof for `exact-value-graph` families
+  (a renamed twin's every line is shared logic), or by subtracting the member's
+  varying spots for token/fuzzy families (an edit inside the part that already
+  differed is not a propagation hazard); unprovable cases do not fire — the gate
+  fires on proof, never on absence of one; and
+- the family is not all-test scaffolding (`scope != "test"`).
+
+Measured on replayed merged PRs against judge-labeled findings (§BR/§BV): the policy
+keeps **every** genuine missed propagation while firing 73% less often than
+span-overlap firing (change-level: 15% of merged changes vs 33%), at 3.7× the
+precision. `--fail-on any` restores the old fire-on-anything behavior for
+ratchet-style use. Each JSON finding carries `fire_eligible`, `witness_kind`,
+`scope`, and per-changed-site `touches_shared`, so a CI wrapper can apply its own
+tier without re-deriving the analysis.
 
 ## Flags
 
@@ -71,7 +88,8 @@ review with the fuzzy channel included.
 |---|---|
 | `--base <ref>` | compare the working tree against this git ref (default `HEAD` = uncommitted changes; `origin/main` for a PR branch) |
 | `--format human\|json\|markdown\|sarif` | output format (default `human`; `markdown` is accepted but currently uses the human-readable review report) |
-| `--fail` | exit non-zero if any family changed inconsistently (CI gate) |
+| `--fail` | exit non-zero when the gate fires (see *The gate* above) |
+| `--fail-on shared-logic\|any` | what `--fail` fires on: `shared-logic` (default, the conservative policy) or `any` flagged finding |
 | `--ignore-file <file>` | suppress accepted divergences (auto-reads `nose.ignore.json`) |
 | `--top N` | show at most N findings (`0` = all; default 30) |
 

--- a/eval/review_fire/policy_eval_2026_06_11.json
+++ b/eval/review_fire/policy_eval_2026_06_11.json
@@ -1,0 +1,895 @@
+{
+ "schema_version": 1,
+ "method": "#243 replay re-run with policy fields; joined 120/120 labeled findings by (repo,commit,arm,changed-site span); policies simulated offline from witness_kind/touches_shared/scope",
+ "finding_level": [
+  {
+   "policy": "any (pre-#245 --fail)",
+   "fires": 120,
+   "tp": 5,
+   "fp": 115,
+   "precision": 0.042
+  },
+  {
+   "policy": "touches-shared (line)",
+   "fires": 64,
+   "tp": 5,
+   "fp": 59,
+   "precision": 0.078
+  },
+  {
+   "policy": "exact-witness only",
+   "fires": 4,
+   "tp": 0,
+   "fp": 4,
+   "precision": 0.0
+  },
+  {
+   "policy": "line OR exact-witness",
+   "fires": 65,
+   "tp": 5,
+   "fp": 60,
+   "precision": 0.077
+  },
+  {
+   "policy": "SHIPPED: (line OR exact-witness) AND scope!=test",
+   "fires": 32,
+   "tp": 5,
+   "fp": 27,
+   "precision": 0.156
+  }
+ ],
+ "change_level": {
+  "default": {
+   "changes": 350,
+   "span_overlap_fire": 115,
+   "gate_fire": 52
+  },
+  "near": {
+   "changes": 350,
+   "span_overlap_fire": 143,
+   "gate_fire": 60
+  }
+ },
+ "rows": [
+  {
+   "sid": "rf-000",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-001",
+   "pos": false,
+   "line": true,
+   "witness": "exact-value-graph",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-002",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-003",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-004",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-005",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-006",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-007",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-008",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-009",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-010",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-011",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-012",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-013",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-014",
+   "pos": false,
+   "line": false,
+   "witness": "structural-similarity",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-015",
+   "pos": false,
+   "line": true,
+   "witness": "exact-value-graph",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-016",
+   "pos": false,
+   "line": false,
+   "witness": "structural-similarity",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-017",
+   "pos": false,
+   "line": false,
+   "witness": "structural-similarity",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-018",
+   "pos": false,
+   "line": true,
+   "witness": "structural-similarity",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-019",
+   "pos": false,
+   "line": true,
+   "witness": "structural-similarity",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-020",
+   "pos": false,
+   "line": true,
+   "witness": "shared-sub-dag",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-021",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-022",
+   "pos": false,
+   "line": true,
+   "witness": "structural-similarity",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-023",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-024",
+   "pos": false,
+   "line": false,
+   "witness": "structural-similarity",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-025",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-026",
+   "pos": false,
+   "line": false,
+   "witness": "structural-similarity",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-027",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-028",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-029",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-030",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-031",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-032",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-033",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-034",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-035",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-036",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-037",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-038",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-039",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-040",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-041",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-042",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-043",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-044",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-045",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-046",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-047",
+   "pos": false,
+   "line": true,
+   "witness": "shared-sub-dag",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-048",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-049",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-050",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-051",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-052",
+   "pos": false,
+   "line": true,
+   "witness": "structural-similarity",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-053",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-054",
+   "pos": false,
+   "line": false,
+   "witness": "structural-similarity",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-055",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-056",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-057",
+   "pos": false,
+   "line": false,
+   "witness": "exact-value-graph",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-058",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-059",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-060",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-061",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "mixed"
+  },
+  {
+   "sid": "rf-062",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-063",
+   "pos": true,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-064",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-065",
+   "pos": true,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-066",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-067",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-068",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-069",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-070",
+   "pos": false,
+   "line": false,
+   "witness": "shared-sub-dag",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-071",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-072",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-073",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-074",
+   "pos": false,
+   "line": false,
+   "witness": "structural-similarity",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-075",
+   "pos": false,
+   "line": false,
+   "witness": "shared-sub-dag",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-076",
+   "pos": true,
+   "line": true,
+   "witness": "shared-sub-dag",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-077",
+   "pos": false,
+   "line": false,
+   "witness": "structural-similarity",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-078",
+   "pos": true,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-079",
+   "pos": false,
+   "line": true,
+   "witness": "shared-sub-dag",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-080",
+   "pos": false,
+   "line": false,
+   "witness": "structural-similarity",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-081",
+   "pos": false,
+   "line": false,
+   "witness": "structural-similarity",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-082",
+   "pos": true,
+   "line": true,
+   "witness": "structural-similarity",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-083",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-084",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-085",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-086",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-087",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-088",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-089",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-090",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-091",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-092",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "mixed"
+  },
+  {
+   "sid": "rf-093",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-094",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-095",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-096",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-097",
+   "pos": false,
+   "line": false,
+   "witness": "shared-sub-dag",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-098",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-099",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-100",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-101",
+   "pos": false,
+   "line": true,
+   "witness": "shared-sub-dag",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-102",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-103",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-104",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-105",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "mixed"
+  },
+  {
+   "sid": "rf-106",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-107",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-108",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-109",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-110",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-111",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-112",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-113",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-114",
+   "pos": false,
+   "line": true,
+   "witness": "exact-value-graph",
+   "scope": "mixed"
+  },
+  {
+   "sid": "rf-115",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  },
+  {
+   "sid": "rf-116",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-117",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-118",
+   "pos": false,
+   "line": false,
+   "witness": "copy-paste-run",
+   "scope": "prod"
+  },
+  {
+   "sid": "rf-119",
+   "pos": false,
+   "line": true,
+   "witness": "copy-paste-run",
+   "scope": "test"
+  }
+ ]
+}


### PR DESCRIPTION
Closes #245 (Phase 2 of #250). Also answers #23 (see below).

## What

`--fail` now fires only on the conservative tier (experiments §BV): the diff must **provably touch lines the changed copy shares with its un-updated sibling**, and the family must not be all-test scaffolding. Two proof shapes, keyed on the family's #230 equivalence witness:

- **`exact-value-graph`**: the whole span is shared logic by the channel's own proof — equal value fingerprints retain literal values, and the typical exact clone is a *renamed* twin whose every line differs textually (a line diff would under-fire exactly on the strongest families).
- **token/fuzzy families**: shared lines = member span − its varying spots vs an un-updated sibling (`copy-paste-run` members may legitimately vary in abstracted identifier/literal spots — discovered by the fixture suite when the witness fast path first over-claimed them).

Unknown (unreadable source, capped spot list) is **not eligible** — the gate fires on proof, never on absence of one. `--fail-on any` restores span-overlap firing for ratchet use.

## Measured (re-replay joined 120/120 to the §BR judge labels; artifact `eval/review_fire/policy_eval_2026_06_11.json`)

| policy | fires (n=120) | TP kept | precision |
|---|---:|---:|---:|
| any (pre-#245 `--fail`) | 120 | 5/5 | 4.2% |
| touches-shared (line proof) | 64 | 5/5 | 7.8% |
| **shipped: (line ∨ exact-witness) ∧ scope ≠ test** | **32** | **5/5** | **15.6%** |

Every genuine missed propagation survives every tier — a real propagation hazard by definition touches shared logic — so the policy is pure noise reduction: **73% fewer fires at 3.7× precision**. Change-level: the gate fires on 15% of replayed merged changes (was 33%). Honest limits in §BV: this is a measured floor on one labelset (top-1 findings, 14 repos, no held-out); the remaining false fires are judgment classes (intentional variants, grouping artifacts) where ignores and family quality are the levers.

## Surface

- Review JSON findings gain `fire_eligible`, `witness_kind`, `scope`, and per-changed-site `touches_shared` — a CI wrapper can apply its own tier without re-deriving the analysis.
- Human output marks gate-firing findings with `[gate: touches shared lines]`.
- Docs: review.md gains *The gate* section; CHANGELOG carries the migration note.

## On #23

§BG-gold3 measured `diff_per_cog` (post-divergence) at harm-AUC 0.65 and this work validates the ordering end-to-end: all 5 true positives sat at **rank 0** under review's existing priority/complexity ordering. The ordering already works; the gate needed precision, not better ranking. Recommending #23 be closed with that answer.

## Tests

`review_fail_fires_on_shared_logic_only` — a varying-spot-only edit is flagged for review but does not fire (`--fail` exits 0; `--fail-on any` exits 1); a shared-line edit fires with `touches_shared: true`. The renamed-twin case is locked by the existing `review_flags_a_clone_changed_in_one_copy_only` (fires via the exact-witness proof). Full review group + fast preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)