### PR TITLE
Lean-prove the graded witness's anti-unification core (#315)

### DIFF
--- a/docs/graded-witness.md
+++ b/docs/graded-witness.md
@@ -101,12 +101,16 @@ not folded into nose's deterministic order on a neutral signal.
   parameter **signature** — a differing *unused* parameter is invisible (a used one
   surfaces as a value-graph hole). Treat `equal_modulo_holes` as "equal within the
   modeled body and matching decorators".
-- The witness is **evidence, not a proof.** Unlike the exact channel it carries no Lean
-  theorem; its soundness is recorded as the `empirical-only` obligation
-  `detect.graded_witness` (see [formal soundness](formal-soundness.md)), defended by the
-  referent check, the decorator comparison, and the witness soundness battery rather than
-  machine-checked. Treat `referent_mismatches`/`caveat_names` as the honest boundary of
-  the claim.
+- **The structural core is machine-checked; the referent gate is not.** The
+  anti-unification core is now a `proven` Lean obligation, `detect.graded_witness` (see
+  [formal soundness](formal-soundness.md)): both copies match their least general
+  generalization (holes are the only freedom) and a hole-free generalization means the
+  terms are equal. Like [`factor_distribute`](formal-soundness.md)'s Num gate, one
+  precondition stays *empirical* and outside the proof — that names both copies consume
+  resolve to the same referent (`compare_referents`), plus the decorator/sink checks.
+  Those fail the family closed when violated and are defended by the witness soundness
+  battery, not by Lean; treat `referent_mismatches`/`caveat_names` as the honest boundary
+  of the claim.
 - It is **best-effort enrichment**, computed at the presentation layer (which has
   source access), exactly like the line-level [`varying_spots`](scan-json.md) — the two
   describe the same divergence at the value-graph and source-line granularities

