### PR TITLE
#317: scope the verify-search broadening; record the type-incoherence finding

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -1803,6 +1803,13 @@ fn verify_battery(probes: &[nose_normalize::Value]) -> Vec<Vec<nose_normalize::V
     // Without these rows the order-sensitive `Str`/`List` model (interp.rs) is starved,
     // and the oracle reads SOUND while the detector reorders untyped `+` (#283-C). Each
     // slot gets a distinct token so every adjacent operand pair differs.
+    //
+    // These rows are kept hand-curated DELIBERATELY: see docs/oracle-value-model.md
+    // (§"Why the battery is not broadened by naive enumeration") — feeding broader typed
+    // inputs (equal strings, bool/null) to slots a typed array/index param would consume
+    // manufactures impossible inputs (a string as an array index) on which the
+    // canonicalizer legitimately differs, producing spurious canon-preservation
+    // violations. A sound broad distinguishing search needs type-domain-aware feeding.
     let s = |t: u64| Value::Str(vec![t]);
     let distinct: [[Value; VERIFY_WIDTH]; 2] = [
         [s(0xC0DE01), s(0xC0DE02), s(0xC0DE03), s(0xC0DE04)],

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -283,6 +283,42 @@ priced, independently shippable fixes**, each with a sound floor — exactly the
 incremental, measured discipline [design §1](design.md) and the
 [co-evolution runbook](adversarial-coevolution.md) call for.
 
+## 7. Why the battery is not broadened by naive enumeration (#317)
+
+#317 proposed replacing the hand-curated input battery (`verify_battery`) with an
+*enumerative* distinguishing-input search. The naive form — feed more value kinds
+(equal strings, bool, null) at more positions — is **unsound**, and the reason is
+worth recording so it is not re-attempted:
+
+The battery is global and positional: row `[a,b,c,d]` is bound to params 0–3 of
+*every* unit, regardless of each param's type. A unit's param carries a coercion only
+when it has **declared domain evidence** (`coerce_to_declared_domain`, interp.rs);
+typed-language array/index params (Java `byte[] bytes`, `int startPos`,
+`String[] a`) carry **none** today, so an incoherent value reaches them uncoerced.
+Feeding, say, a string or a list to a slot a unit uses as an array index manufactures
+an input that **can never occur**, and the canonicalizer legitimately differs on it —
+producing a spurious **canon-preservation** violation (the check is concrete-only but
+does not filter `Err`).
+
+This is not hypothetical, and not new to broadening: the *current* battery already
+trips it. `nose verify` on `netty` reports 3 canon-preservation "violations", all on
+type-incoherent rows — e.g. `isZeroSafe(byte[],int,int)` fed three lists gives
+core `Err` vs full `Bool(false)`; `swap(String[],int,int)` fed a probe row gives
+core `Err,[]` vs full `Err, effects=[…]`. They are masked only because the nightly
+soundness gate's pinned corpus does not include `netty`. **The verify soundness gate
+cannot safely widen its corpus to typed-language repos until this is fixed.**
+
+The sound fix is **type-domain-aware input feeding**: infer each param's domain from
+its *usage* (index operand → Integer, index base / `len` / iteration → Collection,
+arithmetic operand → Number) when no declaration exists, and coerce battery rows
+through it — so the search can broaden without manufacturing impossible inputs. That
+is a behavior-affecting change to the interpreter's binding for *every* verify run
+(per-unit coercion can feed different values to two units in a fingerprint group), so
+it needs corpus-wide re-validation (pinned corpus stays sound, no new false merges,
+completeness stable) and is a separately-priced PR — the same floor-then-model
+discipline as §3. Until then `verify_battery`'s Part 3 stays hand-curated **on
+purpose** (a guard comment there points here).
+
 ---
 
 *See also: [design & direction](design.md) · [formal soundness](formal-soundness.md) ·


### PR DESCRIPTION
#317 asked to replace the hand-curated `verify` input battery with an enumerative distinguishing-input search. I attempted it, and the **naive form is unsound** — this PR records that finding precisely (so it is not re-attempted) plus the design constraint for the sound version, and adds a guard comment. It also surfaces a **pre-existing latent false-positive class** in the oracle.

### Why naive broadening is unsound
The battery is global and positional — row `[a,b,c,d]` binds to params 0–3 of *every* unit regardless of type. A typed array/index param (Java `byte[]`, `int`, `String[]`) carries **no domain evidence**, so coercion (`coerce_to_declared_domain`) is skipped and an incoherent value (a string fed to an array index) reaches it raw. The canonicalizer legitimately differs on that **impossible** input → a spurious **canon-preservation** violation (the check is concrete-only but does not filter `Err`).

### Pre-existing, not just a broadening hazard
The *current* battery already trips this. `nose verify netty` reports **3 canon-preservation "violations"**, all on type-incoherent rows — verified with the actual behaviors:
- `isZeroSafe(byte[],int,int)` fed three lists → core `Err` vs full `Bool(false)`
- `swap(String[],int,int)` fed a probe row → core `Err,[]` vs full `Err, effects=[…]`

They are masked only because the nightly soundness gate's pinned corpus excludes `netty`. **Concrete impact: the verify soundness gate cannot safely widen to typed-language repos until the oracle feeds type-coherent inputs.**

### The sound fix (documented, deferred)
Usage-based param-domain inference + coercion (index operand → Integer, base/`len`/iteration → Collection, arithmetic → Number). It is behavior-affecting for *every* verify run and needs corpus-wide re-validation (pinned corpus stays sound, no new false merges, completeness stable), so it is a separately-priced PR — `docs/oracle-value-model.md §7`.

No battery change here (it stays sound); a guard comment on `verify_battery`'s curated Part 3 points to §7. Pinned-corpus soundness and PR CI are unaffected. Docs + comment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
