### PR TITLE
A global-reassigned function no longer false-merges its callers (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ break.
 ## [Unreleased]
 
 ### Fixed
+- **A `global`-reassigned function no longer false-merges its callers** (#302). A
+  module function rebound from inside another scope (`def setup(): global helper;
+  helper = ...`) does not bind its `def` body at call time, but its callers were given
+  `DirectFunction` evidence and inlined that body — so two files reassigning `helper`
+  to different things false-merged their callers (`helper(a)*10` ≡ `helper(a)*10`
+  though `helper` differs). The frontend now records a `ModuleRebind` source fact on a
+  `global`-declared assignment (the `global`/`nonlocal` keyword is otherwise dropped at
+  lowering), and call-target evidence + content-keyed seeding withhold the name. Precise
+  where the [series-6](https://github.com/corca-ai/nose/pull/303) reassigned-anywhere
+  predicate over-fired: a local `helper = 5` (no `global`) carries no fact and stays a
+  valid target — measured recall-neutral across all 36 Python-bearing corpus repos.
+
+### Fixed
 - **Keyword arguments now bind by name, not position** (#301). A Python call
   `helper(b=p, a=q)` lowered to byte-identical IL as `helper(a=p, b=q)` — the keyword
   names were dropped — so two callers passing different `(name → value)` mappings

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -7494,3 +7494,39 @@ fn keyword_argument_oracle_binds_by_name_issue_301() {
         "the oracle must bind helper(b=p, a=q) by name: a=q=2, b=p=1",
     );
 }
+
+#[test]
+fn global_reassigned_function_fails_closed_issue_302() {
+    // #302: a module function reassigned via `global name; name = ...` from inside another
+    // function no longer binds its `def` body, so its callers must NOT inline that body
+    // (they would false-merge across files that reassign it differently). A LOCAL
+    // assignment to the same name (no `global`) is a different binding and must NOT gate
+    // the function — the precise distinction the series-6 reassigned-anywhere predicate
+    // could not draw (it over-fired). Measured via exact-safety: an inlined caller is
+    // exact-safe; an opaque (un-inlined) one is not.
+    let i = Interner::new();
+    let opts = DetectOptions {
+        min_lines: 1,
+        min_tokens: 1,
+        ..Default::default()
+    };
+    let caller_exact_safe = |src: &str| -> bool {
+        let il = nose_frontend::lower_source(FileId(0), "t.py", src.as_bytes(), Lang::Python, &i)
+            .unwrap();
+        nose_detect::units_of_file(&il, &i, &opts)
+            .iter()
+            .find(|u| u.name.as_deref() == Some("caller"))
+            .expect("caller unit")
+            .exact_safe
+    };
+    let reassigned = "def helper(x):\n    return x * 5 + 1\n\ndef setup():\n    global helper\n    helper = other\n\ndef caller(a):\n    return helper(a) * 10 + a\n";
+    let local_shadow = "def helper(x):\n    return x * 5 + 1\n\ndef elsewhere():\n    helper = 5\n    return helper + 1\n\ndef caller(a):\n    return helper(a) * 10 + a\n";
+    assert!(
+        !caller_exact_safe(reassigned),
+        "a caller of a `global`-reassigned function must not be exact-safe (fail closed)",
+    );
+    assert!(
+        caller_exact_safe(local_shadow),
+        "a local `helper = 5` (no `global`) must NOT gate the function — caller still inlines",
+    );
+}

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -60,6 +60,11 @@ pub(crate) struct Lowering<'a> {
     pub evidence: Vec<EvidenceRecord>,
     pub type_domain_aliases: TypeDomainAliases,
     pub unsigned_32_aliases: Vec<Unsigned32Alias>,
+    /// Stack of `global`-declared names per enclosing function scope (Python). An
+    /// assignment to a name on the top frame REBINDS the module binding, not a local —
+    /// the frontend records that as a `ModuleRebind` source fact so the (otherwise
+    /// information-losing) IL can distinguish it from a local declaration (#302).
+    pub global_decls: Vec<rustc_hash::FxHashSet<Symbol>>,
 }
 
 impl<'a> Lowering<'a> {
@@ -73,7 +78,15 @@ impl<'a> Lowering<'a> {
             evidence: Vec::new(),
             type_domain_aliases: TypeDomainAliases::default(),
             unsigned_32_aliases: Vec::new(),
+            global_decls: Vec::new(),
         }
+    }
+
+    /// Whether `name` is `global`-declared in the current (innermost) function scope.
+    pub(crate) fn name_is_global_declared(&self, name: Symbol) -> bool {
+        self.global_decls
+            .last()
+            .is_some_and(|frame| frame.contains(&name))
     }
 
     /// Source text covered by a CST node.

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -11,7 +11,8 @@ use crate::lower::Lowering;
 use nose_il::{
     stable_symbol_hash, Builtin, EvidenceAnchor, EvidenceKind, FileId, HoFKind, Il,
     ImportEvidenceKind, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload,
-    SourceBindingKind, SourceComprehensionKind, SourceFactKind, SourceOperatorKind, Span, UnitKind,
+    SourceBindingKind, SourceComprehensionKind, SourceFactKind, SourceOperatorKind, Span, Symbol,
+    UnitKind,
 };
 use tree_sitter::Node as TsNode;
 
@@ -247,9 +248,46 @@ fn contains_interpolation(node: TsNode) -> bool {
 }
 
 fn lower_func(lo: &mut Lowering, node: TsNode, method: bool) -> NodeId {
-    crate::lower::function_unit(lo, node, method, lower_params, |lo, b| {
+    // Collect this function's `global` declarations BEFORE lowering its body, so an
+    // assignment to a global-declared name can be recorded as a module rebind (#302).
+    // The frame is scoped to this function — nested functions get their own.
+    let globals = collect_global_declarations(lo, node);
+    lo.global_decls.push(globals);
+    let func = crate::lower::function_unit(lo, node, method, lower_params, |lo, b| {
         lower_docstring_block(lo, b, false)
-    })
+    });
+    lo.global_decls.pop();
+    func
+}
+
+/// The names declared `global` anywhere in a function body, excluding nested function /
+/// lambda scopes (Python `global` is function-scoped). `nonlocal` rebinds an enclosing
+/// *local*, never a module function, so it is not collected.
+fn collect_global_declarations(lo: &Lowering, func: TsNode) -> rustc_hash::FxHashSet<Symbol> {
+    let mut out = rustc_hash::FxHashSet::default();
+    let Some(body) = func.child_by_field_name("body") else {
+        return out;
+    };
+    let mut stack = vec![body];
+    while let Some(n) = stack.pop() {
+        match n.kind() {
+            // Do not descend into nested function/lambda scopes — they have their own
+            // `global` frame.
+            "function_definition" | "lambda" => continue,
+            "global_statement" => {
+                for child in Lowering::named_children(n) {
+                    if child.kind() == "identifier" {
+                        out.insert(lo.sym(lo.text(child)));
+                    }
+                }
+            }
+            _ => {}
+        }
+        for child in Lowering::named_children(n) {
+            stack.push(child);
+        }
+    }
+    out
 }
 
 fn lower_class(lo: &mut Lowering, node: TsNode) -> NodeId {
@@ -304,7 +342,19 @@ fn lower_assignment(lo: &mut Lowering, node: TsNode) -> NodeId {
         Some(r) => lower_expr(lo, r),
         None => lo.empty_block(span),
     };
-    lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs])
+    let assign = lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs]);
+    // `global name; name = value` rebinds the MODULE binding — record it so the IL can
+    // tell this from a local declaration, which it otherwise cannot (the frontend drops
+    // `global`). Gated on a single-identifier target declared `global` in this scope.
+    if let Some(left) = node.child_by_field_name("left") {
+        if left.kind() == "identifier" && lo.name_is_global_declared(lo.sym(lo.text(left))) {
+            lo.record_source_fact(
+                span,
+                SourceFactKind::Binding(SourceBindingKind::ModuleRebind),
+            );
+        }
+    }
+    assign
 }
 
 fn lower_aug_assignment(lo: &mut Lowering, node: TsNode) -> NodeId {

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -592,14 +592,21 @@ pub enum SourceFactKind {
     Binding(SourceBindingKind),
 }
 
-/// Source facts about how a definition BINDS, not what its body computes. A decorated
-/// definition's runtime binding is `decorator(f)`, not `f` — lowering keeps only the
-/// inner body (sound for unit-shape analysis), so any consumer that treats the body as
-/// the NAME's content (call-target evidence, content-keyed seeding, inlining) must see
-/// this fact and fail closed (coevo series 6, S2-A).
+/// Source facts about how a definition BINDS, not what its body computes. Consumers that
+/// treat a `def`'s body as the NAME's content (call-target evidence, content-keyed
+/// seeding, inlining) must see these and fail closed.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub enum SourceBindingKind {
+    /// A decorated definition's runtime binding is `decorator(f)`, not `f` — lowering
+    /// keeps only the inner body (sound for unit-shape analysis) (coevo series 6, S2-A).
     DecoratedDefinition,
+    /// An assignment that REBINDS a module-scope name from inside another scope — a
+    /// Python `global name; name = ...`. The frontend drops `global`/`nonlocal`, so this
+    /// fact (anchored on the assignment, identifying the binding by its target name) is
+    /// the only signal that `name`'s runtime binding is no longer its `def` body. Without
+    /// it a non-top-level `name = x` is indistinguishable from a local declaration, which
+    /// is why the series-6 reassigned-anywhere predicate over-fired (#302).
+    ModuleRebind,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]

