### PR TITLE
Make the graded-witness obligation a required surface

### DIFF
--- a/scripts/check-formal-obligations.py
+++ b/scripts/check-formal-obligations.py
@@ -113,6 +113,19 @@ REQUIRED_OBLIGATIONS = (
         ("crates/nose-normalize/src/value_graph.rs",),
         ("eval_inlined_call",),
     ),
+    # The near-channel graded witness. Required so the obligation can never be silently
+    # dropped while the soundness-bearing code lives — refactoring away `graded_witness`,
+    # `equal_modulo_holes`, or the `compare_referents` check (or removing the obligation's
+    # marker) fails the gate until the registry is updated. NOTE: unlike the entries above
+    # this obligation is `empirical-only`, not `proven` — required-EXISTENCE is enforced
+    # here; the Lean proof remains a tracked gap (the witness is near-channel evidence, not
+    # an exact-channel theorem). When a proof is written, flip the status to `proven` and
+    # the standard `[lean]` checks take over.
+    RequiredObligation(
+        "detect.graded_witness",
+        ("crates/nose-detect/src/witness.rs",),
+        ("graded_witness", "equal_modulo_holes", "compare_referents"),
+    ),
 )
 
 


### PR DESCRIPTION
The #315 graded witness carries an `empirical-only` Lean obligation (`detect.graded_witness`, added in #320). This binds it to its code so it can't be **accidentally forgotten** — the same guard the other proof-sensitive surfaces already use.

### What
Add `detect.graded_witness` to `REQUIRED_OBLIGATIONS` in `scripts/check-formal-obligations.py`, alongside `il.arena.*`, `detect.fragment.*`, `oracle.cutoff`, and `normalize.value_graph.pure_inline`.

The formal-obligation gate now fails if anyone:
- removes the obligation directory,
- drops its `//! proof-obligation: detect.graded_witness` marker, or
- refactors away the bound symbols (`graded_witness`, `equal_modulo_holes`, `compare_referents`)

without updating the registry. So the witness can't silently lose its registered soundness obligation.

### Scope (honest)
This enforces the obligation's **existence and code-binding — not `status = proven`**. The witness is near-channel *evidence*, not an exact-channel theorem, so it stays `empirical-only` (a valid, tracked resting state — like `oracle.completeness`). The Lean proof remains a tracked gap; when one is written, flipping the status to `proven` makes the standard `[lean]` proof-file/type-check enforcement take over. This is the difference between "can never be dropped" (enforceable now, this PR) and "must be proven" (requires writing the proof — separate work).

### Verified
- `check-formal-obligations.py` and its `--self-test` pass.
- Removing the obligation now fails the gate: `required proof-sensitive surface detect.graded_witness is missing` (+ the orphaned-marker error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
