### PR TITLE
review: carry the graded witness on findings (#318)

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3316,6 +3316,9 @@ pub(crate) fn detect_families(
     if channels.abstraction_only() {
         families.retain(|f| f.abstraction_witness.is_some());
     }
+    // The graded witness is NOT attached here: `review` enriches only the *flagged*
+    // families (a small subset of a diff) in `flag_divergences`, not every near family
+    // in the repo — enriching all of them on every gate run would be wasted work.
     Ok(families)
 }
 
@@ -3740,7 +3743,7 @@ fn weight_shared_lines(
 /// families it cannot witness (cross-language, fragments, pathological files) simply
 /// keep their ungraded witness. The representative pair is the family's two largest
 /// copies (`locations[0]` and `locations[1]`).
-fn enrich_graded_witnesses(
+pub(crate) fn enrich_graded_witnesses(
     families: &mut [nose_detect::RefactorFamily],
     opts: &nose_detect::DetectOptions,
 ) {

--- a/crates/nose-cli/src/review.rs
+++ b/crates/nose-cli/src/review.rs
@@ -66,6 +66,13 @@ struct Divergence {
     /// lines it shares with an un-updated sibling. `--fail` fires only on these;
     /// `--fail-on any` restores span-overlap firing.
     fire_eligible: bool,
+    /// The near family's graded equivalence witness (#315), when present — evidence
+    /// for the consumer to judge a fire: a clean `equal_modulo_holes` family is a
+    /// strong missed-propagation candidate, while `referent_mismatches` /
+    /// `decorator-differs` mark a family whose copies are not really the same logic
+    /// (a likely false fire). It does NOT gate `fire_eligible` (that would risk
+    /// dropping a genuine shared-body propagation).
+    graded: Option<nose_detect::GradedWitness>,
     /// Members whose base span was changed by the diff (the edit landed here).
     changed: Vec<Site>,
     /// Sibling members the change did *not* touch (where it may be missing).
@@ -134,7 +141,21 @@ pub(crate) fn cmd_review(args: ReviewArgs) -> Result<()> {
         set.warn_expired();
     }
 
-    let flagged = flag_divergences(&families, ignore_set.as_ref(), &changed, &base_tree.path);
+    // Normalization knobs for the per-flagged-family graded-witness enrichment; must
+    // match how `detect_families` lowered (cfg_norm/dce/block_units default), so the
+    // re-derived unit roots line up with the family locations' spans.
+    let enrich_opts = nose_detect::DetectOptions {
+        min_lines,
+        min_tokens,
+        ..Default::default()
+    };
+    let flagged = flag_divergences(
+        &families,
+        ignore_set.as_ref(),
+        &changed,
+        &base_tree.path,
+        &enrich_opts,
+    );
 
     // base_tree is removed by Drop after we finish reading families.
     drop(base_tree);
@@ -167,12 +188,13 @@ fn flag_divergences(
     ignore_set: Option<&crate::ignores::IgnoreSet>,
     changed: &HashMap<String, Vec<(u32, u32)>>,
     base_root: &Path,
+    enrich_opts: &nose_detect::DetectOptions,
 ) -> Vec<Divergence> {
     let prefix = canonical(base_root);
     let mut lines = crate::FileLineCache::default();
     let mut flagged: Vec<Divergence> = Vec::new();
-    for fam in families {
-        let fam = repo_relative(fam, &prefix);
+    for orig in families {
+        let fam = repo_relative(orig, &prefix);
         if ignore_set.is_some_and(|set| set.match_family(&fam).is_some()) {
             continue;
         }
@@ -183,6 +205,14 @@ fn flag_divergences(
         if changed_members.is_empty() || untouched.is_empty() {
             continue;
         }
+        // This family is flagged; only now compute the graded witness — on a clone with
+        // the original ABSOLUTE base-worktree paths (enrichment re-reads source), so the
+        // cost is paid per flagged family, not per family in the repo.
+        let graded = {
+            let mut abs = orig.clone();
+            crate::enrich_graded_witnesses(std::slice::from_mut(&mut abs), enrich_opts);
+            abs.witness.and_then(|w| w.graded)
+        };
         // The #245 fire policy input: does the diff touch lines this changed
         // member SHARES with an un-updated sibling (its span minus the
         // varying spots)? §BR measured 51% of review false-fires as
@@ -211,6 +241,7 @@ fn flag_divergences(
             scope: fam.scope,
             witness_kind,
             fire_eligible,
+            graded,
             changed: changed_members
                 .iter()
                 .zip(&touches)
@@ -692,6 +723,7 @@ fn review_json(flagged: &[Divergence], base: &str, changed_files: usize) -> Resu
                 "scope": d.scope,
                 "witness_kind": d.witness_kind,
                 "fire_eligible": d.fire_eligible,
+                "graded": d.graded,
                 "changed": d.changed.iter().map(&site).collect::<Vec<_>>(),
                 "not_updated": d.not_updated.iter().map(&site).collect::<Vec<_>>(),
             })

--- a/docs/review.md
+++ b/docs/review.md
@@ -72,8 +72,20 @@ keeps **every** genuine missed propagation while firing 73% less often than
 span-overlap firing (change-level: 15% of merged changes vs 33%), at 3.7× the
 precision. `--fail-on any` restores the old fire-on-anything behavior for
 ratchet-style use. Each JSON finding carries `fire_eligible`, `witness_kind`,
-`scope`, and per-changed-site `touches_shared`, so a CI wrapper can apply its own
+`scope`, per-changed-site `touches_shared`, and — for near families — the family's
+[graded witness](graded-witness.md) (`graded`: `equal_modulo_holes`, `holes`,
+`patterns`, `referent_mismatches`, `caveat_names`), so a CI wrapper can apply its own
 tier without re-deriving the analysis.
+
+The graded witness is **evidence for the consumer, not a fire gate**: a clean
+`equal_modulo_holes` family is a strong missed-propagation candidate, while a
+`referent-mismatch` / `decorator-differs` family is one whose copies are not really
+the same logic (a likely false fire the consumer can down-rank). It deliberately does
+**not** gate `fire_eligible` — a decorator or a same-named-but-different-referent
+difference does not stop a shared-*body* fix from being a genuine missed propagation,
+so suppressing on it would risk the keep-every-propagation property the §BV policy is
+measured against. The fire decision stays the §BV shared-logic proof; the witness only
+makes a borderline fire explainable.
 
 ## Flags
 


### PR DESCRIPTION
Item ① of the #315 follow-up campaign. **#318's headline — fire only on undeniable claims, kill the span-overlap bucket — is already shipped** (experiments §BV / #245: the conservative shared-logic proof policy, measured at 15% fire rate, 3.7× precision, keeping *every* genuine missed propagation). This PR closes the remaining gap the explorer found: the graded witness (#315) was available in `fam.witness.graded` but `nose review` only used `witness.kind`.

### What
`nose review` findings now carry the near family's **graded witness** (`graded`: `equal_modulo_holes`, `holes`, `patterns`, `referent_mismatches`, `caveat_names`) — evidence for the consumer to judge a borderline fire:
- a clean `equal_modulo_holes` family is a strong missed-propagation candidate;
- a `referent-mismatch` / `decorator-differs` family is one whose copies are not really the same logic — a likely false fire to down-rank.

Enriched **lazily, per flagged family only** (a small subset of a diff), using the original absolute base-worktree paths — so the cost is paid where it matters, not for every near family in the repo (**netty review max 11.9s → 4.3s** vs enriching all).

### Why it does NOT gate the fire
Deliberately. A decorator or a same-named-but-different-referent difference does not stop a shared-**body** fix from being a genuine missed propagation, so suppressing on it would risk the keep-every-propagation property §BV is measured against. The fire decision is unchanged; the witness only makes a borderline fire *explainable* (design §2b: the detector fires on the sound proof, the consumer judges the judgment-deep call).

### Validated (§BR replay harness, netty/rxjs/scrapy/rubocop)
- Default gate still fires at **15%** (= §BV — no regression after the detector changes since June 11).
- The witness surfaces and discriminates on real near fires: a scrapy fire carrying `referent-mismatch` on `ScrapyDeprecationWarning` — a likely false fire the consumer can down-rank.
- All 9 review integration tests pass; fmt/clippy/docs/dup-gate(26)/doc-links green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
