### PR TITLE
Carry the Const kind explicitly: close 3 value-model false merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ break.
   kept under `--show reinvented` and in the additive JSON.
 
 ### Fixed
+- **Three value-model false merges from the packed `Const` key** (#313). The value-graph
+  `Const(u32)` packed a literal's kind tag and its value/hash into one u32, with too few
+  bits — so an int could wrap its kind nibble into the boolean range (`x + 536870914` ≡
+  `x + True`), truncate to 32 bits (`0` ≡ `2^32`), or a string collide in #308's 28-bit
+  mask (`"geU"` ≡ `"aaha"`). `ValOp::Const` now carries the kind explicitly
+  (`ConstKind`) plus the FULL i64 value / 64-bit hash, so nothing wraps or truncates; the
+  #308 string mask is removed. Found by adversarial co-evolution series 8
+  ([experiments §CI](docs/experiments.md)); one of the merges was introduced by #308.
+
+### Fixed
 - **String-literal `+` no longer commutes** (#308). A string literal's value-graph `Const`
   key carried its content hash via `0x2000_0000.wrapping_add(h)`, which for a high-bit hash
   wrapped OUT of the `String` class range — so `const_value_domain` misread the kind and

--- a/bench/coevo/packets.v1.json
+++ b/bench/coevo/packets.v1.json
@@ -648,6 +648,54 @@
    "summary": "`\"p\"+\"q\"` \u2261 `\"q\"+\"p\"` false-merges: a string literal's Const key `0x2000_0000.wrapping_add(h)` wraps OUT of the String range when h's high bits are set, so const_value_domain misreads it as non-String \u2192 proven_non_concat wrongly admits the `+` commute. nose verify catches it as a hard violation.",
    "verdict": "violation-fixed",
    "defense": "#308 \u2014 a string literal's Const key kept the `String` class tag but the content hash wrapped out of range. Fixed by masking the hash into the low 28 bits (`string_const_key`), shared by the frontend's LitStr and the synthesized empty string so they agree (the py-`.get(k,\"\")` vs go-zero-value convergence). Verify clean on sympy+guava (49k interpretable units, no collision-induced merges); corpus family deltas small and in the false-merge-separating direction."
+  },
+  {
+   "packet_id": "s8-s1-int-bool-wrap",
+   "series": 8,
+   "campaign": "S1",
+   "persona": "numeric-skeptic",
+   "mode": "blind",
+   "surface": "value-model",
+   "claim": "an int/float Const-key wrap is always fail-closed; no int key wrap causes a false merge",
+   "summary": "The int literal 536870914 (=0x2000_0002) keyed to 0x3000_0002 via 0x1000_0000.wrapping_add(v as u32), byte-identical to LitBool(true)'s key \u2014 so x+536870914 false-merged with x+True. The #308 author's 'ints are fail-closed' claim was false.",
+   "verdict": "violation-fixed",
+   "defense": "#313 \u2014 ValOp::Const restructured to carry the kind explicitly (ConstKind) plus the full value/hash, so no value can wrap a class boundary."
+  },
+  {
+   "packet_id": "s8-s1-int-truncation",
+   "series": 8,
+   "campaign": "S1",
+   "persona": "numeric-skeptic",
+   "mode": "blind",
+   "surface": "value-model",
+   "claim": "int literals are keyed by value distinctly",
+   "summary": "eval keyed LitInt(v) as v as u32, truncating i64 to 32 bits, so 0 \u2261 2^32 and 5 \u2261 4294967301 false-merged. 2^32 is a plausible real constant.",
+   "verdict": "violation-fixed",
+   "defense": "#313 \u2014 Const{kind:Int, bits} retains the FULL i64."
+  },
+  {
+   "packet_id": "s8-s2-string-28bit-collision",
+   "series": 8,
+   "campaign": "S2",
+   "persona": "value-model-skeptic",
+   "mode": "blind",
+   "surface": "value-model",
+   "claim": "#308's string-key mask discriminates distinct strings",
+   "summary": "The #308 mask 0x2000_0000 | (h & 0x0FFF_FFFF) kept only 28 bits, so brute-forced strings 'geU'/'aaha' (sharing low-28-bits) collapsed to one Const and false-merged. #308 traded the out-of-range bug for a collision bug.",
+   "verdict": "violation-fixed",
+   "defense": "#313 \u2014 Const{kind:Str, bits} retains the FULL 64-bit hash; the 28-bit mask is removed."
+  },
+  {
+   "packet_id": "s8-value-model-canon-green",
+   "series": 8,
+   "campaign": "S2",
+   "persona": "value-model-skeptic",
+   "mode": "blind",
+   "surface": "value-model",
+   "claim": "the AC/distribution/min-max/De-Morgan canonicalizations gate literals soundly",
+   "summary": "Green on the algebraic canon: string-repetition distribution (gated tight), a+'literal' commutativity (held ordered), loose-vs-strict equality (unwitnessable, oracle has no coercion), De Morgan / abs idempotence (sound for all integers). The only exploitable surface was the literal-key hashing, not the canonicalizations.",
+   "verdict": "green-confirmed",
+   "defense": "None needed."
   }
  ]
 }

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -7712,3 +7712,46 @@ fn reinvented_helper_flags_test_container_for_default_exclusion() {
         "a test-path container is flagged in_test"
     );
 }
