### PR TITLE
Promote the reinvented-helper channel to the default surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ break.
 
 ## [Unreleased]
 
+### Changed
+- **The reinvented-helper channel is promoted to the default surface.** A hand-labeled
+  [field audit](docs/reinvented-helper-audit-2026-06-13.md) of all 17 corpus findings
+  measured 94% genuine value-duplications and 71% directly actionable (non-test); the
+  bare `nose scan` report now LISTS the non-test findings instead of a one-line count.
+  Test-container findings (`container_in_test` — where "calling the helper" would make a
+  test circular) are a decidable judgment-deep class (§2b), excluded from the default but
+  kept under `--show reinvented` and in the additive JSON.
+
 ### Fixed
 - **String-literal `+` no longer commutes** (#308). A string literal's value-graph `Const`
   key carried its content hash via `0x2000_0000.wrapping_add(h)`, which for a high-bit hash

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3849,29 +3849,27 @@ fn render_scan_report(args: &ScanArgs, view: &ScanReportView) -> Result<()> {
     Ok(())
 }
 
-/// The reinvented-helper section of the human report. The default surface stays a
-/// one-line count (the finding class is new and its field precision is still being
-/// measured — design §2c); `--show reinvented` lists every finding.
+/// How many reinvented-helper findings the bare default surface lists before collapsing
+/// the rest into a "+N more" line — kept short so the section stays a focused aid.
+const REINVENTED_DEFAULT_LIMIT: usize = 5;
+
+/// The reinvented-helper section of the human report. Promoted to the bare-default
+/// surface after a field audit (docs/reinvented-helper-audit-2026-06-13.md): of 17 corpus
+/// findings, ~13/14 non-test ones were genuine value-duplications and ~10 directly
+/// actionable, while the non-actionable noise was dominated by TEST-container findings
+/// (a test asserts the helper's value as a literal — calling it would be circular). So
+/// the default lists the non-test findings (top by weight) and excludes test-container
+/// ones (§2b decidable classification); `--show reinvented` lists EVERY finding.
 fn print_reinvented_helpers(reinvented: &[nose_detect::ReinventedHelper], show: bool) {
     if reinvented.is_empty() {
         return;
     }
-    if !show {
-        println!(
-            "\n{} reinvented-helper finding{} (code that reimplements an existing pure helper inline) · `--show reinvented` lists them",
-            reinvented.len(),
-            if reinvented.len() == 1 { "" } else { "s" },
-        );
-        return;
-    }
-    println!(
-        "\nreinvented helpers — call the existing helper instead (exact matches, experimental):"
-    );
-    for r in reinvented {
+    let print_one = |r: &nose_detect::ReinventedHelper| {
         let helper_name = r.helper_name.as_deref().unwrap_or("-");
         let container_name = r.container_name.as_deref().unwrap_or("-");
+        let approx = if r.site_approximate { " ~approx" } else { "" };
         println!(
-            "  {}:{}-{}  {}  reimplements  {}:{}-{}  {}  (lines {}-{}, ~{} value nodes)",
+            "  {}:{}-{}  {}  reimplements  {}:{}-{}  {}  (lines {}-{}{}, ~{} value nodes)",
             r.container_file,
             r.container_start_line,
             r.container_end_line,
@@ -3882,8 +3880,44 @@ fn print_reinvented_helpers(reinvented: &[nose_detect::ReinventedHelper], show: 
             helper_name,
             r.site_start_line,
             r.site_end_line,
+            approx,
             r.weight,
         );
+    };
+    if show {
+        println!(
+            "\nreinvented helpers — call the existing helper instead (exact matches, experimental):"
+        );
+        for r in reinvented {
+            print_one(r);
+        }
+        return;
+    }
+    // Default surface: non-test findings only, top by weight (already sorted).
+    let shown: Vec<&nose_detect::ReinventedHelper> =
+        reinvented.iter().filter(|r| !r.container_in_test).collect();
+    let test_count = reinvented.len() - shown.len();
+    if shown.is_empty() {
+        println!(
+            "\n{test_count} reinvented-helper finding{} in test code · `--show reinvented` lists them",
+            if test_count == 1 { "" } else { "s" },
+        );
+        return;
+    }
+    println!("\nreinvented helpers — code that reimplements an existing helper; call it instead:");
+    for r in shown.iter().take(REINVENTED_DEFAULT_LIMIT) {
+        print_one(r);
+    }
+    let hidden = shown.len().saturating_sub(REINVENTED_DEFAULT_LIMIT);
+    if hidden > 0 || test_count > 0 {
+        let mut parts = Vec::new();
+        if hidden > 0 {
+            parts.push(format!("{hidden} more"));
+        }
+        if test_count > 0 {
+            parts.push(format!("{test_count} in test code"));
+        }
+        println!("  … {} · `--show reinvented` lists all", parts.join(", "));
     }
 }
 

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -7663,3 +7663,52 @@ fn string_literal_plus_does_not_commute_issue_308() {
         "numeric `+` still commutes — the string fix must not regress it",
     );
 }
+
+#[test]
+fn reinvented_helper_flags_test_container_for_default_exclusion() {
+    // The promotion field audit (2026-06-13) excludes test-container findings from the
+    // bare-default surface (a test asserting the helper's value as a literal is circular
+    // to "fix"). The `container_in_test` flag drives that — set when the container file
+    // is a test path, regardless of the helper's location.
+    let i = Interner::new();
+    let opts = DetectOptions {
+        min_lines: 1,
+        min_tokens: 1,
+        ..Default::default()
+    };
+    let helper = "function big(x, y) {\n    return ((x * 2 + 3) * (x - 4)) / ((x + 5) * (y - 7) + (y * y + 11))\n}\n";
+    let reinventor = "function manual(x, y) {\n    return (((x * 2 + 3) * (x - 4)) / ((x + 5) * (y - 7) + (y * y + 11))) * 7\n}\n";
+    let run = |container_path: &str| -> Option<bool> {
+        let il0 = nose_frontend::lower_source(
+            FileId(0),
+            "helper.js",
+            helper.as_bytes(),
+            Lang::JavaScript,
+            &i,
+        )
+        .unwrap();
+        let il1 = nose_frontend::lower_source(
+            FileId(1),
+            container_path,
+            reinventor.as_bytes(),
+            Lang::JavaScript,
+            &i,
+        )
+        .unwrap();
+        let mut units = nose_detect::units_of_file(&il0, &i, &opts);
+        units.extend(nose_detect::units_of_file(&il1, &i, &opts));
+        nose_detect::reinvented_helpers(&units)
+            .first()
+            .map(|f| f.container_in_test)
+    };
+    assert_eq!(
+        run("src/math.js"),
+        Some(false),
+        "a prod-path container is not flagged in_test"
+    );
+    assert_eq!(
+        run("test/math.test.js"),
+        Some(true),
+        "a test-path container is flagged in_test"
+    );
+}

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -734,6 +734,12 @@ pub struct ReinventedHelper {
     /// computation beyond the helper's. Consumers must not mechanically replace these
     /// exact lines (coevo series 6, S3-1).
     pub site_approximate: bool,
+    /// The container is a TEST file. Such findings are judgment-deep (§2b): the
+    /// "reinvention" is often intentional — a test asserts the helper's expected value as
+    /// a literal (calling it would be circular), or duplicates fixture setup. Kept in
+    /// `--show reinvented` / JSON, excluded from the bare-default surface; a field audit
+    /// (2026-06-13) measured them as the dominant non-actionable class.
+    pub container_in_test: bool,
     /// Value-graph size of the reinvented computation — the ranking key.
     pub weight: u32,
 }
@@ -842,6 +848,7 @@ pub fn reinvented_helpers(units: &[UnitFeat]) -> Vec<ReinventedHelper> {
                 site_start_line: site_start,
                 site_end_line: site_end,
                 site_approximate,
+                container_in_test: report::is_test_path(&c.path),
                 weight: anchor.weight,
             });
         }

