### PR TITLE
Soundness #283-B: gate `-(-a)` / `a&a` on proven-numeric, not optimistic Num

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ break.
 ## [Unreleased]
 
 ### Fixed
+- **`-(-a)` and `a & a` / `a | a` no longer false-merge with a bare `a` on untyped
+  params** (#283-B). These identities hold only for numbers — on a list/string the
+  inner op Errs, so `-(-a)` Errs while `a` does not. Two layers conspired to merge
+  them anyway: the value-independent `algebra` pass cancelled `-(-x) → x`
+  unconditionally (it has no operand type), and the value graph's `Num` gate trusted
+  an OPTIMISTIC param domain that infers `a: Num` *from the very `-`/`&` being
+  rewritten* — circular, since the canonical `a` then carries no numeric constraint.
+  Fix: the algebra pass now preserves `-(-x)` (mirroring the `!!x → x` it already
+  defers), and the cancellations gate on `proven_numeric` — genuine evidence only
+  (numeric literals, annotated / pack-typed params), never the self-referential
+  inference. An untyped `-(-a)` stays distinct from `a`; an annotated `a: int` still
+  cancels. Zero corpus recall change (4294 → 4294 families on `bench/repos`); the
+  pinned corpus held no untyped occurrences, so the merges it removed were all latent
+  false merges (the §AS scenario). Remaining #283 sub-findings: C (untyped `+`
+  commutativity, oracle-blind) and the `/`-division / int32 parts of D.
 - **Floored vs truncated `%` no longer false-merges across languages** (#283-D).
   Python/Ruby `%` is floored (remainder takes the divisor's sign); JS/Go/Java/
   Rust/C `%` is truncated (dividend's sign) — they differ on sign-disagreeing

--- a/bench/coevo/false_merges/README.md
+++ b/bench/coevo/false_merges/README.md
@@ -11,10 +11,16 @@ These are the cardinal sin (design §1: equal fingerprint ⟹ equal behavior).
 Tracked as a P0 in issue #283. Do not delete until #283 closes with these
 moved into the permanent regression battery.
 
-| file | claim violated | verify-caught? |
-|---|---|---|
-| effect_commute.py | commutative `+` reorders observable effects | yes |
-| effect_acchain.py | AC-chain sorts effectful leaves | yes |
-| neg_involution.py | `-(-x)→x` on optimistically-Num param | yes (canon-preservation) |
-| untyped_add_commute.py | `a+b≡b+a` for untyped (string/list concat) | NO — oracle blind |
-| float_assoc.py | `(a+b)+c≡a+(b+c)` for floats | NO — oracle blind |
+| file | claim violated | verify-caught? | status |
+|---|---|---|---|
+| effect_commute.py | commutative `+` reorders observable effects | yes | FIXED #286 (A) — `reorder_safe` |
+| effect_acchain.py | AC-chain sorts effectful leaves | yes | FIXED #286 (A) — `reorder_safe` |
+| neg_involution.py | `-(-x)→x` on optimistically-Num param | yes (canon-preservation) | FIXED #283-B — `proven_numeric` |
+| untyped_add_commute.py | `a+b≡b+a` for untyped (string/list concat) | NO — oracle blind | OPEN (C) |
+| float_assoc.py | `(a+b)+c≡a+(b+c)` for floats | NO — oracle blind | OPEN (C/float) |
+
+FIXED rows are now covered by permanent regression tests (effect cases in the
+value-graph suite; `-(-a)`/`a&a` in `crates/nose-cli/tests/equivalence.rs`,
+`double_negation_cancels_only_for_proven_numeric` +
+`bitwise_self_idempotence_gates_on_proven_numeric`). The reproducer files stay
+until #283 fully closes (the OPEN rows are oracle-blind — see #283-C/-D).

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -6941,3 +6941,51 @@ fn floored_mod_distinguishes_python_ruby_from_c_family() {
         "JS and Go % are both truncated — must converge"
     );
 }
+
+#[test]
+fn double_negation_cancels_only_for_proven_numeric() {
+    // #283-B: `-(-a) → a` is sound ONLY when `a` is a number — on a list `-a` Errs, so
+    // `-(-a)` Errs while `a` does not. The value graph used to infer `a: Num` from the very
+    // `-` it was about to delete (optimistic), and the algebra pass cancelled `-(-x)`
+    // unconditionally. Both are fixed: an UNTYPED param keeps `-(-a)` distinct from `a`; a
+    // genuinely-typed (annotated) param still cancels, preserving sound recall.
+    let i = Interner::new();
+    let negneg_untyped = "def f(a):\n    return -(-a)\n";
+    let ident_untyped = "def f(a):\n    return a\n";
+    let negneg_typed = "def f(a: int):\n    return -(-a)\n";
+    let ident_typed = "def f(a: int):\n    return a\n";
+
+    assert_ne!(
+        value_fp(&i, negneg_untyped, Lang::Python),
+        value_fp(&i, ident_untyped, Lang::Python),
+        "untyped -(-a) must NOT merge with a (it Errs on a list; a does not)"
+    );
+    assert_eq!(
+        value_fp(&i, negneg_typed, Lang::Python),
+        value_fp(&i, ident_typed, Lang::Python),
+        "int-annotated -(-a) is provably numeric — must still cancel to a"
+    );
+}
+
+#[test]
+fn bitwise_self_idempotence_gates_on_proven_numeric() {
+    // #283-B: `a & a → a` / `a | a → a` is sound only for integers (`[1] & [1]` Errs in
+    // Python while `[1]` does not). The optimistic value domain inferred `a: Num` from the
+    // `&`/`|` itself; now an untyped param stays distinct, an annotated one still folds.
+    let i = Interner::new();
+    let untyped_and = "def f(a):\n    return a & a\n";
+    let untyped_id = "def f(a):\n    return a\n";
+    let typed_and = "def f(a: int):\n    return a & a\n";
+    let typed_id = "def f(a: int):\n    return a\n";
+
+    assert_ne!(
+        value_fp(&i, untyped_and, Lang::Python),
+        value_fp(&i, untyped_id, Lang::Python),
+        "untyped a & a must NOT merge with a"
+    );
+    assert_eq!(
+        value_fp(&i, typed_and, Lang::Python),
+        value_fp(&i, typed_id, Lang::Python),
+        "int-annotated a & a is provably numeric — must still fold to a"
+    );
+}

--- a/crates/nose-normalize/src/algebra.rs
+++ b/crates/nose-normalize/src/algebra.rs
@@ -9,8 +9,10 @@
 //!   grouping/ordering of `a + b + c` converges.
 //! - **comparison direction**: `a > b` → `b < a`, `a >= b` → `b <= a`, so only
 //!   `<`/`<=`/`==`/`!=` remain.
-//! - **negation / De Morgan**: `!!x` → `x`, `!(a && b)` → `!a || !b`,
-//!   `!(a == b)` → `a != b`, `!(a < b)` → `b <= a`, `-(-x)` → `x`.
+//! - **negation / De Morgan**: `!(a && b)` → `!a || !b`, `!(a == b)` → `a != b`,
+//!   `!(a < b)` → `b <= a`. The value-DEPENDENT cancellations `!!x → x` (bool
+//!   coercion) and `-(-x) → x` (numeric only) are NOT done here — this pass has no
+//!   operand type, so they are deferred to the value graph's proof-gated canon.
 //!
 //! Value-dependent identities (`x + 0` → `x`) are deferred — they need literal
 //! values, which are abstracted to classes. Full distribution (where the
@@ -93,16 +95,15 @@ impl Rewriter<'_> {
                     self.rewrite_negated(c)
                 }
                 Payload::Op(Op::Neg) => {
-                    // double negation: -(-x) → x
-                    let c = self.old.children(old_id)[0];
-                    if self.old.kind(c) == NodeKind::UnOp
-                        && self.old.node(c).payload == Payload::Op(Op::Neg)
-                    {
-                        let g = self.old.children(c)[0];
-                        self.rewrite(g)
-                    } else {
-                        self.generic(old_id, node.span)
-                    }
+                    // `-(-x)` is `x` ONLY for numbers — on a list/string `-x` Errs, so
+                    // `-(-x)` Errs while `x` does not. Cancelling it HERE is unsound: this
+                    // pass is value-INDEPENDENT and has no operand type, so it would merge a
+                    // `return -(-a)` with an identity `return a` for an untyped param (#283-B,
+                    // exactly the `!!x → x` hazard handled just above). Preserve the double
+                    // negation; the value graph cancels `-(-x) → x` ONLY when `x` is provably
+                    // numeric (`proven_numeric`, genuine evidence — never the optimistic
+                    // "param is Num because `-` was applied to it" inference).
+                    self.generic(old_id, node.span)
                 }
                 _ => self.generic(old_id, node.span),
             },

