### PR TITLE
Sound recall rules (#284): abs idempotence, bitwise De Morgan, min/max AC-flatten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ break.
 
 ## [Unreleased]
 
+### Added
+- **Three sound recall rules from coevo §CE / #284** — behaviorally-equal forms
+  the exact channel now converges, each sound for ALL inputs (no type gate)
+  because the error behavior is preserved on both sides (unlike the §BA identity
+  rewrites): `abs(abs x) ≡ abs x` (idempotence), `~(a&b) ≡ ~a|~b` / `~(a|b) ≡
+  ~a&~b` (bitwise De Morgan, the bitwise twin of the algebra pass's logical
+  one), and `max(max(a,b),c) ≡ max(a,max(b,c))` (MIN/MAX flattening — they were
+  per-level commutative, now associative-flatten-eligible too; associative on
+  the ternary semantics, total even for NaN). Corpus verify unchanged (zero new
+  false merges); hard negatives lock min≠max and `~(a&b)`≠`~(a|b)`.
+
 ### Fixed
 - **Embedded `<script>` extraction (Vue/Svelte/HTML) is now context-aware** (#280,
   coevo §CE). The byte-scanner was naive `find_ci`, so five real shapes broke it:

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -6860,3 +6860,52 @@ fn effectful_commutative_operands_do_not_reorder() {
         "effect-free numeric commutative operands must still converge"
     );
 }
+
+#[test]
+fn sound_recall_rules_converge_with_hard_negatives() {
+    // #284 (coevo §CE / S5-C4): three behaviorally-equal forms that nose now
+    // converges. Each is sound for ALL inputs because the error behavior is
+    // preserved on both sides (unlike the §BA identity rewrites), so no type gate.
+    let i = Interner::new();
+
+    // abs(abs x) ≡ abs x — abs is idempotent; a non-orderable input Errs on both.
+    let abs_nested = "def f(x):\n    a = x if x >= 0 else -x\n    return a if a >= 0 else -a\n";
+    let abs_once = "def g(x):\n    return x if x >= 0 else -x\n";
+    assert_eq!(
+        value_fp(&i, abs_nested, Lang::Python),
+        value_fp(&i, abs_once, Lang::Python),
+        "abs(abs x) must converge with abs x"
+    );
+
+    // ~(a&b) ≡ ~a|~b — bitwise De Morgan; a non-integer Errs on both.
+    let demorgan_l = "def f(a, b):\n    return ~(a & b)\n";
+    let demorgan_r = "def g(a, b):\n    return (~a) | (~b)\n";
+    assert_eq!(
+        value_fp(&i, demorgan_l, Lang::Python),
+        value_fp(&i, demorgan_r, Lang::Python),
+        "~(a&b) must converge with ~a|~b"
+    );
+    // Hard negative: ~(a|b) ≡ ~a&~b, and must NOT collide with the AND form.
+    let demorgan_or = "def h(a, b):\n    return ~(a | b)\n";
+    assert_ne!(
+        value_fp(&i, demorgan_l, Lang::Python),
+        value_fp(&i, demorgan_or, Lang::Python),
+        "~(a&b) and ~(a|b) are different functions"
+    );
+
+    // max(max(a,b),c) ≡ max(a,max(b,c)) — associative on the ternary semantics
+    // (total for all inputs, incl. NaN). Hard negative: min vs max stays distinct.
+    let max_l = "def f(a, b, c):\n    m = a if a > b else b\n    return m if m > c else c\n";
+    let max_r = "def g(a, b, c):\n    n = b if b > c else c\n    return a if a > n else n\n";
+    assert_eq!(
+        value_fp(&i, max_l, Lang::Python),
+        value_fp(&i, max_r, Lang::Python),
+        "nested max must flatten and converge"
+    );
+    let min_l = "def h(a, b, c):\n    m = a if a < b else b\n    return m if m < c else c\n";
+    assert_ne!(
+        value_fp(&i, max_l, Lang::Python),
+        value_fp(&i, min_l, Lang::Python),
+        "max and min chains must stay distinct"
+    );
+}