--- a/crates/nose-detect/src/report.rs
+++ b/crates/nose-detect/src/report.rs
@@ -368,9 +368,13 @@ fn spread(files: usize, modules: usize, languages: usize) -> f64 {
 /// display context plus the opt-in `--scope` filter, never a worthiness input.
 /// Public so presentation layers can scope-guard per-location advice (e.g. never
 /// recommend calling a test helper from production copies).
-pub fn is_test_loc(l: &Loc) -> bool {
-    let p = l.file.to_ascii_lowercase();
-    let path_test = p.contains("/test/")
+/// Whether a file PATH is test code, by the well-known conventions (a `/test(s)/` or
+/// `/spec/` or `/__tests__/` directory, a `_test.go` / `conftest.py` / `.test.` /
+/// `.spec.` file, or a `test_`-prefixed stem). Path-only — the [`is_test_loc`] superset
+/// also consults the unit name and the inline-test-module flag.
+pub(crate) fn is_test_path(file: &str) -> bool {
+    let p = file.to_ascii_lowercase();
+    p.contains("/test/")
         || p.contains("/tests/")
         || p.contains("/__tests__/")
         || p.contains("/spec/")
@@ -381,12 +385,15 @@ pub fn is_test_loc(l: &Loc) -> bool {
         || ["_test.", ".test.", ".spec.", "_spec."]
             .iter()
             .any(|m| p.contains(m))
-        || file_stem(&p).starts_with("test_");
+        || file_stem(&p).starts_with("test_")
+}
+
+pub fn is_test_loc(l: &Loc) -> bool {
     let name_test = l
         .name
         .as_deref()
         .is_some_and(|n| n.starts_with("Test") || n.starts_with("test_"));
-    path_test || name_test || l.in_test_module
+    is_test_path(&l.file) || name_test || l.in_test_module
 }
 
 fn file_stem(path: &str) -> &str {

--- a/docs/home.md
+++ b/docs/home.md
@@ -33,7 +33,8 @@ You want to *run* nose on a codebase and act on what it finds.
 - [configuration](configuration.md) — the `nose.toml` file: excludes, modes, ranking, thresholds, and structured-ignore defaults.
 - [continuous-integration](continuous-integration.md) — the `--fail-on any` gate, baseline-driven incremental adoption, SARIF, and fast re-runs.
 - [structured-ignores](structured-ignores.md) — suppress reviewed findings with reason, owner, expiry, and machine-readable ignored-family output.
-- [reinvented-helpers](reinvented-helpers.md) — the experimental containment channel: code that reimplements an existing pure helper inline instead of calling it.
+- [reinvented-helpers](reinvented-helpers.md) — the containment channel: code that reimplements an existing pure helper inline instead of calling it.
+- [reinvented-helper-audit-2026-06-13](reinvented-helper-audit-2026-06-13.md) — the hand-labeled field audit that promoted the reinvented-helper channel to the default surface.
 - [clone-types](clone-types.md) — what nose covers across the standard Type-1/2/3/4 taxonomy, with its honest limits.
 - [languages](languages.md) — the supported languages and the embedded `<script>` extraction for Vue/Svelte/HTML.
 

--- a/docs/reinvented-helper-audit-2026-06-13.md
+++ b/docs/reinvented-helper-audit-2026-06-13.md
@@ -1,0 +1,64 @@
+# Reinvented-helper field audit — 2026-06-13
+
+A hand-labeled audit of the [reinvented-helper containment channel](reinvented-helpers.md)
+on the full `bench/repos` corpus (105 repos), the **measured-precision instrument** design
+§2c requires before a finding class enters the bare-default surface. It is the basis for
+promoting the channel from a one-line count to a listed default section.
+
+## Method
+
+`nose scan <repo> --format json` over every corpus repo; every `reinvented_helpers`
+finding collected and hand-labeled by reading the helper body and the container's matched
+region. A finding is **actionable** when the container genuinely recomputes the helper's
+value AND replacing it with a call is a valid fix; a **value-duplication** when the two
+genuinely compute the same value but the fix needs consumer judgment (cross-type
+adaptation, a class-override relationship); **noise** when the "reinvention" is wrong,
+circular, or intentional.
+
+## Result — 17 findings, 9 repos
+
+| precision lens | count | rate |
+|---|---|---|
+| genuine value-duplication (the channel's exactness claim) | 16 / 17 | 94% |
+| directly actionable (call the helper as-is) | 10 / 17 | 59% |
+| directly actionable, **non-test code** | 10 / 14 | 71% |
+
+The single non-value-duplication ([15], jsoup `ensureAttributeCapacity` ⟵ `ensureCapacity`)
+is a weak, approximate-site match whose bodies actually differ — it did not reproduce in
+isolation (cross-file context artifact). All others are genuine value matches.
+
+### Actionable (10) — call the helper directly
+- **raylib** `CheckCollisionPointCircle` ⟵ `Vector2DistanceSqr`; `QuaternionInvert` ⟵ `Vector4LengthSqr` (Quaternion is a Vector4 typedef).
+- **libgdx** `quadrilateralCentroid`'s `area1` ⟵ `triangleArea`; `nearestSegmentPoint`'s `length2` ⟵ `Vector2.dst2`; `argb8888` ⟵ `rgb888`; `toFloatBits`'s `color` ⟵ `toIntBits`.
+- **prettier** `isAsConstExpression`'s second disjunct ⟵ `isTsAsConstExpression`.
+- **sympy** `_print_contents`'s else-branch ⟵ `_print`.
+- **delve** `isBadNum` ⟵ `isNum` (`isNum(v) && len(v) > 1 && v[0] == '0'`).
+- **h2database** `getGarbageCollectionCount` ⟵ `getGarbageCollectionTime` — and this one is a **real upstream bug**: the count loop copy-pasted `getCollectionTime()` (should be `getCollectionCount()`), which is *why* it recomputes the time helper's value.
+
+### Value-duplication, consumer-judgment (4)
+- **raylib** `Vector4DistanceSqr` / `Vector4DotProduct` contain the 2D / 3D subcomputation of `Vector2DistanceSqr` / a vendored `ma_vec3f_dot` — genuine, but the helper's parameter type differs (the value model erases types; the call needs adaptation).
+- **sqlalchemy** `visit_mod_binary` (base compiler) ⟵ the pg8000 dialect override — same code path, but a base cannot call a subclass override.
+
+### Noise (3) — all TEST code or weak
+- **sympy** `test_type_G` asserts `positive_roots()`'s value as a dict literal — calling the helper would make the test circular.
+- **prettier** `bar2` ⟵ `bar` — intentional near-identical flow-test inputs.
+- **poetry** `test_python_installer_install` inlines the `mock_get_download_link` fixture — a genuine test DRY, but test scaffolding (judgment-deep, §2b).
+
+## Decision
+
+The non-actionable findings are **dominated by test-container code** (the `test_type_G`
+circular assertion, the prettier test inputs, the poetry fixture). This is a *decidable*
+class (§2b): **test-container findings are excluded from the bare-default surface** (kept
+in `--show reinvented` and the JSON, with `container_in_test: true`). After that filter
+the default surface is 14 findings, **94% genuine value-duplications and 71% directly
+actionable** — dominated by actionable findings, clearing the §2c bar. The channel is
+therefore **promoted**: the default human report lists the (non-test) findings instead of
+a count.
+
+The cross-type value-duplications stay on the surface as genuine evidence — per the
+consumer model (§2), the calling agent prices the type adaptation cheaply; nose carries
+the witness, not the verdict. The [docs caveat](reinvented-helpers.md) on type-checking
+the suggested call stands.
+
+*See also: [reinvented-helpers](reinvented-helpers.md) · [design §2c](design.md) ·
+[field-evaluation](field-evaluation.md).*

--- a/docs/reinvented-helpers.md
+++ b/docs/reinvented-helpers.md
@@ -49,10 +49,13 @@ Two exclusions keep the surface honest:
 
 ## Surface
 
-- **Human report**: a one-line count after the family report; `--show reinvented`
-  lists every finding. The default surface stays a count because the class is new and
-  its field precision is freshly measured, per
-  [design §2c](design.md) — promotion follows the labelset discipline.
+- **Human report**: the default report LISTS the non-test findings (top by weight) —
+  promoted from a one-line count after a [field audit](reinvented-helper-audit-2026-06-13.md)
+  measured them at 94% genuine value-duplications / 71% directly actionable (design §2c).
+  Findings whose CONTAINER is a test file (`container_in_test`) are a decidable
+  judgment-deep class (§2b) — a test asserting the helper's value as a literal would be
+  circular to "fix" — so they are excluded from the default and shown only by
+  `--show reinvented`, which lists every finding.
 - **Scan JSON**: an additive `reinvented_helpers` array (omitted when empty) — see
   [scan-json](scan-json.md#reinvented-helpers).
 - The container being a test file or vendored code is *judgment-deep* non-action

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -348,6 +348,7 @@ existing pure helper inline instead of calling it. One entry per finding:
 | `container_start_line` / `container_end_line` | integer | The container's source range. |
 | `site_start_line` / `site_end_line` | integer | Lines INSIDE the container where the helper's computation lives (falls back to the container range when the matched node carries no span). |
 | `site_approximate` | boolean | The site is the whole-container fallback (the match is a synthesized loop fold with no precise span); the helper's computation is a sub-part of those lines, so do not mechanically replace the exact range. |
+| `container_in_test` | boolean | The container is a test file. Such findings are judgment-deep (a test asserting the helper's value as a literal is circular to "fix") and are excluded from the bare-default human surface, but kept here and under `--show reinvented`. |
 | `weight` | integer | Value-graph size of the matched computation — the ranking key. |
 
 The claim is exact-grade (both units pass the strict exact gate; the match is a


### PR DESCRIPTION
The product side of "measure then promote" (design §2c). A hand-labeled [field audit](docs/reinvented-helper-audit-2026-06-13.md) of **all 17** reinvented-helper findings across the 105-repo corpus.

## Measurement

| precision lens | rate |
|---|---|
| genuine value-duplication (the channel's exactness claim) | **16/17 = 94%** |
| directly actionable, non-test code | **10/14 = 71%** |

The non-actionable noise was **dominated by test-container findings** — a test asserting the helper's value as a literal (calling it would be circular), intentional test-input variants, and a fixture inlined in a test. That is a *decidable* class (§2b).

## Change

- A new **`container_in_test`** flag (path-based, via an extracted `is_test_path`) marks findings whose container is a test file.
- The **bare `nose scan` report now LISTS** the non-test findings (top by weight, capped at 5) instead of a one-line count — the promotion.
- Test-container findings are excluded from the default but kept in `--show reinvented` and the additive JSON (§2b classification, never deletion).
- Cross-type value-duplications stay on the surface as genuine evidence — per the consumer model (§2), the calling agent prices the type adaptation; the [docs caveat](docs/reinvented-helpers.md) on type-checking the suggested call stands.

The audit re-confirmed the channel's headline win — h2database's `getGarbageCollectionCount` copy-pasted `getCollectionTime()` (a real upstream bug, which is *why* it recomputes the time helper) — and flagged one weak approximate match (jsoup) that did not reproduce in isolation.

Full suite green; dup gate 25/25; 1 regression test.

> Note: a concurrent adversarial campaign (series 8, issue #311) found **three confirmed false-merge classes in the value-graph literal keying** (string 28-bit collision from the #308 mask, int 32-bit truncation, int kind-nibble wrap into the Bool range). Those are a *different surface* (the canonicalizer's `Const` encoding) and get a separate structural fix (`ValOp::Const` carrying the kind explicitly). This PR is independent of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)