### PR TITLE
Adversarial co-evolution series 5: the moat's first attack finds latent false merges (P0 #283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ break.
 
 ## [Unreleased]
 
+### Security
+- **Adversarial co-evolution series 5 found latent false merges in the soundness
+  core (P0 #283, experiments §CE)** — the cardinal sin (design §1). The
+  value-graph node-multiset fingerprint is blind to a commutative operator's
+  operand order, so `print(a)+print(b)` and `print(b)+print(a)` get one exact
+  fingerprint though their observable effect order differs (`nose verify`
+  confirms); optimistic `Number` inference makes `-(-a)≡a` / `a&a≡a` merge
+  untyped params; untyped `a+b≡b+a` is wrong for string/list concat; and the
+  verify interpreter is language-blind (Python `%` ≡ JS `%`), so the oracle
+  itself masks cross-language merges. All LATENT — `nose verify bench/repos`
+  stays green (the corpus lacks these shapes, the §AS scenario). Reproducers
+  checked in at `bench/coevo/false_merges/`. Fixes are moat work (value-graph
+  effect sinks, genuine-Num proofs, interpreter language-awareness) tracked in
+  #283; no behavior change shipped this entry.
+
 ### Fixed
 - **Adversarial co-evolution, series 4** (experiments §CD, issue #279) — the AST
   declaration classifier's first attack plus the difference-evidence and

--- a/bench/coevo/false_merges/README.md
+++ b/bench/coevo/false_merges/README.md
@@ -1,0 +1,20 @@
+# Confirmed false-merge reproducers (coevo series 5)
+
+Each `.py`/`.js`/… file holds two functions that `nose scan --mode semantic`
+reports as one `exact-value-graph` family but that compute different things.
+`nose verify <file> --max-violations 0` exits non-zero on the verify-confirmed
+ones — the offline soundness oracle catches them; they are LATENT (the pinned
+corpus does not contain the shapes, so `nose verify bench/repos` stays green —
+the §AS scenario design.md §1 cites as the reason adversarial batteries exist).
+
+These are the cardinal sin (design §1: equal fingerprint ⟹ equal behavior).
+Tracked as a P0 in issue #283. Do not delete until #283 closes with these
+moved into the permanent regression battery.
+
+| file | claim violated | verify-caught? |
+|---|---|---|
+| effect_commute.py | commutative `+` reorders observable effects | yes |
+| effect_acchain.py | AC-chain sorts effectful leaves | yes |
+| neg_involution.py | `-(-x)→x` on optimistically-Num param | yes (canon-preservation) |
+| untyped_add_commute.py | `a+b≡b+a` for untyped (string/list concat) | NO — oracle blind |
+| float_assoc.py | `(a+b)+c≡a+(b+c)` for floats | NO — oracle blind |

--- a/bench/coevo/false_merges/effect_acchain.py
+++ b/bench/coevo/false_merges/effect_acchain.py
@@ -1,0 +1,5 @@
+def chain_fwd(a, b, c):
+    return print(a) + print(b) + print(c)
+
+def chain_rev(a, b, c):
+    return print(c) + print(b) + print(a)

--- a/bench/coevo/false_merges/effect_commute.py
+++ b/bench/coevo/false_merges/effect_commute.py
@@ -1,0 +1,5 @@
+def emit_fwd(a, b):
+    return print(a) + print(b)
+
+def emit_rev(a, b):
+    return print(b) + print(a)

--- a/bench/coevo/false_merges/float_assoc.py
+++ b/bench/coevo/false_merges/float_assoc.py
@@ -1,0 +1,5 @@
+def assoc_l(a, b, c):
+    return (a + b) + c
+
+def assoc_r(a, b, c):
+    return a + (b + c)

--- a/bench/coevo/false_merges/neg_involution.py
+++ b/bench/coevo/false_merges/neg_involution.py
@@ -1,0 +1,5 @@
+def negneg(a):
+    return -(-a)
+
+def ident(a):
+    return a

--- a/bench/coevo/false_merges/untyped_add_commute.py
+++ b/bench/coevo/false_merges/untyped_add_commute.py
@@ -1,0 +1,5 @@
+def add_fwd(a, b):
+    return a + b
+
+def add_rev(a, b):
+    return b + a

--- a/bench/coevo/packets.v1.json
+++ b/bench/coevo/packets.v1.json
@@ -396,6 +396,78 @@
    "summary": "14 gaps; adopted rows for Rust extern crate, Go package clause, Ruby require_relative; AST code-poison (gap 6) and the languages all-members selector (gap 12) already locked by the migration + the partial-path test sharing the same .all() code path",
    "verdict": "violation-fixed",
    "defense": "coverage rows (this PR)"
+  },
+  {
+   "packet_id": "s5-c1-effectful-commute",
+   "series": 5,
+   "campaign": "S5-C1",
+   "persona": "soundness-skeptic",
+   "mode": "blind-executable",
+   "surface": "canonicalizer",
+   "claim": "equal fingerprint \u27f9 equal behavior",
+   "summary": "FALSE MERGE (cardinal sin): print(a)+print(b) \u2261 print(b)+print(a), AC chains, *, ^ \u2014 verify-confirmed; node-multiset fingerprint blind to operand order of a commutative op, effectful calls in value position not emitted as ordered effect sinks",
+   "verdict": "deferred-issue",
+   "defense": "#283 P0 (value-graph effect model)"
+  },
+  {
+   "packet_id": "s5-c1-optimistic-num",
+   "series": 5,
+   "campaign": "S5-C1",
+   "persona": "soundness-skeptic",
+   "mode": "blind-executable",
+   "surface": "canonicalizer",
+   "claim": "type-gated rewrites are sound because the type is PROVEN",
+   "summary": "FALSE MERGE: -(-a)\u2261a, a&a\u2261a, a|a\u2261a \u2014 value domain infers Number from the op itself, so the gate passes for untyped params; differs on list input; verify canon-preservation violation",
+   "verdict": "deferred-issue",
+   "defense": "#283 P0 (genuine vs optimistic Num proof)"
+  },
+  {
+   "packet_id": "s5-c2-untyped-add-commute",
+   "series": 5,
+   "campaign": "S5-C2",
+   "persona": "gate-skeptic",
+   "mode": "blind-executable",
+   "surface": "exact-channel-gates",
+   "claim": "missing type evidence blocks exact acceptance",
+   "summary": "FALSE MERGE (oracle-blind): a+b\u2261b+a and (a+b)+c\u2261a+(b+c) for untyped params admitted to exact channel + commuted/associated; wrong for strings/floats; verify can't witness (battery never feeds 2 distinct strings, models i64)",
+   "verdict": "deferred-issue",
+   "defense": "#283 P0 (require proven-numeric)"
+  },
+  {
+   "packet_id": "s5-c3-interp-language-blind",
+   "series": 5,
+   "campaign": "S5-C3",
+   "persona": "oracle-skeptic",
+   "mode": "blind-executable",
+   "surface": "oracle",
+   "claim": "verify declares behavior-equal only when truly equal",
+   "summary": "the soundness net has holes: py % (floored) \u2261 js % (truncated), py / \u2261 ruby / , js (x|0)+1 \u2261 x+1; interp maps every Op to one Rust i64 op; index-store mutation dropped+faked as effect. Masks cross-language false merges",
+   "verdict": "deferred-issue",
+   "defense": "#283 P0 (interpreter language-awareness)"
+  },
+  {
+   "packet_id": "s5-c4-recall-misses",
+   "series": 5,
+   "campaign": "S5-C4",
+   "persona": "convergence-skeptic",
+   "mode": "blind-executable",
+   "surface": "canonicalizer",
+   "claim": "behaviorally-equal forms converge",
+   "summary": "4 oracle-confirmed recall misses: abs(abs x)\u2261abs x and ~(a&b)\u2261~a|~b (both fully sound, no gate needed \u2014 worth adding); max(max(a,b),c)\u2261max(a,max(b,c)) (compositional: MIN/MAX in is_commutative but not is_assoc_comm_code \u2014 clean e-graph-ledger trigger); x+x\u2261x*2 (documented \u00a7BA gap)",
+   "verdict": "recorded-low-prevalence",
+   "defense": "#284 (sound recall rules: abs-idem, bitwise-DeMorgan, min/max AC)"
+  },
+  {
+   "packet_id": "s5-c5-coverage",
+   "series": 5,
+   "campaign": "S5-C5",
+   "persona": "coverage-auditor",
+   "mode": "informed",
+   "surface": "canonicalizer",
+   "claim": "canon rules are proven or tested",
+   "summary": "15 gaps: byte-pack u16/u32 + low-bit-toggle have NO Lean proof (positive-only tests); many type-gated rules (abs, minmax, idempotence, negation-distrib) have positive tests but NO hard-negative proving the gate holds \u2014 the AC-chain hard-negative gap is highest risk and overlaps the #283 cardinal-sin cluster",
+   "verdict": "recorded-low-prevalence",
+   "defense": "#283 hard-negative + Lean backlog"
   }
  ]
 }

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2135,3 +2135,62 @@ tightening (call-shaped false declarations removed) and the S4-C3 loosening
 neither shape is common there; the value of both fixes is in the field
 (destructured CommonJS requires; Windows-authored BOM files) and the unit
 battery, not the corpus count.
