### PR TITLE
Adversarial co-evolution series 7: fix 3 false merges in the #304/#305 binding code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ break.
 ## [Unreleased]
 
 ### Fixed
+- **Three keyword/argument false merges, found by attacking the just-shipped #304/#305
+  binding code** (adversarial co-evolution series 7, [experiments §CH](docs/experiments.md)):
+  - **Spread arguments** (`f(*args)`, `f(**d)`) were stripped at lowering, so `stats(*xs)`
+    false-merged with `stats(xs)`. A new `Splat` IL node keeps a spread distinct; the
+    inline/oracle fail closed on its dynamic arity.
+  - **`global`-rebind via tuple-unpack / aug-assign / walrus** (`global helper; helper,_=...`
+    / `helper += 1` / `(helper := ...)`) escaped the #302 single-identifier check, so the
+    rebound function's callers still false-merged. A post-lowering pass now records the
+    rebind for every assignment form; recall stays precise (a local `helper = 5` is not
+    gated).
+  - **Reordered effectful keyword arguments** (`f(a=g(), b=h())` vs `f(b=h(), a=g())`) were
+    merged by the #304 name-sort, though Python evaluates arguments in source order. The
+    sort is now gated on `reorder_safe` — pure reorders still converge, effectful ones stay
+    distinct.
+
+### Fixed
 - **A `global`-reassigned function no longer false-merges its callers** (#302). A
   module function rebound from inside another scope (`def setup(): global helper;
   helper = ...`) does not bind its `def` body at call time, but its callers were given

--- a/bench/coevo/packets.v1.json
+++ b/bench/coevo/packets.v1.json
@@ -576,6 +576,78 @@
    "summary": "Boundary re-attack: decorated-METHOD callers (self.helper(a)) still merge across @double/@triple. Root cause is the PRE-EXISTING opaque method-name identity (self.helper keyed by name 'helper'); a no-decorator control with different method bodies merges identically. Not the content-keying mechanism the S2 fix covers, and predates #299.",
    "verdict": "deferred-issue",
    "defense": "Documented opaque-method-identity boundary (clone-types.md: unproven methods are name-keyed). A sound fix needs method receiver-type resolution \u2014 separate from this campaign. The S2 fix's content-keying/evidence paths DO correctly gate decorated methods; only the orthogonal opaque-method-name path remains."
+  },
+  {
+   "packet_id": "s7-s1-splat-erasure",
+   "series": 7,
+   "campaign": "S1",
+   "persona": "py-arg-specialist",
+   "mode": "blind",
+   "surface": "keyword-arg-identity",
+   "claim": "a call's argument identity matches its (name->value) structure; equal fingerprint \u27f9 equal behavior",
+   "summary": "The frontend stripped `*expr`/`**expr` to the bare expr, so `f(*args)` lowered identically to `f(args)` and `f(**d)` to `f(d)`. `stats(*xs)` false-merged with `stats(xs)` (len 3 vs 1 on [[1,2,3]]); the oracle read SOUND (both layers used the stripped IL).",
+   "verdict": "violation-fixed",
+   "defense": "New NodeKind::Splat (declared last) carries `*`/`**`; the call stays fingerprint-distinct from a plain arg. keyword_arg_binding_plan fails closed on a Splat (dynamic arity \u2192 no inline), and the interpreter evaluates a Splat to its inner value only for opaque calls (where the fingerprint already separates them)."
+  },
+  {
+   "packet_id": "s7-s2-rebind-forms",
+   "series": 7,
+   "campaign": "S2",
+   "persona": "py-scoping-lawyer",
+   "mode": "blind",
+   "surface": "global-rebind",
+   "claim": "a `global name; name = ...` function is withheld from DirectFunction evidence / content keying",
+   "summary": "#302 recorded ModuleRebind only for a single-identifier `global helper; helper = x`. Tuple-unpack (`helper, x = ...`), aug-assign (`helper += 1`), and walrus (`(helper := ...)`) all escaped, so the rebound function kept its evidence and callers false-merged.",
+   "verdict": "violation-fixed",
+   "defense": "A post-lowering pass over each function records ModuleRebind on every Assign whose target (Var or Seq-of-Var) names a global-declared symbol, regardless of which lowering path built it. module_rebound_symbols collects names from both Var and Seq LHS. Recall-precise: a local `helper = 5` (no global) carries no fact."
+  },
+  {
+   "packet_id": "s7-s2-4-globals-dynamic",
+   "series": 7,
+   "campaign": "S2",
+   "persona": "py-scoping-lawyer",
+   "mode": "blind",
+   "surface": "global-rebind",
+   "claim": "a module function reassigned anywhere is withheld",
+   "summary": "`globals()['helper'] = other` is a dynamic module rebind with no `global` statement, so the global-frame detection misses it; callers false-merge.",
+   "verdict": "deferred-issue",
+   "defense": "#307 \u2014 a distinct dynamic-write mechanism (no `global` to key off); needs `globals()[<str>] =`/`setattr` subscript recognition + string-literal-to-symbol resolution. Exotic; separate focused fix."
+  },
+  {
+   "packet_id": "s7-s3-effectful-kwarg-reorder",
+   "series": 7,
+   "campaign": "S3",
+   "persona": "interaction-hunter",
+   "mode": "blind",
+   "surface": "keyword-arg-identity",
+   "claim": "reordered same-mapping keyword calls converge soundly",
+   "summary": "The #304 keyword name-sort merged `combine(a=sideA(x), b=sideB(y))` with the reordered `combine(b=sideB(y), a=sideA(x))`. Python evaluates args in SOURCE order, so with effectful values the effect/exception order differs \u2014 a false merge (the oracle witnessed it as advisory; the canonical sort hid it from the hard gate).",
+   "verdict": "violation-fixed",
+   "defense": "Gate the keyword name-sort on `reorder_safe` (the same effect-free predicate as AC operands, \u00a7CE/#286): sort only when every keyword value is effect-free; otherwise keep source order. Pure reorders still converge; effectful ones stay distinct."
+  },
+  {
+   "packet_id": "s7-s4-oracle-parity",
+   "series": 7,
+   "campaign": "S4",
+   "persona": "oracle-attacker",
+   "mode": "blind",
+   "surface": "oracle",
+   "claim": "the oracle binds kwargs/rebinds in lockstep with the value graph; SOUND covers what it reports",
+   "summary": "No oracle blind spot. By-name binding is shared via keyword_arg_binding_plan; source order preserved; rebinds opaque to both; unbindable kwargs fail closed. The oracle stays lockstep-or-stricter \u2014 it WITNESSED the S3 effectful-reorder (advisory) and a string-+ commute (hard violation) rather than silently reading SOUND.",
+   "verdict": "green-confirmed",
+   "defense": "None needed."
+  },
+  {
+   "packet_id": "s7-s4-string-plus-commute",
+   "series": 7,
+   "campaign": "S4",
+   "persona": "oracle-attacker",
+   "mode": "blind",
+   "surface": "canonicalizer",
+   "claim": "`+` commutes only when an operand is proven non-concat (#283-C)",
+   "summary": "`\"p\"+\"q\"` \u2261 `\"q\"+\"p\"` false-merges: a string literal's Const key `0x2000_0000.wrapping_add(h)` wraps OUT of the String range when h's high bits are set, so const_value_domain misreads it as non-String \u2192 proven_non_concat wrongly admits the `+` commute. nose verify catches it as a hard violation.",
+   "verdict": "deferred-issue",
+   "defense": "#308 \u2014 separate canonicalizer/literal-keying subsystem. Masking the hash into range breaks Go-literal-map tests (py/ruby keying interaction); the clean fix carries the literal KIND separately from the content hash. Pre-existing, not from #304/#305."
   }
  ]
 }

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -7530,3 +7530,104 @@ fn global_reassigned_function_fails_closed_issue_302() {
         "a local `helper = 5` (no `global`) must NOT gate the function — caller still inlines",
     );
 }
