### PR TITLE
Release v0.7.0: cut the changelog, bump workspace version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ break.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-12
+
 ### Fixed
 - **Three-way `/` division no longer false-merges across languages** (#283-D). `/` is
   *true-float* in Python 3 / JS (`7/2 == 3.5`), *floored-int* in Ruby (`7/2 == 3`, like

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nose-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "nose-detect"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "nose-frontend",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "nose-eval"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "rustc-hash",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "nose-frontend"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "nose-il"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "lasso",
  "serde",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "nose-normalize"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "nose-il",
  "nose-semantics",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "nose-semantics"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "nose-il",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/corca-ai/nose"
@@ -25,12 +25,12 @@ rust-version = "1.85"
 [workspace.dependencies]
 # Internal crates carry an explicit `version` (not just `path`) so the tree has no
 # wildcard deps and the crates stay publishable; `path` wins for local builds.
-nose-il = { path = "crates/nose-il", version = "0.6.0" }
-nose-semantics = { path = "crates/nose-semantics", version = "0.6.0" }
-nose-frontend = { path = "crates/nose-frontend", version = "0.6.0" }
-nose-normalize = { path = "crates/nose-normalize", version = "0.6.0" }
-nose-detect = { path = "crates/nose-detect", version = "0.6.0" }
-nose-eval = { path = "crates/nose-eval", version = "0.6.0" }
+nose-il = { path = "crates/nose-il", version = "0.7.0" }
+nose-semantics = { path = "crates/nose-semantics", version = "0.7.0" }
+nose-frontend = { path = "crates/nose-frontend", version = "0.7.0" }
+nose-normalize = { path = "crates/nose-normalize", version = "0.7.0" }
+nose-detect = { path = "crates/nose-detect", version = "0.7.0" }
+nose-eval = { path = "crates/nose-eval", version = "0.7.0" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## v0.7.0 — a soundness release

Bumps the workspace version `0.6.0 → 0.7.0` and cuts the `[Unreleased]` changelog to `[0.7.0]`. Tag `v0.7.0` after merge to trigger the cargo-dist release workflow.

### Headline: six confirmed cardinal-sin false merges closed (the #283 cluster)
- floored vs truncated `%` (#290), optimistic-Num `-(-a)`/`a&a` (#291), untyped `a+b ≡ b+a` (#294/#295), JS int32 bitwise (#296), three-way `/` division (#297), effectful AC operands (#286).
- Each: sound, zero corpus recall change, `nose verify` SOUND.

Plus #284 sound recall rules, #275 cache reproducibility, #280 context-aware embedded `<script>`, the adversarial co-evolution series, triage ergonomics, and the post-merge CI speedup.

### Known-latent follow-up
- **#283-C float associativity** (`(a+b)+c ≡ a+(b+c)` for floats) stays open — the corpus reads SOUND; closing it needs the `Float` value-kind oracle (`docs/oracle-value-model.md`). Documented, not a blocker.

### Excluded
- Dependabot tree-sitter grammar bumps (#238–240) are intentionally **not** in this release — grammar version changes touch parsing/fingerprints and warrant separate review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)