### PR TITLE
Soundness #283-D (div): three-way `/` no longer false-merges across languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ break.
 ## [Unreleased]
 
 ### Fixed
+- **Three-way `/` division no longer false-merges across languages** (#283-D). `/` is
+  *true-float* in Python 3 / JS (`7/2 == 3.5`), *floored-int* in Ruby (`7/2 == 3`, like
+  Python `//`), and *truncated-int* in C/Go/Java/Rust (`-7/2 == -3`). A single `Op::Div`
+  for all merged Python `a/b` with C `a/b` (and Ruby `a/b`) though they differ. A distinct
+  `Op::TrueDiv` (Python/JS) vs `Op::FloorDiv` (Ruby, like Python `//`) vs `Op::Div`
+  (C-family) fingerprints them apart: Python `/` ↮ C `/` ↮ Ruby `/`, while Python `/` ≡
+  JS `/` and Ruby `/` ≡ Python `//` still converge. The i64 interpreter models `TrueDiv`
+  like truncated `Div` — blind to the float result but consistent within the op (which only
+  compares with itself), so no false merge; an honest float result needs the `Float` value
+  kind (deferred). Zero corpus recall change (4294 → 4294 families); `nose verify` SOUND.
 - **JS int32 bitwise no longer false-merges with arbitrary-precision bitwise** (#283-D).
   JS-family languages coerce every bitwise operand to int32 (`a & b` is
   `ToInt32(a) & ToInt32(b)`, the result an int32); Python/Ruby bitwise is

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -7086,3 +7086,45 @@ fn js_int32_bitwise_distinguished_from_arbitrary_precision() {
         "De Morgan `~(a&b) ≡ ~a|~b` still holds for JS int32 bitwise"
     );
 }
+
+#[test]
+fn true_div_distinguishes_three_way_division() {
+    // #283-D: `/` is three-way — TRUE-float in Python/JS (`7/2 == 3.5`), FLOORED-int in
+    // Ruby (`7/2 == 3`, like Python `//`), TRUNCATED-int in C/Go/Java/Rust (`-7/2 == -3`).
+    // One `Op::Div` for all was a false merge; Python/JS `/` now lower to `Op::TrueDiv`,
+    // Ruby `/` to `Op::FloorDiv`, C-family stays `Op::Div`.
+    let i = Interner::new();
+    let py = "def f(a, b):\n    return a / b\n";
+    let js = "function f(a, b){ return a / b; }";
+    let rb = "def f(a, b)\n  a / b\nend\n";
+    let c = "int f(int a, int b) { return a / b; }";
+    let py_floor = "def f(a, b):\n    return a // b\n";
+
+    // True-float (py/js) ≠ truncated (c) ≠ floored (ruby).
+    assert_ne!(
+        value_fp(&i, py, Lang::Python),
+        value_fp(&i, c, Lang::C),
+        "Python true-float / must not merge with C truncated /"
+    );
+    assert_ne!(
+        value_fp(&i, py, Lang::Python),
+        value_fp(&i, rb, Lang::Ruby),
+        "Python true-float / must not merge with Ruby floored /"
+    );
+    assert_ne!(
+        value_fp(&i, rb, Lang::Ruby),
+        value_fp(&i, c, Lang::C),
+        "Ruby floored / must not merge with C truncated /"
+    );
+    // Same semantics still converge: Python ≡ JS (true-float); Ruby ≡ Python `//` (floored).
+    assert_eq!(
+        value_fp(&i, py, Lang::Python),
+        value_fp(&i, js, Lang::JavaScript),
+        "Python and JS / are both true-float — must converge"
+    );
+    assert_eq!(
+        value_fp(&i, rb, Lang::Ruby),
+        value_fp(&i, py_floor, Lang::Python),
+        "Ruby / and Python // are both floored — must converge"
+    );
+}

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -1942,6 +1942,12 @@ fn is_ts_type(k: &str) -> bool {
 }
 
 fn js_bin_op(text: &str) -> Option<Op> {
+    // JS `/` is TRUE (float) division (`7 / 2 == 3.5`) — distinct from the C-family
+    // truncated `Op::Div` that `common_bin_op` returns and from floored `Op::FloorDiv`,
+    // so it never shares a fingerprint with them (#283-D).
+    if text == "/" {
+        return Some(Op::TrueDiv);
+    }
     // shared C-family set, plus JS's strict-equality, exponent, and type-test
     // operators. `>>>` (zero-fill shift) is deliberately UNMAPPED: collapsing it
     // onto `Shr` merged `-5 >> 1` (sign-extending, `-3`) with `-5 >>> 1`

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -1214,7 +1214,9 @@ fn py_bin_op(text: &str) -> Option<Op> {
         "*" => Op::Mul,
         // True division and floor division are distinct operations (`5 / 2 == 2.5`
         // vs `5 // 2 == 2`); each gets its own op so they never share a fingerprint.
-        "/" => Op::Div,
+        // Python `/` is TRUE (float) division — distinct from C-family truncated
+        // `Op::Div` and Ruby/Python-`//` floored `Op::FloorDiv` (#283-D).
+        "/" => Op::TrueDiv,
         "//" => Op::FloorDiv,
         "%" => Op::FloorMod,
         "**" => Op::Pow,

--- a/crates/nose-frontend/src/ruby.rs
+++ b/crates/nose-frontend/src/ruby.rs
@@ -452,6 +452,10 @@ fn lower_binary(lo: &mut Lowering, node: TsNode) -> NodeId {
             // Ruby `%` is FLOORED (remainder takes the divisor's sign), unlike the
             // C-family truncated `%` in `common_bin_op` (#283-D).
             "%" => Some(Op::FloorMod),
+            // Ruby integer `/` is FLOORED (`-7 / 2 == -4`), like Python `//` — distinct
+            // from C-family truncated `Op::Div` and Python/JS true-float `Op::TrueDiv`
+            // (#283-D).
+            "/" => Some(Op::FloorDiv),
             other => common_bin_op(other),
         });
     match (l, r, op) {

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -703,6 +703,14 @@ pub enum Op {
     /// (as a single `Op::Mod` for all languages did) is a false merge the verify
     /// interpreter was blind to (#283-D).
     FloorMod,
+    /// True (real) division — the quotient is a float, NOT truncated: Python 3 / JS
+    /// `/` (`7 / 2 == 3.5`). DISTINCT from [`Op::Div`] (C/Go/Java/Rust truncated-int,
+    /// `7 / 2 == 3`) and [`Op::FloorDiv`] (Ruby `/` and Python `//`, floored-int) —
+    /// the three disagree (`7/2` is `3.5`, `3`, `3`; `-7/2` is `-3.5`, `-3`, `-4`), so
+    /// one `Op::Div` for all of them is a false merge (#283-D). The i64 interpreter
+    /// cannot represent the float result, so it stays blind here (consistent within
+    /// the op — no cross-language merge); modeling it needs the `Float` value kind.
+    TrueDiv,
 }
 
 impl Op {

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -1610,6 +1610,18 @@ fn bin(op: Op, a: &Value, b: &Value) -> Value {
                     Int(x.wrapping_div(*y))
                 }
             }
+            // True (float) division. The i64 model cannot represent `3.5`, so it is
+            // modeled like truncated `Div` here — BLIND to the float result but CONSISTENT
+            // within `TrueDiv`, which only ever compares with itself (a distinct op from
+            // `Div`/`FloorDiv`), so no false merge. An honest float result needs the `Float`
+            // value kind (#283-D, deferred). Div-by-zero still Errs.
+            Op::TrueDiv => {
+                if *y == 0 {
+                    Value::Err
+                } else {
+                    Int(x.wrapping_div(*y))
+                }
+            }
             Op::Mod => {
                 if *y == 0 {
                     Value::Err

--- a/crates/nose-normalize/src/value_graph/control.rs
+++ b/crates/nose-normalize/src/value_graph/control.rs
@@ -819,7 +819,9 @@ impl<'a> Builder<'a> {
         }
         let rhs = self.eval(kids[1], env);
         match op {
-            Op::Div | Op::FloorDiv | Op::Mod | Op::FloorMod => self.int_const_eq(rhs, 0),
+            Op::Div | Op::FloorDiv | Op::TrueDiv | Op::Mod | Op::FloorMod => {
+                self.int_const_eq(rhs, 0)
+            }
             Op::Pow => self
                 .static_int_expr(kids[1])
                 .is_some_and(|exp| !(0..=u32::MAX as i64).contains(&exp)),

--- a/crates/nose-normalize/src/value_graph/ops.rs
+++ b/crates/nose-normalize/src/value_graph/ops.rs
@@ -187,6 +187,7 @@ pub(super) fn op_from_code(opc: u32) -> Option<Op> {
         Op::Mul,
         Op::Div,
         Op::FloorDiv,
+        Op::TrueDiv,
         Op::Mod,
         Op::FloorMod,
         Op::Pow,


### PR DESCRIPTION
## What

Closes the **three-way `/` division** part of #283-D — a confirmed cross-language false merge. `/` means three different things:
- **true-float** in Python 3 / JS (`7 / 2 == 3.5`)
- **floored-int** in Ruby (`7 / 2 == 3`, `-7 / 2 == -4`, like Python `//`)
- **truncated-int** in C/Go/Java/Rust (`7 / 2 == 3`, `-7 / 2 == -3`)

A single `Op::Div` for all of them merged Python `a/b` with C `a/b` (and with Ruby `a/b`) even though they differ, and the i64 oracle was blind.

## Fix (the `FloorMod` pattern)

A distinct `Op::TrueDiv`:
- Python / JS `/` → `Op::TrueDiv` (true-float)
- Ruby `/` → `Op::FloorDiv` (floored-int, same as Python `//`)
- C/Go/Java/Rust `/` → `Op::Div` (truncated-int, unchanged)

The three ops fingerprint distinctly, so the cross-language merges are closed; the i64 interpreter models `TrueDiv` like truncated `Div` — blind to the float result, but **consistent within the op** (`TrueDiv` only compares with itself), so no false merge. An honest float result needs the `Float` value kind (deferred).

## Verification

- **Merges closed**: Python `/` ↮ C `/`; Python `/` ↮ Ruby `/`; Ruby `/` ↮ C `/`.
- **Correct convergence kept**: Python `/` ≡ JS `/` (both true-float); Ruby `/` ≡ Python `//` (both floored).
- Regression `true_div_distinguishes_three_way_division` (+ existing floored-`%` test).
- **Corpus SOUND**: `nose verify bench/repos` → `SOUND: no false merges ✓`.
- Recall on `bench/repos`: 4294 → 4294 families (zero).
- Full equivalence (253) and cli (173) suites green.

## Scope

Closes the `/` cross-language false merge. The remaining #283 piece is **C-float** (`(a+b)+c ≡ a+(b+c)` for floats — float non-associativity), and restoring the oracle's float-awareness (the `Float` value kind) — see `docs/oracle-value-model.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
