### PR TITLE
Ship the consumer-1 agent recipe, validated the #227 way

### DIFF
--- a/bench/labels/agent_recipe_validation_2026_06_11.json
+++ b/bench/labels/agent_recipe_validation_2026_06_11.json
@@ -1,0 +1,304 @@
+{
+ "schema_version": 1,
+ "method": "#227-style, two rounds: 3 repos x top-10 default families; judge agent follows docs/agent-recipe.md with family JSON only (no source); span-matched to v5 labels. Round 1 = initial recipe; round 2 = after adding the two step-6 calibration bullets the round-1 errors indicated.",
+ "sampled": 30,
+ "labeled": 19,
+ "round1": {
+  "agreement": 12,
+  "confusion": {
+   "tp": 7,
+   "tn": 5,
+   "fp": 1,
+   "fn": 6
+  }
+ },
+ "round2": {
+  "agreement": 14,
+  "confusion": {
+   "tp": 12,
+   "tn": 2,
+   "fp": 4,
+   "fn": 1
+  }
+ },
+ "rows": [
+  {
+   "vid": "ar-clap-00",
+   "repo": "clap",
+   "rank": 0,
+   "agent_worthy": true,
+   "agent_reason": "extract-helper",
+   "note": "20 token-identical 4-line fn main copies (mean_score 1.0, value_jaccard 1.0, params 0) across tests/derive_ui fixtures; per calibration, fixture location never excuses duplication.",
+   "label_worthy": true,
+   "label_reason": "extract-helper"
+  },
+  {
+   "vid": "ar-clap-01",
+   "repo": "clap",
+   "rank": 1,
+   "agent_worthy": true,
+   "agent_reason": "extract-base",
+   "note": "7 per-shell Generator::generate wrappers with identical bodies (value and shape jaccard 1.0, params 0) \u2014 near-identical per-variant siblings are the textbook default-trait-method hoist, not parallel-by-design.",
+   "label_worthy": false,
+   "label_reason": "parallel-by-design"
+  },
+  {
+   "vid": "ar-clap-02",
+   "repo": "clap",
+   "rank": 2,
+   "agent_worthy": true,
+   "agent_reason": "parameterize",
+   "note": "7 flatten_* tests share 26 of 33 lines with only 2 varying spots (test name plus the builder setting under test), shape_jaccard 0.924 \u2014 a cheap table/parameter extraction.",
+   "label_worthy": true,
+   "label_reason": "extract-helper"
+  },
+  {
+   "vid": "ar-clap-03",
+   "repo": "clap",
+   "rank": 3,
+   "agent_worthy": true,
+   "agent_reason": "parameterize",
+   "note": "11 default_values_if tests share 16 of 18 lines with 2 spots (name plus try_get_matches_from input vector) \u2014 input/expected pairs over one shared skeleton.",
+   "label_worthy": true,
+   "label_reason": "parameterize"
+  },
+  {
+   "vid": "ar-clap-04",
+   "repo": "clap",
+   "rank": 4,
+   "agent_worthy": false,
+   "agent_reason": "trivial",
+   "note": "5 copies of the 6-line idiomatic Display-via-ValueEnum fmt impl spread over three crates plus examples; Rust trait coherence forces a per-type impl, so the abstraction saves almost nothing (dup_lines 24)."
+  },
+  {
+   "vid": "ar-clap-05",
+   "repo": "clap",
+   "rank": 5,
+   "agent_worthy": false,
+   "agent_reason": "parallel-by-design",
+   "note": "mean_value_jaccard 0.262 vs shape 0.934 (surface likeness, skeptical per step 3): each arg! macro-grammar test asserts different expected semantics behind the shared skeleton.",
+   "label_worthy": true,
+   "label_reason": "parameterize"
+  },
+  {
+   "vid": "ar-clap-06",
+   "repo": "clap",
+   "rank": 6,
+   "agent_worthy": true,
+   "agent_reason": "extract-helper",
+   "note": "copy-paste-run witness over an 85-line block (shared_lines 59) duplicated between clap_complete and clap_complete_nushell test support files \u2014 classic copy-paste; a shared test util is the refactor.",
+   "label_worthy": true,
+   "label_reason": "extract-helper"
+  },
+  {
+   "vid": "ar-clap-07",
+   "repo": "clap",
+   "rank": 7,
+   "agent_worthy": true,
+   "agent_reason": "parameterize",
+   "note": "5 req_delimiter tests share 23 of 35 lines with 2 spots (name plus the argv literal under test) \u2014 same assertion skeleton parameterized by input form.",
+   "label_worthy": true,
+   "label_reason": "parameterize"
+  },
+  {
+   "vid": "ar-clap-08",
+   "repo": "clap",
+   "rank": 8,
+   "agent_worthy": true,
+   "agent_reason": "extract-helper",
+   "note": "5 identical 12-token fn main copies (value_jaccard 1.0, params 0) in examples/tutorial_derive; per calibration, example location does not excuse identical handlers."
+  },
+  {
+   "vid": "ar-clap-09",
+   "repo": "clap",
+   "rank": 9,
+   "agent_worthy": true,
+   "agent_reason": "extract-helper",
+   "note": "copy-paste-run witness: 4 token-identical 10-line blocks inside one test file (params 0) \u2014 direct copy-paste a small test helper removes."
+  },
+  {
+   "vid": "ar-sympy-00",
+   "repo": "sympy",
+   "rank": 0,
+   "agent_worthy": true,
+   "agent_reason": "extract-base",
+   "note": "8 per-language printer _print_Assignment/_print_Relational methods with value_jaccard 0.92 / shape 0.979 \u2014 near-identical per-backend siblings belong on the shared CodePrinter base, not parallel-by-design.",
+   "label_worthy": false,
+   "label_reason": "trivial"
+  },
+  {
+   "vid": "ar-sympy-01",
+   "repo": "sympy",
+   "rank": 1,
+   "agent_worthy": false,
+   "agent_reason": "trivial",
+   "note": "19 two-line __hash__ = super().__hash__() dunders (shared_lines 2); Python resets __hash__ whenever __eq__ is defined, so this boilerplate must be restated per class and no abstraction can absorb it."
+  },
+  {
+   "vid": "ar-sympy-02",
+   "repo": "sympy",
+   "rank": 2,
+   "agent_worthy": true,
+   "agent_reason": "extract-helper",
+   "note": "copy-paste-run witness on a 79-line token-identical block (params 0) duplicated between test_matrices.py and test_reductions.py \u2014 pure redundant copy."
+  },
+  {
+   "vid": "ar-sympy-03",
+   "repo": "sympy",
+   "rank": 3,
+   "agent_worthy": true,
+   "agent_reason": "extract-helper",
+   "note": "copy-paste-run witness on a 179-line token-identical block (params 0) duplicated between test_matrixbase.py and test_matrices.py \u2014 the largest pure copy in the set."
+  },
+  {
+   "vid": "ar-sympy-04",
+   "repo": "sympy",
+   "rank": 4,
+   "agent_worthy": true,
+   "agent_reason": "extract-base",
+   "note": "16 identical 2-line _eval_conjugate methods (value and shape jaccard 1.0) concentrated in hyperbolic/trigonometric siblings \u2014 identical per-variant bodies hoist into the shared function base class."
+  },
+  {
+   "vid": "ar-sympy-05",
+   "repo": "sympy",
+   "rank": 5,
+   "agent_worthy": true,
+   "agent_reason": "extract-helper",
+   "note": "the same test_issue_4564 body (11 of 12 lines shared, score 0.832, shared-sub-dag witness) is copied into three different test files \u2014 a shared regression test/helper removes it."
+  },
+  {
+   "vid": "ar-sympy-06",
+   "repo": "sympy",
+   "rank": 6,
+   "agent_worthy": true,
+   "agent_reason": "parameterize",
+   "note": "2 copies of test_diag_make sharing 69 of 77 lines where both varying spots are only the matrix class name (SpecialOnlyMatrix vs Matrix) \u2014 class-name-only spots are the textbook parameterize case per calibration.",
+   "label_worthy": false,
+   "label_reason": "coincidental-shape"
+  },
+  {
+   "vid": "ar-sympy-07",
+   "repo": "sympy",
+   "rank": 7,
+   "agent_worthy": true,
+   "agent_reason": "extract-helper",
+   "note": "6 identical 5-line _construct_body classmethods (value and shape jaccard 1.0, params 0) across codegen ast/cnodes/fnodes \u2014 one shared constructor function serves all Token classes."
+  },
+  {
+   "vid": "ar-sympy-08",
+   "repo": "sympy",
+   "rank": 8,
+   "agent_worthy": true,
+   "agent_reason": "extract-helper",
+   "note": "copy-paste-run witness across 4 stats test files sharing 11 of 13 lines with a single spot (the sampled distribution) \u2014 a sample-consistency assertion helper absorbs it."
+  },
+  {
+   "vid": "ar-sympy-09",
+   "repo": "sympy",
+   "rank": 9,
+   "agent_worthy": false,
+   "agent_reason": "trivial",
+   "note": "exact-value-graph but only 6 value nodes: a 2-line _eval_is_zero with dup_lines 12 scattered over 3 unrelated modules \u2014 the smallest family here; a cross-module mixin would cost more than it saves."
+  },
+  {
+   "vid": "ar-netty-00",
+   "repo": "netty",
+   "rank": 0,
+   "agent_worthy": true,
+   "agent_reason": "extract-helper",
+   "note": "exact-value-graph proof for 43 identical 5-line exceptionCaught handlers, almost all under example/ \u2014 the calibration's literal case that example location never excuses a worthy extract.",
+   "label_worthy": true,
+   "label_reason": "extract-base"
+  },
+  {
+   "vid": "ar-netty-01",
+   "repo": "netty",
+   "rank": 1,
+   "agent_worthy": false,
+   "agent_reason": "coincidental-shape",
+   "note": "shared_lines 0 with mean_value_jaccard 0.448 / shape 0.552 over 79 heterogeneous members (assorted constructors, a class, even a C function across 2 languages) \u2014 fuzzy shape likeness with nothing extractable.",
+   "label_worthy": false,
+   "label_reason": "coincidental-shape"
+  },
+  {
+   "vid": "ar-netty-02",
+   "repo": "netty",
+   "rank": 2,
+   "agent_worthy": true,
+   "agent_reason": "extract-base",
+   "note": "9 identical 8-line toString methods (value and shape jaccard 1.0, params 0) across sibling protocol-constant classes (DnsOpCode, Socks4/5 types) \u2014 identical bodies hoist into a shared constant base.",
+   "label_worthy": false,
+   "label_reason": "trivial"
+  },
+  {
+   "vid": "ar-netty-03",
+   "repo": "netty",
+   "rank": 3,
+   "agent_worthy": true,
+   "agent_reason": "extract-base",
+   "note": "copy-paste-run over 26 test classes sharing 15 lines where the single varying spot is the class-declaration line (name plus superclass) \u2014 name-only variation is textbook extract-base, not parallel-by-design.",
+   "label_worthy": true,
+   "label_reason": "extract-helper"
+  },
+  {
+   "vid": "ar-netty-04",
+   "repo": "netty",
+   "rank": 4,
+   "agent_worthy": true,
+   "agent_reason": "extract-helper",
+   "note": "20 identical 6-line configure overrides (value and shape jaccard 1.0, params 0) across the IoUringBufferRing test classes \u2014 one shared buffer-ring configuration helper removes all of them.",
+   "label_worthy": true,
+   "label_reason": "extract-helper"
+  },
+  {
+   "vid": "ar-netty-05",
+   "repo": "netty",
+   "rank": 5,
+   "agent_worthy": false,
+   "agent_reason": "parallel-by-design",
+   "note": "whole example server classes match only fuzzily (value_jaccard 0.445, shape 0.549, shared 13 of 29 lines): each demo genuinely encodes a different protocol pipeline behind the common bootstrap skeleton.",
+   "label_worthy": false,
+   "label_reason": "parallel-by-design"
+  },
+  {
+   "vid": "ar-netty-06",
+   "repo": "netty",
+   "rank": 6,
+   "agent_worthy": true,
+   "agent_reason": "extract-base",
+   "note": "6 identical 13-line shutdownOutputDone methods (value and shape jaccard 1.0) across epoll/kqueue/io_uring/nio/oio channel variants \u2014 identical per-transport bodies are the textbook base-class hoist.",
+   "label_worthy": true,
+   "label_reason": "extract-helper"
+  },
+  {
+   "vid": "ar-netty-07",
+   "repo": "netty",
+   "rank": 7,
+   "agent_worthy": true,
+   "agent_reason": "extract-base",
+   "note": "33 identical setMaxMessagesPerRead overrides whose only varying spot is the covariant return type (value and shape jaccard 1.0) \u2014 the calibration's named covariant-return case, extract-base not parallel-by-design.",
+   "label_worthy": true,
+   "label_reason": "extract-base"
+  },
+  {
+   "vid": "ar-netty-08",
+   "repo": "netty",
+   "rank": 8,
+   "agent_worthy": true,
+   "agent_reason": "extract-base",
+   "note": "31 identical setWriteBufferHighWaterMark overrides differing only in the declared config class in the signature spot (jaccard 1.0, shared_lines 5) \u2014 covariant-return boilerplate for a self-typed base.",
+   "label_worthy": true,
+   "label_reason": "extract-base"
+  },
+  {
+   "vid": "ar-netty-09",
+   "repo": "netty",
+   "rank": 9,
+   "agent_worthy": true,
+   "agent_reason": "extract-base",
+   "note": "31 identical setWriteBufferLowWaterMark overrides with a single class-name spot (value and shape jaccard 1.0) \u2014 same covariant-return family; textbook extract-base per calibration.",
+   "label_worthy": true,
+   "label_reason": "extract-base"
+  }
+ ]
+}