--- a/crates/nose-normalize/src/value_graph/canonicalize.rs
+++ b/crates/nose-normalize/src/value_graph/canonicalize.rs
@@ -176,6 +176,7 @@ impl<'a> Builder<'a> {
                 let inner = self.nodes[args[0] as usize].args[0];
                 if io == Op::Neg as u32
                     && self.value_law_satisfied(ValueLaw::NumericNegationInvolution, &[inner])
+                    && self.proven_numeric(inner)
                 {
                     return Some(inner);
                 }
@@ -208,7 +209,8 @@ impl<'a> Builder<'a> {
             let bitwise = o == Op::BitAnd as u32 || o == Op::BitOr as u32;
             let logical = o == Op::And as u32 || o == Op::Or as u32;
             if (bitwise
-                && self.value_law_satisfied(ValueLaw::NumericBitwiseIdempotence, &[args[0]]))
+                && self.value_law_satisfied(ValueLaw::NumericBitwiseIdempotence, &[args[0]])
+                && self.proven_numeric(args[0]))
                 || (logical && self.value_law_satisfied(ValueLaw::BooleanIdempotence, &[args[0]]))
             {
                 return Some(args[0]);

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -64,6 +64,40 @@ impl<'a> Builder<'a> {
         self.value_law_satisfied(law, values)
     }
 
+    /// Whether `v` provably evaluates to a Number on every input it does not Err on, using
+    /// ONLY genuine domain evidence — numeric literals and annotated / pack-typed params —
+    /// never the OPTIMISTIC "this param is Num because a numeric op was applied to it"
+    /// inference that `vty` (via `infer_param_value_domains`) folds into a param's domain.
+    ///
+    /// A type-gated rewrite that ERASES the very operation it inferred the domain from —
+    /// `-(-a) → a`, `a & a → a` — cannot trust `vty`: the only thing proving `a: Num` was
+    /// the `-`/`&` being deleted, so the canonical `a` would carry no numeric constraint
+    /// and merge with a bare `def ident(a): a` (differ on a list: `-(-a)` Errs, `a` does
+    /// not). That is #283-B, a confirmed false merge. Such rewrites gate on THIS instead of
+    /// `value_law_satisfied` alone. Fails closed: an untyped param leaf is NOT proven, so
+    /// the rewrite simply does not fire — typed/annotated operands still converge.
+    pub(super) fn proven_numeric(&self, v: ValueId) -> bool {
+        match self.nodes[v as usize].op {
+            ValOp::Const(k) => const_value_domain(k) == ValueDomain::Number,
+            ValOp::Input(cid) => self
+                .param_domain
+                .get(&cid)
+                .is_some_and(|d| d.is_integer_or_number()),
+            ValOp::Clamp => true,
+            // A unary op whose result is numeric ONLY when its operand is (`Neg`, `~`,
+            // `abs`): recurse so the proof bottoms out at a genuine leaf, never at an
+            // optimistic param domain.
+            ValOp::Un(o) => {
+                (o == ABS_CODE || matches!(op_from_code(o), Some(Op::Neg | Op::BitNot)))
+                    && self.nodes[v as usize]
+                        .args
+                        .first()
+                        .is_some_and(|&a| self.proven_numeric(a))
+            }
+            _ => false,
+        }
+    }
+
     pub(super) fn record_value_law(&mut self, law: ValueLaw) {
         if nose_semantics::pack_facing_value_law(law).is_some() {
             self.value_laws.push(law);

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2194,3 +2194,20 @@ obligation and dev/heldout corpus pricing (defense-deferral is a first-class
 verdict, and a rushed soundness patch that misidentifies the mechanism — as the
 first reorder-guard attempt did — is worse than an honest P0). The deliverables
 are the confirmed-reproducer battery, P0 #283, recall #284, and this ledger.
+
+**Remediation (post-series-5, each priced separately).** The deferred fixes then
+shipped as deliberate moat work, every one recall-neutral on `bench/repos`:
+- **A — effectful AC operands (#286).** `reorder_safe` holds any subtree carrying a
+  call/HOF/lambda/opaque (an observable effect the interpreter orders) in place at
+  every operand-sort site; `print(a)+print(b)` no longer merges with its swap.
+- **B — optimistic-Number rewrites (#283-B).** The `algebra` pass stopped cancelling
+  `-(-x)` unconditionally (it has no operand type — same reason `!!x` was already
+  deferred), and `-(-a)→a` / `a&a→a` now gate on `proven_numeric` (genuine evidence,
+  never the self-referential "param is Num because `-`/`&` was applied to it"
+  inference). Untyped stays split; annotated still folds. C4's `abs`/De-Morgan
+  recall and MIN/MAX AC-flatten shipped together as #284.
+- **D (mod) — language-blind `%` (#290).** A distinct `Op::FloorMod` for Python/Ruby
+  floored `%` (interpreted with floor semantics) vs C-family truncated `Op::Mod`;
+  the oracle is no longer blind here. The `/`-division three-way split and JS int32
+  narrowing parts of D, plus C (untyped `+` commutativity — still oracle-blind), stay
+  open in #283.


### PR DESCRIPTION
## What

Fixes #283 sub-finding **B** — the optimistic-Number false merges. `-(-a)`, `a & a`, and `a | a` were each merged with a bare `a` for an **untyped** param, a confirmed cardinal-sin false merge (design §1). These identities hold only for numbers: on a list/string the inner op Errs, so `-(-a)` Errs while `a` returns the value — different behavior, one fingerprint.

## Root cause (two layers)

1. **`algebra` pass cancelled `-(-x) → x` unconditionally.** That pass is value-*independent* — it has no operand type — yet `-(-x) → x` is a value-*dependent* identity (sound only for numbers). The exact same hazard for `!!x → x` (bool coercion) was already deferred there with a "preserve, let the value graph prove it" comment; the `-` twin was missed.
2. **The value graph's `Num` gate trusted an optimistic param domain.** `infer_param_value_domains` infers `a: Number` *from the very `-`/`&` being rewritten*, so the "now SOUND because the operand is PROVEN Num" gate passed for an untyped param — circular reasoning, since the canonical `a` then carries no numeric constraint and collapses onto `def ident(a): a`.

## Fix

- `algebra.rs`: preserve `-(-x)` (emit it generically), mirroring the `!!x` deferral. It now reaches the value graph intact.
- `state.rs`: add `proven_numeric(v)` — true only on **genuine** numeric evidence (numeric literals; annotated / semantic-pack-typed params via `param_domain`), never the optimistic self-referential inference. Fails closed.
- `canonicalize.rs`: the `NumericNegationInvolution` and `NumericBitwiseIdempotence` rewrites now require `proven_numeric` in addition to the existing language/requirement gate.

Untyped `-(-a)` / `a & a` stay distinct from `a`; an annotated `a: int` still cancels (sound recall preserved).

## Verification

- **No false merges**: `nose verify bench/repos` → `SOUND: no false merges ✓`. The neg_involution reproducer is now clean (`0 ≤ 0`).
- **Zero recall change**: `4294 → 4294` semantic clone families on `bench/repos` (the corpus held no untyped occurrences — the removed merges were all latent, the §AS scenario). Canon-preservation at the pre-existing baseline.
- Two regression tests (`double_negation_cancels_only_for_proven_numeric`, `bitwise_self_idempotence_gates_on_proven_numeric`): untyped split, typed folds.
- dup-gate 25/25; suite green.

## Scope

The B sub-finding of #283. Remaining open: **C** (untyped `+` commutativity / associativity — still oracle-blind) and the `/`-division three-way semantics + JS int32 narrowing parts of **D**. Both are root-caused in #283. Reproducer files (`untyped_add_commute.py`, `float_assoc.py`) stay until #283 fully closes; the now-fixed rows are covered by permanent regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
