### PR TITLE
perf: enrich graded witness only when JSON emits it; index referents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ break.
 
 ## [Unreleased]
 
+### Performance
+- **Interactive `nose scan` no longer pays for the graded witness it does not show.**
+  The graded witness (#315) is serialized only by `--format json`; the human and SARIF
+  surfaces never render it. Enrichment now runs only when JSON is emitted, so a default
+  human scan skips it entirely — ~2.8s of a ~4.6s `--mode near` scan on netty (3249 near
+  families), now ~1.9s. JSON output is unchanged. Referent resolution in the witness is
+  also indexed (sorted call-target evidence + a name-by-span map) instead of an
+  O(units × evidence) scan, and the anti-unification hot path no longer clones argument
+  vectors. A `NOSE_TIME`-gated `enrich` stage timing was added.
+
 ### Fixed
 - **Graded witness now sees definition-site decorators** (#315 follow-up). A decorator's
   arguments are dropped at lowering, so `@click.argument("x")` and

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3511,7 +3511,7 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
         }
     }
     weight_shared_lines(&mut families, &refs, &settings.exclude);
-    enrich_graded_witnesses(&mut families, &opts);
+    enrich_witnesses_for_format(&mut families, &opts, args.format);
     let sort = settings.sort;
     families.sort_by(|a, b| {
         sort.score(b)
@@ -3743,6 +3743,21 @@ fn weight_shared_lines(
 /// families it cannot witness (cross-language, fragments, pathological files) simply
 /// keep their ungraded witness. The representative pair is the family's two largest
 /// copies (`locations[0]` and `locations[1]`).
+/// Attach graded witnesses only when they will actually be emitted. The witness is
+/// serialized solely by the JSON report (the human and SARIF surfaces never render it),
+/// and re-deriving it for every near family is the dominant scan cost on large repos
+/// (netty: ~2.8s of a ~4.6s near scan) — so the common interactive `nose scan` (human)
+/// pays nothing for evidence it does not show.
+fn enrich_witnesses_for_format(
+    families: &mut [nose_detect::RefactorFamily],
+    opts: &nose_detect::DetectOptions,
+    format: ReportFormat,
+) {
+    if matches!(format, ReportFormat::Json) {
+        time_stage("enrich", || enrich_graded_witnesses(families, opts));
+    }
+}
+
 pub(crate) fn enrich_graded_witnesses(
     families: &mut [nose_detect::RefactorFamily],
     opts: &nose_detect::DetectOptions,
@@ -4198,10 +4213,10 @@ fn print_hotspots_refs(families: &[&nose_detect::RefactorFamily]) {
     }
 }
 
-/// Run the corpus discover+parse+lower step, printing its wall time under
-/// `NOSE_TIME` (the in-pipeline stages report themselves; this covers the
-/// frontend, which usually dominates and is otherwise invisible).
-fn time_lower<T>(f: impl FnOnce() -> T) -> T {
+/// Time a named CLI-side stage under `NOSE_TIME` (the in-pipeline detector stages
+/// report themselves; this covers post-detection CLI work — lowering, the graded-witness
+/// enrichment — that is otherwise invisible).
+fn time_stage<T>(label: &str, f: impl FnOnce() -> T) -> T {
     if std::env::var_os("NOSE_TIME").is_none() {
         return f();
     }
@@ -4209,10 +4224,17 @@ fn time_lower<T>(f: impl FnOnce() -> T) -> T {
     let out = f();
     eprintln!(
         "  [time] {:<12} {:>7.1}ms",
-        "lower",
+        label,
         t0.elapsed().as_secs_f64() * 1e3
     );
     out
+}
+
+/// Run the corpus discover+parse+lower step, printing its wall time under
+/// `NOSE_TIME` (the in-pipeline stages report themselves; this covers the
+/// frontend, which usually dominates and is otherwise invisible).
+fn time_lower<T>(f: impl FnOnce() -> T) -> T {
+    time_stage("lower", f)
 }
 
 fn total_dup_lines_refs(fs: &[&nose_detect::RefactorFamily]) -> u32 {

--- a/crates/nose-detect/src/witness.rs
+++ b/crates/nose-detect/src/witness.rs
@@ -244,8 +244,13 @@ impl<'a> Au<'a> {
         }
         self.matched_a.insert(x);
         self.matched_b.insert(y);
-        let (ax, ay) = (nx.args.clone(), ny.args.clone());
-        for (cx, cy) in ax.into_iter().zip(ay) {
+        // Recurse on each aligned argument pair. Index rather than clone the two arg
+        // vecs: this is the per-node hot path, and the immutable borrow of each node is
+        // released before the `&mut self` recursive call.
+        let arity = self.a.dag.nodes[x as usize].args.len();
+        for i in 0..arity {
+            let cx = self.a.dag.nodes[x as usize].args[i];
+            let cy = self.b.dag.nodes[y as usize].args[i];
             self.unify(cx, cy, depth + 1);
         }
     }

--- a/crates/nose-normalize/src/value_graph/value_dag.rs
+++ b/crates/nose-normalize/src/value_graph/value_dag.rs
@@ -259,6 +259,13 @@ pub struct FileReferents<'a> {
     interner: &'a Interner,
     def_by_span: FxHashMap<(u32, u32), NodeId>,
     def_by_name: FxHashMap<Symbol, Vec<NodeId>>,
+    /// Unit name keyed by definition start-byte, for `def_name` — avoids an O(units)
+    /// scan per call-target.
+    name_by_start: FxHashMap<u32, Symbol>,
+    /// `CallTarget` evidence (anchor span + kind) sorted by anchor start-byte, so the
+    /// per-unit lookup is a range scan, not a full `il.evidence` walk (the latter was
+    /// O(units × evidence) — the §BQ "index the hot lookups" rule).
+    call_evidence: Vec<(Span, CallTargetEvidenceKind)>,
     import_evidence: Vec<(Span, ImportEvidenceKind)>,
     /// Content-hash memo shared across the file's units (definitions are re-referenced).
     memo: std::cell::RefCell<FxHashMap<u32, u64>>,
@@ -268,6 +275,7 @@ impl<'a> FileReferents<'a> {
     pub fn new(il: &'a Il, interner: &'a Interner) -> Self {
         let mut def_by_span: FxHashMap<(u32, u32), NodeId> = FxHashMap::default();
         let mut def_by_name: FxHashMap<Symbol, Vec<NodeId>> = FxHashMap::default();
+        let mut name_by_start: FxHashMap<u32, Symbol> = FxHashMap::default();
         for u in &il.units {
             let s = il.node(u.root).span;
             def_by_span
@@ -275,6 +283,7 @@ impl<'a> FileReferents<'a> {
                 .or_insert(u.root);
             if let Some(n) = u.name {
                 def_by_name.entry(n).or_default().push(u.root);
+                name_by_start.entry(s.start_byte).or_insert(n);
             }
         }
         for stmt in top_level_statements_for(il) {
@@ -290,11 +299,22 @@ impl<'a> FileReferents<'a> {
                 _ => None,
             })
             .collect();
+        let mut call_evidence: Vec<(Span, CallTargetEvidenceKind)> = il
+            .evidence
+            .iter()
+            .filter_map(|ev| match ev.kind {
+                EvidenceKind::CallTarget(k) => Some((ev.anchor.span(), k)),
+                _ => None,
+            })
+            .collect();
+        call_evidence.sort_by_key(|(s, _)| s.start_byte);
         FileReferents {
             il,
             interner,
             def_by_span,
             def_by_name,
+            name_by_start,
+            call_evidence,
             import_evidence,
             memo: std::cell::RefCell::new(FxHashMap::default()),
         }
@@ -330,12 +350,9 @@ impl<'a> FileReferents<'a> {
     }
 
     fn def_name(&self, span: Span) -> Option<String> {
-        self.il
-            .units
-            .iter()
-            .find(|u| self.il.node(u.root).span.start_byte == span.start_byte)
-            .and_then(|u| u.name)
-            .map(|s| self.interner.resolve(s).to_string())
+        self.name_by_start
+            .get(&span.start_byte)
+            .map(|&s| self.interner.resolve(s).to_string())
     }
 
     /// The names the unit rooted at `root` consumes, each with a resolved referent.
@@ -349,18 +366,24 @@ impl<'a> FileReferents<'a> {
         out
     }
 
-    /// Referents from `CallTarget` evidence anchored inside the unit.
+    /// Referents from `CallTarget` evidence anchored inside the unit. `call_evidence` is
+    /// sorted by anchor start-byte, so we binary-search to the unit's span and scan only
+    /// that window instead of walking all of `il.evidence` per unit.
     fn call_target_referents(&self, root: NodeId) -> Vec<VgReferent> {
         let il = self.il;
         let unit_span = il.node(root).span;
         let mut out: Vec<VgReferent> = Vec::new();
-        for ev in &il.evidence {
-            if !span_within(unit_span, ev.anchor.span()) {
+        let lo = self
+            .call_evidence
+            .partition_point(|(s, _)| s.start_byte < unit_span.start_byte);
+        for (span, k) in self.call_evidence[lo..]
+            .iter()
+            .take_while(|(s, _)| s.start_byte <= unit_span.end_byte)
+        {
+            if !span_within(unit_span, *span) {
                 continue;
             }
-            let EvidenceKind::CallTarget(k) = ev.kind else {
-                continue;
-            };
+            let k = *k;
             let (name_key, referent, name) = match k {
                 CallTargetEvidenceKind::DirectFunction {
                     target_span,


### PR DESCRIPTION
Maintenance-sweep perf + code-quality pass (part 1 of 2; docs follow separately).

### The win: interactive scan no longer pays for unshown evidence
The graded witness (#315) is serialized **only by `--format json`** — the human and SARIF surfaces never render it — yet enrichment ran for every near family on every scan. On large repos that re-derivation **dominates**: measured `~2.8s of a ~4.6s --mode near scan on netty` (3249 near families, via the new `NOSE_TIME` `enrich` stage). Gating enrichment on the output format means the common interactive `nose scan` (human) skips it entirely:

| netty `--mode near --top 0` | before | after |
|---|---|---|
| human (default) | ~4.6s | **~1.9s** |
| `--format json` | ~4.6s | ~4.6s (unchanged — full witness contract) |

### Also (witness path, helps the JSON case + review)
- **Indexed referent resolution** in `FileReferents`: `CallTarget` evidence is sorted by anchor start-byte and range-scanned per unit (was an O(units × evidence) walk — the §BQ "index the hot lookups" rule), and def-names resolve via a start-byte map instead of a per-call `il.units` scan.
- **Anti-unification hot path** indexes argument pairs instead of cloning both arg vecs per node.
- Added a `NOSE_TIME`-gated `enrich` stage timing (post-detection CLI work was otherwise invisible).

### Safety
Output unchanged: referent-mismatch still fires (commons-lang `of`/`equals`, scrapy `ScrapyDeprecationWarning`), JSON byte-identical across thread counts (determinism invariant), all tests + dup-gate(26) + clippy + fmt pass. The referent index produces identical results — it only changes *how* the evidence is found.

Deferred (documented follow-up): the `--format json --top 0` path still enriches all families (the full-audit contract); narrowing it to emitted families needs a pipeline refactor and is left for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
