### PR TITLE
Soundness #283-D (int32): JS bitwise narrowed, no longer merges with bigint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ break.
 ## [Unreleased]
 
 ### Fixed
+- **JS int32 bitwise no longer false-merges with arbitrary-precision bitwise** (#283-D).
+  JS-family languages coerce every bitwise operand to int32 (`a & b` is
+  `ToInt32(a) & ToInt32(b)`, the result an int32); Python/Ruby bitwise is
+  arbitrary-precision. They differ outside int32 range (`2^40 & 2^40` is `0` in JS,
+  `2^40` in Python), so one `Bin(BitAnd)` for both was a confirmed active false merge
+  the i64 oracle was blind to. The value graph now wraps the **leaf** operands of a JS
+  `& | ^ ~` expression in a `ToInt32` narrowing node: the fingerprint differs from
+  arbitrary-precision bitwise (merge closed), while wrapping only leaves keeps the op
+  structure intact so the De Morgan (#284) and idempotence (#283-B) canons still fire
+  over int32. Within JS, `a&b` still commutes with `b&a`. Zero corpus recall change
+  (4294 → 4294 families); `nose verify` SOUND. Shifts (`<< >> >>>`) and the IL-interpreter
+  int32 modeling (restoring the oracle's safety net) are deferred follow-ups; see
+  `docs/oracle-value-model.md` §3.2.
 - **Untyped `a + b` no longer false-merges with `b + a`** (#283-C). `+` *commutes* only
   for numbers — for strings/lists it is *ordered* concat (`"x"+"y" ≠ "y"+"x"`). The
   detector reordered `+` operands whenever neither was *proven* a string/list, which for

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -7055,3 +7055,34 @@ fn untyped_add_commute_gates_on_proven_numeric() {
         "int-annotated a + b is provably numeric — commuting to b + a must still converge"
     );
 }
+
+#[test]
+fn js_int32_bitwise_distinguished_from_arbitrary_precision() {
+    // #283-D: JS bitwise coerces operands to int32 (`a & b` is `ToInt32(a) & ToInt32(b)`),
+    // while Python/Ruby bitwise is arbitrary-precision. They differ for operands outside
+    // int32 range (`2^40 & 2^40` is `0` in JS, `2^40` in Python), so one `Bin(BitAnd)` for
+    // both was a false merge. JS bitwise leaves now carry a `ToInt32` wrap → distinct
+    // fingerprint; within-JS `&` still commutes; the De Morgan canon still fires.
+    let i = Interner::new();
+    let js = "function f(a, b){ return a & b; }";
+    let py = "def f(a, b):\n    return a & b\n";
+    let js_swapped = "function g(a, b){ return b & a; }";
+    let js_demorgan_a = "function f(a, b){ return ~(a & b); }";
+    let js_demorgan_b = "function g(a, b){ return (~a) | (~b); }";
+
+    assert_ne!(
+        value_fp(&i, js, Lang::JavaScript),
+        value_fp(&i, py, Lang::Python),
+        "JS int32 `&` must not merge with Python arbitrary-precision `&`"
+    );
+    assert_eq!(
+        value_fp(&i, js, Lang::JavaScript),
+        value_fp(&i, js_swapped, Lang::JavaScript),
+        "within JS, `a & b` still commutes with `b & a`"
+    );
+    assert_eq!(
+        value_fp(&i, js_demorgan_a, Lang::JavaScript),
+        value_fp(&i, js_demorgan_b, Lang::JavaScript),
+        "De Morgan `~(a&b) ≡ ~a|~b` still holds for JS int32 bitwise"
+    );
+}

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -113,8 +113,15 @@ impl<'a> Builder<'a> {
             NodeKind::BinOp => self.eval_binop_expr(expr, node.payload, env),
             NodeKind::UnOp => {
                 let kids = self.il.children(expr).to_vec();
-                let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+                let mut a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
                 let op = op_code(node.payload);
+                // JS `~x` is `~ToInt32(x)`, an int32 — narrow the operand so it fingerprints
+                // distinctly from arbitrary-precision `~` (#283-D).
+                if op == Op::BitNot as u32 {
+                    for v in a.iter_mut() {
+                        *v = self.js_int32_narrow(*v);
+                    }
+                }
                 self.mk(ValOp::Un(op), a)
             }
             NodeKind::Field => self.eval_field_expr(expr, node.payload, env),
@@ -298,6 +305,7 @@ impl<'a> Builder<'a> {
             if let Some(v) = self.c_u32_be_byte_pack_pattern(&operands) {
                 return v;
             }
+            self.narrow_js_bitwise_leaves(op, &mut operands);
             let do_sort = (op != Op::Add as u32
                 || self.add_values_not_concat(ValueLaw::AddAssociativity, &operands))
                 && operands.iter().all(|&v| self.reorder_safe(v));
@@ -315,6 +323,7 @@ impl<'a> Builder<'a> {
         if let Some(v) = self.c_u32_be_byte_pack_pattern(&operands) {
             return v;
         }
+        self.narrow_js_bitwise_leaves(op, &mut operands);
         let do_sort = (op != Op::Add as u32
             || self.add_values_not_concat(ValueLaw::AddAssociativity, &operands))
             && operands.iter().all(|&v| self.reorder_safe(v));
@@ -326,6 +335,20 @@ impl<'a> Builder<'a> {
             acc = self.mk(ValOp::Bin(op), vec![acc, o]);
         }
         acc
+    }
+
+    /// Wrap each LEAF operand of a JS-family `&`/`|`/`^` chain in `ToInt32` (a no-op for
+    /// other ops and non-JS languages). Done after flattening so the wrap lands on the
+    /// chain's leaves, not its intermediate (already int32) results — giving JS bitwise a
+    /// fingerprint distinct from arbitrary-precision bitwise while keeping the op structure
+    /// intact for the De Morgan / idempotence canons (#283-D). Shifts and `~` are narrowed
+    /// at their own build sites.
+    fn narrow_js_bitwise_leaves(&mut self, op: u32, operands: &mut [ValueId]) {
+        if op == Op::BitAnd as u32 || op == Op::BitOr as u32 || op == Op::BitXor as u32 {
+            for v in operands.iter_mut() {
+                *v = self.js_int32_narrow(*v);
+            }
+        }
     }
 
     fn eval_field_expr(

--- a/crates/nose-normalize/src/value_graph/ops.rs
+++ b/crates/nose-normalize/src/value_graph/ops.rs
@@ -271,6 +271,15 @@ pub(super) const ABS_CODE: u32 = 0xAB5;
 pub(super) const MIN_CODE: u32 = 0x319;
 pub(super) const MAX_CODE: u32 = 0x32A;
 pub(super) const JS_PROTOTYPE_IN_CODE: u32 = 0x4A53_494E;
+/// `Un` op code for the JS `ToInt32` coercion that every JS bitwise operator applies to
+/// its operands (`a & b` is `ToInt32(a) & ToInt32(b)`, the result an int32). Wrapping the
+/// LEAF operands of a JS-family bitwise expression in this gives JS bitwise a fingerprint
+/// distinct from arbitrary-precision (`Python`/`Ruby`) bitwise — closing the cross-language
+/// false merge (`2^40 & 2^40` is `0` in JS, `2^40` in Python; #283-D). The bitwise op
+/// STRUCTURE is preserved (only leaves are wrapped, intermediate results are already
+/// int32), so the De Morgan / idempotence / byte-pack canons keep matching. Clear of the
+/// `Op` discriminants and the other synthesized `Un` codes.
+pub(super) const TO_INT32_CODE: u32 = 0x132;
 /// Salt for a strict (`===`/`!==`) comparison against a null-ish operand — a shape
 /// the null/undefined-conflating value model cannot express as `Bin(Eq)` without
 /// merging it with the loose check (see `eval`'s strict-null handling).

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -98,6 +98,9 @@ impl<'a> Builder<'a> {
             // A unary op whose result is numeric ONLY when its operand is (`Neg`, `~`,
             // `abs`): recurse so the proof bottoms out at a genuine leaf, never at an
             // optimistic param domain.
+            // `ToInt32` ALWAYS yields a number (it coerces, never Errs), regardless of its
+            // operand; `abs`/`Neg`/`~` are numeric only when their operand is.
+            ValOp::Un(o) if o == TO_INT32_CODE => true,
             ValOp::Un(o) => {
                 (o == ABS_CODE || matches!(op_from_code(o), Some(Op::Neg | Op::BitNot)))
                     && self.nodes[v as usize]
@@ -106,6 +109,31 @@ impl<'a> Builder<'a> {
                         .is_some_and(|&a| self.proven_numeric(a))
             }
             _ => false,
+        }
+    }
+
+    /// Whether `v` is already an int32-valued node — a JS-family bitwise result (its result
+    /// is int32) or an existing `ToInt32`. Such a value needs no further narrowing when it
+    /// feeds another bitwise op, which keeps the wrap to the LEAF operands only (#283-D).
+    pub(super) fn is_int32_valued(&self, v: ValueId) -> bool {
+        match self.nodes[v as usize].op {
+            ValOp::Un(o) => o == TO_INT32_CODE || matches!(op_from_code(o), Some(Op::BitNot)),
+            ValOp::Bin(o) => matches!(
+                op_from_code(o),
+                Some(Op::BitAnd | Op::BitOr | Op::BitXor | Op::Shl | Op::Shr)
+            ),
+            _ => false,
+        }
+    }
+
+    /// Wrap a JS-family bitwise operand in `ToInt32` (the coercion every JS bitwise operator
+    /// applies), unless it is already int32-valued. A no-op for non-JS languages, whose
+    /// bitwise ops are arbitrary-precision (`Python`/`Ruby`) or type-width. #283-D.
+    pub(super) fn js_int32_narrow(&mut self, v: ValueId) -> ValueId {
+        if self.is_js_like_lang() && !self.is_int32_valued(v) {
+            self.mk(ValOp::Un(TO_INT32_CODE), vec![v])
+        } else {
+            v
         }
     }
 
@@ -193,7 +221,7 @@ impl<'a> Builder<'a> {
                 }
             }
             ValOp::Un(o) => {
-                if *o == ABS_CODE {
+                if *o == ABS_CODE || *o == TO_INT32_CODE {
                     ValueDomain::Number
                 } else if let Some(op) = op_from_code(*o) {
                     operators.unary_result_domain(op)


### PR DESCRIPTION
## What

Closes the **JS int32 bitwise** part of #283-D — a confirmed active cross-language false merge: JS `a & b` (int32) merged with Python/Ruby `a & b` (arbitrary precision), but they differ for operands outside int32 range (`2^40 & 2^40` → JS `0`, Python `2^40`). The oracle was blind (both modeled as i64 `x & y`), so `nose verify` read SOUND while the detector merged them.

## Fix

JS-family languages coerce every bitwise operand to int32 (`a & b` is `ToInt32(a) & ToInt32(b)`, the result an int32). The value graph now wraps the **leaf** operands of a JS `&` / `|` / `^` / `~` expression in a `ToInt32` narrowing node:

- The fingerprint differs from arbitrary-precision bitwise → JS `a&b` no longer merges with Python/Ruby `a&b`. **Closed.**
- Only **leaves** are wrapped (intermediate bitwise results are already int32), so the op *structure* is intact — the De Morgan (`~(a&b) ≡ ~a|~b`, #284) and idempotence (#283-B) canons keep matching, now over int32.
- `ToInt32` always yields a number, so it threads cleanly through `proven_numeric` / `proven_non_concat` / the value domain.

## Verification

- **False merge closed**: JS `a&b` ↮ Python `a&b`; within JS, `a&b` ≡ `b&a` (commutes); JS `~(a&b)` ≡ `~a|~b` (De Morgan still fires). Regression `js_int32_bitwise_distinguished_from_arbitrary_precision`.
- **Corpus SOUND**: `nose verify bench/repos` → `SOUND: no false merges ✓`.
- Recall on `bench/repos`: 4294 → 4294 families (zero — the pinned corpus has no JS↔non-JS cross-language bitwise clone to split).
- Full equivalence (252) and cli (173) suites green.

## Scope

Closes the `& | ^ ~` int32 surface (the confirmed `a & b` case). **Deferred** to a follow-up: shifts (`<< >> >>>` — `>>>` is uint32, and shift-count masking `& 31` is a finer behavioral detail) and the IL-interpreter int32 modeling (the value-graph fingerprint already closes the merge; modeling int32 in `nose verify`'s IL interpreter would *restore the safety net* for hypothetical future int32 merges — a separate "un-blind the oracle" improvement). C/Java fixed-width `int` bitwise reconverging with JS is the recall-recovery part of the full width model (not a soundness requirement). See `docs/oracle-value-model.md` §3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
