### PR TITLE
Re-validate scan-JSON agent usability after the #315 gap fixes

### DIFF
--- a/bench/labels/scanjson_agent_revalidate_2026_06_13.json
+++ b/bench/labels/scanjson_agent_revalidate_2026_06_13.json
@@ -1,0 +1,556 @@
+{
+ "CASE-1 antlr4 cross-lang (was: undecidable \u2014 no equivalence witness)": {
+  "languages": 4,
+  "members": 8,
+  "files": 4,
+  "shared_lines": 0,
+  "params": 0,
+  "scope": "prod",
+  "recommended_surface": "default",
+  "witness_kind": "structural-similarity",
+  "mean_value_jaccard": 0.061,
+  "mean_shape_jaccard": 0.229,
+  "graded": null,
+  "varying_spots": [],
+  "locations": [
+   {
+    "file": "atn/PredictionContext.java",
+    "lines": [
+     345,
+     465
+    ],
+    "kind": "Method",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "v4/prediction_context.go",
+    "lines": [
+     546,
+     661
+    ],
+    "kind": "Function",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "context/PredictionContextUtils.js",
+    "lines": [
+     131,
+     239
+    ],
+    "kind": "Function",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "antlr4/PredictionContext.py",
+    "lines": [
+     443,
+     534
+    ],
+    "kind": "Function",
+    "looks_generated": null,
+    "enclosing": null
+   }
+  ]
+ },
+ "CASE-2 arrow locales (was: wrongly 'worthy' \u2014 no difference evidence)": {
+  "languages": 1,
+  "members": 4,
+  "files": 1,
+  "shared_lines": 13,
+  "params": 2,
+  "scope": "prod",
+  "recommended_surface": "default",
+  "witness_kind": "structural-similarity",
+  "mean_value_jaccard": 1.0,
+  "mean_shape_jaccard": 1.0,
+  "graded": {
+   "holes": 0,
+   "equal_modulo_holes": true,
+   "patterns": null,
+   "referent_mismatches": null,
+   "caveat_names": null,
+   "spots": []
+  },
+  "varying_spots": [
+   {
+    "a": "delta: Union[int, float] = 0,",
+    "b": "delta: Union[float, int] = 1,  # key is always future when only_distance=False"
+   },
+   {
+    "a": "# German uses a different case without 'in' or 'ago' humanized: str = self.timeframes_only_distance[timeframe].format( trunc(abs(delta)) )",
+    "b": "# Sinhala uses a different case without 'in' or 'ago' humanized = self.timeframes_only_distance[timeframe].format(trunc(abs(delta)))"
+   }
+  ],
+  "locations": [
+   {
+    "file": "arrow/locales.py",
+    "lines": [
+     2111,
+     2132
+    ],
+    "kind": "Method",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "arrow/locales.py",
+    "lines": [
+     6110,
+     6128
+    ],
+    "kind": "Method",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "arrow/locales.py",
+    "lines": [
+     6483,
+     6500
+    ],
+    "kind": "Method",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "arrow/locales.py",
+    "lines": [
+     5657,
+     5671
+    ],
+    "kind": "Method",
+    "looks_generated": null,
+    "enclosing": null
+   }
+  ]
+ },
+ "CASE-3 cmark scanners.c (was: wrongly 'worthy' \u2014 generated not flagged)": {
+  "languages": 1,
+  "members": 63,
+  "files": 1,
+  "shared_lines": 23,
+  "params": 4,
+  "scope": "prod",
+  "recommended_surface": "generated",
+  "witness_kind": "structural-similarity",
+  "mean_value_jaccard": 0.98,
+  "mean_shape_jaccard": 0.99,
+  "graded": {
+   "holes": 36,
+   "equal_modulo_holes": false,
+   "patterns": null,
+   "referent_mismatches": null,
+   "caveat_names": null,
+   "spots": [
+    {
+     "class": "literal",
+     "a": "if (yych <= ',')",
+     "b": "if (yych <= 'Z') {"
+    },
+    {
+     "class": "operator",
+     "a": "if (yych <= '.') {",
+     "b": "if (yych <= '=') {"
+    },
+    {
+     "class": "literal",
+     "a": "if (yych <= '=') {",
+     "b": "if (yych <= '>')"
+    },
+    {
+     "class": "operator",
+     "a": "if (yych <= '-')",
+     "b": null
+    },
+    {
+     "class": "operator",
+     "a": null,
+     "b": "if (yych <= 'Z') {"
+    },
+    {
+     "class": "literal",
+     "a": "if (yych <= '=') {",
+     "b": "if (yych <= '@')"
+    }
+   ]
+  },
+  "varying_spots": [
+   {
+    "a": "if (yych <= '-') goto yy31; goto yy27;",
+    "b": "if (yych >= '.') goto yy27;"
+   },
+   {
+    "a": "goto yy32;",
+    "b": "goto yy29;"
+   },
+   {
+    "a": "goto yy32;",
+    "b": "goto yy29;"
+   },
+   {
+    "a": "goto yy32;",
+    "b": "goto yy29;"
+   }
+  ],
+  "locations": [
+   {
+    "file": "src/scanners.c",
+    "lines": [
+     1692,
+     1720
+    ],
+    "kind": "Block",
+    "looks_generated": true,
+    "enclosing": "_scan_autolink_email"
+   },
+   {
+    "file": "src/scanners.c",
+    "lines": [
+     1642,
+     1669
+    ],
+    "kind": "Block",
+    "looks_generated": true,
+    "enclosing": "_scan_autolink_email"
+   },
+   {
+    "file": "src/scanners.c",
+    "lines": [
+     1749,
+     1776
+    ],
+    "kind": "Block",
+    "looks_generated": true,
+    "enclosing": "_scan_autolink_email"
+   },
+   {
+    "file": "src/scanners.c",
+    "lines": [
+     1800,
+     1827
+    ],
+    "kind": "Block",
+    "looks_generated": true,
+    "enclosing": "_scan_autolink_email"
+   }
+  ]
+ },
+ "CASE-4 alacritty vi_mode.rs (was: wrong scope=prod)": {
+  "languages": 1,
+  "members": 2,
+  "files": 1,
+  "shared_lines": 18,
+  "params": 3,
+  "scope": "test",
+  "recommended_surface": "default",
+  "witness_kind": "copy-paste-run",
+  "mean_value_jaccard": null,
+  "mean_shape_jaccard": null,
+  "graded": null,
+  "varying_spots": [
+   {
+    "a": "fn semantic_wide() {",
+    "b": "fn word_wide() {"
+   },
+   {
+    "a": "cursor = cursor.motion(&mut term, ViMotion::SemanticRight);",
+    "b": "cursor = cursor.motion(&mut term, ViMotion::WordRight);"
+   },
+   {
+    "a": "cursor = cursor.motion(&mut term, ViMotion::SemanticLeft);",
+    "b": "cursor = cursor.motion(&mut term, ViMotion::WordLeft);"
+   }
+  ],
+  "locations": [
+   {
+    "file": "src/vi_mode.rs",
+    "lines": [
+     686,
+     709
+    ],
+    "kind": "Block",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "src/vi_mode.rs",
+    "lines": [
+     762,
+     785
+    ],
+    "kind": "Block",
+    "looks_generated": null,
+    "enclosing": null
+   }
+  ]
+ },
+ "FRESH flask (top family)": {
+  "languages": 1,
+  "members": 9,
+  "files": 2,
+  "shared_lines": 2,
+  "params": 0,
+  "scope": "test",
+  "recommended_surface": "default",
+  "witness_kind": "exact-value-graph",
+  "mean_value_jaccard": null,
+  "mean_shape_jaccard": null,
+  "graded": null,
+  "varying_spots": [],
+  "locations": [
+   {
+    "file": "tests/test_blueprints.py",
+    "lines": [
+     439,
+     440
+    ],
+    "kind": "Function",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "tests/test_blueprints.py",
+    "lines": [
+     448,
+     449
+    ],
+    "kind": "Function",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "tests/test_blueprints.py",
+    "lines": [
+     472,
+     473
+    ],
+    "kind": "Function",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "tests/test_blueprints.py",
+    "lines": [
+     489,
+     490
+    ],
+    "kind": "Function",
+    "looks_generated": null,
+    "enclosing": null
+   }
+  ]
+ },
+ "FRESH gin (top family)": {
+  "languages": 1,
+  "members": 12,
+  "files": 1,
+  "shared_lines": 15,
+  "params": 2,
+  "scope": "test",
+  "recommended_surface": "default",
+  "witness_kind": "structural-similarity",
+  "mean_value_jaccard": 0.507,
+  "mean_shape_jaccard": 0.9,
+  "graded": {
+   "holes": 1,
+   "equal_modulo_holes": true,
+   "patterns": null,
+   "referent_mismatches": null,
+   "caveat_names": [
+    "assert",
+    "http",
+    "io",
+    "string"
+   ],
+   "spots": [
+    {
+     "class": "input",
+     "a": "DebugMode,",
+     "b": "TestMode,"
+    }
+   ]
+  },
+  "varying_spots": [
+   {
+    "a": "func TestLoadHTMLGlobDebugMode(t *testing.T) {",
+    "b": "func TestLoadHTMLGlobTestMode(t *testing.T) {"
+   },
+   {
+    "a": "DebugMode,",
+    "b": "TestMode,"
+   }
+  ],
+  "locations": [
+   {
+    "file": "gin/gin_test.go",
+    "lines": [
+     65,
+     83
+    ],
+    "kind": "Function",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "gin/gin_test.go",
+    "lines": [
+     123,
+     141
+    ],
+    "kind": "Function",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "gin/gin_test.go",
+    "lines": [
+     143,
+     161
+    ],
+    "kind": "Function",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "gin/gin_test.go",
+    "lines": [
+     190,
+     208
+    ],
+    "kind": "Function",
+    "looks_generated": null,
+    "enclosing": null
+   }
+  ]
+ },
+ "FRESH rxjs (top family)": {
+  "languages": 1,
+  "members": 31,
+  "files": 31,
+  "shared_lines": 21,
+  "params": 1,
+  "scope": "test",
+  "recommended_surface": "default",
+  "witness_kind": "copy-paste-run",
+  "mean_value_jaccard": null,
+  "mean_shape_jaccard": null,
+  "graded": null,
+  "varying_spots": [
+   {
+    "a": "finalize(() => {",
+    "b": "tap(() => {"
+   }
+  ],
+  "locations": [
+   {
+    "file": "operators/finalize-spec.ts",
+    "lines": [
+     253,
+     276
+    ],
+    "kind": "Block",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "operators/tap-spec.ts",
+    "lines": [
+     293,
+     316
+    ],
+    "kind": "Block",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "operators/audit-spec.ts",
+    "lines": [
+     447,
+     468
+    ],
+    "kind": "Block",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "operators/catchError-spec.ts",
+    "lines": [
+     463,
+     484
+    ],
+    "kind": "Block",
+    "looks_generated": null,
+    "enclosing": null
+   }
+  ]
+ },
+ "FRESH jedis (top family)": {
+  "languages": 1,
+  "members": 19,
+  "files": 19,
+  "shared_lines": 4,
+  "params": 0,
+  "scope": "test",
+  "recommended_surface": "default",
+  "witness_kind": "structural-similarity",
+  "mean_value_jaccard": 1.0,
+  "mean_shape_jaccard": 1.0,
+  "graded": {
+   "holes": 0,
+   "equal_modulo_holes": true,
+   "patterns": null,
+   "referent_mismatches": null,
+   "caveat_names": [
+    "endpoint",
+    "protocol"
+   ],
+   "spots": []
+  },
+  "varying_spots": [],
+  "locations": [
+   {
+    "file": "bloom/BloomRedisClientCommandsIT.java",
+    "lines": [
+     18,
+     21
+    ],
+    "kind": "Method",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "bloom/CMSRedisClientCommandsIT.java",
+    "lines": [
+     18,
+     21
+    ],
+    "kind": "Method",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "bloom/CuckooRedisClientCommandsIT.java",
+    "lines": [
+     18,
+     21
+    ],
+    "kind": "Method",
+    "looks_generated": null,
+    "enclosing": null
+   },
+   {
+    "file": "bloom/TDigestRedisClientCommandsIT.java",
+    "lines": [
+     18,
+     21
+    ],
+    "kind": "Method",
+    "looks_generated": null,
+    "enclosing": null
+   }
+  ]
+ }
+}

