### PR TITLE
Re-sweep two shelved knobs: doubling stays rejected; anchor floor gets a knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ break.
   `nose capabilities` advertises the new `scan.default_modes` truthfully.
 
 ### Added
+- `NOSE_ANCHOR_MIN_WEIGHT` research knob: overrides the sub-DAG anchor weight
+  floor (default 20). The #248 sweep (experiments §BW) measured floor 8 at
+  +0.9pp held-out worthy-recall with flat P@10 and consolidated corpus
+  families, but 3× more small families on near-only gate surfaces — so the
+  default stays conservative and recall-first consumers can opt in.
 - `nose verify`'s oracle now explores BOTH arms of a symbolic If/ternary
   condition under recorded assumptions instead of bailing the unit (#244,
   experiments §BU): conditioned, never guessed — each path's trace carries a

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -347,7 +347,7 @@ fn anchor_partial_score(weight: u32) -> f64 {
     let floor: f64 = env_or("NOSE_ANCHOR_SCORE", 0.72);
     let cap: f64 = env_or("NOSE_ANCHOR_SCORE_CAP", 0.90);
     let half: f64 = env_or("NOSE_ANCHOR_SCORE_REF", 60.0_f64).max(1.0); // extra weight at half-saturation
-    let extra = (f64::from(weight) - f64::from(nose_normalize::ANCHOR_MIN_WEIGHT)).max(0.0);
+    let extra = (f64::from(weight) - f64::from(nose_normalize::anchor_min_weight())).max(0.0);
     floor + (cap - floor) * (extra / (extra + half))
 }
 

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -36,7 +36,7 @@ pub use interp::{
     behavior_has_sym, run_unit, run_unit_paths, Behavior, Value, MAX_SYM_BRANCH_SITES,
 };
 pub use value_graph::{
-    value_anchors, value_fingerprint, value_fingerprint_and_contracts,
+    anchor_min_weight, value_anchors, value_fingerprint, value_fingerprint_and_contracts,
     value_fingerprint_and_contracts_with_context, value_fingerprint_contracts,
     value_fingerprint_lits, value_fingerprint_lits_anchors, value_fingerprint_lits_anchors_laws,
     value_fingerprint_lits_anchors_laws_with_context, value_fingerprint_lits_anchors_with_context,

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -43,7 +43,7 @@ mod state;
 mod stdlib;
 
 pub use api::{
-    value_anchors, value_fingerprint, value_fingerprint_and_contracts,
+    anchor_min_weight, value_anchors, value_fingerprint, value_fingerprint_and_contracts,
     value_fingerprint_and_contracts_with_context, value_fingerprint_contracts,
     value_fingerprint_lits, value_fingerprint_lits_anchors, value_fingerprint_lits_anchors_laws,
     value_fingerprint_lits_anchors_laws_with_context, value_fingerprint_lits_anchors_with_context,

--- a/crates/nose-normalize/src/value_graph/api.rs
+++ b/crates/nose-normalize/src/value_graph/api.rs
@@ -42,14 +42,32 @@ pub fn value_fingerprint_lits(
 
 /// The default minimum sub-computation size (in value-nodes) for a node to be an extractable
 /// anchor. Below this a shared sub-DAG is a common idiom (`x+1`, `len(xs)`), not a refactor.
+/// The #248 sweep (experiments §BW) measured the §BJ 8–20 band: floor 8 gains real
+/// worthy-recall (+0.9pp held-out, flat P@10, default-surface families CONSOLIDATE on
+/// corpus repos) but floods the near-only gate surface with small families (nose's own
+/// dup-gate 24 → 73) — recall-positive, burden-heavy. The default stays 20; recall-first
+/// consumers can set `NOSE_ANCHOR_MIN_WEIGHT=8`.
 pub const ANCHOR_MIN_WEIGHT: u32 = 20;
+
+/// The effective anchor weight floor: `ANCHOR_MIN_WEIGHT` unless the research
+/// knob `NOSE_ANCHOR_MIN_WEIGHT` overrides it (#248 — the §BJ 8–20 band sweep).
+/// A research surface like `NOSE_ANCHOR_SCORE*`, not a product setting.
+pub fn anchor_min_weight() -> u32 {
+    static V: OnceLock<u32> = OnceLock::new();
+    *V.get_or_init(|| {
+        std::env::var("NOSE_ANCHOR_MIN_WEIGHT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(ANCHOR_MIN_WEIGHT)
+    })
+}
 
 /// Heavy sub-DAG anchor hashes of a unit — see `Builder::anchors`. Two units sharing a (rare)
 /// anchor share an extractable sub-computation: a partial / sub-DAG clone.
 pub fn value_anchors(il: &Il, root: NodeId, interner: &Interner) -> Anchors {
     let mut b = Builder::new(il, interner);
     b.build_unit(root);
-    b.anchors(ANCHOR_MIN_WEIGHT)
+    b.anchors(anchor_min_weight())
 }
 
 /// `value_fingerprint_lits` plus the unit's heavy sub-DAG anchors, all from ONE value-graph
@@ -101,7 +119,7 @@ pub fn value_fingerprint_lits_anchors_laws_with_context(
 
 fn finish_fingerprint_law_bundle(mut b: Builder<'_>) -> FingerprintLawBundle {
     let (v, l, r) = b.fingerprint_lits();
-    let a = b.anchors(ANCHOR_MIN_WEIGHT);
+    let a = b.anchors(anchor_min_weight());
     b.value_laws.sort_unstable();
     b.value_laws.dedup();
     (v, l, r, a, b.value_laws)

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1667,3 +1667,44 @@ work are the levers, not more gate logic. The §BG-gold3 ordering result also
 closes here: all 5 positives sat at rank 0 under review's existing
 priority/complexity ordering on this labelset — the post-divergence ordering
 already works; the gate needed precision, not better ranking (#23's answer).
+
+## BW. Re-sweeping two shelved knobs — one stays shelved, one yields a usable knob
+
+#248 executed the §AY discipline (re-sweep old blockers when the system improves)
+on the two smallest parked items.
+
+**Num-gated doubling (`x*2 ≡ x+x`) — still rejected, now with corpus evidence.**
+§AY rejected it for verify cost, §BA for cross-language soundness (the canonical
+form depends on operands proving Num — since supplied by `ValueDomain`). Before
+re-implementing, the §BS behavior-keyed instrument gave a prevalence check the
+original attempts never had: across all 163 corpus-wide behavior-equal
+fingerprint-split leads, **zero** pairs are split by the doubling representation
+(4 textual `x+x`/`2*x` matches, all in battery-artifact pairs of unrelated
+computations). Doubling is precisely the numeric shape the oracle interprets
+best, so the instrument's blind spot argument is weak here. Verdict: the idiom
+splits nothing real; rejected without re-implementation — the re-sweep's value
+is the evidence trail.
+
+**The §BJ 8–20 anchor-mass band — measured, knob shipped, default kept.**
+`NOSE_ANCHOR_MIN_WEIGHT` (research surface, like `NOSE_ANCHOR_SCORE*`) now
+overrides the anchor weight floor; the never-run §BJ sweep ran at 20/16/12/8
+(105 repos, native order):
+
+| floor | dev P@10 | dev recall | heldout P@10 | heldout recall |
+|---|---:|---:|---:|---:|
+| 20 (default) | 58% [54–64] | 95.2% | 55% [49–60] | 96.9% |
+| 16 | 58% [53–63] | 95.4% | 54% [48–59] | 97.1% |
+| 12 | 61% [56–66] | 95.7% | 54% [48–59] | 97.3% |
+| 8 | 60% [55–65] | 96.6% | 55% [49–60] | **97.8%** |
+
+The recall gain is real and monotone (+1.4pp dev / +0.9pp held-out at floor 8)
+with P@10 flat across overlapping CIs — and on corpus repos the default surface
+CONSOLIDATES (more shared anchors merge related families: netty 4,882 → 3,120
+total) at a 5–15% scan-time cost. §BJ's "weak refactor targets" expectation was
+half wrong. The other half was right where it bites: on the near-only gate
+surface, nose's own dup-gate jumps 24 → 73 "substantial" families — the band IS
+dense in small real-but-marginal near-duplicates, and the dogfood budget is a
+never-loosen ratchet. **Verdict: default stays 20; the knob ships.** A
+recall-first consumer (design §2's agent) can set `NOSE_ANCHOR_MIN_WEIGHT=8` for
++0.9pp held-out worthy-recall at no measured precision cost; gate-shaped
+surfaces keep the conservative floor.


### PR DESCRIPTION
Closes #248 (the #250 campaign's "anytime" tier). Experiments §BW records both verdicts.

## Num-gated doubling (`x*2 ≡ x+x`) — still rejected, now with corpus evidence

§AY rejected it on verify cost, §BA on cross-language soundness. Before re-implementing under the since-matured `ValueDomain` Num gating, the §BS behavior-keyed instrument supplied the prevalence check the original attempts never had: **zero of 163 corpus-wide behavior-equal fingerprint-split leads are split by the doubling representation** (the 4 textual `x+x`/`2*x` matches all sit in battery-artifact pairs of unrelated computations). Doubling is exactly the numeric shape the oracle interprets best, so the instrument blind-spot caveat is weak here. Rejected without re-implementation; the re-sweep's value is the evidence trail.

## The §BJ 8–20 anchor-mass band — measured for the first time; knob ships, default stays

New `NOSE_ANCHOR_MIN_WEIGHT` research knob (like `NOSE_ANCHOR_SCORE*`); sweep at 20/16/12/8 over all 105 repos, native order:

| floor | dev P@10 | dev recall | heldout P@10 | heldout recall |
|---|---:|---:|---:|---:|
| 20 (default) | 58% [54–64] | 95.2% | 55% [49–60] | 96.9% |
| 8 | 60% [55–65] | 96.6% | 55% [49–60] | **97.8%** |

The recall gain is real and monotone with P@10 flat — and corpus default surfaces **consolidate** (more shared anchors merge related families: netty 4,882 → 3,120 total, scan +5–15% time). But the near-only gate surface floods with small families: **nose's own dup-gate jumps 24 → 73** "substantial" near-duplicates — §BJ's "weak refactor targets" expectation confirmed exactly where it bites, and the dogfood budget is a never-loosen ratchet.

**Verdict: default stays 20; the knob ships.** A recall-first consumer (design §2's agent) sets `NOSE_ANCHOR_MIN_WEIGHT=8` for +0.9pp held-out worthy-recall at no measured precision cost; gate-shaped surfaces keep the conservative floor.

Fast preflight green (with forced re-lint on edited files — the #258 lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)