### PR TITLE
AST declaration classifier: sound-direction prescreen + parallel parsing erase the migration's perf cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ break.
 ## [Unreleased]
 
 ### Changed
+- **The AST declaration classifier is cost-neutral** (§CC addendum): the
+  migration's serial per-file re-parse cost +29% wall on family-dense scans
+  (measured A/B vs the prior binary); a sound-direction prescreen plus
+  parallel candidate-file parsing brings sympy to 4.67 s and a 1,364-file TS
+  app to 0.55 s — at or under the pre-migration baseline, with byte-identical
+  classification.
 - **Declaration classification now rests on AST facts** (experiments §CC):
   `nose_frontend::declaration_facts` derives per-line declaration/comment/code
   facts from the tree-sitter AST (ERROR subtrees never count as declarations;

--- a/bench/coevo/packets.v1.json
+++ b/bench/coevo/packets.v1.json
@@ -324,6 +324,18 @@
    "summary": "exact-channel law provenance is structurally measure-zero; product role = near influence + proof discipline; Phase 3+ gated on a priced consumer case (roadmap entry gate added)",
    "verdict": "refuted",
    "defense": "#270 closed; semantic-kernel-roadmap Phase-3 entry gate"
+  },
+  {
+   "packet_id": "s4-ast-parse-cost",
+   "series": 4,
+   "campaign": "perf",
+   "persona": "user-question",
+   "mode": "measured",
+   "surface": "performance-determinism",
+   "claim": "the AST migration is cost-neutral",
+   "summary": "A/B vs pre-AST binary: sympy 4.96->6.42s (+29%), craken-agents 0.546->0.760s (+39%) \u2014 serial re-parse of nearly every family-hosting file. Defense: sound-direction prescreen (declaration starters + mid-statement continuation shapes; false negatives only fail open) + parallel parse of unique candidate files. After: sympy 4.67s, craken-agents 0.550s \u2014 at or under the pre-AST baseline, classification byte-identical (42/10). The prescreen's first draft dropped a mid-statement-start family (caught by classification diff, not timing) \u2014 even perf-only gates need the classification diff check",
+   "verdict": "violation-fixed",
+   "defense": "prescreen + rayon parse (this PR)"
   }
  ]
 }

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -4104,19 +4104,51 @@ fn family_declaration_run(
 fn declaration_run_ids(
     families: &[nose_detect::RefactorFamily],
 ) -> std::collections::HashSet<String> {
-    // One classification pass, one cache pair: members of different families
-    // share files (coevo C3), and the AST facts parse each file once.
+    // Three passes (coevo s4 perf packet): a cheap serial prescreen picks the
+    // candidate families, the unique candidate files parse in PARALLEL (the
+    // serial per-file AST parse cost +29% wall on sympy), and the final pass
+    // classifies against the shared facts.
     let mut lines = FileLineCache::default();
-    let mut facts = std::collections::HashMap::new();
-    families
+    let mut candidates: Vec<&nose_detect::RefactorFamily> = Vec::new();
+    let mut wanted: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for f in families {
+        if f.locations.is_empty() {
+            continue;
+        }
+        let pass = f.locations.iter().all(|l| {
+            l.end_line.saturating_sub(l.start_line) <= DECLARATION_SPAN_CAP
+                && lines
+                    .whole(&l.file)
+                    .is_some_and(|all| declaration_prescreen(all, l.start_line, l.end_line))
+        });
+        if pass {
+            candidates.push(f);
+            wanted.extend(f.locations.iter().map(|l| l.file.clone()));
+        }
+    }
+    let facts: std::collections::HashMap<String, Option<nose_frontend::DeclarationFacts>> = wanted
+        .into_iter()
+        .collect::<Vec<_>>()
+        .into_par_iter()
+        .map(|file| {
+            let parsed = std::path::Path::new(&file)
+                .extension()
+                .and_then(|e| e.to_str())
+                .and_then(|ext| {
+                    let src = std::fs::read_to_string(&file).ok()?;
+                    nose_frontend::declaration_facts(ext, &src)
+                });
+            (file, parsed)
+        })
+        .collect();
+    candidates
         .iter()
         .filter(|f| {
-            !f.locations.is_empty()
-                && f.locations
-                    .iter()
-                    .all(|l| declaration_run_span(l, &mut lines, &mut facts))
+            f.locations
+                .iter()
+                .all(|l| declaration_run_span(l, &mut lines, &facts))
         })
-        .map(baseline::family_id)
+        .map(|f| baseline::family_id(f))
         .collect()
 }
 
@@ -4126,25 +4158,71 @@ const DECLARATION_SPAN_CAP: u32 = 80;
 fn declaration_run_span(
     loc: &nose_detect::Loc,
     lines: &mut FileLineCache,
-    facts: &mut std::collections::HashMap<String, Option<nose_frontend::DeclarationFacts>>,
+    facts: &std::collections::HashMap<String, Option<nose_frontend::DeclarationFacts>>,
 ) -> bool {
     if loc.end_line.saturating_sub(loc.start_line) > DECLARATION_SPAN_CAP {
         return false;
     }
-    let facts = facts.entry(loc.file.clone()).or_insert_with(|| {
-        let ext = std::path::Path::new(&loc.file)
-            .extension()
-            .and_then(|e| e.to_str())?;
-        let src = std::fs::read_to_string(&loc.file).ok()?;
-        nose_frontend::declaration_facts(ext, &src)
-    });
-    let Some(facts) = facts else {
+    let Some(Some(facts)) = facts.get(&loc.file) else {
         return false;
     };
     let Some(all) = lines.whole(&loc.file) else {
         return false;
     };
     span_is_declarations(facts, all, loc.start_line, loc.end_line)
+}
+
+/// Cheap starter check before the AST parse. Comment lines are transparent;
+/// the first content line must begin like wiring. False negatives only fail
+/// open (the family keeps its ranked surface), so this can never misclassify.
+fn declaration_prescreen(all: &[String], start: u32, end: u32) -> bool {
+    const STARTERS: &[&str] = &[
+        "import",
+        "from ",
+        "use ",
+        "pub use ",
+        "pub mod ",
+        "pub extern ",
+        "pub(",
+        "#include",
+        "#pragma",
+        "package ",
+        "require",
+        "export ",
+        "extern ",
+        "mod ",
+    ];
+    let end = (end as usize).min(all.len());
+    if start == 0 || start as usize > end {
+        return false;
+    }
+    for line in &all[start as usize - 1..end] {
+        let t = line.trim_start();
+        if t.is_empty() || t.starts_with("//") || t.starts_with("/*") {
+            continue;
+        }
+        if t.starts_with('#') && !t.starts_with("#include") && !t.starts_with("#pragma") {
+            continue;
+        }
+        // A span may begin INSIDE a multi-line import (specifier list or its
+        // closer) — the AST node covers those lines, so let the parse decide.
+        if t.starts_with('}') || t.starts_with(')') {
+            return true;
+        }
+        if t.chars()
+            .all(|c| c.is_alphanumeric() || matches!(c, '_' | '$' | ',' | ' ' | '.'))
+        {
+            return true;
+        }
+        // CommonJS wiring needs the call, not just the keyword.
+        for head in ["const ", "let ", "var "] {
+            if t.starts_with(head) {
+                return t.contains("= require(");
+            }
+        }
+        return STARTERS.iter().any(|s| t.starts_with(s));
+    }
+    false
 }
 
 /// The line rule over AST facts: every line in the span must be blank, a

--- a/docs/adversarial-coevolution.md
+++ b/docs/adversarial-coevolution.md
@@ -100,7 +100,11 @@ Rotate campaigns across these; each entry names what to read and what claim to a
    blowups), and byte-determinism under repeated runs and `RAYON_NUM_THREADS`
    variation. Pricing for this surface IS the measurement (`NOSE_TIME=1` per-stage
    breakdown); fixture-generation note: vary token *shape* in synthetic filler, or
-   Type-2 identifier abstraction bridges your blocks into one run.
+   Type-2 identifier abstraction bridges your blocks into one run. Defenses on
+   THIS surface take a paired pre-gate (§CC addendum): the classification diff
+   AND a wall-time A/B on a family-dense repo against the prior binary — a perf
+   fix can silently change classification, and a classification fix can
+   silently cost time.
 
 ## Target packet format — executable, self-verified (series 3)
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2053,3 +2053,18 @@ blocks). Verdict: pass — recall-direction diff, zero cost.
   Silent-miss direction; sound fix needs cross-file cache invalidation (core
   work, reproducer attached to the issue). Method note: **the test suite is a
   discriminating-input arsenal** — informed attackers should mine it.