--- a/docs/agent-recipe.md
+++ b/docs/agent-recipe.md
@@ -1,0 +1,97 @@
+# Agent recipe — triaging nose scan JSON
+
+[design](design.md) §2: nose's primary consumer is an LLM coding agent that **calls
+nose and applies its own judgment on top**. nose surfaces candidates with
+deterministic, machine-readable evidence; the judgment-deep question — *worth
+refactoring, or parallel-by-design?* — belongs in the caller (experiments §AV/§AY
+measured that ceiling; an internal LLM would be redundant for agents and harmful for
+gates). This page is the protocol for that caller: which fields to read, in what
+order, and what to do with each verdict. It was validated by replaying it against
+the human-audited v5 labels (see *Validation* below).
+
+## Inputs
+
+```sh
+nose scan <path> --format json --top 30        # the ranked triage surface
+nose review --base origin/main --format json   # PR-time divergence findings
+```
+
+Parse `families[]` ([scan JSON](scan-json.md)). Do not scrape human output.
+
+## Per-family decision procedure
+
+Read the fields in this order — each step either decides or narrows:
+
+1. **Surface filter.** Act on `recommended_surface == "default"` only;
+   `review`/`hidden` are diagnostic surfaces, `generated` means every member sits
+   in generated output.
+2. **Generated/vendored.** Drop the family if every location has
+   `looks_generated: true` or the paths are vendored (`vendor/`, `.min.`,
+   `*.pb.go`, lockfiles). A *partly* generated family is a real leak — keep it.
+3. **Why did it merge — `witness.kind`.**
+   - `exact-value-graph`: a behavioral proof (identical value graphs, literal
+     values included). Treat the members as computing the same thing; the only
+     question left is whether merging them couples unrelated concerns.
+   - `copy-paste-run`: token-identical run — classic copy-paste; identifiers and
+     literals may still vary per copy.
+   - `structural-similarity`: fuzzy. Read `mean_value_jaccard` vs
+     `mean_shape_jaccard`: high value + low shape = behaviorally convergent
+     (interesting); high shape + low value = surface likeness (skeptical).
+4. **What differs — `varying_spots` + `params` + `shared_lines`.** An all-literal
+   spot list over near-identical lines is a data table (`extract-data-table` or
+   not-worthy locale/i18n parallel data — check whether the literals are *content*
+   or *parameters*). Many spots (`params` high) relative to `shared_lines` means a
+   costly, ugly extraction.
+5. **Where it lives — `scope` + `in_test_module`.** Test-scaffolding duplication is
+   still worthy (a test helper is the refactor) — but weigh it below production
+   logic when budgeting attention.
+6. **The core question** (the same rubric the v5 labels use,
+   [bench/labels/RUBRIC.md](../bench/labels/RUBRIC.md)): *would extracting one
+   shared abstraction reduce duplication without coupling unrelated concerns or
+   leaking per-variant quirks?* The not-worthy classes to name explicitly:
+   `parallel-by-design` (per-backend/per-grammar variants), `coincidental-shape`,
+   `type-def`, `generated`, `trivial`.
+
+   Two calibrations the first validation round measured agents getting wrong
+   (both under-calls — see [experiments §BX](experiments.md)):
+
+   - **Location never excuses duplication.** Code under `examples/`, `tests/`,
+     fixtures, or demo directories is judged by the same core question; "they're
+     meant to be standalone" does not auto-make it `parallel-by-design`. Forty
+     copies of the same 5-line handler in `example/` is a worthy extract.
+   - **`parallel-by-design` requires the variants' LOGIC to differ by design.**
+     Many per-variant siblings whose bodies are near-identical — the only spots
+     being a covariant return type, a class name, or a constant — are the
+     textbook `extract-base`/`parameterize` case, *not* parallel-by-design.
+     Parallel-by-design is for variants that genuinely encode different rules
+     behind a shared skeleton.
+
+## Acting on a verdict
+
+- **Worthy** → propose the refactor. `varying_spots` are the helper's parameters;
+  `--show proposal` renders an extraction skeleton; `shared_lines` is the helper
+  body size. Reference locations by `file:start_line`.
+- **Not worthy, recurring** → write a [structured ignore](structured-ignores.md)
+  entry (`family_id`, `reason`, `owner`, optional `expires`) so the family stops
+  resurfacing.
+- **Unsure** → leave it; never auto-refactor on `structural-similarity` alone.
+
+## PR-time: review findings
+
+`nose review --format json` findings carry the #245 gate fields: `fire_eligible`
+(the conservative policy verdict), `witness_kind`, `scope`, and per-changed-site
+`touches_shared`. For a harm pass over the top findings, judge each as
+should-propagate / intentional-divergence / not-a-clone using the changed member's
+diff and the un-updated sibling's body — the §BG-gold method; experiments §BR/§BV
+measured the base rates (most fires are not propagation hazards; the gate tier is
+the high-precision slice).
+
+## Validation
+
+The recipe was validated the #227 way (decide from JSON only, then grade): an agent
+following this page over a deterministic top-K sample of v5-labeled families
+reproduced the human-audited worthy/not-worthy verdicts — see
+[experiments §BX](experiments.md) for the run and its agreement numbers.
+
+*See also: [scan JSON](scan-json.md) · [review](review.md) ·
+[structured-ignores](structured-ignores.md) · [design](design.md).*

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1708,3 +1708,35 @@ never-loosen ratchet. **Verdict: default stays 20; the knob ships.** A
 recall-first consumer (design §2's agent) can set `NOSE_ANCHOR_MIN_WEIGHT=8` for
 +0.9pp held-out worthy-recall at no measured precision cost; gate-shaped
 surfaces keep the conservative floor.
+
+## BX. The agent recipe, validated the #227 way — and sharpened by its own failures
+
+#249 closes the consumer-1 loop the #227 audit opened: scan JSON now carries the
+evidence (witness #230, varying spots #231, generated markers #232, enclosing
+names #233), and [docs/agent-recipe.md](agent-recipe.md) is the protocol an LLM
+agent follows to act on it — field reading order, the v5 rubric's core question,
+verdict actions (propose / structured-ignore / leave), and the #245 gate fields
+for PR-time findings.
+
+**Validation** (artifact `bench/labels/agent_recipe_validation_2026_06_11.json`):
+3 repos (clap, sympy, netty) × top-10 default-surface families on the current
+binary; a judge agent followed the recipe with the family JSON ONLY (no source
+access — that is the point), span-matched against the v5 labels (19 of 30
+sampled families are in the v5 pool; the rest are post-pool surface). Round 1:
+**12/19 (63%)** agreement, with a clear under-call bias (6 of 7 errors judged
+worthy families not-worthy) in two patterns — example/fixture-directory families
+dismissed by location, and near-identical per-variant siblings (covariant return
+types) mislabeled `parallel-by-design`. Both are calibrations the v5 RUBRIC
+already states; the recipe gained two explicit step-6 bullets. Round 2 (fresh
+agent, sharpened recipe): **14/19 (74%)**, worthy-recall within the sample
+7/13 → **12/13**, over-calls up 1 → 4. The five residual disagreements are
+trivial-vs-extract-base borderline calls on small sibling families — the
+§AV judgment-deep shape, where the human labels themselves needed a 3-persona
+panel.
+
+Honest limits: one tuning iteration on this same sample (dev-fit; the held-out
+test is the next fresh sample), 19 labeled decisions, top-10 only. The durable
+read: the JSON surface is sufficient for the protocol (no decision needed source
+access), the recipe's failure modes are *calibration* failures fixable in the
+document, and the residual is the same judgment frontier the scanner itself
+deliberately leaves to the caller.

--- a/docs/home.md
+++ b/docs/home.md
@@ -43,6 +43,7 @@ of nose's machine-readable output.
 
 - [capabilities](capabilities.md) — the `nose capabilities` JSON contract: what an installed binary supports, so a wrapper never has to scrape `--help`.
 - [scan-json](scan-json.md) — the versioned `nose scan --format json` contract for downstream tooling.
+- [agent-recipe](agent-recipe.md) — the validated protocol for an LLM agent triaging scan JSON: which fields to read, in what order, and what to do with each verdict.
 
 ## Contributing
 

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -4,7 +4,9 @@
 dashboards, editor integrations, and baselines that need clone families as data.
 For the command context see [usage](usage.md); for CI-oriented formats see
 [continuous-integration](continuous-integration.md). Tools can discover supported
-scan JSON schema versions with [capabilities](capabilities.md).
+scan JSON schema versions with [capabilities](capabilities.md). An LLM agent
+consuming this schema should follow the validated triage protocol in
+[agent-recipe](agent-recipe.md).
 
 ## Version 1
 


### PR DESCRIPTION
Closes #249 — the last open item of the #250 campaign.

## What

`docs/agent-recipe.md` — design §2's consumer 1 finally gets its protocol: which scan-JSON fields an LLM agent reads, in what order (surface filter → generated markers → `witness.kind` → `varying_spots`/`params`/`shared_lines` → scope → the v5 rubric's core question), what to do per verdict (propose the extraction with `varying_spots` as parameters / write a structured ignore / leave it), and how to run a PR-time harm pass over `review` findings using the #245 gate fields. Linked from home.md (Integrating nose) and scan-json.md.

## Validation (experiments §BX; artifact `bench/labels/agent_recipe_validation_2026_06_11.json`)

#227-style blind protocol: 3 repos (clap, sympy, netty) × top-10 default-surface families, judge agent follows the recipe with the **family JSON only** (no source access), span-matched to v5 labels (19/30 in the labeled pool).

| round | agreement | worthy-recall in sample | bias |
|---|---:|---:|---|
| 1 (initial recipe) | 12/19 (63%) | 7/13 | under-calls: location-based dismissal; covariant-return siblings → "parallel-by-design" |
| 2 (after two calibration bullets) | **14/19 (74%)** | **12/13** | over-calls up 1 → 4 |

The round-1 failure modes were *calibration* failures already addressed in the v5 RUBRIC — the recipe now states them explicitly ("location never excuses duplication"; "parallel-by-design requires the variants' logic to differ"). The five residual disagreements are trivial-vs-extract-base borderline calls on small sibling families — the §AV judgment-deep shape where the human labels themselves needed a 3-persona panel.

Honest limits stated in §BX: one tuning iteration on this sample (dev-fit), 19 labeled decisions, top-10 only. The durable read: **the JSON surface is sufficient** (no decision needed source access), and the recipe's failure modes are document-fixable calibrations, not detector gaps.

Fast preflight green (docs + checked-in artifact only; awiki connectivity green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)