+
+#[test]
+fn splat_argument_is_distinct_from_plain_argument_coevo_s7_s1() {
+    // coevo series 7, S1: `f(*args)` unpacks an iterable into positional params and
+    // `f(**d)` unpacks a mapping into keywords — neither is `f(arg)`. The frontend used
+    // to strip the splat, so `stats(*xs)` lowered identically to `stats(xs)` and the two
+    // false-merged (different on `[[1,2,3]]`: len 3 vs 1). A `Splat` node now keeps them
+    // distinct.
+    let i = Interner::new();
+    let helper = "def stats(a):\n    total = len(a)\n    return total * total + total\n";
+    let via_splat = "def via(xs):\n    return stats(*xs)\n";
+    let via_plain = "def via(xs):\n    return stats(xs)\n";
+    let fp = |c: &str| value_fp_named(&i, &format!("{helper}\n{c}"), Lang::Python, "via");
+    assert_ne!(
+        fp(via_splat),
+        fp(via_plain),
+        "a `*args` spread must not fingerprint as a plain positional argument",
+    );
+    let via_kwsplat = "def via(d):\n    return stats(**d)\n";
+    assert_ne!(
+        fp(via_kwsplat),
+        fp(via_plain),
+        "a `**kwargs` spread must not fingerprint as a plain positional argument",
+    );
+    assert_ne!(
+        fp(via_splat),
+        fp(via_kwsplat),
+        "`*args` and `**kwargs` spreads must stay distinct from each other",
+    );
+}
+
+#[test]
+fn global_rebind_recorded_for_all_assignment_forms_coevo_s7_s2() {
+    // coevo series 7, S2: the #302 fix recorded `ModuleRebind` only for a plain
+    // single-identifier `global helper; helper = x`. Tuple-unpack, aug-assign, and walrus
+    // all lower to an `Assign` too and must also withhold the rebound function. Measured
+    // via exact-safety: a caller of a rebound function is opaque (not exact-safe).
+    let i = Interner::new();
+    let opts = DetectOptions {
+        min_lines: 1,
+        min_tokens: 1,
+        ..Default::default()
+    };
+    let caller_exact_safe = |src: &str| -> bool {
+        let il = nose_frontend::lower_source(FileId(0), "t.py", src.as_bytes(), Lang::Python, &i)
+            .unwrap();
+        nose_detect::units_of_file(&il, &i, &opts)
+            .iter()
+            .find(|u| u.name.as_deref() == Some("caller"))
+            .expect("caller unit")
+            .exact_safe
+    };
+    let helper = "def helper(x):\n    return x * 5 + 1\n";
+    let caller = "def caller(a):\n    return helper(a) * 10 + a\n";
+    let tuple = format!(
+        "{helper}\ndef setup():\n    global helper\n    helper, spare = other, 0\n\n{caller}"
+    );
+    let aug = format!("{helper}\ndef setup():\n    global helper\n    helper += 1\n\n{caller}");
+    let walrus =
+        format!("{helper}\ndef setup():\n    global helper\n    (helper := other)\n\n{caller}");
+    for (label, src) in [
+        ("tuple-unpack", &tuple),
+        ("aug-assign", &aug),
+        ("walrus", &walrus),
+    ] {
+        assert!(
+            !caller_exact_safe(src),
+            "a caller of a `global`-rebound function ({label}) must not be exact-safe",
+        );
+    }
+    // Precise: a LOCAL `helper = 5` (no `global`) still leaves the function inlinable.
+    let local =
+        format!("{helper}\ndef elsewhere():\n    helper = 5\n    return helper + 1\n\n{caller}");
+    assert!(
+        caller_exact_safe(&local),
+        "a local shadow (no `global`) must NOT withhold the function",
+    );
+}
+
+#[test]
+fn effectful_keyword_reorder_stays_distinct_coevo_s7_s3() {
+    // coevo series 7, S3: the keyword name-sort (#304) is sound only for effect-free
+    // values — Python evaluates args in SOURCE order, so reordering effectful keyword
+    // values changes the effect/exception order. With a call-valued keyword the two
+    // orderings must stay distinct; with pure values they still converge.
+    let i = Interner::new();
+    let eff_a = "def use(x, y):\n    return combine(a=sideA(x), b=sideB(y))\n";
+    let eff_b = "def use(x, y):\n    return combine(b=sideB(y), a=sideA(x))\n";
+    assert_ne!(
+        value_fp_named(&i, eff_a, Lang::Python, "use"),
+        value_fp_named(&i, eff_b, Lang::Python, "use"),
+        "reordered EFFECTFUL keyword values must not converge (eval order differs)",
+    );
+    let pure_a = "def use(p, q):\n    return combine(a=p, b=q)\n";
+    let pure_b = "def use(p, q):\n    return combine(b=q, a=p)\n";
+    assert_eq!(
+        value_fp_named(&i, pure_a, Lang::Python, "use"),
+        value_fp_named(&i, pure_b, Lang::Python, "use"),
+        "reordered PURE keyword values still converge (no observable order)",
+    );
+}

