### PR TITLE
Adversarial co-evolution series 2: fresh subagent attackers (blind/informed/personas)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ break.
 ## [Unreleased]
 
 ### Fixed
+- **Adversarial co-evolution, series 2** (experiments §CA, issue #272): first run
+  with fresh-subagent attackers (blind/informed modes, persona rotation — now in
+  the runbook). The blind grammar-lawyer found what two authored passes missed:
+  open multi-line declarations consumed interior lines unvalidated and closers
+  were suffix checks (`os.Exit(1))` could "close" a Go import block;
+  `require 'fs' + 1` rode arithmetic on a require; `#include <stdio.h> int x = 1;`
+  rode a definition on a directive) — interiors now validate as per-language
+  specifiers, closers match strict shapes, and C/Ruby arguments must be lone
+  string literals. The "call the existing helper" hint no longer bypasses the
+  high-parameter caution. Seven untested-but-supported declaration shapes locked
+  as fixtures (incl. ASI imports, `pub(crate) use`); the scan-JSON contract
+  checker now requires the `generated`/`declaration` surface-count keys and the
+  checked-in v1 example was refreshed. The review `--fail` gate and the scan-JSON
+  contract survived their blind attackers with zero violations. Corpus price
+  after all tightening: unchanged (2,265 declaration families, zero
+  reclassification).
 - **Adversarial co-evolution, series 1** (experiments §BZ, issue #268): five
   white-box campaigns against nose's own claims. Claim-violation fixes — the
   declaration filter now enforces a *single-statement discipline* (a line mixing

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -4188,10 +4188,15 @@ fn span_is_only_declarations(lines: &[String], lang: DeclLang) -> bool {
             continue;
         }
         if open {
-            // Inside a multi-line declaration only specifier lines can occur
-            // in code that parsed; consume until the statement closes.
+            // Series-2 hardening: tree-sitter is error-tolerant, so "the file
+            // parsed" does NOT guarantee the interior of an open declaration
+            // holds only specifiers. Every interior line must itself be a
+            // valid specifier, and the close must be the strict closer shape
+            // (`os.Exit(1))` is not `)`; `} || x();` is not `};`).
             if declaration_closes(line, lang) {
                 open = false;
+            } else if !declaration_interior(line, lang) {
+                return false;
             }
             continue;
         }
@@ -4206,6 +4211,69 @@ fn span_is_only_declarations(lines: &[String], lang: DeclLang) -> bool {
     }
     // An unclosed statement means the span cut through code we did not prove.
     !open && any
+}
+
+/// A line INSIDE an open multi-line declaration: import/use specifiers only.
+fn declaration_interior(line: &str, lang: DeclLang) -> bool {
+    match lang {
+        // `from x import (` interiors: names, commas, `as` aliases.
+        DeclLang::Python => is_module_list(line),
+        // `import {` / `export {` interiors: specifiers incl. `$`, `as`, `type`.
+        DeclLang::JsTs => {
+            !line.is_empty()
+                && line
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || matches!(c, '_' | '$' | ',' | ' '))
+        }
+        // `import (` interiors: optional alias (`name`, `_`, `.`) + quoted path.
+        DeclLang::Go => go_import_spec(line),
+        // `use x::{` interiors: path segments, nested groups, `*`, `as`.
+        DeclLang::Rust => {
+            !line.is_empty()
+                && line.chars().all(|c| {
+                    c.is_alphanumeric() || matches!(c, '_' | ':' | ',' | ' ' | '{' | '}' | '*')
+                })
+        }
+        // No multi-line declarations open for these.
+        DeclLang::Java | DeclLang::C | DeclLang::Ruby => false,
+    }
+}
+
+/// `[alias ]"path"` with nothing after the closing quote.
+fn go_import_spec(line: &str) -> bool {
+    let rest = match line.find('"') {
+        Some(0) => line,
+        Some(i) => {
+            let alias = &line[..i];
+            let alias = alias.trim();
+            if !alias.is_empty()
+                && !alias
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || matches!(c, '_' | '.'))
+            {
+                return false;
+            }
+            &line[i..]
+        }
+        None => return false,
+    };
+    let inner = rest.strip_prefix('"').and_then(|r| r.strip_suffix('"'));
+    matches!(inner, Some(path) if !path.contains('"'))
+}
+
+/// A bare string-literal argument (`'lit'` / `"lit"`, optionally parenthesized)
+/// with nothing riding after it — `require 'fs' + 1` is arithmetic, not wiring.
+fn lone_string_argument(arg: &str) -> bool {
+    let arg = arg.trim();
+    let arg = arg
+        .strip_prefix('(')
+        .and_then(|a| a.strip_suffix(')'))
+        .map(str::trim)
+        .unwrap_or(arg);
+    arg.len() >= 2
+        && ((arg.starts_with('\'') && arg.ends_with('\''))
+            || (arg.starts_with('"') && arg.ends_with('"')))
+        && !arg[1..arg.len() - 1].contains(['\'', '"'])
 }
 
 fn is_full_line_comment(line: &str, lang: DeclLang) -> bool {
@@ -4338,9 +4406,19 @@ fn java_declaration(line: &str) -> DeclLine {
 
 fn c_declaration(line: &str) -> DeclLine {
     if let Some(rest) = line.strip_prefix("#include") {
-        if rest.starts_with([' ', '<', '"']) {
-            return DeclLine::Complete;
+        if !rest.starts_with([' ', '<', '"']) {
+            return DeclLine::No;
         }
+        let arg = rest.trim();
+        let angle = arg.starts_with('<')
+            && arg.ends_with('>')
+            && !arg[1..arg.len() - 1].contains(['<', '>']);
+        return if angle || lone_string_argument(arg) {
+            DeclLine::Complete
+        } else {
+            // `#include <stdio.h> int x = 1;` rides code on the directive.
+            DeclLine::No
+        };
     }
     if line == "#pragma once" {
         return DeclLine::Complete;
@@ -4351,10 +4429,20 @@ fn c_declaration(line: &str) -> DeclLine {
 fn ruby_declaration(line: &str) -> DeclLine {
     // A modifier conditional (`require 'x' if cond`) rides an expression on
     // the declaration — more than a bare require, so it fails open (C5).
+    // Series 2: the argument must be a lone string literal — `require 'fs' + 1`
+    // is arithmetic on the require's return value, not wiring.
     let conditional = line.contains(" if ") || line.contains(" unless ");
-    for head in ["require ", "require_relative ", "require("] {
-        if line.starts_with(head) && semicolon_free(line) && !conditional {
-            return DeclLine::Complete;
+    if conditional || !semicolon_free(line) {
+        return DeclLine::No;
+    }
+    for head in ["require_relative", "require"] {
+        if let Some(rest) = line.strip_prefix(head) {
+            return if (rest.starts_with(' ') || rest.starts_with('(')) && lone_string_argument(rest)
+            {
+                DeclLine::Complete
+            } else {
+                DeclLine::No
+            };
         }
     }
     DeclLine::No
@@ -4362,13 +4450,33 @@ fn ruby_declaration(line: &str) -> DeclLine {
 
 fn declaration_closes(line: &str, lang: DeclLang) -> bool {
     match lang {
-        DeclLang::Python | DeclLang::Go => line.ends_with(')'),
+        // The strict closer shapes (series 2): `os.Exit(1))` is not `)`,
+        // `} || x();` is not `};` or `} from 'lit';`. Python's closer may
+        // carry the final import names (`    b)`) — the corpus re-price
+        // caught the bare-`)` rule leaking 4 real parenthesized imports.
+        DeclLang::Python => match line.strip_suffix(')') {
+            Some(body) => {
+                let body = body.trim();
+                body.is_empty() || is_module_list(body)
+            }
+            None => false,
+        },
+        DeclLang::Go => line == ")",
         DeclLang::JsTs => {
-            line.starts_with('}')
-                && (line.ends_with(';') || line.ends_with('\'') || line.ends_with('"'))
-                && lone_terminal_semicolon(line)
+            let Some(rest) = line.strip_prefix('}') else {
+                return false;
+            };
+            let rest = rest.trim();
+            if rest == ";" || rest.is_empty() {
+                return true;
+            }
+            let Some(src) = rest.strip_prefix("from ") else {
+                return false;
+            };
+            let src = src.strip_suffix(';').unwrap_or(src);
+            lone_string_argument(src)
         }
-        DeclLang::Rust => line.ends_with("};"),
+        DeclLang::Rust => line == "};",
         // Java/C/Ruby declarations are single-line; nothing opens.
         DeclLang::Java | DeclLang::C | DeclLang::Ruby => false,
     }
@@ -4658,10 +4766,21 @@ fn family_hint(f: &nose_detect::RefactorFamily) -> String {
             } else {
                 format!("{inline_copies} sites reimplement")
             };
-            return format!(
+            let base = format!(
                 "{sites} `{name}` — call the existing helper ({})",
                 helper.file
             );
+            // Series 2: many varying spots mean the copies diverge from the
+            // helper — the early return must not bypass the caution.
+            return if f.params >= HIGH_PARAM_SPOTS && f.languages == 1 {
+                format!(
+                    "{base} — high-parameter ({} varying spots): verify the \
+                     copies really match the helper before swapping in calls",
+                    f.params
+                )
+            } else {
+                base
+            };
         }
     }
 
@@ -5810,6 +5929,29 @@ mod tests {
     }
 
     #[test]
+    fn helper_hint_carries_the_high_parameter_caution() {
+        // S2-C2: the early return must not bypass the params caution — six
+        // varying spots mean the inline copies diverge from the helper.
+        let mut f = fam(1, 2, &[None, None, None]);
+        f.params = 8;
+        f.shared_lines = 12;
+        f.locations = vec![
+            {
+                let mut l = loc_at("core/math.ts", 10, 14, nose_il::UnitKind::Function);
+                l.name = Some("clamp".to_string());
+                l
+            },
+            loc_at("ui/model.ts", 80, 84, nose_il::UnitKind::Block),
+            loc_at("worker/job.ts", 33, 37, nose_il::UnitKind::Block),
+        ];
+        let hint = family_hint(&f);
+        assert!(
+            hint.contains("call the existing helper") && hint.contains("high-parameter (8"),
+            "helper advice at 8 varying spots must carry the caution: {hint}"
+        );
+    }
+
+    #[test]
     fn helper_hint_never_points_at_generated_code() {
         let mut f = fam(1, 2, &[None, None]);
         f.locations = vec![
@@ -5894,6 +6036,21 @@ mod tests {
                 "#include <stdio.h>\n#include \"x.h\"\n#pragma once",
             ),
             (DeclLang::Ruby, "require 'json'\nrequire_relative 'x'"),
+            // S2-C3 coverage rows: shapes the code supports but no test locked.
+            (DeclLang::Rust, "pub(crate) use crate::x::Y;"),
+            (DeclLang::Go, "import http \"net/http\""),
+            (DeclLang::Python, "from os import path"),
+            (DeclLang::Ruby, "require('json')"),
+            (DeclLang::C, "#include<stdio.h>"),
+            (DeclLang::JsTs, "import{a} from './a';"),
+            // ASI: a multi-line import may close without a semicolon.
+            (DeclLang::JsTs, "import {\n  a,\n} from './ab'"),
+            // The closer may carry the final import names (corpus re-price
+            // regression in series 2: bare-`)` leaked real Python imports).
+            (
+                DeclLang::Python,
+                "from typing import (\n    Any,\n    Mapping)",
+            ),
         ];
         for (lang, src) in yes {
             assert!(
@@ -5931,6 +6088,14 @@ mod tests {
             // C5 boundary re-attack on the C1 defense itself.
             (DeclLang::JsTs, "import { a } from './a';;"),
             (DeclLang::Ruby, "require 'x' if expensive_check()"),
+            // S2-C1 blind-attacker packets: open-block interiors and closers
+            // were unvalidated (tree-sitter error tolerance voids any "the
+            // file parsed, so interiors are specifiers" assumption).
+            (DeclLang::Ruby, "require 'fs' + 1"),
+            (DeclLang::C, "#include <stdio.h> int x = 1;"),
+            (DeclLang::JsTs, "import {\n  a,\n} || x();"),
+            (DeclLang::Go, "import (\n\t\"fmt\"\n\tos.Exit(1))"),
+            (DeclLang::Rust, "use std::{\ninvalid;\n};"),
         ];
         for (lang, src) in no {
             assert!(

--- a/crates/nose-cli/tests/cli/support.rs
+++ b/crates/nose-cli/tests/cli/support.rs
@@ -378,7 +378,15 @@ fn assert_scan_json_surface_counts_contract(
     let surface_counts = ranking["surface_counts"]
         .as_object()
         .expect("ranking.surface_counts object");
-    for key in ["default", "review", "hidden", "debug", "fragments"] {
+    for key in [
+        "default",
+        "review",
+        "hidden",
+        "debug",
+        "generated",
+        "declaration",
+        "fragments",
+    ] {
         assert!(
             surface_counts.contains_key(key),
             "ranking.surface_counts.{key} missing: {json}"

--- a/crates/nose-cli/tests/fixtures/scan-json-v1.json
+++ b/crates/nose-cli/tests/fixtures/scan-json-v1.json
@@ -91,6 +91,7 @@
       "hidden": 0,
       "debug": 0,
       "generated": 0,
+      "declaration": 0,
       "fragments": {
         "total": 0,
         "default": 0,

--- a/docs/adversarial-coevolution.md
+++ b/docs/adversarial-coevolution.md
@@ -34,6 +34,32 @@ proof obligation, and false-merge risk surface. Hence three parties:
 An attack **counts only if it prices**. The attacker's fitness function is priced misses,
 not misses.
 
+### Attacker modes (added by series 2)
+
+The attacker is a **fresh subagent**, not the session that authored the surface: spawn
+it with the surface's source, the claim sentence, and the packet format — and nothing
+else. Authoring context is attack-bias (series 1's Ruby modifier-if hole survived the
+author's own C1 sweep and fell only to the boundary re-attack); a clean context removes
+exactly that bias.
+
+- **Blind mode** (the default): the attacker must NOT be shown the existing tests,
+  batteries, or the author's reasoning — anchoring on tested cases reintroduces the
+  staleness the isolation exists to remove. Inputs: source of the surface, the claim
+  with its doc pointer, the packet format.
+- **Informed mode**: a separate attacker gets the test suite *as the target* and
+  attacks its coverage — untested language rows, boundary values, asymmetries between
+  the yes and no fixture sets. Blind and informed find different things; keep their
+  packet pools separate until assessment so neither anchors the other.
+- **Persona rotation**: vary the attacker's stance per campaign — grammar lawyer,
+  performance attacker, soundness skeptic, language specialist, docs-vs-code auditor —
+  and record in the ledger which persona found what, so the rotation itself can be
+  tuned on evidence.
+- **The limit, unchanged**: subagents share the base model's priors. Isolation removes
+  *authoring-context* bias, not *model* blind spots — the mechanical generator
+  ([design §4b](design.md)) and the distribution adversary ([design §2c](design.md)
+  fresh-repo audits, field feedback) remain the decorrelation arms that no amount of
+  subagent spawning replaces.
+
 ## Attack surfaces
 
 Rotate campaigns across these; each entry names what to read and what claim to attack.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1861,3 +1861,71 @@ measured campaign costs. Series wall-clock: ~70 minutes of agent time for five
 campaigns (C1 ~12, C2 ~8, C3 ~15, C4 ~20, C5 ~6, recording ~10), plus ~3 min per
 corpus re-price sweep and 23 s per full e2e suite run — cheap enough to run per
 release.
+
+## CA. Adversarial co-evolution, series 2 — fresh subagent attackers (blind/informed/personas)
+
+Second runbook execution (#272), first under the series-2 **attacker modes**: five
+fresh-context subagents — no authoring history, blind ones denied the test suite —
+with persona rotation (grammar lawyer, adversarial reviewer, coverage auditor,
+CI-gate skeptic, docs-vs-code auditor). The author stayed assessor/defender only.
+The mode change paid for itself in round one.
+
+**S2-C1 (blind, grammar lawyer → declaration matchers).** The fresh attacker found
+the class the author's two passes missed: **open multi-line declarations consumed
+interior lines unvalidated**, and closers were suffix checks (`os.Exit(1))` "closes"
+a Go import block; `} || x();` "closes" a JS import; `require 'fs' + 1` rides
+arithmetic on a Ruby require; `#include <stdio.h> int x = 1;` rides a definition on
+a directive). The author's series-1 assumption — "in code that parsed, only
+specifiers can occur inside an open declaration" — is void because tree-sitter is
+error-tolerant: parse success does not certify interior content. Defense, third
+wave of the same generalization: **interior lines must validate as specifiers
+per-language, closers must match strict shapes exactly, and trailing arguments
+(C includes, Ruby requires) must be lone string literals**. Five new violation
+packets locked as fail-open tests. Two fail-open leaks (Python docstrings,
+multi-line block comments inside spans) priced LOW — they require *identical*
+comments in both members — and recorded, not defended.
+
+**S2-C2 (blind, adversarial reviewer → grouping/hints).** One priced hit: the
+"call the existing helper" early return **bypassed the high-parameter caution** —
+a copy diverging from the helper at 8 spots got unqualified advice. Fixed; caution
+now rides the helper hint. Refuted/recorded: identical-span double families and
+repeated in-family locations (upstream invariants), transitive chaining (accepted
+in §BZ), helper visibility (judgment-axis → consumer), witness-kind future-proofing
+(closed set, verified by S2-C5).
+
+**S2-C3 (informed, coverage auditor → the declaration battery).** 15 gaps ranked;
+7 adopted as fixture rows the code supported but no test locked: `pub(crate) use`,
+single-line aliased Go import, single-line `from X import Y`, `require('json')`,
+`#include<no-space>`, `import{` no-space, and the ASI multi-line import closing
+without a semicolon. The informed attacker also confirmed the `no`-table's
+asymmetries were intentional. (Multilingual e2e flagged as the one structural gap;
+deferred — unit rows cover matcher logic, one e2e covers the pipeline.)
+
+**S2-C4 (blind, CI-gate skeptic → review --fail).** Ten packets, **zero
+violations**: every aggressive configuration traced to a sound fail-closed branch
+(capped varying-spot lists refuse to prove; first-sibling selection can only
+under-fire; insertion boundary arithmetic correct at the edges). Two
+conservative-direction notes recorded (sibling-selection incompleteness, spot-cap
+misses) — both consistent with "fires on proof, never on absence of one".
+
+**S2-C5 (blind, docs-vs-code → scan JSON contract).** Contract verified exhaustively
+in both directions: zero undocumented emissions, zero documented-but-missing fields,
+invariants hold (counts sum, `overlap_primary_id` slices-only, witness kinds exact).
+One stale artifact: the checked-in v1 example fixture lacked `declaration: 0` and
+the contract checker didn't require it — fixture refreshed, checker now asserts
+`generated` and `declaration` keys.
+
+**Corpus price** — and the assessor catching the defender: the first re-price
+after tightening came back 2,261 (py 254 → 250). The bare-`)` strict closer had
+broken a real Python idiom — parenthesized imports whose final names share the
+closing line (`    Mapping)`) — a fail-open regression the synthetic battery
+missed and the corpus instrument caught. Closer refined to "module-list + `)`"
+and locked as a fixture row; final price: **2,265 declaration families, 43
+repos, 1 worthy span-overlap, zero reclassification** — identical to series 1.
+Three waves of hardening, zero recall cost, and one demonstration that the
+label-join re-price is a regression gate, not a formality. **Mode verdict**: blind subagents found
+a class two authored passes missed (the isolation works); the informed auditor
+produced complementary coverage, not duplicates (keep the modes separate); the
+docs-vs-code persona returned green at near-zero cost (cheap to keep in rotation).
+Series wall-clock ~50 min: 5 parallel attackers ~8 min, assessment+defense ~30 min,
+recording ~10 min.


### PR DESCRIPTION
## What

Adversarial co-evolution **series 2** — the first run under the new attacker modes, which this PR also adds to the runbook: the attacker is a **fresh subagent** (no authoring context), **blind mode** denies it the test suite, **informed mode** targets the test suite's coverage, and personas rotate. The author acted only as assessor/defender. Ledger in experiments §CA; tracking issue #272.

## Did the mode change pay? Yes — round one.

The blind grammar-lawyer found the class **two authored passes (series 1 C1 + C5 re-attack) missed**: open multi-line declarations consumed interior lines unvalidated, and closers were suffix checks. `os.Exit(1))` could "close" a Go import block; `} || x();` a JS import; `require 'fs' + 1` rode arithmetic on a require; `#include <stdio.h> int x = 1;` rode a definition on a directive. The series-1 assumption "the file parsed, so interiors are specifiers" is void — tree-sitter is error-tolerant.

## Defenses (claim-violation class)

- **Third wave of the single-statement discipline**: interior lines of open declarations validate as per-language specifiers; closers match strict shapes exactly (`)`, `};`, `}` + optional `from 'lit'`); C include and Ruby require arguments must be lone string literals. Five violation packets locked as fail-open tests.
- **Helper hint**: the early return no longer bypasses the high-parameter caution (8-spot divergence now carries "verify the copies really match the helper").
- **Coverage (informed attacker)**: 7 supported-but-untested shapes locked as fixtures — `pub(crate) use`, aliased single-line Go import, single-line `from X import Y`, `require('json')`, `#include<no-space>`, `import{` no-space, ASI multi-line import.
- **Contract artifacts**: scan-JSON checker now requires `generated`/`declaration` surface-count keys; stale v1 example fixture refreshed.

## Green with teeth

- review `--fail` gate (blind CI-skeptic, 10 packets): zero violations — every aggressive shape traced to a sound fail-closed branch; two conservative-direction notes recorded.
- scan JSON contract (blind docs-vs-code): exhaustive two-direction audit, zero mismatches, invariants hold.

## Pricing

The first re-price caught the defender over-tightening: the bare-`)` Python closer leaked 4 real parenthesized imports (py 254 → 250) — the corpus instrument caught a fail-open regression the synthetic battery missed; closer refined to "module-list + `)`" and locked. Final price: **2,265 declaration families, 43 repos, zero worthy-label reclassification** — identical to series 1. Three hardening waves, zero recall cost. Low-prevalence fail-open leaks (identical docstrings/block comments in both members) priced LOW and recorded, not defended. Series wall-clock ~50 min (5 parallel attackers ~8 min).

Closes #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
