### PR TITLE
Keyword arguments bind by name, not position (#301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ break.
 
 ## [Unreleased]
 
+### Fixed
+- **Keyword arguments now bind by name, not position** (#301). A Python call
+  `helper(b=p, a=q)` lowered to byte-identical IL as `helper(a=p, b=q)` — the keyword
+  names were dropped — so two callers passing different `(name → value)` mappings
+  false-merged as an "exact behavior match" (e.g. `(p-q)*3+p` vs `(q-p)*3+q`). Keyword
+  arguments now lower to a `KwArg` node carrying the name; the value graph keys a call's
+  keyword args by name (so `f(a=p, b=q)` ≡ `f(b=q, a=p)` but ≠ `f(a=q, b=p)`), and both
+  interprocedural inlining and the behavioral oracle bind keywords by the same plan. A
+  recall *gain* as well as a soundness fix: same-mapping reordered keyword calls now
+  converge. Ruby was already sound (it keeps keyword keys as distinct literals).
+
 ### Added
 - **Reinvented-helper containment findings** (experimental). A new exact-grade finding
   class: a function that reimplements an existing pure single-return helper inline

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -7443,3 +7443,54 @@ fn reinvented_helper_rejects_bound_blind_fold_coevo_s6_s3() {
         "a fold whose bound the value hash drops must not match a different-bound fold",
     );
 }
+
+#[test]
+fn keyword_argument_mapping_is_by_name_not_position_issue_301() {
+    // #301 (coevo series 6, S1): Python keyword arguments lower to a KwArg node carrying
+    // the name, so a call's argument identity is BY NAME. Two callers passing the SAME
+    // (name -> value) mapping in different orders converge; two passing DIFFERENT
+    // mappings do not — the inline binds `helper(b=p, a=q)` to the right parameters.
+    let i = Interner::new();
+    let helper = "def helper(a, b):\n    base = a - b\n    return base * 3 + a\n";
+    let call_ab = "def run(p, q):\n    return helper(a=p, b=q)\n";
+    let call_ba_same = "def run(p, q):\n    return helper(b=q, a=p)\n"; // same mapping, reordered
+    let call_ba_diff = "def run(p, q):\n    return helper(b=p, a=q)\n"; // different mapping
+    let fp = |c: &str| value_fp_named(&i, &format!("{helper}\n{c}"), Lang::Python, "run");
+    assert_eq!(
+        fp(call_ab),
+        fp(call_ba_same),
+        "same keyword->value mapping in different order must converge",
+    );
+    assert_ne!(
+        fp(call_ab),
+        fp(call_ba_diff),
+        "different keyword->value mapping must NOT converge (the #301 false merge)",
+    );
+}
+
+#[test]
+fn keyword_argument_oracle_binds_by_name_issue_301() {
+    // The verify oracle must bind keyword args by name too, so it neither mis-binds a
+    // reordered keyword call (a silent false merge) nor needlessly excludes it. The
+    // differently-mapped callers compute different values on the same inputs.
+    use nose_normalize::{run_unit, Value};
+    let i = Interner::new();
+    let src_diff = "def helper(a, b):\n    return (a - b) * 3 + a\n\ndef run(p, q):\n    return helper(b=p, a=q)\n";
+    let il = nose_frontend::lower_source(FileId(0), "t.py", src_diff.as_bytes(), Lang::Python, &i)
+        .unwrap();
+    let n = normalize(&il, &i, &NormalizeOptions::default());
+    let run = n
+        .units
+        .iter()
+        .find(|u| u.name.is_some_and(|s| i.resolve(s) == "run"))
+        .map(|u| u.root)
+        .expect("run unit");
+    // run(p=1, q=2) calls helper(b=1, a=2) → (a-b)*3+a = (2-1)*3+2 = 5.
+    assert_eq!(
+        run_unit(&n, &i, run, &[Value::Int(1), Value::Int(2)])
+            .expect("interpretable")
+            .ret,
+        Value::Int(5),
+        "the oracle must bind helper(b=p, a=q) by name: a=q=2, b=p=1",
+    );
+}

--- a/crates/nose-detect/src/abstraction.rs
+++ b/crates/nose-detect/src/abstraction.rs
@@ -312,6 +312,7 @@ fn token_label(token: &WitnessToken) -> &'static str {
             NodeKind::Lambda => "Lambda",
             NodeKind::Seq => "Seq",
             NodeKind::HoF => "HoF",
+            NodeKind::KwArg => "KwArg",
             NodeKind::Raw => "Raw",
         },
     }

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -689,10 +689,7 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             lo.await_boundary(span, value)
         }
         "named_expression" => lower_named_expr(lo, node),
