### PR TITLE
Adversarial co-evolution series 6: defend the #299 surfaces

### DIFF
--- a/bench/coevo/packets.v1.json
+++ b/bench/coevo/packets.v1.json
@@ -468,6 +468,114 @@
    "summary": "15 gaps: byte-pack u16/u32 + low-bit-toggle have NO Lean proof (positive-only tests); many type-gated rules (abs, minmax, idempotence, negation-distrib) have positive tests but NO hard-negative proving the gate holds \u2014 the AC-chain hard-negative gap is highest risk and overlaps the #283 cardinal-sin cluster",
    "verdict": "recorded-low-prevalence",
    "defense": "#283 hard-negative + Lean backlog"
+  },
+  {
+   "packet_id": "s6-s2a-decorator-content-key",
+   "series": 6,
+   "campaign": "S2",
+   "persona": "binding-lawyer",
+   "mode": "blind",
+   "surface": "content-keyed-callee-identity",
+   "claim": "a reassigned/shadowed/decorated callee binding fails closed to opaque, never inheriting a function's content",
+   "summary": "Python decorators are dropped in lowering, so @double vs @triple (and decorated-vs-plain) callers false-merged as 'exact behavior match' (caller(1)=40 vs 60). DirectFunction evidence + content-keyed seeding both attributed the bare body to the name.",
+   "verdict": "violation-fixed",
+   "defense": "New SourceFactKind::Binding(DecoratedDefinition) recorded at decorated_definition lowering; call_target_evidence and content-keyed seeding both skip decorated definitions (decorated_definition_at_node). Fail-closed: decorated callers stay opaque."
+  },
+  {
+   "packet_id": "s6-s2b-out-of-scope-reassignment",
+   "series": 6,
+   "campaign": "S2",
+   "persona": "binding-lawyer",
+   "mode": "blind",
+   "surface": "content-keyed-callee-identity",
+   "claim": "a module function reassigned anywhere in the file is not provably its def body",
+   "summary": "`global helper; helper = special_a` inside another function (Python) / bare module reassignment from a function (JS) was invisible to scope_bound (which only checks the call site's lexical enclosing scopes) and to collect_function_binding_hashes (no mutation check). Raw body inlined; callers false-merged (caller(1)=1000 vs 2000). Cross-language.",
+   "verdict": "deferred-issue",
+   "defense": "#302 \u2014 the natural gate (reassigned-anywhere) cannot be made precise: the frontend drops global/nonlocal, so a non-top-level `name = x` is indistinguishable from a local shadow. The broad predicate over-fired, killing legitimate inlines at 37 corpus repos (netty -26, raylib -11) for zero soundness gain there \u2014 reverted per 'the defender's ceiling is provability'. Needs frontend global-binding tracking. Only the precise decorator fact (S2-A) shipped."
+  },
+  {
+   "packet_id": "s6-s3-2-caller-via-inline-span",
+   "series": 6,
+   "campaign": "S3",
+   "persona": "claims-auditor",
+   "mode": "blind",
+   "surface": "reinvented-helpers",
+   "claim": "Callers are never findings; the site is INSIDE the container",
+   "summary": "A pure caller of a function that inline-reinvents the helper was itself reported (called_helper_returns is one call level deep, keyed on the direct callee's own return hash), with a site line outside its own range.",
+   "verdict": "violation-fixed",
+   "defense": "Reject a finding whose matched anchor carries a REAL (non-zero) source span outside [container_start,container_end] \u2014 that span belongs to the inlined callee, so the unit is a transitive caller. Zero-span loop-fold anchors (the flagship) fall back to container range and stay."
+  },
+  {
+   "packet_id": "s6-s3-3-bound-blind-reduce",
+   "series": 6,
+   "campaign": "S3",
+   "persona": "claims-auditor",
+   "mode": "blind",
+   "surface": "reinvented-helpers",
+   "claim": "the matched sub-computation is the SAME computation, never merely similar; matching a fold while iterating differently is not containment",
+   "summary": "For indexed while loops the bound is absorbed into a pointer-length contract and dropped from cond_sinks AND the Reduce hash, so a fold over i<n-1 (or an unrelated bound m) value-exactly 'contained' a fold over i<n though they differ on almost every input (11 vs 22 on xs=[1,1],n=2). The documented guard-inclusion check was vacuous (cond_sinks empty).",
+   "verdict": "violation-fixed",
+   "defense": "sink_profile now reports used_length_contract; a helper that relied on a pointer-length contract is ineligible (its return hash does not faithfully determine its value). Conservative: also drops the same-bound true-positive shape (S3-1) since the bound is unrecoverable from the hash \u2014 sound recall loss. Genuine length iteration records no contract and stays eligible."
+  },
+  {
+   "packet_id": "s6-s3-1-approximate-site",
+   "series": 6,
+   "campaign": "S3",
+   "persona": "claims-auditor",
+   "mode": "blind",
+   "surface": "reinvented-helpers",
+   "claim": "replace the matched lines with a call (the site is the helper's computation)",
+   "summary": "For a loop-fold helper the matched node has no span, so the site falls back to the whole container, which includes computation beyond the helper (e.g. total*extra+9). Mechanically replacing those lines deletes the extra computation.",
+   "verdict": "violation-fixed",
+   "defense": "Honesty, not suppression: a site_approximate flag (JSON + struct) marks whole-container fallbacks; docs reframe the fix as advisory ('call the helper for the matched part'), not a mechanical line replacement. The finding is TRUE; only the fix wording was over-strong."
+  },
+  {
+   "packet_id": "s6-s3-4-type-erasure-fix",
+   "series": 6,
+   "campaign": "S3",
+   "persona": "claims-auditor",
+   "mode": "blind",
+   "surface": "reinvented-helpers",
+   "claim": "replace the matched lines with a call to the helper that already exists (the fix compiles)",
+   "summary": "Field access hashes by name only, so a Go container over struct Span value-exactly 'contains' a helper taking Vec2; the suggested NormBlend(s) is a compile error under Go nominal typing \u2014 the helper cannot be called with the container's operand.",
+   "verdict": "recorded-low-prevalence",
+   "defense": "Routes to consumer judgment (the value model erases types by design, clone-types.md). Docs add the type-erasure caveat: in statically-typed languages the suggested call must be type-checked by the consumer. Not suppressed \u2014 the computation IS structurally identical; only callability is undecidable here. No corpus instance observed."
+  },
+  {
+   "packet_id": "s6-s1-keyword-arg-order",
+   "series": 6,
+   "campaign": "S1",
+   "persona": "soundness-skeptic",
+   "mode": "blind",
+   "surface": "canonicalizer",
+   "claim": "interprocedural inlining is behavior-preserving; equal fingerprint implies equal behavior",
+   "summary": "Python keyword arguments lower to their value in source order, dropping the name, so helper(b=p,a=q) is byte-identical IL to helper(a=p,b=q) and the two callers false-merge as 'exact behavior match' (-2 vs 5 on p=1,q=2). Pre-existing frontend gap; occurs on the opaque-call path too (inline not load-bearing).",
+   "verdict": "deferred-issue",
+   "defense": "#301 \u2014 sound fix needs IL Call keyword identity (new node/metadata) canonicalized by name + threaded through the value graph and inline binding + cross-language battery; exceeds the series-6 (#299-surfaces) scope. Reproducer attached."
+  },
+  {
+   "packet_id": "s6-s4-oracle-lockstep",
+   "series": 6,
+   "campaign": "S4",
+   "persona": "oracle-attacker",
+   "mode": "blind",
+   "surface": "oracle",
+   "claim": "nose verify witnesses or fail-closed excludes every inline-created merge; SOUND covers the exact-claim surface",
+   "summary": "No violation. Inline admission and the oracle's callee-execution gate resolve the same DirectFunction target from the same evidence, so the oracle is at least as general as the inline. Census: ~43% of inline-created merge mass is oracle-opaque, all in the fail-closed uninterpretable bucket (free module globals, floats, JS C-style for-loops) \u2014 exclusion mass, not silent SOUND.",
+   "verdict": "green-confirmed",
+   "defense": "None needed. Minor cosmetic note: verify labels the bucket 'uninterpretable' while --exclusion-census JSON says 'battery-bail'."
+  },
+  {
+   "packet_id": "s6-boundary-decorated-method",
+   "series": 6,
+   "campaign": "S2",
+   "persona": "author",
+   "mode": "boundary-reattack",
+   "surface": "content-keyed-callee-identity",
+   "claim": "decorated callers fail closed (boundary edge: methods, not functions)",
+   "summary": "Boundary re-attack: decorated-METHOD callers (self.helper(a)) still merge across @double/@triple. Root cause is the PRE-EXISTING opaque method-name identity (self.helper keyed by name 'helper'); a no-decorator control with different method bodies merges identically. Not the content-keying mechanism the S2 fix covers, and predates #299.",
+   "verdict": "deferred-issue",
+   "defense": "Documented opaque-method-identity boundary (clone-types.md: unproven methods are name-keyed). A sound fix needs method receiver-type resolution \u2014 separate from this campaign. The S2 fix's content-keying/evidence paths DO correctly gate decorated methods; only the orthogonal opaque-method-name path remains."
   }
  ]
 }

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -7345,3 +7345,101 @@ fn reinvented_helper_skips_effectful_and_guard_mismatched_helpers() {
         "an effectful helper must not produce containment findings",
     );
 }