--- a/crates/nose-detect/src/abstraction.rs
+++ b/crates/nose-detect/src/abstraction.rs
@@ -313,6 +313,7 @@ fn token_label(token: &WitnessToken) -> &'static str {
             NodeKind::Seq => "Seq",
             NodeKind::HoF => "HoF",
             NodeKind::KwArg => "KwArg",
+            NodeKind::Splat => "Splat",
             NodeKind::Raw => "Raw",
         },
     }

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -82,13 +82,6 @@ impl<'a> Lowering<'a> {
         }
     }
 
-    /// Whether `name` is `global`-declared in the current (innermost) function scope.
-    pub(crate) fn name_is_global_declared(&self, name: Symbol) -> bool {
-        self.global_decls
-            .last()
-            .is_some_and(|frame| frame.contains(&name))
-    }
-
     /// Source text covered by a CST node.
     pub(crate) fn text(&self, n: TsNode) -> &'a str {
         n.utf8_text(self.src).unwrap_or("")

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -256,8 +256,71 @@ fn lower_func(lo: &mut Lowering, node: TsNode, method: bool) -> NodeId {
     let func = crate::lower::function_unit(lo, node, method, lower_params, |lo, b| {
         lower_docstring_block(lo, b, false)
     });
+    record_global_rebinds(lo, func);
     lo.global_decls.pop();
     func
+}
+
+/// Mark every assignment in this function whose target rebinds a `global`-declared name
+/// with a `ModuleRebind` fact, regardless of which lowering path built it — a plain
+/// `helper = x`, a tuple unpack `helper, y = ...` (Seq target), an aug-assign
+/// `helper += 1`, or a walrus `(helper := x)` all lower to an `Assign` with a `Var` or
+/// `Seq`-of-`Var` target. Operating on the LOWERED IL (post-body) catches all forms
+/// uniformly, where the original per-`lower_assignment` hook missed every form but the
+/// first (coevo series 7, S2). Nested function/lambda scopes are skipped — they carry
+/// their own `global` frame.
+fn record_global_rebinds(lo: &mut Lowering, func: NodeId) {
+    let Some(frame) = lo.global_decls.last() else {
+        return;
+    };
+    if frame.is_empty() {
+        return;
+    }
+    let frame = frame.clone();
+    let mut rebind_spans: Vec<Span> = Vec::new();
+    let mut stack: Vec<NodeId> = lo.b.children(func).to_vec();
+    while let Some(n) = stack.pop() {
+        match lo.b.kind(n) {
+            NodeKind::Func | NodeKind::Lambda => continue,
+            NodeKind::Assign => {
+                if let Some(&lhs) = lo.b.children(n).first() {
+                    if assign_target_rebinds_global(lo, lhs, &frame) {
+                        rebind_spans.push(lo.b.node(n).span);
+                    }
+                }
+            }
+            _ => {}
+        }
+        stack.extend(lo.b.children(n).iter().copied());
+    }
+    for span in rebind_spans {
+        lo.record_source_fact(
+            span,
+            SourceFactKind::Binding(SourceBindingKind::ModuleRebind),
+        );
+    }
+}
+
+/// Whether a lowered assignment target (a `Var`, or a `Seq` of targets from a tuple/list
+/// unpack) names a `global`-declared symbol. Attribute/index targets (`obj.x = `,
+/// `d[k] = `) are NOT name rebinds and are ignored.
+fn assign_target_rebinds_global(
+    lo: &Lowering,
+    target: NodeId,
+    frame: &rustc_hash::FxHashSet<Symbol>,
+) -> bool {
+    match lo.b.kind(target) {
+        NodeKind::Var => {
+            matches!(lo.b.node(target).payload, Payload::Name(s) if frame.contains(&s))
+        }
+        NodeKind::Seq => {
+            lo.b.children(target)
+                .to_vec()
+                .iter()
+                .any(|&c| assign_target_rebinds_global(lo, c, frame))
+        }
+        _ => false,
+    }
 }
 
 /// The names declared `global` anywhere in a function body, excluding nested function /