--- a/docs/home.md
+++ b/docs/home.md
@@ -81,6 +81,7 @@ You want to *change* nose or understand how it works inside.
 - [adversarial-coevolution](adversarial-coevolution.md) — the cross-axis campaign runbook: a white-box attacker derives structurally-missed patterns, an assessor prices them, a defender ships the largest sound generalization.
 - [field-evaluation](field-evaluation.md) — qualitative results from running nose on real third-party projects.
 - [scanjson-agent-audit-2026-06-10](scanjson-agent-audit-2026-06-10.md) — can an LLM agent decide and act from scan JSON alone? The measured gap list for consumer 1's evidence surface.
+- [scanjson-agent-audit-2026-06-13](scanjson-agent-audit-2026-06-13.md) — the re-validation after the gap fixes (incl. the graded witness): all five gaps closed, 8/8 decidable from JSON alone.
 - [fragment-quality-audit-2026-06-10](fragment-quality-audit-2026-06-10.md) — labeled Java/Python hidden/review exact-fragment sample and the resulting surface policy.
 - [dogfooding](dogfooding.md) — nose run on its own source, and what its findings taught us.
 

--- a/docs/scanjson-agent-audit-2026-06-10.md
+++ b/docs/scanjson-agent-audit-2026-06-10.md
@@ -1,5 +1,9 @@
 # Scan-JSON agent-usability audit, 2026-06-10
 
