### PR TITLE
CLI first-run usability: truthful help, journey-ordered commands, loud path errors, report hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ break.
 ## [Unreleased]
 
 ### Changed
+- **CLI usability pass for first-time users.** `nose scan`, `nose review`, and
+  `nose stats` now **error on a named path that doesn't exist** (a typo'd path
+  in a CI gate must fail loudly) instead of warning and exiting 0; a path that
+  exists but contains no supported files still warns and reports an empty scan.
+  Top-level help and command descriptions were rewritten to match the current
+  default channel mix (`syntax,semantic,near`, stale since the #241 flip) and
+  mention `nose review`; the command list is ordered by user journey (`scan`,
+  `review` first) with one-line summaries (details live in each command's
+  `--help`). The human scan report prints a friendly line instead of
+  `0 clone families … (showing 0)` when nothing is found, and ends with a
+  one-line hint pointing at `--show diff`, `--show proposal`, and `--top 0`
+  when extra views weren't already requested. README and getting-started were
+  refreshed to match (quick-start sample output, `nose review` introduction).
+
 - **`nose review --fail` now fires on the conservative gate tier by default**
   (#245, experiments §BV): only findings where the diff provably touches lines
   the changed copy shares with its un-updated sibling (by the family's own

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # nose
 
-**nose** finds refactoring candidates and semantic code clone families across Python,
-JavaScript, TypeScript, Go, Rust, Java, C, Ruby, and embedded `<script>` logic in Vue,
-Svelte, and HTML.
-
-It ships as one self-contained Rust binary. By default, `nose scan` combines a
-same-language copy-paste floor with exact modeled semantic matches, then ranks clone
-families by how cleanly they can be extracted.
+**nose** finds duplicated code worth refactoring — literal copy-paste, renamed
+copies, and the same logic written in a different style or language — across
+Python, JavaScript, TypeScript, Go, Rust, Java, C, Ruby, and the embedded
+`<script>` logic in Vue, Svelte, and HTML. One self-contained Rust binary; no
+runtime, services, or network.
 
 ## Install
 
@@ -18,31 +16,42 @@ brew install corca-ai/tap/nose
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/corca-ai/nose/releases/latest/download/nose-cli-installer.sh | sh
 ```
 
-To build from source:
+## Quick start
 
-```sh
-cargo build --release
-./target/release/nose scan examples --min-size 8
+Point `nose scan` at a directory. It groups duplicated code into clone families
+and ranks them by how cleanly each folds into one shared helper, so the report
+reads top-down as a refactoring to-do list:
+
+```
+$ nose scan src
+scanned 23 files · python 14 · typescript 9
+4 clone families, ranked by extractability (cleanest to fold into one helper)  ·  ~118 duplicated lines  (showing 4)
+
+#1  id b221962180c09063 · 2 copies · 8 of 10 lines shared, 2 spots differ · ~8 lines removable
+    → local duplication — extract a method from the repeated block
+    src/loaders/users.py:1-10  load_users
+    src/loaders/orders.py:12-21  load_orders
+…
 ```
 
-## First Scan
+The everyday commands:
 
 ```sh
-nose scan path/to/project
-nose scan src --format markdown > REFACTOR.md
-nose scan src --format json --top 50
-nose scan src --mode syntax --fail-on any
-nose review --base origin/main --fail
+nose scan src --show diff                  # also show exactly what differs inside each family
+nose scan src --format markdown            # a report to paste into a PR or issue
+nose review --base origin/main             # PR check: a change applied to one clone copy but not its siblings
+nose scan src --mode syntax --fail-on any  # jscpd-style copy-paste gate for CI
+nose scan src --format json                # machine-readable output for tooling and agents
 ```
 
-`nose scan` respects `.gitignore` files inside scanned trees. The default surface
-includes fuzzy near-duplicates; use `--mode semantic` for exact semantic-only findings,
-or `--mode syntax,semantic` to drop the fuzzy channel.
+By default `nose scan` runs all three channels — `syntax` (copy-paste runs),
+`semantic` (exact same-logic Type-4 clones), and `near` (fuzzy near-duplicates) —
+and respects `.gitignore`. Pass `--mode` to run exactly the channels you list.
 
 ## Documentation
 
-- [Documentation home](docs/home.md) — entry point for using, integrating, and contributing.
 - [Getting started](docs/getting-started.md) — first scan and how to read the report.
+- [Documentation home](docs/home.md) — entry point for using, integrating, and contributing.
 - [Usage](docs/usage.md) — command and flag reference.
 - [Configuration](docs/configuration.md) — `nose.toml`, excludes, modes, thresholds, ignores.
 - [Contributing](CONTRIBUTING.md) — development workflow and quality gates.

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -19,13 +19,15 @@ use std::path::PathBuf;
 #[command(
     name = "nose",
     version,
-    about = "Find code clone families across syntax, semantic, and near-duplicate channels",
-    long_about = "nose lowers each language into one normalized IL and finds duplicated code.\n\
-                  • `nose scan <paths>` — default: syntax + semantic clone families\n\
-                  • `nose scan <paths> --mode near` — opt into Type-3 near-duplicates\n\
-                  • `nose stats <paths>`    — IL lowering coverage\n\
-                  • `nose il <file>`        — inspect the IL\n\
-                  • `nose capabilities`     — machine-readable integration contract"
+    about = "Find duplicated code worth refactoring — exact, semantic (Type-4), and near-duplicate clone families",
+    long_about = "nose lowers each language into one normalized IL, groups duplicated code into\n\
+                  clone families, and ranks them by how cleanly each folds into one shared helper.\n\
+                  • `nose scan <paths>`                — find refactoring candidates (copy-paste + exact semantic + near-duplicates)\n\
+                  • `nose scan <paths> --show diff`    — also show exactly what differs inside each family\n\
+                  • `nose review --base origin/main`   — flag a change applied to one clone copy but not its siblings\n\
+                  • `nose stats <paths>`               — IL lowering coverage per language\n\
+                  • `nose il <file>`                   — inspect the IL (why two snippets do/don't converge)\n\
+                  • `nose capabilities`                — machine-readable integration contract"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -34,28 +36,6 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Cmd {
-    /// Emit the machine-readable capability contract for integrations.
-    Capabilities,
-    /// Dump the IL for a source file (inspection / debugging the transpiler).
-    Il {
-        /// Path to a source file.
-        path: PathBuf,
-        /// Output format.
-        #[arg(long, default_value = "sexpr")]
-        format: Format,
-        /// Show normalized (canonical) IL instead of raw.
-        #[arg(long)]
-        normalized: bool,
-        /// Disable control-flow normalization (ablation).
-        #[arg(long)]
-        no_cfg_norm: bool,
-    },
-    /// Validate semantic-pack v0 manifests and declared conformance fixtures.
-    #[command(name = "semantic-pack")]
-    SemanticPack {
-        #[command(subcommand)]
-        cmd: SemanticPackCmd,
-    },
     /// Research interface for raw unit clone pairs/groups.
     /// Hidden: `scan` is the user-facing command; `detect` is the strict/research
     /// and benchmark interface (`--bench-schema`, `--dump`, …).
@@ -116,8 +96,13 @@ enum Cmd {
         #[arg(long)]
         dump: Option<PathBuf>,
     },
-    /// Find clone families. Default: syntax (CPD) + exact semantic. Passing --mode
-    /// replaces that default with exactly the channels listed.
+    /// Find duplicated code and rank refactoring candidates (the everyday command).
+    ///
+    /// Scans files/directories (respecting .gitignore), groups duplicated code into
+    /// clone families, and ranks them by extractability — how cleanly each family
+    /// folds into one shared helper. Default channels: `syntax,semantic,near`
+    /// (copy-paste runs + exact semantic Type-4 + fuzzy near-duplicates). Passing
+    /// --mode replaces that default with exactly the channels listed.
     Scan {
         /// Paths to source files or directories (recursively scanned).
         #[arg(required = true)]
@@ -202,9 +187,12 @@ enum Cmd {
         #[arg(long, hide = true)]
         min_lines: Option<u32>,
     },
-    /// Flag clone families changed inconsistently in a diff: a copy was edited but its
-    /// sibling clones were not — a likely un-propagated change. Needs a git repository.
-    /// e.g. `nose review --base origin/main` in CI, or `nose review` for local changes.
+    /// Flag a change applied to one clone copy but not its siblings (PR/CI check).
+    ///
+    /// Compares the working tree to a git ref and reports clone families changed
+    /// inconsistently in that diff: a copy was edited but its sibling clones were
+    /// not — a likely un-propagated change. Needs a git repository. e.g.
+    /// `nose review --base origin/main` in CI, or `nose review` for local changes.
     Review {
         /// Paths to scan (recursively). Defaults to the current directory.
         paths: Vec<PathBuf>,
@@ -297,6 +285,28 @@ enum Cmd {
         #[arg(long)]
         json: bool,
     },
+    /// Dump the IL for a source file — debug why two snippets do or don't converge.
+    Il {
+        /// Path to a source file.
+        path: PathBuf,
+        /// Output format.
+        #[arg(long, default_value = "sexpr")]
+        format: Format,
+        /// Show normalized (canonical) IL instead of raw.
+        #[arg(long)]
+        normalized: bool,
+        /// Disable control-flow normalization (ablation).
+        #[arg(long)]
+        no_cfg_norm: bool,
+    },
+    /// Emit the machine-readable capability contract for integrations.
+    Capabilities,
+    /// Validate semantic-pack v0 manifests and declared conformance fixtures.
+    #[command(name = "semantic-pack")]
+    SemanticPack {
+        #[command(subcommand)]
+        cmd: SemanticPackCmd,
+    },
     /// Dump per-unit detection features (value-graph / shape / return fingerprints)
     /// as JSON — the raw signal, before candidate generation or thresholding. Lets a
     /// convergence evaluator measure representation-convergence and behavioral-separation
@@ -358,12 +368,13 @@ enum Cmd {
         #[arg(long)]
         exclusion_census: Option<PathBuf>,
     },
-    /// EXPERIMENT (leaps 2+3): measure a behavioral-equivalence ACCEPTANCE gate — group
-    /// interpretable units by their behavior on an input battery (two units are
-    /// "accepted" iff identical on every input) and, against a Type-4 manifest, report
-    /// the recall it recovers BEYOND exact-fingerprint matching and the hard-negative
-    /// false merges it would introduce. `--battery wide` is the leap-3 bounded checker
-    /// (a much larger structured input domain — does more checking kill the false merges?).
+    /// EXPERIMENTAL Type-4 benchmark harness (research tool, not a stable interface).
+    ///
+    /// Measures a behavioral-equivalence ACCEPTANCE gate: groups interpretable units
+    /// by their behavior on an input battery (two units are "accepted" iff identical
+    /// on every input) and, against a Type-4 manifest, reports the recall it recovers
+    /// BEYOND exact-fingerprint matching and the hard-negative false merges it would
+    /// introduce. `--battery wide` is the larger bounded input domain.
     BehavioralGate {
         /// Path to the generated Type-4 corpus `sources/` directory.
         #[arg(required = true)]
@@ -1620,6 +1631,7 @@ fn run_scan_cmd(cmd: Cmd) -> Result<()> {
     else {
         unreachable!("run_scan_cmd requires Cmd::Scan")
     };
+    require_paths_exist(&paths)?;
     cmd_scan(ScanArgs {
         paths,
         top,
@@ -1665,6 +1677,7 @@ fn run_review_cmd(cmd: Cmd) -> Result<()> {
     } else {
         paths
     };
+    require_paths_exist(&paths)?;
     review::cmd_review(review::ReviewArgs {
         paths,
         base,
@@ -3109,6 +3122,7 @@ fn cmd_eval(
 }
 
 fn cmd_stats(paths: Vec<PathBuf>, top: usize, json: bool) -> Result<()> {
+    require_paths_exist(&paths)?;
     let refs = paths_as_refs(&paths);
     let corpus = nose_frontend::lower_corpus_many(&refs);
     warn_if_empty(&corpus, &paths);
@@ -3321,6 +3335,21 @@ fn relativize_loc(loc: &mut nose_detect::Loc, cwd: &std::path::Path) {
 
 /// Stderr notice that discovery found nothing — so a mistyped path or unsupported
 /// tree doesn't masquerade as "no duplication found".
+/// A named path that doesn't exist is a usage error, not an empty scan: a typo'd
+/// path in a CI gate must fail loudly instead of passing on a 0-file report.
+/// "Exists but contains no supported files" stays a warning (`warn_no_files`).
+fn require_paths_exist(paths: &[PathBuf]) -> Result<()> {
+    let missing: Vec<String> = paths
+        .iter()
+        .filter(|p| !p.exists())
+        .map(|p| p.display().to_string())
+        .collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    anyhow::bail!("path does not exist: {}", missing.join(", "))
+}
+
 fn warn_no_files(paths: &[PathBuf]) {
     let joined = paths
         .iter()
@@ -4073,6 +4102,16 @@ fn print_refactor_human(
     proposal: bool,
     omitted_note: Option<&str>,
 ) {
+    if all.is_empty() {
+        println!(
+            "no {} found — nothing above the reporting thresholds",
+            mode.report_label(0)
+        );
+        if let Some(note) = omitted_note {
+            println!("{note}");
+        }
+        return;
+    }
     println!(
         "{} {}, ranked by {}  ·  ~{} duplicated lines  (showing {})",
         all.len(),
@@ -4128,6 +4167,14 @@ fn print_refactor_human(
         if proposal && f.locations.len() >= 2 {
             print_member_proposal(&f.locations[0], &f.locations[1], f.locations.len());
         }
+    }
+    // Discoverability: the report's natural next steps, shown once a real report
+    // exists and only when no extra view was already requested.
+    if !shown.is_empty() && !diff && !proposal {
+        println!(
+            "\nhint: `--show diff` shows what differs inside each family · `--show proposal` \
+             drafts the extraction · `--top 0` lists every family"
+        );
     }
 }
 

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1122,7 +1122,7 @@ fn inline_nose_ignore_suppresses_a_site() {
     fs::write(dir.join("b/f.py"), format!("# nose-ignore\n{body}")).unwrap();
     let p = dir.to_str().unwrap();
     assert!(
-        run(&["scan", p, "--min-size", "12"]).contains("0 clone"),
+        run(&["scan", p, "--min-size", "12"]).contains("no clone families found"),
         "the marked copy must be suppressed, leaving no family"
     );
     let _ = fs::remove_dir_all(&dir);
@@ -1916,6 +1916,41 @@ fn top_zero_shows_all_families() {
     assert!(
         all >= 6,
         "--top 0 should include every distinct family (expected >=6, got {all})"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn scan_errors_on_nonexistent_path() {
+    // A typo'd path in a CI gate must fail loudly, not pass on an empty report.
+    let out = Command::new(bin())
+        .args(["scan", "/nonexistent/nose-test-path"])
+        .output()
+        .expect("run nose");
+    assert!(
+        !out.status.success(),
+        "scan on a missing path must exit non-zero"
+    );
+    let err = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        err.contains("path does not exist"),
+        "stderr names the problem: {err}"
+    );
+}
+
+#[test]
+fn scan_human_report_ends_with_show_hint() {
+    let dir = make_project("hint");
+    let p = dir.to_str().unwrap();
+    let plain = run(&["scan", p, "--min-size", "12"]);
+    assert!(
+        plain.contains("hint: `--show diff`"),
+        "default report points at the next step: {plain}"
+    );
+    let with_diff = run(&["scan", p, "--min-size", "12", "--show", "diff"]);
+    assert!(
+        !with_diff.contains("hint: `--show diff`"),
+        "hint disappears once a view is requested: {with_diff}"
     );
     let _ = fs::remove_dir_all(&dir);
 }

--- a/crates/nose-cli/tests/cli/output_contract.rs
+++ b/crates/nose-cli/tests/cli/output_contract.rs
@@ -99,7 +99,7 @@ fn scan_human_hides_hidden_exact_fragments() {
         "1",
     ]);
     assert!(
-        out.contains("0 semantic clone families"),
+        out.contains("no semantic clone families found"),
         "hidden proof fragments should not be top-level human findings: {out}"
     );
     assert!(

--- a/crates/nose-cli/tests/cli/semantic_boundaries.rs
+++ b/crates/nose-cli/tests/cli/semantic_boundaries.rs
@@ -546,7 +546,7 @@ fn scan_human_hides_generated_header_families() {
         "12",
     ]);
     assert!(
-        out.contains("0 semantic clone families"),
+        out.contains("no semantic clone families found"),
         "generated-header families should not be top-level human findings: {out}"
     );
     assert!(

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,10 +110,27 @@ exact same-logic clones, and fuzzy near-duplicates). Passing `--mode` replaces
 that default with exactly the channels you list — see
 [clone-types](clone-types.md) for what each one finds.
 
+## The second command: `nose review`
+
+Once a codebase has clones, the risky moment is editing one of them: a fix
+applied to one copy and missed in its siblings ships a half-fixed bug.
+`nose review` compares the working tree to a git ref and flags exactly that
+situation in your diff:
+
+```sh
+nose review                      # review uncommitted local changes (vs HEAD)
+nose review --base origin/main   # review a PR branch, e.g. in CI
+```
+
+See [review](review.md) for how findings are ranked, the conservative `--fail`
+gate policy, and CI wiring.
+
 ## Where to go next
 
 - **[usage](usage.md)** — every command and flag, the ranking keys, and the scan
   modes in full.
+- **[review](review.md)** — the git-aware companion command: catch a clone
+  changed in one copy but not its siblings.
 - **[configuration](configuration.md)** — commit a `nose.toml` so CI and teammates
   don't retype long flag lists.
 - **[continuous-integration](continuous-integration.md)** — turn a scan into a

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -55,6 +55,11 @@ families wholly inside files with generated-code headers are omitted with a shor
 count line; `--format json --top 0` keeps the post-ranking diagnostic families that
 survive rank-time pruning.
 
+A named path that doesn't exist is an error (exit non-zero) — a typo'd path in a
+CI gate must fail loudly. A path that exists but contains no supported source
+files warns on stderr and reports an empty scan. The same rule applies to
+`nose review` and `nose stats`.
+
 ### Flags
 
 Grouped by what they do. Config-backed scan defaults are listed in


### PR DESCRIPTION
## What

A first-run usability audit of the CLI (fresh-user walkthrough: `--help`, first scan, error cases, feature discovery), the fixes it produced, and a user-first refresh of README/getting-started.

## Audit findings → fixes

1. **Help text contradicted the shipped default.** Top-level `--help` still said the default is `syntax + semantic` and told users to "opt into" `near` — stale since the #241 default flip. The `scan` one-liner had the same stale claim, and the long-help bullets never mentioned `nose review` at all. → Rewritten to the current truth; `review` is now in the overview.
2. **Command list ordered by implementation history, not user journey.** `capabilities`, `il`, `semantic-pack` appeared before `scan`. → Now: `scan`, `review`, `stats`, `il`, `capabilities`, `semantic-pack`, `behavioral-gate`.
3. **Research jargon walls in the command list.** `behavioral-gate`'s "EXPERIMENT (leaps 2+3)…" paragraph (and `review`'s long paragraph) rendered in full in the main help. → First-line summaries; detail moved to each command's own `--help`.
4. **A typo'd path passed silently.** `nose scan /no/such/path` warned and exited 0 — a mistyped path in a CI gate masquerades as "no duplication found". → `scan`/`review`/`stats` now exit non-zero with `path does not exist: …`; an existing-but-empty tree keeps the warning + empty report (unchanged).
5. **Dead-end report moments.** `0 clone families, ranked by extractability … (showing 0)` on a clean scan → now a plain "no clone families found" line. A successful report gave no pointer to the next step → one deterministic trailing `hint:` line pointing at `--show diff`, `--show proposal`, `--top 0` (suppressed when a view was already requested; human format only — JSON/markdown/SARIF contracts untouched).

## Docs

- **README**: stale default-mix description fixed (near was missing); quick-start now shows sample output; everyday commands are labeled; structure otherwise kept minimal per AGENTS.md.
- **getting-started**: new short `nose review` section (the second product surface was previously absent from the on-ramp) + next-steps link.
- **usage**: documents the new missing-path error rule.
- **CHANGELOG**: entry under `[Unreleased]`.

## Verification

- `cargo test -p nose-cli --release`: 168 passed (3 assertions updated to the new zero-findings line — same semantics; 2 new regression tests: missing-path error, hint-line behavior).
- `./scripts/check-ci-local.sh --fast` green locally (edited files touched first to defeat the clippy cache skip).
- Duplication-gate parsing checked: the count extraction (`^([0-9]+) `) is unaffected by the new empty-line and `hint:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
