### PR TITLE
Declaration classification moves onto AST facts; deferred-queue dispositions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ break.
 
 ## [Unreleased]
 
+### Changed
+- **Declaration classification now rests on AST facts** (experiments §CC):
+  `nose_frontend::declaration_facts` derives per-line declaration/comment/code
+  facts from the tree-sitter AST (ERROR subtrees never count as declarations;
+  stray code on a declaration line poisons it), replacing the four-times-
+  hardened text line grammar (−351 lines net). The 47-row adversarial battery
+  transferred unchanged. Corpus effect: +14 families correctly classify
+  (recovered fail-open leaks: multi-line imports with trailing comments,
+  star-imports, mid-file `use` blocks); zero worthy-label cost.
+- Deferred-queue dispositions: #269 closed (synthetic-only, revisit condition
+  recorded), #270 closed (Phase-3 entry gate added to the semantic-kernel
+  roadmap: pack expansion requires a priced consumer case), #275 escalated to
+  a reproduced `--cache-dir` equivalence violation (imported-literal
+  convergence disappears under the cache; reproducer on the issue).
+
 ### Fixed
 - **Adversarial co-evolution, series 3** (experiments §CB, issue #274; method
   upgrades: executable self-verified packets, the bench/coevo packet ledger,

--- a/bench/coevo/packets.v1.json
+++ b/bench/coevo/packets.v1.json
@@ -203,7 +203,7 @@
    "claim": "--cache-dir scans behave identically to non-cached scans",
    "summary": "build_units_cached skips the corpus-level resolve_imported_immutable_bindings pass (frontend lib.rs:195); 6 attacker probes + 2 assessor probes (imported-binding vs literal, default and semantic modes) could NOT expose an output divergence",
    "verdict": "deferred-issue",
-   "defense": "#275 structural asymmetry, no discriminating input found"
+   "defense": "#275 ESCALATED: reproduced (cold 1 exact family vs cached 0) via a converging shape mined from equivalence.rs \u2014 the test suite as discriminating-input arsenal"
   },
   {
    "packet_id": "s3-c3-test-naming-conventions",
@@ -288,6 +288,42 @@
    "summary": "an Explore-type attacker refused the executable contract (read-only self-interpretation); re-spawned as general-purpose with /tmp-only write scope \u2014 runbook should name the agent capability requirement",
    "verdict": "violation-fixed",
    "defense": "runbook attacker-modes note (series-3 PR)"
+  },
+  {
+   "packet_id": "s4-ast-facts-migration",
+   "series": 4,
+   "campaign": "disposition",
+   "persona": "defender",
+   "mode": "escalation",
+   "surface": "decidability-filters",
+   "claim": "wave counting: a 3rd+ hardening wave demands a generalization-level escalation",
+   "summary": "four text-grammar waves replaced by nose_frontend::declaration_facts (tree-sitter node facts + code-poison pass); 474 lines of matchers deleted; the 47-row battery carried over unchanged; EOF-newline and end-column-0 over-cover caught by the battery during migration",
+   "verdict": "violation-fixed",
+   "defense": "AST-facts migration (this PR)"
+  },
+  {
+   "packet_id": "s4-disposition-269",
+   "series": 4,
+   "campaign": "disposition",
+   "persona": "assessor",
+   "mode": "re-price",
+   "surface": "performance-determinism",
+   "claim": "few-huge-files serialization is worth core work",
+   "summary": "synthetic-only; real corpus worst cases run seconds at healthy parallelism; revisit condition recorded (real repo >10s at <200% CPU)",
+   "verdict": "refuted",
+   "defense": "#269 closed with condition"
+  },
+  {
+   "packet_id": "s4-disposition-270",
+   "series": 4,
+   "campaign": "disposition",
+   "persona": "assessor",
+   "mode": "re-price",
+   "surface": "exact-channel-gates",
+   "claim": "LawPack expansion is justified by axis breadth",
+   "summary": "exact-channel law provenance is structurally measure-zero; product role = near influence + proof discipline; Phase 3+ gated on a priced consumer case (roadmap entry gate added)",
+   "verdict": "refuted",
+   "defense": "#270 closed; semantic-kernel-roadmap Phase-3 entry gate"
   }
  ]
 }

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -4104,17 +4104,17 @@ fn family_declaration_run(
 fn declaration_run_ids(
     families: &[nose_detect::RefactorFamily],
 ) -> std::collections::HashSet<String> {
-    // One classification pass, one cache: members of different families share
-    // files, and a per-member full read made this O(families × file size)
-    // (coevo C3 measured it on a 123-family / 2-file pathological input).
+    // One classification pass, one cache pair: members of different families
+    // share files (coevo C3), and the AST facts parse each file once.
     let mut lines = FileLineCache::default();
+    let mut facts = std::collections::HashMap::new();
     families
         .iter()
         .filter(|f| {
             !f.locations.is_empty()
                 && f.locations
                     .iter()
-                    .all(|l| declaration_run_span(l, &mut lines))
+                    .all(|l| declaration_run_span(l, &mut lines, &mut facts))
         })
         .map(baseline::family_id)
         .collect()
@@ -4123,478 +4123,61 @@ fn declaration_run_ids(
 /// An import run longer than this is implausible; skip the read and fail open.
 const DECLARATION_SPAN_CAP: u32 = 80;
 
-fn declaration_run_span(loc: &nose_detect::Loc, lines: &mut FileLineCache) -> bool {
+fn declaration_run_span(
+    loc: &nose_detect::Loc,
+    lines: &mut FileLineCache,
+    facts: &mut std::collections::HashMap<String, Option<nose_frontend::DeclarationFacts>>,
+) -> bool {
     if loc.end_line.saturating_sub(loc.start_line) > DECLARATION_SPAN_CAP {
         return false;
     }
-    let Some(lang) = declaration_lang(&loc.file) else {
+    let facts = facts.entry(loc.file.clone()).or_insert_with(|| {
+        let ext = std::path::Path::new(&loc.file)
+            .extension()
+            .and_then(|e| e.to_str())?;
+        let src = std::fs::read_to_string(&loc.file).ok()?;
+        nose_frontend::declaration_facts(ext, &src)
+    });
+    let Some(facts) = facts else {
         return false;
     };
     let Some(all) = lines.whole(&loc.file) else {
         return false;
     };
-    let s = loc.start_line.saturating_sub(1) as usize;
-    let e = (loc.end_line as usize).min(all.len());
-    if s >= e {
+    span_is_declarations(facts, all, loc.start_line, loc.end_line)
+}
+
+/// The line rule over AST facts: every line in the span must be blank, a
+/// comment, or part of a declaration statement; a single code-poisoned line
+/// (any named leaf outside declarations/comments — `import os; evil()` puts
+/// `evil()`'s leaves on the import's line) disqualifies the span; and at
+/// least one declaration line must be present.
+fn span_is_declarations(
+    facts: &nose_frontend::DeclarationFacts,
+    all: &[String],
+    start: u32,
+    end: u32,
+) -> bool {
+    let end = (end as usize).min(all.len()) as u32;
+    if start == 0 || start > end {
         return false;
     }
-    span_is_only_declarations(&all[s..e], lang)
-}
-
-#[derive(Clone, Copy, PartialEq)]
-enum DeclLang {
-    Python,
-    JsTs,
-    Go,
-    Rust,
-    Java,
-    C,
-    Ruby,
-}
-
-fn declaration_lang(file: &str) -> Option<DeclLang> {
-    let ext = std::path::Path::new(file).extension()?.to_str()?;
-    Some(match ext {
-        "py" | "pyi" => DeclLang::Python,
-        // Embedded-script containers carry JS/TS inside; clone spans sit in
-        // the script body, so the JS/TS line grammar applies.
-        "js" | "jsx" | "mjs" | "cjs" | "ts" | "tsx" | "mts" | "cts" | "vue" | "svelte" | "html"
-        | "htm" => DeclLang::JsTs,
-        "go" => DeclLang::Go,
-        "rs" => DeclLang::Rust,
-        "java" => DeclLang::Java,
-        "c" | "h" => DeclLang::C,
-        "rb" => DeclLang::Ruby,
-        _ => return None,
-    })
-}
-
-/// What one trimmed source line contributes to a declaration run.
-enum DeclLine {
-    /// Not provably a declaration — the span fails (fail-open).
-    No,
-    /// A complete single-line declaration.
-    Complete,
-    /// Opens a multi-line declaration; consumed until its closing line.
-    Opens,
-}
-
-fn span_is_only_declarations(lines: &[String], lang: DeclLang) -> bool {
-    let mut open = false;
     let mut any = false;
-    for raw in lines {
-        let line = raw.trim();
-        if line.is_empty() || is_full_line_comment(line, lang) {
+    for line_no in start..=end {
+        if facts.is_code_line(line_no) {
+            return false;
+        }
+        if facts.is_declaration_line(line_no) {
+            any = true;
             continue;
         }
-        if open {
-            // Series-2 hardening: tree-sitter is error-tolerant, so "the file
-            // parsed" does NOT guarantee the interior of an open declaration
-            // holds only specifiers. Every interior line must itself be a
-            // valid specifier, and the close must be the strict closer shape
-            // (`os.Exit(1))` is not `)`; `} || x();` is not `};`).
-            if declaration_closes(line, lang) {
-                open = false;
-            } else if !declaration_interior(line, lang) {
-                return false;
-            }
+        if facts.is_comment_line(line_no) || all[line_no as usize - 1].trim().is_empty() {
             continue;
         }
-        match declaration_opens(line, lang) {
-            DeclLine::No => return false,
-            DeclLine::Complete => any = true,
-            DeclLine::Opens => {
-                any = true;
-                open = true;
-            }
-        }
-    }
-    // An unclosed statement means the span cut through code we did not prove.
-    !open && any
-}
-
-/// A line INSIDE an open multi-line declaration: import/use specifiers only.
-fn declaration_interior(line: &str, lang: DeclLang) -> bool {
-    match lang {
-        // `from x import (` interiors: names, commas, `as` aliases.
-        DeclLang::Python => is_module_list(line),
-        // `import {` / `export {` interiors: specifiers incl. `$`, `as`, `type`.
-        DeclLang::JsTs => {
-            !line.is_empty()
-                && line
-                    .chars()
-                    .all(|c| c.is_alphanumeric() || matches!(c, '_' | '$' | ',' | ' '))
-        }
-        // `import (` interiors: optional alias (`name`, `_`, `.`) + quoted path.
-        DeclLang::Go => go_import_spec(line),
-        // `use x::{` interiors: path segments, nested groups, `*`, `as`.
-        DeclLang::Rust => {
-            !line.is_empty()
-                && line.chars().all(|c| {
-                    c.is_alphanumeric() || matches!(c, '_' | ':' | ',' | ' ' | '{' | '}' | '*')
-                })
-        }
-        // No multi-line declarations open for these.
-        DeclLang::Java | DeclLang::C | DeclLang::Ruby => false,
-    }
-}
-
-/// `[alias ]"path"` with nothing after the closing quote.
-fn go_import_spec(line: &str) -> bool {
-    let rest = match line.find('"') {
-        Some(0) => line,
-        Some(i) => {
-            let alias = &line[..i];
-            let alias = alias.trim();
-            if !alias.is_empty()
-                && !alias
-                    .chars()
-                    .all(|c| c.is_alphanumeric() || matches!(c, '_' | '.'))
-            {
-                return false;
-            }
-            &line[i..]
-        }
-        None => return false,
-    };
-    let inner = rest.strip_prefix('"').and_then(|r| r.strip_suffix('"'));
-    matches!(inner, Some(path) if !path.contains('"'))
-}
-
-/// A bare string-literal argument (`'lit'` / `"lit"`, optionally parenthesized)
-/// with nothing riding after it — `require 'fs' + 1` is arithmetic, not wiring.
-fn lone_string_argument(arg: &str) -> bool {
-    let arg = arg.trim();
-    let arg = arg
-        .strip_prefix('(')
-        .and_then(|a| a.strip_suffix(')'))
-        .map(str::trim)
-        .unwrap_or(arg);
-    arg.len() >= 2
-        && ((arg.starts_with('\'') && arg.ends_with('\''))
-            || (arg.starts_with('"') && arg.ends_with('"')))
-        && !arg[1..arg.len() - 1].contains(['\'', '"'])
-}
-
-fn is_full_line_comment(line: &str, lang: DeclLang) -> bool {
-    match lang {
-        DeclLang::Python | DeclLang::Ruby => line.starts_with('#'),
-        _ => line.starts_with("//") || (line.starts_with("/*") && line.ends_with("*/")),
-    }
-}
-
-fn declaration_opens(line: &str, lang: DeclLang) -> DeclLine {
-    match lang {
-        DeclLang::Python => python_declaration(line),
-        DeclLang::JsTs => jsts_declaration(line),
-        DeclLang::Go => go_declaration(line),
-        DeclLang::Rust => rust_declaration(line),
-        DeclLang::Java => java_declaration(line),
-        DeclLang::C => c_declaration(line),
-        DeclLang::Ruby => ruby_declaration(line),
-    }
-}
-
-fn python_declaration(line: &str) -> DeclLine {
-    // A trailing `# comment` is inert on a declaration line (the corpus
-    // re-price caught the validated form dropping real `import x  # noqa`
-    // and single-line parenthesized imports — 18 families).
-    let line = line.split('#').next().unwrap_or(line).trim_end();
-    if let Some(rest) = line.strip_prefix("import ") {
-        return if is_module_list(rest) {
-            DeclLine::Complete
-        } else {
-            DeclLine::No
-        };
-    }
-    if let Some(rest) = line.strip_prefix("from ") {
-        if let Some((module, names)) = rest.split_once(" import ") {
-            // S3-C1: the imported NAMES must be a name list (or `*`) — the
-            // simple form accepted `from x import max("a", "b")` unchecked
-            // while the parenthesized form validated its interior.
-            if !is_module_list(module) {
-                return DeclLine::No;
-            }
-            if line.ends_with('(') && names == "(" {
-                return DeclLine::Opens;
-            }
-            if !semicolon_free(line) {
-                return DeclLine::No;
-            }
-            // A single-line parenthesized list is the same wiring:
-            // `from x import (a, b)`.
-            let names = names.trim();
-            let names = names
-                .strip_prefix('(')
-                .and_then(|n| n.strip_suffix(')'))
-                .map(str::trim)
-                .unwrap_or(names);
-            return if names == "*" || is_module_list(names) {
-                DeclLine::Complete
-            } else {
-                DeclLine::No
-            };
-        }
-    }
-    DeclLine::No
-}
-
-fn jsts_declaration(line: &str) -> DeclLine {
-    let stmt_done = line.ends_with(';') || line.ends_with('\'') || line.ends_with('"');
-    let single = lone_terminal_semicolon(line);
-    if line.starts_with("import ") || line.starts_with("import{") {
-        return if stmt_done && single {
-            if jsts_wiring_line_valid(line, "import") {
-                DeclLine::Complete
-            } else {
-                DeclLine::No
-            }
-        } else if !stmt_done && single {
-            DeclLine::Opens
-        } else {
-            DeclLine::No
-        };
-    }
-    // Re-exports are declaration wiring only with a `from` source (a barrel
-    // line); `export const …` is code and must fail.
-    if line.starts_with("export ") && line.contains(" from ") && stmt_done && single {
-        return if jsts_wiring_line_valid(line, "export") {
-            DeclLine::Complete
-        } else {
-            DeclLine::No
-        };
-    }
-    if (line.starts_with("export {") || line.starts_with("export *")) && !stmt_done && single {
-        return DeclLine::Opens;
-    }
-    for head in ["const ", "let ", "var "] {
-        if let Some(rest) = line.strip_prefix(head) {
-            if is_require_line(rest) && single {
-                return DeclLine::Complete;
-            }
-        }
-    }
-    DeclLine::No
-}
-
-/// A single-line `import`/`export … from` must be PURE wiring (S3-C1):
-/// `import { x } from Math.max("a", "b");` smuggles a call into the from
-/// clause, so the source must be a lone string literal and the specifier
-/// section must hold only specifier tokens.
-fn jsts_wiring_line_valid(line: &str, keyword: &str) -> bool {
-    let body = line.strip_suffix(';').unwrap_or(line);
-    match body.rfind(" from ") {
-        Some(i) => {
-            let specifiers = &body[keyword.len()..i];
-            let source = body[i + " from ".len()..].trim();
-            lone_string_argument(source)
-                && specifiers.chars().all(|c| {
-                    c.is_alphanumeric() || matches!(c, '_' | '$' | ',' | ' ' | '{' | '}' | '*')
-                })
-        }
-        // Side-effect import: `import './polyfill';`
-        None => keyword == "import" && lone_string_argument(body[keyword.len()..].trim()),
-    }
-}
-
-fn go_declaration(line: &str) -> DeclLine {
-    if line == "import (" {
-        return DeclLine::Opens;
-    }
-    if let Some(rest) = line.strip_prefix("import ") {
-        return if rest.contains('"') && rest.trim_end().ends_with('"') && semicolon_free(line) {
-            DeclLine::Complete
-        } else {
-            DeclLine::No
-        };
-    }
-    if let Some(rest) = line.strip_prefix("package ") {
-        return if is_module_list(rest) {
-            DeclLine::Complete
-        } else {
-            DeclLine::No
-        };
-    }
-    DeclLine::No
-}
-
-fn rust_declaration(line: &str) -> DeclLine {
-    let body = line
-        .strip_prefix("pub ")
-        .or_else(|| {
-            line.starts_with("pub(")
-                .then(|| line.split_once(") ").map(|(_, b)| b))
-                .flatten()
-        })
-        .unwrap_or(line);
-    if body.starts_with("use ") || body.starts_with("extern crate ") {
-        return if body.ends_with(';') && lone_terminal_semicolon(body) {
-            DeclLine::Complete
-        } else if body.ends_with('{') && semicolon_free(body) {
-            DeclLine::Opens
-        } else {
-            DeclLine::No
-        };
-    }
-    if let Some(rest) = body.strip_prefix("mod ") {
-        if rest.ends_with(';') && is_module_list(&rest[..rest.len() - 1]) {
-            return DeclLine::Complete;
-        }
-    }
-    DeclLine::No
-}
-
-fn java_declaration(line: &str) -> DeclLine {
-    // S3-C1: the path must BE a dotted name (optionally `static`, trailing
-    // `*`) — shape checks alone accepted `import java.util.x + y;`.
-    for head in ["import ", "package "] {
-        if let Some(rest) = line.strip_prefix(head) {
-            if !line.ends_with(';') || !lone_terminal_semicolon(line) {
-                return DeclLine::No;
-            }
-            let body = rest[..rest.len() - 1].trim();
-            let body = body.strip_prefix("static ").unwrap_or(body);
-            return if !body.is_empty()
-                && body
-                    .chars()
-                    .all(|c| c.is_alphanumeric() || matches!(c, '.' | '_' | '*'))
-            {
-                DeclLine::Complete
-            } else {
-                DeclLine::No
-            };
-        }
-    }
-    DeclLine::No
-}
-
-fn c_declaration(line: &str) -> DeclLine {
-    if let Some(rest) = line.strip_prefix("#include") {
-        if !rest.starts_with([' ', '<', '"']) {
-            return DeclLine::No;
-        }
-        let arg = rest.trim();
-        let angle = arg.starts_with('<')
-            && arg.ends_with('>')
-            && !arg[1..arg.len() - 1].contains(['<', '>']);
-        return if angle || lone_string_argument(arg) {
-            DeclLine::Complete
-        } else {
-            // `#include <stdio.h> int x = 1;` rides code on the directive.
-            DeclLine::No
-        };
-    }
-    if line == "#pragma once" {
-        return DeclLine::Complete;
-    }
-    DeclLine::No
-}
-
-fn ruby_declaration(line: &str) -> DeclLine {
-    // A modifier conditional (`require 'x' if cond`) rides an expression on
-    // the declaration — more than a bare require, so it fails open (C5).
-    // Series 2: the argument must be a lone string literal — `require 'fs' + 1`
-    // is arithmetic on the require's return value, not wiring.
-    let conditional = line.contains(" if ") || line.contains(" unless ");
-    if conditional || !semicolon_free(line) {
-        return DeclLine::No;
-    }
-    for head in ["require_relative", "require"] {
-        if let Some(rest) = line.strip_prefix(head) {
-            return if (rest.starts_with(' ') || rest.starts_with('(')) && lone_string_argument(rest)
-            {
-                DeclLine::Complete
-            } else {
-                DeclLine::No
-            };
-        }
-    }
-    DeclLine::No
-}
-
-fn declaration_closes(line: &str, lang: DeclLang) -> bool {
-    match lang {
-        // The strict closer shapes (series 2): `os.Exit(1))` is not `)`,
-        // `} || x();` is not `};` or `} from 'lit';`. Python's closer may
-        // carry the final import names (`    b)`) — the corpus re-price
-        // caught the bare-`)` rule leaking 4 real parenthesized imports.
-        DeclLang::Python => match line.strip_suffix(')') {
-            Some(body) => {
-                let body = body.trim();
-                body.is_empty() || is_module_list(body)
-            }
-            None => false,
-        },
-        DeclLang::Go => line == ")",
-        DeclLang::JsTs => {
-            let Some(rest) = line.strip_prefix('}') else {
-                return false;
-            };
-            let rest = rest.trim();
-            if rest == ";" || rest.is_empty() {
-                return true;
-            }
-            let Some(src) = rest.strip_prefix("from ") else {
-                return false;
-            };
-            let src = src.strip_suffix(';').unwrap_or(src);
-            lone_string_argument(src)
-        }
-        DeclLang::Rust => line == "};",
-        // Java/C/Ruby declarations are single-line; nothing opens.
-        DeclLang::Java | DeclLang::C | DeclLang::Ruby => false,
-    }
-}
-
-/// The single-statement discipline (coevo series 1, C1): a declaration line
-/// must BE one declaration, not merely *start* with one — `import x; evil()`
-/// rides real code on a recognized prefix, and classifying it would break the
-/// "provably no extraction exists" claim. For `;`-terminated grammars the
-/// only `;` may be the final character; for grammars whose declarations carry
-/// no `;` at all, any `;` means a second statement and the line fails open.
-fn lone_terminal_semicolon(line: &str) -> bool {
-    match line.find(';') {
-        None => true,
-        Some(i) => i == line.len() - 1,
-    }
-}
-
-fn semicolon_free(line: &str) -> bool {
-    !line.contains(';')
-}
-
-/// Strict `NAME = require('literal')` shape for the CommonJS arm: a single
-/// identifier, a single string-literal argument, nothing after the call. A
-/// multi-declarator line (`…, b = compute();`) must fail open.
-fn is_require_line(rest: &str) -> bool {
-    let Some((name, call)) = rest.split_once("= require(") else {
-        return false;
-    };
-    let name = name.trim();
-    if name.is_empty()
-        || !name
-            .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
-    {
+        // Uncovered non-blank content (stray tokens, mid-statement cuts).
         return false;
     }
-    let call = call.trim_end();
-    let Some(arg) = call.strip_suffix(");").or_else(|| call.strip_suffix(')')) else {
-        return false;
-    };
-    let arg = arg.trim();
-    arg.len() >= 2
-        && ((arg.starts_with('\'') && arg.ends_with('\''))
-            || (arg.starts_with('"') && arg.ends_with('"')))
-        && !arg[1..arg.len() - 1].contains(['\'', '"'])
-}
-
-/// Bare module-path lists: identifiers, dots, commas, spaces, and `as`
-/// aliases only — anything else (operators, parens, strings) is code.
-fn is_module_list(s: &str) -> bool {
-    !s.is_empty()
-        && s.chars()
-            .all(|c| c.is_alphanumeric() || matches!(c, '_' | '.' | ',' | ' '))
+    any
 }
 
 fn family_all_generated_source(
@@ -6079,79 +5662,68 @@ mod tests {
         );
     }
 
-    fn decl_lines(src: &str) -> Vec<String> {
-        src.lines().map(str::to_string).collect()
+    /// Run the whole-source span through the AST-facts classifier — the same
+    /// path `declaration_run_span` takes, minus the file I/O.
+    fn ast_classifies(ext: &str, src: &str) -> bool {
+        let Some(facts) = nose_frontend::declaration_facts(ext, src) else {
+            return false;
+        };
+        let all: Vec<String> = src.lines().map(str::to_string).collect();
+        let end = all.len().max(1) as u32;
+        span_is_declarations(&facts, &all, 1, end)
     }
 
     #[test]
     fn declaration_spans_classify_per_language() {
-        let yes: &[(DeclLang, &str)] = &[
+        let yes: &[(&str, &str)] = &[
+            ("ts", "import { a } from './a';\nimport { b } from './b';"),
+            ("ts", "import {\n  a,\n  b,\n} from './ab';"),
+            ("ts", "export { a } from './a';\nexport * from './b';"),
+            ("ts", "const fs = require('fs');"),
+            ("py", "import os\nfrom typing import (\n    Any,\n)"),
             (
-                DeclLang::JsTs,
-                "import { a } from './a';\nimport { b } from './b';",
-            ),
-            (DeclLang::JsTs, "import {\n  a,\n  b,\n} from './ab';"),
-            (
-                DeclLang::JsTs,
-                "export { a } from './a';\nexport * from './b';",
-            ),
-            (DeclLang::JsTs, "const fs = require('fs');"),
-            (
-                DeclLang::Python,
-                "import os\nfrom typing import (\n    Any,\n)",
-            ),
-            (
-                DeclLang::Go,
+                "go",
                 "package main\n\nimport (\n\t\"fmt\"\n\talias \"net/http\"\n)",
             ),
             (
-                DeclLang::Rust,
+                "rs",
                 "use std::fmt;\npub use crate::x::{\n    A,\n};\nmod wiring;",
             ),
             (
-                DeclLang::Java,
+                "java",
                 "package com.x;\nimport java.util.List;\nimport static java.util.Map.entry;",
             ),
-            (
-                DeclLang::C,
-                "#include <stdio.h>\n#include \"x.h\"\n#pragma once",
-            ),
-            (DeclLang::Ruby, "require 'json'\nrequire_relative 'x'"),
+            ("c", "#include <stdio.h>\n#include \"x.h\"\n#pragma once"),
+            ("rb", "require 'json'\nrequire_relative 'x'"),
             // S2-C3 coverage rows: shapes the code supports but no test locked.
-            (DeclLang::Rust, "pub(crate) use crate::x::Y;"),
-            (DeclLang::Go, "import http \"net/http\""),
-            (DeclLang::Python, "from os import path"),
-            (DeclLang::Ruby, "require('json')"),
-            (DeclLang::C, "#include<stdio.h>"),
-            (DeclLang::JsTs, "import{a} from './a';"),
+            ("rs", "pub(crate) use crate::x::Y;"),
+            ("go", "import http \"net/http\""),
+            ("py", "from os import path"),
+            ("rb", "require('json')"),
+            ("c", "#include<stdio.h>"),
+            ("ts", "import{a} from './a';"),
             // ASI: a multi-line import may close without a semicolon.
-            (DeclLang::JsTs, "import {\n  a,\n} from './ab'"),
+            ("ts", "import {\n  a,\n} from './ab'"),
             // The closer may carry the final import names (corpus re-price
             // regression in series 2: bare-`)` leaked real Python imports).
-            (
-                DeclLang::Python,
-                "from typing import (\n    Any,\n    Mapping)",
-            ),
+            ("py", "from typing import (\n    Any,\n    Mapping)"),
             // S3-C5 coverage adoptions.
-            (
-                DeclLang::Go,
-                "import (\n\t. \"fmt\"\n\t_ \"encoding/json\"\n)",
-            ),
-            (DeclLang::Rust, "use std::{\n    io::{self, Read},\n};"),
-            (DeclLang::JsTs, "import {\n  $ref,\n} from './x';"),
-            (DeclLang::JsTs, "export {\n  a,\n  b,\n} from './lib';"),
-            (DeclLang::JsTs, "const $lib = require('lib');"),
-            (DeclLang::Python, "from typing import (\n    Dict as D,\n)"),
-            (DeclLang::Python, "from x import *"),
+            ("go", "import (\n\t. \"fmt\"\n\t_ \"encoding/json\"\n)"),
+            ("rs", "use std::{\n    io::{self, Read},\n};"),
+            ("ts", "import {\n  $ref,\n} from './x';"),
+            ("ts", "export {\n  a,\n  b,\n} from './lib';"),
+            ("ts", "const $lib = require('lib');"),
+            ("py", "from typing import (\n    Dict as D,\n)"),
+            ("py", "from x import *"),
             // Corpus re-price regressions (series 3): inert trailing comments
             // and single-line parenthesized name lists are real wiring.
-            (DeclLang::Python, "import os  # noqa"),
-            (DeclLang::Python, "from os import path  # comment"),
-            (DeclLang::Python, "from x import (a, b)"),
+            ("py", "import os  # noqa"),
+            ("py", "from os import path  # comment"),
+            ("py", "from x import (a, b)"),
         ];
-        for (lang, src) in yes {
+        for (ext, src) in yes {
             assert!(
-                span_is_only_declarations(&decl_lines(src), *lang),
+                ast_classifies(ext, src),
                 "should classify as declarations: {src}"
             );
         }
@@ -6162,57 +5734,51 @@ mod tests {
         // Fail-open: anything not provably a declaration keeps the family on
         // its ranked surface — misclassifying a real finding is the error
         // class this filter must never make.
-        let no: &[(DeclLang, &str)] = &[
-            (
-                DeclLang::JsTs,
-                "import { a } from './a';\nexport const x = a;",
-            ),
-            (DeclLang::JsTs, "import {\n  a,"),
-            (DeclLang::Python, "import os\nx = os.environ"),
-            (DeclLang::Go, "import (\n\t\"fmt\""),
-            (DeclLang::Rust, "use std::fmt;\nfn main() {}"),
-            (DeclLang::Java, "import java.util.List;\nclass X {}"),
-            (DeclLang::C, "#include <stdio.h>\n#define MAX 4"),
-            (DeclLang::Ruby, "require 'json'\nputs 'hi'"),
-            (DeclLang::Python, ""),
+        let no: &[(&str, &str)] = &[
+            ("ts", "import { a } from './a';\nexport const x = a;"),
+            ("ts", "import {\n  a,"),
+            ("py", "import os\nx = os.environ"),
+            ("go", "import (\n\t\"fmt\""),
+            ("rs", "use std::fmt;\nfn main() {}"),
+            ("java", "import java.util.List;\nclass X {}"),
+            ("c", "#include <stdio.h>\n#define MAX 4"),
+            ("rb", "require 'json'\nputs 'hi'"),
+            ("py", ""),
             // C1 claim-violation packets: a single LINE mixing a declaration
             // with executable code must never classify (the "provably no
             // extraction exists" claim breaks if real code rides along).
-            (DeclLang::JsTs, "import { a } from './a'; doEvil();"),
-            (DeclLang::JsTs, "var a = require('a'), b = compute();"),
-            (DeclLang::Go, "import \"fmt\"; func main() { hack() }"),
-            (DeclLang::Ruby, "require 'json'; system('x')"),
-            (DeclLang::Python, "from x import y; z = 1"),
-            (DeclLang::Java, "import java.util.List; int x = 1;"),
-            (DeclLang::Rust, "use std::fmt; let x = 1;"),
-            (DeclLang::C, "#includeevil <x.h>"),
+            ("ts", "import { a } from './a'; doEvil();"),
+            ("ts", "var a = require('a'), b = compute();"),
+            ("go", "import \"fmt\"; func main() { hack() }"),
+            ("rb", "require 'json'; system('x')"),
+            ("py", "from x import y; z = 1"),
+            ("java", "import java.util.List; int x = 1;"),
+            ("rs", "use std::fmt; let x = 1;"),
+            ("c", "#includeevil <x.h>"),
             // C5 boundary re-attack on the C1 defense itself.
-            (DeclLang::JsTs, "import { a } from './a';;"),
-            (DeclLang::Ruby, "require 'x' if expensive_check()"),
+            ("ts", "import { a } from './a';;"),
+            ("rb", "require 'x' if expensive_check()"),
             // S2-C1 blind-attacker packets: open-block interiors and closers
             // were unvalidated (tree-sitter error tolerance voids any "the
             // file parsed, so interiors are specifiers" assumption).
-            (DeclLang::Ruby, "require 'fs' + 1"),
-            (DeclLang::C, "#include <stdio.h> int x = 1;"),
-            (DeclLang::JsTs, "import {\n  a,\n} || x();"),
-            (DeclLang::Go, "import (\n\t\"fmt\"\n\tos.Exit(1))"),
-            (DeclLang::Rust, "use std::{\ninvalid;\n};"),
+            ("rb", "require 'fs' + 1"),
+            ("c", "#include <stdio.h> int x = 1;"),
+            ("ts", "import {\n  a,\n} || x();"),
+            ("go", "import (\n\t\"fmt\"\n\tos.Exit(1))"),
+            ("rs", "use std::{\ninvalid;\n};"),
             // S3-C1 blind-attacker packets: from-clause sources, Python name
             // lists, and Java paths smuggled expressions through shape checks.
-            (DeclLang::JsTs, "import { x } from Math.max(\"a\", \"b\");"),
-            (DeclLang::JsTs, "export { x } from path.join(\"c\", \"d\");"),
-            (DeclLang::Python, "from x import max(\"a\", \"b\")"),
-            (DeclLang::Java, "import java.util.x + y;"),
-            (DeclLang::Java, "package com.example.x + y;"),
+            ("ts", "import { x } from Math.max(\"a\", \"b\");"),
+            ("ts", "export { x } from path.join(\"c\", \"d\");"),
+            ("py", "from x import max(\"a\", \"b\")"),
+            ("java", "import java.util.x + y;"),
+            ("java", "package com.example.x + y;"),
             // S3-C5 boundary re-attacks on the strict closers.
-            (DeclLang::Rust, "use std::{\n  A,\n}x;"),
-            (DeclLang::Go, "import (\n\tfunc() \"x\"\n)"),
+            ("rs", "use std::{\n  A,\n}x;"),
+            ("go", "import (\n\tfunc() \"x\"\n)"),
         ];
-        for (lang, src) in no {
-            assert!(
-                !span_is_only_declarations(&decl_lines(src), *lang),
-                "must fail open on: {src:?}"
-            );
+        for (ext, src) in no {
+            assert!(!ast_classifies(ext, src), "must fail open on: {src:?}");
         }
     }
 }

--- a/crates/nose-frontend/src/declaration_facts.rs
+++ b/crates/nose-frontend/src/declaration_facts.rs
@@ -1,0 +1,207 @@
+//! AST-derived declaration facts for the CLI's declaration-run classifier.
+//!
+//! Four hardening waves of a text line-grammar (experiments §BY/§BZ/§CA/§CB)
+//! kept leaking payload-validation holes because line text is the wrong
+//! abstraction level — the parser already knows which statements are
+//! import/use/include wiring. This module exposes that knowledge as per-line
+//! facts so the classifier's claim ("provably only declarations") rests on the
+//! grammar, not on regex-shaped approximations of it.
+//!
+//! Fail-open posture is inherited from the parser: subtrees containing ERROR
+//! nodes are never marked as declarations (tree-sitter's error tolerance is
+//! exactly why "the file parsed" proves nothing — §CA), and any named leaf
+//! outside a declaration/comment poisons its lines as code.
+
+use crate::lower::{grammar, is_trivia, parse};
+use tree_sitter::Node;
+
+/// Per-line classification of one source file, 1-based and inclusive.
+pub struct DeclarationFacts {
+    /// Lines carrying import/use/include/package wiring statements.
+    declaration: Vec<(u32, u32)>,
+    /// Lines carrying comments (inert on a declaration run).
+    comment: Vec<(u32, u32)>,
+    /// Lines where any OTHER named code starts or continues — one poisoned
+    /// line disqualifies a span no matter what else covers it.
+    code: Vec<(u32, u32)>,
+}
+
+impl DeclarationFacts {
+    fn mark(ranges: &mut Vec<(u32, u32)>, node: Node) {
+        let start = node.start_position().row as u32 + 1;
+        let end_pos = node.end_position();
+        // A node whose text ends in a newline "ends" at column 0 of the NEXT
+        // row; counting that row would over-claim the following line.
+        let mut end = end_pos.row as u32 + 1;
+        if end_pos.column == 0 && end > start {
+            end -= 1;
+        }
+        ranges.push((start, end));
+    }
+
+    fn covers(ranges: &[(u32, u32)], line: u32) -> bool {
+        ranges.iter().any(|&(s, e)| s <= line && line <= e)
+    }
+
+    pub fn is_declaration_line(&self, line: u32) -> bool {
+        Self::covers(&self.declaration, line)
+    }
+
+    pub fn is_comment_line(&self, line: u32) -> bool {
+        Self::covers(&self.comment, line)
+    }
+
+    pub fn is_code_line(&self, line: u32) -> bool {
+        Self::covers(&self.code, line)
+    }
+}
+
+/// Compute declaration facts for one file, selected by extension (the same
+/// vocabulary `nose scan` discovers by). Returns `None` for extensions without
+/// a standalone grammar here — notably the embedded-script containers
+/// (`vue`/`svelte`/`html`), which fail open in the classifier (zero corpus
+/// presence on the declaration surface, measured §BY).
+pub fn declaration_facts(ext: &str, src: &str) -> Option<DeclarationFacts> {
+    let (key, lang_fn): (u16, fn() -> tree_sitter::Language) = match ext {
+        "py" | "pyi" => (grammar::PYTHON, || tree_sitter_python::LANGUAGE.into()),
+        "js" | "jsx" | "mjs" | "cjs" => (grammar::JAVASCRIPT, || {
+            tree_sitter_javascript::LANGUAGE.into()
+        }),
+        "ts" | "mts" | "cts" => (grammar::TYPESCRIPT, || {
+            tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
+        }),
+        "tsx" => (grammar::TSX, || tree_sitter_typescript::LANGUAGE_TSX.into()),
+        "go" => (grammar::GO, || tree_sitter_go::LANGUAGE.into()),
+        "rs" => (grammar::RUST, || tree_sitter_rust::LANGUAGE.into()),
+        "java" => (grammar::JAVA, || tree_sitter_java::LANGUAGE.into()),
+        "c" | "h" => (grammar::C, || tree_sitter_c::LANGUAGE.into()),
+        "rb" => (grammar::RUBY, || tree_sitter_ruby::LANGUAGE.into()),
+        _ => return None,
+    };
+    // Newline-terminated grammars (C preprocessor directives) read a missing
+    // EOF newline as a MISSING token, which would fail-open the last line.
+    let owned;
+    let src = if src.ends_with('\n') {
+        src
+    } else {
+        owned = format!("{src}\n");
+        &owned
+    };
+    let tree = parse(key, lang_fn, src.as_bytes()).ok()?;
+    let mut facts = DeclarationFacts {
+        declaration: Vec::new(),
+        comment: Vec::new(),
+        code: Vec::new(),
+    };
+    walk(tree.root_node(), key, src.as_bytes(), &mut facts);
+    Some(facts)
+}
+
+fn walk(node: Node, key: u16, src: &[u8], facts: &mut DeclarationFacts) {
+    if is_trivia(node.kind()) {
+        DeclarationFacts::mark(&mut facts.comment, node);
+        return;
+    }
+    // A subtree containing a parse ERROR can never prove anything.
+    if !node.has_error() && is_declaration(node, key, src) {
+        DeclarationFacts::mark(&mut facts.declaration, node);
+        return;
+    }
+    if node.named_child_count() == 0 {
+        if node.is_named() {
+            DeclarationFacts::mark(&mut facts.code, node);
+        }
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        walk(child, key, src, facts);
+    }
+}
+
+fn is_declaration(node: Node, key: u16, src: &[u8]) -> bool {
+    let kind = node.kind();
+    match key {
+        grammar::PYTHON => matches!(
+            kind,
+            "import_statement" | "import_from_statement" | "future_import_statement"
+        ),
+        grammar::JAVASCRIPT | grammar::TYPESCRIPT | grammar::TSX => match kind {
+            "import_statement" => true,
+            // Re-exports are wiring only with a `from` source.
+            "export_statement" => node.child_by_field_name("source").is_some(),
+            // CommonJS: `const x = require('lit');` — exactly one declarator,
+            // a bare require call with one string-literal argument.
+            "lexical_declaration" | "variable_declaration" => {
+                let mut cursor = node.walk();
+                let declarators: Vec<Node> = node
+                    .named_children(&mut cursor)
+                    .filter(|n| n.kind() == "variable_declarator")
+                    .collect();
+                declarators.len() == 1
+                    && node.named_child_count() == 1
+                    && declarators[0]
+                        .child_by_field_name("value")
+                        .is_some_and(|value| is_require_call(value, src))
+            }
+            _ => false,
+        },
+        grammar::GO => matches!(kind, "import_declaration" | "package_clause"),
+        grammar::RUST => match kind {
+            "use_declaration" | "extern_crate_declaration" => true,
+            // `mod x;` is wiring; `mod x { … }` is code.
+            "mod_item" => node.child_by_field_name("body").is_none(),
+            _ => false,
+        },
+        grammar::JAVA => matches!(kind, "import_declaration" | "package_declaration"),
+        grammar::C => match kind {
+            "preproc_include" => true,
+            // `#pragma once` is header wiring; other pragmas are semantics.
+            "preproc_call" => node
+                .utf8_text(src)
+                .is_ok_and(|text| text.trim() == "#pragma once"),
+            _ => false,
+        },
+        grammar::RUBY => {
+            kind == "call"
+                && node
+                    .child_by_field_name("method")
+                    .and_then(|m| m.utf8_text(src).ok())
+                    .is_some_and(|m| m == "require" || m == "require_relative")
+                && node.child_by_field_name("receiver").is_none()
+                && lone_string_arguments(node, "argument_list")
+        }
+        _ => false,
+    }
+}
+
+/// `require('lit')` / `require("lit")` with exactly one plain string argument.
+fn is_require_call(node: Node, src: &[u8]) -> bool {
+    node.kind() == "call_expression"
+        && node
+            .child_by_field_name("function")
+            .and_then(|f| f.utf8_text(src).ok())
+            .is_some_and(|f| f == "require")
+        && lone_string_arguments(node, "arguments")
+}
+
+/// The node's argument list holds exactly one plain string (no interpolation,
+/// no expressions riding along).
+fn lone_string_arguments(node: Node, list_kind: &str) -> bool {
+    let Some(args) = node
+        .child_by_field_name("arguments")
+        .filter(|args| args.kind() == list_kind || list_kind == "arguments")
+    else {
+        return false;
+    };
+    let mut cursor = args.walk();
+    let named: Vec<Node> = args.named_children(&mut cursor).collect();
+    named.len() == 1
+        && named[0].kind() == "string"
+        && named[0].named_children(&mut named[0].walk()).all(|part| {
+            matches!(
+                part.kind(),
+                "string_content" | "string_fragment" | "string_start" | "string_end"
+            )
+        })
+}

--- a/crates/nose-frontend/src/lib.rs
+++ b/crates/nose-frontend/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod c;
 mod coverage;
+mod declaration_facts;
 mod embedded;
 mod go;
 mod java;
@@ -16,6 +17,7 @@ mod rust;
 mod type_domain_aliases;
 
 pub use coverage::{coverage, CoverageReport};
+pub use declaration_facts::{declaration_facts, DeclarationFacts};
 
 use nose_il::{Corpus, FileId, Il, Interner, Lang};
 use rayon::prelude::*;

--- a/docs/adversarial-coevolution.md
+++ b/docs/adversarial-coevolution.md
@@ -169,6 +169,20 @@ Every packet and its verdict accumulates in **`bench/coevo/packets.v1.json`**
    [eval/declaration_runs](../eval/declaration_runs/RESULTS.md) precedent); the
    zero-false-merge and determinism gates ([CONTRIBUTING](../CONTRIBUTING.md)).
 
+   **The accept-distribution pre-gate** (promoted after two consecutive catches,
+   §CA/§CB): a defense that tightens a filter ships only after the corpus
+   re-price diffs CLEAN against the currently-classified family set — the
+   defender writes validators from attack shapes and systematically under-sees
+   the accept distribution (series 2's bare-`)` closer, series 3's
+   `# noqa`/parenthesized-import drops). The 3-minute sweep runs BEFORE the
+   merge, not after it.
+
+   **Wave counting**: a surface taking its third hardening wave needs a
+   generalization-level escalation, not another wave — four waves of the
+   declaration text grammar ended in the AST-facts migration
+   (`nose_frontend::declaration_facts`), which deleted the matcher class and
+   carried the entire 47-row battery over unchanged.
+
    **Defense-deferral is a first-class verdict**: a priced packet whose sound defense
    exceeds the campaign's scope (detector-core work, new proof obligations) closes as
    `deferred: #issue` with the packet and measurement attached — series 1 produced

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2006,3 +2006,50 @@ rows. Final price: **2,265 declaration families, 43 repos, 1 worthy
 span-overlap, zero reclassification** — identical through four hardening
 waves. The label-join re-price has now caught a fail-open regression in two
 consecutive series; it is a regression gate in fact, not just in name.
+
+## CC. The AST-facts migration + the deferred-queue dispositions
+
+The series-3 evaluation set three preconditions for series 4; this section
+records all three.
+
+**Wave counting cashes out: declaration classification moves onto AST facts.**
+Four hardening waves of the text line-grammar (§BY → §BZ → §CA → §CB) kept
+leaking payload-validation holes because line text approximates what the parser
+already knows. `nose_frontend::declaration_facts(ext, src)` now exposes
+per-line facts from the tree-sitter AST — declaration statements (per-language
+node kinds incl. validated CJS `require` and Ruby `require` calls), comment
+lines, and a **code-poison pass** (any named leaf outside declarations/comments
+poisons its lines, which kills `import os; evil()` shapes structurally). ERROR
+subtrees are never marked declarations, so tree-sitter's error tolerance — the
+root cause behind §CA's interior-smuggling packets — now works FOR the
+classifier instead of against it. The CLI's four-wave matcher stack (474 lines:
+seven per-language line grammars, interior/closer validation, string-argument
+helpers) is deleted; net −351 lines. **The 47-row adversarial battery carried
+over unchanged** and caught two migration bugs before any corpus run (EOF
+newline = MISSING token; node-end at column 0 over-covering the next line).
+
+**The accept-distribution pre-gate, first scheduled run.** The corpus re-price
+under the AST engine: **2,279 declaration families (+14 vs the text engine's
+2,265: py +12, java +1, rs +1), 43+ repos, worthy overlaps unchanged, zero
+worthy reclassification.** Sampled spans confirm the +14 are genuine
+recoveries of recorded-low fail-open leaks the line grammar could not express
+(multi-line imports with trailing comments and star-imports, mid-file `use`
+blocks). Verdict: pass — recall-direction diff, zero cost.
+
+**Deferred-queue dispositions.**
+- **#269 (few-huge-files serialization): closed, no-prevalence.** Synthetic-only;
+  real corpus worst cases run seconds at healthy parallelism; revisit condition
+  recorded (a real repo > 10 s in `normalize+extract` at < 200% CPU).
+- **#270 (law-provenance gating): closed, re-priced.** The three gates are each
+  sound (refuted five-for-five in §BZ); the product conclusion is a Phase-3
+  **entry gate** in the semantic-kernel roadmap: pack expansion now requires a
+  priced consumer case, not axis breadth.
+- **#275 (cache equivalence): ESCALATED from lead to reproduced violation.**
+  The discriminating input that eight black-box probes missed came from mining
+  the equivalence-test suite for a guaranteed-convergence shape: imported
+  literal binding (`from tables import LOOKUP`) vs inline literal. Cold
+  `--mode semantic`: 1 family, witness exact-value-graph; with `--cache-dir`:
+  0 families — the cached path skips `resolve_imported_immutable_bindings`.
+  Silent-miss direction; sound fix needs cross-file cache invalidation (core
+  work, reproducer attached to the issue). Method note: **the test suite is a
+  discriminating-input arsenal** — informed attackers should mine it.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -853,6 +853,15 @@ Remaining after the #109 closeout:
 
 ## Phase 3: first-party packs
 
+**Entry gate (2026-06-12, #270 disposition):** further LawPack/pack expansion is
+gated on a *priced consumer case* — a measured situation where pack-fed
+exact-channel evidence changes a real report. The clamp-law escalation
+([experiments §BZ](experiments.md), #270) showed exact-channel law provenance is
+structurally measure-zero in the field (typed evidence ∧ bound proof ∧
+strict-exact eligibility ≈ never co-occur in real code); the laws' product role
+today is `near`-channel influence plus proof discipline. Breadth alone no longer
+justifies a tranche ([design §2c](design.md)).
+
 - Convert Python, JavaScript/TypeScript, Go, Rust, Java, C, Ruby, and embedded
   JS/TS containers into first-party compiled packs.
 - Split stdlib knowledge, including dependency-backed type-domain alias rows,


### PR DESCRIPTION
## What

The three series-4 preconditions from the series-3 evaluation, executed (experiments §CC):

1. **AST-facts migration** — the wave-counting heuristic cashes out. `nose_frontend::declaration_facts(ext, src)` derives per-line declaration/comment/code facts from the tree-sitter AST: per-language declaration node kinds (incl. validated CommonJS/Ruby `require` calls), comments as inert lines, and a **code-poison pass** (any named leaf outside declarations/comments disqualifies its lines — `import os; evil()` dies structurally). ERROR subtrees never count as declarations, so tree-sitter's error tolerance now works *for* the classifier. The four-times-hardened text line grammar (474 lines: seven per-language matchers, interior/closer validation, string-argument helpers) is deleted — **net −351 lines** — and the **47-row adversarial battery transferred unchanged**, catching two migration bugs (EOF-newline MISSING token; node-end column-0 over-cover) before any corpus run.
2. **Accept-distribution pre-gate promoted into the runbook** (after two consecutive catches) and run as such here: AST-engine corpus price **2,279 (+14 vs text)** — sampled spans confirm the +14 are genuine recoveries of recorded fail-open leaks (multi-line imports with trailing comments, star-imports, mid-file `use` blocks); worthy overlaps unchanged, zero reclassification. Also recorded: the wave-counting rule itself.
3. **Deferred-queue dispositions**: #269 closed (synthetic-only; revisit condition recorded), #270 closed (Phase-3 **entry gate** added to the semantic-kernel roadmap — pack expansion requires a priced consumer case, not axis breadth), **#275 escalated from lead to reproduced violation**: mining the equivalence-test suite for a guaranteed-convergence shape exposed the divergence eight black-box probes missed — cold `--mode semantic` finds the imported-literal family (exact-value-graph), `--cache-dir` loses it. Reproducer on the issue; sound fix is cross-file cache invalidation (core work).

## Verification

- Unit: full 47-row yes/no battery green on the AST engine; helper-hint and grouping suites unchanged.
- E2E: 172 green.
- Corpus: pre-gate pass as above (+14 recall-direction, zero worthy cost), sampled-span audit included in §CC.
- dup-gate 24/24; fast preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
