### PR TITLE
String-literal + no longer commutes: keep the Const key in its class range (#308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ break.
 ## [Unreleased]
 
 ### Fixed
+- **String-literal `+` no longer commutes** (#308). A string literal's value-graph `Const`
+  key carried its content hash via `0x2000_0000.wrapping_add(h)`, which for a high-bit hash
+  wrapped OUT of the `String` class range — so `const_value_domain` misread the kind and
+  `proven_non_concat` wrongly admitted the operands to `+` commutativity, false-merging
+  `"p" + "q"` with `"q" + "p"`. String keys now mask the hash into range
+  (`string_const_key`), shared between the frontend's `LitStr` and the synthesized empty
+  string so cross-language map-default lookups still converge. Surfaced as a residual by
+  adversarial co-evolution series 7 ([experiments §CH](docs/experiments.md)); `nose verify`
+  flagged it as a hard violation.
+
+### Fixed
 - **Three keyword/argument false merges, found by attacking the just-shipped #304/#305
   binding code** (adversarial co-evolution series 7, [experiments §CH](docs/experiments.md)):
   - **Spread arguments** (`f(*args)`, `f(**d)`) were stripped at lowering, so `stats(*xs)`

--- a/bench/coevo/packets.v1.json
+++ b/bench/coevo/packets.v1.json
@@ -646,8 +646,8 @@
    "surface": "canonicalizer",
    "claim": "`+` commutes only when an operand is proven non-concat (#283-C)",
    "summary": "`\"p\"+\"q\"` \u2261 `\"q\"+\"p\"` false-merges: a string literal's Const key `0x2000_0000.wrapping_add(h)` wraps OUT of the String range when h's high bits are set, so const_value_domain misreads it as non-String \u2192 proven_non_concat wrongly admits the `+` commute. nose verify catches it as a hard violation.",
-   "verdict": "deferred-issue",
-   "defense": "#308 \u2014 separate canonicalizer/literal-keying subsystem. Masking the hash into range breaks Go-literal-map tests (py/ruby keying interaction); the clean fix carries the literal KIND separately from the content hash. Pre-existing, not from #304/#305."
+   "verdict": "violation-fixed",
+   "defense": "#308 \u2014 a string literal's Const key kept the `String` class tag but the content hash wrapped out of range. Fixed by masking the hash into the low 28 bits (`string_const_key`), shared by the frontend's LitStr and the synthesized empty string so they agree (the py-`.get(k,\"\")` vs go-zero-value convergence). Verify clean on sympy+guava (49k interpretable units, no collision-induced merges); corpus family deltas small and in the false-merge-separating direction."
   }
  ]
 }

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -7631,3 +7631,35 @@ fn effectful_keyword_reorder_stays_distinct_coevo_s7_s3() {
         "reordered PURE keyword values still converge (no observable order)",
     );
 }
