### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ break.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-11
+
 ### Changed
 - **CLI usability pass for first-time users.** `nose scan`, `nose review`, and
   `nose stats` now **error on a named path that doesn't exist** (a typo'd path

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nose-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "nose-detect"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "nose-frontend",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "nose-eval"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "rustc-hash",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "nose-frontend"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "nose-il"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "lasso",
  "serde",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "nose-normalize"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "nose-il",
  "nose-semantics",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "nose-semantics"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "nose-il",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/corca-ai/nose"
@@ -25,12 +25,12 @@ rust-version = "1.85"
 [workspace.dependencies]
 # Internal crates carry an explicit `version` (not just `path`) so the tree has no
 # wildcard deps and the crates stay publishable; `path` wins for local builds.
-nose-il = { path = "crates/nose-il", version = "0.5.0" }
-nose-semantics = { path = "crates/nose-semantics", version = "0.5.0" }
-nose-frontend = { path = "crates/nose-frontend", version = "0.5.0" }
-nose-normalize = { path = "crates/nose-normalize", version = "0.5.0" }
-nose-detect = { path = "crates/nose-detect", version = "0.5.0" }
-nose-eval = { path = "crates/nose-eval", version = "0.5.0" }
+nose-il = { path = "crates/nose-il", version = "0.6.0" }
+nose-semantics = { path = "crates/nose-semantics", version = "0.6.0" }
+nose-frontend = { path = "crates/nose-frontend", version = "0.6.0" }
+nose-normalize = { path = "crates/nose-normalize", version = "0.6.0" }
+nose-detect = { path = "crates/nose-detect", version = "0.6.0" }
+nose-eval = { path = "crates/nose-eval", version = "0.6.0" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Cut the changelog (`[Unreleased]` → `[0.6.0] - 2026-06-11`, fresh empty `[Unreleased]` above) and bump the workspace version 0.5.0 → 0.6.0 (internal path deps + `Cargo.lock` follow), per the CONTRIBUTING release runbook.

Headline changes shipping in 0.6.0 (see CHANGELOG):
- `nose review --fail` fires on the conservative shared-logic gate tier by default (#245)
- `nose scan` default channel mix is now `syntax,semantic,near` (#241)
- CLI first-run usability pass + README/getting-started refresh (#261)
- `NOSE_ANCHOR_MIN_WEIGHT` research knob (#248); oracle symbolic-condition path exploration (#244); Ruby builder-loop convergence (#247)
- 2–4× faster end-to-end scans (§BQ evidence indexing)

After merge, `v0.6.0` is tagged on the merge commit; cargo-dist builds the binaries, publishes the GitHub Release, and pushes the Homebrew formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)