### PR TITLE
Soundness #283-D (mod): floored vs truncated `%` no longer false-merges across languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ break.
 
 ## [Unreleased]
 
+### Fixed
+- **Floored vs truncated `%` no longer false-merges across languages** (#283-D).
+  Python/Ruby `%` is floored (remainder takes the divisor's sign); JS/Go/Java/
+  Rust/C `%` is truncated (dividend's sign) — they differ on sign-disagreeing
+  operands (`-1 % 3 == 2` floored vs `== -1` truncated). A single `Op::Mod` for
+  all languages merged them (a false merge the verify interpreter, also blind,
+  could not catch). A distinct `Op::FloorMod` is now lowered for Python/Ruby and
+  evaluated with floor semantics: Python `%` no longer merges with JS `%`, while
+  Python ≡ Ruby and JS ≡ Go still converge (recall preserved). The remaining
+  #283-D cases — three-way division semantics (`/` is true-float in Python/JS,
+  floored-int in Ruby, truncated-int in C/Go/Java/Rust, with no float in the
+  interpreter model) and JS bitwise int32 narrowing — are root-caused in the
+  issue and remain open.
+
 ### Added
 - **Three sound recall rules from coevo §CE / #284** — behaviorally-equal forms
   the exact channel now converges, each sound for ALL inputs (no type gate)

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -6909,3 +6909,35 @@ fn sound_recall_rules_converge_with_hard_negatives() {
         "max and min chains must stay distinct"
     );
 }
+
+#[test]
+fn floored_mod_distinguishes_python_ruby_from_c_family() {
+    // #283-D: Python/Ruby `%` is FLOORED (remainder takes the divisor's sign);
+    // C/Go/Java/JS/Rust `%` is TRUNCATED (dividend's sign). They differ on
+    // sign-disagreeing operands (`-1 % 3 == 2` vs `== -1`), so a single `Op::Mod`
+    // for all languages was a false merge the interpreter was blind to.
+    let i = Interner::new();
+    let py = "def rem(a, b):\n    return a % b\n";
+    let rb = "def rem(a, b)\n  a % b\nend\n";
+    let js = "function rem(a, b){ return a % b; }";
+    let go = "package p\nfunc Rem(a int, b int) int { return a % b }\n";
+
+    // Floored ≠ truncated: Python must NOT converge with JS.
+    assert_ne!(
+        value_fp(&i, py, Lang::Python),
+        value_fp(&i, js, Lang::JavaScript),
+        "Python floored % must not merge with JS truncated %"
+    );
+    // Same semantics still converge: Python ≡ Ruby (both floored).
+    assert_eq!(
+        value_fp(&i, py, Lang::Python),
+        value_fp(&i, rb, Lang::Ruby),
+        "Python and Ruby % are both floored — must converge"
+    );
+    // JS ≡ Go (both truncated).
+    assert_eq!(
+        value_fp(&i, js, Lang::JavaScript),
+        value_fp(&i, go, Lang::Go),
+        "JS and Go % are both truncated — must converge"
+    );
+}

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -1216,7 +1216,7 @@ fn py_bin_op(text: &str) -> Option<Op> {
         // vs `5 // 2 == 2`); each gets its own op so they never share a fingerprint.
         "/" => Op::Div,
         "//" => Op::FloorDiv,
-        "%" => Op::Mod,
+        "%" => Op::FloorMod,
         "**" => Op::Pow,
         "&" => Op::BitAnd,
         "|" => Op::BitOr,

--- a/crates/nose-frontend/src/ruby.rs
+++ b/crates/nose-frontend/src/ruby.rs
@@ -448,7 +448,12 @@ fn lower_binary(lo: &mut Lowering, node: TsNode) -> NodeId {
     let op = node
         .child_by_field_name("operator")
         .map(|o| lo.text(o))
-        .and_then(common_bin_op);
+        .and_then(|t| match t {
+            // Ruby `%` is FLOORED (remainder takes the divisor's sign), unlike the
+            // C-family truncated `%` in `common_bin_op` (#283-D).
+            "%" => Some(Op::FloorMod),
+            other => common_bin_op(other),
+        });
     match (l, r, op) {
         (Some(l), Some(r), Some(op)) => lo.add(NodeKind::BinOp, Payload::Op(op), span, &[l, r]),
         _ => raw_kids(lo, node),

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -696,6 +696,13 @@ pub enum Op {
     /// any negative operand (`-5 // 2 == -3` vs `-5 / 2 == -2`), so conflating
     /// them is a false merge.
     FloorDiv,
+    /// Floored modulo (remainder takes the sign of the DIVISOR): Python/Ruby `%`.
+    /// DISTINCT from [`Op::Mod`], the C-family truncated remainder (sign of the
+    /// DIVIDEND) used by JS/Go/Java/Rust/C — they differ on any sign-disagreeing
+    /// operands (`-1 % 3 == 2` floored vs `== -1` truncated), so conflating them
+    /// (as a single `Op::Mod` for all languages did) is a false merge the verify
+    /// interpreter was blind to (#283-D).
+    FloorMod,
 }
 
 impl Op {

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -1617,6 +1617,21 @@ fn bin(op: Op, a: &Value, b: &Value) -> Value {
                     Int(x.wrapping_rem(*y))
                 }
             }
+            // Floored modulo (Python/Ruby `%`): the remainder takes the sign of the
+            // DIVISOR. Truncated `wrapping_rem` takes the dividend's sign, so adjust
+            // by adding the divisor when they disagree (#283-D). `-1 %% 3 == 2`.
+            Op::FloorMod => {
+                if *y == 0 {
+                    Value::Err
+                } else {
+                    let r = x.wrapping_rem(*y);
+                    Int(if r != 0 && (r < 0) != (*y < 0) {
+                        r.wrapping_add(*y)
+                    } else {
+                        r
+                    })
+                }
+            }
             // Floor division rounds the quotient toward −∞ (Python `//`): the
             // truncating quotient is decremented when the remainder is nonzero
             // and the operands disagree in sign (`-5 // 2 == -3`, `5 // -2 == -3`).

--- a/crates/nose-normalize/src/value_graph/control.rs
+++ b/crates/nose-normalize/src/value_graph/control.rs
@@ -819,7 +819,7 @@ impl<'a> Builder<'a> {
         }
         let rhs = self.eval(kids[1], env);
         match op {
-            Op::Div | Op::FloorDiv | Op::Mod => self.int_const_eq(rhs, 0),
+            Op::Div | Op::FloorDiv | Op::Mod | Op::FloorMod => self.int_const_eq(rhs, 0),
             Op::Pow => self
                 .static_int_expr(kids[1])
                 .is_some_and(|exp| !(0..=u32::MAX as i64).contains(&exp)),

--- a/crates/nose-normalize/src/value_graph/ops.rs
+++ b/crates/nose-normalize/src/value_graph/ops.rs
@@ -188,6 +188,7 @@ pub(super) fn op_from_code(opc: u32) -> Option<Op> {
         Op::Div,
         Op::FloorDiv,
         Op::Mod,
+        Op::FloorMod,
         Op::Pow,
         Op::Eq,
         Op::Ne,


### PR DESCRIPTION
## What

Fixes the `%` part of #283-D — the verify interpreter (and the detector) were language-blind for modulo, false-merging Python/Ruby floored `%` with C-family truncated `%`.

`a % b` differs by language: Python/Ruby floor (remainder takes the **divisor's** sign), while JS/Go/Java/Rust/C truncate (dividend's sign) — e.g. `-1 % 3` is `2` floored, `-1` truncated. Every frontend lowered `%` to one `Op::Mod`, so `py a%b` and `js a%b` got one fingerprint (false merge), and the interpreter evaluated both as truncated `wrapping_rem` (blind, so the oracle couldn't catch it).

## Fix

A distinct `Op::FloorMod` (mirroring the existing `Op::FloorDiv`, added for the same reason): Python and Ruby `%` lower to it; C-family stays `Op::Mod`. The interpreter evaluates `FloorMod` with floor semantics (adjust the truncated remainder by the divisor when their signs disagree). Wired through `op_from_code` and the div-by-zero check.

## Verification

- **False merge gone, recall preserved**: Python `%` no longer merges with JS `%` (was 1 family → 0); Python ≡ Ruby (both floored, 1 family) and JS ≡ Go (both truncated, 1 family) still converge. Regression test asserts all three.
- Interpreter floored-mod correct; corpus false-merge count unchanged (click clean; sympy/nushell canon-preservation = pre-existing baseline).
- dup-gate 25/25 (Rust `%` stays truncated, nose's own source unaffected); suite green.

## Scope

The `%` sub-case of #283-D. The remaining D work — three-way `/` semantics (true-float Python/JS vs floored-int Ruby vs truncated-int C/Go/Java/Rust, with no float in the i64 interpreter model → the true-float case must fail closed, a recall change to price) and JS int32 bitwise narrowing — is precisely root-caused in #283 and stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