+
+#[test]
+fn decorated_function_callers_fail_closed_coevo_s6_s2a() {
+    // coevo series 6, S2-A: Python decorators are dropped in lowering, so a decorated
+    // helper's runtime binding is `decorator(f)`, not the bare body. The fix records a
+    // SourceFactKind::Binding(DecoratedDefinition) fact so the decorated def gets no
+    // DirectFunction evidence — its callers fall back to an opaque call and are NOT
+    // admitted to the exact `semantic` channel (exact_safe=false), so they can never be
+    // reported as an "exact behavior match" that hides the decorator's effect. A caller
+    // of a PLAIN helper still inlines and stays exact_safe.
+    let i = Interner::new();
+    let opts = DetectOptions {
+        min_lines: 1,
+        min_tokens: 1,
+        ..Default::default()
+    };
+    let caller_exact_safe = |src: &str| -> bool {
+        let il = nose_frontend::lower_source(FileId(0), "t.py", src.as_bytes(), Lang::Python, &i)
+            .unwrap();
+        nose_detect::units_of_file(&il, &i, &opts)
+            .iter()
+            .find(|u| u.name.as_deref() == Some("caller"))
+            .expect("caller unit")
+            .exact_safe
+    };
+    let decorated = "def double(f):\n    return lambda x: f(x) * 2\n\n@double\ndef helper(x):\n    return x * 5 + 1\n\ndef caller(a):\n    return helper(a) * 10 + a\n";
+    let plain =
+        "def helper(x):\n    return x * 5 + 1\n\ndef caller(a):\n    return helper(a) * 10 + a\n";
+    assert!(
+        !caller_exact_safe(decorated),
+        "a caller of a DECORATED helper must not be exact-safe (no inline, fail closed)",
+    );
+    assert!(
+        caller_exact_safe(plain),
+        "a caller of a PLAIN helper still inlines and stays exact-safe (no recall loss)",
+    );
+}
+
+#[test]
+fn reinvented_helper_excludes_caller_via_inlined_span_coevo_s6_s2() {
+    // coevo series 6, S3-2: a pure caller of a function that inline-reinvents the helper
+    // must NOT itself be reported (the called-helper record is one call level deep). The
+    // span-containment gate rejects it: the matched anchor's real span lies outside the
+    // caller's own line range (it belongs to the inlined callee).
+    let i = Interner::new();
+    let opts = DetectOptions {
+        min_lines: 1,
+        min_tokens: 1,
+        ..Default::default()
+    };
+    let helper = "function big(x, y) {\n    return ((x * 2 + 3) * (x - 4)) / ((x + 5) * (y - 7) + (y * y + 11))\n}\n";
+    // `reinventor` reimplements `big` inline; `passThrough` merely CALLS reinventor.
+    let src = "function reinventor(x, y) {\n    return (((x * 2 + 3) * (x - 4)) / ((x + 5) * (y - 7) + (y * y + 11))) + 1\n}\n\nfunction passThrough(x, y) {\n    return reinventor(x, y) + 2\n}\n";
+    let il0 =
+        nose_frontend::lower_source(FileId(0), "h.js", helper.as_bytes(), Lang::JavaScript, &i)
+            .unwrap();
+    let il1 = nose_frontend::lower_source(FileId(1), "r.js", src.as_bytes(), Lang::JavaScript, &i)
+        .unwrap();
+    let mut units = nose_detect::units_of_file(&il0, &i, &opts);
+    units.extend(nose_detect::units_of_file(&il1, &i, &opts));
+    let findings = nose_detect::reinvented_helpers(&units);
+    assert!(
+        findings
+            .iter()
+            .all(|f| f.container_name.as_deref() != Some("passThrough")),
+        "a caller of an inline-reinventor must not be reported as reinventing the helper, got {:?}",
+        findings
+            .iter()
+            .map(|f| f.container_name.clone())
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn reinvented_helper_rejects_bound_blind_fold_coevo_s6_s3() {
+    // coevo series 6, S3-3: an indexed `while i < n` fold absorbs the bound into a
+    // pointer-length contract, dropping it from the value hash, so a fold over a
+    // DIFFERENT bound must NOT be reported as containment (it computes a different value).
+    let i = Interner::new();
+    let opts = DetectOptions {
+        min_lines: 1,
+        min_tokens: 1,
+        ..Default::default()
+    };
+    let helper = "def poly_sum(xs, n):\n    total = 0\n    i = 0\n    while i < n:\n        total = total + xs[i] * xs[i] + 3 * xs[i] + 7\n        i = i + 1\n    return total\n";
+    let container = "def poly_partial(xs, n, k):\n    total = 0\n    i = 0\n    while i < n - 1:\n        total = total + xs[i] * xs[i] + 3 * xs[i] + 7\n        i = i + 1\n    return total * k + 9\n";
+    let il0 = nose_frontend::lower_source(FileId(0), "a.py", helper.as_bytes(), Lang::Python, &i)
+        .unwrap();
+    let il1 =
+        nose_frontend::lower_source(FileId(1), "b.py", container.as_bytes(), Lang::Python, &i)
+            .unwrap();
+    let mut units = nose_detect::units_of_file(&il0, &i, &opts);
+    units.extend(nose_detect::units_of_file(&il1, &i, &opts));
+    assert!(
+        nose_detect::reinvented_helpers(&units).is_empty(),
+        "a fold whose bound the value hash drops must not match a different-bound fold",
+    );
+}

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -729,6 +729,11 @@ pub struct ReinventedHelper {
     /// Source lines INSIDE the container where the helper's computation lives.
     pub site_start_line: u32,
     pub site_end_line: u32,
+    /// The site is APPROXIMATE — the matched computation is a synthesized loop fold with
+    /// no precise source span, so the site is the whole container range and includes
+    /// computation beyond the helper's. Consumers must not mechanically replace these
+    /// exact lines (coevo series 6, S3-1).
+    pub site_approximate: bool,
     /// Value-graph size of the reinvented computation — the ranking key.
     pub weight: u32,
 }
@@ -757,6 +762,7 @@ pub fn reinvented_helpers(units: &[UnitFeat]) -> Vec<ReinventedHelper> {
             && u.fragment_kind.is_none()
             && u.exact_safe
             && u.pure_single_return
+            && !u.used_length_contract
             && u.returns.len() == 1
             && u.value.len() >= REINVENTED_HELPER_MIN_NODES
             && u.token_count >= REINVENTED_HELPER_MIN_TOKENS
@@ -802,12 +808,27 @@ pub fn reinvented_helpers(units: &[UnitFeat]) -> Vec<ReinventedHelper> {
                 .min_by_key(|&h| (&units[h].path, units[h].start_line));
             let Some(h) = rep else { continue };
             let h = &units[h];
+            // A matched anchor with a REAL (non-zero) source span must lie inside the
+            // container's own line range. A span outside it means the shared computation
+            // textually lives in a DIFFERENT function that this unit merely inlined
+            // (generalized inlining splices a callee's value graph in) — the unit is a
+            // transitive CALLER, not a reinventor, and `called_helper_returns` (one call
+            // level deep) does not catch a two-hop chain. Reject (coevo series 6, S3-2).
+            // A synthesized loop-fold anchor carries no span (line 0); it falls back to
+            // the container range and is the faithful flagship case, so it is allowed.
+            let real_span = anchor.line_start != 0;
+            let inside = anchor.line_start >= c.start_line && anchor.line_end <= c.end_line;
+            if real_span && !inside {
+                continue;
+            }
             // Loop-exit nodes (a synthesized `Reduce`) may carry no source span; fall
-            // back to the container's own range rather than reporting line 0.
-            let (site_start, site_end) = if anchor.line_start == 0 {
-                (c.start_line, c.end_line)
+            // back to the container's own range rather than reporting line 0. When this
+            // fallback fires the site is the WHOLE container (approximate — the matched
+            // computation is a sub-part), flagged for honest consumer reporting.
+            let (site_start, site_end, site_approximate) = if anchor.line_start == 0 {
+                (c.start_line, c.end_line, true)
             } else {
-                (anchor.line_start, anchor.line_end)
+                (anchor.line_start, anchor.line_end, false)
             };
             out.push(ReinventedHelper {
                 helper_file: h.path.clone(),
@@ -820,6 +841,7 @@ pub fn reinvented_helpers(units: &[UnitFeat]) -> Vec<ReinventedHelper> {
                 container_end_line: c.end_line,
                 site_start_line: site_start,
                 site_end_line: site_end,
+                site_approximate,
                 weight: anchor.weight,
             });
         }

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -84,6 +84,12 @@ pub struct UnitFeat {
     /// (same iteration scheme), not just the return value.
     #[serde(default)]
     pub cond_sinks: Vec<u64>,
+    /// The build relied on a pointer-length contract (a free-param loop bound assumed to
+    /// be `len(array)`), which drops the bound from the value hash — so the return hash
+    /// does not faithfully determine the value. Makes the unit ineligible as a
+    /// containment helper (coevo series 6, S3-3).
+    #[serde(default)]
+    pub used_length_contract: bool,
     /// Return-sink hashes of every SAME-FILE function this unit provably calls
     /// (`CallTarget::DirectFunction` evidence), sorted+deduped. A containment match on
     /// one of these hashes is the unit *using* a helper, not reinventing it.
@@ -439,6 +445,7 @@ struct GatedUnit {
     returns: Vec<u64>,
     pure_single_return: bool,
     cond_sinks: Vec<u64>,
+    used_length_contract: bool,
     anchors: Vec<nose_normalize::Anchor>,
     semantic_laws: Vec<ValueLaw>,
     unit_start: Option<Instant>,
@@ -648,17 +655,23 @@ fn gate_unit(
     // literal-only multiset for data-table detection. Computed before the size
     // gate so the gate can consult semantic richness (below).
     let value_start = unit_timer.start();
-    let (value, lits, returns, anchors, semantic_laws, (pure_single_return, cond_sinks)) =
-        if let Some(context) = ctx.value_context {
-            nose_normalize::value_fingerprint_lits_anchors_laws_with_context(
-                ctx.il,
-                root,
-                ctx.interner,
-                context,
-            )
-        } else {
-            nose_normalize::value_fingerprint_lits_anchors_laws(ctx.il, root, ctx.interner)
-        };
+    let (
+        value,
+        lits,
+        returns,
+        anchors,
+        semantic_laws,
+        (pure_single_return, cond_sinks, used_length_contract),
+    ) = if let Some(context) = ctx.value_context {
+        nose_normalize::value_fingerprint_lits_anchors_laws_with_context(
+            ctx.il,
+            root,
+            ctx.interner,
+            context,
+        )
+    } else {
+        nose_normalize::value_fingerprint_lits_anchors_laws(ctx.il, root, ctx.interner)
+    };
     let value_ms = UnitTimer::elapsed(value_start);
 
     // Size gate. A short unit normally isn't a meaningful clone — EXCEPT a
@@ -694,6 +707,7 @@ fn gate_unit(
         returns,
         pure_single_return,
         cond_sinks,
+        used_length_contract,
         anchors,
         semantic_laws,
         unit_start,
@@ -723,6 +737,7 @@ fn extract_unit(
         returns,
         pure_single_return,
         cond_sinks,
+        used_length_contract,
         anchors,
         semantic_laws,
         unit_start,
@@ -778,6 +793,7 @@ fn extract_unit(
         returns,
         pure_single_return,
         cond_sinks,
+        used_length_contract,
         called_helper_returns: Vec::new(),
         anchors,
         semantic_laws,

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -11,7 +11,7 @@ use crate::lower::Lowering;
 use nose_il::{
     stable_symbol_hash, Builtin, EvidenceAnchor, EvidenceKind, FileId, HoFKind, Il,
     ImportEvidenceKind, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload,
-    SourceComprehensionKind, SourceFactKind, SourceOperatorKind, Span, UnitKind,
+    SourceBindingKind, SourceComprehensionKind, SourceFactKind, SourceOperatorKind, Span, UnitKind,
 };
 use tree_sitter::Node as TsNode;
 
@@ -48,9 +48,19 @@ fn lower_stmt(lo: &mut Lowering, node: TsNode, in_class: bool) -> Option<NodeId>
             Some(out)
         }
         "decorated_definition" => {
-            // Ignore decorators; lower the wrapped definition.
+            // Lower only the wrapped definition — but RECORD the decoration as a
+            // binding source fact: the runtime binding is `decorator(f)`, not `f`,
+            // so call-target evidence / content-keyed seeding / inlining must not
+            // attribute the bare body to the name (coevo series 6, S2-A: `@double`
+            // vs `@triple` callers false-merged as "exact behavior match").
             let def = node.child_by_field_name("definition")?;
-            lower_stmt(lo, def, in_class)
+            let def_span = lo.span(def);
+            let lowered = lower_stmt(lo, def, in_class)?;
+            lo.record_source_fact(
+                def_span,
+                SourceFactKind::Binding(SourceBindingKind::DecoratedDefinition),
+            );
+            Some(lowered)
         }
         "class_definition" => {
             let out = lower_class(lo, node);

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -25,9 +25,10 @@ pub use node::{
     EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceProvenance, EvidenceRecord,
     EvidenceStatus, GuardEvidenceKind, HoFKind, ImportEvidenceKind, JsRecordGuardComparison,
     JsRecordGuardNullCheck, LibraryApiEvidenceKind, LitClass, LoopKind, Node, NodeId, NodeKind, Op,
-    ParamSemantic, Payload, PlaceEvidenceKind, SequenceSurfaceKind, SourceCallKind, SourceCastKind,
-    SourceComprehensionKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
-    SourcePatternKind, SourceProtocolKind, SourceRangeKind, SymbolEvidenceKind, TypeEvidenceKind,
+    ParamSemantic, Payload, PlaceEvidenceKind, SequenceSurfaceKind, SourceBindingKind,
+    SourceCallKind, SourceCastKind, SourceComprehensionKind, SourceFactKind, SourceLiteralKind,
+    SourceOperatorKind, SourcePatternKind, SourceProtocolKind, SourceRangeKind, SymbolEvidenceKind,
+    TypeEvidenceKind,
 };
 pub use span::{FileId, FileMeta, Lang, Span};
 

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -579,6 +579,17 @@ pub enum SourceFactKind {
     Comprehension(SourceComprehensionKind),
     Range(SourceRangeKind),
     Pattern(SourcePatternKind),
+    Binding(SourceBindingKind),
+}
+
+/// Source facts about how a definition BINDS, not what its body computes. A decorated
+/// definition's runtime binding is `decorator(f)`, not `f` — lowering keeps only the
+/// inner body (sound for unit-shape analysis), so any consumer that treats the body as
+/// the NAME's content (call-target evidence, content-keyed seeding, inlining) must see
+/// this fact and fail closed (coevo series 6, S2-A).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub enum SourceBindingKind {
+    DecoratedDefinition,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]

--- a/crates/nose-normalize/src/call_target_evidence.rs
+++ b/crates/nose-normalize/src/call_target_evidence.rs
@@ -104,6 +104,17 @@ fn unique_direct_function_targets(
         if ambiguous.contains(&name) {
             continue;
         }
+        // A decorated `def` binds `decorator(f)`, not the lowered body — fail closed:
+        // no DirectFunction evidence, so the inline, the content-keyed exact admission,
+        // and the behavioral oracle all stay opaque (coevo series 6, S2-A). Out-of-scope
+        // REASSIGNMENT (`global name; name = ...`) is a separate, deferred gap: the
+        // frontend drops `global`/`nonlocal`, so a non-top-level `name = x` is
+        // indistinguishable from a local declaration — gating on it fails OPEN-the-
+        // wrong-way (kills valid inlines of clean helpers whose name a local shadows;
+        // measured 37-repo recall loss). It needs frontend global-binding tracking (#302).
+        if nose_semantics::decorated_definition_at_node(il, unit.root) {
+            continue;
+        }
         let target = DirectFunctionTarget {
             root: unit.root,
             name_hash: interner.symbol_hash(name),

--- a/crates/nose-normalize/src/module_facts.rs
+++ b/crates/nose-normalize/src/module_facts.rs
@@ -5,6 +5,53 @@ use nose_semantics::{
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
+/// Whether the module-level binding `name` is mutated ANYWHERE in the file — a
+/// non-top-level assignment (e.g. `global name; name = other` inside a function, a bare
+/// reassignment in a JS function), a receiver-mutation call, or an opaque argument
+/// escape — excluding occurrences that are locally shadowed. The check the call-target
+/// evidence and content-keyed seeding layers gate on: a mutated binding's content is
+/// not the `def`'s body (coevo series 6, S2-B).
+pub fn module_binding_mutated_in_file(
+    il: &Il,
+    interner: &Interner,
+    name: Symbol,
+    local_scope_nodes: &[bool],
+    top_level: &[NodeId],
+) -> bool {
+    let shadowed =
+        shadowed_js_like_module_binding_nodes_for_symbol_in_scope(il, name, local_scope_nodes);
+    let refers = |node: NodeId| -> bool {
+        node_symbol_in_scope(il, node, local_scope_nodes).is_some_and(|symbol| symbol == name)
+    };
+    fn contains(il: &Il, node: NodeId, refers: &dyn Fn(NodeId) -> bool) -> bool {
+        refers(node) || il.children(node).iter().any(|&c| contains(il, c, refers))
+    }
+    il.nodes.iter().enumerate().any(|(idx, node)| {
+        let node_id = NodeId(idx as u32);
+        if shadowed.contains(&node_id) {
+            return false;
+        }
+        match node.kind {
+            NodeKind::Call => {
+                if let Some(receiver) = receiver_mutation_call_receiver(il, interner, node_id) {
+                    return refers(receiver);
+                }
+                if let Some(args) = opaque_argument_escape_args(il, node_id) {
+                    return args.iter().any(|&arg| contains(il, arg, &refers));
+                }
+                false
+            }
+            NodeKind::Assign if !top_level.contains(&node_id) => {
+                match binding_write_target(il, node_id) {
+                    Some(lhs) => contains(il, lhs, &refers),
+                    None => false,
+                }
+            }
+            _ => false,
+        }
+    })
+}
+
 pub fn top_level_statements_for(il: &Il) -> Vec<NodeId> {
     let mut out = Vec::new();
     for &stmt in il.children(il.root) {

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -57,7 +57,6 @@ use crate::combine;
 use crate::module_facts::{
     assignment_name_in_scope, collect_all_node_symbols_in_scope,
     collect_module_mutations_in_scope_with_direct_definitions, local_scope_nodes,
-    node_symbol_in_scope, shadowed_js_like_module_binding_nodes_for_symbol_in_scope,
     top_level_statements_for,
 };
 use field_state::FieldStateKey;
@@ -95,20 +94,19 @@ use nose_semantics::{
     go_zero_map_default_kind, go_zero_map_entry_contract_for_node,
     go_zero_map_literal_contract_for_node, go_zero_map_lookup_contract, import_fact_evidence_rhs,
     imported_literal_producer_evidence_for_node, imported_namespace_symbol,
-    map_builder_index_write_contract, nullish_global_contract, opaque_argument_escape_args,
-    own_property_guard_for_node, receiver_mutation_call_receiver, record_shape_guard_for_node,
-    reduction_builtin_contract, ruby_shovel_append_parts, semantics, seq_surface_contract_for_node,
-    source_comprehension_at_node, source_operator_at_node, source_pattern_at_node,
-    source_range_at_node, unproven_membership_like_method_contract, BuiltinArgContract,
-    CBytePackWidth, CardinalityPredicate, CardinalityThreshold, ComparisonLaw, DomainEvidence,
-    DomainRequirement, GoZeroMapDefaultKind, ImportFactKind, ImportedNamespaceFunctionSemantic,
-    IndexMembershipThreshold, IndexWriteReceiverContract, IteratorAdapterReceiverContract,
-    JavaMapFactoryKind, LibraryApiCalleeContract, LibraryApiSpanCall,
-    LibraryCollectionFactoryResult, LibraryMapFactoryResult, MapKeyViewKind, MethodBuiltinArgs,
-    MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract, ScalarIntegerMethod,
-    SeqSurfaceContract, StaticIndexMembershipKind, ValueDomain, ValueLaw, SEQ_VALUE_COLLECTION,
-    SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR, SEQ_VALUE_RECORD_GUARD,
-    SEQ_VALUE_UNTAGGED,
+    map_builder_index_write_contract, nullish_global_contract, own_property_guard_for_node,
+    record_shape_guard_for_node, reduction_builtin_contract, ruby_shovel_append_parts, semantics,
+    seq_surface_contract_for_node, source_comprehension_at_node, source_operator_at_node,
+    source_pattern_at_node, source_range_at_node, unproven_membership_like_method_contract,
+    BuiltinArgContract, CBytePackWidth, CardinalityPredicate, CardinalityThreshold, ComparisonLaw,
+    DomainEvidence, DomainRequirement, GoZeroMapDefaultKind, ImportFactKind,
+    ImportedNamespaceFunctionSemantic, IndexMembershipThreshold, IndexWriteReceiverContract,
+    IteratorAdapterReceiverContract, JavaMapFactoryKind, LibraryApiCalleeContract,
+    LibraryApiSpanCall, LibraryCollectionFactoryResult, LibraryMapFactoryResult, MapKeyViewKind,
+    MethodBuiltinArgs, MethodReceiverContract, MethodSemanticContract, ReductionBuiltinContract,
+    ScalarIntegerMethod, SeqSurfaceContract, StaticIndexMembershipKind, ValueDomain, ValueLaw,
+    SEQ_VALUE_COLLECTION, SEQ_VALUE_MAP, SEQ_VALUE_OWN_PROPERTY_GUARD, SEQ_VALUE_PAIR,
+    SEQ_VALUE_RECORD_GUARD, SEQ_VALUE_UNTAGGED,
 };
 use ops::*;
 use rustc_hash::{FxHashMap, FxHashSet};

--- a/crates/nose-normalize/src/value_graph/api.rs
+++ b/crates/nose-normalize/src/value_graph/api.rs
@@ -18,17 +18,18 @@ pub type Anchors = Vec<Anchor>;
 /// heavy sub-DAG [`Anchors`].
 pub type FingerprintBundle = (Vec<u64>, Vec<u64>, Vec<u64>, Anchors);
 /// [`FingerprintBundle`] plus value-law provenance and the unit's containment sink
-/// profile — the final pair is `(pure single return, cond guard hashes)`: whether the
-/// build's sinks are exactly one `Return` plus iteration `Cond` guards (no effects,
-/// throws, or breaks), and the sorted guard-value hashes of those `Cond` sinks. The
-/// reinvented-helper containment channel keys on both.
+/// profile — the final triple is `(pure single return, cond guard hashes, used length
+/// contract)`: whether the build's sinks are exactly one `Return` plus iteration `Cond`
+/// guards (no effects, throws, or breaks), the sorted guard-value hashes of those `Cond`
+/// sinks, and whether the build relied on a pointer-length contract (which drops a loop
+/// bound from the value hash). The reinvented-helper containment channel keys on all three.
 pub type FingerprintLawBundle = (
     Vec<u64>,
     Vec<u64>,
     Vec<u64>,
     Anchors,
     Vec<ValueLaw>,
-    (bool, Vec<u64>),
+    (bool, Vec<u64>, bool),
 );
 
 /// Public entry: the value-graph fingerprint of the unit rooted at `root`

--- a/crates/nose-normalize/src/value_graph/context.rs
+++ b/crates/nose-normalize/src/value_graph/context.rs
@@ -300,6 +300,12 @@ impl<'a> Builder<'a> {
             let Some(name) = unit.name else {
                 continue;
             };
+            // A decorated definition's runtime binding is `decorator(f)`, not the
+            // lowered body, so it must not be content-keyed (coevo series 6, S2-A
+            // false merge: `@double` vs `@triple` callers).
+            if nose_semantics::decorated_definition_at_node(self.il, unit.root) {
+                continue;
+            }
             // Content-keyed identity covers both the straight-line binding-safe set and
             // the generalized pure-shape set: a call whose inline attempt fails the
             // runtime fence still falls back to a content hash (never a bare name), so
@@ -334,56 +340,13 @@ impl<'a> Builder<'a> {
 
     pub(super) fn module_binding_mutated(&self, name: Symbol) -> bool {
         let top_level = self.top_level_statements();
-        let shadowed = shadowed_js_like_module_binding_nodes_for_symbol_in_scope(
+        crate::module_facts::module_binding_mutated_in_file(
             self.il,
+            self.interner,
             name,
             &self.local_scope_nodes,
-        );
-        self.il.nodes.iter().enumerate().any(|(idx, node)| {
-            let node_id = NodeId(idx as u32);
-            if shadowed.contains(&node_id) {
-                return false;
-            }
-            match node.kind {
-                NodeKind::Call => self.call_mutates_binding(node_id, name).unwrap_or(false),
-                NodeKind::Assign if !top_level.contains(&node_id) => self
-                    .assignment_mutates_binding(node_id, name)
-                    .unwrap_or(false),
-                _ => false,
-            }
-        })
-    }
-
-    fn assignment_mutates_binding(&self, assign: NodeId, name: Symbol) -> Option<bool> {
-        let lhs = binding_write_target(self.il, assign)?;
-        Some(self.node_contains_symbol(lhs, name))
-    }
-
-    fn call_mutates_binding(&self, call: NodeId, name: Symbol) -> Option<bool> {
-        if let Some(receiver) = receiver_mutation_call_receiver(self.il, self.interner, call) {
-            return Some(self.node_refers_to_symbol(receiver, name));
-        }
-        if let Some(args) = opaque_argument_escape_args(self.il, call) {
-            return Some(args.iter().any(|&arg| self.node_contains_symbol(arg, name)));
-        }
-        Some(false)
-    }
-
-    fn node_refers_to_symbol(&self, node: NodeId, name: Symbol) -> bool {
-        self.node_symbol(node).is_some_and(|symbol| symbol == name)
-    }
-
-    fn node_symbol(&self, node: NodeId) -> Option<Symbol> {
-        node_symbol_in_scope(self.il, node, &self.local_scope_nodes)
-    }
-
-    fn node_contains_symbol(&self, node: NodeId, name: Symbol) -> bool {
-        self.node_refers_to_symbol(node, name)
-            || self
-                .il
-                .children(node)
-                .iter()
-                .any(|&child| self.node_contains_symbol(child, name))
+            &top_level,
+        )
     }
 
     pub(super) fn node_refers_to_cid(&self, node: NodeId, cid: u32) -> bool {

--- a/crates/nose-normalize/src/value_graph/output.rs
+++ b/crates/nose-normalize/src/value_graph/output.rs
@@ -77,10 +77,20 @@ impl<'a> Builder<'a> {
     /// The unit's sink profile for the containment channel: whether the build emitted
     /// exactly one `Return` and nothing irreversible (no ordered effects, throws, or
     /// breaks — `flush_fields` has already run, so flushed field state would show up as
-    /// `Effect` sinks here), plus the sorted guard-value hashes of its `Cond` sinks
-    /// (loop iteration guards — value-relevant bookkeeping a containment match must
-    /// also find in the container).
-    pub(super) fn sink_profile(&self) -> (bool, Vec<u64>) {
+    /// `Effect` sinks here); the sorted guard-value hashes of its `Cond` sinks (loop
+    /// iteration guards a containment match must also find in the container); and whether
+    /// the build RELIED ON a pointer-length contract.
+    ///
+    /// The last flag is a containment soundness gate (coevo series 6, S3-3): an indexed
+    /// `while i < n` loop where `n` is a free param assumed to be `len(array)` records a
+    /// `(array, n)` contract and drops the bound from BOTH the `Cond` sinks and the
+    /// `Reduce` value hash. Two such folds with DIFFERENT bounds (`i < n` vs `i < n-1`)
+    /// then share a return hash though they compute different values — the guard-
+    /// inclusion check is vacuous because `cond_sinks` is empty. Such a helper's value
+    /// is not faithfully determined by its return hash, so it is ineligible as a
+    /// containment helper. Genuine length iteration (`for x in xs`, `while i < len(xs)`)
+    /// records no contract and stays eligible — the flagship case is unaffected.
+    pub(super) fn sink_profile(&self) -> (bool, Vec<u64>, bool) {
         let mut returns = 0usize;
         let mut conds: Vec<u64> = Vec::new();
         let mut other = false;
@@ -93,7 +103,7 @@ impl<'a> Builder<'a> {
         }
         conds.sort_unstable();
         conds.dedup();
-        (!other && returns == 1, conds)
+        (!other && returns == 1, conds, !self.contracts.is_empty())
     }
 
     pub(super) fn fingerprint_lits(&self) -> (Vec<u64>, Vec<u64>, Vec<u64>) {

--- a/crates/nose-semantics/src/evidence.rs
+++ b/crates/nose-semantics/src/evidence.rs
@@ -101,7 +101,27 @@ pub fn source_fact_at_node(il: &Il, node: NodeId, kind: SourceFactKind) -> bool 
         }
         SourceFactKind::Range(range) => source_range_at_node(il, node) == Some(range),
         SourceFactKind::Pattern(pattern) => source_pattern_at_node(il, node) == Some(pattern),
+        SourceFactKind::Binding(binding) => source_binding_at_node(il, node) == Some(binding),
     }
+}
+
+pub fn source_binding_at_node(il: &Il, node: NodeId) -> Option<SourceBindingKind> {
+    let span = il.node(node).span;
+    match evidence_at_span(il, span, |evidence| match evidence {
+        EvidenceKind::Source(SourceFactKind::Binding(binding)) => Some(binding),
+        _ => None,
+    }) {
+        EvidenceResolution::Found(binding) => Some(binding),
+        _ => None,
+    }
+}
+
+/// The definition rooted at `node` was DECORATED in source: its runtime binding is the
+/// decorator's result, not the lowered body. Consumers that attribute the body to the
+/// function's NAME (call-target evidence, content-keyed seeding, inlining) must treat
+/// such a binding as unprovable and fail closed.
+pub fn decorated_definition_at_node(il: &Il, node: NodeId) -> bool {
+    source_binding_at_node(il, node) == Some(SourceBindingKind::DecoratedDefinition)
 }
 
 pub fn source_operator_at_node(il: &Il, node: NodeId) -> Option<SourceOperatorKind> {

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -11,9 +11,10 @@ use nose_il::{
     EffectEvidenceKind, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind, EvidenceRecord,
     EvidenceStatus, GuardEvidenceKind, HoFKind, Il, ImportEvidenceKind, Interner, Lang,
     LibraryApiEvidenceKind, LitClass, NodeId, NodeKind, Op, ParamSemantic, Payload,
-    SequenceSurfaceKind, SourceCallKind, SourceCastKind, SourceComprehensionKind, SourceFactKind,
-    SourceLiteralKind, SourceOperatorKind, SourcePatternKind, SourceProtocolKind, SourceRangeKind,
-    Span, Symbol, SymbolEvidenceKind, TypeEvidenceKind,
+    SequenceSurfaceKind, SourceBindingKind, SourceCallKind, SourceCastKind,
+    SourceComprehensionKind, SourceFactKind, SourceLiteralKind, SourceOperatorKind,
+    SourcePatternKind, SourceProtocolKind, SourceRangeKind, Span, Symbol, SymbolEvidenceKind,
+    TypeEvidenceKind,
 };
 use rustc_hash::FxHashMap;
 

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -103,6 +103,15 @@ core canonicalizations, but not a per-scan or whole-pipeline proof. See
 - **Name-only library semantics** are not accepted. A method named `map`, `then`,
   `collect`, or `contains` is exact only when the language, symbol/receiver,
   shadowing/import, arity, and effect/demand obligations for that API are proven.
+- **Unproven method calls share an opaque identity keyed by the method name.** An
+  unresolved `obj.foo(x)` is modeled as one opaque operation keyed by `foo`, so two
+  callers of same-named methods on *different* receiver types — or whose `foo` bodies
+  differ but nose cannot resolve which is called — converge. Resolving them needs
+  receiver-type analysis the value model erases. A consequence: a behavior-changing
+  decorator on a method (`@cached`, `@retry`) is invisible to its callers' fingerprints
+  (the decorator is dropped in lowering and the call is name-keyed) — see
+  [experiments §CG](experiments.md). Free-function calls do NOT share this hazard:
+  decorated function definitions fail closed (no `DirectFunction` evidence).
 - **Recursion ↔ iteration** is partially modeled — a bounded subset converges (see
   [normalization](normalization.md)); general recursion↔iteration remains out of scope.
 - The behavioral *proof* (`nose verify`) covers only interpretable (≈ pure) units; detection

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2271,3 +2271,77 @@ nodes. After: 2 findings on sympy, both hand-verified true.
 mechanism, pointed at containment instead of pair recovery, yields a small,
 high-precision, novel finding surface at +2.4% scan cost. Floor-first shipped; exact
 admission and default-surface promotion follow the labelset discipline.
+
+## CG. Adversarial co-evolution, series 6 — the #299 surfaces (generalized inline, content keying, containment, oracle)
+
+One protocol pass ([adversarial-coevolution](adversarial-coevolution.md)) aimed by the
+freshness slot rule at the code merged in #299 (commit `fa35de2`). Four blind-mode
+attackers, persona-rotated, executable packets, on the four claims #299 introduced.
+Tracking issue #300; ledger `bench/coevo/packets.v1.json` (cases `s6-*`).
+
+**S1 — generalized inline soundness (soundness-skeptic).** One violation: Python
+keyword arguments lower to their value in source order, dropping the name, so
+`helper(b=p, a=q)` is byte-identical IL to `helper(a=p, b=q)` and the two callers
+false-merge as "exact behavior match" (−2 vs 5 on p=1,q=2). **Pre-existing** (occurs on
+the opaque-call path; inline not load-bearing) and cross-language; the sound fix needs
+IL Call keyword identity (a representational change). **Deferred #301.** The fence,
+fold, in-loop-return poison, and Cond-passthrough all held against direct attack.
+
+**S2 — content-keyed callee identity (binding-lawyer).** Two violations, split on
+fixability:
+- **S2-A (decorators) — fixed.** Python decorators are dropped in lowering, so `@double`
+  vs `@triple` callers false-merged (caller(1)=40 vs 60). Fix: a new
+  `SourceFactKind::Binding(DecoratedDefinition)` recorded at lowering; `DirectFunction`
+  evidence and content-keyed seeding both skip decorated definitions. Precise, no
+  over-fire; corpus effect is 4 Python repos (poetry, click, sqlalchemy, sympy), net −2
+  families — genuine decorator-driven false merges removed.
+- **S2-B (out-of-scope reassignment) — deferred #302.** `global helper; helper = x`
+  inside another function inlines the original body (callers 1000 vs 2000). The natural
+  gate ("name reassigned anywhere?") **cannot be made precise**: the frontend drops
+  `global`/`nonlocal`, so a non-top-level `name = x` is indistinguishable from a local
+  shadow. The broad predicate **over-fired — 37 corpus repos of recall loss** (netty −26,
+  raylib −11) for zero soundness gain there — so it was reverted per *the defender's
+  ceiling is provability*. Needs frontend global-binding tracking (same class as S1).
+
+**S3 — reinvented-helper containment (claims-auditor).** Four packets; two false
+findings fixed in code, two over-strong claims fixed in docs:
+- **S3-2 (caller via inlined-callee span) — fixed.** A pure caller of a function that
+  inline-reinvents the helper was itself reported (the called-helper record is one call
+  level deep). Fix: reject a finding whose matched anchor carries a REAL source span
+  outside the container's own line range — that span belongs to the inlined callee.
+- **S3-3 (bound-blind Reduce) — fixed.** An indexed `while i < n` absorbs the bound into
+  a pointer-length contract, dropping it from `cond_sinks` AND the `Reduce` hash, so a
+  fold over `i < n-1` value-exactly "contained" a fold over `i < n` (11 vs 22 on
+  xs=[1,1]). Fix: `sink_profile` now reports `used_length_contract`; contract-bound
+  helpers are ineligible (their return hash doesn't determine their value). Conservative
+  — also drops the same-bound true positive (S3-1's shape), a sound recall loss, since
+  the bound is unrecoverable from the hash. Genuine length iteration is unaffected.
+- **S3-1 (approximate site) / S3-4 (type-erased fix) — docs honesty.** A loop-fold match
+  has no precise span, so the site is the whole container (`site_approximate` flag
+  added); and field access hashes by name, so a Go container can value-exactly contain a
+  helper of a different struct type whose call would not compile. Both are TRUE findings
+  with an over-strong *fix* claim — reframed as advisory (call the helper for the matched
+  part; type-check the suggested call), not mechanical line replacement.
+
+**S4 — oracle completeness (oracle-attacker). Green.** No violation. The inline
+admission and the oracle's callee-execution gate resolve the same `DirectFunction`
+target from the same evidence, so the oracle is at least as general as the inline.
+Census: ~43% of the inline-created merge mass is oracle-opaque — all in the fail-closed
+`uninterpretable` bucket (free module globals, floats, JS C-style for-loops), exclusion
+mass, not silent SOUND.
+
+**Boundary re-attack.** One round on the new gates. Decorated *methods* still merge
+across `@double`/`@triple` — but a no-decorator control with different method bodies
+merges identically, so the cause is the **pre-existing opaque method-name identity**
+(`self.helper` keyed by name), not the S2 content path, and predates #299. Recorded as a
+known boundary (clone-types: unproven methods are name-keyed). Conditional reassignment
+and length-contract-vs-`for` boundaries held.
+
+**Verdict.** Two ships (S2-A decorator fact, S3 containment gates), four defers/greens
+(S1 #301, S2-B #302, S3-1/S3-4 docs, S4 green). Net corpus: **16 reinvented findings
+preserved** (the S3 gates removed only synthetic adversarial cases, zero real-finding
+recall), **−2 false merges** removed from 4 Python repos by the decorator fact, recall
+otherwise neutral, soundness and determinism re-verified. The campaign's sharpest lesson
+is S2-B: a false merge whose only available defense is an unprovable guess is a
+*deferred* finding, not a shipped guess — the 37-repo over-fire is exactly the §BA "17
+false merges" failure mode in the recall direction.

--- a/docs/reinvented-helpers.md
+++ b/docs/reinvented-helpers.md
@@ -19,16 +19,26 @@ For a finding `container ⟵ helper`:
   rides, so the matched sub-computation and the helper body are *the same
   computation*, never merely similar;
 - every loop-guard (`Cond`) hash of the helper is also present in the container's
-  fingerprint — matching a fold while iterating differently is not containment.
+  fingerprint — matching a fold while iterating differently is not containment;
+- the helper did **not** rely on a pointer-length contract (a free-param loop bound
+  `while i < n` assumed to be `len(array)`). Such a bound is dropped from BOTH the
+  guard set and the value hash, so two folds with different bounds (`i < n` vs `i < n-1`)
+  would share a return hash though they compute different values — and the guard-
+  inclusion check above is then vacuous. Contract-bound helpers are excluded fail-closed;
+  genuine length iteration (`for x in xs`, `while i < len(xs)`) records no contract and
+  stays eligible (coevo series 6, S3-3).
 
 Two exclusions keep the surface honest:
 
 - **Callers are never findings.** [Generalized pure inlining](normalization.md) splices
   a callee's value graph into its caller's fingerprint, so every well-behaved caller
-  would otherwise "contain" its helper. A unit's provable same-file call targets
-  (`CallTarget::DirectFunction`) are recorded, and a match on a called helper's return
-  hash — directly or via a behaviorally-equal twin — is skipped: calling is the fix,
-  not the smell.
+  would otherwise "contain" its helper. Two guards exclude callers: a unit's provable
+  same-file call targets (`CallTarget::DirectFunction`) are recorded and a match on a
+  called helper's return hash — directly or via a behaviorally-equal twin — is skipped;
+  and a matched anchor carrying a REAL source span OUTSIDE the container's own line
+  range is rejected, since that span belongs to a different (inlined) function the unit
+  merely calls — the case a one-level call-target record misses on a two-hop chain
+  (coevo series 6, S3-2). Calling is the fix, not the smell.
 - **Idiom-sized helpers are never matched.** The helper must clear both a value-graph
   floor (≥ 8 nodes) and a source floor (≥ 20 tokens). Value-graph weight alone cannot
   tell a compressed accumulator loop (a whole loop canonicalizes to a ~4-node `Reduce`
@@ -47,6 +57,25 @@ Two exclusions keep the surface honest:
   [scan-json](scan-json.md#reinvented-helpers).
 - The container being a test file or vendored code is *judgment-deep* non-action
   ([design §2b](design.md)): the consumer decides; nose carries the locations.
+
+## The suggested fix is advisory, not mechanical
+
+The finding says *this computation already exists as a helper* — it does **not** promise
+that mechanically replacing the reported lines compiles or preserves behavior. Two
+boundaries the consumer must check (coevo series 6, S3-1/S3-4):
+
+- **Approximate site.** When the matched computation is a synthesized loop fold (a
+  `Reduce` with no precise source span), the site falls back to the WHOLE container range
+  and `site_approximate` is `true` in the JSON. The helper's computation is then a
+  *sub-part* of those lines (the container does more — e.g. `total * extra + 9` around
+  the fold), so the fix is "call the helper for the matched part", not "delete these
+  lines". The flagship `mean = sum(xs) / len(xs)` is exactly this shape: `sum` is the
+  reinvented helper; `/ len` stays.
+- **Types are erased.** The value model abstracts away nominal types
+  ([clone-types](clone-types.md)), so a container over one struct type can value-exactly
+  contain a helper taking a *different* struct type with same-named fields. In a
+  statically-typed language (Go/Java/Rust/C) the suggested call may not type-check — the
+  consumer must confirm the helper is callable with the container's operands.
 
 ## Measured (2026-06-12, the 105-repo corpus)
 

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -347,6 +347,7 @@ existing pure helper inline instead of calling it. One entry per finding:
 | `container_file` / `container_name` | string / string? | The unit containing the reimplementation. |
 | `container_start_line` / `container_end_line` | integer | The container's source range. |
 | `site_start_line` / `site_end_line` | integer | Lines INSIDE the container where the helper's computation lives (falls back to the container range when the matched node carries no span). |
+| `site_approximate` | boolean | The site is the whole-container fallback (the match is a synthesized loop fold with no precise span); the helper's computation is a sub-part of those lines, so do not mechanically replace the exact range. |
 | `weight` | integer | Value-graph size of the matched computation — the ranking key. |
 
 The claim is exact-grade (both units pass the strict exact gate; the match is a


### PR DESCRIPTION
One adversarial co-evolution protocol pass ([docs/adversarial-coevolution.md](docs/adversarial-coevolution.md)), aimed by the freshness slot rule at the four claims #299 introduced. Four blind-mode, persona-rotated attackers; executable self-verified packets; ledger cases `s6-*` in `bench/coevo/packets.v1.json`; closeout in [experiments §CG](docs/experiments.md). Tracking issue #300.

## Ships (defended in code)

**S2-A — decorator fail-closed** (soundness). Python decorators are dropped in lowering, so a decorated helper's runtime binding is `decorator(f)`, not the bare body — `@double` vs `@triple` callers false-merged as *"exact behavior match"* (`caller(1)` = 40 vs 60). A new `SourceFactKind::Binding(DecoratedDefinition)` is recorded at lowering; `DirectFunction` evidence and content-keyed seeding both skip decorated definitions, so the callers fall back to opaque and leave the exact channel. Corpus: 4 Python repos, net −2 families (genuine decorator false merges removed), recall otherwise neutral.

**S3-2 — containment caller exclusion**. A pure caller of a function that inline-reinvents a helper was reported as reinventing it (the called-helper record is one call level deep). Reject a finding whose matched anchor carries a *real* source span outside the container's own line range — that span belongs to the inlined callee.

**S3-3 — containment bound-blindness**. An indexed `while i < n` absorbs the bound into a pointer-length contract, dropping it from the `Reduce` hash, so a fold over `i < n-1` value-exactly "contained" a fold over `i < n` (11 vs 22 on `xs=[1,1]`). `sink_profile` now reports `used_length_contract`; contract-bound helpers are ineligible (conservative, sound — also drops the same-bound true positive since the bound is unrecoverable from the hash).

**S3-1 / S3-4 — docs honesty**. A loop-fold match has no precise span (new `site_approximate` JSON flag) and field access is name-keyed (a cross-type fix may not compile). Both are *true* findings with an over-strong **fix** claim — reframed as advisory (call the helper for the matched part; type-check the call), not mechanical line replacement.

## Deferred / green

| case | verdict | why |
|---|---|---|
| S1 keyword-arg order | deferred **#301** | `helper(b=p,a=q)` is byte-identical IL to `helper(a=p,b=q)`; needs IL Call keyword identity. Pre-existing (opaque path too). |
| S2-B out-of-scope reassignment | deferred **#302** | the frontend drops `global`/`nonlocal`, so "reassigned anywhere?" can't be made precise — the broad predicate **over-fired at 37 repos** (netty −26) for zero soundness gain, reverted per *the defender's ceiling is provability*. |
| S4 oracle completeness | **green** | inline and oracle resolve the same `DirectFunction` target from the same evidence; ~43% of inline-created merge mass is fail-closed excluded, not silent SOUND. |
| boundary: decorated methods | recorded | merge via the **pre-existing** opaque method-name identity (a no-decorator control merges identically), out of scope — noted in clone-types. |

## Verified

- **Soundness**: `nose verify --max-violations 0` clean on sympy (37,564 units, 14,086 interpretable, 0 false merges).
- **Determinism**: byte-identical scan JSON across thread counts (redis).
- **Recall-neutral**: the 16 reinvented findings are all preserved (the S3 gates removed only synthetic adversarial cases); the reverted S2-B over-fire restored netty/raylib to exact pre-campaign counts.
- 3 regression tests added (decorator exact-safe, S3-2 caller exclusion, S3-3 bound-blind).

The campaign's sharpest lesson is S2-B: a false merge whose only available defense is an unprovable guess is a *deferred* finding, not a shipped guess — the 37-repo over-fire is the §BA "17 false merges" failure mode in the recall direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)