+
+## CE. Adversarial co-evolution, series 5 — the moat's first attack finds the cardinal sin
+
+Fifth runbook execution (#282), the first against the soundness CORE
+(canonicalizer, exact-channel gate, oracle). It paid out the highest-value
+result the project can produce: **confirmed false merges** — the cardinal sin
+(design §1). All are LATENT: `nose verify bench/repos` stays green because the
+pinned corpus lacks these shapes, exactly the §AS scenario design.md cites as
+the whole reason adversarial batteries exist. Reproducers checked in at
+`bench/coevo/false_merges/`; tracked P0 #283.
+
+**S5-C1 (blind soundness-skeptic → canonicalizer).** Two false-merge families,
+both verify-confirmed (the offline oracle's `--max-violations 0` gate fires):
+(a) **effectful operands of a commutative/AC op** — `print(a)+print(b)` ≡
+`print(b)+print(a)` (and AC chains, `*`, `^`); (b) **optimistic-Number
+rewrites** — `-(-a)`≡`a`, `a&a`≡`a`, `a|a`≡`a` because the value domain infers
+`Number` for a bare param *from the operation applied to it*, so the
+"type-PROVEN" gate passes untyped. Root-causing (a) corrected a wrong first fix:
+the merge is NOT via operand reordering in the canonicalizer (disabling the
+reorder swap leaves them merged) — the exact-channel **node-multiset
+fingerprint is inherently blind to a commutative op's operand order**, and
+effectful calls in value position never emit ordered effect sinks. The fix is
+the value-graph effect model, not a reorder guard — a speculative reorder-guard
+patch was written, shown not to fix it, and reverted.
+
+**S5-C2 (blind gate-skeptic → exact gate).** `a+b`≡`b+a` and `(a+b)+c`≡
+`a+(b+c)` for untyped params: `+` commutativity/associativity treats Unknown
+operands as numeric optimistically; wrong for strings (`"x"+"y"`) and floats
+(`1e100`-cancellation). The detector merges; the verify oracle is BLIND
+(below), so these evade the hard gate.
+
+**S5-C3 (blind oracle-skeptic → `nose verify`).** The safety net itself has
+holes: the interpreter maps every `Op` to one Rust `i64` operation, so Python
+`%` (floored) ≡ JS `%` (truncated), Python `/` (true) ≡ Ruby `/` (floored),
+JS `(x|0)+1` ≡ `x+1` (no int32 narrowing) — it declares non-equivalent
+cross-language units behavior-equal, masking the very class of merge it exists
+to catch. Index-store mutation is dropped and faked as a generic effect instead
+of bailing. This is why S5-C2 evades detection and must be fixed first.
+
+**S5-C4 (blind convergence-skeptic → recall).** Four oracle-confirmed
+behaviorally-equal misses: `abs(abs x)`≡`abs x` and `~(a&b)`≡`~a|~b` (both
+fully sound to add, #284); `max(max(a,b),c)`≡`max(a,max(b,c))` (compositional —
+MIN/MAX are commutative but not AC-flatten-eligible in `ops.rs`; the cleanest
+e-graph-revisit trigger); `x+x`≡`x*2` (the documented §BA gap).
+
+**S5-C5 (informed coverage auditor).** 15 gaps; the byte-pack (u16/u32) and
+low-bit-toggle rules have NO Lean proof (positive tests only), and many
+type-gated rules have positive tests but no hard-negative proving the gate
+holds — the AC-chain hard-negative gap is highest-risk and overlaps the #283
+cluster.
+
+**Verdict.** Series 5 is the validation of the entire adversarial paradigm: the
+moat read clean on 105 repos while five distinct latent false merges (and a
+holed oracle) sat in the core — found only by white-box crafting (§AS, exactly).
+No same-session code fix shipped: every fix is moat work requiring a Lean
+obligation and dev/heldout corpus pricing (defense-deferral is a first-class
+verdict, and a rushed soundness patch that misidentifies the mechanism — as the
+first reorder-guard attempt did — is worse than an honest P0). The deliverables
+are the confirmed-reproducer battery, P0 #283, recall #284, and this ledger.


### PR DESCRIPTION
## What

Adversarial co-evolution **series 5** (ledger §CE, issue #282) — the first attack on the soundness CORE (canonicalizer, exact-channel gate, oracle). It produced the highest-value result the project can yield: **confirmed latent false merges** — the cardinal sin (design §1).

This PR ships **no code fix** (honest by design — see below). It lands the confirmed-reproducer battery, the ledger, and the docs; the fixes are tracked as P0 #283.

## The findings (all reproducers in `bench/coevo/false_merges/`)

- **A — effectful commutative operands** (verify-confirmed): `print(a)+print(b)` ≡ `print(b)+print(a)` (and AC chains, `*`, `^`). The node-multiset fingerprint is blind to a commutative op's operand order; effectful calls in value position emit no ordered effect sink, so observable order is lost from the fingerprint while `nose verify` preserves it (gate fires).
- **B — optimistic Number inference** (verify-confirmed): `-(-a)≡a`, `a&a≡a`, `a|a≡a` — the value domain infers `Number` for a bare param *from the operation itself*, so the "type-PROVEN" gate passes untyped; differs on list input.
- **C — untyped `+` commutativity/associativity** (oracle-blind): `a+b≡b+a`, `(a+b)+c≡a+(b+c)` — wrong for strings/floats; the verify battery structurally can't witness it.
- **D — the verify interpreter is language-blind**: Python `%` ≡ JS `%`, Python `/` ≡ Ruby `/`, JS `(x|0)+1 ≡ x+1` — the soundness net itself masks cross-language merges (must be fixed before C can be measured).
- Recall (#284): `abs(abs x)`, bitwise De Morgan, min/max AC-flatten — sound to add.

All LATENT: `nose verify bench/repos` stays green (the corpus lacks these shapes — the §AS scenario design.md §1 cites as the reason adversarial batteries exist). This series validates the entire paradigm: the moat read clean on 105 repos while five distinct latent false merges sat in the core, found only by white-box crafting.

## Why no code fix

I wrote a speculative reorder-guard in the canonicalizer, **proved by reproduction it does not fix A** (disabling the operand swap leaves them merged — the merge is in the multiset fingerprint, not the reorder), and reverted it. Every real fix (value-graph effect sinks, genuine-vs-optimistic Num proofs, interpreter language-awareness) is moat work needing a Lean obligation + dev/heldout corpus pricing. Per the runbook, defense-deferral with a confirmed reproducer is a first-class verdict, and a rushed soundness patch that misidentifies the mechanism is worse than an honest P0.

## Verification

- Baseline restored (speculative change reverted); `nose verify bench/repos/click` green; crafted cases reproduce.
- No `crates/` change → dup-gate 24/24, fast preflight green, awiki 42-doc connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