@@ -342,19 +405,7 @@ fn lower_assignment(lo: &mut Lowering, node: TsNode) -> NodeId {
         Some(r) => lower_expr(lo, r),
         None => lo.empty_block(span),
     };
-    let assign = lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs]);
-    // `global name; name = value` rebinds the MODULE binding — record it so the IL can
-    // tell this from a local declaration, which it otherwise cannot (the frontend drops
-    // `global`). Gated on a single-identifier target declared `global` in this scope.
-    if let Some(left) = node.child_by_field_name("left") {
-        if left.kind() == "identifier" && lo.name_is_global_declared(lo.sym(lo.text(left))) {
-            lo.record_source_fact(
-                span,
-                SourceFactKind::Binding(SourceBindingKind::ModuleRebind),
-            );
-        }
-    }
-    assign
+    lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs])
 }
 
 fn lower_aug_assignment(lo: &mut Lowering, node: TsNode) -> NodeId {
@@ -711,12 +762,15 @@ fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
             lo.add(NodeKind::Seq, Payload::None, span, &kids)
         }
         "dictionary" => lower_dictionary(lo, node),
-        // splats / unpacking: strip to the inner expression
-        "list_splat" | "dictionary_splat" | "list_splat_pattern" | "dictionary_splat_pattern" => {
-            node.named_child(0)
-                .map(|c| lower_expr(lo, c))
-                .unwrap_or_else(|| lo.empty_block(span))
-        }
+        // `*expr` / `**expr` spread: keep a `Splat` marker so a spread argument is
+        // distinct from a plain one (`f(*args)` ≠ `f(args)`); coevo series 7, S1.
+        "list_splat" | "dictionary_splat" => lower_splat(lo, node),
+        // Splat PATTERNS (assignment targets like `a, *rest = xs`) strip to the inner
+        // expression — they are bind sites, not call arguments.
+        "list_splat_pattern" | "dictionary_splat_pattern" => node
+            .named_child(0)
+            .map(|c| lower_expr(lo, c))
+            .unwrap_or_else(|| lo.empty_block(span)),
         // A standalone dict-comprehension `pair` (`{k: v for ...}`) is the loop
         // contribution `DictEntry(k, v)`. Plain dict literals use
         // `lower_dictionary_pair` instead so cross-language map literals retain a
