### PR TITLE
Fix #275: --cache-dir reproduces cross-file imported-literal resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ break.
 ## [Unreleased]
 
 ### Fixed
+- **`--cache-dir` now reproduces cross-file imported-literal convergence** (#275).
+  The cache keyed each file's units on its source bytes and lowered files
+  independently, skipping the corpus-level `resolve_imported_immutable_bindings`
+  pass — so a cached scan under-merged an `imported LOOKUP.get(k)` with an inline
+  `{…}.get(k)` that the non-cached scan converges. The cached path now lowers and
+  resolves the whole corpus every run (the smaller half of the work, §BQ) and
+  caches only the dominant normalize+extract step, keyed on an interner-independent
+  value-retaining hash of each file's **post-resolve** IL. Cached output is now
+  byte-identical to non-cached (incl. imported-literal families); editing a
+  provider's literal invalidates dependents' entries; warm-cache speedup is
+  retained (~2.2× on sympy). Cache schema bumped v7 → v8.
 - **Soundness: effectful operands of a commutative operator no longer false-merge**
   (#283 sub-finding A, experiments §CE). The value-graph canonicalizer sorted a
   commutative/AC operator's operands by structural hash, so `print(a) + print(b)`

--- a/crates/nose-cli/src/cache.rs
+++ b/crates/nose-cli/src/cache.rs
@@ -1,73 +1,61 @@
-//! Optional on-disk cache of per-file detection units, keyed by source-content
-//! hash. Re-running nose on a project where most files are unchanged then skips
-//! the dominant cost (parse + lower + normalize + extract) for those files and
+//! Optional on-disk cache of per-file detection units, keyed by the **resolved
+//! IL** content hash. Re-running nose on a project where most files are unchanged
+//! then skips the dominant cost (normalize + extract) for those files and
 //! deserializes their units instead.
 //!
-//! Soundness rests on one property: a [`UnitFeat`]'s features are all
-//! content-derived hashes (interner-independent), so a file's units depend only on
-//! its bytes, its language, and the unit-affecting options — never on the rest of
-//! the corpus. Each file is therefore lowered with a throwaway interner and cached
-//! independently. The cache key folds in a schema version and an options signature,
-//! so a format or option change transparently misses (never returns stale units).
+//! The corpus is lowered AND cross-file-resolved every run
+//! (`lower_corpus_filtered` — parse + lower + `resolve_imported_immutable_bindings`,
+//! the smaller half of the work per experiments §BQ); only the dominant
+//! normalize+extract step is cached. The key is a content hash of each file's
+//! *post-resolve* IL, so a file whose imported-immutable-literal context changed
+//! (its provider edited) gets a different key and recomputes — fixing #275, where
+//! the old source-content key skipped resolution entirely and the cached scan
+//! under-merged cross-file imported-literal convergence. A [`UnitFeat`]'s features
+//! are interner-independent content hashes, so a hit needs no interner; the key
+//! folds in a schema version and an options signature so a format/option change
+//! transparently misses.
 
 use nose_detect::{DetectOptions, Stream, UnitFeat};
-use nose_il::{FileId, Interner, Lang};
+use nose_il::{Corpus, Interner};
 use rayon::prelude::*;
 use std::path::Path;
 
 /// Bump when the cached payload's layout, extraction, or feature hashing changes — old
-/// cache entries then live under a different directory and are ignored. (v7: cached
-/// units include pack-facing value-law provenance.)
-const SCHEMA: u32 = 7;
+/// cache entries then live under a different directory and are ignored. (v8: keyed by
+/// the post-resolve IL hash, not the source-content hash — fixes #275.)
+const SCHEMA: u32 = 8;
 
 pub(crate) struct CachedUnits {
     pub units: Vec<UnitFeat>,
     pub streams: Vec<Stream>,
     pub files: usize,
-    pub langs: Vec<(&'static str, usize)>,
 }
 
-/// Build detection units **and contiguous-channel streams** for every source file under
-/// `roots`, using the on-disk cache at `dir`.
-/// Falls back to recomputation for any file that misses (or whose entry fails to
-/// read/parse), writing it back. Both the units and the stream are content-derived
-/// (interner-independent), so a file's entry depends only on its bytes/language/options.
-pub(crate) fn build_units_cached(
-    roots: &[&Path],
-    exclude: &[String],
-    opts: &DetectOptions,
-    dir: &Path,
-) -> CachedUnits {
+/// Build detection units **and contiguous-channel streams** for every file in an
+/// already lowered+resolved `corpus`, using the on-disk cache at `dir`. The
+/// corpus is lowered and cross-file-resolved by the caller (`lower_corpus_filtered`),
+/// so each file's IL already carries its imported-immutable-literal inlining; the
+/// cache keys on that *post-resolve* IL (fixing #275) and only the dominant
+/// normalize+extract step is cached. A cache hit needs no interner (features are
+/// content-derived); a miss recomputes and writes back.
+pub(crate) fn build_units_cached(corpus: &Corpus, opts: &DetectOptions, dir: &Path) -> CachedUnits {
     // One bucket per (schema, options signature): changing an option that affects
     // units lands in a fresh bucket, so stale entries are never read.
     let bucket = dir.join(format!("v{SCHEMA}-{:016x}", options_signature(opts)));
     let _ = std::fs::create_dir_all(&bucket);
 
-    // Discover + sort (same deterministic order the non-cached path uses).
-    let mut paths: Vec<(String, Lang)> = roots
-        .iter()
-        .flat_map(|r| nose_frontend::discover_paths(r, exclude))
-        .collect();
-    paths.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-    let mut counts: std::collections::HashMap<&'static str, usize> =
-        std::collections::HashMap::new();
-    for (_, lang) in &paths {
-        *counts.entry(lang.name()).or_insert(0) += 1;
-    }
-    let mut langs: Vec<(&'static str, usize)> = counts.into_iter().collect();
-    langs.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
-
-    let per_file: Vec<(Vec<UnitFeat>, Option<Stream>)> = paths
+    let per_file: Vec<(Vec<UnitFeat>, Stream)> = corpus
+        .files
         .par_iter()
-        .map(|(path, lang)| {
-            let src = match std::fs::read(path) {
-                Ok(s) => s,
-                Err(_) => return (Vec::new(), None),
-            };
-            let entry = bucket.join(format!("{:016x}.json", content_hash(*lang, &src)));
+        .map(|il| {
+            let path = il.meta.path.clone();
+            // Key on the post-resolve IL content hash — a stable, interner-
+            // independent fold of every node's structural hash. Two files with
+            // the same resolved IL (incl. identical imported-literal context)
+            // share the entry; a provider edit changes a dependent's key.
+            let key = resolved_il_hash(il, &corpus.interner);
+            let entry = bucket.join(format!("{key:016x}.json"));
 
-            // Hit: load and retarget the path (identical content at another path
-            // shares the entry; only `path` differs between them).
             if let Ok(bytes) = std::fs::read(&entry) {
                 if let Ok((mut units, mut stream)) =
                     serde_json::from_slice::<(Vec<UnitFeat>, Stream)>(&bytes)
@@ -76,55 +64,49 @@ pub(crate) fn build_units_cached(
                         u.path = path.clone();
                     }
                     stream.set_path(path.clone());
-                    return (units, Some(stream));
+                    return (units, stream);
                 }
             }
 
-            // Miss: lower with a throwaway interner (features are portable), build the
-            // units and the contiguous stream from that one IL, and write both back.
-            let interner = Interner::new();
-            let il = match nose_frontend::lower_source(FileId(0), path, &src, *lang, &interner) {
-                Ok(il) => il,
-                Err(_) => return (Vec::new(), None),
-            };
-            let units = nose_detect::units_of_file(&il, &interner, opts);
-            let stream = nose_detect::file_stream(&il, &interner);
+            let units = nose_detect::units_of_file(il, &corpus.interner, opts);
+            let stream = nose_detect::file_stream(il, &corpus.interner);
             if let Ok(bytes) = serde_json::to_vec(&(&units, &stream)) {
                 let _ = std::fs::write(&entry, bytes);
             }
-            (units, Some(stream))
+            (units, stream)
         })
         .collect();
 
-    // Count only files that actually read + lowered (a `Some` stream), so the reported
-    // count matches the non-cached path, which `filter_map`s read/parse failures away.
-    let files = per_file.iter().filter(|(_, s)| s.is_some()).count();
+    let files = per_file.len();
     let mut all_units = Vec::new();
     let mut all_streams = Vec::new();
     for (u, s) in per_file {
         all_units.extend(u);
-        if let Some(s) = s {
-            all_streams.push(s);
-        }
+        all_streams.push(s);
     }
     CachedUnits {
         units: all_units,
         streams: all_streams,
         files,
-        langs,
     }
 }
 
-/// 64-bit FNV-1a over the language tag and source bytes. Collisions are
-/// astronomically unlikely at corpus scale; a clash would at worst reuse one file's
-/// units for another (never a crash), so 64 bits is ample for a cache.
-fn content_hash(lang: Lang, src: &[u8]) -> u64 {
+/// Content hash of a file's *post-resolve* IL — the cache key. Uses
+/// `valued_tree_hash`: an interner-INDEPENDENT fold that retains literal values.
+/// Interner-independence is essential because the corpus shares one interner whose
+/// symbol ids depend on parallel interning order — serializing the raw IL (with
+/// those ids) gave a key that varied run-to-run and never warm-hit. Value-retention
+/// is essential because the structural `subtree_hashes` erases literal values, so a
+/// resolved `LOOKUP = {…: 1}` vs `{…: 9}` would collide — the very post-resolve
+/// distinction #275 turns on. The language and resolution evidence count
+/// (resolution always rewrites the inlined literal into the nodes, which the valued
+/// hash captures; the evidence count guards the rare evidence-only delta) complete
+/// the key.
+fn resolved_il_hash(il: &nose_il::Il, interner: &Interner) -> u64 {
     let mut h = crate::fnv::OFFSET_BASIS;
-    h = crate::fnv::mix(h, lang as u8 as u64);
-    for &b in src {
-        h = crate::fnv::mix(h, b as u64);
-    }
-    h
+    h = crate::fnv::mix(h, il.meta.lang as u8 as u64);
+    h = crate::fnv::mix(h, il.evidence.len() as u64);
+    crate::fnv::mix(h, nose_normalize::valued_tree_hash(il, interner))
 }
 
 /// Fold every unit-affecting option into one value; changing any of them changes
@@ -152,11 +134,11 @@ mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
 
-    /// `files` must count only files that were actually read+lowered — matching the
-    /// non-cached path (which `filter_map`s read/parse failures away). A discovered but
-    /// unreadable file used to inflate the count.
+    /// `files` counts the lowered corpus the caller hands in — which already
+    /// excludes unreadable/parse-failed files (`lower_corpus_filtered` filter_maps
+    /// them). So a corpus where one file failed to read yields `files == 1`.
     #[test]
-    fn file_count_excludes_unreadable_files() {
+    fn file_count_matches_lowered_corpus() {
         let dir = std::env::temp_dir().join(format!("nose_cache_count_{}", std::process::id()));
         let cache = std::env::temp_dir().join(format!("nose_cache_dir_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
@@ -166,20 +148,18 @@ mod tests {
         std::fs::write(dir.join("ok.py"), "def f():\n    return 1\n").unwrap();
         let bad = dir.join("bad.py");
         std::fs::write(&bad, "def g():\n    return 2\n").unwrap();
-        // Make `bad.py` unreadable so `std::fs::read` fails (skips root, where this is moot).
         std::fs::set_permissions(&bad, std::fs::Permissions::from_mode(0o000)).unwrap();
 
         let readable = std::fs::read(&bad).is_ok();
-        let out = build_units_cached(&[dir.as_path()], &[], &DetectOptions::default(), &cache);
+        let corpus = nose_frontend::lower_corpus_filtered(&[dir.as_path()], &[]);
+        let out = build_units_cached(&corpus, &DetectOptions::default(), &cache);
 
-        // Restore perms so cleanup can proceed.
         let _ = std::fs::set_permissions(&bad, std::fs::Permissions::from_mode(0o644));
         let _ = std::fs::remove_dir_all(&dir);
         let _ = std::fs::remove_dir_all(&cache);
 
         if readable {
-            // Running as root (CI sometimes) — the unreadable file is still readable, so
-            // the discrepancy can't be exercised; don't assert.
+            // Running as root (CI sometimes) — the unreadable file is still readable.
             return;
         }
         assert_eq!(out.files, 1, "only the readable file should be counted");

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3618,19 +3618,21 @@ fn scan_report(
     detector: &dyn nose_detect::Detector,
 ) -> (nose_detect::Report, ScanScope) {
     if let Some(dir) = &args.cache_dir {
+        // Lower AND cross-file-resolve the corpus every run (the smaller half of
+        // the work, §BQ), then cache only the dominant normalize+extract step
+        // keyed on the post-resolve IL. This makes the cached scan identical to
+        // the non-cached path including imported-immutable-literal convergence
+        // (#275), which the old per-file source-content cache skipped.
+        let corpus = time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude));
+        warn_if_empty(&corpus, &args.paths);
+        let scope = ScanScope::from_corpus(&corpus);
         let cache::CachedUnits {
             units,
             streams,
             files,
-            langs,
-        } = time_lower(|| cache::build_units_cached(refs, exclude, opts, dir));
-        if files == 0 {
-            warn_no_files(&args.paths);
-        }
-        // The cache path supplies both cached unit features and syntax streams, so every
-        // selected scan channel behaves the same as the non-cached path.
+        } = cache::build_units_cached(&corpus, opts, dir);
         let report = nose_detect::detect_from_units(units, files, &streams, opts, detector).0;
-        (report, ScanScope { files, langs })
+        (report, scope)
     } else {
         let corpus = time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude));
         warn_if_empty(&corpus, &args.paths);

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -321,6 +321,79 @@ fn cache_output_matches_uncached_cold_and_warm() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// #275: the cached path must reproduce cross-file imported-immutable-literal
+/// convergence. An inline `{…}.get(k)` and an `imported LOOKUP.get(k)` resolving
+/// to the same literal form one family; the old source-content cache key skipped
+/// the corpus resolve pass and under-merged. Editing the provider's literal must
+/// also bust the importer's cached entry.
+#[test]
+fn cache_reproduces_cross_file_imported_literal_resolution() {
+    let dir = std::env::temp_dir().join(format!("nose_c275_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("a")).unwrap();
+    fs::create_dir_all(dir.join("b")).unwrap();
+    fs::write(
+        dir.join("a/local.py"),
+        "def lookup(key, other):\n    return {\"red\": 1, \"blue\": 2}.get(key, 0)\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("tables.py"),
+        "LOOKUP = {\"red\": 1, \"blue\": 2}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("b/imported.py"),
+        "from tables import LOOKUP\n\ndef lookup(key, other):\n    return LOOKUP.get(key, 0)\n",
+    )
+    .unwrap();
+    let p = dir.to_str().unwrap();
+    let cache = dir.join(".cache");
+    let cd = cache.to_str().unwrap();
+    let args = |extra: &[&str]| {
+        let mut v = vec![
+            "scan",
+            p,
+            "--mode",
+            "semantic",
+            "--min-size",
+            "1",
+            "--min-lines",
+            "1",
+            "--format",
+            "json",
+            "--top",
+            "0",
+        ];
+        v.extend_from_slice(extra);
+        run(&v)
+    };
+    let fams = |out: &str| scan_families(&scan_json(out)).len();
+
+    let uncached = args(&[]);
+    let cold = args(&["--cache-dir", cd]);
+    let warm = args(&["--cache-dir", cd]);
+    assert_eq!(fams(&uncached), 1, "uncached: imported literal converges");
+    assert_eq!(uncached, cold, "cold cache must match uncached (#275)");
+    assert_eq!(cold, warm, "warm cache must match cold (#275)");
+
+    // Edit the provider's literal — the importer now resolves to a different
+    // literal and must no longer merge; the cached entry must invalidate.
+    fs::write(
+        dir.join("tables.py"),
+        "LOOKUP = {\"red\": 9, \"blue\": 2}\n",
+    )
+    .unwrap();
+    let edited_uncached = args(&[]);
+    let edited_cached = args(&["--cache-dir", cd]);
+    assert_eq!(fams(&edited_uncached), 0, "edited: literals now differ");
+    assert_eq!(
+        edited_uncached, edited_cached,
+        "cache must invalidate on provider literal change (#275)"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn fail_flag_sets_exit_code_as_ci_gate() {
     let dir = make_project("fail");

--- a/crates/nose-normalize/src/commutative.rs
+++ b/crates/nose-normalize/src/commutative.rs
@@ -12,21 +12,41 @@ use nose_il::{Il, Interner, NodeId, NodeKind, Payload};
 /// reproducible across runs despite parallel interning; canonical ids are
 /// alpha-invariant after the `alpha` pass has run.
 pub fn subtree_hashes(il: &Il, interner: &Interner) -> Vec<u64> {
+    per_node_hashes(il, interner, node_tag)
+}
+
+/// An interner-INDEPENDENT content hash of `il`'s whole tree that RETAINS literal
+/// values (via [`node_tag_valued`], unlike [`subtree_hashes`] whose `node_tag`
+/// erases them). The detection-unit cache keys on this: it is stable across runs
+/// (no interner-relative symbol ids leak in — names/literals resolve to content
+/// hashes) yet distinguishes `{…: 1}` from `{…: 9}`, so a file whose post-resolve
+/// IL changed (an inlined imported literal differs) gets a different key.
+pub fn valued_tree_hash(il: &Il, interner: &Interner) -> u64 {
+    per_node_hashes(il, interner, node_tag_valued)
+        .into_iter()
+        .fold(crate::SEED, combine)
+}
+
+/// Per-node structural hashes under a chosen `(kind, payload)` tagger. The arena
+/// is post-order (children precede parents), so one forward pass interns each
+/// node's hash from its already-computed children — the shared core of
+/// [`subtree_hashes`] (shape, value-blind) and [`valued_tree_hash`] (value-keeping).
+fn per_node_hashes(
+    il: &Il,
+    interner: &Interner,
+    tag: fn(NodeKind, Payload, &Interner) -> u64,
+) -> Vec<u64> {
     let n = il.nodes.len();
     let mut hashes = vec![0u64; n];
     for i in 0..n {
-        hashes[i] = hash_node(il, NodeId(i as u32), &hashes, interner);
+        let node = il.node(NodeId(i as u32));
+        let mut h = tag(node.kind, node.payload, interner);
+        for &c in il.children(NodeId(i as u32)) {
+            h = combine(h, hashes[c.0 as usize]);
+        }
+        hashes[i] = h;
     }
     hashes
-}
-
-fn hash_node(il: &Il, id: NodeId, hashes: &[u64], interner: &Interner) -> u64 {
-    let node = il.node(id);
-    let mut h = node_tag(node.kind, node.payload, interner);
-    for &c in il.children(id) {
-        h = combine(h, hashes[c.0 as usize]);
-    }
-    h
 }
 
 /// A discriminant for `(kind, payload)`. Canonical ids (`Cid`) contribute their

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -31,7 +31,7 @@ pub mod module_facts;
 mod recursion;
 mod value_graph;
 
-pub use commutative::{node_tag, node_tag_valued, subtree_hashes};
+pub use commutative::{node_tag, node_tag_valued, subtree_hashes, valued_tree_hash};
 pub use interp::{
     behavior_has_sym, run_unit, run_unit_paths, Behavior, Value, MAX_SYM_BRANCH_SITES,
 };


### PR DESCRIPTION
## What

Fixes #275 — `--cache-dir` scans diverged from non-cached scans on cross-file imported-immutable-literal convergence (escalated to a reproduced violation in coevo series 3 by mining the equivalence test suite for a guaranteed-convergence shape).

The cache lowered each file **independently** (throwaway interner) and keyed units on the source bytes, skipping the corpus-level `resolve_imported_immutable_bindings` pass. So an `imported LOOKUP.get(k)` and an inline `{…}.get(k)` — one family in a cold scan — silently under-merged under `--cache-dir`. Safe direction (under-merge, never a false merge), but a real break of the cache's "behaves the same as the non-cached path" contract.

## Fix

The cached path now lowers **and cross-file-resolves the whole corpus every run** (`lower_corpus_filtered` — the smaller half of the work per §BQ) and caches only the dominant normalize+extract step, keyed on the **post-resolve** IL. The key is `valued_tree_hash`: an interner-independent fold (so it's stable across runs — the corpus's shared-interner symbol ids are not in it) that **retains literal values** (so a resolved `{…: 1}` vs `{…: 9}` doesn't collide — the structural `subtree_hashes` erases values and would have). Cache schema bumped v7 → v8.

## Verification

- **Correctness**: cold == cached byte-identical on a real multi-file repo; the #275 imported-literal family appears under `--cache-dir`; editing the provider's literal invalidates the importer's entry (cached result tracks cold: 1 → 0). New regression test `cache_reproduces_cross_file_imported_literal_resolution`.
- **Determinism**: cache keys identical across two fresh runs; cached output byte-identical across `RAYON_NUM_THREADS=1/4`.
- **Performance**: warm cache 4.6s → 2.05s on sympy (normalize+extract genuinely skipped: user-time 26s → 9s); cold-fill ≈ no-cache.
- dup-gate 25/25, full nose-cli suite green.

Closes #275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