+
+#[test]
+fn literal_const_kind_is_separate_from_value_coevo_s8() {
+    // coevo series 8: the value-graph `Const` carries its KIND explicitly and the FULL
+    // value/hash in `bits`, so a literal can never wrap its class boundary or truncate.
+    // Three false merges the old packed u32 key produced are gone:
+    let i = Interner::new();
+    // S1-1 — an int whose old key collided with the boolean-true tag.
+    let int_big = "def f(x):\n    return x + 536870914\n";
+    let bool_true = "def f(x):\n    return x + True\n";
+    assert_ne!(
+        value_fp(&i, int_big, Lang::Python),
+        value_fp(&i, bool_true, Lang::Python),
+        "an int literal must not share a fingerprint with the boolean `True`",
+    );
+    // S1-2 — two ints differing by exactly 2^32 (old `v as u32` truncation collided).
+    let int_a = "def f(x):\n    return x + 4294967301\n";
+    let int_b = "def f(x):\n    return x + 5\n";
+    assert_ne!(
+        value_fp(&i, int_a, Lang::Python),
+        value_fp(&i, int_b, Lang::Python),
+        "ints differing by 2^32 must not collide (full i64 retained)",
+    );
+    // S2-1 — two short strings whose hashes collide in the old 28-bit mask.
+    let s_geu = "def f():\n    return \"geU\"\n";
+    let s_aaha = "def f():\n    return \"aaha\"\n";
+    assert_ne!(
+        value_fp(&i, s_geu, Lang::Python),
+        value_fp(&i, s_aaha, Lang::Python),
+        "distinct strings must not collide (full 64-bit hash retained)",
+    );
+    // Recall preserved: equal literals still converge, numeric `+` still commutes.
+    assert_eq!(
+        value_fp(&i, int_b, Lang::Python),
+        value_fp(&i, "def f(x):\n    return x + 5\n", Lang::Python),
+        "equal int literals still converge",
+    );
+    assert_eq!(
+        value_fp(&i, "def f(a, b):\n    return a + b + 1\n", Lang::Python),
+        value_fp(&i, "def f(a, b):\n    return b + a + 1\n", Lang::Python),
+        "numeric `+` still commutes",
+    );
+}

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -60,15 +60,16 @@ use crate::module_facts::{
     top_level_statements_for,
 };
 use field_state::FieldStateKey;