@@ -951,6 +1005,23 @@ fn lower_dictionary_pair(lo: &mut Lowering, node: TsNode) -> NodeId {
 /// not source position (`f(a=p,b=q)` must not equal `f(b=p,a=q)`). The value graph keys
 /// a call's keyword args by name; an unhandled consumer treats `KwArg` opaquely (fail
 /// closed). A keyword arg with no resolvable name falls back to the bare value.
+/// `*expr` / `**expr` spread argument → a `Splat` marker over the inner expression so a
+/// spread is fingerprint-distinct from a plain argument and the inline/oracle fail closed
+/// on its dynamic arity (coevo series 7, S1).
+fn lower_splat(lo: &mut Lowering, node: TsNode) -> NodeId {
+    let span = lo.span(node);
+    let inner = node
+        .named_child(0)
+        .map(|c| lower_expr(lo, c))
+        .unwrap_or_else(|| lo.empty_block(span));
+    let mark = lo.sym(if node.kind() == "list_splat" {
+        "*"
+    } else {
+        "**"
+    });
+    lo.add(NodeKind::Splat, Payload::Name(mark), span, &[inner])
+}
+
 fn lower_keyword_argument(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
     let value = node

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -93,6 +93,16 @@ pub enum NodeKind {
     /// not converge with positional ones). Declared LAST so adding it does not shift the
     /// discriminants (and thus the shape hashes) of the existing kinds.
     KwArg,
+
+    /// An unpacked argument: `*iterable` (positional spread) or `**mapping` (keyword
+    /// spread). Payload: `Name` (`"*"` or `"**"`) to distinguish the two. Children:
+    /// `[inner]`. Without this, the frontend stripped `*expr`/`**expr` to the bare
+    /// `expr`, so `f(*args)` lowered identically to `f(args)` — a false merge, since a
+    /// spread changes the calling convention (`stats(*[[1,2,3]])` ≠ `stats([[1,2,3]])`).
+    /// Carrying it keeps the call distinct; the inline binding plan and the oracle fail
+    /// closed on a spread (the arity is dynamic). Declared LAST, like `KwArg`, so the
+    /// discriminants stay stable.
+    Splat,
 }
 
 /// Per-node data. Most nodes carry [`Payload::None`]; the variant in use is

--- a/crates/nose-il/src/sexpr.rs
+++ b/crates/nose-il/src/sexpr.rs
@@ -81,6 +81,7 @@ fn kind_name(k: NodeKind) -> &'static str {
         Seq => "seq",
         HoF => "hof",
         KwArg => "kwarg",
+        Splat => "splat",
         Raw => "raw",
     }
 }