+> **Follow-up:** the five gaps below were subsequently closed; the
+> [2026-06-13 re-validation](scanjson-agent-audit-2026-06-13.md) re-decided the four
+> failures plus a fresh sample at 8/8 from JSON alone.
+
 [design](design.md) §2 names scan-JSON evidence richness as **the** lever for consumer 1
 (LLM agents calling nose): the output "should carry *why* two units are equivalent,
 *what* differs, exact locations, and the behavior contract, so the agent can decide and

--- a/docs/scanjson-agent-audit-2026-06-13.md
+++ b/docs/scanjson-agent-audit-2026-06-13.md
@@ -1,0 +1,67 @@
+# Scan-JSON agent-usability re-validation, 2026-06-13
+
+The [2026-06-10 audit](scanjson-agent-audit-2026-06-10.md) measured whether an LLM agent
+([design](design.md) §2's consumer 1) can decide and act from scan JSON alone, and scored
+**14 of 18** families decidable — with a ranked list of five evidence gaps behind the four
+failures. Since then those gaps have been filled, most recently by the
+[graded witness](graded-witness.md) (#315, which targeted gaps 1–2). This re-validation
+asks: **do the fixes actually close the gaps?** The data artifact is
+[bench/labels/scanjson_agent_revalidate_2026_06_13.json](../bench/labels/scanjson_agent_revalidate_2026_06_13.json).
+
+## Protocol
+
+The four previously-failed families were re-located in the current detector output (the
+*same discriminating cases*; detection has shifted since June 10, so this is the same
+protocol on the same cases, not byte-identical families), plus a fresh four-repo sample
+(top default family of `flask`, `gin`, `rxjs`, `jedis`). An independent agent decided
+worthy / not-worthy / **undecidable** for each using **only the scan-JSON object** — no
+source access — and named the JSON fields that drove the call. Decisions were then graded
+against the known truth.
+
+## The five gaps are closed
+
+Each gap from the 2026-06-10 ranking now carries its evidence in the JSON:
+
+| gap (2026-06-10) | closing evidence (confirmed in output) |
+|---|---|
+| 1. no equivalence witness on default families | `witness.kind` on every family + `mean_value_jaccard`/`mean_shape_jaccard` for near; `witness.graded` for same-language near ([graded witness](graded-witness.md), #315) |
+| 2. no difference evidence | `varying_spots` (per-side text) + `witness.graded.spots` (classified holes with text) — #315 |
+| 3. generated markers neither surfaced nor honored | `looks_generated` per location + `recommended_surface: "generated"` (off the default surface) |
+| 4. block locations carry no enclosing unit name | `enclosing_unit` (file/span/kind/name) on every block location |
+| 5. Rust inline `mod tests` scope-tagged `prod` | `scope: "test"` (inline-test-module awareness in `is_test_loc`) |
+
+## Score
+
+**8 of 8 decidable from the JSON alone** — the four previously-failed cases are all now
+decidable, and all four decisions are correct against the truth:
+
+| case | 2026-06-10 | now | closing field |
+|---|---|---|---|
+| antlr4 cross-lang (`PredictionContext`) | undecidable | not-worthy (cross-language port) | `languages: 4` + the witness's `mean_value_jaccard` |
+| arrow `locales.py` | wrongly *worthy* | not-worthy (parallel-by-design locale code) | `varying_spots` (the `German`↔`Sinhala` difference evidence) |
+| cmark `scanners.c` | wrongly *worthy* | not-worthy (generated) | `recommended_surface: "generated"` + `looks_generated` |
+| alacritty `vi_mode.rs` | wrong scope | not-worthy (test scaffold) | `scope: "test"` |
+
+The fresh sample was also 4/4 decidable, with the graded witness actively driving two of
+them: `gin` (one `input` hole, `DebugMode`↔`TestMode` — a parameterized test) and `jedis`
+(`caveat_names: [endpoint, protocol]` — per-class setup, not a clean hoist).
+
+## What this concludes — and does not
+
+The consumer-1 loop [design](design.md) §2 calls **the** lever now closes on this sample:
+the JSON carries *why* (witness kind/Jaccard), *what differs* (varying spots, graded
+holes), *where* (spans, enclosing names), and the *non-action signals* (generated, test
+scope) an agent needs to decide without re-deriving the analysis.
+
+Honest limits: the sample is small (8) and every family resolved to *not-worthy* — this
+set has no genuine prod refactor target to confirm the *worthy* direction with equal force
+(the `worthy` arm is exercised by the [benchmark](benchmark.md)'s P@10, not here). The
+weakest decision (`flask`) rests on `scope: test` + `shared_lines: 2` alone — a 2-line body
+carries no `varying_spots`/`graded`/`enclosing`, so it is decided on size, not content. The
+recurring fresh-repo head-of-ranking audit ([design](design.md) §2c) remains the standing
+instrument; this confirms the #315 evidence investment paid off against the gaps it
+targeted.
+
+*See also: [scanjson-agent-audit-2026-06-10](scanjson-agent-audit-2026-06-10.md) ·
+[graded-witness](graded-witness.md) · [scan JSON](scan-json.md) · [design](design.md) ·
+[agent-recipe](agent-recipe.md).*


### PR DESCRIPTION
Closes the loop on why #315 was prioritized: did the graded witness (and the other evidence fixes) actually make scan JSON sufficient for an LLM agent (consumer 1) to decide from?

The [2026-06-10 audit](https://github.com/corca-ai/nose/blob/main/docs/scanjson-agent-audit-2026-06-10.md) scored **14/18** families decidable from JSON alone, with five ranked evidence gaps behind the four failures. All five are now closed — **gaps 1–2 by the graded witness (#315)**, gaps 3–5 by the generated-marker / enclosing-name / inline-test-scope fixes.

### Result
Re-decided the four previously-failed cases (same protocol, same discriminating cases) + a fresh four-repo sample, **JSON-only**, via an independent agent: **8/8 decidable**, all four prior failures now correct against truth.

| case | was | now | closing field |
|---|---|---|---|
| antlr4 cross-lang | undecidable | not-worthy (port) | `languages` + witness `mean_value_jaccard` |
| arrow locales | wrongly worthy | not-worthy | `varying_spots` (#315 difference evidence) |
| cmark scanners.c | wrongly worthy | not-worthy (generated) | `recommended_surface: generated` + `looks_generated` |
| alacritty vi_mode.rs | wrong scope | not-worthy (test) | `scope: test` |

Fresh sample 4/4, with the graded witness driving two (`gin` one-hole parameterized test; `jedis` `caveat_names: [endpoint, protocol]`).

### Honest limits
Small sample (8), all resolving to *not-worthy* — the *worthy* arm is exercised by the [benchmark](https://github.com/corca-ai/nose/blob/main/docs/benchmark.md) P@10, not here. The weakest call (`flask`) rests on `scope`+`shared_lines` alone. Docs + data artifact only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