-        "keyword_argument" => node
-            .child_by_field_name("value")
-            .map(|v| lower_expr(lo, v))
-            .unwrap_or_else(|| lo.empty_block(span)),
+        "keyword_argument" => lower_keyword_argument(lo, node),
         "assignment" => lower_assignment(lo, node),
         "augmented_assignment" => lower_aug_assignment(lo, node),
         // comprehension clauses, if ever reached directly: lower the meaningful part
@@ -898,6 +895,25 @@ fn lower_dictionary_pair(lo: &mut Lowering, node: TsNode) -> NodeId {
         .collect();
     let tag = lo.sym("pair");
     lo.add(NodeKind::Seq, Payload::Name(tag), span, &kids)
+}
+
+/// `f(name=value)` — keep the keyword NAME so the call's argument identity is by name,
+/// not source position (`f(a=p,b=q)` must not equal `f(b=p,a=q)`). The value graph keys
+/// a call's keyword args by name; an unhandled consumer treats `KwArg` opaquely (fail
+/// closed). A keyword arg with no resolvable name falls back to the bare value.
+fn lower_keyword_argument(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let value = node
+        .child_by_field_name("value")
+        .map(|v| lower_expr(lo, v))
+        .unwrap_or_else(|| lo.empty_block(span));
+    match node.child_by_field_name("name") {
+        Some(name) => {
+            let sym = lo.sym(lo.text(name));
+            lo.add(NodeKind::KwArg, Payload::Name(sym), span, &[value])
+        }
+        None => value,
+    }
 }
 
 fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -83,6 +83,16 @@ pub enum NodeKind {
     /// `Name` holds the original tree-sitter node kind for debugging. Children:
     /// whatever sub-IL was produced. Detection treats these opaquely.
     Raw,
+
+    /// A keyword/named call argument `name=value`. Payload: `Name` (the keyword,
+    /// content-hashed, never alpha-renamed — it labels a parameter, not a binding).
+    /// Children: `[value]`. Appears only as a child of `Call`. Keyword arguments are
+    /// order-independent BY NAME, so the value graph keys a call's keyword args by their
+    /// names (not positions): `f(a=p, b=q)` ≡ `f(b=q, a=p)` but ≠ `f(a=q, b=p)`. An
+    /// unhandled consumer treats it opaquely (fail closed: keyword calls then simply do
+    /// not converge with positional ones). Declared LAST so adding it does not shift the
+    /// discriminants (and thus the shape hashes) of the existing kinds.
+    KwArg,
 }
 
 /// Per-node data. Most nodes carry [`Payload::None`]; the variant in use is

--- a/crates/nose-il/src/sexpr.rs
+++ b/crates/nose-il/src/sexpr.rs
@@ -80,6 +80,7 @@ fn kind_name(k: NodeKind) -> &'static str {
         Lambda => "lambda",
         Seq => "seq",
         HoF => "hof",
+        KwArg => "kwarg",
         Raw => "raw",
     }
 }