--- a/formal/obligations/detect/graded_witness/Proof.lean
+++ b/formal/obligations/detect/graded_witness/Proof.lean
@@ -1,0 +1,99 @@
+/-
+Soundness of the graded witness's anti-unification core (#315).
+
+The witness aligns two units' value graphs by their least general generalization
+(anti-unification): identical sub-structure is kept; each spot where the two differ
+becomes a HOLE. The `equal_modulo_holes` grade then claims the two are equal except at
+those holes. This file machine-checks that structural core over a term model:
+
+  1. `au_matches_left` / `au_matches_right` — both inputs MATCH their anti-unification:
+     it is a genuine generalization (a hole matches anything; non-hole structure must
+     coincide). So everything the generalization pins down (its non-hole part) is shared
+     by both, and the holes are the only freedom — exactly "equal modulo the holes".
+  2. `holefree_au_eq` — when the anti-unification has NO holes, the two terms are equal.
+     This is the degenerate k = 0 case the witness reports as fully-equal (and the exact
+     channel's `equal_modulo_holes` with zero holes).
+
+Boundary (modeled as a precondition, like `factor_distribute`'s Num gate): this proves
+the STRUCTURAL claim over abstract op/leaf identity. The Rust witness additionally
+requires that names both units consume resolve to the SAME referent (`compare_referents`)
+— two leaves with equal abstract key but different referents are split by that check, not
+by this model. That gate's correctness stays empirical (the referent/decorator/sink
+checks and the soundness battery); this file is the structural half it rests on.
+-/
+
+namespace NoseGradedWitness
+
+/-- A value term: a leaf identified by an abstract key (op/const identity), or an
+op-keyed binary node. Binary is without loss of generality for the alignment core. -/
+inductive Term where
+  | leaf : Nat → Term
+  | bin : Nat → Term → Term → Term
+
+/-- A generalization: a hole (a varying spot), or structure mirroring `Term`. -/
+inductive Pat where
+  | hole : Pat
+  | leaf : Nat → Pat
+  | bin : Nat → Pat → Pat → Pat
+
+/-- Anti-unification (least general generalization): identical structure is kept,
+any disagreement collapses to a hole. -/
+def au : Term → Term → Pat
+  | .leaf a, .leaf b => if a = b then .leaf a else .hole
+  | .bin oa la ra, .bin ob lb rb =>
+      if oa = ob then .bin oa (au la lb) (au ra rb) else .hole
+  | _, _ => .hole
+
+/-- `Matches t p`: the term `t` conforms to the generalization `p` — a hole accepts
+anything; non-hole structure must coincide node-for-node. -/
+def Matches : Term → Pat → Prop
+  | _, .hole => True
+  | .leaf a, .leaf b => a = b
+  | .bin oa la ra, .bin ob lb rb => oa = ob ∧ Matches la lb ∧ Matches ra rb
+  | _, _ => False
+
+/-- A generalization with no holes — it pins down the whole term. -/
+def HoleFree : Pat → Prop
+  | .hole => False
+  | .leaf _ => True
+  | .bin _ l r => HoleFree l ∧ HoleFree r
+
+/-- The left input always matches its anti-unification: the LGG is a generalization. -/
+theorem au_matches_left : ∀ t1 t2 : Term, Matches t1 (au t1 t2)
+  | .leaf a, .leaf b => by
+      by_cases h : a = b <;> simp [au, Matches, h]
+  | .leaf _, .bin _ _ _ => by simp [au, Matches]
+  | .bin _ _ _, .leaf _ => by simp [au, Matches]
+  | .bin oa la ra, .bin ob lb rb => by
+      by_cases h : oa = ob
+      · simp [au, Matches, h, au_matches_left la lb, au_matches_left ra rb]
+      · simp [au, Matches, h]
+
+/-- Symmetrically, the right input matches its anti-unification. -/
+theorem au_matches_right : ∀ t1 t2 : Term, Matches t2 (au t1 t2)
+  | .leaf a, .leaf b => by
+      by_cases h : a = b <;> simp [au, Matches, h] <;> omega
+  | .leaf _, .bin _ _ _ => by simp [au, Matches]
+  | .bin _ _ _, .leaf _ => by simp [au, Matches]
+  | .bin oa la ra, .bin ob lb rb => by
+      by_cases h : oa = ob
+      · subst h
+        simp [au, Matches, au_matches_right la lb, au_matches_right ra rb]
+      · simp [au, Matches, h]
+
+/-- If the anti-unification has no holes, the two terms are equal — the k = 0 case the
+witness reports as fully-equal. -/
+theorem holefree_au_eq : ∀ t1 t2 : Term, HoleFree (au t1 t2) → t1 = t2
+  | .leaf a, .leaf b => by
+      by_cases h : a = b <;> simp [au, HoleFree, h]
+  | .leaf _, .bin _ _ _ => by simp [au, HoleFree]
+  | .bin _ _ _, .leaf _ => by simp [au, HoleFree]
+  | .bin oa la ra, .bin ob lb rb => by
+      by_cases h : oa = ob
+      · subst h
+        intro hf
+        simp [au, HoleFree] at hf
+        rw [holefree_au_eq la lb hf.1, holefree_au_eq ra rb hf.2]
+      · simp [au, HoleFree, h]
+
+end NoseGradedWitness

--- a/formal/obligations/detect/graded_witness/meta.toml
+++ b/formal/obligations/detect/graded_witness/meta.toml
@@ -1,8 +1,16 @@
 id = "detect.graded_witness"
-status = "empirical-only"
-kind = "soundness-boundary"
-summary = "The near-channel graded witness's `equal_modulo_holes` grade asserts the two copies' value graphs are equal modulo the reported holes, scoped to the modeled unit body (not definition-site decorators/annotations or signature). It is near-channel evidence, defended by the referent check, the decorator/attribute source comparison, and the witness soundness battery — NOT a machine-checked theorem. Recorded empirical-only so the Lean proof is a tracked gap; a name resolving to different referents, a differing decorator, an unaligned sink, or an over-deep/large pair all fail closed."
+status = "proven"
+kind = "soundness"
+summary = "The graded witness's `equal_modulo_holes` grade asserts the two copies' value graphs are equal modulo the reported holes. Its STRUCTURAL core — anti-unification soundness — is machine-checked: both inputs match their least general generalization (it is a real generalization; holes are the only freedom), and a hole-free anti-unification means the terms are equal (the k=0 case). Like `factor_distribute`'s Num gate, one precondition stays empirical and is NOT part of the proof: that names both copies consume resolve to the same referent (`compare_referents`), plus the decorator/sink checks — these fail the family closed when violated and are defended by the witness soundness battery, not by Lean."
 
 [rust]
 files = ["crates/nose-detect/src/witness.rs"]
 symbols = ["graded_witness", "equal_modulo_holes", "compare_referents"]
+
+[lean]
+proof = "Proof.lean"
+theorems = [
+  "NoseGradedWitness.au_matches_left",
+  "NoseGradedWitness.au_matches_right",
+  "NoseGradedWitness.holefree_au_eq",
+]


### PR DESCRIPTION
Item ③ of the #315 follow-up campaign. Upgrades `detect.graded_witness` from **empirical-only → proven** by machine-checking the witness's structural core in Lean 4.

### Proven (`formal/obligations/detect/graded_witness/Proof.lean`)
Over a term model with holes:
- **`au_matches_left` / `au_matches_right`** — both inputs *match* their least general generalization: the anti-unification is a real generalization, holes are the only freedom, so the non-hole structure is genuinely shared ("equal modulo the holes").
- **`holefree_au_eq`** — a hole-free anti-unification means the two terms are *equal* (the k=0 case the witness reports as fully-equal, and the exact channel's degenerate case).

### Boundary (empirical, by design — same shape as `factor_distribute`'s Num gate)
One precondition stays outside the proof: that names both copies consume resolve to the **same referent** (`compare_referents`), plus the decorator/sink checks. Those fail the family closed when violated and are defended by the witness soundness battery, not by Lean. The proof is the structural half the referent gate rests on — exactly how `factor_distribute` proves distributivity *under* its Num gate without proving the Rust gate itself.

### Enforcement
The #321 required-obligation guard already binds `detect.graded_witness` to its code; flipping to `proven` means the formal gate now also enforces the **Lean file** (the obligation can neither be dropped nor silently reverted to unproven while `graded_witness`/`equal_modulo_holes`/`compare_referents` live).

Lean type-checks clean (v4.30.0); obligation lint (22 obligations, was empirical-only), `--self-test`, and the full `check-lean-proofs.sh` gate all pass. Pure formal+docs — no Rust change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