+
+**§CC addendum — the migration's performance packet (surface 8).** The AST
+engine shipped with a regression the §CC pre-gate did not measure (the
+re-price checks classification, not time): A/B against the pre-AST binary
+showed sympy 4.96 → 6.42 s (+29%) and a 1,364-file TS app 0.546 → 0.760 s —
+the classifier serially re-parsed nearly every family-hosting file. Defense:
+a **sound-direction prescreen** (the span's first content line must look like
+wiring or a mid-statement continuation; false negatives only fail open) plus
+**parallel parsing** of the unique candidate files. After: sympy 4.67 s,
+craken-agents 0.550 s — at or under the pre-AST baseline with byte-identical
+classification. Two lessons folded back: (1) the prescreen's first draft
+silently dropped a mid-statement-start family — caught by the classification
+diff, not by timing, so perf defenses take the SAME pre-gate; (2) the
+performance surface needs its own baseline pair in the pre-gate (wall time on
+a family-dense repo, A/B against the prior binary), now noted in the runbook.


### PR DESCRIPTION
## What

The user's "성능 저하 문제는 없었어?" was, in runbook terms, a performance-surface attack — and it hit. The §CC pre-gate checks **classification**, not time, so the AST migration shipped with a regression: A/B against the pre-AST binary measured **sympy 4.96 → 6.42 s (+29%)** and a 1,364-file TS app **0.546 → 0.760 s** — the classifier serially re-parsed nearly every family-hosting file.

## Defense (both halves sound by direction)

1. **Prescreen**: a span's first content line must look like wiring (declaration starters) or a mid-statement continuation (specifier list / closer). False negatives only fail open — the prescreen can never misclassify, only skip work. Its first draft *did* silently drop a mid-statement-start family; the classification diff caught it (timing didn't), which is now a runbook rule.
2. **Parallel parsing** of the surviving unique candidate files (rayon).

## After

- sympy **4.67 s**, craken-agents **0.550 s** — at or under the pre-AST baseline.
- Classification byte-identical: corpus re-price 2,279, same per-extension split, zero worthy reclassification; e2e 172 green; dup-gate 24/24.
- Runbook: the performance surface now requires a **paired pre-gate** — classification diff AND wall-time A/B vs the prior binary (a perf fix can silently change classification; a classification fix can silently cost time). Ledger packet `s4-ast-parse-cost`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)