--- a/crates/nose-normalize/src/call_args.rs
+++ b/crates/nose-normalize/src/call_args.rs
@@ -1,0 +1,52 @@
+//! Shared argument→parameter binding for calls with keyword arguments.
+//!
+//! Keyword arguments (`f(name=value)`) bind by NAME, not position. Both the value-graph
+//! builder and the behavioral interpreter must resolve the same mapping, so the
+//! IL-only analysis (which value-node feeds which parameter) lives here once: each
+//! consumer then evaluates the chosen argument node in its own value domain.
+
+use nose_il::{Il, NodeId, NodeKind, Payload, Symbol};
+
+/// Resolve a call's positional + keyword arguments to a binding plan: a list of
+/// `(param_cid, arg_value_node)` pairs covering every parameter exactly once.
+///
+/// `param_cids` are the callee's parameter canonical ids in declaration order;
+/// `call_args` are the call's argument nodes (the children after the callee). Positional
+/// args fill parameters left-to-right; a `KwArg` binds to the parameter whose original
+/// name (via `il.cid_names`) matches its keyword. Returns `None` — the fail-closed signal
+/// every caller routes to its opaque path — for a keyword naming no parameter, a
+/// double-bind, an over-long positional run, or any parameter left unbound. The returned
+/// node for a keyword argument is its VALUE child, so callers evaluate the value, not the
+/// `KwArg` wrapper (#301).
+pub(crate) fn keyword_arg_binding_plan(
+    il: &Il,
+    param_cids: &[u32],
+    call_args: &[NodeId],
+) -> Option<Vec<(u32, NodeId)>> {
+    let param_name = |cid: u32| -> Option<Symbol> { il.cid_names.get(cid as usize).copied() };
+    let mut plan: Vec<(u32, NodeId)> = Vec::with_capacity(param_cids.len());
+    let mut bound = vec![false; param_cids.len()];
+    let mut pos = 0usize;
+    for &arg in call_args {
+        let (idx, value_node) = if il.kind(arg) == NodeKind::KwArg {
+            let Payload::Name(kw) = il.node(arg).payload else {
+                return None;
+            };
+            let idx = param_cids.iter().position(|&c| param_name(c) == Some(kw))?;
+            (idx, *il.children(arg).first()?)
+        } else {
+            let idx = pos;
+            if idx >= param_cids.len() {
+                return None;
+            }
+            pos += 1;
+            (idx, arg)
+        };
+        if bound[idx] {
+            return None;
+        }
+        bound[idx] = true;
+        plan.push((param_cids[idx], value_node));
+    }
+    bound.iter().all(|&b| b).then_some(plan)
+}

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -801,6 +801,17 @@ impl<'a> Interp<'a> {
             }
             NodeKind::Call => self.eval_call(node, env),
             NodeKind::HoF => self.eval_hof(node, env),
+            // A keyword argument reached outside a resolved call's own by-name binding
+            // (e.g. inside an opaque/library call): evaluate its value. The keyword name
+            // is not needed here — fingerprint-equal units share identical keyword
+            // structure, so the name never distinguishes members of a checked group, and
+            // `eval_user_call` does its own by-name binding for proven targets (#301).
+            NodeKind::KwArg => self
+                .il
+                .children(node)
+                .first()
+                .ok_or(Unsupported)
+                .and_then(|&v| self.eval(v, env)),
             _ => Err(Unsupported),
         }
     }
@@ -1083,28 +1094,28 @@ impl<'a> Interp<'a> {
             let ident = subtree_sig(self.il, self.interner, callee);
             return self.opaque_call(ident, &kids[1..], env);
         };
