### PR TITLE
Adversarial co-evolution series 4: AST classifier child-inspection, evidence honesty, BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ break.
 
 ## [Unreleased]
 
+### Fixed
+- **Adversarial co-evolution, series 4** (experiments §CD, issue #279) — the AST
+  declaration classifier's first attack plus the difference-evidence and
+  encoding surfaces:
+  - **Declaration classifier: call-shaped entries inspect their children**
+    (S4-C1). `const { a = steal() } = require('lit')`, a computed key, and a
+    Ruby `require('x') { … }` block smuggled live calls onto an import line
+    because the node-kind match returned before recursing; the JS binding name
+    and Ruby block must now execute nothing. Plain destructuring stays wiring.
+  - **`N of M lines shared` is honest** (S4-C2): the displayed count is now the
+    representative pair's physical invariant-line count, so the summary can no
+    longer read `5 of 6 shared, 2 spots differ` (5+2>6) or undercount repeated
+    identical lines; the majority-voted set still drives ranking weight.
+  - **UTF-8 BOM no longer flips classification** (S4-C3): a BOM'd import-only
+    file stays a declaration run (stripped in the classifier and prescreen),
+    matching the IL-lowering path that already tolerated it.
+  - Embedded `<script>` text-extraction defects deferred (#280, grammar-driven
+    boundary detection is frontend core work); coverage rows adopted for Rust
+    `extern crate`, Go `package`, Ruby `require_relative`.
+
 ### Changed
 - **The AST declaration classifier is cost-neutral** (§CC addendum): the
   migration's serial per-file re-parse cost +29% wall on family-dense scans

--- a/bench/coevo/packets.v1.json
+++ b/bench/coevo/packets.v1.json
@@ -336,6 +336,66 @@
    "summary": "A/B vs pre-AST binary: sympy 4.96->6.42s (+29%), craken-agents 0.546->0.760s (+39%) \u2014 serial re-parse of nearly every family-hosting file. Defense: sound-direction prescreen (declaration starters + mid-statement continuation shapes; false negatives only fail open) + parallel parse of unique candidate files. After: sympy 4.67s, craken-agents 0.550s \u2014 at or under the pre-AST baseline, classification byte-identical (42/10). The prescreen's first draft dropped a mid-statement-start family (caught by classification diff, not timing) \u2014 even perf-only gates need the classification diff check",
    "verdict": "violation-fixed",
    "defense": "prescreen + rayon parse (this PR)"
+  },
+  {
+   "packet_id": "s4-c1-uninspected-children",
+   "series": 4,
+   "campaign": "S4-C1",
+   "persona": "grammar-lawyer",
+   "mode": "blind-executable",
+   "surface": "decidability-filters",
+   "claim": "a declaration node proves its whole line range is wiring",
+   "summary": "4 reproduced: call-shaped declaration entries (JS require-binding, Ruby require) mark the node and early-return WITHOUT recursing, so a destructuring default `{a=steal()}`, computed key `{[exfil()]:x}`, or Ruby block `require('x'){launch}` smuggles a call onto the import line; node-kind whitelist never inspected the name-pattern/block child",
+   "verdict": "violation-fixed",
+   "defense": "subtree_executes guard on JS binding name + Ruby block-field check (this PR)"
+  },
+  {
+   "packet_id": "s4-c2-shared-lines-semantics",
+   "series": 4,
+   "campaign": "S4-C2",
+   "persona": "evidence-skeptic",
+   "mode": "blind-executable",
+   "surface": "ranking-grouping-hints",
+   "claim": "N of M lines shared is the representative pair's invariant count; honest",
+   "summary": "6 packets: shared_lines was a majority vote across up to 8 members but displayed against the rep pair (5 of 6 shared + 2 spots = 7 in a 6-line body), and HashSet-deduped (3 identical buf.append counted once -> 2 of 6). Fixed display to the rep pair's physical invariant count (rank set keeps majority vote for shared_weight). Remaining packets (params from one pair = lower bound; languages==1 gate drops mixed-family evidence; removable on 0-shared) recorded as documented lower-bound behavior",
+   "verdict": "violation-fixed",
+   "defense": "SharedLines{rank_lines,display,params} split (this PR); residuals recorded"
+  },
+  {
+   "packet_id": "s4-c3-bom-misclass",
+   "series": 4,
+   "campaign": "S4-C3",
+   "persona": "robustness-attacker",
+   "mode": "blind-executable",
+   "surface": "performance-determinism",
+   "claim": "encoding never changes classification; determinism holds",
+   "summary": "a UTF-8 BOM on any member of an import-only family flipped it from declaration to default (tree-sitter error leaf in line-1 region) in py+rust; the IL-lowering path already tolerated it. Determinism/CRLF/multibyte/no-trailing-newline all GREEN (3 packets BOM only)",
+   "verdict": "violation-fixed",
+   "defense": "strip BOM in declaration_facts + prescreen (this PR)"
+  },
+  {
+   "packet_id": "s4-c4-embedded-text-extraction",
+   "series": 4,
+   "campaign": "S4-C4",
+   "persona": "container-attacker",
+   "mode": "blind-executable",
+   "surface": "embedded-containers",
+   "claim": "embedded <script> extraction is correct and line-accurate",
+   "summary": "5 reproduced: </script> in a JS string truncates (miss); commented-out <script> analyzed live + span swallows </body></html>; generic=\"T extends X<Y>\" attribute > breaks tag-end; end_line over-claims onto the close tag; unclosed <script> dropped. All from text byte-scanning, not parsing",
+   "verdict": "deferred-issue",
+   "defense": "#280 (grammar-driven boundary detection is frontend core work)"
+  },
+  {
+   "packet_id": "s4-c5-coverage",
+   "series": 4,
+   "campaign": "S4-C5",
+   "persona": "coverage-auditor",
+   "mode": "informed",
+   "surface": "decidability-filters",
+   "claim": "the AST classifier's per-language kinds are covered",
+   "summary": "14 gaps; adopted rows for Rust extern crate, Go package clause, Ruby require_relative; AST code-poison (gap 6) and the languages all-members selector (gap 12) already locked by the migration + the partial-path test sharing the same .all() code path",
+   "verdict": "violation-fixed",
+   "defense": "coverage rows (this PR)"
   }
  ]
 }

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3676,17 +3676,21 @@ fn weight_shared_lines(
             .iter()
             .find_map(|b| varying_spots_of(&f.locations[0], b, &mut lines))
             .unwrap_or_default();
-        if let Some((shared, params)) = shared_lines_of(&f.locations, &mut lines) {
-            let substantive: f64 = shared
+        if let Some(s) = shared_lines_of(&f.locations, &mut lines) {
+            let substantive: f64 = s
+                .rank_lines
                 .iter()
                 .filter(|l| !is_trivial_line(l))
                 .map(|l| idf.weight(l))
                 .sum();
             // Gate ramps 0→1 as substantive shared content goes 0→2 lines.
             let gate = (substantive / 2.0).clamp(0.0, 1.0);
-            f.shared_lines = shared.len() as u32;
-            f.shared_weight = shared.len() as f64 * gate;
-            f.params = params;
+            // Display is the representative pair's physical invariant count;
+            // ranking weights the majority-voted set. `shared_weight` keeps
+            // using the rank set so the robust signal still drives the order.
+            f.shared_lines = s.display;
+            f.shared_weight = s.rank_lines.len() as f64 * gate;
+            f.params = s.params;
         }
     }
 }
