### PR TITLE
Fix #280: context-aware embedded <script> extraction (Vue/Svelte/HTML)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ break.
 ## [Unreleased]
 
 ### Fixed
+- **Embedded `<script>` extraction (Vue/Svelte/HTML) is now context-aware** (#280,
+  coevo §CE). The byte-scanner was naive `find_ci`, so five real shapes broke it:
+  a `</script>` inside a JS string truncated the block (missed dup); a
+  commented-out `<script>` was analyzed as live and the span swallowed the
+  surrounding markup; a Vue 3.3 `generic="T extends Record<string, number>"`
+  attribute `>` was taken as the tag end (span started mid-tag); an unclosed
+  `<script>` (valid HTML) was dropped (missed dup); and trailing markup left as
+  blank lines made the whole-block span bleed past `</script>`. The scanner now
+  skips HTML comments, finds the tag-end `>` outside quoted attributes, finds
+  `</script>` outside JS strings/comments, extracts an unclosed block to EOF, and
+  truncates the analyzed buffer at the last script byte so spans stop at the
+  content. Plain and multi-block extraction, `lang="ts"` detection, and
+  same-as-plain-JS convergence are unchanged.
 - **`--cache-dir` now reproduces cross-file imported-literal convergence** (#275).
   The cache keyed each file's units on its source bytes and lowered files
   independently, skipping the corpus-level `resolve_imported_immutable_bindings`

--- a/crates/nose-frontend/src/embedded.rs
+++ b/crates/nose-frontend/src/embedded.rs
@@ -40,29 +40,137 @@ pub(crate) fn lower(
 
 /// Byte ranges of every `<script>…</script>` block's *content*, plus whether any
 /// block declares TypeScript (`lang="ts"`/`tsx` or a TypeScript `type`).
+///
+/// A small stateful scanner rather than naive substring search, because five real
+/// shapes (coevo §CE / #280) defeat `find_ci`: a `<script>` *inside an HTML
+/// comment* must be skipped; the opening tag's `>` must not be taken from inside a
+/// quoted attribute value (Vue 3.3 `generic="T extends Record<string, number>"`);
+/// the closing `</script>` must not be taken from inside a JS string or comment in
+/// the script body; and an unclosed `<script>` (valid HTML — the browser runs it to
+/// EOF) must extract to EOF, not vanish; and trailing markup must not extend the block span (see blank_except).
 fn extract_scripts(src: &[u8]) -> (Vec<(usize, usize)>, bool) {
     let mut ranges = Vec::new();
     let mut is_ts = false;
     let mut pos = 0;
-    while let Some(open) = find_ci(src, b"<script", pos) {
-        // End of the opening tag (best-effort: first `>` after `<script`).
-        let Some(rel) = src[open..].iter().position(|&b| b == b'>') else {
+    while pos < src.len() {
+        // Skip HTML comments so a commented-out `<script>` is never extracted.
+        if src[pos..].starts_with(b"<!--") {
+            pos = find_ci(src, b"-->", pos + 4)
+                .map(|c| c + 3)
+                .unwrap_or(src.len());
+            continue;
+        }
+        let Some(open) = find_script_open(src, pos) else {
             break;
         };
-        let tag_end = open + rel;
+        // End of the opening tag: the first `>` NOT inside a quoted attribute.
+        let Some(tag_end) = tag_end(src, open) else {
+            break;
+        };
         if open_tag_is_ts(&src[open..tag_end]) {
             is_ts = true;
         }
         let content_start = tag_end + 1;
-        let Some(close) = find_ci(src, b"</script", content_start) else {
-            break;
-        };
+        // Closing `</script>`, ignoring matches inside JS strings/comments; an
+        // unclosed block runs to EOF.
+        let close = script_close(src, content_start).unwrap_or(src.len());
         if close > content_start {
             ranges.push((content_start, close));
         }
-        pos = close + b"</script".len();
+        pos = (close + b"</script".len())
+            .min(src.len())
+            .max(content_start + 1);
     }
     (ranges, is_ts)
+}
+
+/// The next `<script` that starts a tag (followed by whitespace, `>`, or EOF),
+/// skipping HTML comments encountered along the way.
+fn find_script_open(src: &[u8], mut pos: usize) -> Option<usize> {
+    loop {
+        let open = find_ci(src, b"<script", pos)?;
+        // Skip if it sits inside a comment that began before `pos`.
+        if let Some(c) = find_ci(src, b"<!--", pos) {
+            if c < open {
+                let end = find_ci(src, b"-->", c + 4)
+                    .map(|e| e + 3)
+                    .unwrap_or(src.len());
+                if open < end {
+                    pos = end;
+                    continue;
+                }
+            }
+        }
+        // `<scripts>` / `<scripting` are not a script tag.
+        match src.get(open + b"<script".len()) {
+            Some(b) if b.is_ascii_whitespace() || *b == b'>' => return Some(open),
+            None => return Some(open),
+            _ => pos = open + b"<script".len(),
+        }
+    }
+}
+
+/// The index of the `>` that closes the opening tag at `open`, skipping any `>`
+/// inside a quoted attribute value.
+fn tag_end(src: &[u8], open: usize) -> Option<usize> {
+    let mut i = open + b"<script".len();
+    let mut quote: Option<u8> = None;
+    while i < src.len() {
+        let b = src[i];
+        match quote {
+            Some(q) if b == q => quote = None,
+            Some(_) => {}
+            None if b == b'"' || b == b'\'' => quote = Some(b),
+            None if b == b'>' => return Some(i),
+            None => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// The index of the `</script` that closes the block whose content starts at
+/// `content_start`, ignoring `</script` that falls inside a JS string literal,
+/// template literal, or `//` / `/* */` comment.
+fn script_close(src: &[u8], content_start: usize) -> Option<usize> {
+    let mut i = content_start;
+    let mut quote: Option<u8> = None;
+    while i < src.len() {
+        if let Some(q) = quote {
+            if src[i] == b'\\' {
+                i += 2;
+                continue;
+            }
+            if src[i] == q {
+                quote = None;
+            }
+            i += 1;
+            continue;
+        }
+        if src[i..].starts_with(b"//") {
+            i = src[i..]
+                .iter()
+                .position(|&b| b == b'\n')
+                .map_or(src.len(), |n| i + n);
+            continue;
+        }
+        if src[i..].starts_with(b"/*") {
+            i = find_ci(src, b"*/", i + 2)
+                .map(|e| e + 2)
+                .unwrap_or(src.len());
+            continue;
+        }
+        if matches!(src[i], b'"' | b'\'' | b'`') {
+            quote = Some(src[i]);
+            i += 1;
+            continue;
+        }
+        if src[i..].starts_with(b"</script") {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
 }
 
 /// Does a `<script …>` opening tag select TypeScript?
@@ -75,14 +183,22 @@ fn open_tag_is_ts(tag: &[u8]) -> bool {
 }
 
 /// Replace every byte outside `keep` with a space, preserving `\n`/`\r` so line
-/// numbers stay aligned with the original file.
+/// numbers stay aligned with the original file, and TRUNCATE the buffer at the
+/// last kept byte. Truncation matters: trailing markup left as blanked lines made
+/// the top-level (whole-script-block) unit's span bleed past `</script>` onto the
+/// closing tag and following markup (coevo §CE / #280 defect 4). Markup BETWEEN
+/// blocks stays blanked (offsets preserved); only the tail after the final block
+/// is dropped.
 fn blank_except(src: &[u8], keep: &[(usize, usize)]) -> Vec<u8> {
-    let mut out: Vec<u8> = src
+    let end = keep.iter().map(|&(_, e)| e).max().unwrap_or(0);
+    let mut out: Vec<u8> = src[..end]
         .iter()
         .map(|&b| if b == b'\n' || b == b'\r' { b } else { b' ' })
         .collect();
     for &(s, e) in keep {
-        out[s..e].copy_from_slice(&src[s..e]);
+        if e <= end {
+            out[s..e].copy_from_slice(&src[s..e]);
+        }
     }
     out
 }
@@ -98,4 +214,68 @@ fn find_ci(hay: &[u8], needle: &[u8], from: usize) -> Option<usize> {
 
 fn contains_ci(hay: &[u8], needle: &[u8]) -> bool {
     find_ci(hay, needle, 0).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_scripts;
+
+    /// Content of every extracted `<script>` block, as text.
+    fn scripts(src: &str) -> Vec<String> {
+        let (ranges, _) = extract_scripts(src.as_bytes());
+        ranges
+            .into_iter()
+            .map(|(s, e)| String::from_utf8(src.as_bytes()[s..e].to_vec()).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn closing_script_inside_a_js_string_does_not_truncate() {
+        // #280 defect 1.
+        let s = scripts("<script>\nconst x = \"</script>\";\nfn();\n</script>");
+        assert_eq!(s.len(), 1);
+        assert!(
+            s[0].contains("fn();"),
+            "block ran past the string literal: {s:?}"
+        );
+    }
+
+    #[test]
+    fn script_inside_an_html_comment_is_skipped() {
+        // #280 defect 2.
+        let s = scripts("<!--\n<script>dead();</script>\n-->\n<script>live();</script>");
+        assert_eq!(s.len(), 1, "only the live block: {s:?}");
+        assert!(s[0].contains("live()") && !s[0].contains("dead()"));
+    }
+
+    #[test]
+    fn tag_end_skips_a_greater_than_inside_an_attribute() {
+        // #280 defect 3 (Vue 3.3 `generic="T extends Record<string, number>"`).
+        let s = scripts(
+            "<script setup generic=\"T extends Record<string, number>\">\nbody();\n</script>",
+        );
+        assert_eq!(s.len(), 1);
+        assert!(
+            s[0].trim_start().starts_with("body()"),
+            "content started mid-tag: {s:?}"
+        );
+    }
+
+    #[test]
+    fn unclosed_script_extracts_to_eof() {
+        // #280 defect 5 (valid HTML — the browser runs it to EOF).
+        let s = scripts("<body>\n<script>\nfn();\nmore();\n");
+        assert_eq!(s.len(), 1);
+        assert!(s[0].contains("fn();") && s[0].contains("more();"), "{s:?}");
+    }
+
+    #[test]
+    fn plain_blocks_and_multi_block_still_extract() {
+        // Regression guard: the common shapes are unchanged.
+        assert_eq!(scripts("<script>a();</script>").len(), 1);
+        let two = scripts("<script setup>a();</script>\n<script>b();</script>");
+        assert_eq!(two.len(), 2);
+        // Import-only / plain content unaffected; markup between blocks ignored.
+        assert!(scripts("<template><div/></template>\n<script>x();</script>")[0].contains("x()"));
+    }
 }


### PR DESCRIPTION
## What

Fixes #280 — embedded `<script>` extraction for Vue/Svelte/HTML used naive `find_ci` byte-scanning, which five real shapes (coevo series 4, blind container-attacker) defeated:

1. `</script>` inside a JS string literal truncated the block → cross-container dup missed.
2. A commented-out `<script>` (`<!-- <script>…</script> -->`) was analyzed as live, and the span swallowed `</body></html>` markup.
3. A Vue 3.3 `generic="T extends Record<string, number>"` attribute's `>` was taken as the opening-tag end → span started mid-tag.
4. The whole-script-block span bled past `</script>` onto the closing tag / following markup.
5. An unclosed `<script>` (valid HTML — the browser runs it to EOF) was dropped → dup missed.

## Fix

`extract_scripts` is now a small stateful scanner (not a grammar, but context-aware): it skips HTML comments, finds the opening tag's `>` while skipping quoted attribute values, finds `</script>` while skipping JS strings / template literals / `//` / `/* */` comments in the body, extracts an unclosed block to EOF, and `blank_except` truncates the analyzed buffer at the last script byte so the top-level unit span stops at the content instead of trailing markup.

## Verification

All five reproduce-then-pass:
- string-`</script>` and unclosed blocks now form families (were 0).
- commented-out `<script>` excluded; span is exactly the live block (`9-16`, was `9-18` onto markup).
- `generic=…<…>` span starts at line 2 (the script), not line 1 (the tag); end no longer over-claims (`2-11`, was `1-12`).

Five new `extract_scripts` unit tests; existing `embedded_scripts_converge_with_plain_js_ts` + multi-block/`lang=ts` coverage still green; dup-gate 25/25; suite green.

Closes #280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
