### PR TITLE
Soundness #283-A: effect-free-reorder guard stops the effectful commutative false merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ break.
 
 ## [Unreleased]
 
+### Fixed
+- **Soundness: effectful operands of a commutative operator no longer false-merge**
+  (#283 sub-finding A, experiments §CE). The value-graph canonicalizer sorted a
+  commutative/AC operator's operands by structural hash, so `print(a) + print(b)`
+  converged with `print(b) + print(a)` though their observable effect order
+  differs (a false merge `nose verify` confirms). It now sorts only when every
+  operand is effect-free (no call/HOF/lambda/loop/opaque node in the subtree);
+  effect-free numeric operands still converge (`a+b+1 ≡ 1+b+a`). The remaining
+  #283 sub-findings (optimistic-Number rewrites, untyped `+` commutativity, the
+  language-blind verify interpreter) are root-caused in the issue and remain open.
+
 ### Security
 - **Adversarial co-evolution series 5 found latent false merges in the soundness
   core (P0 #283, experiments §CE)** — the cardinal sin (design §1). The

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -6829,3 +6829,34 @@ fn symbolic_condition_paths_fail_closed_past_the_cap() {
         "the bail is reported as a path-cap bail for the census"
     );
 }
+
+#[test]
+fn effectful_commutative_operands_do_not_reorder() {
+    // coevo §CE / #283-A: `print(a) + print(b)` commutes by VALUE but the
+    // interpreter observes effect order, so reordering it to `print(b) + print(a)`
+    // is a false merge. Effect-bearing operands must hold their position; only
+    // effect-free numeric operands reorder.
+    let i = Interner::new();
+    let fwd = "def f(a, b):\n    return print(a) + print(b)\n";
+    let rev = "def g(a, b):\n    return print(b) + print(a)\n";
+    assert_ne!(
+        value_fp(&i, fwd, Lang::Python),
+        value_fp(&i, rev, Lang::Python),
+        "effectful commutative operands must not reorder into one fingerprint"
+    );
+    let chain_fwd = "def f(a, b, c):\n    return print(a) + print(b) + print(c)\n";
+    let chain_rev = "def g(a, b, c):\n    return print(c) + print(b) + print(a)\n";
+    assert_ne!(
+        value_fp(&i, chain_fwd, Lang::Python),
+        value_fp(&i, chain_rev, Lang::Python),
+        "effectful AC chains must not sort into one fingerprint"
+    );
+    // Effect-FREE numeric operands still converge (the common case is unaffected).
+    let pure_fwd = "def f(a, b):\n    return a + b + 1\n";
+    let pure_rev = "def g(a, b):\n    return 1 + b + a\n";
+    assert_eq!(
+        value_fp(&i, pure_fwd, Lang::Python),
+        value_fp(&i, pure_rev, Lang::Python),
+        "effect-free numeric commutative operands must still converge"
+    );
+}

--- a/crates/nose-normalize/src/value_graph/canonicalize.rs
+++ b/crates/nose-normalize/src/value_graph/canonicalize.rs
@@ -70,11 +70,37 @@ impl<'a> Builder<'a> {
             if is_commutative(o)
                 && args.len() == 2
                 && !concat
+                && self.reorder_safe(args[0])
+                && self.reorder_safe(args[1])
                 && self.vhash[args[0] as usize] > self.vhash[args[1] as usize]
             {
                 args.swap(0, 1);
             }
         }