--- a/crates/nose-normalize/src/value_graph/canonicalize.rs
+++ b/crates/nose-normalize/src/value_graph/canonicalize.rs
@@ -115,6 +115,45 @@ impl<'a> Builder<'a> {
 
     fn unary_canon(&mut self, op: &ValOp, args: &[ValueId]) -> Option<ValueId> {
         let ValOp::Un(o) = *op else { return None };
+        // ABS IDEMPOTENCE: `abs(abs x) → abs x` (#284). `abs` is always ≥ 0 so the
+        // outer is a no-op; on a non-orderable input both sides Err identically
+        // (the inner `abs` Errs, propagating), so it is sound for ALL inputs — no
+        // type gate. `ABS_CODE` is synthesized from a ternary by `minmax_pattern`.
+        if o == ABS_CODE && !args.is_empty() {
+            if let ValOp::Un(io) = self.nodes[args[0] as usize].op {
+                if io == ABS_CODE {
+                    return Some(args[0]);
+                }
+            }
+        }
+        // BITWISE DE MORGAN: `~(a & b) → ~a | ~b`, `~(a | b) → ~a & ~b` (#284).
+        // Two's-complement identity for all integers; on a non-integer operand
+        // `~`/`&`/`|` Err on both the original and the distributed form, so it is
+        // sound for ALL inputs. Pushing `~` inward gives a canonical form that
+        // converges `~(a&b)` with an explicit `~a | ~b`. (The LOGICAL De Morgan,
+        // over `Not`/`And`/`Or`, is handled by the `algebra` IL pass; this is its
+        // bitwise twin, which that pass never reaches.)
+        if o == Op::BitNot as u32 && !args.is_empty() {
+            if let ValOp::Bin(bo) = self.nodes[args[0] as usize].op {
+                let flip = if bo == Op::BitAnd as u32 {
+                    Some(Op::BitOr as u32)
+                } else if bo == Op::BitOr as u32 {
+                    Some(Op::BitAnd as u32)
+                } else {
+                    None
+                };
+                if let Some(out_op) = flip {
+                    let inner = self.nodes[args[0] as usize].args.clone();
+                    let negated: Vec<ValueId> = inner
+                        .iter()
+                        .map(|&t| self.mk(ValOp::Un(Op::BitNot as u32), vec![t]))
+                        .collect();
+                    if negated.len() == 2 {
+                        return Some(self.mk(ValOp::Bin(out_op), negated));
+                    }
+                }
+            }
+        }
         // NEGATED COMPARISON: `!(a<=b) → a>b`, `!(a<b) → a>=b`, `!(a==b) → a!=b`, etc.
         // Sound for a total order, and on non-numeric operands both sides Err
         // (`!(Err)` propagates — see interp `un`), so the rewrite preserves behavior.

--- a/crates/nose-normalize/src/value_graph/ops.rs
+++ b/crates/nose-normalize/src/value_graph/ops.rs
@@ -212,11 +212,7 @@ pub(super) fn op_from_code(opc: u32) -> Option<Op> {
 }
 
 pub(super) fn is_commutative(opc: u32) -> bool {
-    is_assoc_comm_code(opc)
-        || opc == Op::Eq as u32
-        || opc == Op::Ne as u32
-        || opc == MIN_CODE
-        || opc == MAX_CODE
+    is_assoc_comm_code(opc) || opc == Op::Eq as u32 || opc == Op::Ne as u32
 }
 
 /// Coarse type of a `Const` value node from its key range (mirrors the `eval` Lit keys):
@@ -246,6 +242,14 @@ pub(super) fn is_assoc_comm_code(opc: u32) -> bool {
         || opc == Op::BitAnd as u32
         || opc == Op::BitOr as u32
         || opc == Op::BitXor as u32
+        // MIN/MAX (synthesized from ternaries by `minmax_pattern`) are
+        // associative AND commutative on the ternary semantics — for ALL inputs,
+        // including floats/NaN, because `x if x<y else y` is total (coevo §CE /
+        // #284). Flattening nested min/max converges `max(max(a,b),c)` with
+        // `max(a,max(b,c))`. They were already in `is_commutative` (per-level
+        // operand sorting); this lets the chain flatten across levels too.
+        || opc == MIN_CODE
+        || opc == MAX_CODE
 }
 
 /// `Reduce` op codes for the selection reductions (min/max). Kept clear of the small


### PR DESCRIPTION
## What

Adds the three sound recall rules from coevo series 5 (S5-C4, the convergence-skeptic) — behaviorally-equal forms the exact channel failed to converge. Closes #284.

Each is sound for **all** inputs with **no type gate**, because the error behavior is preserved on both sides — the distinction from the §BA identity rewrites (`-(-x)→x`), which were unsound precisely because the rewritten form dropped an error the original raised:

- **`abs(abs x) ≡ abs x`** (idempotence in `unary_canon`): `abs` is always ≥0; a non-orderable input Errs on both sides.
- **`~(a&b) ≡ ~a|~b`, `~(a|b) ≡ ~a&~b`** (bitwise De Morgan in `unary_canon`): two's-complement identity for all integers; a non-integer Errs on both sides. The bitwise twin of the logical De Morgan the `algebra` IL pass already does (over `Not`/`And`/`Or`), which never reaches `BitNot`/`BitAnd`/`BitOr`.
- **`max(max(a,b),c) ≡ max(a,max(b,c))`** (MIN/MAX added to `is_assoc_comm_code`): associative on the ternary semantics — `x if x<y else y` is total, so it holds even for floats/NaN. MIN/MAX were already commutative (per-level operand sorting); this lets the chain flatten across levels. The compositional `is_commutative` ⊇ `is_assoc_comm_code` definition is simplified accordingly.

## Verification

- All three converge (value-fingerprint equality); the oracle reports `SOUND` on each.
- **Corpus verify unchanged**: canon-preservation counts identical to `main` (redis 4, sympy 20, nushell 1 — pre-existing local-corpus drift), zero new false merges (click clean).
- Hard negatives lock the boundaries: `max`-chain ≠ `min`-chain, `~(a&b)` ≠ `~(a|b)`; the `(a-b)-c` ≠ `a-(b-c)` non-associativity guard still holds.
- dup-gate 25/25; suite green.

Closes #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