--- a/crates/nose-normalize/src/call_args.rs
+++ b/crates/nose-normalize/src/call_args.rs
@@ -24,6 +24,11 @@ pub(crate) fn keyword_arg_binding_plan(
     call_args: &[NodeId],
 ) -> Option<Vec<(u32, NodeId)>> {
     let param_name = |cid: u32| -> Option<Symbol> { il.cid_names.get(cid as usize).copied() };
+    // A spread argument (`*args`/`**kwargs`) has dynamic arity — it cannot bind to fixed
+    // parameters, so any call carrying one fails closed (no inline; the oracle bails).
+    if call_args.iter().any(|&a| il.kind(a) == NodeKind::Splat) {
+        return None;
+    }
     let mut plan: Vec<(u32, NodeId)> = Vec::with_capacity(param_cids.len());
     let mut bound = vec![false; param_cids.len()];
     let mut pos = 0usize;

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -812,6 +812,17 @@ impl<'a> Interp<'a> {
                 .first()
                 .ok_or(Unsupported)
                 .and_then(|&v| self.eval(v, env)),
+            // A spread argument reached in an opaque/library call: evaluate its inner
+            // value. A spread to a PROVEN target already bailed (`keyword_arg_binding_plan`
+            // rejects it), so this only feeds an opaque `Sym` — where the value graph also
+            // keeps the spread fingerprint-distinct, so the two never share a checked group
+            // (coevo series 7, S1).
+            NodeKind::Splat => self
+                .il
+                .children(node)
+                .first()
+                .ok_or(Unsupported)
+                .and_then(|&v| self.eval(v, env)),
             _ => Err(Unsupported),
         }
     }

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -498,10 +498,16 @@ impl<'a> Builder<'a> {
                 positional.push(v);
             }
         }
