### PR TITLE
Adversarial co-evolution series 1: five campaigns, claim-violation defenses, runbook learnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ break.
 
 ## [Unreleased]
 
+### Fixed
+- **Adversarial co-evolution, series 1** (experiments §BZ, issue #268): five
+  white-box campaigns against nose's own claims. Claim-violation fixes — the
+  declaration filter now enforces a *single-statement discipline* (a line mixing
+  a declaration with code, e.g. `import pdb;pdb.post_mortem()`, a multi-declarator
+  `require`, or a Ruby modifier-conditional `require`, can no longer classify;
+  shapes found verbatim in the corpus); the "call the existing helper" hint never
+  points production copies at a test-code or generated-file helper; the
+  declaration classifier reads each file once per scan instead of once per family
+  member. Corpus price after all tightening: identical (2,265 declaration
+  families, zero worthy-label loss). Two priced findings deferred with
+  measurements: few-huge-files inputs serialize `normalize+extract` (#269), and
+  semantic-laws provenance is structurally gated to ~zero field probability
+  (#270 — the clamp-law escalation was refuted five-for-five by sound gates,
+  explaining the LawPack audit's zero-provenance result). The runbook gained the
+  performance/determinism attack surface, the claim-violation pricing asymmetry,
+  defense-deferral verdicts, and measured campaign costs.
+
 ### Added
 - **Triage ergonomics from the 0.6.0 field feedback** (issues #263/#264):
   - **Opportunity grouping**: families whose members are overlapping slices of

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -4104,9 +4104,18 @@ fn family_declaration_run(
 fn declaration_run_ids(
     families: &[nose_detect::RefactorFamily],
 ) -> std::collections::HashSet<String> {
+    // One classification pass, one cache: members of different families share
+    // files, and a per-member full read made this O(families × file size)
+    // (coevo C3 measured it on a 123-family / 2-file pathological input).
+    let mut lines = FileLineCache::default();
     families
         .iter()
-        .filter(|f| !f.locations.is_empty() && f.locations.iter().all(declaration_run_span))
+        .filter(|f| {
+            !f.locations.is_empty()
+                && f.locations
+                    .iter()
+                    .all(|l| declaration_run_span(l, &mut lines))
+        })
         .map(baseline::family_id)
         .collect()
 }
@@ -4114,17 +4123,22 @@ fn declaration_run_ids(
 /// An import run longer than this is implausible; skip the read and fail open.
 const DECLARATION_SPAN_CAP: u32 = 80;
 
-fn declaration_run_span(loc: &nose_detect::Loc) -> bool {
+fn declaration_run_span(loc: &nose_detect::Loc, lines: &mut FileLineCache) -> bool {
     if loc.end_line.saturating_sub(loc.start_line) > DECLARATION_SPAN_CAP {
         return false;
     }
     let Some(lang) = declaration_lang(&loc.file) else {
         return false;
     };
-    let Some(lines) = read_lines(&loc.file, loc.start_line, loc.end_line) else {
+    let Some(all) = lines.whole(&loc.file) else {
         return false;
     };
-    span_is_only_declarations(&lines, lang)
+    let s = loc.start_line.saturating_sub(1) as usize;
+    let e = (loc.end_line as usize).min(all.len());
+    if s >= e {
+        return false;
+    }
+    span_is_only_declarations(&all[s..e], lang)
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -4225,8 +4239,10 @@ fn python_declaration(line: &str) -> DeclLine {
         if rest.contains(" import ") {
             return if line.ends_with('(') {
                 DeclLine::Opens
-            } else {
+            } else if semicolon_free(line) {
                 DeclLine::Complete
+            } else {
+                DeclLine::No
             };
         }
     }
@@ -4235,24 +4251,27 @@ fn python_declaration(line: &str) -> DeclLine {
 
 fn jsts_declaration(line: &str) -> DeclLine {
     let stmt_done = line.ends_with(';') || line.ends_with('\'') || line.ends_with('"');
+    let single = lone_terminal_semicolon(line);
     if line.starts_with("import ") || line.starts_with("import{") {
-        return if stmt_done {
+        return if stmt_done && single {
             DeclLine::Complete
-        } else {
+        } else if !stmt_done && single {
             DeclLine::Opens
+        } else {
+            DeclLine::No
         };
     }
     // Re-exports are declaration wiring only with a `from` source (a barrel
     // line); `export const …` is code and must fail.
-    if line.starts_with("export ") && line.contains(" from ") && stmt_done {
+    if line.starts_with("export ") && line.contains(" from ") && stmt_done && single {
         return DeclLine::Complete;
     }
-    if (line.starts_with("export {") || line.starts_with("export *")) && !stmt_done {
+    if (line.starts_with("export {") || line.starts_with("export *")) && !stmt_done && single {
         return DeclLine::Opens;
     }
     for head in ["const ", "let ", "var "] {
         if let Some(rest) = line.strip_prefix(head) {
-            if rest.contains("= require(") && stmt_done {
+            if is_require_line(rest) && single {
                 return DeclLine::Complete;
             }
         }
@@ -4265,7 +4284,7 @@ fn go_declaration(line: &str) -> DeclLine {
         return DeclLine::Opens;
     }
     if let Some(rest) = line.strip_prefix("import ") {
-        return if rest.contains('"') {
+        return if rest.contains('"') && rest.trim_end().ends_with('"') && semicolon_free(line) {
             DeclLine::Complete
         } else {
             DeclLine::No
@@ -4291,9 +4310,9 @@ fn rust_declaration(line: &str) -> DeclLine {
         })
         .unwrap_or(line);
     if body.starts_with("use ") || body.starts_with("extern crate ") {
-        return if body.ends_with(';') {
+        return if body.ends_with(';') && lone_terminal_semicolon(body) {
             DeclLine::Complete
-        } else if body.ends_with('{') {
+        } else if body.ends_with('{') && semicolon_free(body) {
             DeclLine::Opens
         } else {
             DeclLine::No
@@ -4308,22 +4327,33 @@ fn rust_declaration(line: &str) -> DeclLine {
 }
 
 fn java_declaration(line: &str) -> DeclLine {
-    if (line.starts_with("import ") || line.starts_with("package ")) && line.ends_with(';') {
+    if (line.starts_with("import ") || line.starts_with("package "))
+        && line.ends_with(';')
+        && lone_terminal_semicolon(line)
+    {
         return DeclLine::Complete;
     }
     DeclLine::No
 }
 
 fn c_declaration(line: &str) -> DeclLine {
-    if line.starts_with("#include") || line == "#pragma once" {
+    if let Some(rest) = line.strip_prefix("#include") {
+        if rest.starts_with([' ', '<', '"']) {
+            return DeclLine::Complete;
+        }
+    }
+    if line == "#pragma once" {
         return DeclLine::Complete;
     }
     DeclLine::No
 }
 
 fn ruby_declaration(line: &str) -> DeclLine {
+    // A modifier conditional (`require 'x' if cond`) rides an expression on
+    // the declaration — more than a bare require, so it fails open (C5).
+    let conditional = line.contains(" if ") || line.contains(" unless ");
     for head in ["require ", "require_relative ", "require("] {
-        if line.starts_with(head) {
+        if line.starts_with(head) && semicolon_free(line) && !conditional {
             return DeclLine::Complete;
         }
     }
@@ -4336,11 +4366,55 @@ fn declaration_closes(line: &str, lang: DeclLang) -> bool {
         DeclLang::JsTs => {
             line.starts_with('}')
                 && (line.ends_with(';') || line.ends_with('\'') || line.ends_with('"'))
+                && lone_terminal_semicolon(line)
         }
         DeclLang::Rust => line.ends_with("};"),
         // Java/C/Ruby declarations are single-line; nothing opens.
         DeclLang::Java | DeclLang::C | DeclLang::Ruby => false,
     }
+}
+
+/// The single-statement discipline (coevo series 1, C1): a declaration line
+/// must BE one declaration, not merely *start* with one — `import x; evil()`
+/// rides real code on a recognized prefix, and classifying it would break the
+/// "provably no extraction exists" claim. For `;`-terminated grammars the
+/// only `;` may be the final character; for grammars whose declarations carry
+/// no `;` at all, any `;` means a second statement and the line fails open.
+fn lone_terminal_semicolon(line: &str) -> bool {
+    match line.find(';') {
+        None => true,
+        Some(i) => i == line.len() - 1,
+    }
+}
+
+fn semicolon_free(line: &str) -> bool {
+    !line.contains(';')
+}
+
+/// Strict `NAME = require('literal')` shape for the CommonJS arm: a single
+/// identifier, a single string-literal argument, nothing after the call. A
+/// multi-declarator line (`…, b = compute();`) must fail open.
+fn is_require_line(rest: &str) -> bool {
+    let Some((name, call)) = rest.split_once("= require(") else {
+        return false;
+    };
+    let name = name.trim();
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+    {
+        return false;
+    }
+    let call = call.trim_end();
+    let Some(arg) = call.strip_suffix(");").or_else(|| call.strip_suffix(')')) else {
+        return false;
+    };
+    let arg = arg.trim();
+    arg.len() >= 2
+        && ((arg.starts_with('\'') && arg.ends_with('\''))
+            || (arg.starts_with('"') && arg.ends_with('"')))
+        && !arg[1..arg.len() - 1].contains(['\'', '"'])
 }
 
 /// Bare module-path lists: identifiers, dots, commas, spaces, and `as`
@@ -4571,8 +4645,13 @@ fn family_hint(f: &nose_detect::RefactorFamily) -> String {
         .iter()
         .filter(|l| l.kind == UnitKind::Block || l.is_fragment)
         .count();
+    // Coevo C2 guards: never point production copies at a helper that lives
+    // in test code (tests may call prod, not the reverse), and never
+    // recommend calling into a generated file (not the maintainer's API).
     if let [helper] = named_units[..] {
-        if inline_copies >= 1 && inline_copies == f.locations.len() - 1 {
+        let helper_callable =
+            !helper.looks_generated && (f.scope == "test" || !nose_detect::is_test_loc(helper));
+        if helper_callable && inline_copies >= 1 && inline_copies == f.locations.len() - 1 {
             let name = helper.name.as_deref().unwrap_or("the helper");
             let sites = if inline_copies == 1 {
                 "1 site reimplements".to_string()
@@ -5681,6 +5760,75 @@ mod tests {
     }
 
     #[test]
+    fn helper_hint_never_points_prod_at_a_test_helper() {
+        // Coevo C2: the named function lives in test code while the inline
+        // copies are production — "call the existing helper" would be wrong-
+        // direction advice, so the hint falls back to plain extraction.
+        let mut f = fam(1, 2, &[None, None, None]);
+        f.scope = "mixed";
+        f.locations = vec![
+            {
+                let mut l = loc_at("tests/helpers.ts", 10, 14, nose_il::UnitKind::Function);
+                l.name = Some("clamp".to_string());
+                l
+            },
+            loc_at("ui/model.ts", 80, 84, nose_il::UnitKind::Block),
+            loc_at("worker/job.ts", 33, 37, nose_il::UnitKind::Block),
+        ];
+        let hint = family_hint(&f);
+        assert!(
+            !hint.contains("call the existing helper"),
+            "a test-code helper must not be recommended to prod copies: {hint}"
+        );
+        // All-test families may keep the recommendation: tests calling a test
+        // helper is exactly the refactor.
+        f.scope = "test";
+        assert!(
+            family_hint(&f).contains("call the existing helper"),
+            "an all-test family may still consolidate on its test helper"
+        );
+    }
+
+    #[test]
+    fn helper_hint_allows_test_copies_to_call_a_prod_helper() {
+        // C5 boundary: the inverse direction is fine — tests calling a
+        // production helper is exactly the refactor.
+        let mut f = fam(1, 2, &[None, None]);
+        f.scope = "mixed";
+        f.locations = vec![
+            {
+                let mut l = loc_at("core/math.ts", 10, 14, nose_il::UnitKind::Function);
+                l.name = Some("clamp".to_string());
+                l
+            },
+            loc_at("tests/model.spec.ts", 80, 84, nose_il::UnitKind::Block),
+        ];
+        assert!(
+            family_hint(&f).contains("call the existing helper"),
+            "prod helper recommended to test copies is the right direction"
+        );
+    }
+
+    #[test]
+    fn helper_hint_never_points_at_generated_code() {
+        let mut f = fam(1, 2, &[None, None]);
+        f.locations = vec![
+            {
+                let mut l = loc_at("gen/api.ts", 10, 14, nose_il::UnitKind::Function);
+                l.name = Some("encode".to_string());
+                l.looks_generated = true;
+                l
+            },
+            loc_at("ui/model.ts", 80, 84, nose_il::UnitKind::Block),
+        ];
+        let hint = family_hint(&f);
+        assert!(
+            !hint.contains("call the existing helper"),
+            "a generated-file helper is not the maintainer's API: {hint}"
+        );
+    }
+
+    #[test]
     fn hint_flags_high_parameter_extractions() {
         let mut f = fam(1, 1, &[None, None]);
         f.params = 8;
@@ -5769,6 +5917,20 @@ mod tests {
             (DeclLang::C, "#include <stdio.h>\n#define MAX 4"),
             (DeclLang::Ruby, "require 'json'\nputs 'hi'"),
             (DeclLang::Python, ""),
+            // C1 claim-violation packets: a single LINE mixing a declaration
+            // with executable code must never classify (the "provably no
+            // extraction exists" claim breaks if real code rides along).
+            (DeclLang::JsTs, "import { a } from './a'; doEvil();"),
+            (DeclLang::JsTs, "var a = require('a'), b = compute();"),
+            (DeclLang::Go, "import \"fmt\"; func main() { hack() }"),
+            (DeclLang::Ruby, "require 'json'; system('x')"),
+            (DeclLang::Python, "from x import y; z = 1"),
+            (DeclLang::Java, "import java.util.List; int x = 1;"),
+            (DeclLang::Rust, "use std::fmt; let x = 1;"),
+            (DeclLang::C, "#includeevil <x.h>"),
+            // C5 boundary re-attack on the C1 defense itself.
+            (DeclLang::JsTs, "import { a } from './a';;"),
+            (DeclLang::Ruby, "require 'x' if expensive_check()"),
         ];
         for (lang, src) in no {
             assert!(

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -23,7 +23,7 @@ pub use fragment::{
     fragment_behavior, free_input_cids, synthesize_wrapper, Effect, EffectSite, Exit,
     FragmentContract, FragmentKind, Place, ProofFacts,
 };
-pub use report::{rank_families, RefactorFamily, VaryingSpot};
+pub use report::{is_test_loc, rank_families, RefactorFamily, VaryingSpot};
 pub use units::UnitFeat;
 
 /// Build one file's syntax-channel token stream from its (raw) IL. Exposed so the

--- a/crates/nose-detect/src/report.rs
+++ b/crates/nose-detect/src/report.rs
@@ -362,7 +362,9 @@ fn spread(files: usize, modules: usize, languages: usize) -> f64 {
 
 /// Is this site test code, by the usual path / unit-name conventions? Conservative:
 /// only well-known markers, so production code is never misclassified as a test.
-fn is_test_loc(l: &Loc) -> bool {
+/// Public so presentation layers can scope-guard per-location advice (e.g. never
+/// recommend calling a test helper from production copies).
+pub fn is_test_loc(l: &Loc) -> bool {
     let p = l.file.to_ascii_lowercase();
     let path_test = p.contains("/test/")
         || p.contains("/tests/")

--- a/docs/adversarial-coevolution.md
+++ b/docs/adversarial-coevolution.md
@@ -63,6 +63,15 @@ Rotate campaigns across these; each entry names what to read and what claim to a
    stated conditions (e.g. a family that groups but is two genuine opportunities).
 7. **The clone-type claims** — [clone-types](clone-types.md) honest limits. Attack: a
    limit statement that is no longer true (stale fences are silent recall loss).
+8. **Performance & determinism claims** (added by series 1, [§BZ](experiments.md)) —
+   the moat's speed/determinism legs ([design §1](design.md)). Attack: inputs whose
+   shape concentrates cost (few huge files serialize per-file parallelism — the §BH
+   class; §BZ measured 3.1 s on two 4.8 k-line files vs 0.63 s on a 1,364-file repo),
+   super-linear presentation-layer passes (per-member file re-reads, per-file pair
+   blowups), and byte-determinism under repeated runs and `RAYON_NUM_THREADS`
+   variation. Pricing for this surface IS the measurement (`NOSE_TIME=1` per-stage
+   breakdown); fixture-generation note: vary token *shape* in synthetic filler, or
+   Type-2 identifier abstraction bridges your blocks into one run.
 
 ## Target packet format
 
@@ -92,12 +101,26 @@ Reuse the [frontier platform](frontier-platform.md) evidence shape
    on splits. Reject without prejudice anything unpriced; record the rejection — an
    evidence-backed rejection is a result ([§BW](experiments.md) re-rejected doubling and
    that *was* the deliverable).
+
+   **The claim-violation asymmetry** (series 1, [§BZ](experiments.md)): pricing gates
+   *recall-direction* attacks ("nose should also detect X"). An attack that breaks a
+   **"provably…" claim itself** — a §2b filter classifying real code, a hint giving
+   unsafe advice, a false merge — is soundness-class and is fixed at ANY prevalence,
+   exactly like a false merge. Every C1/C2/C5 hit in series 1 was this kind.
 4. **Defend.** Priced packets only. The defense is the largest sound generalization, and
    it ships through ALL of: adversarial battery including the packet's hard negatives;
    Lean obligation if proof-sensitive ([formal-soundness](formal-soundness.md));
    corpus label join showing zero worthy-label loss (the
    [eval/declaration_runs](../eval/declaration_runs/RESULTS.md) precedent); the
    zero-false-merge and determinism gates ([CONTRIBUTING](../CONTRIBUTING.md)).
+
+   **Defense-deferral is a first-class verdict**: a priced packet whose sound defense
+   exceeds the campaign's scope (detector-core work, new proof obligations) closes as
+   `deferred: #issue` with the packet and measurement attached — series 1 produced
+   two (#269 few-huge-files serialization, #270 law-provenance gating). An attack
+   **refuted by an existing sound gate is a green result with teeth**: record what
+   refuted it (series 1's clamp escalation was refuted five-for-five and the refutation
+   trail explained the LawPack zero-provenance field mystery).
 5. **Boundary re-attack.** One round: attack the new generalization's edges (its type
    gates, fail-open conditions, thresholds) before the campaign closes — the
    doubling → type-gating cycle ([§AY/§BA](experiments.md)) is the model.
@@ -121,11 +144,27 @@ Reuse the [frontier platform](frontier-platform.md) evidence shape
 - A campaign that finds nothing priced is a **green result**, not a failure — say so in
   the closeout.
 
-## Cadence
+## Cadence & cost (measured, series 1)
 
 On demand ("run adversarial co-evolution" = one full protocol pass) or per release
 alongside the [hazard release checklist](hazard-release-checklist.md). A campaign is
 bounded: 3–5 surfaces, one boundary re-attack round, one experiments.md section.
+A *series* of campaigns may share one tracking issue (series 1 ran five under #268)
+and one combined ledger section when run in a single session.
+
+Measured execution speed ([§BZ](experiments.md), series 1 on an M-class laptop):
+
+| unit of work | wall time |
+|---|---|
+| one campaign (attack → price → defend → re-attack) | ~6–20 min of agent time |
+| five-campaign series incl. recording | ~70 min |
+| corpus re-price sweep (105 repos, declaration filter) | ~3 min |
+| full nose-cli e2e suite | ~23 s |
+| pathological perf fixture scan (the C3 packet) | ≤ 3.2 s |
+
+Budget rule of thumb: a release-cadence series costs about an hour of agent time and
+two corpus sweeps; the dominant human cost is arbitrating judgment-axis packets,
+which series 1 needed zero of.
 
 ---
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1787,3 +1787,77 @@ twin whose every line differs textually: that is not mechanically decidable,
 so per §2b it stays with ranking (extractability already sinks these) and the
 upstream fix — keeping import declarations out of module-unit fingerprints —
 is a detector change to price separately.
+
+## BZ. Adversarial co-evolution, series 1 — five campaigns, the runbook's first execution
+
+First execution of the [adversarial-coevolution runbook](adversarial-coevolution.md)
+(#268): five bounded campaigns rotating the attack surfaces, run end-to-end by an
+agent in one session. The attacked commit is the #267 merge; defenses landed on the
+`coevo/series-1` branch with the full gate battery.
+
+**C1 — declaration filter, claim-violation direction.** White-box reading of the
+§BY matchers found the recognizers matched a declaration *prefix*, not a
+declaration *line*: `import pdb;pdb.post_mortem()`, `require 'x'; File.open(…)`,
+and jekyll's multi-declarator `_ref = require('./protocol'), Parser = _ref.Parser…`
+all classify — and all three shapes exist verbatim in the pinned corpus. Eight
+violation packets (py/js/go/ruby/java/rust/c) locked as fail-open tests; the
+generalized defense is the **single-statement discipline** (a lone terminal
+semicolon for `;`-grammars, none for the rest, strict `NAME = require('lit')`
+shape, `#include` delimiter check) — one rule family, not eight patches.
+Corpus re-price after tightening: **identical** (2,265 declaration families,
+43 repos, worthy overlaps unchanged) — the fix is free.
+
+**C2 — grouping/hints.** Two violations of the "call the existing helper is safe
+advice" claim: a helper living in test code recommended to production copies
+(wrong direction), and a helper in a generated file (not the maintainer's API).
+Both guarded (`is_test_loc` exported from nose-detect; `looks_generated` check)
+and locked with direction tests — the inverse (test copies → prod helper) stays
+recommended. Union-find chaining (A∩B, B∩C ⟹ one group without A∩C) was attacked
+and **accepted**: a chain of ≥50%-overlaps is one connected region.
+
+**C3 — performance & determinism (new surface).** Pathological input: two ~4.8k-line
+Python files, 240 import blocks + 7.2k tiny units. Measured: **3.1 s wall vs 0.63 s
+for a 1,364-file real repo** — `NOSE_TIME` attributes 2.46 s to `normalize+extract`
+at ~1 core (per-file parallelism serializes on few-huge-files inputs; the §BH class
+in structural form — filed #269, defense deferred to core work). The CLI-layer
+share (~0.1 s) was the declaration classifier's per-member full-file reads —
+defended by routing the classification pass through one `FileLineCache` (246 reads
+→ 2 on the fixture). Determinism: byte-identical JSON across repeated runs and
+`RAYON_NUM_THREADS=1/4/default`. A failed fixture iteration was itself a finding:
+uniform-shaped filler lines (`CONST_A_i = n`) token-match across files as Type-2
+runs and bridge import blocks — synthetic-input design must vary token *shape*,
+not just names.
+
+**C4 — exact gates / oracle, price-only.** Six probes: `+=` vs `= +`, ternary vs
+if/else, `not(a==b)` vs `!=`, guard-return vs nested-if, index- vs
+element-iteration all **converge** (the last is stronger than documented). The
+clamp-law probe escalated five levels and was **refuted by a sound gate at every
+level**: untyped forms differ under NaN (type gate); unproven bounds differ when
+`lo > hi` (bound-order gate); and the realistic `raise ValueError()` guard leaves
+value fingerprints *equal* (the law fires — verified) but the opaque constructor
+call disqualifies the unit from strict-exact eligibility (sound: shadowed
+`ValueError` = different behavior). Only the test-fixture shape `raise 0` passes
+all three gates and emits `value-graph.clamp.integer-ordered-minmax` provenance.
+This **explains the LawPack field audit's zero-provenance mystery** (10,967
+families, 0 laws): provenance requires (int evidence) ∧ (bound proof) ∧
+(strict-exact-safe unit), and the third conjunct has ~zero field probability.
+Filed #270 with directions (pairwise-identical-opaque-effect admission,
+call-target evidence for builtin constructors, or re-pricing LawPack investment).
+
+**C5 — limit-claim freshness + boundary re-attack.** clone-types spot-checked
+fresh (index-iteration convergence is within the documented index-assignment
+modeling). Re-attacking the C1 defense found one more hit: Ruby modifier
+conditionals (`require 'x' if expensive_check()`) ride an expression on the
+declaration — tightened and locked. The C2 guard's intended direction locked by
+test.
+
+**Series learnings folded into the runbook**: the claim-violation asymmetry
+(pricing gates *recall* attacks; violations of a "provably…" claim are
+soundness-class and fixed at any prevalence — all of C1/C2/C5's hits were these);
+defense-deferral as a first-class verdict (C3 core finding → #269, C4 structural
+finding → #270); a performance/determinism attack surface with the §BH-class
+serialization shape; series-level tracking (one issue, five campaigns); and
+measured campaign costs. Series wall-clock: ~70 minutes of agent time for five
+campaigns (C1 ~12, C2 ~8, C3 ~15, C4 ~20, C5 ~6, recording ~10), plus ~3 min per
+corpus re-price sweep and 23 s per full e2e suite run — cheap enough to run per
+release.

--- a/eval/declaration_runs/RESULTS.md
+++ b/eval/declaration_runs/RESULTS.md
@@ -27,3 +27,12 @@ number in [experiments §BY](../../docs/experiments.md).
 - The classifier under test is the shipped one (`declaration_run_ids` in
   `crates/nose-cli/src/main.rs`), exercised through `nose scan --format json
   --top 0`.
+
+## Re-price after the C1/C5 single-statement discipline (coevo series 1)
+
+The §BZ campaign tightened every matcher (terminal-semicolon rule, strict
+require shape, `#include` delimiter, Ruby modifier-conditional rejection).
+Re-running this sweep afterwards is byte-for-byte identical: 2,265 families,
+43 repos, same per-extension split, same single worthy overlap. The
+violations the discipline closes exist in the corpus as *lines* but not as
+all-declaration family spans — the fix is free at corpus scale.


### PR DESCRIPTION
## What

First execution of the [adversarial co-evolution runbook](docs/adversarial-coevolution.md): five white-box campaigns (C1–C5) against nose's own claims, run end-to-end per the protocol, with the runbook updated from what the series taught. Full ledger in experiments §BZ; tracking issue #268.

## Findings → defenses (claim-violation class, fixed at any prevalence)

- **C1, declaration filter**: the §BY matchers recognized declaration *prefixes*, not declaration *lines* — `import pdb;pdb.post_mortem()`, `require 'x'; File.open(…)`, and jekyll's multi-declarator `require` (all found verbatim in the corpus) would classify off the default surface. Defense: the **single-statement discipline** (terminal-semicolon rule per grammar family, strict `NAME = require('lit')` shape, `#include` delimiter) — one generalized rule, eight locked violation packets.
- **C2, hints**: "call the existing helper" could point production copies at a test-code helper (wrong direction) or a generated file. Guarded (`is_test_loc` now public from nose-detect) with direction-locking tests; union-find chaining attacked and *accepted* (a chain of ≥50% overlaps is one region).
- **C3, performance (new surface)**: declaration classifier re-read each file per family member — now one `FileLineCache` per classification pass (246 → 2 reads on the C3 fixture). Determinism byte-identical across thread counts.
- **C5, boundary re-attack**: Ruby modifier-conditionals (`require 'x' if cond`) ride an expression on the declaration — tightened.

## Priced findings, deferred with measurements

- **#269**: few-huge-files inputs serialize `normalize+extract` (3.1 s for two 4.8k-line files vs 0.63 s for a 1,364-file repo; `NOSE_TIME` breakdown attached) — the §BH class in structural form; defense is detector-core work.
- **#270**: the clamp-law escalation was **refuted five-for-five by sound gates** (NaN typing, bound-order proof, strict-exact eligibility) — and the refutation trail explains the LawPack field audit's zero-provenance mystery: provenance requires three gates whose conjunction has ~zero field probability.

## Runbook updates from series learnings

- Attack surface 8: **performance & determinism** (incl. the fixture-design lesson: vary token *shape* or Type-2 abstraction bridges your synthetic blocks).
- **Claim-violation pricing asymmetry**: pricing gates recall-direction attacks; violations of a "provably…" claim are soundness-class and fixed unconditionally.
- **Defense-deferral** and **refuted-by-sound-gate** as first-class verdicts.
- **Measured costs**: ~6–20 min/campaign, ~70 min for the series, ~3 min per corpus re-price, 23 s per e2e suite — the 실행속도 table the cadence section now carries.

## Verification

- All violation packets locked as fail-open tests; full nose-cli suite green (171 e2e + units).
- Corpus re-price after every tightening: byte-identical (2,265 declaration families, 43 repos, zero worthy-label loss) — recorded in eval/declaration_runs/RESULTS.md.
- Determinism: byte-identical JSON across repeated runs and RAYON_NUM_THREADS=1/4/default.
- dup-gate 24/24, fast preflight green.

Closes #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