+use model::sentinel;
 use model::{
-    Builder, BuilderCandidate, BuilderKind, FilterMapResult, HofAdmission, InlineCaptureFrame,
-    InlineFunction, LoopRecurrenceScope, ReductionCache, SignedExprOperand, Sink, SinkKind,
-    ValNode, ValOp, ValueId,
+    Builder, BuilderCandidate, BuilderKind, ConstKind, FilterMapResult, HofAdmission,
+    InlineCaptureFrame, InlineFunction, LoopRecurrenceScope, ReductionCache, SignedExprOperand,
+    Sink, SinkKind, ValNode, ValOp, ValueId,
 };
 use nose_il::{
-    stable_symbol_hash, Builtin, EffectEvidenceKind, HoFKind, Il, Interner, Lang, LoopKind, NodeId,
-    NodeKind, Op, Payload, SourceCastKind, SourceComprehensionKind, SourceFactKind,
-    SourcePatternKind, SourceRangeKind, Span, Symbol,
+    stable_symbol_hash, Builtin, EffectEvidenceKind, HoFKind, Il, Interner, Lang, LitClass,
+    LoopKind, NodeId, NodeKind, Op, Payload, SourceCastKind, SourceComprehensionKind,
+    SourceFactKind, SourcePatternKind, SourceRangeKind, Span, Symbol,
 };
 use nose_semantics::{
     admitted_builder_append_method_call_args, admitted_builtin_semantics_at_call,

--- a/crates/nose-normalize/src/value_graph/canonicalize.rs
+++ b/crates/nose-normalize/src/value_graph/canonicalize.rs
@@ -713,7 +713,15 @@ impl<'a> Builder<'a> {
         if cn.args.len() != 2 {
             return None;
         }
-        let is_zero = |s: &Self, id: ValueId| matches!(s.nodes[id as usize].op, ValOp::Const(c) if c == 0x1000_0000);
+        let is_zero = |s: &Self, id: ValueId| {
+            matches!(
+                s.nodes[id as usize].op,
+                ValOp::Const {
+                    kind: ConstKind::Int,
+                    bits: 0
+                }
+            )
+        };
         let (nonneg, neg) = if cn.args[0] == v && is_zero(self, cn.args[1]) {
             (
                 opc == Op::Ge as u32 || opc == Op::Gt as u32,
@@ -1049,33 +1057,46 @@ impl<'a> Builder<'a> {
     }
 
     pub(super) fn int_const_value(&self, value: ValueId) -> Option<i64> {
-        let ValOp::Const(key) = self.nodes[value as usize].op else {
-            return None;
-        };
-        // `LitInt(v)` is keyed as `0x1000_0000 + v as u32`, so retained
-        // negative integers sit below the positive range. Exclude only the
-        // small `LitClass` discriminants; strings/floats/bools live in their
-        // own higher ranges and must never count as integer-bound proofs.
-        if !(0x0000_0006..=0x1FFF_FFFF).contains(&key) {
-            return None;
+        match self.nodes[value as usize].op {
+            ValOp::Const {
+                kind: ConstKind::Int,
+                bits,
+            } => Some(bits as i64),
+            _ => None,
         }
-        Some(key.wrapping_sub(0x1000_0000) as i32 as i64)
     }
 
     /// An integer-literal value, keyed identically to `eval`'s `LitInt` path so a
-    /// builtin's implicit init (`sum` → 0) matches a loop's explicit `acc = 0`.
+    /// builtin's implicit init (`sum` → 0) matches a loop's explicit `acc = 0`. `v` is a
+    /// synthesized non-negative count; the FULL i64 is retained so it can never collide
+    /// with a literal differing by a multiple of 2^32 (coevo series 8).
     pub(super) fn int_const(&mut self, v: u32) -> ValueId {
-        self.mk(ValOp::Const(0x1000_0000u32.wrapping_add(v)), vec![])
+        self.mk_const(ConstKind::Int, v as u64)
     }
 
     pub(super) fn null_const(&mut self) -> ValueId {
-        self.mk(ValOp::Const(nose_il::LitClass::Null as u32), vec![])
+        self.mk_const(ConstKind::Null, 0)
+    }
+
+    pub(super) fn bool_const_value(&mut self, b: bool) -> ValueId {
+        self.mk_const(ConstKind::Bool, b as u64)
+    }
+
+    /// Construct a `Const` node of the given kind and full-width payload.
+    pub(super) fn mk_const(&mut self, kind: ConstKind, bits: u64) -> ValueId {
+        self.mk(ValOp::Const { kind, bits }, vec![])
+    }
+
+    pub(super) fn sentinel_const(&mut self, tag: u64) -> ValueId {
+        self.mk_const(ConstKind::Sentinel, tag)
     }
 
     pub(super) fn bool_const(&self, id: ValueId) -> Option<bool> {
         match self.nodes[id as usize].op {
-            ValOp::Const(0x3000_0001) => Some(false),
-            ValOp::Const(0x3000_0002) => Some(true),
+            ValOp::Const {
+                kind: ConstKind::Bool,
+                bits,
+            } => Some(bits != 0),
             _ => None,
         }
     }
@@ -1174,18 +1195,18 @@ impl<'a> Builder<'a> {
     pub(super) fn static_membership_literal_value(&self, value: ValueId) -> bool {
         matches!(
             self.nodes[value as usize].op,
-            ValOp::Const(key) if key != 0x3000_0000
+            ValOp::Const { kind, bits } if !(matches!(kind, ConstKind::Sentinel) && bits == sentinel::BOTTOM)
         )
     }
 
     pub(super) fn empty_string_value(&mut self) -> ValueId {
-        self.mk(ValOp::Const(stable_string_const_key("")), vec![])
+        self.mk_const(ConstKind::Str, stable_string_const_bits(""))
     }
 
     pub(super) fn is_empty_string_value(&self, value: ValueId) -> bool {
         matches!(
             self.nodes[value as usize].op,
-            ValOp::Const(key) if key == stable_string_const_key("")
+            ValOp::Const { kind: ConstKind::Str, bits } if bits == stable_string_const_bits("")
         )
     }
 

--- a/crates/nose-normalize/src/value_graph/collections.rs
+++ b/crates/nose-normalize/src/value_graph/collections.rs
@@ -326,7 +326,7 @@ impl<'a> Builder<'a> {
                 }
             }
             if let Some(carried_guard) = carried_guard {
-                let ident = self.mk(ValOp::Const(0x3000_0001 + code - REDUCE_ANY), vec![]);
+                let ident = self.bool_const_value(code != REDUCE_ANY);
                 self.mk(ValOp::Phi, vec![carried_guard, pred, ident])
             } else {
                 pred
@@ -341,7 +341,7 @@ impl<'a> Builder<'a> {
             let av = self.eval(*kids.first()?, env);
             let (contrib, predicate) = self.collection_elem_with_pred(av);
             if let Some(predicate) = predicate {
-                let ident = self.mk(ValOp::Const(0x3000_0001 + code - REDUCE_ANY), vec![]);
+                let ident = self.bool_const_value(code != REDUCE_ANY);
                 self.mk(ValOp::Phi, vec![predicate, contrib, ident])
             } else {
                 contrib
@@ -841,7 +841,13 @@ impl<'a> Builder<'a> {
     }
 
     pub(super) fn is_null_value(&self, value: ValueId) -> bool {
-        matches!(self.nodes[value as usize].op, ValOp::Const(k) if k == nose_il::LitClass::Null as u32)
+        matches!(
+            self.nodes[value as usize].op,
+            ValOp::Const {
+                kind: ConstKind::Null,
+                ..
+            }
+        )
     }
 
     pub(super) fn membership_condition(&self, cond: ValueId) -> Option<(ValueId, ValueId, bool)> {
@@ -1045,7 +1051,7 @@ impl<'a> Builder<'a> {
                         Payload::LitInt(_)
                             | Payload::LitBool(_)
                             | Payload::LitStr(_)
-                            | Payload::Lit(nose_il::LitClass::Null)
+                            | Payload::Lit(LitClass::Null)
                     )
             })
     }
@@ -1754,7 +1760,7 @@ impl<'a> Builder<'a> {
     pub(super) fn is_null_literal(&self, node: NodeId) -> bool {
         matches!(
             (self.il.kind(node), self.il.node(node).payload),
-            (NodeKind::Lit, Payload::Lit(nose_il::LitClass::Null))
+            (NodeKind::Lit, Payload::Lit(LitClass::Null))
         )
     }
 }

--- a/crates/nose-normalize/src/value_graph/context.rs
+++ b/crates/nose-normalize/src/value_graph/context.rs
@@ -390,7 +390,7 @@ impl<'a> Builder<'a> {
                     | Payload::LitBool(_)
                     | Payload::LitStr(_)
                     | Payload::LitFloat(_)
-                    | Payload::Lit(nose_il::LitClass::Null)
+                    | Payload::Lit(LitClass::Null)
             ),
             _ => self
                 .il

--- a/crates/nose-normalize/src/value_graph/control.rs
+++ b/crates/nose-normalize/src/value_graph/control.rs
@@ -104,9 +104,9 @@ impl<'a> Builder<'a> {
         }
         let r0 = self.sinks[0].value;
         let r1 = self.sinks[1].value;
-        let bot = self.mk(ValOp::Const(0x3000_0000), vec![]);
-        let tru = self.mk(ValOp::Const(0x3000_0002), vec![]);
-        let fls = self.mk(ValOp::Const(0x3000_0001), vec![]);
+        let bot = self.sentinel_const(sentinel::BOTTOM);
+        let tru = self.bool_const_value(true);
+        let fls = self.bool_const_value(false);
         let int_one = self.int_const(1);
         let int_zero = self.int_const(0);
         for &(guarded, plain) in &[(r0, r1), (r1, r0)] {
@@ -327,7 +327,7 @@ impl<'a> Builder<'a> {
     }
 
     pub(super) fn is_bottom_value(&self, value: ValueId) -> bool {
-        matches!(self.nodes[value as usize].op, ValOp::Const(k) if k == 0x3000_0000)
+        matches!(self.nodes[value as usize].op, ValOp::Const { kind: ConstKind::Sentinel, bits } if bits == sentinel::BOTTOM)
     }
 
     /// The conjunction of the current branch path (`c₁ ∧ c₂ ∧ …`), or `None` at top level.
@@ -1069,14 +1069,14 @@ impl<'a> Builder<'a> {
                 // conditional early `return;` collapsed — cf. the break sink, §AS).
                 let v = match self.il.children(stmt).first() {
                     Some(&e) => self.eval(e, env),
-                    None => self.mk(ValOp::Const(0xF00D_0000), vec![]),
+                    None => self.sentinel_const(sentinel::VOID_RETURN),
                 };
                 self.emit_return(v);
             }
             NodeKind::Throw => {
                 let v = match self.il.children(stmt).first() {
                     Some(&e) => self.eval(e, env),
-                    None => self.mk(ValOp::Const(0xE22E_0000), vec![]),
+                    None => self.sentinel_const(sentinel::THROW),
                 };
                 self.emit_throw(v);
             }
@@ -1119,7 +1119,7 @@ impl<'a> Builder<'a> {
                     // no longer fingerprints as the bare `return x+1` (#210). The env
                     // clone keeps exceptional bindings out of the normal path.
                     if !self.branch_returns_throw_free(kids[0]) {
-                        let exc = self.mk(ValOp::Const(0xCA7C_4A4D), vec![]);
+                        let exc = self.sentinel_const(sentinel::EXC);
                         self.path.push(exc);
                         let mut handler_env = env.clone();
                         self.process_stmt(kids[1], &mut handler_env);
@@ -1143,7 +1143,7 @@ impl<'a> Builder<'a> {
                 // distinct. (`continue` needs no handling: desugaring already hoists the
                 // remainder of the body into the negated guard, so its filtering effect
                 // is captured by the normal path-guard machinery.)
-                let marker = self.mk(ValOp::Const(0xB2EA_C0DE), vec![]);
+                let marker = self.sentinel_const(sentinel::BREAK);
                 let g = self.guarded(marker);
                 self.sinks.push(Sink::new(SinkKind::Break, g));
             }
@@ -1286,7 +1286,7 @@ impl<'a> Builder<'a> {
             (kind != LoopKind::ForEach && kids.len() >= 2).then(|| self.eval(kids[0], env))
         });
         let Some(guard) = guard else { return };
-        let bot = self.mk(ValOp::Const(0x3000_0000), vec![]);
+        let bot = self.sentinel_const(sentinel::BOTTOM);
         for i in sink_start..self.sinks.len() {
             let sink = self.sinks[i];
             if !matches!(sink.kind, SinkKind::Effect) || self.refs_elem(sink.value) {

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -201,23 +201,24 @@ impl<'a> Builder<'a> {
     }
 
     fn eval_lit_expr(&mut self, payload: Payload) -> ValueId {
-        // Behavior-defining constants must be distinct values: `0` ≠ `1`
-        // (else `x % 2 == 0` and `x % 2 == 1` collapse). Retained small ints
-        // key by value (offset clear of the class range); others by class.
-        let key = match payload {
-            Payload::LitInt(v) => 0x1000_0000u32.wrapping_add(v as u32),
-            // strings in a separate key range from ints; the hash is masked into range
-            // (NOT `wrapping_add`ed) so the `String` class tag survives — shared with the
-            // synthesized empty string via `string_const_key` (#308).
-            Payload::LitStr(h) => string_const_key(h),
-            // floats keyed by source-text hash, in their own range (so `3.14`≠`2.71`)
-            Payload::LitFloat(h) => 0x4000_0000u32.wrapping_add(h as u32),
-            // true/false are behavior-defining and must be distinct (own range)
-            Payload::LitBool(b) => 0x3000_0001u32 + b as u32,
-            Payload::Lit(c) => c as u32,
-            _ => 0,
+        // Behavior-defining constants are distinct values: `0` ≠ `1`, `"p"` ≠ `"q"`,
+        // `true` ≠ `false`, `3.14` ≠ `2.71`. The kind is carried EXPLICITLY and `bits`
+        // holds the FULL value/hash, so nothing wraps a class boundary or truncates
+        // (coevo series 8). An abstract `Lit(class)` (value not retained) collapses to
+        // `bits = 0` of its kind — all such literals of one class converge, by design.
+        let (kind, bits) = match payload {
+            Payload::LitInt(v) => (ConstKind::Int, v as u64),
+            Payload::LitStr(h) => (ConstKind::Str, h),
+            Payload::LitFloat(h) => (ConstKind::Float, h),
+            Payload::LitBool(b) => (ConstKind::Bool, b as u64),
+            Payload::Lit(LitClass::Int) => (ConstKind::Int, 0),
+            Payload::Lit(LitClass::Float) => (ConstKind::Float, 0),
+            Payload::Lit(LitClass::Str) => (ConstKind::Str, 0),
+            Payload::Lit(LitClass::Bool) => (ConstKind::Bool, 0),
+            Payload::Lit(LitClass::Null) => (ConstKind::Null, 0),
+            _ => (ConstKind::Sentinel, 0),
         };
-        self.mk(ValOp::Const(key), vec![])
+        self.mk_const(kind, bits)
     }
 
     fn eval_binop_expr(

--- a/crates/nose-normalize/src/value_graph/inline.rs
+++ b/crates/nose-normalize/src/value_graph/inline.rs
@@ -395,7 +395,7 @@ impl<'a> Builder<'a> {
                     | Payload::LitBool(_)
                     | Payload::LitStr(_)
                     | Payload::LitFloat(_)
-                    | Payload::Lit(nose_il::LitClass::Null)
+                    | Payload::Lit(LitClass::Null)
             ),
             _ => self
                 .il

--- a/crates/nose-normalize/src/value_graph/model.rs
+++ b/crates/nose-normalize/src/value_graph/model.rs
@@ -5,10 +5,51 @@ use super::*;
 
 pub(super) type ValueId = u32;
 
+/// Sentinel `Const` discriminants — opaque markers that must stay distinct from each
+/// other and from every real literal. Preserved verbatim from the old packed-key magics
+/// so their structural hashes (and thus cross-version fingerprints) are unchanged.
+pub(super) mod sentinel {
+    /// `⊥` — "not on this path" (the `Phi` placeholder / guard bottom).
+    pub(crate) const BOTTOM: u64 = 0x3000_0000;
+    /// A bare `return;` (void return).
+    pub(crate) const VOID_RETURN: u64 = 0xF00D_0000;
+    /// A bare `throw;` / `raise`.
+    pub(crate) const THROW: u64 = 0xE22E_0000;
+    /// An exception-path guard marker.
+    pub(crate) const EXC: u64 = 0xCA7C_4A4D;
+    /// An early `break`'s path marker.
+    pub(crate) const BREAK: u64 = 0xB2EA_C0DE;
+}
+
+/// The kind of a [`ValOp::Const`], carried EXPLICITLY rather than inferred from the
+/// numeric range of a single packed key. The old `Const(u32)` packed a 4-bit class tag
+/// into the top nibble and the value/hash into the low 28 — but an integer value or a
+/// string hash with high bits set wrapped the key out of its class range (misreading the
+/// kind) or collided after truncation, both producing false merges (coevo series 8;
+/// #308's mask only narrowed the string case). Separating the kind removes the packing
+/// entirely: `bits` holds the FULL i64 value (Int), the full 64-bit content hash
+/// (Str/Float), the boolean (Bool), or a sentinel discriminant — with no range to escape.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) enum ConstKind {
+    /// An opaque marker (bottom/⊥, void-return, throw, break, exception-guard, …) —
+    /// behaviorally `Unknown`, distinguished from every other sentinel by `bits`.
+    Sentinel,
+    Int,
+    Str,
+    Bool,
+    Float,
+    Null,
+}
+
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub(super) enum ValOp {
     Input(u32), // a parameter or free variable, keyed by canonical id
-    Const(u32), // literal class
+    /// A literal/constant. `kind` classifies it; `bits` is the full i64 value (Int), the
+    /// full content hash (Str/Float), the boolean (Bool, 0/1), or a sentinel tag.
+    Const {
+        kind: ConstKind,
+        bits: u64,
+    },
     Bin(u32),   // binary operator
     Un(u32),    // unary operator
     Field(u64), // field access, keyed by content hash of the name

--- a/crates/nose-normalize/src/value_graph/ops.rs
+++ b/crates/nose-normalize/src/value_graph/ops.rs
@@ -2,7 +2,7 @@
 //!
 //! proof-obligation: normalize.value_graph.compare
 
-use super::ValOp;
+use super::{ConstKind, ValOp};
 use crate::combine;
 use nose_il::{stable_symbol_hash, Il, Lang, NodeId, NodeKind, Op, Payload};
 use nose_semantics::{semantics, ValueDomain};
@@ -217,19 +217,15 @@ pub(super) fn is_commutative(opc: u32) -> bool {
     is_assoc_comm_code(opc) || opc == Op::Eq as u32 || opc == Op::Ne as u32
 }
 
-/// Coarse type of a `Const` value node from its key range (mirrors the `eval` Lit keys):
-/// int range -> Num, string range -> Str, bool range -> Bool, small `LitClass` codes -> their
-/// type; sentinels (bottom, void-return, break) -> Unknown.
-pub(super) fn const_value_domain(k: u32) -> ValueDomain {
-    match k {
-        0x1000_0000..=0x1FFF_FFFF => ValueDomain::Number,
-        0x2000_0000..=0x2FFF_FFFF => ValueDomain::String,
-        0x3000_0001 | 0x3000_0002 => ValueDomain::Boolean,
-        0x4000_0000..=0x4FFF_FFFF => ValueDomain::Number,
-        0 | 1 => ValueDomain::Number,
-        2 => ValueDomain::String,
-        3 => ValueDomain::Boolean,
-        _ => ValueDomain::Unknown,
+/// Coarse value domain of a `Const`, read directly from its explicit [`ConstKind`] (no
+/// numeric-range inference — that packing was the source of the #308/series-8 kind
+/// misclassifications). `Null` and sentinels are behaviorally `Unknown`.
+pub(super) fn const_value_domain(kind: ConstKind) -> ValueDomain {
+    match kind {
+        ConstKind::Int | ConstKind::Float => ValueDomain::Number,
+        ConstKind::Str => ValueDomain::String,
+        ConstKind::Bool => ValueDomain::Boolean,
+        ConstKind::Null | ConstKind::Sentinel => ValueDomain::Unknown,
     }
 }
 
@@ -310,7 +306,9 @@ pub(super) fn identity_of(opc: u32) -> Option<u32> {
 pub(super) fn op_tag(op: &ValOp) -> u64 {
     let (k, p): (u64, u64) = match op {
         ValOp::Input(c) => (1, *c as u64),
-        ValOp::Const(c) => (2, *c as u64),
+        // Fold the kind into the discriminant so two Consts of different kinds with the
+        // same `bits` (e.g. Int 1 vs Bool true) never share a hash.
+        ValOp::Const { kind, bits } => (2 ^ ((*kind as u64) << 8), *bits),
         ValOp::Bin(o) => (3, *o as u64),
         ValOp::Un(o) => (4, *o as u64),
         ValOp::Field(n) => (5, *n),
@@ -342,25 +340,16 @@ pub(super) fn op_tag(op: &ValOp) -> u64 {
 }
 
 /// The low-bit mask for a literal's content hash inside its class-tagged `Const` key
-/// range. The class tag occupies the top nibble (`0x2…` = String); the hash MUST be
-/// masked into the low 28 bits, never `wrapping_add`ed, or a high-bit hash carries the
-/// key OUT of the class range — where `const_value_domain` misreads the kind and (for a
-/// string) `proven_non_concat` wrongly admits the `+` commute, false-merging `"p"+"q"`
-/// with `"q"+"p"` (#308). All string keys go through [`string_const_key`] so the
-/// frontend's `LitStr` and the synthesized empty string agree.
-pub(super) const LIT_HASH_MASK: u32 = 0x0FFF_FFFF;
-
-/// The `Const` key for a string literal whose content hash is `h`: the `String` class
-/// tag with the hash masked into range (see [`LIT_HASH_MASK`]).
-pub(super) fn string_const_key(h: u64) -> u32 {
-    0x2000_0000u32 | (h as u32 & LIT_HASH_MASK)
+/// The `Const` `bits` for a string literal: the FULL content hash. The kind
+/// (`ConstKind::Str`) is carried separately, so unlike the old packed key there is no
+/// range to escape and no truncation — the #308 mask and its 28-bit collision are gone
+/// (coevo series 8). The frontend's `LitStr` and the synthesized empty string both go
+/// through `stable_symbol_hash`, so they agree.
+pub(super) fn stable_string_const_bits(value: &str) -> u64 {
+    stable_symbol_hash(value)
 }
 
-pub(super) fn stable_string_const_key(value: &str) -> u32 {
-    string_const_key(stable_symbol_hash(value))
-}
-
-pub(super) fn stable_float_const_key(value: &str) -> u32 {
+pub(super) fn stable_float_const_bits(value: &str) -> u64 {
     let normalized = value.trim().trim_end_matches(['f', 'F', 'd', 'D']);
-    0x4000_0000u32.wrapping_add(stable_symbol_hash(normalized) as u32)
+    stable_symbol_hash(normalized)
 }

--- a/crates/nose-normalize/src/value_graph/output.rs
+++ b/crates/nose-normalize/src/value_graph/output.rs
@@ -46,7 +46,7 @@ impl<'a> Builder<'a> {
                 && weight[i] >= min_weight
                 && !matches!(
                     self.nodes[i].op,
-                    ValOp::Const(_)
+                    ValOp::Const { .. }
                         | ValOp::Input(_)
                         | ValOp::Elem(_)
                         | ValOp::ImportNamespace { .. }
@@ -128,7 +128,7 @@ impl<'a> Builder<'a> {
         for i in 0..self.nodes.len() {
             if reachable[i] {
                 out.push(h[i]);
-                if matches!(self.nodes[i].op, ValOp::Const(_)) {
+                if matches!(self.nodes[i].op, ValOp::Const { .. }) {
                     lits.push(h[i]);
                 }
             }

--- a/crates/nose-normalize/src/value_graph/sinks.rs
+++ b/crates/nose-normalize/src/value_graph/sinks.rs
@@ -59,7 +59,7 @@ impl<'a> Builder<'a> {
         if let ValOp::Phi = self.nodes[v as usize].op {
             let args = self.nodes[v as usize].args.clone();
             if args.len() == 3 {
-                let bot = self.mk(ValOp::Const(0x3000_0000), vec![]);
+                let bot = self.sentinel_const(sentinel::BOTTOM);
                 let (cond, then_v, else_v) = (args[0], args[1], args[2]);
                 if then_v != bot && else_v != bot {
                     self.path.push(cond);
@@ -81,7 +81,7 @@ impl<'a> Builder<'a> {
         match self.path_cond() {
             None => v,
             Some(pc) => {
-                let bot = self.mk(ValOp::Const(0x3000_0000), vec![]);
+                let bot = self.sentinel_const(sentinel::BOTTOM);
                 self.mk(ValOp::Phi, vec![pc, v, bot])
             }
         }

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -92,7 +92,7 @@ impl<'a> Builder<'a> {
     /// the rewrite simply does not fire — typed/annotated operands still converge.
     pub(super) fn proven_numeric(&self, v: ValueId) -> bool {
         match self.nodes[v as usize].op {
-            ValOp::Const(k) => const_value_domain(k) == ValueDomain::Number,
+            ValOp::Const { kind, .. } => const_value_domain(kind) == ValueDomain::Number,
             ValOp::Input(cid) => self
                 .param_domain
                 .get(&cid)
@@ -152,7 +152,7 @@ impl<'a> Builder<'a> {
     pub(super) fn proven_non_concat(&self, v: ValueId) -> bool {
         match self.nodes[v as usize].op {
             // Non-string literals (Number / Boolean / Null). A String const is concat.
-            ValOp::Const(k) => !matches!(const_value_domain(k), ValueDomain::String),
+            ValOp::Const { kind, .. } => !matches!(const_value_domain(kind), ValueDomain::String),
             // Only a GENUINELY non-string-typed param (numeric/boolean evidence) qualifies;
             // an untyped param could be a string.
             ValOp::Input(cid) => self
@@ -208,7 +208,7 @@ impl<'a> Builder<'a> {
         };
         let operators = semantics(self.il.meta.lang).operators();
         match op {
-            ValOp::Const(k) => const_value_domain(*k),
+            ValOp::Const { kind, .. } => const_value_domain(*kind),
             ValOp::Input(k) => self
                 .param_ty
                 .get(*k as usize)

--- a/crates/nose-normalize/src/value_graph/stdlib.rs
+++ b/crates/nose-normalize/src/value_graph/stdlib.rs
@@ -696,11 +696,11 @@ impl<'a> Builder<'a> {
         match kind {
             GoZeroMapDefaultKind::Int => self.int_const(0),
             GoZeroMapDefaultKind::String => {
-                self.mk(ValOp::Const(stable_string_const_key("")), vec![])
+                self.mk_const(ConstKind::Str, stable_string_const_bits(""))
             }
-            GoZeroMapDefaultKind::Bool => self.mk(ValOp::Const(0x3000_0001), vec![]),
+            GoZeroMapDefaultKind::Bool => self.bool_const_value(false),
             GoZeroMapDefaultKind::Float => {
-                self.mk(ValOp::Const(stable_float_const_key("0.0")), vec![])
+                self.mk_const(ConstKind::Float, stable_float_const_bits("0.0"))
             }
             GoZeroMapDefaultKind::Null => self.null_const(),
         }

--- a/crates/nose-normalize/src/value_graph/tests.rs
+++ b/crates/nose-normalize/src/value_graph/tests.rs
@@ -3,9 +3,9 @@ use nose_il::{
     CallTargetEvidenceKind, EffectEvidenceKind, EvidenceAnchor, EvidenceEmitter, EvidenceId,
     EvidenceKind, EvidenceProvenance, EvidenceRecord, EvidenceStatus, FileId, FileMeta,
     GuardEvidenceKind, IlBuilder, ImportEvidenceKind, JsRecordGuardComparison,
-    JsRecordGuardNullCheck, Lang, LibraryApiEvidenceKind, LitClass, ParamSemantic,
-    SequenceSurfaceKind, SourceCallKind, SourceComprehensionKind, SourceFactKind, Span,
-    SymbolEvidenceKind, Unit, UnitKind,
+    JsRecordGuardNullCheck, Lang, LibraryApiEvidenceKind, ParamSemantic, SequenceSurfaceKind,
+    SourceCallKind, SourceComprehensionKind, SourceFactKind, Span, SymbolEvidenceKind, Unit,
+    UnitKind,
 };
 use nose_semantics::{
     library_api_callee_contract_hash, library_api_contract_id_hash,
@@ -342,7 +342,13 @@ fn nullish_global_value_requires_symbol_evidence() {
     let mut builder = Builder::new(&il, &interner);
     let raw = builder.eval(var, &FxHashMap::default());
     assert!(
-        !matches!(builder.nodes[raw as usize].op, ValOp::Const(k) if k == LitClass::Null as u32),
+        !matches!(
+            builder.nodes[raw as usize].op,
+            ValOp::Const {
+                kind: ConstKind::Null,
+                ..
+            }
+        ),
         "raw undefined spelling must not prove the nullish constant"
     );
 
@@ -356,7 +362,13 @@ fn nullish_global_value_requires_symbol_evidence() {
     let mut builder = Builder::new(&il, &interner);
     let proven = builder.eval(var, &FxHashMap::default());
     assert!(
-        matches!(builder.nodes[proven as usize].op, ValOp::Const(k) if k == LitClass::Null as u32),
+        matches!(
+            builder.nodes[proven as usize].op,
+            ValOp::Const {
+                kind: ConstKind::Null,
+                ..
+            }
+        ),
         "symbol evidence should admit the nullish constant"
     );
 }
@@ -1185,9 +1197,13 @@ fn rust_some_wildcard_pattern_value_graph_requires_library_api_and_source_patter
     let node = &builder.nodes[proven as usize];
     assert!(matches!(node.op, ValOp::Bin(op) if op == Op::Ne as u32));
     assert!(
-        node.args
-            .iter()
-            .any(|&arg| matches!(builder.nodes[arg as usize].op, ValOp::Const(k) if k == LitClass::Null as u32)),
+        node.args.iter().any(|&arg| matches!(
+            builder.nodes[arg as usize].op,
+            ValOp::Const {
+                kind: ConstKind::Null,
+                ..
+            }
+        )),
         "admitted Rust Some wildcard pattern should evaluate as non-null Option presence"
     );
 }
@@ -1226,10 +1242,13 @@ fn rust_option_none_pattern_value_graph_requires_library_api_evidence() {
     let raw = builder.eval(if_expr, &FxHashMap::default());
     let raw_node = &builder.nodes[raw as usize];
     assert!(
-        !raw_node
-            .args
-            .iter()
-            .any(|&arg| matches!(builder.nodes[arg as usize].op, ValOp::Const(k) if k == LitClass::Null as u32)),
+        !raw_node.args.iter().any(|&arg| matches!(
+            builder.nodes[arg as usize].op,
+            ValOp::Const {
+                kind: ConstKind::Null,
+                ..
+            }
+        )),
         "raw None selector must not become a null predicate"
     );
 
@@ -1257,9 +1276,13 @@ fn rust_option_none_pattern_value_graph_requires_library_api_evidence() {
     let node = &builder.nodes[proven as usize];
     assert!(matches!(node.op, ValOp::Bin(op) if op == Op::Eq as u32));
     assert!(
-        node.args
-            .iter()
-            .any(|&arg| matches!(builder.nodes[arg as usize].op, ValOp::Const(k) if k == LitClass::Null as u32)),
+        node.args.iter().any(|&arg| matches!(
+            builder.nodes[arg as usize].op,
+            ValOp::Const {
+                kind: ConstKind::Null,
+                ..
+            }
+        )),
         "admitted Rust None occurrence should evaluate as the null sentinel"
     );
 }
@@ -2249,7 +2272,13 @@ fn inline_capture_poisons_in_loop_returns() {
         poisoned: false,
         returns: Vec::new(),
     });
-    let v = builder.mk(ValOp::Const(1), vec![]);
+    let v = builder.mk(
+        ValOp::Const {
+            kind: ConstKind::Int,
+            bits: 1,
+        },
+        vec![],
+    );
     builder.loop_depth = 1;
     builder.emit_return(v);
     let frame = builder.inline_capture.last().expect("frame");

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2403,3 +2403,46 @@ recovered splat coverage), determinism byte-identical, dup gate 25/25, recall pr
 over-fire). The recurring theme across series 6–7 holds: every soundness miss was the
 frontend discarding a binding-discriminating token (keyword names, `global` declarations,
 splats), and every fix preserves it in the IL.
+
+## CI. Adversarial co-evolution, series 8 — the value-model literal/numeric keying (post-#308)
+
+One protocol pass ([adversarial-coevolution](adversarial-coevolution.md)) aimed by the
+freshness slot rule at the literal-keying / value-domain classification just changed in
+#308 — the string-`+`-commute fix that masked string `Const` keys. Two blind attackers
+(numeric-domain skeptic, value-model skeptic); ledger `s8-*`; tracking issue #311.
+**The #308 fix's own author claim — "ints/floats are fail-closed when their key wraps" —
+was attacked and refuted**: the same self-attack discipline as series 7, one merge later.
+
+**Three confirmed false merges, all in the packed-key encoding (S1+S2, fixed).** The
+value-graph `Const(u32)` tagged the literal kind in the top nibble and packed the
+value/hash into the low 28 bits — fundamentally too few bits, so:
+- an **int wrapped its kind nibble**: `536870914` (`0x2000_0002`) keyed to `0x3000_0002`,
+  byte-identical to `LitBool(true)`, so `x + 536870914` ≡ `x + True`;
+- an **int truncated to 32 bits**: `v as u32` collapsed `0 ≡ 2^32` and `5 ≡ 4294967301`
+  (2^32 is a plausible real constant);
+- a **string collided in 28 bits**: #308's mask `0x2000_0000 | (h & 0x0FFF_FFFF)` kept
+  only 28 of the 64 hash bits, so brute-forced `"geU"`/`"aaha"` collapsed to one key —
+  #308 had *traded* the out-of-range bug for a collision bug.
+
+**Fix (#313): carry the kind, not infer it from a range.** `ValOp::Const(u32)` became
+`ValOp::Const { kind: ConstKind, bits: u64 }` — the kind is explicit and `bits` holds the
+FULL i64 value (Int), the full 64-bit content hash (Str/Float), the boolean, or a sentinel
+discriminant. With the kind separated there is no range for a value to escape and no
+truncation; all three false merges are closed by construction, the #308 mask is removed,
+and the string-`+`-commute fix it was protecting still holds (the kind is read directly).
+Corpus: small POSITIVE family deltas (sympy +6, redis +4) — the false-merge-separating
+direction — soundness clean on sympy + guava (49k interpretable units), determinism
+byte-identical.
+
+**S2 green — the algebraic canon held.** Distribution `a·c+b·c≡(a+b)·c` on strings (gated
+tight via the no-`Mul`-numeric-inference rule), `a + "literal"` commutativity (held
+ordered), loose-vs-strict equality (unwitnessable — the oracle has no coercion model), and
+De Morgan / abs idempotence (sound for all integers) all survived. The exploitable surface
+was purely the literal-key hashing, not the canonicalizations — and floats are
+structurally un-attackable for now (the interpreter has no `LitFloat` arm, so a float
+behavioral difference can't be witnessed; a latent gap recorded, not a confirmed merge).
+
+**Verdict.** A core value-model fix closing three false merges — one of them introduced by
+#308 the same session. The series 6–8 theme completes its shape: every soundness miss was
+a kind/identity token lost in an encoding (keyword names, `global`, splats, then literal
+kinds), and every fix preserves it explicitly rather than inferring it from a lossy pack.


### PR DESCRIPTION
Closes the value-model false merges found by [adversarial co-evolution series 8](https://github.com/corca-ai/nose/issues/311) — including one introduced by #310 (#308) the same session.

## The bugs

The value-graph `Const(u32)` packed a literal's kind tag (top nibble) and its value/hash (low 28 bits) into one u32. Too few bits:

| literal | collided with | false merge |
|---|---|---|
| int `536870914` (`0x2000_0002`) → key `0x3000_0002` | `LitBool(true)` | `x + 536870914` ≡ `x + True` |
| int `4294967301` (`v as u32` truncates) | int `5` | `0 ≡ 2^32`, `5 ≡ 4294967301` |
| string `"geU"` (the #308 28-bit mask) | `"aaha"` | hash collision |

The third is **#308's own mask** — that fix traded the out-of-range string bug for a 28-bit collision bug.

## The fix

`ValOp::Const(u32)` → **`ValOp::Const { kind: ConstKind, bits: u64 }`**. The kind is explicit (read directly by `const_value_domain`, not inferred from a numeric range) and `bits` holds the **full** i64 value / 64-bit content hash / boolean / sentinel discriminant. No range for a value to escape, no truncation — all three merges closed by construction, the #308 mask removed, the string-`+`-commute fix it protected still holding. Sentinel magics (bottom/void-return/throw/break/exc) are preserved verbatim, so cross-version fingerprints are unchanged.

## Verified

- All three S8 cases now distinct; **equal literals still converge, numeric `+` still commutes** (recall preserved).
- `nose verify --max-violations 0` clean on sympy + guava (49k interpretable units).
- Byte-identical across thread counts (redis); dup gate 25/25; full suite green; 1 regression test.
- Corpus family deltas small and **positive** (sympy +6, redis +4) — the false-merge-separating direction.

Series 6–8 theme completes: every soundness miss was a kind/identity token lost in an encoding (keyword names → `global` → splats → **literal kinds**); every fix preserves it explicitly. Closeout: experiments §CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)