+    }
+
+    /// Effect-free ⇒ safe to reorder past a sibling operand. A subtree with a
+    /// call/HOF/lambda/opaque node can carry an observable effect whose order the
+    /// interpreter tracks, so it is held in place (coevo §CE / §AS).
+    pub(super) fn reorder_safe(&self, v: ValueId) -> bool {
+        let mut seen = FxHashSet::default();
+        let mut stack = vec![v];
+        while let Some(n) = stack.pop() {
+            if !seen.insert(n) {
+                continue;
+            }
+            match self.nodes[n as usize].op {
+                ValOp::Call(_)
+                | ValOp::Hof(_)
+                | ValOp::Lambda(_)
+                | ValOp::Loop(_)
+                | ValOp::Recurrence(_)
+                | ValOp::Opaque(_) => return false,
+                _ => {}
+            }
+            stack.extend(self.nodes[n as usize].args.iter().copied());
+        }
+        true
     }
 
     fn u16_byte_pack(&mut self, op: &ValOp, args: &[ValueId]) -> Option<ValueId> {
@@ -306,7 +332,7 @@ impl<'a> Builder<'a> {
                 for &a in args {
                     self.flatten_into(a, o, &mut leaves);
                 }
-                if leaves.len() > 2 {
+                if leaves.len() > 2 && leaves.iter().all(|&v| self.reorder_safe(v)) {
                     leaves.sort_unstable_by_key(|&v| self.vhash[v as usize]);
                     return Some(self.intern_ac_chain(o, &leaves));
                 }

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -254,9 +254,14 @@ impl<'a> Builder<'a> {
         let mut operands = Vec::new();
         self.flatten_into(a, Op::Add as u32, &mut operands);
         self.flatten_into(neg_b, Op::Add as u32, &mut operands);
-        // Sort unless an operand is proven concat (string/list); otherwise the
-        // operands Err in the oracle regardless of order, so sorting is safe.
-        if self.add_values_not_concat(ValueLaw::AddAssociativity, &operands) {
+        // Sort unless an operand is proven concat (string/list), OR carries an
+        // observable effect — `f() - g()` reordered to `g() - f()` keeps the
+        // value but swaps the effect trace, a false merge the interpreter
+        // catches (coevo §CE / §AS). Effect-free numeric operands Err in the
+        // oracle regardless of order, so sorting them is safe.
+        if self.add_values_not_concat(ValueLaw::AddAssociativity, &operands)
+            && operands.iter().all(|&v| self.reorder_safe(v))
+        {
             operands.sort_by_key(|&v| self.vhash[v as usize]);
         }
         let mut acc = operands[0];
@@ -293,8 +298,9 @@ impl<'a> Builder<'a> {
             if let Some(v) = self.c_u32_be_byte_pack_pattern(&operands) {
                 return v;
             }
-            let do_sort = op != Op::Add as u32
-                || self.add_values_not_concat(ValueLaw::AddAssociativity, &operands);
+            let do_sort = (op != Op::Add as u32
+                || self.add_values_not_concat(ValueLaw::AddAssociativity, &operands))
+                && operands.iter().all(|&v| self.reorder_safe(v));
             if do_sort {
                 operands.sort_by_key(|&v| self.vhash[v as usize]);
             }
@@ -309,8 +315,9 @@ impl<'a> Builder<'a> {
         if let Some(v) = self.c_u32_be_byte_pack_pattern(&operands) {
             return v;
         }
-        let do_sort = op != Op::Add as u32
-            || self.add_values_not_concat(ValueLaw::AddAssociativity, &operands);
+        let do_sort = (op != Op::Add as u32
+            || self.add_values_not_concat(ValueLaw::AddAssociativity, &operands))
+            && operands.iter().all(|&v| self.reorder_safe(v));
         if do_sort {
             operands.sort_by_key(|&v| self.vhash[v as usize]);
         }

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -142,3 +142,15 @@ extractable duplication, and merging the two would conflate unrelated responsibi
 of the recognizer logic was introduced — the new recognizer mirrors the value graph's existing
 admission check rather than re-implementing it. The gate budget is therefore re-baselined to 23
 while continuing to ratchet against new avoidable duplication.
+
+## Budget 24 → 25 and the effect-free-reorder soundness guard
+
+The #283-A fix (coevo §CE) stops the value-graph canonicalizer from sorting the operands of a
+commutative/AC operator when any operand carries an observable effect — `print(a) + print(b)` must
+not converge with `print(b) + print(a)`. Holding effectful operands in source order shifts a few of
+nose's own value-graph fingerprints, which nudges one **pre-existing** large-span dispatch
+near-family — `interp.rs` ↔ `value_graph/eval.rs` ↔ `value_graph/control.rs`, sharing ~12 of ~1082
+lines — past the substantial (value ≥ 40) line. That is a spurious whole-function-span match (three
+big match-dispatch bodies that share a sliver of control shape), not extractable duplication and not
+new code. The gate budget is re-baselined to 25 while continuing to ratchet against new avoidable
+duplication.

--- a/scripts/check-duplication.sh
+++ b/scripts/check-duplication.sh
@@ -40,7 +40,11 @@ MIN_VALUE=40   # ignore small/incidental similarity; gate only on substantial fa
 # stores, loop-effect keying) made one PRE-EXISTING cross-crate near-family visible —
 # the assignment-name counting loops in value_graph/context.rs::seed_module_value_bindings
 # and module_imports.rs::collect_statement_exports (small, cross-crate; reviewed, kept).
-BUDGET=24      # accepted substantial families today (see docs/dogfooding.md)
+# Re-baselined 24 -> 25 in the #283-A fix: the effect-free-reorder guard shifts a few
+# self-source value-graph fingerprints, nudging one PRE-EXISTING large-span dispatch
+# near-family (interp.rs / value_graph/eval.rs / control.rs, sharing ~12 of ~1082 lines)
+# past the value >= 40 line — a spurious whole-function span, not new duplication.
+BUDGET=25      # accepted substantial families today (see docs/dogfooding.md)
 BIN="${NOSE_BIN:-./target/release/nose}"
 GATE_ARGS=(scan crates --exclude tests --mode near --min-value "$MIN_VALUE")
 


### PR DESCRIPTION
## What

Fixes **sub-finding A** of the P0 soundness issue #283 — the headline cardinal sin from coevo series 5: effectful operands of a commutative/AC operator false-merge.

`print(a) + print(b)` and `print(b) + print(a)` got one `exact-value-graph` fingerprint (verify-confirmed false merge — they differ on a=3,b=0: effect trace [3,0] vs [0,3]). The merge is not from `order_bin_operands` (a first guess, disproven by reproduction — disabling its swap left them merged); the real sort site is `eval_assoc_comm_chain` / `eval_sub_chain` in `value_graph/eval.rs`, which sort commutative operands by structural hash before `mk`.

## Fix

Sort commutative/AC operands only when **every operand is effect-free** — `reorder_safe`: no `Call`/`Hof`/`Lambda`/`Loop`/`Recurrence`/`Opaque` node anywhere in the subtree (a bounded DAG walk). Applied at all three sort sites in `eval.rs`, with defense-in-depth guards on `order_bin_operands` and `ac_chain_canon` in `canonicalize.rs`. Effect-free numeric operands reorder exactly as before — the common case is untouched.

## Verification

- `print(a)+print(b)` ≢ `print(b)+print(a)`, AC chains likewise (was: merged). Effect-free `a+b+1 ≡ 1+b+a` still converges. New regression test in `equivalence.rs`; full equivalence suite (246) + e2e (172) green.
- Corpus false-merge count unchanged on sampled repos; pre-existing canon-preservation advisories on redis/sympy are identical to `main` (local-corpus drift, not introduced here).
- dup-gate re-baselined **24 → 25**: the fingerprint shift nudges one pre-existing large-span dispatch near-family (interp/eval/control, ~12 of ~1082 lines) past value≥40 — a spurious whole-function span, not new duplication (justified in `check-duplication.sh` + `docs/dogfooding.md`).

## Scope

Partially addresses #283 — sub-finding A only. B (optimistic-Number rewrites), C (untyped `+` commutativity), float associativity, and D (language-blind verify interpreter) are precisely root-caused in the issue and remain open; D is the keystone (oracle-only, no recall cost) that would make B/C corpus-catchable, so it should land before C/float are corpus-priced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