@@ -4197,7 +4201,10 @@ fn declaration_prescreen(all: &[String], start: u32, end: u32) -> bool {
         return false;
     }
     for line in &all[start as usize - 1..end] {
-        let t = line.trim_start();
+        // A leading UTF-8 BOM is invisible to the AST classifier (it strips
+        // one) — the prescreen must too, or a BOM'd first import never reaches
+        // the parse (coevo S4-C3).
+        let t = line.trim_start_matches('\u{feff}').trim_start();
         if t.is_empty() || t.starts_with("//") || t.starts_with("/*") {
             continue;
         }
@@ -4766,17 +4773,34 @@ fn anti_unify(a: &[&str], b: &[&str]) -> (Vec<String>, u32, u32) {
 /// just the closest pair — so a diverging copy shrinks the count honestly rather than
 /// the flattering pair count overstating `N of M shared`. Parameters come from the first
 /// pair that reads (a lower bound on the varying spots). `None` if no pair reads.
-fn shared_lines_of(
-    locs: &[nose_detect::Loc],
-    cache: &mut FileLineCache,
-) -> Option<(Vec<String>, u32)> {
-    // Lines invariant across the representative pair, plus the parameter count.
+/// What the difference analysis yields for a family: the lines that drive the
+/// *ranking* weight, the *displayed* invariant-line count, and the parameter
+/// count — kept as three values because the display count and the ranking set
+/// answer different questions (coevo S4-C2).
+struct SharedLines {
+    /// Majority-voted invariant lines (deduped, sorted) — the robust signal the
+    /// ranking weights by IDF. Robustness is the point: a 6-copy family isn't
+    /// tanked because its 6th copy diverges.
+    rank_lines: Vec<String>,
+    /// The representative pair's invariant **physical** line count — what the
+    /// `N of M shared, K spots differ` summary shows. Counted (not deduped) and
+    /// taken from the same pair as `params`, so `display + params` partitions
+    /// the pair's diff and the summary can never read `5 of 6 + 2 spots`
+    /// (the §S4-C2 self-contradiction) or undercount repeated lines.
+    display: u32,
+    params: u32,
+}
+
+fn shared_lines_of(locs: &[nose_detect::Loc], cache: &mut FileLineCache) -> Option<SharedLines> {
+    // The representative pair: invariant lines (for the majority vote), the
+    // physical invariant-line count (for display), and the hole count.
     let pair = |a: &nose_detect::Loc, b: &nose_detect::Loc, cache: &mut FileLineCache| {
         let la = cache.slice(&a.file, a.start_line, a.end_line)?;
         let lb = cache.slice(&b.file, b.start_line, b.end_line)?;
         let ar: Vec<&str> = la.iter().map(String::as_str).collect();
         let br: Vec<&str> = lb.iter().map(String::as_str).collect();
         let mut shared = Vec::new();
+        let mut display = 0u32;
         let mut params = 0u32;
         let mut in_hole = false;
         for (tag, line) in &line_diff(&ar, &br) {
@@ -4784,6 +4808,10 @@ fn shared_lines_of(
                 in_hole = false;
                 let t = line.trim();
                 if !t.is_empty() {
+                    // Every physical invariant line counts toward display (so
+                    // three identical `buf.append(x)` lines count as 3); the
+                    // dedup happens only in the majority-vote set below.
+                    display += 1;
                     shared.push(t.to_string());
                 }
             } else if !in_hole {
@@ -4791,26 +4819,23 @@ fn shared_lines_of(
                 params += 1;
             }
         }
-        Some((shared, params))
+        Some((shared, display, params))
     };
     const MEMBER_CAP: usize = 8;
-    // Count, per representative-line, how many other members share it. Keep the lines
-    // shared by a *majority* (≥60%) of members: honest about a diverging copy (a line
-    // only one other member has is dropped) yet robust to a single outlier (a 6-copy
-    // family isn't tanked because its 6th copy differs). Parameters come from the first
-    // pair (a lower bound on the varying spots).
     let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
     let mut n_others = 0usize;
     let mut params = 0u32;
+    let mut display = 0u32;
     for b in locs.iter().skip(1).take(MEMBER_CAP - 1) {
-        let Some((s, p)) = pair(&locs[0], b, cache) else {
+        let Some((s, d, p)) = pair(&locs[0], b, cache) else {
             continue;
         };
-        // Parameters come from the first pair that actually reads — keyed on
-        // `n_others`, not the loop index, so an unreadable representative pair
-        // doesn't silently drop the count to zero.
+        // Display and params come from the first pair that actually reads —
+        // keyed on `n_others`, not the loop index, so an unreadable
+        // representative pair doesn't silently drop them to zero.
         if n_others == 0 {
             params = p;
+            display = d;
         }
         n_others += 1;
         let uniq: std::collections::HashSet<String> = s.into_iter().collect();
@@ -4822,7 +4847,7 @@ fn shared_lines_of(
         return None;
     }
     let need = ((n_others as f64) * 0.6).ceil().max(1.0) as usize;
-    let mut shared: Vec<String> = counts
+    let mut rank_lines: Vec<String> = counts
         .into_iter()
         .filter(|(_, c)| *c >= need)
         .map(|(l, _)| l)
@@ -4831,8 +4856,12 @@ fn shared_lines_of(
     // and float addition isn't associative, so a `HashMap`-iteration order would make
     // `shared_weight` (and, via sort ties, the family order) vary run-to-run and across
     // thread counts — violating the byte-identical-output guarantee.
-    shared.sort_unstable();
-    Some((shared, params))
+    rank_lines.sort_unstable();
+    Some(SharedLines {
+        rank_lines,
+        display,
+        params,
+    })
 }
 
 /// The varying spots between two location line-blocks (#223): each maximal
@@ -5482,14 +5511,15 @@ mod tests {
         // from the representative by one parameter line.
         let locs = vec![mk(f0), mk(missing), mk(f2)];
         let mut cache = FileLineCache(std::collections::HashMap::new());
-        let (shared, params) = shared_lines_of(&locs, &mut cache).expect("a later pair reads");
+        let s = shared_lines_of(&locs, &mut cache).expect("a later pair reads");
 
         assert!(
-            shared.contains(&"shared1".to_string()),
-            "shared lines extracted: {shared:?}"
+            s.rank_lines.contains(&"shared1".to_string()),
+            "shared lines extracted: {:?}",
+            s.rank_lines
         );
         assert_eq!(
-            params, 1,
+            s.params, 1,
             "params must come from the first successful pair, not iteration 0"
         );
 
@@ -5785,6 +5815,10 @@ mod tests {
             // The closer may carry the final import names (corpus re-price
             // regression in series 2: bare-`)` leaked real Python imports).
             ("py", "from typing import (\n    Any,\n    Mapping)"),
+            // S4-C5 coverage adoptions (supported kinds with no locked row).
+            ("rs", "extern crate serde;\nextern crate serde_json;"),
+            ("go", "package main"),
+            ("rb", "require_relative './helpers'"),
             // S3-C5 coverage adoptions.
             ("go", "import (\n\t. \"fmt\"\n\t_ \"encoding/json\"\n)"),
             ("rs", "use std::{\n    io::{self, Read},\n};"),
@@ -5854,9 +5888,32 @@ mod tests {
             // S3-C5 boundary re-attacks on the strict closers.
             ("rs", "use std::{\n  A,\n}x;"),
             ("go", "import (\n\tfunc() \"x\"\n)"),
+            // S4-C1: call-shaped declaration entries whose binding/block
+            // smuggles execution past the node-kind whitelist.
+            (
+                "js",
+                "const { boom = stealCreditCards() } = require('lit');",
+            ),
+            ("js", "const { [exfiltrate()]: grabbed } = require('lit');"),
+            (
+                "ts",
+                "const { boom = stealCreditCards() } = require('lit');",
+            ),
+            ("rb", "require('socket') { launch_missiles }"),
         ];
         for (ext, src) in no {
             assert!(!ast_classifies(ext, src), "must fail open on: {src:?}");
         }
+    }
+
+    #[test]
+    fn declaration_spans_inert_destructure_still_classifies() {
+        // The S4-C1 fix must not over-reject: a plain destructuring require
+        // executes nothing and stays wiring.
+        assert!(ast_classifies(
+            "js",
+            "const { boom, fizz } = require('lit');"
+        ));
+        assert!(ast_classifies("py", "\u{feff}import os")); // BOM-tolerant
     }
 }

--- a/crates/nose-frontend/src/declaration_facts.rs
+++ b/crates/nose-frontend/src/declaration_facts.rs
@@ -78,13 +78,22 @@ pub fn declaration_facts(ext: &str, src: &str) -> Option<DeclarationFacts> {
         "rb" => (grammar::RUBY, || tree_sitter_ruby::LANGUAGE.into()),
         _ => return None,
     };
-    // Newline-terminated grammars (C preprocessor directives) read a missing
-    // EOF newline as a MISSING token, which would fail-open the last line.
+    // A UTF-8 BOM (Windows-authored files) makes tree-sitter emit an error
+    // leaf in the line-1 region, which poisoned the first declaration and
+    // flipped import-only families onto the default surface (coevo S4-C3).
+    // The main IL-lowering path already tolerates it; strip it here too, on a
+    // single owned buffer that also normalizes the missing-EOF-newline case
+    // (C preprocessor directives read a missing final newline as MISSING).
+    let stripped = src.strip_prefix('\u{feff}').unwrap_or(src);
     let owned;
-    let src = if src.ends_with('\n') {
+    let src = if stripped.ends_with('\n') && std::ptr::eq(stripped, src) {
         src
     } else {
-        owned = format!("{src}\n");
+        owned = if stripped.ends_with('\n') {
+            stripped.to_string()
+        } else {
+            format!("{stripped}\n")
+        };
         &owned
     };
     let tree = parse(key, lang_fn, src.as_bytes()).ok()?;
@@ -131,7 +140,12 @@ fn is_declaration(node: Node, key: u16, src: &[u8]) -> bool {
             // Re-exports are wiring only with a `from` source.
             "export_statement" => node.child_by_field_name("source").is_some(),
             // CommonJS: `const x = require('lit');` — exactly one declarator,
-            // a bare require call with one string-literal argument.
+            // a bare require call with one string-literal argument, and a
+            // binding target that EXECUTES NOTHING. The early-return mark
+            // skips the subtree, so a destructuring default/computed key
+            // (`const { a = steal() } = require('lit')`) would smuggle a call
+            // onto the import's line undetected (coevo S4-C1) — the binding
+            // pattern must therefore be call-free.
             "lexical_declaration" | "variable_declaration" => {
                 let mut cursor = node.walk();
                 let declarators: Vec<Node> = node
@@ -143,6 +157,9 @@ fn is_declaration(node: Node, key: u16, src: &[u8]) -> bool {
                     && declarators[0]
                         .child_by_field_name("value")
                         .is_some_and(|value| is_require_call(value, src))
+                    && declarators[0]
+                        .child_by_field_name("name")
+                        .is_none_or(|name| !subtree_executes(name))
             }
             _ => false,
         },
@@ -170,9 +187,35 @@ fn is_declaration(node: Node, key: u16, src: &[u8]) -> bool {
                     .is_some_and(|m| m == "require" || m == "require_relative")
                 && node.child_by_field_name("receiver").is_none()
                 && lone_string_arguments(node, "argument_list")
+                // `require('x') { launch() }` carries a block that executes
+                // (coevo S4-C1) — a bare require has none.
+                && node.child_by_field_name("block").is_none()
         }
         _ => false,
     }
+}
+
+/// Does this subtree contain a node that EXECUTES code (a call, an awaited
+/// expression, a defined function body)? Used to reject call-shaped
+/// declaration entries whose binding target smuggles execution — the
+/// early-return mark would otherwise skip the subtree. Bounded DAG walk.
+fn subtree_executes(node: Node) -> bool {
+    const EXECUTES: &[&str] = &[
+        "call_expression",
+        "call",
+        "await_expression",
+        "arrow_function",
+        "function_expression",
+        "function",
+        "new_expression",
+        "yield_expression",
+    ];
+    if EXECUTES.contains(&node.kind()) {
+        return true;
+    }
+    let mut cursor = node.walk();
+    let children: Vec<Node> = node.named_children(&mut cursor).collect();
+    children.into_iter().any(subtree_executes)
 }
 
 /// `require('lit')` / `require("lit")` with exactly one plain string argument.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2068,3 +2068,70 @@ silently dropped a mid-statement-start family — caught by the classification
 diff, not by timing, so perf defenses take the SAME pre-gate; (2) the
 performance surface needs its own baseline pair in the pre-gate (wall time on
 a family-dense repo, A/B against the prior binary), now noted in the runbook.
+
+## CD. Adversarial co-evolution, series 4 — the AST classifier's first attack, evidence honesty, encoding
+
+Fourth runbook execution (#279), five fresh-subagent campaigns against the
+newest code (the AST declaration classifier from §CC, the all-members ignore
+fix) plus two never-attacked surfaces (the #223 difference-evidence contract;
+encoding/embedded-container robustness). The AST migration that ended four
+text-grammar waves took its own first attack — and leaked, but at the node
+level, not the line level.
+
+**S4-C1 (blind grammar-lawyer → the AST classifier).** Four reproduced
+violations, one root cause: `walk` marks a node `declaration` and **returns
+without recursing** the moment `is_declaration` matches the kind, so the two
+*call-shaped* whitelist entries (JS `const … = require()`, Ruby `require`)
+never inspect their non-wiring children. A destructuring default
+(`const { a = steal() } = require('lit')`), a computed key
+(`{ [exfil()]: x }`), and a Ruby block (`require('x') { launch }`) each smuggle
+a live call onto the import's line. The code-poison pass never saw them because
+the subtree was skipped. Defense: the JS binding `name` and the Ruby `block`
+field must execute nothing (`subtree_executes`, a bounded kind-walk for
+call/await/arrow/new/yield) — plain destructuring (`const { a, b } =
+require()`) stays inert wiring. Locked as no-rows.
+
+**S4-C2 (blind evidence-skeptic → the #223 difference contract).** Six packets;
+two were displayed-dishonesty bugs. `shared_lines` was a ≥60% **majority vote
+across up to 8 members** but shown against the representative pair, so a 6-line
+body could read `5 of 6 lines shared, 2 spots differ` (5+2=7) and three
+identical `buf.append(x)` lines deduped to `2 of 6`. Split into
+`SharedLines { rank_lines, display, params }`: the display count is now the
+representative pair's physical invariant-line count (partitions the pair's diff
+with `params`, no dedup), while the majority-voted `rank_lines` still drives
+`shared_weight` so the ranking keeps its outlier robustness. The other four
+(params from one pair = a documented lower bound; the `languages == 1` gate
+dropping a same-language extractable sub-pair in a mixed family; `removable` on
+a zero-shared structural match) are recorded as documented lower-bound
+behavior, not fixed.
+
+**S4-C3 (blind robustness-attacker → encoding/determinism).** Determinism held
+byte-identical across repeats and `RAYON_NUM_THREADS`; CRLF, multibyte
+identifiers, no-trailing-newline, long lines all green. One violation: a UTF-8
+**BOM** on any member of an import-only family flipped it from `declaration` to
+`default` (the BOM makes tree-sitter emit a line-1 error leaf that poisons the
+first declaration), in Python and Rust — while the IL-lowering path already
+tolerated it. Defense: strip a leading BOM in both `declaration_facts` and the
+prescreen.
+
+**S4-C4 (blind container-attacker → embedded `<script>`).** Five reproduced
+defects, all from text byte-scanning instead of parsing: `</script>` in a JS
+string literal truncates the block (miss); a commented-out `<script>` is
+analyzed live and the span swallows `</body></html>`; a Vue 3.3
+`generic="T extends Record<…>"` attribute `>` breaks tag-end detection;
+`end_line` over-claims onto the closing tag; an unclosed `<script>` is dropped.
+Deferred as #280 — grammar-driven boundary detection is frontend core work.
+
+**S4-C5 (informed coverage auditor).** 14 gaps; adopted Rust `extern crate`, Go
+`package`, and Ruby `require_relative` rows. The AST code-poison check (gap 6)
+and the languages all-members selector (gap 12) were already locked — the first
+by the migration routing every no-row through the AST engine, the second by
+sharing the `.all()` code path the partial-path test exercises.
+
+**Corpus price** (the pre-gate): **2,279 declaration families, same
+per-extension split as §CC, zero worthy reclassification** — the S4-C1
+tightening (call-shaped false declarations removed) and the S4-C3 loosening
+(BOM'd files now classify) net to no change on the pinned corpus, because
+neither shape is common there; the value of both fixes is in the field
+(destructured CommonJS requires; Windows-authored BOM files) and the unit
+battery, not the corpus count.


### PR DESCRIPTION
## What

Adversarial co-evolution **series 4** (ledger §CD, issue #279): five fresh-subagent campaigns against the newest code — the AST declaration classifier (§CC) and the all-members ignore fix — plus two never-attacked surfaces (the #223 difference-evidence contract; encoding/embedded robustness). The migration that ended four text-grammar waves took its own first attack and leaked at the node level.

## Violations fixed

- **S4-C1 — call-shaped declaration entries skipped their children.** `walk` marked a node `declaration` and returned before recursing, so JS `const { a = steal() } = require('lit')`, a computed key `{ [exfil()]: x }`, and Ruby `require('x') { launch }` smuggled live calls onto an import line (4 reproduced). Fix: the JS binding `name` and Ruby `block` must execute nothing (`subtree_executes`); plain destructuring stays inert wiring (green control locked).
- **S4-C2 — `N of M lines shared` was self-contradictory** (6 packets). `shared_lines` was a ≥60% majority vote across up to 8 members but displayed against the representative pair: a 6-line body read `5 of 6 shared, 2 spots differ` (5+2=7), and three identical `buf.append(x)` lines deduped to `2 of 6`. Split into `SharedLines { rank_lines, display, params }` — display is the rep pair's physical invariant count (partitions the diff with `params`), the majority set still drives `shared_weight`. The other four (params=lower bound from one pair, `languages==1` gate, removable on zero-shared) recorded as documented behavior.
- **S4-C3 — a UTF-8 BOM flipped an import-only family from `declaration` to `default`** (py + rust) because tree-sitter emits a line-1 error leaf; the IL-lowering path already tolerated it. Fix: strip the BOM in `declaration_facts` and the prescreen. Determinism, CRLF, multibyte, no-trailing-newline all green.

## Deferred / coverage

- **#280** — embedded `<script>` extraction is text byte-scanning, not parsing: `</script>` in a string literal truncates, commented-out `<script>` analyzed live, `generic="T extends X<Y>"` attribute breaks tag-end, end_line over-claims onto the close tag, unclosed `<script>` dropped (5 reproduced). Grammar-driven boundary detection is frontend core work.
- S4-C5 informed audit: adopted Rust `extern crate` / Go `package` / Ruby `require_relative` rows; AST code-poison and the languages all-members selector were already locked by the migration and the partial-path test's shared code path.

## Verification

- Unit battery (now 3 tests, all rows through the AST engine) + e2e 172 green.
- Pre-gate corpus re-price: 2,279 families, same split as series 3, zero worthy reclassification (S4-C1 tighten + S4-C3 loosen net neutral on the corpus).
- dup-gate 24/24; fast preflight green.

Closes #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