+
+#[test]
+fn string_literal_plus_does_not_commute_issue_308() {
+    // #308: a string literal's value-graph `Const` key must stay inside the `String`
+    // class range so `proven_non_concat` classifies it correctly. The old
+    // `0x2000_0000.wrapping_add(hash)` carried a high-bit hash OUT of range, where the
+    // string read as non-concat and `"p" + "q"` wrongly commuted with `"q" + "p"`
+    // (different values "pq" vs "qp"). The masked key keeps strings in range.
+    let i = Interner::new();
+    let pq = "def f():\n    return \"p\" + \"q\"\n";
+    let qp = "def f():\n    return \"q\" + \"p\"\n";
+    assert_ne!(
+        value_fp(&i, pq, Lang::Python),
+        value_fp(&i, qp, Lang::Python),
+        "string concatenation is ordered — `\"p\"+\"q\"` must not merge with `\"q\"+\"p\"`",
+    );
+    // The masked key still discriminates distinct strings (no class collision).
+    let pr = "def f():\n    return \"p\" + \"r\"\n";
+    assert_ne!(
+        value_fp(&i, pq, Lang::Python),
+        value_fp(&i, pr, Lang::Python),
+        "distinct string literals must stay distinct under the masked key",
+    );
+    // And numeric `+` still commutes (the fix is string-specific, recall preserved).
+    let ab = "def f(a, b):\n    return a + b + 1\n";
+    let ba = "def f(a, b):\n    return b + a + 1\n";
+    assert_eq!(
+        value_fp(&i, ab, Lang::Python),
+        value_fp(&i, ba, Lang::Python),
+        "numeric `+` still commutes — the string fix must not regress it",
+    );
+}

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -206,8 +206,10 @@ impl<'a> Builder<'a> {
         // key by value (offset clear of the class range); others by class.
         let key = match payload {
             Payload::LitInt(v) => 0x1000_0000u32.wrapping_add(v as u32),
-            // strings in a separate key range from ints to avoid collision
-            Payload::LitStr(h) => 0x2000_0000u32.wrapping_add(h as u32),
+            // strings in a separate key range from ints; the hash is masked into range
+            // (NOT `wrapping_add`ed) so the `String` class tag survives — shared with the
+            // synthesized empty string via `string_const_key` (#308).
+            Payload::LitStr(h) => string_const_key(h),
             // floats keyed by source-text hash, in their own range (so `3.14`≠`2.71`)
             Payload::LitFloat(h) => 0x4000_0000u32.wrapping_add(h as u32),
             // true/false are behavior-defining and must be distinct (own range)

--- a/crates/nose-normalize/src/value_graph/ops.rs
+++ b/crates/nose-normalize/src/value_graph/ops.rs
@@ -341,8 +341,23 @@ pub(super) fn op_tag(op: &ValOp) -> u64 {
     combine(k.wrapping_mul(0xF00D), p)
 }
 
+/// The low-bit mask for a literal's content hash inside its class-tagged `Const` key
+/// range. The class tag occupies the top nibble (`0x2…` = String); the hash MUST be
+/// masked into the low 28 bits, never `wrapping_add`ed, or a high-bit hash carries the
+/// key OUT of the class range — where `const_value_domain` misreads the kind and (for a
+/// string) `proven_non_concat` wrongly admits the `+` commute, false-merging `"p"+"q"`
+/// with `"q"+"p"` (#308). All string keys go through [`string_const_key`] so the
+/// frontend's `LitStr` and the synthesized empty string agree.
+pub(super) const LIT_HASH_MASK: u32 = 0x0FFF_FFFF;
+
+/// The `Const` key for a string literal whose content hash is `h`: the `String` class
+/// tag with the hash masked into range (see [`LIT_HASH_MASK`]).
+pub(super) fn string_const_key(h: u64) -> u32 {
+    0x2000_0000u32 | (h as u32 & LIT_HASH_MASK)
+}
+
 pub(super) fn stable_string_const_key(value: &str) -> u32 {
-    0x2000_0000u32.wrapping_add(stable_symbol_hash(value) as u32)
+    string_const_key(stable_symbol_hash(value))
 }
 
 pub(super) fn stable_float_const_key(value: &str) -> u32 {


### PR DESCRIPTION
Closes #308 (a confirmed hard false merge deferred from [coevo series 7](https://github.com/corca-ai/nose/pull/309), S4 residual).

## The bug

A string literal's value-graph `Const` key tags the class in the top nibble (`0x2…` = String) and carried the content hash via `0x2000_0000.wrapping_add(h)`. For a hash whose low 32 bits exceed `0x0FFF_FFFF` (the common case), the add carries the key **out of the String range**, where `const_value_domain` reads it as `Unknown`/`Number` — so `proven_non_concat` wrongly returns true and the #283-C *"`+` commutes only on proven-non-concat operands"* gate is bypassed:

```python
def f(): return "p" + "q"   # "pq"
def f(): return "q" + "p"   # "qp"   ← false-merged; nose verify flags a hard violation
```

## The fix

Mask the content hash into the low 28 bits so the class tag always survives:
```rust
fn string_const_key(h: u64) -> u32 { 0x2000_0000 | (h as u32 & 0x0FFF_FFFF) }
```

Crucially, this is **shared** between the frontend's `LitStr` (`eval_lit_expr`) and the synthesized empty string (`stable_string_const_key` / `empty_string_value`). Masking only one of them splits them apart and broke the Python `.get(k, "")` vs Go zero-value map-default convergence (the test failure that originally deferred this) — masking **both** keeps them equal *and* in range.

String-specific: ints/floats classify as `Number` regardless, so their range wrap is fail-closed (a misclassified int/float won't commute — sound, not a false merge).

## Verified

- **Soundness**: `nose verify --max-violations 0` clean on sympy and **guava** (49k interpretable units total) — no collision-induced merges from the now-28-bit hash.
- **Determinism**: byte-identical scan JSON across thread counts (redis).
- **Recall-precise**: corpus family deltas are small and mixed (sympy −2, guava +10, …) — the false-merge-*separating* direction, not collisions (which would only merge).
- Full suite green (incl. the previously-failing Go-literal-map tests, now passing); dup gate 25/25; 1 regression test.

This was the last known hard false merge surfaced across the series 6–7 campaigns. Same root shape as the binding fixes — a kind/identity token lost in an encoding — but in the canonicalizer's literal keying rather than the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)