### PR TITLE
Soundness #283-C (battery floor): feed distinct strings to the verify oracle

### DIFF
--- a/bench/coevo/false_merges/README.md
+++ b/bench/coevo/false_merges/README.md
@@ -16,8 +16,8 @@ moved into the permanent regression battery.
 | effect_commute.py | commutative `+` reorders observable effects | yes | FIXED #286 (A) — `reorder_safe` |
 | effect_acchain.py | AC-chain sorts effectful leaves | yes | FIXED #286 (A) — `reorder_safe` |
 | neg_involution.py | `-(-x)→x` on optimistically-Num param | yes (canon-preservation) | FIXED #283-B — `proven_numeric` |
-| untyped_add_commute.py | `a+b≡b+a` for untyped (string/list concat) | NO — oracle blind | OPEN (C) |
-| float_assoc.py | `(a+b)+c≡a+(b+c)` for floats | NO — oracle blind | OPEN (C/float) |
+| untyped_add_commute.py | `a+b≡b+a` for untyped (string/list concat) | **yes** (battery floor) | OPEN (C) — oracle now witnesses it; detector gate pending |
+| float_assoc.py | `(a+b)+c≡a+(b+c)` for floats | NO — oracle blind | OPEN (C/float) — needs the `Float` value kind (D-div) |
 
 FIXED rows are now covered by permanent regression tests (effect cases in the
 value-graph suite; `-(-a)`/`a&a` in `crates/nose-cli/tests/equivalence.rs`,

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -1787,6 +1787,24 @@ fn verify_battery(probes: &[nose_normalize::Value]) -> Vec<Vec<nose_normalize::V
             battery.push(row);
         }
     }
+    // Part 3: ORDER-SENSITIVITY rows for non-commutative `+` (string / list CONCAT).
+    // The combinatorial pool is int/list-only and the probes inject ONE string at a
+    // time, so two DISTINCT strings (or two distinct lists) are never bound to two
+    // params at once — the only input on which `a+b` and `b+a` differ under concat.
+    // Without these rows the order-sensitive `Str`/`List` model (interp.rs) is starved,
+    // and the oracle reads SOUND while the detector reorders untyped `+` (#283-C). Each
+    // slot gets a distinct token so every adjacent operand pair differs.
+    let s = |t: u64| Value::Str(vec![t]);
+    let distinct: [[Value; VERIFY_WIDTH]; 2] = [
+        [s(0xC0DE01), s(0xC0DE02), s(0xC0DE03), s(0xC0DE04)],
+        [l(&[1, 1]), l(&[2, 2]), l(&[3, 3]), l(&[4, 4])],
+    ];
+    for row in &distinct {
+        battery.push(row.to_vec());
+        let mut rev = row.to_vec();
+        rev.reverse();
+        battery.push(rev);
+    }
     battery
 }
 


### PR DESCRIPTION
## What

The **battery floor** for #283 sub-finding **C** (untyped `+` commutativity), per the [oracle-value-model](../blob/main/docs/oracle-value-model.md) go/no-go doc §3.1. Strengthens the `verify` oracle so it can *witness* the string-concat case of `a+b ≢ b+a`; no detector change, no recall cost.

## Why

The verify oracle already models strings as an **order-sensitive free monoid** (`interp.rs` `Value::Str`), so `"x"+"y" ≠ "y"+"x"` is representable. But the input battery (`verify_battery`, `main.rs`) is starved of the input that exercises it: the combinatorial pool is integer/list-only, and string probes are injected **one position at a time** (others filled with a list). So two **distinct strings** were never bound to two params at once — the only input on which `a+b` and `b+a` differ under concat. The oracle therefore read `SOUND` while the model could, in principle, witness the divergence (#283-C, the §AS pattern inside the oracle's own inputs).

## Change

Add a small set of **order-sensitivity rows** to `verify_battery`: distinct string tokens and distinct lists across all four slots (plus reversed), so every adjacent operand pair differs.

## Verification

- **Oracle now witnesses it:** `nose verify bench/coevo/false_merges/untyped_add_commute.py` → `1 VIOLATION (false merge)` — previously oracle-blind. The reproducer flips from "NO — oracle blind" to "caught."
- **Corpus stays SOUND:** `nose verify bench/repos` → `SOUND: no false merges ✓`. The pinned corpus contains no untyped-`+` reorder false merge, so the floor ships safely on its own.
- **No recall cost:** the change touches only the oracle's input battery, not the detector or the fingerprint — `nose scan` output is unchanged. dup-gate 25/25; suite green.

## Scope

This is the floor, not the close. The detector still reorders untyped `+` (`order_bin_operands`); closing that — gating the reorder on *proven* non-concat operands, with the recall cost measured — is the follow-up PR (#283-C's detector gate). The `float_assoc.py` half of C stays oracle-blind: float non-associativity needs the `Float` value kind (D-div), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