--- a/crates/nose-normalize/src/call_target_evidence.rs
+++ b/crates/nose-normalize/src/call_target_evidence.rs
@@ -96,6 +96,11 @@ fn unique_direct_function_targets(
     let parents = parent_map(il);
     let mut targets = FxHashMap::default();
     let mut ambiguous = FxHashSet::default();
+    // Names rebound at module scope from inside another function (`global name; name =
+    // ...`): the runtime binding is no longer the `def` body, so the name is not a
+    // DirectFunction target. Precise — a local `name = x` (no `global`) carries no fact
+    // and stays a valid target (#302). Empty for non-Python and the common case.
+    let rebound = nose_semantics::module_rebound_symbols(il);
     for unit in &il.units {
         if unit.kind != UnitKind::Function || !is_top_level_function_root(il, &parents, unit.root) {
             continue;
@@ -104,15 +109,11 @@ fn unique_direct_function_targets(
         if ambiguous.contains(&name) {
             continue;
         }
-        // A decorated `def` binds `decorator(f)`, not the lowered body — fail closed:
-        // no DirectFunction evidence, so the inline, the content-keyed exact admission,
-        // and the behavioral oracle all stay opaque (coevo series 6, S2-A). Out-of-scope
-        // REASSIGNMENT (`global name; name = ...`) is a separate, deferred gap: the
-        // frontend drops `global`/`nonlocal`, so a non-top-level `name = x` is
-        // indistinguishable from a local declaration — gating on it fails OPEN-the-
-        // wrong-way (kills valid inlines of clean helpers whose name a local shadows;
-        // measured 37-repo recall loss). It needs frontend global-binding tracking (#302).
-        if nose_semantics::decorated_definition_at_node(il, unit.root) {
+        // A decorated `def` binds `decorator(f)`, not the lowered body (coevo series 6,
+        // S2-A); a `global`-reassigned name binds whatever was last assigned, not its
+        // `def` body (#302). Both fail closed: no DirectFunction evidence, so the inline,
+        // the content-keyed exact admission, and the behavioral oracle all stay opaque.
+        if nose_semantics::decorated_definition_at_node(il, unit.root) || rebound.contains(&name) {
             continue;
         }
         let target = DirectFunctionTarget {

--- a/crates/nose-normalize/src/value_graph/context.rs
+++ b/crates/nose-normalize/src/value_graph/context.rs
@@ -291,6 +291,10 @@ impl<'a> Builder<'a> {
 
     fn collect_function_binding_hashes(&mut self) -> Vec<(Symbol, u64)> {
         let mut bindings = Vec::new();
+        // Names rebound at module scope (`global name; name = ...`) — not content-keyable
+        // for the same reason as decorated defs: the name's runtime value is not its `def`
+        // body (#302).
+        let rebound = nose_semantics::module_rebound_symbols(self.il);
         // Indexed loop: the body needs `&mut self` but never mutates `units`.
         for i in 0..self.il.units.len() {
             let unit = self.il.units[i];
@@ -300,10 +304,12 @@ impl<'a> Builder<'a> {
             let Some(name) = unit.name else {
                 continue;
             };
-            // A decorated definition's runtime binding is `decorator(f)`, not the
-            // lowered body, so it must not be content-keyed (coevo series 6, S2-A
-            // false merge: `@double` vs `@triple` callers).
-            if nose_semantics::decorated_definition_at_node(self.il, unit.root) {
+            // A decorated definition's runtime binding is `decorator(f)` (coevo series 6,
+            // S2-A); a `global`-reassigned name binds whatever was last assigned (#302).
+            // Neither may be content-keyed (their callers would inherit the wrong body).
+            if nose_semantics::decorated_definition_at_node(self.il, unit.root)
+                || rebound.contains(&name)
+            {
                 continue;
             }
             // Content-keyed identity covers both the straight-line binding-safe set and

--- a/crates/nose-semantics/src/evidence.rs
+++ b/crates/nose-semantics/src/evidence.rs
@@ -124,6 +124,30 @@ pub fn decorated_definition_at_node(il: &Il, node: NodeId) -> bool {
     source_binding_at_node(il, node) == Some(SourceBindingKind::DecoratedDefinition)
 }
 
+/// The module-scope names a `ModuleRebind` fact reports as reassigned from inside another
+/// scope (a Python `global name; name = ...`). A top-level function with such a name is
+/// not provably its `def` body — its callers must not inline it, and it must not be
+/// content-keyed or admitted to the exact channel (#302). Precise where the series-6
+/// reassigned-anywhere predicate over-fired: a local `name = x` (no `global`) carries no
+/// fact, so the function stays a valid target.
+pub fn module_rebound_symbols(il: &Il) -> rustc_hash::FxHashSet<Symbol> {
+    let mut out = rustc_hash::FxHashSet::default();
+    for idx in 0..il.nodes.len() {
+        let node = NodeId(idx as u32);
+        if il.kind(node) != NodeKind::Assign
+            || source_binding_at_node(il, node) != Some(SourceBindingKind::ModuleRebind)
+        {
+            continue;
+        }
+        if let Some((lhs, _)) = il.assignment_var_parts(node) {
+            if let Some(name) = il.var_name(lhs) {
+                out.insert(name);
+            }
+        }
+    }
+    out
+}
+
 pub fn source_operator_at_node(il: &Il, node: NodeId) -> Option<SourceOperatorKind> {
     let span = il.node(node).span;
     match evidence_at_span(il, span, |evidence| match evidence {

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -241,7 +241,16 @@ downstream value-graph.
   a pure in-file helper can beta-substitute the helper body only when the call
   occurrence carries `CallTarget::DirectFunction` evidence for the exact target
   unit. The callee spelling is not a proof channel; missing, ambiguous, or
-  conflicting target evidence leaves the call opaque.
+  conflicting target evidence leaves the call opaque. Two binding facts withhold
+  that evidence even for a unique same-file definition, because the name's runtime
+  binding is then NOT its `def` body: a **decorated** definition (`@d def f` binds
+  `d(f)`), and a name **rebound at module scope** from inside another function
+  (`global f; f = ...`). The frontend drops `global`/`nonlocal`, so the rebind is
+  recorded as a `ModuleRebind` source fact on the assignment — without it a
+  non-top-level `f = x` is indistinguishable from a local declaration, which is why
+  a coarse reassigned-anywhere predicate over-fires (it kills valid inlines whose
+  name a local merely shadows). A local `f = 5` carries no fact and stays a valid
+  target (#302).
 
   Admission is *generalized*, not whitelisted: the callee body may contain loops,
   branches, builder appends, and nested proven calls — it is evaluated through the


### PR DESCRIPTION
Closes #302 (a confirmed false merge deferred from [coevo series 6](https://github.com/corca-ai/nose/pull/303), S2-B).

## The bug

A module function rebound from inside another scope does not bind its `def` body at call time, but its callers were given `DirectFunction` evidence and **inlined that body** — so two files reassigning `helper` to different things false-merged their callers:

```python
def helper(x): return x + 1
def setup():   global helper; helper = special_a   # ← rebinds the module name
def caller(a): return helper(a) * 10 + a           # merged across files, but helper differs
```

## Why series 6 deferred it, and how this is precise

The series-6 attempt — gate evidence on *"is this name reassigned anywhere?"* — **over-fired at 37 corpus repos** and was reverted. The cause: the frontend **drops `global`/`nonlocal`**, so a non-top-level `name = x` is indistinguishable from a local declaration. A coarse predicate kills valid inlines whose name a local merely shadows.

This fix preserves the missing information (the same pattern as #301):

- The Python frontend collects each function's `global` declarations (scoped — it does not descend into nested functions) and records a **`SourceBindingKind::ModuleRebind`** fact on an assignment to a global-declared name.
- `call-target evidence` and content-keyed seeding withhold the rebound name (mirroring the series-6 decorator fact), so its callers stay opaque and never inherit the `def` body.

Precise, not coarse — a local `helper = 5` (no `global`) carries no fact and stays a valid `DirectFunction` target:

| case | before | after |
|---|---|---|
| `global helper; helper = x` (rebind) | callers merge ❌ | callers opaque ✓ |
| `helper = 5` (local shadow elsewhere) | callers merge ✓ | callers merge ✓ |

## Verified

- **Recall-neutral**: family counts unchanged across **all 36 Python-bearing corpus repos** (0 deltas) — versus series-6's 37-repo over-fire.
- **Soundness**: `nose verify --max-violations 0` clean on sympy, flask, requests, poetry, click, sqlalchemy.
- **Determinism**: byte-identical scan JSON across thread counts (sympy).
- Full suite green; dup gate 25/25; nested-`global` and clean-inline boundary cases covered; 1 regression test.

Both #301 and #302 closed the same root cause this session: **the frontend discarded the binding-discriminating information** (keyword names, `global` declarations); preserving it as an IL node / source fact is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)