-        // Evaluate the arguments in the CURRENT frame (call-by-value), left to right.
-        let mut argv = Vec::with_capacity(kids.len().saturating_sub(1));
-        for &a in &kids[1..] {
-            let value = self.eval(a, env)?;
+        // Bind arguments to the CALLEE's parameters in a fresh environment by the shared
+        // plan (matching the value graph): positional left-to-right, keyword by name. An
+        // unresolvable mapping bails the unit (Unsupported) so the oracle never mis-binds
+        // a reordered keyword call (#301). Locals start empty; the effect trace, field
+        // state, and step budget are shared.
+        let params = self.il.children(target).to_vec();
+        let param_cids: Vec<u32> = params
+            .iter()
+            .filter_map(|&p| match (self.il.kind(p), self.il.node(p).payload) {
+                (NodeKind::Param, Payload::Cid(c)) => Some(c),
+                _ => None,
+            })
+            .collect();
+        let plan = crate::call_args::keyword_arg_binding_plan(self.il, &param_cids, &kids[1..])
+            .ok_or(Unsupported)?;
+        let mut fenv: FxHashMap<u32, Value> = FxHashMap::default();
+        for (cid, value_node) in plan {
+            let value = self.eval(value_node, env)?;
             if matches!(value, Value::Err) {
                 return Ok(Value::Err);
             }
-            argv.push(value);
-        }
-        // Bind them positionally to the CALLEE's parameters in a fresh environment; locals
-        // start empty, exactly like a real call. The effect trace, field state, and step budget
-        // are shared with the caller (so effects stay ordered and runaway recursion terminates).
-        let params = self.il.children(target).to_vec();
-        let mut fenv: FxHashMap<u32, Value> = FxHashMap::default();
-        let mut pi = 0;
-        for &p in &params {
-            if self.il.kind(p) == NodeKind::Param {
-                if let Payload::Cid(c) = self.il.node(p).payload {
-                    fenv.insert(c, argv.get(pi).cloned().unwrap_or(Value::Null));
-                    pi += 1;
-                }
-            }
+            fenv.insert(cid, value);
         }
         let body = *params.last().ok_or(Unsupported)?;
         let result = self.exec(body, &mut fenv);

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -16,6 +16,7 @@
 mod algebra;
 mod alpha;
 mod binding_evidence;
+mod call_args;
 mod call_target_evidence;
 mod cfg_norm;
 mod commutative;

--- a/crates/nose-normalize/src/value_graph/collections.rs
+++ b/crates/nose-normalize/src/value_graph/collections.rs
@@ -1157,7 +1157,30 @@ impl<'a> Builder<'a> {
         let contract = occurrence.contract;
         let ImportedNamespaceFunctionSemantic::ProductReduction { op, identity } =
             contract.result.semantic;
-        let coll = self.eval(*kids.get(1)?, env);
+        // Split args into the positional iterable and an optional `start=` seed: the
+        // seed may be positional (`prod(xs, 1)`) or keyword (`prod(xs, start=1)`). An
+        // unrecognized keyword is an arg shape this recognizer does not model — bail to
+        // the opaque path (sound) rather than guess (#301).
+        let mut iterable = None;
+        let mut seed_node = None;
+        for &a in &kids[1..] {
+            if self.il.kind(a) == NodeKind::KwArg {
+                let Payload::Name(name) = self.il.node(a).payload else {
+                    return None;
+                };
+                if self.interner.resolve(name) != "start" {
+                    return None;
+                }
+                seed_node = Some(*self.il.children(a).first()?);
+            } else if iterable.is_none() {
+                iterable = Some(a);
+            } else if seed_node.is_none() {
+                seed_node = Some(a);
+            } else {
+                return None;
+            }
+        }
+        let coll = self.eval(iterable?, env);
         let (coll_op, args) = {
             let n = &self.nodes[coll as usize];
             (n.op.clone(), n.args.clone())
@@ -1170,9 +1193,8 @@ impl<'a> Builder<'a> {
             ValOp::Hof(k) if k == HoFKind::Map as u32 && args.len() == 1 => args[0],
             _ => self.elem(coll),
         };
-        let init = kids
-            .get(2)
-            .map(|&i| self.eval(i, env))
+        let init = seed_node
+            .map(|i| self.eval(i, env))
             .unwrap_or_else(|| self.int_const(identity));
         Some(self.mk(ValOp::Reduce(op as u32), vec![init, contrib]))
     }

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -134,6 +134,22 @@ impl<'a> Builder<'a> {
                 let hash = self.valued_subtree_hash(expr);
                 self.mk(ValOp::Lambda(hash), vec![])
             }
+            // A keyword call argument `name=value` evaluated outside a call's own
+            // kwarg handling (e.g. a kwarg that survived into an opaque position): key
+            // it by the keyword name so `a=p` ≠ `b=p` and ≠ positional `p`.
+            NodeKind::KwArg => {
+                let name_hash = match node.payload {
+                    Payload::Name(s) => self.interner.symbol_hash(s),
+                    _ => 0,
+                };
+                let value = self
+                    .il
+                    .children(expr)
+                    .first()
+                    .map(|&v| self.eval(v, env))
+                    .unwrap_or_else(|| self.mk(ValOp::Opaque(0), vec![]));
+                self.mk(ValOp::KwArg(name_hash), vec![value])
+            }
             // Any unlowered / unhandled construct — notably `Raw`, which wraps a
             // macro, C compound literal, `#ifdef`, parse-ERROR, etc. Key it by its full
             // subtree hash (surface kind + lowered children), exactly like `Lambda`, so
@@ -467,12 +483,30 @@ impl<'a> Builder<'a> {
         if let Some(v) = self.eval_inlined_call(expr, &kids, env) {
             return v;
         }
-        let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+        // Keyword arguments are order-independent BY NAME, so evaluate positional args
+        // in source order but the keyword args as a name-sorted suffix: `f(a=p, b=q)`
+        // and `f(b=q, a=p)` converge, while `f(a=p, b=q)` and `f(a=q, b=p)` (different
+        // mapping) stay distinct. The first child is the callee (or, for a builtin, the
+        // first arg) and is never a keyword.
+        let mut positional: Vec<ValueId> = Vec::new();
+        let mut keyword: Vec<ValueId> = Vec::new();
+        for &k in &kids {
+            let v = self.eval(k, env);
+            if self.il.kind(k) == NodeKind::KwArg {
+                keyword.push(v);
+            } else {
+                positional.push(v);
+            }
+        }
+        if !keyword.is_empty() {
+            keyword.sort_unstable_by_key(|&v| self.vhash[v as usize]);
+            positional.extend(keyword);
+        }
         let tag = match payload {
             Payload::Builtin(b) => builtin_tag(b),
             _ => 0,
         };
-        self.mk(ValOp::Call(tag), a)
+        self.mk(ValOp::Call(tag), positional)
     }
 
     fn eval_builtin_predicate_call(

--- a/crates/nose-normalize/src/value_graph/inline.rs
+++ b/crates/nose-normalize/src/value_graph/inline.rs
@@ -189,10 +189,15 @@ impl<'a> Builder<'a> {
         if self.inline_stack.len() >= INLINE_MAX_DEPTH || self.inline_stack.contains(&root) {
             return None;
         }
+        // Bind arguments to parameters by the shared plan: positional left-to-right,
+        // keyword (`name=value`) by name. A keyword naming no param, a double-bind, or
+        // any param left unbound fails closed to the opaque path — so `helper(b=p, a=q)`
+        // substitutes the RIGHT operands, never the positional ones (#301).
+        let plan = crate::call_args::keyword_arg_binding_plan(self.il, &target.params, &kids[1..])?;
         let mut fenv: FxHashMap<u32, ValueId> = FxHashMap::default();
-        for (pi, &pc) in target.params.iter().enumerate() {
-            let av = self.eval(kids[pi + 1], env);
-            fenv.insert(pc, av);
+        for (pc, arg) in plan {
+            let v = self.eval(arg, env);
+            fenv.insert(pc, v);
         }
         self.inline_stack.push(root);
         let value = self.inline_eval_pure_body(target.body, &mut fenv);

--- a/crates/nose-normalize/src/value_graph/model.rs
+++ b/crates/nose-normalize/src/value_graph/model.rs
@@ -14,6 +14,7 @@ pub(super) enum ValOp {
     Field(u64), // field access, keyed by content hash of the name
     Index,      // base[index]
     Call(u32),  // 0 = opaque callee; otherwise builtin discriminant + 1
+    KwArg(u64), // a named call argument, keyed by the keyword-name hash; args = [value]
     Hof(u32),   // higher-order op kind
     Clamp,      // numeric clamp over proven integer bounds: args = [x, lo, hi]
     Seq(u64),   // aggregate literal, keyed by lowered sequence kind

--- a/crates/nose-normalize/src/value_graph/ops.rs
+++ b/crates/nose-normalize/src/value_graph/ops.rs
@@ -316,6 +316,7 @@ pub(super) fn op_tag(op: &ValOp) -> u64 {
         ValOp::Field(n) => (5, *n),
         ValOp::Index => (6, 0),
         ValOp::Call(t) => (7, *t as u64),
+        ValOp::KwArg(n) => (23, *n),
         ValOp::Hof(h) => (8, *h as u64),
         ValOp::Clamp => (20, 0),
         ValOp::Seq(t) => (9, *t),

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -226,6 +226,17 @@ downstream value-graph.
   values take `-1`, and the branch split avoids overflow at both signed extremes.
   It deliberately does not apply to overloadable or coercive operator surfaces.
 
+  **Keyword arguments bind by name, not position.** A Python `f(name=value)` lowers to
+  a `KwArg` node carrying the keyword (the Ruby frontend already keeps the key in its
+  pair form). The value graph evaluates a call's positional args in order but its keyword
+  args as a name-sorted suffix, and interprocedural inlining binds each keyword to the
+  parameter whose name matches (via `cid_names`). So `f(a=p, b=q)` ≡ `f(b=q, a=p)` (same
+  mapping, reordered) but ≠ `f(a=q, b=p)` (different mapping) — the call's identity is the
+  `(name → value)` mapping. An unrecognized keyword (one naming no parameter, or one a
+  builtin recognizer does not model) fails closed to the opaque path. The behavioral
+  oracle binds keywords by the same plan, so the merges it reports are genuinely verified
+  (#301).
+
   Interprocedural pure-helper inlining also lives in the value graph. A call to
   a pure in-file helper can beta-substitute the helper body only when the call
   occurrence carries `CallTarget::DirectFunction` evidence for the exact target


### PR DESCRIPTION
Closes #301 (a confirmed false merge deferred from [coevo series 6](https://github.com/corca-ai/nose/pull/303), S1).

## The bug

A Python call `helper(b=p, a=q)` lowered to **byte-identical IL** as `helper(a=p, b=q)` — the keyword names were dropped at lowering — so two callers passing DIFFERENT `(name → value)` mappings false-merged as an *"exact behavior match"*:

```python
def helper(a, b): return (a - b) * 3 + a
def run(p, q):    return helper(a=p, b=q)   # (p-q)*3+p
def run(p, q):    return helper(b=p, a=q)   # (q-p)*3+q   ← merged, but -2 vs 5 on (1,2)
```

This is the cardinal sin — equal fingerprint, different behavior.

## The fix

- **`NodeKind::KwArg`** (declared *last*, so existing discriminants and shape hashes are unchanged — see note below) carries the keyword name; the Python frontend lowers `name=value` to it.
- **The value graph** evaluates positional args in order but keyword args as a **name-sorted suffix** (`ValOp::KwArg` keyed by the name), so a call's identity is its `(name → value)` mapping: `f(a=p, b=q)` ≡ `f(b=q, a=p)` but ≠ `f(a=q, b=p)`.
- **A shared `keyword_arg_binding_plan`** resolves args → params (positional left-to-right, keyword by name via `cid_names`; fail-closed on any unresolved / double / unbound mapping). Both interprocedural inlining and the **verify oracle** bind by it — so the oracle never mis-binds a reordered call, and the merges it reports are genuinely verified.
- **Builtin recognizers** that read a named optional arg unwrap it by name (`math.prod(xs, start=1)` still converges with the product loop); an unrecognized keyword fails closed to the opaque path.

A **recall gain** as well as a soundness fix: same-mapping reordered keyword calls now converge (they did not before, even on the opaque path). **Ruby was already sound** (it keeps keyword keys as distinct literals); its recall is unchanged.

## Verified

- **Soundness**: `nose verify --max-violations 0` clean on sympy (Python/kwarg-dense, 14,052 interpretable) + flask, requests, poetry, click, sqlalchemy.
- **Determinism**: byte-identical scan JSON across thread counts (flask).
- **Oracle coverage**: interpretable count recovered to within 34 units of baseline after teaching `interp` to evaluate `KwArg` (fail-closed before).
- Full suite green; dup gate 25/25; 2 regression tests.

## Note: discriminant stability

`node_tag` hashes `kind as u64`, so inserting a NodeKind variant mid-enum shifts every later discriminant and perturbs all shape hashes — which tipped unrelated frontend families across the dup-gate threshold (25 → 27). Declaring `KwArg` **after `Raw`** keeps every existing discriminant fixed; only genuinely kwarg-bearing code changes. Gate back to 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)