### PR TITLE
Improve semantic scan extraction hot paths

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -2497,22 +2497,18 @@ fn collect_verify_recs(
                 .count();
             let value_context = (func_count > 1)
                 .then(|| nose_normalize::ValueFingerprintContext::new(&n, &corpus.interner));
-            // The exact channel's claim surface for this file, from the RAW lowered
-            // IL (the same input the detector extracts from), keyed by line span.
-            let claim_by_span: std::collections::HashMap<(u32, u32), bool> =
-                nose_detect::units_of_file(
-                    il,
-                    &corpus.interner,
-                    &nose_detect::DetectOptions::default(),
-                )
+            let exact_safe_roots: Vec<_> = n
+                .units
                 .iter()
-                .map(|f| {
-                    (
-                        (f.start_line, f.end_line),
-                        nose_detect::exact_claim_eligible(f),
-                    )
+                .filter_map(|unit| {
+                    let root = unit.root;
+                    (n.kind(root) == nose_il::NodeKind::Func
+                        && !verify_battery_over_budget(subtree_node_count(&n, root), battery.len()))
+                    .then_some(root)
                 })
                 .collect();
+            let exact_safe_by_span =
+                nose_detect::exact_safe_roots_by_span(&n, &corpus.interner, &exact_safe_roots);
             collect_file_verify_recs(
                 &n,
                 &core,
@@ -2520,7 +2516,7 @@ fn collect_verify_recs(
                 &corpus.interner,
                 battery,
                 &mut oracle,
-                &claim_by_span,
+                &exact_safe_by_span,
             );
             oracle
         })
@@ -2581,9 +2577,7 @@ fn collect_file_verify_recs(
     interner: &Interner,
     battery: &[Vec<nose_normalize::Value>],
     oracle: &mut VerifyOracle,
-    // A span the detector never extracted stays CLAIMABLE (fail closed: an
-    // unknown unit must not silently exempt itself from the gate).
-    claim_by_span: &std::collections::HashMap<(u32, u32), bool>,
+    exact_safe_by_span: &std::collections::HashMap<(u32, u32), bool>,
 ) {
     let file_path = &n.meta.path;
     let core_func = func_span_index(core);
@@ -2685,6 +2679,11 @@ fn collect_file_verify_recs(
             }
         }
         let span = n.node(root).span;
+        let exact_safe = exact_safe_by_span
+            .get(&(span.start_line, span.end_line))
+            .copied()
+            .unwrap_or(true);
+        let claimable = nose_detect::exact_claim_eligible_parts(exact_safe, fp.len());
         oracle.recs.push(VerifyRec {
             fp,
             beh,
@@ -2693,10 +2692,7 @@ fn collect_file_verify_recs(
             end: span.end_line,
             tokens,
             loc: format!("{}:{}", file_path, span.start_line),
-            claimable: claim_by_span
-                .get(&(span.start_line, span.end_line))
-                .copied()
-                .unwrap_or(true),
+            claimable,
             domain_sig: param_domain_signature(n, root),
         });
     }

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -35,7 +35,7 @@ pub fn file_stream(il: &Il, interner: &Interner) -> Stream {
     contiguous::stream(il, interner)
 }
 
-use nose_il::{Corpus, Il, Interner, NodeKind, UnitKind};
+use nose_il::{Corpus, Il, Interner, NodeId, NodeKind, UnitKind};
 use nose_normalize::NormalizeOptions;
 use nose_semantics::ValueLaw;
 use rayon::prelude::*;
@@ -159,7 +159,36 @@ const EXACT_VALUE_MIN: usize = 4;
 /// oracle's HARD soundness gate is scoped to exactly this surface; collisions
 /// between lossy fingerprints are diagnostics, not product false merges (#210).
 pub fn exact_claim_eligible(u: &UnitFeat) -> bool {
-    u.exact_safe && u.value.len() >= EXACT_VALUE_MIN
+    exact_claim_eligible_parts(u.exact_safe, u.value.len())
+}
+
+/// The exact-claim gate when the caller already has the two relevant facts.
+pub fn exact_claim_eligible_parts(exact_safe: bool, value_len: usize) -> bool {
+    exact_safe && value_len >= EXACT_VALUE_MIN
+}
+
+/// Strict exact-safety by source-line span for known roots.
+///
+/// `verify` already computes value fingerprints for the normalized functions it can
+/// afford to interpret. This helper lets it reuse those fingerprints and ask only for
+/// the exact-safety half of the product claim, without running full unit extraction for
+/// soon-to-be-excluded oversized functions.
+pub fn exact_safe_roots_by_span(
+    il: &Il,
+    interner: &Interner,
+    roots: &[NodeId],
+) -> HashMap<(u32, u32), bool> {
+    let facts = strict_exact::StrictFacts::collect(il, interner);
+    roots
+        .iter()
+        .map(|&root| {
+            let span = il.node(root).span;
+            (
+                (span.start_line, span.end_line),
+                strict_exact::strict_exact_safe_tree(il, interner, &facts, root),
+            )
+        })
+        .collect()
 }
 
 impl Detector for ExactBehaviorDetector {

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -482,9 +482,8 @@ pub(crate) fn extract(
         })
         .collect();
     let parents = if block_units {
-        collect_block_units(il, il.root, &mut roots);
         let parents = build_parent_index(il);
-        collect_exact_statement_fragment_units(il, il.root, &parents, interner, &mut roots);
+        collect_extra_unit_roots(il, il.root, &parents, interner, &mut roots);
         Some(parents)
     } else {
         None
@@ -560,9 +559,8 @@ pub fn unit_dags_at(
         })
         .collect();
     if opts.block_units {
-        collect_block_units(&n, n.root, &mut roots);
         let parents = build_parent_index(&n);
-        collect_exact_statement_fragment_units(&n, n.root, &parents, interner, &mut roots);
+        collect_extra_unit_roots(&n, n.root, &parents, interner, &mut roots);
     }
     let facts = StrictFacts::collect(&n, interner);
     let context =
@@ -649,6 +647,20 @@ fn inline_test_module_spans(il: &Il, interner: &Interner) -> Vec<(u32, u32)> {
 
 /// Gate one unit root: collect its pre-order, apply the container/size/dense gates
 /// (reporting skips), and compute the strict-exact verdict and value fingerprint.
+fn exact_safe_for_unit(ctx: &UnitExtractCtx<'_>, root: NodeId, exact_fragment: bool) -> bool {
+    strict_exact_safe_tree(ctx.il, ctx.interner, ctx.facts, root)
+        || (exact_fragment
+            && ctx.parents.is_some_and(|parents| {
+                strict_exact_self_field_fragment_safe(
+                    ctx.il,
+                    ctx.interner,
+                    ctx.facts,
+                    parents,
+                    root,
+                )
+            }))
+}
+
 fn gate_unit(
     ctx: &UnitExtractCtx<'_>,
     unit_root: UnitRoot,
@@ -700,19 +712,14 @@ fn gate_unit(
     }
 
     let safe_start = unit_timer.start();
-    let strict_exact_safe = strict_exact_safe_tree(ctx.il, ctx.interner, ctx.facts, root);
-    let exact_safe = strict_exact_safe
-        || (exact_fragment
-            && ctx.parents.is_some_and(|parents| {
-                strict_exact_self_field_fragment_safe(
-                    ctx.il,
-                    ctx.interner,
-                    ctx.facts,
-                    parents,
-                    root,
-                )
-            }));
+    let exact_safe = exact_safe_for_unit(ctx, root, exact_fragment);
     let safe_ms = UnitTimer::elapsed(safe_start);
+
+    if exact_fragment && !exact_safe {
+        skip(unit_timer, safe_ms, None);
+        return None;
+    }
+
     // The value graph is the semantic fingerprint (already sorted), with the
     // literal-only multiset for data-table detection. Computed before the size
     // gate so the gate can consult semantic richness (below).
@@ -932,8 +939,40 @@ fn unit_minhash(value: &[u64], shapes: &[u64], shape_features: bool, seeds: &[u6
     }
 }
 
-/// Collect sub-function block roots (loops / ifs / try) as extra unit candidates.
-fn collect_block_units(il: &Il, node: NodeId, out: &mut Vec<UnitRoot>) {
+/// Collect sub-function blocks and exact statement fragments in one DFS.
+fn collect_extra_unit_roots(
+    il: &Il,
+    root: NodeId,
+    parents: &[Option<NodeId>],
+    interner: &Interner,
+    out: &mut Vec<UnitRoot>,
+) {
+    let mut block_roots = Vec::new();
+    let mut exact_roots = Vec::new();
+    collect_extra_unit_root_candidates(
+        il,
+        root,
+        parents,
+        interner,
+        true,
+        &mut block_roots,
+        &mut exact_roots,
+    );
+    out.extend(block_roots);
+    for (root, kind) in exact_roots {
+        push_or_upgrade_exact_fragment_root(out, root, kind);
+    }
+}
+
+fn collect_extra_unit_root_candidates(
+    il: &Il,
+    node: NodeId,
+    parents: &[Option<NodeId>],
+    interner: &Interner,
+    exact_enabled: bool,
+    block_roots: &mut Vec<UnitRoot>,
+    exact_roots: &mut Vec<(NodeId, FragmentKind)>,
+) {
     let is_statement_if = il.kind(node) == NodeKind::If
         && il
             .children(node)
@@ -941,46 +980,53 @@ fn collect_block_units(il: &Il, node: NodeId, out: &mut Vec<UnitRoot>) {
             .skip(1)
             .any(|&child| il.kind(child) == NodeKind::Block);
     if matches!(il.kind(node), NodeKind::Loop | NodeKind::Try) || is_statement_if {
-        out.push(UnitRoot {
+        block_roots.push(UnitRoot {
             root: node,
             kind: UnitKind::Block,
             name: None,
             fragment_kind: None,
         });
     }
+    if exact_enabled && exact_fragment_candidate_node(il, node) {
+        if let Some(contract) =
+            crate::fragment::recognize::recognize_contract(il, node, parents, interner)
+        {
+            let kind = contract.kind;
+            // The contract path is the production authority. Keep the old predicate
+            // matrix as a debug-only differential guard while it remains in-tree.
+            debug_assert!(
+                exact_statement_fragment_root(il, node, parents, interner)
+                    .is_some_and(|predicate_kind| predicate_kind == kind),
+                "predicate path must agree with contract-first fragment production for {kind:?}"
+            );
+            exact_roots.push((node, kind));
+        }
+    }
+    let child_exact_enabled = exact_enabled && il.kind(node) != NodeKind::Lambda;
     for &c in il.children(node) {
-        collect_block_units(il, c, out);
+        collect_extra_unit_root_candidates(
+            il,
+            c,
+            parents,
+            interner,
+            child_exact_enabled,
+            block_roots,
+            exact_roots,
+        );
     }
 }
 
-/// Collect single-statement fragments that can become exact semantic units even when
-/// their enclosing function is unsafe because of unrelated siblings.
-fn collect_exact_statement_fragment_units(
-    il: &Il,
-    node: NodeId,
-    parents: &[Option<NodeId>],
-    interner: &Interner,
-    out: &mut Vec<UnitRoot>,
-) {
-    if il.kind(node) == NodeKind::Lambda {
-        return;
-    }
-    if let Some(contract) =
-        crate::fragment::recognize::recognize_contract(il, node, parents, interner)
-    {
-        let kind = contract.kind;
-        // The contract path is the production authority. Keep the old predicate
-        // matrix as a debug-only differential guard while it remains in-tree.
-        debug_assert!(
-            exact_statement_fragment_root(il, node, parents, interner)
-                .is_some_and(|predicate_kind| predicate_kind == kind),
-            "predicate path must agree with contract-first fragment production for {kind:?}"
-        );
-        push_or_upgrade_exact_fragment_root(out, node, kind);
-    }
-    for &c in il.children(node) {
-        collect_exact_statement_fragment_units(il, c, parents, interner, out);
-    }
+fn exact_fragment_candidate_node(il: &Il, node: NodeId) -> bool {
+    matches!(
+        il.kind(node),
+        NodeKind::Return
+            | NodeKind::Throw
+            | NodeKind::Assign
+            | NodeKind::ExprStmt
+            | NodeKind::If
+            | NodeKind::Loop
+            | NodeKind::Block
+    )
 }
 
 fn push_or_upgrade_exact_fragment_root(out: &mut Vec<UnitRoot>, root: NodeId, kind: FragmentKind) {
@@ -3237,6 +3283,40 @@ mod tests {
                 .iter()
                 .any(|unit| unit.fragment_kind == Some(FragmentKind::DirectReturn)),
             "contract-first collector should still produce the exact direct-return fragment"
+        );
+    }
+
+    #[test]
+    fn exact_fragment_collector_does_not_enter_lambda_bodies() {
+        let interner = Interner::new();
+        let fragments = lowered_fragment_units(
+            "function f(x) { const g = () => { return (x + 1) * (x + 2); }; return x; }\n",
+            Lang::JavaScript,
+            &interner,
+        );
+
+        assert!(
+            fragments
+                .iter()
+                .all(|unit| unit.fragment_kind != Some(FragmentKind::DirectReturn)),
+            "lambda-local returns must not become enclosing-file exact fragments"
+        );
+    }
+
+    #[test]
+    fn exact_fragment_collector_keeps_self_field_body_blocks() {
+        let interner = Interner::new();
+        let fragments = lowered_fragment_units(
+            "class C { int value; int limit; void set(int v, int n) { this.value = (v + 1) * (v + 1); this.limit = n + 3; } }\n",
+            Lang::Java,
+            &interner,
+        );
+
+        assert!(
+            fragments
+                .iter()
+                .any(|unit| unit.fragment_kind == Some(FragmentKind::SelfFieldBody)),
+            "body-level self-field fragments are rooted at Block nodes"
         );
     }
 

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -62,7 +62,7 @@ use crate::combine;
 use crate::module_facts::{
     assignment_name_in_scope, collect_all_node_symbols_in_scope,
     collect_module_mutations_in_scope_with_direct_definitions, local_scope_nodes,
-    top_level_statements_for,
+    node_symbol_in_scope, top_level_statements_for,
 };
 use field_state::FieldStateKey;
 use model::sentinel;

--- a/crates/nose-normalize/src/value_graph/api.rs
+++ b/crates/nose-normalize/src/value_graph/api.rs
@@ -125,7 +125,7 @@ pub fn value_fingerprint_lits_anchors_laws_with_context(
     interner: &Interner,
     context: &ValueFingerprintContext,
 ) -> FingerprintLawBundle {
-    let mut b = Builder::new(il, interner).with_context(context);
+    let mut b = Builder::new_with_context(il, interner, context);
     b.build_unit_with_context(root, Some(context));
     finish_fingerprint_law_bundle(b)
 }
@@ -166,7 +166,7 @@ pub fn value_fingerprint_lits_with_context(
     interner: &Interner,
     context: &ValueFingerprintContext,
 ) -> (Vec<u64>, Vec<u64>, Vec<u64>) {
-    let mut b = Builder::new(il, interner).with_context(context);
+    let mut b = Builder::new_with_context(il, interner, context);
     b.build_unit_with_context(root, Some(context));
     b.fingerprint_lits()
 }
@@ -199,7 +199,7 @@ pub fn value_fingerprint_and_contracts_with_context(
     interner: &Interner,
     context: &ValueFingerprintContext,
 ) -> (Vec<u64>, Vec<(u32, u32)>) {
-    let mut b = Builder::new(il, interner).with_context(context);
+    let mut b = Builder::new_with_context(il, interner, context);
     b.build_unit_with_context(root, Some(context));
     finish_fingerprint_contracts(b)
 }

--- a/crates/nose-normalize/src/value_graph/context.rs
+++ b/crates/nose-normalize/src/value_graph/context.rs
@@ -28,9 +28,12 @@ impl ValueFingerprintContext {
         let module = ModuleSeedContext::new(il, interner);
         let subtree_hashes = OnceLock::new();
         let (function_bindings, inline_candidates) = {
-            let mut b = Builder::new(il, interner)
-                .with_shared_subtree_hashes(&subtree_hashes)
-                .with_local_scope_nodes(&module.local_scope);
+            let mut b = Builder::new_with_local_scope_nodes(
+                il,
+                interner,
+                Cow::Borrowed(&module.local_scope),
+            )
+            .with_shared_subtree_hashes(&subtree_hashes);
             b.seed_module_value_bindings_from_context(&module, None);
             (
                 b.collect_function_binding_hashes(),
@@ -53,6 +56,7 @@ struct ModuleSeedContext {
     assignment_deps: FxHashMap<Symbol, FxHashSet<Symbol>>,
     mutated_bindings: FxHashSet<Symbol>,
     unit_symbols: FxHashSet<Symbol>,
+    subtree_symbols: Vec<OnceLock<Vec<Symbol>>>,
 }
 
 impl ModuleSeedContext {
@@ -105,6 +109,7 @@ impl ModuleSeedContext {
             &local_scope,
             &direct_definitions,
         );
+        let subtree_symbols = (0..il.nodes.len()).map(|_| OnceLock::new()).collect();
 
         Self {
             local_scope,
@@ -113,12 +118,13 @@ impl ModuleSeedContext {
             assignment_deps,
             mutated_bindings,
             unit_symbols,
+            subtree_symbols,
         }
     }
 
     fn required_bindings_for(&self, il: &Il, root: NodeId) -> FxHashSet<Symbol> {
         let mut required = FxHashSet::default();
-        collect_all_node_symbols_in_scope(il, root, &self.local_scope, &mut required);
+        required.extend(self.symbols_in_subtree(il, root).iter().copied());
         let mut stack: Vec<Symbol> = required.iter().copied().collect();
         while let Some(name) = stack.pop() {
             let Some(deps) = self.assignment_deps.get(&name) else {
@@ -131,6 +137,27 @@ impl ModuleSeedContext {
             }
         }
         required
+    }
+
+    fn symbols_in_subtree(&self, il: &Il, node: NodeId) -> &[Symbol] {
+        self.subtree_symbols
+            .get(node.0 as usize)
+            .map(|slot| slot.get_or_init(|| self.collect_symbols_in_subtree(il, node)))
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    fn collect_symbols_in_subtree(&self, il: &Il, node: NodeId) -> Vec<Symbol> {
+        let mut symbols = Vec::new();
+        if let Some(symbol) = node_symbol_in_scope(il, node, &self.local_scope) {
+            symbols.push(symbol);
+        }
+        for &child in il.children(node) {
+            symbols.extend_from_slice(self.symbols_in_subtree(il, child));
+        }
+        symbols.sort_unstable();
+        symbols.dedup();
+        symbols
     }
 }
 
@@ -158,19 +185,22 @@ impl ValueFingerprintContext {
 }
 
 impl<'a> Builder<'a> {
+    pub(super) fn new_with_context(
+        il: &'a Il,
+        interner: &'a Interner,
+        context: &'a ValueFingerprintContext,
+    ) -> Self {
+        Builder::new_with_local_scope_nodes(
+            il,
+            interner,
+            Cow::Borrowed(&context.module.local_scope),
+        )
+        .with_shared_subtree_hashes(&context.subtree_hashes)
+    }
+
     pub(super) fn with_shared_subtree_hashes(mut self, hashes: &'a OnceLock<Vec<u64>>) -> Self {
         self.shared_subtree_hashes = Some(hashes);
         self
-    }
-
-    pub(super) fn with_local_scope_nodes(mut self, local_scope_nodes: &'a [bool]) -> Self {
-        self.local_scope_nodes = Cow::Borrowed(local_scope_nodes);
-        self
-    }
-
-    pub(super) fn with_context(self, context: &'a ValueFingerprintContext) -> Self {
-        self.with_shared_subtree_hashes(&context.subtree_hashes)
-            .with_local_scope_nodes(&context.module.local_scope)
     }
 }
 

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -6,6 +6,14 @@ use super::*;
 
 impl<'a> Builder<'a> {
     pub(super) fn new(il: &'a Il, interner: &'a Interner) -> Self {
+        Self::new_with_local_scope_nodes(il, interner, Cow::Owned(local_scope_nodes(il)))
+    }
+
+    pub(super) fn new_with_local_scope_nodes(
+        il: &'a Il,
+        interner: &'a Interner,
+        local_scope_nodes: Cow<'a, [bool]>,
+    ) -> Self {
         Builder {
             il,
             interner,
@@ -35,7 +43,7 @@ impl<'a> Builder<'a> {
             inline_stack: Vec::new(),
             inline_capture: Vec::new(),
             loop_depth: 0,
-            local_scope_nodes: Cow::Owned(local_scope_nodes(il)),
+            local_scope_nodes,
             loop_recurrence: None,
             next_loop_key_base: 0,
             contracts: Vec::new(),

--- a/crates/nose-normalize/src/value_graph/value_dag.rs
+++ b/crates/nose-normalize/src/value_graph/value_dag.rs
@@ -515,13 +515,11 @@ pub fn value_dag(
     context: Option<&ValueFingerprintContext>,
     referents: &FileReferents<'_>,
 ) -> ValueDag {
-    let mut b = Builder::new(il, interner);
-    if let Some(ctx) = context {
-        b = b.with_context(ctx);
-        b.build_unit_with_context(root, Some(ctx));
-    } else {
-        b.build_unit(root);
-    }
+    let mut b = match context {
+        Some(ctx) => Builder::new_with_context(il, interner, ctx),
+        None => Builder::new(il, interner),
+    };
+    b.build_unit_with_context(root, context);
     let nodes = b
         .nodes
         .iter()

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2446,3 +2446,55 @@ behavioral difference can't be witnessed; a latent gap recorded, not a confirmed
 #308 the same session. The series 6–8 theme completes its shape: every soundness miss was
 a kind/identity token lost in an encoding (keyword names, `global`, splats, then literal
 kinds), and every fix preserves it explicitly rather than inferring it from a lossy pack.
+
+## CJ. Scan performance — profiler-first extraction hotspots (2026-06-13)
+
+Performance pass against `origin/main` (`6f61fb3`) using `NOSE_TIME=1`,
+`NOSE_TIME_NORMALIZE=1`, `NOSE_TIME_UNIT_SUMMARY=1`, and macOS `sample` on the pinned
+local bench repos. The profiling target was the semantic scan `normalize+extract` path,
+not candidate scoring: on sympy, the instrumented baseline spent `2726.2ms` in
+`normalize+extract` after lowering, with cumulative unit timing dominated by value graph
+builds for units that were later skipped (`Block value=4837.6ms`, `Function
+value=2270.3ms`). The hottest skipped block file was
+`sympy/physics/quantum/tests/test_spin.py` (`1326` block candidates, `1325` skipped,
+`739.8ms` value time).
+
+Five profiler-backed hotspots were removed without changing scan output:
+
+1. Context-backed value graph builders now borrow the file-level `local_scope_nodes`
+   bitmap directly. The old `Builder::new(...).with_context(...)` path built a fresh
+   bitmap before replacing it with the shared one.
+2. Exact fragments that fail the exact-safety gate return before value fingerprinting.
+   The later dense gate already required `exact_safe && value.len() >= EXACT_VALUE_MIN`,
+   so this only removes dead work.
+3. Exact-fragment recognition is called only for node kinds any migrated recognizer can
+   accept (`Return`, `Throw`, `Assign`, `ExprStmt`, `If`, `Loop`, `Block`).
+4. Block-unit collection and exact-fragment candidate collection share one DFS while
+   preserving the old output order: block roots first, exact-only roots appended, and
+   lambda bodies still excluded from exact-fragment collection.
+5. Module-seed required bindings memoize module-scoped symbols per subtree. Repeated
+   overlapping `collect_all_node_symbols_in_scope` walks across many per-file roots now
+   reuse the cached subtree symbol sets.
+
+The local fast gate exposed one adjacent verify-only hotspot while validating the
+change: `verify` asked `units_of_file` for the exact claim surface before applying the
+node-row battery budget, so a 4,908-token C function that was ultimately reported as
+`battery-bail` still spent `71.55s` in release value-graph canonicalization. Verify now
+computes exact-safety only for functions under the battery budget and combines that with
+the fingerprint it already builds (`exact_claim_eligible_parts`), avoiding duplicate unit
+extraction for excluded functions.
+
+Measured output was byte-identical (`cmp`) for sympy, rubocop, and prettier semantic
+scans. The instrumented sympy run dropped `normalize+extract` from `2726.2ms` to
+`2082.2ms` (about `-23.6%`). A lower-overhead warm reverse-order sympy pair dropped
+`normalize+extract` from `3176.9ms` to `2211.3ms` (about `-30.4%`). Smaller repo checks
+kept the same direction after repeat/reverse runs: rubocop repeated pairs moved from
+`234.1/271.5ms` to `157.2/185.1ms`, and prettier moved from `343.4ms` to `83.2ms`.
+
+Regression coverage: `cargo test -p nose-detect`, `cargo test -p nose-normalize`, and
+`cargo test -p nose-cli --test cli exact_fragments`. Two unit tests pin the collector
+semantics most likely to regress: lambda-local returns stay excluded, and Java
+`SelfFieldBody` fragments rooted at `Block` still collect. The verify battery-bail
+regression test now completes in `0.93s` in the debug CLI test harness; the release
+reproducer above drops from `71.55s` to `0.56s`; and `./scripts/check-ci-local.sh
+--fast` passes.


### PR DESCRIPTION
## Summary
- remove five profiler-backed semantic scan extraction hotspots: shared local-scope reuse, exact-fragment early safety skip, fragment-kind prefiltering, fused block/fragment root traversal, and cached module subtree symbols
- avoid verify claim-surface unit extraction for functions that will be excluded by the battery budget
- document the 2026-06-13 profiling pass and measured results in docs/experiments.md

## Measurements
- sympy scan JSON stayed byte-identical vs origin/main
- instrumented sympy normalize+extract: 2726.2ms -> 2082.2ms
- warm reverse-order sympy normalize+extract: 3176.9ms -> 2211.3ms
- verify oversized battery-bail release repro: 71.55s -> 0.56s

## Tests
- cargo test -p nose-detect
- cargo test -p nose-normalize
- cargo test -p nose-cli --test cli exact_fragments
- cargo test -p nose-cli --test cli verify_json_reports_battery_bail_exclusions -- --nocapture
- awiki lint --root docs
- ./scripts/check-ci-local.sh --fast
