### PR TITLE
CI: move the coverage job post-merge, off the PR critical path (~13m → ~5m)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,14 @@ jobs:
 
   coverage:
     name: test coverage (llvm-cov)
+    # Coverage is a QUALITY ratchet, not a soundness gate, and its instrumented
+    # rebuild + re-run of the whole suite is by far the slowest job (~13 min vs the
+    # ~5 min `test` job — it was the entire PR wall-clock). Run it on the trunk only
+    # (post-merge `push` to main), keeping it OFF the PR critical path. Every
+    # soundness gate (test, dup-gate, lean proofs, MSRV, nightly corpus-verify)
+    # still blocks each PR; a coverage dip is caught here on main and fixed forward.
+    # `pull_request` events skip this job (it shows as neutral, never pending).
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -108,6 +108,9 @@ cargo build --release
 step "test (release)"
 cargo test --release
 
+# In CI this is a POST-MERGE gate (runs on push to main, not on PRs — it is the
+# slowest job and is a quality ratchet, not a soundness gate). Kept here so --full
+# stays a complete local mirror; run it before merging if you touched test coverage.
 step "coverage gate (cargo-llvm-cov, >= 86% lines)"
 need_cmd cargo-llvm-cov "install it with: cargo install cargo-llvm-cov"
 cargo llvm-cov --workspace --summary-only --fail-under-lines 86


### PR DESCRIPTION
## Problem

PR wall-clock was gated entirely by one job:

| job | time | kind |
|---|---|---|
| **test coverage (llvm-cov)** | **~13 min** | quality metric (lines ≥ 86%) |
| build · test · lint · dup-gate | ~5 min | correctness + soundness |
| msrv / supply-chain / docs / formal | 19–30 s | — |

The coverage job's 12m43s is a single step: an **instrumented rebuild** (can't reuse the release cache — different profile) **plus a re-run of the whole suite under instrumentation** (2–5× slower execution), all to produce one number. Meanwhile the `test` job's 5 min is mostly irreducible test execution (3m44s; clippy/build are cache-warm at 9s/51s).

## Fix

Coverage (line ≥ 86%) is a **quality ratchet, not a soundness gate**. The actual safety net — the test suite, the duplication gate, the Lean proofs, MSRV, and the nightly corpus-verify — keeps blocking **every PR**. So gate the coverage job to `push` events (post-merge on `main` only):

```yaml
if: github.event_name == 'push'
```

The trunk still enforces ≥ 86%; a dip is caught on the main run and fixed forward. On PRs the job skips (neutral, never pending). **PR wall-clock ~13 min → ~5 min**, with no change to any gate that decides correctness or soundness.

## Rejected: cargo-nextest

I measured it rather than assuming. On this suite, under a CI-like 3-thread constraint:

| runner | time |
|---|---|
| `cargo test --release` | **57.7 s** |
| `cargo nextest run --release` | **62.4 s** (slower) |

nextest parallelizes across test *binaries*, but here one binary (`nose-cli`, 470 of 965 tests) dominates — so there's no cross-binary gain to capture, and nextest's process-per-test overhead makes it net slower. The test job's cost is test execution, not scheduling. Kept `cargo test`.

## Safety

- No Rust touched; no soundness gate moved off PRs.
- `coverage` still runs (on `main`), still fails at < 86%.
- Local `--full` mirror keeps the coverage step, annotated as a post-merge gate.
- This PR is itself the demonstration: its own checks run without the 13-min coverage job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
