### PR TITLE
Soundness #283-C (gate): untyped `a + b` no longer commutes with `b + a`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ break.
 ## [Unreleased]
 
 ### Fixed
+- **Untyped `a + b` no longer false-merges with `b + a`** (#283-C). `+` *commutes* only
+  for numbers — for strings/lists it is *ordered* concat (`"x"+"y" ≠ "y"+"x"`). The
+  detector reordered `+` operands whenever neither was *proven* a string/list, which for
+  an untyped param is optimistic. The fix, in three precise pieces:
+  - The verify oracle already models strings as an order-sensitive free monoid, but its
+    input battery never fed two distinct strings to two params at once, so it read SOUND
+    while the merge was live — the battery now has order-sensitivity rows (#294) and the
+    oracle witnesses it.
+  - The `+`-COMMUTATIVITY gate (`add_values_not_concat`) now requires **at least one**
+    operand to be `proven_non_concat` (genuine evidence it is never a string/list — never
+    the optimistic inference, the #283-B channel). That is the exact sound condition: if
+    one operand is numeric then any other either commutes or hits `num + str → Err` in
+    every order. So `x + 4`, `x*x + y*y`, and any sum touching a number still commute;
+    only `a + b` with two concat-possible operands stays ordered.
+  - `+`-ASSOCIATIVITY (`(a+b)+c ≡ a+(b+c)`) is sound for ALL types (concat is associative),
+    so the AC canon still *flattens* untyped `+` — only the operand *sort* (commutativity)
+    is gated. And a `Reduce(Add)` (a `sum`) forces its elements numeric, so the per-element
+    `+` of `sum(x+y for …)` is commuted in that context, keeping generator ≡ loop ≡ `reduce`
+    cross-form convergence.
+
+  Zero corpus recall change (4294 → 4294 families on `bench/repos`); `nose verify` SOUND.
+  The audit surfaced ~15 latent false merges encoded in the test suite's own fixtures
+  (untyped `+` commutation as a "clone" vehicle), now corrected. The `(a+b)+c ≡ a+(b+c)`
+  *float* non-associativity half of C stays open — it needs the `Float` value kind (D-div);
+  see `docs/oracle-value-model.md`.
 - **`-(-a)` and `a & a` / `a | a` no longer false-merge with a bare `a` on untyped
   params** (#283-B). These identities hold only for numbers — on a list/string the
   inner op Errs, so `-(-a)` Errs while `a` does not. Two layers conspired to merge

--- a/bench/coevo/false_merges/README.md
+++ b/bench/coevo/false_merges/README.md
@@ -16,11 +16,13 @@ moved into the permanent regression battery.
 | effect_commute.py | commutative `+` reorders observable effects | yes | FIXED #286 (A) — `reorder_safe` |
 | effect_acchain.py | AC-chain sorts effectful leaves | yes | FIXED #286 (A) — `reorder_safe` |
 | neg_involution.py | `-(-x)→x` on optimistically-Num param | yes (canon-preservation) | FIXED #283-B — `proven_numeric` |
-| untyped_add_commute.py | `a+b≡b+a` for untyped (string/list concat) | **yes** (battery floor) | OPEN (C) — oracle now witnesses it; detector gate pending |
+| untyped_add_commute.py | `a+b≡b+a` for untyped (string/list concat) | yes (battery floor #294) | FIXED #283-C — `proven_numeric` `+`-reorder gate |
 | float_assoc.py | `(a+b)+c≡a+(b+c)` for floats | NO — oracle blind | OPEN (C/float) — needs the `Float` value kind (D-div) |
 
 FIXED rows are now covered by permanent regression tests (effect cases in the
-value-graph suite; `-(-a)`/`a&a` in `crates/nose-cli/tests/equivalence.rs`,
+value-graph suite; `-(-a)`/`a&a`/`a+b` in `crates/nose-cli/tests/equivalence.rs`,
 `double_negation_cancels_only_for_proven_numeric` +
-`bitwise_self_idempotence_gates_on_proven_numeric`). The reproducer files stay
-until #283 fully closes (the OPEN rows are oracle-blind — see #283-C/-D).
+`bitwise_self_idempotence_gates_on_proven_numeric` +
+`untyped_add_commute_gates_on_proven_numeric`). The reproducer files stay until
+#283 fully closes (the remaining OPEN row, `float_assoc.py`, is oracle-blind — its
+float non-associativity needs the `Float` value kind, D-div — see #283-D).

--- a/crates/nose-cli/tests/cli/exact_fragments.rs
+++ b/crates/nose-cli/tests/cli/exact_fragments.rs
@@ -224,7 +224,7 @@ fn semantic_scan_reports_exact_safe_return_fragments_under_opaque_functions() {
         ),
         (
             "product_b.py",
-            "def product_right(ys):\n    return (4 + ys[2]) * (ys[1] + ys[0])\n    trace(ys)\n",
+            "def product_right(ys):\n    return (4 + ys[2]) * (ys[0] + ys[1])\n    trace(ys)\n",
         ),
         (
             "product_neg.py",
@@ -309,7 +309,7 @@ fn semantic_scan_reports_exact_safe_conditional_return_fragments_under_opaque_fu
         ),
         (
             "sum_guard_b.py",
-            "def sum_guard_right(ys):\n    if 10 < ys[1] + ys[0]:\n        return ys[1] + ys[0]\n    trace(ys)\n",
+            "def sum_guard_right(ys):\n    if 10 < ys[0] + ys[1]:\n        return ys[0] + ys[1]\n    trace(ys)\n",
         ),
         (
             "sum_guard_neg.py",
@@ -321,7 +321,7 @@ fn semantic_scan_reports_exact_safe_conditional_return_fragments_under_opaque_fu
         ),
         (
             "both_guard_b.py",
-            "def both_guard_right(ys):\n    if ys[1] > 0 and ys[0] > 0:\n        return ys[1] + ys[0]\n    trace(ys)\n",
+            "def both_guard_right(ys):\n    if ys[1] > 0 and ys[0] > 0:\n        return ys[0] + ys[1]\n    trace(ys)\n",
         ),
         (
             "both_guard_mutated.py",
@@ -409,7 +409,7 @@ fn semantic_scan_reports_exact_safe_conditional_throw_fragments_under_opaque_fun
         ),
         (
             "sum_throw_guard_b.js",
-            "function sumThrowRight(ys) {\n  if (10 < ys[1] + ys[0]) {\n    throw ys[1] + ys[0];\n  }\n  trace(ys);\n}\n",
+            "function sumThrowRight(ys) {\n  if (10 < ys[0] + ys[1]) {\n    throw ys[0] + ys[1];\n  }\n  trace(ys);\n}\n",
         ),
         (
             "sum_throw_guard_neg.js",
@@ -421,7 +421,7 @@ fn semantic_scan_reports_exact_safe_conditional_throw_fragments_under_opaque_fun
         ),
         (
             "both_throw_guard_b.js",
-            "function bothThrowRight(ys) {\n  if (ys[1] > 0 && ys[0] > 0) {\n    throw ys[1] + ys[0];\n  }\n  trace(ys);\n}\n",
+            "function bothThrowRight(ys) {\n  if (ys[1] > 0 && ys[0] > 0) {\n    throw ys[0] + ys[1];\n  }\n  trace(ys);\n}\n",
         ),
         (
             "both_throw_guard_mutated.js",
@@ -487,7 +487,7 @@ fn semantic_scan_reports_exact_safe_empty_branch_conditional_exit_fragments_unde
         ),
         (
             "empty_else_throw_b.js",
-            "function emptyElseThrowRight(ys) {\n  if (10 < ys[1] + ys[0]) {\n    throw ys[1] + ys[0];\n  } else {\n  }\n  trace(ys);\n}\n",
+            "function emptyElseThrowRight(ys) {\n  if (10 < ys[0] + ys[1]) {\n    throw ys[0] + ys[1];\n  } else {\n  }\n  trace(ys);\n}\n",
         ),
         (
             "empty_else_throw_neg.js",
@@ -499,7 +499,7 @@ fn semantic_scan_reports_exact_safe_empty_branch_conditional_exit_fragments_unde
         ),
         (
             "empty_then_throw_b.js",
-            "function emptyThenThrowRight(ys) {\n  if (ys[1] > 0 && ys[0] > 0) {\n  } else {\n    throw ys[1] + ys[0];\n  }\n  trace(ys);\n}\n",
+            "function emptyThenThrowRight(ys) {\n  if (ys[1] > 0 && ys[0] > 0) {\n  } else {\n    throw ys[0] + ys[1];\n  }\n  trace(ys);\n}\n",
         ),
         (
             "empty_then_throw_mutated.js",
@@ -571,7 +571,7 @@ fn semantic_scan_reports_exact_safe_conditional_bare_return_fragments_under_opaq
         ),
         (
             "bare_sum_b.js",
-            "function bareSumRight(ys) {\n  if (10 < ys[1] + ys[0]) {\n    return;\n  }\n  trace(ys);\n}\n",
+            "function bareSumRight(ys) {\n  if (10 < ys[0] + ys[1]) {\n    return;\n  }\n  trace(ys);\n}\n",
         ),
         (
             "bare_sum_mutated.js",
@@ -670,7 +670,7 @@ fn semantic_scan_reports_exact_safe_conditional_expr_effect_fragments_under_opaq
         ),
         (
             "push_sum_b.js",
-            "function pushSumRight(ys, dst) {\n  if (10 < ys[1] + ys[0]) {\n    dst.push(ys[1] + ys[0]);\n  }\n  trace(ys);\n}\n",
+            "function pushSumRight(ys, dst) {\n  if (10 < ys[0] + ys[1]) {\n    dst.push(ys[0] + ys[1]);\n  }\n  trace(ys);\n}\n",
         ),
         (
             "push_sum_neg.js",
@@ -682,7 +682,7 @@ fn semantic_scan_reports_exact_safe_conditional_expr_effect_fragments_under_opaq
         ),
         (
             "push_else_b.js",
-            "function pushElseRight(ys, dst) {\n  if (ys[1] > 0 && ys[0] > 0) {\n  } else {\n    dst.push(ys[1] + ys[0]);\n  }\n  trace(ys);\n}\n",
+            "function pushElseRight(ys, dst) {\n  if (ys[1] > 0 && ys[0] > 0) {\n  } else {\n    dst.push(ys[0] + ys[1]);\n  }\n  trace(ys);\n}\n",
         ),
         (
             "push_else_mutated.js",
@@ -780,7 +780,7 @@ fn semantic_scan_reports_exact_safe_branch_temp_consumption_fragments_under_opaq
         ),
         (
             "temp_throw_b.js",
-            "function tempThrowRight(ys) {\n  if (10 < ys[1] + ys[0]) {\n    throw ys[1] + ys[0];\n  }\n  trace(ys);\n}\n",
+            "function tempThrowRight(ys) {\n  if (10 < ys[0] + ys[1]) {\n    throw ys[0] + ys[1];\n  }\n  trace(ys);\n}\n",
         ),
         (
             "temp_throw_neg.js",
@@ -1011,7 +1011,7 @@ fn semantic_scan_reports_exact_safe_nested_conditional_effect_fragments_under_op
         ),
         (
             "nested_push_b.js",
-            "function nestedPushRight(ys, dst) {\n  if (ys[1] > 0 && ys[0] > 0) {\n    dst.push(ys[1] + ys[0]);\n  } else {\n    if (0 < ys[2]) {\n      dst.push(ys[2] * ys[2]);\n    }\n  }\n  trace(ys);\n}\n",
+            "function nestedPushRight(ys, dst) {\n  if (ys[1] > 0 && ys[0] > 0) {\n    dst.push(ys[0] + ys[1]);\n  } else {\n    if (0 < ys[2]) {\n      dst.push(ys[2] * ys[2]);\n    }\n  }\n  trace(ys);\n}\n",
         ),
         (
             "nested_push_mutated.js",
@@ -1023,7 +1023,7 @@ fn semantic_scan_reports_exact_safe_nested_conditional_effect_fragments_under_op
         ),
         (
             "nested_push_sum_b.js",
-            "function nestedPushSumRight(ys, dst) {\n  if (10 < ys[1] + ys[0]) {\n    dst.push(ys[1] + ys[0]);\n  } else {\n    if (0 < ys[2]) {\n      dst.push(ys[2] * ys[2]);\n    }\n  }\n  trace(ys);\n}\n",
+            "function nestedPushSumRight(ys, dst) {\n  if (10 < ys[0] + ys[1]) {\n    dst.push(ys[0] + ys[1]);\n  } else {\n    if (0 < ys[2]) {\n      dst.push(ys[2] * ys[2]);\n    }\n  }\n  trace(ys);\n}\n",
         ),
         (
             "nested_push_sum_neg.js",
@@ -1035,7 +1035,7 @@ fn semantic_scan_reports_exact_safe_nested_conditional_effect_fragments_under_op
         ),
         (
             "nested_push_product_b.js",
-            "function nestedPushProductRight(ys, dst) {\n  if (10 < (1 + ys[0])) {\n    dst.push(2 * (1 + ys[0]));\n  } else {\n    if (ys[2] + ys[1] > 0) {\n      dst.push(ys[2] + ys[1]);\n    }\n  }\n  trace(ys);\n}\n",
+            "function nestedPushProductRight(ys, dst) {\n  if (10 < (1 + ys[0])) {\n    dst.push(2 * (1 + ys[0]));\n  } else {\n    if (ys[1] + ys[2] > 0) {\n      dst.push(ys[1] + ys[2]);\n    }\n  }\n  trace(ys);\n}\n",
         ),
         (
             "nested_push_product_neg.js",
@@ -3970,7 +3970,7 @@ fn semantic_scan_reports_exact_safe_throw_fragments_under_opaque_functions() {
         ),
         (
             "throw_product_b.js",
-            "function throwProductRight(ys) {\n  throw (4 + ys[2]) * (ys[1] + ys[0]);\n  trace(ys);\n}\n",
+            "function throwProductRight(ys) {\n  throw (4 + ys[2]) * (ys[0] + ys[1]);\n  trace(ys);\n}\n",
         ),
         (
             "throw_product_mutated.js",

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -241,7 +241,14 @@ fn large_generated_ac_formula_stays_compact_and_distinct() {
     let forward = params.join(" + ");
     let reverse = params.iter().rev().cloned().collect::<Vec<_>>().join(" + ");
     let changed = format!("{} + x0 * x0", params[1..].join(" + "));
-    let src = |expr: &str| format!("def f({}):\n    return {expr}\n", params.join(", "));
+    // Annotate the params `: int` so the long `+` chain is PROVEN numeric and commutes
+    // (#283-C gates untyped `+` reorder; this test is about AC compaction, not the gate).
+    let typed_params = params
+        .iter()
+        .map(|p| format!("{p}: int"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let src = |expr: &str| format!("def f({typed_params}):\n    return {expr}\n");
 
     let fp = value_fp(&i, &src(&forward), Lang::Python);
     assert_eq!(
@@ -1659,10 +1666,23 @@ fn reduction_keeps_behavior_distinct() {
 #[test]
 fn commutative_reconcile() {
     let i = Interner::new();
-    let a = "def f(a, b):\n    return a + b\n";
-    let b = "def g(a, b):\n    return b + a\n";
-    // Numeric `+` commutativity is reconciled by the value graph (gated on non-concat).
-    assert_eq!(value_fp(&i, a, Lang::Python), value_fp(&i, b, Lang::Python));
+    // `+` commutativity is reconciled by the value graph ONLY when an operand is proven
+    // non-concat (#283-C): untyped `a + b` could be string concat (`"x"+"y" != "y"+"x"`),
+    // so it stays ordered; an int-annotated `+` is provably numeric and still commutes.
+    let untyped_a = "def f(a, b):\n    return a + b\n";
+    let untyped_b = "def g(a, b):\n    return b + a\n";
+    assert_ne!(
+        value_fp(&i, untyped_a, Lang::Python),
+        value_fp(&i, untyped_b, Lang::Python),
+        "untyped a + b must not merge with b + a (string concat is ordered)"
+    );
+    let typed_a = "def f(a: int, b: int):\n    return a + b\n";
+    let typed_b = "def g(a: int, b: int):\n    return b + a\n";
+    assert_eq!(
+        value_fp(&i, typed_a, Lang::Python),
+        value_fp(&i, typed_b, Lang::Python),
+        "int-annotated a + b is provably numeric — must still commute"
+    );
 }
 
 #[test]
@@ -2354,14 +2374,36 @@ fn cfg_continue_guard_equals_nested() {
 #[test]
 fn algebra_associativity() {
     let i = Interner::new();
+    // ASSOCIATIVITY (`(a+b)+c` ≡ `a+(b+c)`) is sound for ALL types — string concat is
+    // associative — so the value graph reconciles it even for UNTYPED params. COMMUTATIVITY
+    // (`(a+b)+c` ≡ `c+(a+b)`) is gated on non-concat (#283-C): untyped stays distinct, an
+    // int-annotated chain still fully canonicalizes. (Reconciled by the value graph, not the
+    // algebra IL pass — so check the fingerprint, not the IL hash.)
     let left = "def f(a, b, c):\n    return (a + b) + c\n";
     let right = "def g(a, b, c):\n    return a + (b + c)\n";
     let mixed = "def h(a, b, c):\n    return c + (a + b)\n";
-    // `+` commutativity/associativity is reconciled by the value graph (type-GATED on
-    // concat), not the algebra IL pass — so check the fingerprint, not the IL hash.
     let hl = value_fp(&i, left, Lang::Python);
-    assert_eq!(hl, value_fp(&i, right, Lang::Python));
-    assert_eq!(hl, value_fp(&i, mixed, Lang::Python));
+    assert_eq!(
+        hl,
+        value_fp(&i, right, Lang::Python),
+        "associativity is sound untyped"
+    );
+    assert_ne!(
+        hl,
+        value_fp(&i, mixed, Lang::Python),
+        "untyped commutativity stays gated (operands could be strings)"
+    );
+    let t = |src: &str| value_fp(&i, src, Lang::Python);
+    let tl = t("def f(a: int, b: int, c: int):\n    return (a + b) + c\n");
+    assert_eq!(
+        tl,
+        t("def g(a: int, b: int, c: int):\n    return a + (b + c)\n")
+    );
+    assert_eq!(
+        tl,
+        t("def h(a: int, b: int, c: int):\n    return c + (a + b)\n"),
+        "int-annotated + fully commutes and associates"
+    );
 }
 
 #[test]
@@ -6987,5 +7029,29 @@ fn bitwise_self_idempotence_gates_on_proven_numeric() {
         value_fp(&i, typed_and, Lang::Python),
         value_fp(&i, typed_id, Lang::Python),
         "int-annotated a & a is provably numeric — must still fold to a"
+    );
+}
+
+#[test]
+fn untyped_add_commute_gates_on_proven_numeric() {
+    // #283-C: `a + b → b + a` (commuting the operands of `+`) is sound only when both are
+    // numbers — for strings/lists `+` is ORDERED concat (`"x"+"y" != "y"+"x"`). The detector
+    // reordered untyped `+` optimistically. Now the reorder gates on proven-numeric operands:
+    // an untyped `a+b` stays distinct from `b+a`, while an int-annotated one still converges.
+    let i = Interner::new();
+    let fwd_untyped = "def f(a, b):\n    return a + b\n";
+    let rev_untyped = "def f(a, b):\n    return b + a\n";
+    let fwd_typed = "def f(a: int, b: int):\n    return a + b\n";
+    let rev_typed = "def f(a: int, b: int):\n    return b + a\n";
+
+    assert_ne!(
+        value_fp(&i, fwd_untyped, Lang::Python),
+        value_fp(&i, rev_untyped, Lang::Python),
+        "untyped a + b must NOT merge with b + a (string concat is ordered)"
+    );
+    assert_eq!(
+        value_fp(&i, fwd_typed, Lang::Python),
+        value_fp(&i, rev_typed, Lang::Python),
+        "int-annotated a + b is provably numeric — commuting to b + a must still converge"
     );
 }

--- a/crates/nose-normalize/src/value_graph/canonicalize.rs
+++ b/crates/nose-normalize/src/value_graph/canonicalize.rs
@@ -9,6 +9,7 @@ use super::*;
 
 impl<'a> Builder<'a> {
     pub(super) fn mk(&mut self, mut op: ValOp, mut args: Vec<ValueId>) -> ValueId {
+        self.commute_numeric_reduce_contrib(&op, &mut args);
         self.order_bin_operands(&mut op, &mut args);
         if let Some(v) = self.u16_byte_pack(&op, &args) {
             return v;
@@ -363,20 +364,78 @@ impl<'a> Builder<'a> {
     // synthesized here). Sound: any operand permutation of an AC chain is denotation-
     // preserving (`normalize.value_graph.algebra`). String/list `+` is NOT reordered
     // (it is ordered concat); `* & | ^` Err on non-numeric regardless of order.
+    /// A `Reduce(Add)` (a `sum`) forces its elements numeric — `sum` of non-numbers Errs
+    /// in EVERY order — so the per-element contribution's top-level `+` is numeric here and
+    /// may be commuted even when its operands are not context-free provable as non-concat:
+    /// `sum(x+y for …)` equals `sum(y+x for …)` (numeric-equal, or both Err). Sorting the
+    /// contribution's `+` operands at the point the reduction is built recovers the
+    /// generator ≡ loop ≡ `reduce` cross-form convergence (a core Type-4 case) that the
+    /// context-free `+` gate (#283-C) would otherwise split. Sound by the Reduce(Add)
+    /// numeric context, not a context-free claim — so it lives here, not in `proven_non_concat`.
+    fn commute_numeric_reduce_contrib(&mut self, op: &ValOp, args: &mut [ValueId]) {
+        let ValOp::Reduce(o) = *op else { return };
+        if o != Op::Add as u32 || args.is_empty() {
+            return;
+        }
+        // The element contribution is the last arg (`[init, contrib]` or `[contrib]`); the
+        // optional seed in slot 0 is left alone.
+        let idx = args.len() - 1;
+        args[idx] = self.commute_add_in_numeric_context(args[idx]);
+    }
+
+    /// Sort the operands of a top-level `+` known numeric by its enclosing `Reduce(Add)`,
+    /// recursing through the `Phi(cond, contrib, identity)` a FILTERED reduction builds
+    /// (`sum(x+y for … if g)`) so the guarded `x+y` is reached too. The guard condition
+    /// (slot 0) is untouched.
+    fn commute_add_in_numeric_context(&mut self, v: ValueId) -> ValueId {
+        match self.nodes[v as usize].op {
+            ValOp::Bin(b) if b == Op::Add as u32 => {
+                let mut leaves = Vec::new();
+                self.flatten_into(v, b, &mut leaves);
+                if leaves.len() >= 2 && leaves.iter().all(|&l| self.reorder_safe(l)) {
+                    leaves.sort_unstable_by_key(|&l| self.vhash[l as usize]);
+                    self.intern_ac_chain(b, &leaves)
+                } else {
+                    v
+                }
+            }
+            ValOp::Phi => {
+                let a = self.nodes[v as usize].args.clone();
+                if a.len() == 3 {
+                    let then_branch = self.commute_add_in_numeric_context(a[1]);
+                    let else_branch = self.commute_add_in_numeric_context(a[2]);
+                    if then_branch != a[1] || else_branch != a[2] {
+                        return self.mk(ValOp::Phi, vec![a[0], then_branch, else_branch]);
+                    }
+                }
+                v
+            }
+            _ => v,
+        }
+    }
+
     fn ac_chain_canon(&mut self, op: &ValOp, args: &[ValueId]) -> Option<ValueId> {
         let ValOp::Bin(o) = *op else { return None };
         if is_assoc_comm_code(o) && args.len() == 2 {
-            let concat = o == Op::Add as u32
-                && !self.add_values_not_concat(ValueLaw::AddAssociativity, args);
-            if !concat {
-                let mut leaves = Vec::new();
-                for &a in args {
-                    self.flatten_into(a, o, &mut leaves);
-                }
-                if leaves.len() > 2 && leaves.iter().all(|&v| self.reorder_safe(v)) {
+            let mut leaves = Vec::new();
+            for &a in args {
+                self.flatten_into(a, o, &mut leaves);
+            }
+            if leaves.len() > 2 && leaves.iter().all(|&v| self.reorder_safe(v)) {
+                // ASSOCIATIVITY — re-grouping a flat chain into one canonical left-leaning
+                // shape — is sound for ALL types, string/list concat included
+                // (`"a"+"b"+"c"` is `"abc"` however parenthesized). So ALWAYS flatten and
+                // rebuild, converging `(a+b)+c` with `a+(b+c)` even for untyped params.
+                // COMMUTATIVITY — sorting the operands — is the part gated on non-concat
+                // (#283-C): apply it for every AC op except a concat-possible `+`, so
+                // `c+(a+b)` (a reorder) stays distinct from `(a+b)+c` for untyped operands
+                // while numeric/typed sums still fully canonicalize.
+                let commute = o != Op::Add as u32
+                    || self.add_values_not_concat(ValueLaw::AddCommutativity, &leaves);
+                if commute {
                     leaves.sort_unstable_by_key(|&v| self.vhash[v as usize]);
-                    return Some(self.intern_ac_chain(o, &leaves));
                 }
+                return Some(self.intern_ac_chain(o, &leaves));
             }
         }
         None

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -60,8 +60,19 @@ impl<'a> Builder<'a> {
             })
     }
 
+    /// Whether a `+` chain may be treated as commutative (so its operands can be reordered)
+    /// rather than as ordered string/list concat. `value_law_satisfied` alone accepts an
+    /// UNKNOWN operand optimistically — which false-merges `a+b` with `b+a` for two untyped
+    /// params that are actually strings (`"x"+"y" != "y"+"x"`, now witnessed by the oracle,
+    /// #283-C). The exact condition is that AT LEAST ONE operand is PROVEN non-concat (never
+    /// a string/list): if one operand is numeric, then for any other operand the sum either
+    /// stays numeric (commutes) or hits `num + str` → `Err` in EVERY order (Err propagates
+    /// symmetrically), so the chain is permutation-invariant. Only when NO operand is proven
+    /// non-concat could they all be strings/lists, where order matters. So `x + 4`,
+    /// `x*x + y*y`, and any sum touching a number still commute; only `a + b` with two
+    /// concat-possible operands stays ordered.
     pub(super) fn add_values_not_concat(&self, law: ValueLaw, values: &[ValueId]) -> bool {
-        self.value_law_satisfied(law, values)
+        self.value_law_satisfied(law, values) && values.iter().any(|&v| self.proven_non_concat(v))
     }
 
     /// Whether `v` provably evaluates to a Number on every input it does not Err on, using
@@ -93,6 +104,59 @@ impl<'a> Builder<'a> {
                         .args
                         .first()
                         .is_some_and(|&a| self.proven_numeric(a))
+            }
+            _ => false,
+        }
+    }
+
+    /// Whether `v` provably never evaluates to a String or Sequence — the condition `+`
+    /// COMMUTATIVITY actually needs (concat is the only non-commutative `+`, #283-C). This
+    /// is WEAKER than `proven_numeric`: it admits values that are numeric-OR-error but never
+    /// a string/list, so a sound reorder is not lost just because an operand's numeric-ness
+    /// is unprovable. The key fact: among the modeled ops only `Add` (string concat) and
+    /// `Mul` (string repetition, `"ab"*3`) can yield a string/list; every other op
+    /// (`Sub`/`Div`/`Mod`/`Pow`/bitwise/shift/comparison and all unary) ERRORS on a
+    /// string/list operand, so its result is never one. Fails closed: an untyped param,
+    /// index, field, call, or `Phi` could be a string, so it is NOT proven non-concat.
+    pub(super) fn proven_non_concat(&self, v: ValueId) -> bool {
+        match self.nodes[v as usize].op {
+            // Non-string literals (Number / Boolean / Null). A String const is concat.
+            ValOp::Const(k) => !matches!(const_value_domain(k), ValueDomain::String),
+            // Only a GENUINELY non-string-typed param (numeric/boolean evidence) qualifies;
+            // an untyped param could be a string.
+            ValOp::Input(cid) => self
+                .param_domain
+                .get(&cid)
+                .is_some_and(|d| d.is_integer_or_number() || d.is_boolean()),
+            ValOp::Clamp => true,
+            // Every unary op (`Neg`/`~`/`!`/`abs`/int32-narrow) errors or returns a
+            // bool/number on a string operand — never a string.
+            ValOp::Un(_) => true,
+            ValOp::Bin(o) => {
+                let args = &self.nodes[v as usize].args;
+                if let Some(op) = op_from_code(o) {
+                    match op {
+                        // Concat / repetition: result is a string/list only when an operand
+                        // is — so non-concat iff every operand is. `Mul(x, x)` is special:
+                        // `str * str` errors (you cannot repeat by a string), so a squared
+                        // value is never a string regardless of `x`.
+                        Op::Add => args.iter().all(|&a| self.proven_non_concat(a)),
+                        Op::Mul => {
+                            (args.len() == 2 && args[0] == args[1])
+                                || args.iter().all(|&a| self.proven_non_concat(a))
+                        }
+                        // Short-circuit `&&`/`||` yield an operand's VALUE, so non-concat iff
+                        // both operands are.
+                        Op::And | Op::Or => args.iter().all(|&a| self.proven_non_concat(a)),
+                        // Everything else (`Sub`/`Div`/`Mod`/`Pow`/`FloorDiv`/`FloorMod`/
+                        // bitwise/shift/comparisons) errors on a string/list → never one.
+                        _ => true,
+                    }
+                } else {
+                    // MIN/MAX of the modeled ternary are numeric; other synthesized codes
+                    // (byte-pack, etc.) are numeric too.
+                    o == MIN_CODE || o == MAX_CODE
+                }
             }
             _ => false,
         }


### PR DESCRIPTION
## What

Closes the **string/list-commutativity half of #283-C**: the detector no longer reorders untyped `+`, so `a + b` stops false-merging with `b + a`. Builds on the battery floor (#294) that made the oracle *witness* it.

## The gate, in three precise pieces

`+` *commutes* for numbers but is **ordered concat** for strings/lists (`"x"+"y" ≠ "y"+"x"`). The detector reordered `+` operands whenever neither was *proven* a string/list — optimistic for an untyped param.

1. **Commutativity gate** (`add_values_not_concat`): require **at least one** operand `proven_non_concat` — genuine evidence it is never a string/list, never the optimistic inference (the #283-B channel). This is the *exact* sound condition: if one operand is numeric, any other either commutes or hits `num + str → Err` in **every** order (Err propagates symmetrically), so the chain is permutation-invariant. Only `a + b` with two concat-possible operands could be two strings, where order matters. So `x + 4`, `x*x + y*y`, and any sum touching a number still commute.
2. **Associativity preserved**: `(a+b)+c ≡ a+(b+c)` is sound for *all* types (concat is associative), so the AC canon still **flattens** untyped `+` — only the operand **sort** (commutativity) is gated.
3. **Numeric-reduction context**: a `Reduce(Add)` (`sum`) forces its elements numeric, so the per-element `+` of `sum(x+y for …)` is commuted there (recursing through the `Phi(guard, x+y, 0)` a *filtered* reduction builds) — keeping `sum`/comprehension ≡ loop ≡ `reduce` cross-form convergence, the core Type-4 case a context-free gate would split.

## Verification

- **Detector**: untyped `a+b` ↮ `b+a`; int-annotated `a+b` ≡ `b+a`; `x*x+y*y` ≡ `y*y+x*x`; `sum(x+y for…)` ≡ nested loop. Regression `untyped_add_commute_gates_on_proven_numeric`; full equivalence suite (251) and exact-fragment suite (30) green.
- **Corpus SOUND**: `nose verify bench/repos` → `SOUND: no false merges ✓`.
- **Zero recall cost**: `4294 → 4294` families on `bench/repos`.
- **Bonus**: the audit surfaced **~15 latent false merges encoded in the test suite's own fixtures** (untyped `+` commutation as a "clone" vehicle, e.g. `(xs[0]+xs[1])*(...) ≡ (...)*(ys[1]+ys[0])`, behaviorally different for strings) — now corrected to sound forms.
- dup-gate 25/25.

## Scope

Closes C's string/list commutativity. The `(a+b)+c ≡ a+(b+c)` **float** non-associativity half stays open — it needs the `Float` value kind (D-div); see `docs/oracle-value-model.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
