### PR TITLE
#315: enrich only the families scan JSON serializes (~34× on --top N)

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3518,7 +3518,6 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
         }
     }
     weight_shared_lines(&mut families, &refs, &settings.exclude);
-    enrich_witnesses_for_format(&mut families, &opts, args.format);
     let sort = settings.sort;
     families.sort_by(|a, b| {
         sort.score(b)
@@ -3532,25 +3531,27 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
     if args.write_baseline {
         return write_scan_baseline(&args, &families);
     }
-    let baseline_comparison = if let Some(path) = args.baseline.as_ref() {
-        let accepted = baseline::load(path)?;
-        let comparison = BaselineComparison::new(path, &accepted, &families);
-        families.retain(|f| !accepted.keys.contains(&baseline::family_key(f)));
-        Some(comparison)
-    } else {
-        None
-    };
-    let (families, ignored_families) = partition_ignored(families, settings.ignore_set.as_ref());
+    let baseline_comparison = apply_scan_baseline(&args, &mut families)?;
+    let (families, mut ignored_families) =
+        partition_ignored(families, settings.ignore_set.as_ref());
     let mut families = families;
     let overrides = classify_surface_overrides(&mut families, &refs, &settings.exclude);
-    let families = families;
 
     // `--top 0` means "no limit": show every family (documented in docs/usage.md).
     let limit = if settings.top == 0 {
-        usize::MAX
+        families.len()
     } else {
-        settings.top
+        settings.top.min(families.len())
     };
+    enrich_serialized_witnesses(
+        &mut families,
+        &mut ignored_families,
+        limit,
+        &opts,
+        args.format,
+    );
+    let families = families;
+
     let shown = families.iter().take(limit).collect::<Vec<_>>();
     let reportable_families = families
         .iter()
@@ -3765,6 +3766,42 @@ fn enrich_witnesses_for_format(
     }
 }
 
+/// Enrich the graded witness on exactly the families scan JSON serializes — the top
+/// `limit` shown families plus every ignored family — and nothing else. The witness is
+/// JSON-only and computed per family, so the thousands of lower-ranked near families JSON
+/// never prints can skip it (netty `--top 50`: ~2.3s → a fraction). `--top 0` sets
+/// `limit == families.len()`, so it still enriches everything — the full-audit contract.
+/// Human/SARIF skip entirely (they don't render the witness).
+fn enrich_serialized_witnesses(
+    families: &mut [nose_detect::RefactorFamily],
+    ignored: &mut [IgnoredFamily],
+    limit: usize,
+    opts: &nose_detect::DetectOptions,
+    format: ReportFormat,
+) {
+    enrich_witnesses_for_format(&mut families[..limit], opts, format);
+    enrich_ignored_witnesses_for_format(ignored, opts, format);
+}
+
+/// Enrich the graded witness on ignored families, which scan JSON serializes under
+/// `ignored_families` (so an audit of the ignore set sees the same evidence as an active
+/// family). They are wrapped in [`IgnoredFamily`], so enrich each in place; the set is the
+/// user's ignore list — typically small, often empty — so the lost batching is immaterial.
+fn enrich_ignored_witnesses_for_format(
+    ignored: &mut [IgnoredFamily],
+    opts: &nose_detect::DetectOptions,
+    format: ReportFormat,
+) {
+    if !matches!(format, ReportFormat::Json) {
+        return;
+    }
+    time_stage("enrich_ignored", || {
+        for fam in ignored {
+            enrich_graded_witnesses(std::slice::from_mut(&mut fam.family), opts);
+        }
+    });
+}
+
 pub(crate) fn enrich_graded_witnesses(
     families: &mut [nose_detect::RefactorFamily],
     opts: &nose_detect::DetectOptions,
@@ -3974,6 +4011,22 @@ fn write_scan_baseline(args: &ScanArgs, families: &[nose_detect::RefactorFamily]
         path.display()
     );
     Ok(())
+}
+
+/// Compare against an accepted baseline: build the comparison, then drop already-accepted
+/// families in place so only new/changed duplication is reported and gated. `None` when no
+/// `--baseline` is set. (`--write-baseline` is handled earlier, before this runs.)
+fn apply_scan_baseline(
+    args: &ScanArgs,
+    families: &mut Vec<nose_detect::RefactorFamily>,
+) -> Result<Option<BaselineComparison>> {
+    let Some(path) = args.baseline.as_ref() else {
+        return Ok(None);
+    };
+    let accepted = baseline::load(path)?;
+    let comparison = BaselineComparison::new(path, &accepted, families);
+    families.retain(|f| !accepted.keys.contains(&baseline::family_key(f)));
+    Ok(Some(comparison))
 }
 
 fn partition_ignored(

--- a/docs/graded-witness.md
+++ b/docs/graded-witness.md
@@ -97,10 +97,13 @@ not folded into nose's deterministic order on a neutral signal.
   fragments and pathological (generated/minified) files.
 - **The unit body, plus decorators by source — not the full signature.** The witness
   compares the two units' *value graphs* (the modeled body), augmented by the
-  source-level decorator/attribute check above. What it still does not model: the
-  parameter **signature** — a differing *unused* parameter is invisible (a used one
-  surfaces as a value-graph hole). Treat `equal_modulo_holes` as "equal within the
-  modeled body and matching decorators".
+  source-level decorator/attribute check above. What it does not model is the parameter
+  **signature** — a differing *unused* parameter is invisible. This is a deliberate,
+  sound boundary, not a gap: a parameter that the body *uses* already surfaces as a
+  value-graph hole (it appears as an input the two copies bind differently), and a
+  parameter the body *never reads* cannot change behavior, so omitting it leaves the
+  "equal body ⟹ equal behavior" claim intact. Treat `equal_modulo_holes` as "equal
+  within the modeled body and matching decorators".
 - **The structural core is machine-checked; the referent gate is not.** The
   anti-unification core is now a `proven` Lean obligation, `detect.graded_witness` (see
   [formal soundness](formal-soundness.md)): both copies match their least general


### PR DESCRIPTION
The #315 graded witness is serialized **only** in scan JSON, yet enrichment ran over *every* near family before the `--top` slice was taken. So `nose scan --format json --top N` enriched thousands of lower-ranked near families it would never print.

### The cost (netty)
- `--format json --top 50`: enrich **2333ms** to emit 50 families — 2160 near families enriched, ~97% discarded.

### The fix
Move enrichment after sort + partition and run it on **exactly the set scan JSON serializes**:
- the top `limit` families (`shown`), plus
- **every** ignored family — `ignored_families` carries the witness too, so an ignore-set audit sees the same evidence as an active family.

`--top 0` sets `limit == families.len()`, so the **full-audit contract is unchanged** (it still enriches everything). Human/SARIF skip entirely, as before (they don't render the witness).

### Result
| run | enrich before | enrich after |
|---|---|---|
| netty `--top 50` | 2333 ms | **69 ms** (~34×) |
| netty `--top 0` | 2504 ms | 2487 ms (contract, unchanged) |

**Output is byte-identical before/after** — the narrowing only skips enrichment of families JSON never prints. Verified with `cmp` on netty (`--top 50`, `--top 0`); plus a per-family witness-equality check on netty (incl. **151 ignored families** under an ignore set — all 28 graded witnesses preserved) and guava (`--top 30`, 15 graded) against the full-audit run.

### Also
- Extracted `apply_scan_baseline` to keep `cmd_scan` under the clippy line budget.
- Documents the witness's **signature boundary** as a *sound* one, not a gap: a *used* parameter already surfaces as a value-graph hole, and an *unused* one cannot affect behavior — so omitting the signature leaves "equal body ⟹ equal behavior" intact (`docs/graded-witness.md`). This closes the "signature modeling" loose end as an intentional, justified scope rather than new code.

Gates: fmt, clippy `-D warnings`, full workspace tests (18 suites), dup-gate (26/26) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