-        if !keyword.is_empty() {
+        // The name-sort is sound only when EVERY keyword value is effect-free: Python
+        // evaluates arguments in SOURCE order, so `f(a=g(), b=h())` and `f(b=h(), a=g())`
+        // run `g`/`h` in different orders — observably different if they raise or have
+        // side effects. Reordering them would false-merge the two (coevo series 7, S3;
+        // the same `reorder_safe` discipline as effectful AC operands, §CE/#286). With an
+        // effectful keyword value, keep source order, so the two stay distinct.
+        if !keyword.is_empty() && keyword.iter().all(|&v| self.reorder_safe(v)) {
             keyword.sort_unstable_by_key(|&v| self.vhash[v as usize]);
-            positional.extend(keyword);
         }
+        positional.extend(keyword);
         let tag = match payload {
             Payload::Builtin(b) => builtin_tag(b),
             _ => 0,

--- a/crates/nose-semantics/src/evidence.rs
+++ b/crates/nose-semantics/src/evidence.rs
@@ -139,13 +139,30 @@ pub fn module_rebound_symbols(il: &Il) -> rustc_hash::FxHashSet<Symbol> {
         {
             continue;
         }
-        if let Some((lhs, _)) = il.assignment_var_parts(node) {
-            if let Some(name) = il.var_name(lhs) {
-                out.insert(name);
-            }
+        // The target is a `Var` (`helper = `, `helper += `, `(helper := )`) or a `Seq`
+        // of targets from a tuple/list unpack (`helper, y = `). Collect every name
+        // written — each global-declared one is a module rebind (coevo series 7, S2).
+        if let Some(&lhs) = il.children(node).first() {
+            collect_target_names(il, lhs, &mut out);
         }
     }
     out
+}
+
+fn collect_target_names(il: &Il, target: NodeId, out: &mut rustc_hash::FxHashSet<Symbol>) {
+    match il.kind(target) {
+        NodeKind::Var => {
+            if let Some(name) = il.var_name(target) {
+                out.insert(name);
+            }
+        }
+        NodeKind::Seq => {
+            for &c in il.children(target) {
+                collect_target_names(il, c, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 pub fn source_operator_at_node(il: &Il, node: NodeId) -> Option<SourceOperatorKind> {

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2345,3 +2345,61 @@ otherwise neutral, soundness and determinism re-verified. The campaign's sharpes
 is S2-B: a false merge whose only available defense is an unprovable guess is a
 *deferred* finding, not a shipped guess — the 37-repo over-fire is exactly the §BA "17
 false merges" failure mode in the recall direction.
+
+## CH. Adversarial co-evolution, series 7 — the binding-provenance machinery (#304 kwargs, #305 global-rebind)
+
+One protocol pass ([adversarial-coevolution](adversarial-coevolution.md)) aimed by the
+freshness slot rule at the code merged the same session in #304 (keyword-argument
+by-name binding) and #305 (global-rebind detection) — commit `6a20b84`. Four blind-mode,
+persona-rotated attackers; ledger cases `s7-*` in `bench/coevo/packets.v1.json`. Tracking
+issue #306. **The session's own fresh code, attacked immediately — three of the four
+attackers found real false merges in it.** This is the §AS lesson applied to one's own
+work: do not assume a just-shipped fix is correct; craft against it.
+
+**S1 — splat erasure (Python arg specialist). Two violations, fixed.** The frontend
+stripped `*expr`/`**expr` to the bare expression, so `f(*args)` lowered identically to
+`f(args)` and `f(**d)` to `f(d)`. `stats(*xs)` false-merged with `stats(xs)` (len 3 vs 1
+on `[[1,2,3]]`), and `nose verify` read SOUND because both the value graph and the oracle
+used the stripped IL — the §AS "green corpus, latent false merge" scenario. Fix: a new
+`NodeKind::Splat` (declared last, so discriminants/shape-hashes are unchanged) carries the
+`*`/`**` marker; the call stays fingerprint-distinct, the inline binding plan fails closed
+on a spread (dynamic arity), and the oracle evaluates a spread to its inner value only for
+opaque calls (where the fingerprint already separates the forms).
+
+**S2 — rebind forms (Python scoping lawyer). Four soundness misses, three fixed + one
+deferred.** #305 recorded the `ModuleRebind` fact in one place — a single-identifier
+`global helper; helper = x`. Tuple-unpack (`helper, x = ...`), aug-assign (`helper += 1`),
+and walrus (`(helper := ...)`) all lower to an `Assign` via different paths and escaped.
+Fix: a post-lowering pass over each function records `ModuleRebind` on every `Assign`
+whose target (a `Var`, or a `Seq` of them) names a `global`-declared symbol — uniform
+across forms. `globals()['helper'] = ...` (a dynamic write with no `global` statement)
+is a distinct mechanism, deferred as #307. The attacker's two recall probes self-refuted:
+the gate stays precise (a local `helper = 5` carries no fact), so — unlike series-6's
+reassigned-anywhere predicate — there is no over-fire (measured: small mixed family
+deltas, the signature of false merges *separating*, not recall loss).
+
+**S3 — effectful keyword reorder (interaction hunter). Two violations, fixed.** The #304
+keyword name-sort converged `combine(a=sideA(x), b=sideB(y))` with the reordered
+`combine(b=sideB(y), a=sideA(x))`. But Python evaluates arguments in SOURCE order, so when
+the keyword values are effectful (a call that raises or has side effects) the two orders
+observably differ. This is the §CE/#286 lesson again — reordering operands is sound only
+when they are effect-free. Fix: gate the keyword name-sort on `reorder_safe`; pure
+reorders still converge, effectful ones stay in source order.
+
+**S4 — oracle parity (oracle attacker). Green.** No oracle blind spot: by-name binding is
+shared through `keyword_arg_binding_plan`, source order is preserved, rebinds are opaque
+to both layers, and unbindable kwargs fail closed (excluded). The oracle stayed
+lockstep-or-stricter — it WITNESSED the S3 effectful reorder (advisory) and surfaced a
+residual **string-literal `+` commute** (`"p"+"q"` ≡ `"q"+"p"`, a hard violation) caused
+by a string `Const` key wrapping out of its domain range — a pre-existing canonicalizer
+bug in a different subsystem, deferred as #308.
+
+**Verdict.** Three ships (S1 splat, S2 rebind forms, S3 effectful reorder) and three
+defers/greens (S2-4 globals #307, S4 green, S4-residual string-+ #308). Every shipped fix
+is a false merge the just-merged #304/#305 introduced or left — the campaign's value is
+exactly that it attacked fresh code instead of trusting it. Soundness re-verified
+(`nose verify --max-violations 0` clean on sympy, 13,928 interpretable after the oracle
+recovered splat coverage), determinism byte-identical, dup gate 25/25, recall precise (no
+over-fire). The recurring theme across series 6–7 holds: every soundness miss was the
+frontend discarding a binding-discriminating token (keyword names, `global` declarations,
+splats), and every fix preserves it in the IL.

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -226,12 +226,18 @@ downstream value-graph.
   values take `-1`, and the branch split avoids overflow at both signed extremes.
   It deliberately does not apply to overloadable or coercive operator surfaces.
 
+  **Spread arguments are kept distinct.** `*iterable` / `**mapping` lower to a `Splat`
+  node, not the bare inner expression, so `f(*args)` does not fingerprint as `f(args)`
+  (a spread changes the calling convention). A call carrying a spread has dynamic arity:
+  the inline binding plan and the oracle fail closed on it (coevo series 7, S1).
+
   **Keyword arguments bind by name, not position.** A Python `f(name=value)` lowers to
   a `KwArg` node carrying the keyword (the Ruby frontend already keeps the key in its
   pair form). The value graph evaluates a call's positional args in order but its keyword
   args as a name-sorted suffix, and interprocedural inlining binds each keyword to the
   parameter whose name matches (via `cid_names`). So `f(a=p, b=q)` ≡ `f(b=q, a=p)` (same
-  mapping, reordered) but ≠ `f(a=q, b=p)` (different mapping) — the call's identity is the
+  mapping, reordered — only when the keyword VALUES are effect-free, since Python
+  evaluates arguments in source order) but ≠ `f(a=q, b=p)` (different mapping) — the call's identity is the
   `(name → value)` mapping. An unrecognized keyword (one naming no parameter, or one a
   builtin recognizer does not model) fails closed to the opaque path. The behavioral
   oracle binds keywords by the same plan, so the merges it reports are genuinely verified


### PR DESCRIPTION
One adversarial co-evolution pass ([runbook](docs/adversarial-coevolution.md)), aimed by the freshness slot rule at the keyword-argument (#304) and global-rebind (#305) code merged **the same session**. Four blind-mode, persona-rotated attackers — **three found real false merges in the just-shipped code.** Tracking issue #306; closeout [experiments §CH](docs/experiments.md); ledger `s7-*`.

This is the §AS lesson applied to one's own work: don't trust a just-merged fix — craft against it.

## Fixed

**S1 — splat erasure.** The frontend stripped `*expr`/`**expr` to the bare expression, so `f(*args)` lowered identically to `f(args)`:
```python
def stats(a): return len(a)*len(a) + len(a)
def via(xs): return stats(*xs)   # on [[1,2,3]]: len=3 → 12
def via(xs): return stats(xs)    # on [[1,2,3]]: len=1 → 2   ← false-merged, oracle read SOUND
```
A new `NodeKind::Splat` (declared last → stable discriminants/shape-hashes) carries `*`/`**`; the call stays fingerprint-distinct, the inline binding plan fails closed on the dynamic arity, and the interpreter evaluates a spread to its inner value only for opaque calls (where the fingerprint already separates the forms).

**S2 — `global`-rebind via tuple-unpack / aug-assign / walrus.** #302 recorded the `ModuleRebind` fact only for a single-identifier `global helper; helper = x`. `helper, _ = ...`, `helper += 1`, and `(helper := ...)` all escaped, so the rebound function's callers still false-merged. A post-lowering pass now records the rebind for **every** assignment form (any `Assign` whose `Var`/`Seq` target names a `global`-declared symbol). Recall-precise — a local `helper = 5` (no `global`) carries no fact, **no over-fire** (small mixed corpus deltas = false merges *separating*, not recall loss). `globals()['fn'] = ...` (dynamic, no `global`) deferred → #307.

**S3 — reordered effectful keyword arguments.** The #304 name-sort merged `f(a=g(), b=h())` with `f(b=h(), a=g())` — but Python evaluates arguments in **source order**, so effectful values run in different orders (different effects/exceptions). The sort is now gated on `reorder_safe` (the §CE/#286 effect-free discipline): pure reorders still converge, effectful ones stay distinct.

## Green / deferred

- **S4 — oracle parity: green.** No blind spot — by-name binding is shared via `keyword_arg_binding_plan`, source order preserved, rebinds opaque to both layers, unbindable kwargs fail closed. The oracle stayed lockstep-or-stricter.
- **S4 residual — string-literal `+` commute** (`"p"+"q"` ≡ `"q"+"p"`): a pre-existing canonicalizer bug (a string `Const` key wrapping out of its domain range), different subsystem → #308.

## Verified

- **Soundness**: `nose verify --max-violations 0` clean on sympy (13,928 interpretable — the oracle's new `Splat` handling recovered splat-call coverage that fail-closed exclusion had dropped).
- **Determinism**: byte-identical scan JSON across thread counts (flask).
- **Recall precise**: no over-fire (unlike series-6's reassigned-anywhere predicate) — Python corpus deltas are small and mixed.
- Full suite green; dup gate 25/25; 3 regression tests.

Series 6–7 theme: every soundness miss was the frontend discarding a binding-discriminating token (keyword names, `global` declarations, splats); every fix preserves it in the IL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)