### PR TITLE
Soundness (coevo series 9): close the JS-shift and Ruby-`*` false merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ break.
   vectors. A `NOSE_TIME`-gated `enrich` stage timing was added.
 
 ### Fixed
+- **Two cross-/intra-language false merges closed (adversarial co-evolution series 9).**
+  - **JS bitwise *shifts* are now int32.** #283-D narrowed JS `& | ^` (and `~`) to int32 so
+    they fingerprint distinctly from arbitrary-precision Python/Ruby bitwise, but `<<`/`>>`
+    were left un-narrowed — so JS `a << b` (which shifts `ToInt32(a)`) false-merged with
+    Python's arbitrary-precision `a << b`, though e.g. `1 << 31` is `-2147483648` in JS and
+    `2147483648` in Python. JS shifts now narrow their shifted operand at the build site.
+  - **Ruby `*` is held ordered.** `*` is string/array *repetition* in Ruby and asymmetric —
+    `"ab" * 3` → `"ababab"` but `3 * "ab"` raises — yet the algebra pass folded a constant
+    to the chain's end and the value graph sorted operands by hash, false-merging the two.
+    `*` is now commuted only when sound: Ruby gates on no operand being a possible
+    string/sequence; Python repetition (commutative, `3 * "ab"` == `"ab" * 3`) and
+    JS/TS/Java/Go/C numeric `*` are unaffected. Corpus output is byte-identical (the merges
+    were latent); the soundness oracle stays clean. See [experiments §CK](docs/experiments.md).
 - **Graded witness now sees definition-site decorators** (#315 follow-up). A decorator's
   arguments are dropped at lowering, so `@click.argument("x")` and
   `@click.argument("x", metavar="m")` produce the same value graph — the witness used to

--- a/bench/coevo/false_merges/README.md
+++ b/bench/coevo/false_merges/README.md
@@ -17,12 +17,16 @@ moved into the permanent regression battery.
 | effect_acchain.py | AC-chain sorts effectful leaves | yes | FIXED #286 (A) — `reorder_safe` |
 | neg_involution.py | `-(-x)→x` on optimistically-Num param | yes (canon-preservation) | FIXED #283-B — `proven_numeric` |
 | untyped_add_commute.py | `a+b≡b+a` for untyped (string/list concat) | yes (battery floor #294) | FIXED #283-C — `proven_numeric` `+`-reorder gate |
+| ruby_star_repetition.rb | Ruby `*` reorders, but `"ab"*3` ≠ `3*"ab"` (repetition is asymmetric) | yes | FIXED series 9 — `ac_chain_commutes` Ruby-`*` gate |
+| (cross-lang shift) | JS `a<<b`/`a>>b` (int32) ≡ Python arbitrary-precision `<<`/`>>` | n/a (cross-language — no single-file repro) | FIXED series 9 — JS shift operand int32-narrowed |
 | float_assoc.py | `(a+b)+c≡a+(b+c)` for floats | NO — oracle blind | OPEN (C/float) — needs the `Float` value kind (D-div) |
 
 FIXED rows are now covered by permanent regression tests (effect cases in the
 value-graph suite; `-(-a)`/`a&a`/`a+b` in `crates/nose-cli/tests/equivalence.rs`,
 `double_negation_cancels_only_for_proven_numeric` +
 `bitwise_self_idempotence_gates_on_proven_numeric` +
-`untyped_add_commute_gates_on_proven_numeric`). The reproducer files stay until
-#283 fully closes (the remaining OPEN row, `float_assoc.py`, is oracle-blind — its
+`untyped_add_commute_gates_on_proven_numeric`; the series-9 shift and Ruby-`*` cases in
+`js_shift_is_int32_and_distinct_from_arbitrary_precision` +
+`ruby_star_repetition_is_ordered_but_other_multiply_commutes`). The reproducer files stay
+until #283 fully closes (the remaining OPEN row, `float_assoc.py`, is oracle-blind — its
 float non-associativity needs the `Float` value kind, D-div — see #283-D).

--- a/bench/coevo/false_merges/ruby_star_repetition.rb
+++ b/bench/coevo/false_merges/ruby_star_repetition.rb
@@ -1,0 +1,13 @@
+# Ruby `*` is string/array REPETITION and asymmetric: `"ab" * 3` → "ababab" but
+# `3 * "ab"` raises (Integer#* rejects a String). The algebra pass folded the constant
+# to the chain end and the value graph sorted commutative operands by hash, so the two
+# orders false-merged into one exact-value-graph family. Series 9; FIXED — `*` commute is
+# now gated (Ruby + possible-string operand stays ordered). LATENT: the pinned corpus has
+# no such pair, so `nose verify bench/repos` stayed green.
+def rep_str_first
+  "ab" * 3
+end
+
+def rep_int_first
+  3 * "ab"
+end

--- a/bench/coevo/packets.v1.json
+++ b/bench/coevo/packets.v1.json
@@ -9,7 +9,7 @@
    "mode": "authored",
    "surface": "decidability-filters",
    "claim": "declaration matchers match a declaration LINE, not a prefix",
-   "summary": "import pdb;pdb.post_mortem() / multi-declarator require / require 'x'; File.open \u2014 all classify",
+   "summary": "import pdb;pdb.post_mortem() / multi-declarator require / require 'x'; File.open — all classify",
    "verdict": "violation-fixed",
    "defense": "single-statement discipline (PR #271)"
   },
@@ -81,7 +81,7 @@
    "mode": "blind",
    "surface": "decidability-filters",
    "claim": "open multi-line declaration interiors hold only specifiers",
-   "summary": "os.Exit(1)) closes a Go import; } || x(); closes a JS import; require 'fs' + 1; #include <stdio.h> int x = 1; \u2014 tree-sitter error tolerance voids the parsed-file assumption",
+   "summary": "os.Exit(1)) closes a Go import; } || x(); closes a JS import; require 'fs' + 1; #include <stdio.h> int x = 1; — tree-sitter error tolerance voids the parsed-file assumption",
    "verdict": "violation-fixed",
    "defense": "interior validation + strict closers + lone string args (PR #273)"
   },
@@ -93,7 +93,7 @@
    "mode": "blind",
    "surface": "decidability-filters",
    "claim": "import-list names can smuggle code",
-   "summary": "`eval,` inside from-import parens is still an import name \u2014 wiring, not code",
+   "summary": "`eval,` inside from-import parens is still an import name — wiring, not code",
    "verdict": "refuted",
    "defense": null
   },
@@ -129,7 +129,7 @@
    "mode": "blind",
    "surface": "ranking-grouping-hints",
    "claim": "grouping/hints misbehave on degenerate inputs",
-   "summary": "identical-span double families and repeated in-family locations cannot occur (upstream invariants); transitive chaining accepted \u00a7BZ; helper visibility is judgment-axis; witness-kind set verified closed by S2-C5",
+   "summary": "identical-span double families and repeated in-family locations cannot occur (upstream invariants); transitive chaining accepted §BZ; helper visibility is judgment-axis; witness-kind set verified closed by S2-C5",
    "verdict": "refuted",
    "defense": null
   },
@@ -189,7 +189,7 @@
    "mode": "blind-executable",
    "surface": "decidability-filters",
    "claim": "single-line import/export wiring is pure wiring",
-   "summary": "import/export { x } from Math.max(\"a\",\"b\"); / from x import max(\"a\",\"b\") / import java.util.x + y; \u2014 6 self-verified packets with family ids; from-clause sources, Python name lists, Java paths were shape-checked only",
+   "summary": "import/export { x } from Math.max(\"a\",\"b\"); / from x import max(\"a\",\"b\") / import java.util.x + y; — 6 self-verified packets with family ids; from-clause sources, Python name lists, Java paths were shape-checked only",
    "verdict": "violation-fixed",
    "defense": "from-source + specifier + name-list + dotted-path validation (series-3 PR)"
   },
@@ -203,7 +203,7 @@
    "claim": "--cache-dir scans behave identically to non-cached scans",
    "summary": "build_units_cached skips the corpus-level resolve_imported_immutable_bindings pass (frontend lib.rs:195); 6 attacker probes + 2 assessor probes (imported-binding vs literal, default and semantic modes) could NOT expose an output divergence",
    "verdict": "deferred-issue",
-   "defense": "#275 ESCALATED: reproduced (cold 1 exact family vs cached 0) via a converging shape mined from equivalence.rs \u2014 the test suite as discriminating-input arsenal"
+   "defense": "#275 ESCALATED: reproduced (cold 1 exact family vs cached 0) via a converging shape mined from equivalence.rs — the test suite as discriminating-input arsenal"
   },
   {
    "packet_id": "s3-c3-test-naming-conventions",
@@ -213,7 +213,7 @@
    "mode": "blind-executable",
    "surface": "ranking-grouping-hints",
    "claim": "production code is NEVER misclassified as test (is_test_loc doc)",
-   "summary": "prod validator named test_data_loader.py and OpenAPI spec/ dir tag as test \u2014 ecosystem conventions win by design; the NEVER wording was the violation",
+   "summary": "prod validator named test_data_loader.py and OpenAPI spec/ dir tag as test — ecosystem conventions win by design; the NEVER wording was the violation",
    "verdict": "violation-fixed",
    "defense": "doc claim softened (conventions win; scope is display context); markers unchanged"
   },
@@ -237,7 +237,7 @@
    "mode": "blind-executable",
    "surface": "baseline-ignores",
    "claim": "structured ignores never hide members their selector does not cover",
-   "summary": "paths:[vendor/**] suppressed a family whose other copy lives in src/ \u2014 first-party duplication silently passed --fail-on any (any-member matching was even documented); switched to ALL-members selector semantics",
+   "summary": "paths:[vendor/**] suppressed a family whose other copy lives in src/ — first-party duplication silently passed --fail-on any (any-member matching was even documented); switched to ALL-members selector semantics",
    "verdict": "violation-fixed",
    "defense": "all-members matching in ignores.rs + doc + gate test (series-3 PR)"
   },
@@ -285,7 +285,7 @@
    "mode": "meta",
    "surface": "runbook",
    "claim": "executable-packet attackers can reproduce",
-   "summary": "an Explore-type attacker refused the executable contract (read-only self-interpretation); re-spawned as general-purpose with /tmp-only write scope \u2014 runbook should name the agent capability requirement",
+   "summary": "an Explore-type attacker refused the executable contract (read-only self-interpretation); re-spawned as general-purpose with /tmp-only write scope — runbook should name the agent capability requirement",
    "verdict": "violation-fixed",
    "defense": "runbook attacker-modes note (series-3 PR)"
   },
@@ -333,7 +333,7 @@
    "mode": "measured",
    "surface": "performance-determinism",
    "claim": "the AST migration is cost-neutral",
-   "summary": "A/B vs pre-AST binary: sympy 4.96->6.42s (+29%), craken-agents 0.546->0.760s (+39%) \u2014 serial re-parse of nearly every family-hosting file. Defense: sound-direction prescreen (declaration starters + mid-statement continuation shapes; false negatives only fail open) + parallel parse of unique candidate files. After: sympy 4.67s, craken-agents 0.550s \u2014 at or under the pre-AST baseline, classification byte-identical (42/10). The prescreen's first draft dropped a mid-statement-start family (caught by classification diff, not timing) \u2014 even perf-only gates need the classification diff check",
+   "summary": "A/B vs pre-AST binary: sympy 4.96->6.42s (+29%), craken-agents 0.546->0.760s (+39%) — serial re-parse of nearly every family-hosting file. Defense: sound-direction prescreen (declaration starters + mid-statement continuation shapes; false negatives only fail open) + parallel parse of unique candidate files. After: sympy 4.67s, craken-agents 0.550s — at or under the pre-AST baseline, classification byte-identical (42/10). The prescreen's first draft dropped a mid-statement-start family (caught by classification diff, not timing) — even perf-only gates need the classification diff check",
    "verdict": "violation-fixed",
    "defense": "prescreen + rayon parse (this PR)"
   },
@@ -404,8 +404,8 @@
    "persona": "soundness-skeptic",
    "mode": "blind-executable",
    "surface": "canonicalizer",
-   "claim": "equal fingerprint \u27f9 equal behavior",
-   "summary": "FALSE MERGE (cardinal sin): print(a)+print(b) \u2261 print(b)+print(a), AC chains, *, ^ \u2014 verify-confirmed; node-multiset fingerprint blind to operand order of a commutative op, effectful calls in value position not emitted as ordered effect sinks",
+   "claim": "equal fingerprint ⟹ equal behavior",
+   "summary": "FALSE MERGE (cardinal sin): print(a)+print(b) ≡ print(b)+print(a), AC chains, *, ^ — verify-confirmed; node-multiset fingerprint blind to operand order of a commutative op, effectful calls in value position not emitted as ordered effect sinks",
    "verdict": "deferred-issue",
    "defense": "#283 P0 (value-graph effect model)"
   },
@@ -417,7 +417,7 @@
    "mode": "blind-executable",
    "surface": "canonicalizer",
    "claim": "type-gated rewrites are sound because the type is PROVEN",
-   "summary": "FALSE MERGE: -(-a)\u2261a, a&a\u2261a, a|a\u2261a \u2014 value domain infers Number from the op itself, so the gate passes for untyped params; differs on list input; verify canon-preservation violation",
+   "summary": "FALSE MERGE: -(-a)≡a, a&a≡a, a|a≡a — value domain infers Number from the op itself, so the gate passes for untyped params; differs on list input; verify canon-preservation violation",
    "verdict": "deferred-issue",
    "defense": "#283 P0 (genuine vs optimistic Num proof)"
   },
@@ -429,7 +429,7 @@
    "mode": "blind-executable",
    "surface": "exact-channel-gates",
    "claim": "missing type evidence blocks exact acceptance",
-   "summary": "FALSE MERGE (oracle-blind): a+b\u2261b+a and (a+b)+c\u2261a+(b+c) for untyped params admitted to exact channel + commuted/associated; wrong for strings/floats; verify can't witness (battery never feeds 2 distinct strings, models i64)",
+   "summary": "FALSE MERGE (oracle-blind): a+b≡b+a and (a+b)+c≡a+(b+c) for untyped params admitted to exact channel + commuted/associated; wrong for strings/floats; verify can't witness (battery never feeds 2 distinct strings, models i64)",
    "verdict": "deferred-issue",
    "defense": "#283 P0 (require proven-numeric)"
   },
@@ -441,7 +441,7 @@
    "mode": "blind-executable",
    "surface": "oracle",
    "claim": "verify declares behavior-equal only when truly equal",
-   "summary": "the soundness net has holes: py % (floored) \u2261 js % (truncated), py / \u2261 ruby / , js (x|0)+1 \u2261 x+1; interp maps every Op to one Rust i64 op; index-store mutation dropped+faked as effect. Masks cross-language false merges",
+   "summary": "the soundness net has holes: py % (floored) ≡ js % (truncated), py / ≡ ruby / , js (x|0)+1 ≡ x+1; interp maps every Op to one Rust i64 op; index-store mutation dropped+faked as effect. Masks cross-language false merges",
    "verdict": "deferred-issue",
    "defense": "#283 P0 (interpreter language-awareness)"
   },
@@ -453,7 +453,7 @@
    "mode": "blind-executable",
    "surface": "canonicalizer",
    "claim": "behaviorally-equal forms converge",
-   "summary": "4 oracle-confirmed recall misses: abs(abs x)\u2261abs x and ~(a&b)\u2261~a|~b (both fully sound, no gate needed \u2014 worth adding); max(max(a,b),c)\u2261max(a,max(b,c)) (compositional: MIN/MAX in is_commutative but not is_assoc_comm_code \u2014 clean e-graph-ledger trigger); x+x\u2261x*2 (documented \u00a7BA gap)",
+   "summary": "4 oracle-confirmed recall misses: abs(abs x)≡abs x and ~(a&b)≡~a|~b (both fully sound, no gate needed — worth adding); max(max(a,b),c)≡max(a,max(b,c)) (compositional: MIN/MAX in is_commutative but not is_assoc_comm_code — clean e-graph-ledger trigger); x+x≡x*2 (documented §BA gap)",
    "verdict": "recorded-low-prevalence",
    "defense": "#284 (sound recall rules: abs-idem, bitwise-DeMorgan, min/max AC)"
   },
@@ -465,7 +465,7 @@
    "mode": "informed",
    "surface": "canonicalizer",
    "claim": "canon rules are proven or tested",
-   "summary": "15 gaps: byte-pack u16/u32 + low-bit-toggle have NO Lean proof (positive-only tests); many type-gated rules (abs, minmax, idempotence, negation-distrib) have positive tests but NO hard-negative proving the gate holds \u2014 the AC-chain hard-negative gap is highest risk and overlaps the #283 cardinal-sin cluster",
+   "summary": "15 gaps: byte-pack u16/u32 + low-bit-toggle have NO Lean proof (positive-only tests); many type-gated rules (abs, minmax, idempotence, negation-distrib) have positive tests but NO hard-negative proving the gate holds — the AC-chain hard-negative gap is highest risk and overlaps the #283 cardinal-sin cluster",
    "verdict": "recorded-low-prevalence",
    "defense": "#283 hard-negative + Lean backlog"
   },
@@ -491,7 +491,7 @@
    "claim": "a module function reassigned anywhere in the file is not provably its def body",
    "summary": "`global helper; helper = special_a` inside another function (Python) / bare module reassignment from a function (JS) was invisible to scope_bound (which only checks the call site's lexical enclosing scopes) and to collect_function_binding_hashes (no mutation check). Raw body inlined; callers false-merged (caller(1)=1000 vs 2000). Cross-language.",
    "verdict": "deferred-issue",
-   "defense": "#302 \u2014 the natural gate (reassigned-anywhere) cannot be made precise: the frontend drops global/nonlocal, so a non-top-level `name = x` is indistinguishable from a local shadow. The broad predicate over-fired, killing legitimate inlines at 37 corpus repos (netty -26, raylib -11) for zero soundness gain there \u2014 reverted per 'the defender's ceiling is provability'. Needs frontend global-binding tracking. Only the precise decorator fact (S2-A) shipped."
+   "defense": "#302 — the natural gate (reassigned-anywhere) cannot be made precise: the frontend drops global/nonlocal, so a non-top-level `name = x` is indistinguishable from a local shadow. The broad predicate over-fired, killing legitimate inlines at 37 corpus repos (netty -26, raylib -11) for zero soundness gain there — reverted per 'the defender's ceiling is provability'. Needs frontend global-binding tracking. Only the precise decorator fact (S2-A) shipped."
   },
   {
    "packet_id": "s6-s3-2-caller-via-inline-span",
@@ -503,7 +503,7 @@
    "claim": "Callers are never findings; the site is INSIDE the container",
    "summary": "A pure caller of a function that inline-reinvents the helper was itself reported (called_helper_returns is one call level deep, keyed on the direct callee's own return hash), with a site line outside its own range.",
    "verdict": "violation-fixed",
-   "defense": "Reject a finding whose matched anchor carries a REAL (non-zero) source span outside [container_start,container_end] \u2014 that span belongs to the inlined callee, so the unit is a transitive caller. Zero-span loop-fold anchors (the flagship) fall back to container range and stay."
+   "defense": "Reject a finding whose matched anchor carries a REAL (non-zero) source span outside [container_start,container_end] — that span belongs to the inlined callee, so the unit is a transitive caller. Zero-span loop-fold anchors (the flagship) fall back to container range and stay."
   },
   {
    "packet_id": "s6-s3-3-bound-blind-reduce",
@@ -515,7 +515,7 @@
    "claim": "the matched sub-computation is the SAME computation, never merely similar; matching a fold while iterating differently is not containment",
    "summary": "For indexed while loops the bound is absorbed into a pointer-length contract and dropped from cond_sinks AND the Reduce hash, so a fold over i<n-1 (or an unrelated bound m) value-exactly 'contained' a fold over i<n though they differ on almost every input (11 vs 22 on xs=[1,1],n=2). The documented guard-inclusion check was vacuous (cond_sinks empty).",
    "verdict": "violation-fixed",
-   "defense": "sink_profile now reports used_length_contract; a helper that relied on a pointer-length contract is ineligible (its return hash does not faithfully determine its value). Conservative: also drops the same-bound true-positive shape (S3-1) since the bound is unrecoverable from the hash \u2014 sound recall loss. Genuine length iteration records no contract and stays eligible."
+   "defense": "sink_profile now reports used_length_contract; a helper that relied on a pointer-length contract is ineligible (its return hash does not faithfully determine its value). Conservative: also drops the same-bound true-positive shape (S3-1) since the bound is unrecoverable from the hash — sound recall loss. Genuine length iteration records no contract and stays eligible."
   },
   {
    "packet_id": "s6-s3-1-approximate-site",
@@ -537,9 +537,9 @@
    "mode": "blind",
    "surface": "reinvented-helpers",
    "claim": "replace the matched lines with a call to the helper that already exists (the fix compiles)",
-   "summary": "Field access hashes by name only, so a Go container over struct Span value-exactly 'contains' a helper taking Vec2; the suggested NormBlend(s) is a compile error under Go nominal typing \u2014 the helper cannot be called with the container's operand.",
+   "summary": "Field access hashes by name only, so a Go container over struct Span value-exactly 'contains' a helper taking Vec2; the suggested NormBlend(s) is a compile error under Go nominal typing — the helper cannot be called with the container's operand.",
    "verdict": "recorded-low-prevalence",
-   "defense": "Routes to consumer judgment (the value model erases types by design, clone-types.md). Docs add the type-erasure caveat: in statically-typed languages the suggested call must be type-checked by the consumer. Not suppressed \u2014 the computation IS structurally identical; only callability is undecidable here. No corpus instance observed."
+   "defense": "Routes to consumer judgment (the value model erases types by design, clone-types.md). Docs add the type-erasure caveat: in statically-typed languages the suggested call must be type-checked by the consumer. Not suppressed — the computation IS structurally identical; only callability is undecidable here. No corpus instance observed."
   },
   {
    "packet_id": "s6-s1-keyword-arg-order",
@@ -551,7 +551,7 @@
    "claim": "interprocedural inlining is behavior-preserving; equal fingerprint implies equal behavior",
    "summary": "Python keyword arguments lower to their value in source order, dropping the name, so helper(b=p,a=q) is byte-identical IL to helper(a=p,b=q) and the two callers false-merge as 'exact behavior match' (-2 vs 5 on p=1,q=2). Pre-existing frontend gap; occurs on the opaque-call path too (inline not load-bearing).",
    "verdict": "deferred-issue",
-   "defense": "#301 \u2014 sound fix needs IL Call keyword identity (new node/metadata) canonicalized by name + threaded through the value graph and inline binding + cross-language battery; exceeds the series-6 (#299-surfaces) scope. Reproducer attached."
+   "defense": "#301 — sound fix needs IL Call keyword identity (new node/metadata) canonicalized by name + threaded through the value graph and inline binding + cross-language battery; exceeds the series-6 (#299-surfaces) scope. Reproducer attached."
   },
   {
    "packet_id": "s6-s4-oracle-lockstep",
@@ -561,7 +561,7 @@
    "mode": "blind",
    "surface": "oracle",
    "claim": "nose verify witnesses or fail-closed excludes every inline-created merge; SOUND covers the exact-claim surface",
-   "summary": "No violation. Inline admission and the oracle's callee-execution gate resolve the same DirectFunction target from the same evidence, so the oracle is at least as general as the inline. Census: ~43% of inline-created merge mass is oracle-opaque, all in the fail-closed uninterpretable bucket (free module globals, floats, JS C-style for-loops) \u2014 exclusion mass, not silent SOUND.",
+   "summary": "No violation. Inline admission and the oracle's callee-execution gate resolve the same DirectFunction target from the same evidence, so the oracle is at least as general as the inline. Census: ~43% of inline-created merge mass is oracle-opaque, all in the fail-closed uninterpretable bucket (free module globals, floats, JS C-style for-loops) — exclusion mass, not silent SOUND.",
    "verdict": "green-confirmed",
    "defense": "None needed. Minor cosmetic note: verify labels the bucket 'uninterpretable' while --exclusion-census JSON says 'battery-bail'."
   },
@@ -575,7 +575,7 @@
    "claim": "decorated callers fail closed (boundary edge: methods, not functions)",
    "summary": "Boundary re-attack: decorated-METHOD callers (self.helper(a)) still merge across @double/@triple. Root cause is the PRE-EXISTING opaque method-name identity (self.helper keyed by name 'helper'); a no-decorator control with different method bodies merges identically. Not the content-keying mechanism the S2 fix covers, and predates #299.",
    "verdict": "deferred-issue",
-   "defense": "Documented opaque-method-identity boundary (clone-types.md: unproven methods are name-keyed). A sound fix needs method receiver-type resolution \u2014 separate from this campaign. The S2 fix's content-keying/evidence paths DO correctly gate decorated methods; only the orthogonal opaque-method-name path remains."
+   "defense": "Documented opaque-method-identity boundary (clone-types.md: unproven methods are name-keyed). A sound fix needs method receiver-type resolution — separate from this campaign. The S2 fix's content-keying/evidence paths DO correctly gate decorated methods; only the orthogonal opaque-method-name path remains."
   },
   {
    "packet_id": "s7-s1-splat-erasure",
@@ -584,10 +584,10 @@
    "persona": "py-arg-specialist",
    "mode": "blind",
    "surface": "keyword-arg-identity",
-   "claim": "a call's argument identity matches its (name->value) structure; equal fingerprint \u27f9 equal behavior",
+   "claim": "a call's argument identity matches its (name->value) structure; equal fingerprint ⟹ equal behavior",
    "summary": "The frontend stripped `*expr`/`**expr` to the bare expr, so `f(*args)` lowered identically to `f(args)` and `f(**d)` to `f(d)`. `stats(*xs)` false-merged with `stats(xs)` (len 3 vs 1 on [[1,2,3]]); the oracle read SOUND (both layers used the stripped IL).",
    "verdict": "violation-fixed",
-   "defense": "New NodeKind::Splat (declared last) carries `*`/`**`; the call stays fingerprint-distinct from a plain arg. keyword_arg_binding_plan fails closed on a Splat (dynamic arity \u2192 no inline), and the interpreter evaluates a Splat to its inner value only for opaque calls (where the fingerprint already separates them)."
+   "defense": "New NodeKind::Splat (declared last) carries `*`/`**`; the call stays fingerprint-distinct from a plain arg. keyword_arg_binding_plan fails closed on a Splat (dynamic arity → no inline), and the interpreter evaluates a Splat to its inner value only for opaque calls (where the fingerprint already separates them)."
   },
   {
    "packet_id": "s7-s2-rebind-forms",
@@ -611,7 +611,7 @@
    "claim": "a module function reassigned anywhere is withheld",
    "summary": "`globals()['helper'] = other` is a dynamic module rebind with no `global` statement, so the global-frame detection misses it; callers false-merge.",
    "verdict": "deferred-issue",
-   "defense": "#307 \u2014 a distinct dynamic-write mechanism (no `global` to key off); needs `globals()[<str>] =`/`setattr` subscript recognition + string-literal-to-symbol resolution. Exotic; separate focused fix."
+   "defense": "#307 — a distinct dynamic-write mechanism (no `global` to key off); needs `globals()[<str>] =`/`setattr` subscript recognition + string-literal-to-symbol resolution. Exotic; separate focused fix."
   },
   {
    "packet_id": "s7-s3-effectful-kwarg-reorder",
@@ -621,9 +621,9 @@
    "mode": "blind",
    "surface": "keyword-arg-identity",
    "claim": "reordered same-mapping keyword calls converge soundly",
-   "summary": "The #304 keyword name-sort merged `combine(a=sideA(x), b=sideB(y))` with the reordered `combine(b=sideB(y), a=sideA(x))`. Python evaluates args in SOURCE order, so with effectful values the effect/exception order differs \u2014 a false merge (the oracle witnessed it as advisory; the canonical sort hid it from the hard gate).",
+   "summary": "The #304 keyword name-sort merged `combine(a=sideA(x), b=sideB(y))` with the reordered `combine(b=sideB(y), a=sideA(x))`. Python evaluates args in SOURCE order, so with effectful values the effect/exception order differs — a false merge (the oracle witnessed it as advisory; the canonical sort hid it from the hard gate).",
    "verdict": "violation-fixed",
-   "defense": "Gate the keyword name-sort on `reorder_safe` (the same effect-free predicate as AC operands, \u00a7CE/#286): sort only when every keyword value is effect-free; otherwise keep source order. Pure reorders still converge; effectful ones stay distinct."
+   "defense": "Gate the keyword name-sort on `reorder_safe` (the same effect-free predicate as AC operands, §CE/#286): sort only when every keyword value is effect-free; otherwise keep source order. Pure reorders still converge; effectful ones stay distinct."
   },
   {
    "packet_id": "s7-s4-oracle-parity",
@@ -633,7 +633,7 @@
    "mode": "blind",
    "surface": "oracle",
    "claim": "the oracle binds kwargs/rebinds in lockstep with the value graph; SOUND covers what it reports",
-   "summary": "No oracle blind spot. By-name binding is shared via keyword_arg_binding_plan; source order preserved; rebinds opaque to both; unbindable kwargs fail closed. The oracle stays lockstep-or-stricter \u2014 it WITNESSED the S3 effectful-reorder (advisory) and a string-+ commute (hard violation) rather than silently reading SOUND.",
+   "summary": "No oracle blind spot. By-name binding is shared via keyword_arg_binding_plan; source order preserved; rebinds opaque to both; unbindable kwargs fail closed. The oracle stays lockstep-or-stricter — it WITNESSED the S3 effectful-reorder (advisory) and a string-+ commute (hard violation) rather than silently reading SOUND.",
    "verdict": "green-confirmed",
    "defense": "None needed."
   },
@@ -645,9 +645,9 @@
    "mode": "blind",
    "surface": "canonicalizer",
    "claim": "`+` commutes only when an operand is proven non-concat (#283-C)",
-   "summary": "`\"p\"+\"q\"` \u2261 `\"q\"+\"p\"` false-merges: a string literal's Const key `0x2000_0000.wrapping_add(h)` wraps OUT of the String range when h's high bits are set, so const_value_domain misreads it as non-String \u2192 proven_non_concat wrongly admits the `+` commute. nose verify catches it as a hard violation.",
+   "summary": "`\"p\"+\"q\"` ≡ `\"q\"+\"p\"` false-merges: a string literal's Const key `0x2000_0000.wrapping_add(h)` wraps OUT of the String range when h's high bits are set, so const_value_domain misreads it as non-String → proven_non_concat wrongly admits the `+` commute. nose verify catches it as a hard violation.",
    "verdict": "violation-fixed",
-   "defense": "#308 \u2014 a string literal's Const key kept the `String` class tag but the content hash wrapped out of range. Fixed by masking the hash into the low 28 bits (`string_const_key`), shared by the frontend's LitStr and the synthesized empty string so they agree (the py-`.get(k,\"\")` vs go-zero-value convergence). Verify clean on sympy+guava (49k interpretable units, no collision-induced merges); corpus family deltas small and in the false-merge-separating direction."
+   "defense": "#308 — a string literal's Const key kept the `String` class tag but the content hash wrapped out of range. Fixed by masking the hash into the low 28 bits (`string_const_key`), shared by the frontend's LitStr and the synthesized empty string so they agree (the py-`.get(k,\"\")` vs go-zero-value convergence). Verify clean on sympy+guava (49k interpretable units, no collision-induced merges); corpus family deltas small and in the false-merge-separating direction."
   },
   {
    "packet_id": "s8-s1-int-bool-wrap",
@@ -657,9 +657,9 @@
    "mode": "blind",
    "surface": "value-model",
    "claim": "an int/float Const-key wrap is always fail-closed; no int key wrap causes a false merge",
-   "summary": "The int literal 536870914 (=0x2000_0002) keyed to 0x3000_0002 via 0x1000_0000.wrapping_add(v as u32), byte-identical to LitBool(true)'s key \u2014 so x+536870914 false-merged with x+True. The #308 author's 'ints are fail-closed' claim was false.",
+   "summary": "The int literal 536870914 (=0x2000_0002) keyed to 0x3000_0002 via 0x1000_0000.wrapping_add(v as u32), byte-identical to LitBool(true)'s key — so x+536870914 false-merged with x+True. The #308 author's 'ints are fail-closed' claim was false.",
    "verdict": "violation-fixed",
-   "defense": "#313 \u2014 ValOp::Const restructured to carry the kind explicitly (ConstKind) plus the full value/hash, so no value can wrap a class boundary."
+   "defense": "#313 — ValOp::Const restructured to carry the kind explicitly (ConstKind) plus the full value/hash, so no value can wrap a class boundary."
   },
   {
    "packet_id": "s8-s1-int-truncation",
@@ -669,9 +669,9 @@
    "mode": "blind",
    "surface": "value-model",
    "claim": "int literals are keyed by value distinctly",
-   "summary": "eval keyed LitInt(v) as v as u32, truncating i64 to 32 bits, so 0 \u2261 2^32 and 5 \u2261 4294967301 false-merged. 2^32 is a plausible real constant.",
+   "summary": "eval keyed LitInt(v) as v as u32, truncating i64 to 32 bits, so 0 ≡ 2^32 and 5 ≡ 4294967301 false-merged. 2^32 is a plausible real constant.",
    "verdict": "violation-fixed",
-   "defense": "#313 \u2014 Const{kind:Int, bits} retains the FULL i64."
+   "defense": "#313 — Const{kind:Int, bits} retains the FULL i64."
   },
   {
    "packet_id": "s8-s2-string-28bit-collision",
@@ -683,7 +683,7 @@
    "claim": "#308's string-key mask discriminates distinct strings",
    "summary": "The #308 mask 0x2000_0000 | (h & 0x0FFF_FFFF) kept only 28 bits, so brute-forced strings 'geU'/'aaha' (sharing low-28-bits) collapsed to one Const and false-merged. #308 traded the out-of-range bug for a collision bug.",
    "verdict": "violation-fixed",
-   "defense": "#313 \u2014 Const{kind:Str, bits} retains the FULL 64-bit hash; the 28-bit mask is removed."
+   "defense": "#313 — Const{kind:Str, bits} retains the FULL 64-bit hash; the 28-bit mask is removed."
   },
   {
    "packet_id": "s8-value-model-canon-green",
@@ -696,6 +696,66 @@
    "summary": "Green on the algebraic canon: string-repetition distribution (gated tight), a+'literal' commutativity (held ordered), loose-vs-strict equality (unwitnessable, oracle has no coercion), De Morgan / abs idempotence (sound for all integers). The only exploitable surface was the literal-key hashing, not the canonicalizations.",
    "verdict": "green-confirmed",
    "defense": "None needed."
+  },
+  {
+   "packet_id": "s9-vm-shl-int32",
+   "series": 9,
+   "campaign": "S1",
+   "persona": "soundness-skeptic",
+   "mode": "blind",
+   "surface": "value-model",
+   "claim": "#283-D narrowed JS `& | ^` to int32 so they don't merge with arbitrary-precision Python/Ruby bitwise; the same gap is closed for shifts",
+   "summary": "JS `a << b` shifts ToInt32(a) (32-bit, mod-32) but built a bare Bin(Shl,[a,b]) identical to Python's arbitrary-precision `<<` — false-merging cross-language though `1 << 31` is -2147483648 in JS, 2147483648 in Python (verified with node/python3).",
+   "verdict": "violation-fixed",
+   "defense": "eval_binop_expr narrows the shifted operand via js_int32_narrow for JS Shl/Shr (no-op for non-JS); fingerprints split, JS-vs-JS still converge. Regression: equivalence.rs::js_shift_is_int32_and_distinct_from_arbitrary_precision."
+  },
+  {
+   "packet_id": "s9-vm-shr-int32",
+   "series": 9,
+   "campaign": "S1",
+   "persona": "soundness-skeptic",
+   "mode": "blind",
+   "surface": "value-model",
+   "claim": "same int32-narrowing gap for the right-shift operator `>>`",
+   "summary": "JS `a >> b` is a sign-propagating int32 shift; `(2**32) >> 0` is 0 in JS but 2**32 in Python. Same bare Bin(Shr) false merge as `<<`. (`>>>` was already kept distinct — unmapped in js_bin_op.)",
+   "verdict": "violation-fixed",
+   "defense": "same JS Shl/Shr operand narrowing in eval_binop_expr (series 9)."
+  },
+  {
+   "packet_id": "s9-vm-ruby-mul-strrep",
+   "series": 9,
+   "campaign": "S1",
+   "persona": "soundness-skeptic",
+   "mode": "blind",
+   "surface": "value-model",
+   "claim": "`* & | ^` Err on non-numeric regardless of order, so reordering their operands is always sound",
+   "summary": "FALSE for Ruby `*`: string/array repetition is asymmetric — `\"ab\" * 3` → \"ababab\" but `3 * \"ab\"` raises (Integer#* rejects String). The algebra pass folded a constant to the chain end and the value graph sorted operands by hash, false-merging the two orders (also `[1,2]*3` vs `3*[1,2]`).",
+   "verdict": "violation-fixed",
+   "defense": "ac_chain_commutes gates `*` commute on lang!=Ruby || all-proven-non-concat, applied at all reorder sites (algebra build_assoc + fold_arith skip for Ruby Mul; value-graph AC-chain + 2-operand swap). Largest sound generalization: Python repetition (commutative) and JS/Java/Go/C numeric `*` keep full commutativity — corpus output byte-identical. Regression: equivalence.rs::ruby_star_repetition_is_ordered_but_other_multiply_commutes."
+  },
+  {
+   "packet_id": "s9-oracle-eq-err-incoherent",
+   "series": 9,
+   "campaign": "S2",
+   "persona": "oracle-bail-skeptic",
+   "mode": "blind",
+   "surface": "oracle",
+   "claim": "`nose verify` canon-preservation bails are fail-closed and report no spurious violation",
+   "summary": "RE-CONFIRMS and SHARPENS the documented §7 type-incoherence false-positive class: the trigger is an EQUALITY (==/!=) canon meeting an `Err` operand (relational `<` over the same incoherent subscript is clean; a bare subscript is clean), and it is LANGUAGE-INDEPENDENT (untyped Python `b[s]==0` reproduces it), so the root is collect_file_verify_recs's concrete-only canon check not filtering `Err`, not declared-param-domain absence per se. Masked on the nightly gate because netty is not in the pinned corpus.",
+   "verdict": "recorded-low-prevalence",
+   "defense": "Deferred (same as §7). The cheap candidate — skip canon-preservation rows where either behavior carries Err — needs soundness vetting against the cross-unit false-merge check (Err-vs-value IS a distinguishing behavior there), so it is not shipped blind. Boundary recorded in oracle-value-model.md §7."
+  },
+  {
+   "packet_id": "s9-perf-enrich-narrowing",
+   "series": 9,
+   "campaign": "S3",
+   "persona": "perf-determinism",
+   "mode": "blind",
+   "surface": "performance-determinism",
+   "claim": "#328 enrich-only-emitted is byte-identical to full enrichment for every --top/ignore, and scan JSON is deterministic under thread variation",
+   "summary": "GREEN with teeth. jedis (2508 families, 1063 near+graded): 2560 per-family witness comparisons across --top {0,5,30} + a 6-entry ignore file spanning near ranks 2..2507 — zero witness loss, all 6 ignored families keep graded at --top 5. Determinism 9/9 byte-identical (cmp) across RAYON_NUM_THREADS=1 vs default and repeats on jedis/commons-lang/flask.",
+   "verdict": "green-confirmed",
+   "defense": "n/a — the merge-time content-invariance and determinism claims hold."
   }
  ]
 }

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -6702,6 +6702,80 @@ fn js_unsigned_shift_stays_distinct_from_signed_shift() {
 }
 
 #[test]
+fn js_shift_is_int32_and_distinct_from_arbitrary_precision() {
+    // series 9: `& | ^` were narrowed to int32 (#283-D) but `<<`/`>>` were not, so JS
+    // `a << b` (shifts ToInt32(a), 32-bit) false-merged with Python's arbitrary-precision
+    // `a << b` — e.g. `1 << 31` is -2147483648 in JS but 2147483648 in Python.
+    let i = Interner::new();
+    let js_shl = "function f(a, b) { return a << b; }";
+    let py_shl = "def f(a, b):\n    return a << b\n";
+    let js_shr = "function g(a, b) { return a >> b; }";
+    let py_shr = "def g(a, b):\n    return a >> b\n";
+    assert_ne!(
+        value_fp(&i, js_shl, Lang::JavaScript),
+        value_fp(&i, py_shl, Lang::Python),
+        "JS `<<` is int32; must not merge with arbitrary-precision Python `<<`"
+    );
+    assert_ne!(
+        value_fp(&i, js_shr, Lang::JavaScript),
+        value_fp(&i, py_shr, Lang::Python),
+        "JS `>>` is int32; must not merge with arbitrary-precision Python `>>`"
+    );
+    // Recall preserved: same-language shifts (and JS-vs-JS) still converge.
+    let js_shl2 = "function h(x, y) { return x << y; }";
+    assert_eq!(
+        value_fp(&i, js_shl, Lang::JavaScript),
+        value_fp(&i, js_shl2, Lang::JavaScript),
+        "two JS `<<` must still converge"
+    );
+    let py_shl2 = "def h(x, y):\n    return x << y\n";
+    assert_eq!(
+        value_fp(&i, py_shl, Lang::Python),
+        value_fp(&i, py_shl2, Lang::Python),
+        "two Python `<<` must still converge"
+    );
+}
+
+#[test]
+fn ruby_star_repetition_is_ordered_but_other_multiply_commutes() {
+    // series 9: `*` is string/array REPETITION in Ruby and asymmetric — `"ab" * 3` →
+    // "ababab" but `3 * "ab"` raises (`Integer#*` rejects a String). Reordering its
+    // operands (the algebra pass folded a constant to the end; the value graph sorted
+    // by hash) false-merged the two. Only Ruby is gated: Python repetition commutes and
+    // JS/Java/Go/C `*` is numeric.
+    let i = Interner::new();
+    let rb_str_first = "def a\n  \"ab\" * 3\nend\n";
+    let rb_int_first = "def b\n  3 * \"ab\"\nend\n";
+    assert_ne!(
+        value_fp(&i, rb_str_first, Lang::Ruby),
+        value_fp(&i, rb_int_first, Lang::Ruby),
+        "Ruby `\"ab\" * 3` (repeats) must not merge with `3 * \"ab\"` (raises)"
+    );
+    let rb_arr_first = "def a\n  [1, 2] * 3\nend\n";
+    let rb_arr_int_first = "def b\n  3 * [1, 2]\nend\n";
+    assert_ne!(
+        value_fp(&i, rb_arr_first, Lang::Ruby),
+        value_fp(&i, rb_arr_int_first, Lang::Ruby),
+        "Ruby `[1,2] * 3` (repeats) must not merge with `3 * [1,2]` (raises)"
+    );
+    // Largest-sound-generalization guard: only Ruby is gated.
+    let js_xy = "function p(x, y) { return x * y; }";
+    let js_yx = "function q(x, y) { return y * x; }";
+    assert_eq!(
+        value_fp(&i, js_xy, Lang::JavaScript),
+        value_fp(&i, js_yx, Lang::JavaScript),
+        "JS `x * y` is numeric and must still commute with `y * x`"
+    );
+    let py_sx = "def p(s):\n    return s * 3\n";
+    let py_xs = "def q(s):\n    return 3 * s\n";
+    assert_eq!(
+        value_fp(&i, py_sx, Lang::Python),
+        value_fp(&i, py_xs, Lang::Python),
+        "Python `s * 3` repetition commutes (`3 * s` is equal) and must still converge"
+    );
+}
+
+#[test]
 fn js_nullish_assignment_desugars_to_nullish_coalescing() {
     // `x ??= y` is `x = x ?? y` — and is NOT `x += y` (the old unmapped-operator
     // fallback silently defaulted compound assignments to Add).

--- a/crates/nose-normalize/src/algebra.rs
+++ b/crates/nose-normalize/src/algebra.rs
@@ -23,7 +23,7 @@
 //! proof-obligation: normalize.value_graph.compare
 
 use crate::combine;
-use nose_il::{Il, IlBuilder, Interner, NodeId, NodeKind, Op, Payload, Span};
+use nose_il::{Il, IlBuilder, Interner, Lang, NodeId, NodeKind, Op, Payload, Span};
 use nose_semantics::{semantics, ComparisonLaw};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -141,7 +141,12 @@ impl Rewriter<'_> {
             // `2 + 3` → `5`, `x + 2 + 3` → `x + 5`, `x + 0` → `x`, `x * 1` → `x`. SOUND —
             // `x` is still evaluated either way. NOT `x * 0 → 0` (would drop `x`'s
             // side effects). Only the arithmetic ring ops; bitwise/logical left as-is.
-            if matches!(op, Op::Add | Op::Mul) {
+            // EXCEPT Ruby `*`: it is string/array REPETITION and asymmetric (`3 * s` Errs
+            // when `s` is a String but `s * 3` repeats), so folding a constant to the end —
+            // a commute — would change behavior. Hold it ordered; the value graph commutes
+            // it type-gated (series 9). Numeric Ruby `*` still converges there.
+            let ruby_mul = op == Op::Mul && self.old.meta.lang == Lang::Ruby;
+            if matches!(op, Op::Add | Op::Mul) && !ruby_mul {
                 return self.fold_arith(op, span, &leaves);
             }
             let operands: Vec<(NodeId, u64)> = leaves.iter().map(|&c| self.rewrite(c)).collect();
@@ -257,14 +262,19 @@ impl Rewriter<'_> {
     ///   • logical `and`/`or` — short-circuit value-and/or is associative but NOT
     ///     commutative (`1 or 2` = 1 ≠ `2 or 1`); kept in source order, canonicalized to
     ///     the positional `Phi` by the value graph.
-    /// Bitwise `&`/`|`/`^` and `*` (string`*`int repetition is commutative too) stay sorted.
+    ///   • Ruby `*` — string/array repetition is non-commutative in Ruby (`"ab" * 3` →
+    ///     "ababab" but `3 * "ab"` raises); kept ordered, commuted type-gated by the value
+    ///     graph (series 9). Python `*` repetition IS commutative and JS/Java/Go/C `*` is
+    ///     numeric, so only Ruby is held.
+    /// Bitwise `&`/`|`/`^` and non-Ruby `*` stay sorted (associativity is always applied).
     fn build_assoc(
         &mut self,
         op: Op,
         span: Span,
         mut operands: Vec<(NodeId, u64)>,
     ) -> (NodeId, u64) {
-        if !matches!(op, Op::And | Op::Or | Op::Add) {
+        let ruby_mul = op == Op::Mul && self.old.meta.lang == Lang::Ruby;
+        if !matches!(op, Op::And | Op::Or | Op::Add) && !ruby_mul {
             operands.sort_by_key(|&(_, h)| h);
         }
         let mut iter = operands.into_iter();

--- a/crates/nose-normalize/src/value_graph/canonicalize.rs
+++ b/crates/nose-normalize/src/value_graph/canonicalize.rs
@@ -58,19 +58,17 @@ impl<'a> Builder<'a> {
                 args.swap(0, 1);
             }
         }
-        // Canonicalize commutative operands by structural hash. `+` commutes UNLESS an
-        // operand is PROVEN string/list — concat is non-commutative (`s + x` ≠ `x + s`)
-        // and the free-monoid oracle distinguishes the orders. Unknown operands keep
-        // commuting (optimistic, and the oracle still checks it), so the common untyped
-        // numeric case is unaffected; only known-concat is held ordered. Other
-        // commutative ops Err on non-numeric regardless of order, so stay safe.
+        // Canonicalize commutative operands by structural hash. The commute is gated per op
+        // (`ac_chain_commutes`): `+` is held ordered when an operand is PROVEN string/list
+        // (concat, `s + x` ≠ `x + s`, #283-C) and `*` when it could be a Ruby string/list
+        // repetition (`"ab" * 3` ≠ `3 * "ab"`, series 9) — both distinguished by the
+        // free-monoid oracle. Unknown operands keep commuting (optimistic, oracle-checked),
+        // so the common untyped numeric case is unaffected; `& | ^`, `==`/`!=`, min/max all
+        // Err-or-symmetric regardless of order and stay safe.
         if let ValOp::Bin(o) = *op {
-            let concat = o == Op::Add as u32
-                && args.len() == 2
-                && !self.add_values_not_concat(ValueLaw::AddCommutativity, args);
             if is_commutative(o)
                 && args.len() == 2
-                && !concat
+                && self.ac_chain_commutes(o, args, ValueLaw::AddCommutativity)
                 && self.reorder_safe(args[0])
                 && self.reorder_safe(args[1])
                 && self.vhash[args[0] as usize] > self.vhash[args[1] as usize]
@@ -426,12 +424,11 @@ impl<'a> Builder<'a> {
                 // shape — is sound for ALL types, string/list concat included
                 // (`"a"+"b"+"c"` is `"abc"` however parenthesized). So ALWAYS flatten and
                 // rebuild, converging `(a+b)+c` with `a+(b+c)` even for untyped params.
-                // COMMUTATIVITY — sorting the operands — is the part gated on non-concat
-                // (#283-C): apply it for every AC op except a concat-possible `+`, so
-                // `c+(a+b)` (a reorder) stays distinct from `(a+b)+c` for untyped operands
-                // while numeric/typed sums still fully canonicalize.
-                let commute = o != Op::Add as u32
-                    || self.add_values_not_concat(ValueLaw::AddCommutativity, &leaves);
+                // COMMUTATIVITY — sorting the operands — is gated per op (`ac_chain_commutes`):
+                // a concat-possible `+` (#283-C) and a Ruby string/list `*` (series 9) stay
+                // ordered, so `c+(a+b)` and `3*"ab"` keep their source order, while numeric/
+                // typed sums and products still fully canonicalize.
+                let commute = self.ac_chain_commutes(o, &leaves, ValueLaw::AddCommutativity);
                 if commute {
                     leaves.sort_unstable_by_key(|&v| self.vhash[v as usize]);
                 }

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -268,7 +268,14 @@ impl<'a> Builder<'a> {
         if is_assoc_comm_code(op) {
             self.eval_assoc_comm_chain(op, &kids, env)
         } else {
-            let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+            let mut a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+            // JS `a << b` / `a >> b` shift `ToInt32(a)` (32-bit, sign-propagating), unlike
+            // Python/Ruby's arbitrary-precision shifts — narrow the shifted operand so JS
+            // shifts fingerprint distinctly and never false-merge cross-language. (`>>>` is
+            // already kept distinct: js_bin_op leaves it unmapped.) #283-D, series 9.
+            if (op == Op::Shl as u32 || op == Op::Shr as u32) && !a.is_empty() {
+                a[0] = self.js_int32_narrow(a[0]);
+            }
             self.mk(ValOp::Bin(op), a)
         }
     }
@@ -325,8 +332,7 @@ impl<'a> Builder<'a> {
                 return v;
             }
             self.narrow_js_bitwise_leaves(op, &mut operands);
-            let do_sort = (op != Op::Add as u32
-                || self.add_values_not_concat(ValueLaw::AddAssociativity, &operands))
+            let do_sort = self.ac_chain_commutes(op, &operands, ValueLaw::AddAssociativity)
                 && operands.iter().all(|&v| self.reorder_safe(v));
             if do_sort {
                 operands.sort_by_key(|&v| self.vhash[v as usize]);
@@ -343,8 +349,7 @@ impl<'a> Builder<'a> {
             return v;
         }
         self.narrow_js_bitwise_leaves(op, &mut operands);
-        let do_sort = (op != Op::Add as u32
-            || self.add_values_not_concat(ValueLaw::AddAssociativity, &operands))
+        let do_sort = self.ac_chain_commutes(op, &operands, ValueLaw::AddAssociativity)
             && operands.iter().all(|&v| self.reorder_safe(v));
         if do_sort {
             operands.sort_by_key(|&v| self.vhash[v as usize]);
@@ -360,8 +365,8 @@ impl<'a> Builder<'a> {
     /// other ops and non-JS languages). Done after flattening so the wrap lands on the
     /// chain's leaves, not its intermediate (already int32) results — giving JS bitwise a
     /// fingerprint distinct from arbitrary-precision bitwise while keeping the op structure
-    /// intact for the De Morgan / idempotence canons (#283-D). Shifts and `~` are narrowed
-    /// at their own build sites.
+    /// intact for the De Morgan / idempotence canons (#283-D). Shifts (`eval_binop_expr`) and
+    /// `~` (`eval_inner`) are narrowed at their own build sites.
     fn narrow_js_bitwise_leaves(&mut self, op: u32, operands: &mut [ValueId]) {
         if op == Op::BitAnd as u32 || op == Op::BitOr as u32 || op == Op::BitXor as u32 {
             for v in operands.iter_mut() {

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -86,6 +86,31 @@ impl<'a> Builder<'a> {
         self.value_law_satisfied(law, values) && values.iter().any(|&v| self.proven_non_concat(v))
     }
 
+    /// Whether an associative-commutative chain's operands may be COMMUTED (reordered).
+    /// Associativity — regrouping a flat chain — is sound for every type and handled by the
+    /// caller; this gates only the SORT. Commutativity is op- and language-specific:
+    /// - `+` is ordered string/list concat unless proven non-concat (#283-C, via `add_law`).
+    /// - `*` is string/list REPETITION in Ruby, and there it is asymmetric: `"ab" * 3` →
+    ///   "ababab" but `3 * "ab"` raises (`Integer#*` rejects a String). Python repetition
+    ///   commutes (`3 * "ab"` == `"ab" * 3`), and JS/TS/Java/Go/C `*` is always numeric — so
+    ///   only Ruby `*` needs gating, and only when an operand could be a string/sequence
+    ///   (series 9). Reordering a numeric `*` is always sound.
+    /// - `& | ^` Err on a non-numeric operand in every order, so they always commute.
+    pub(super) fn ac_chain_commutes(
+        &self,
+        op: u32,
+        operands: &[ValueId],
+        add_law: ValueLaw,
+    ) -> bool {
+        if op == Op::Add as u32 {
+            self.add_values_not_concat(add_law, operands)
+        } else if op == Op::Mul as u32 {
+            self.il.meta.lang != Lang::Ruby || operands.iter().all(|&v| self.proven_non_concat(v))
+        } else {
+            true
+        }
+    }
+
     /// Whether `v` provably evaluates to a Number on every input it does not Err on, using
     /// ONLY genuine domain evidence — numeric literals and annotated / pack-typed params —
     /// never the OPTIMISTIC "this param is Num because a numeric op was applied to it"

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2498,3 +2498,74 @@ semantics most likely to regress: lambda-local returns stay excluded, and Java
 regression test now completes in `0.93s` in the debug CLI test harness; the release
 reproducer above drops from `71.55s` to `0.56s`; and `./scripts/check-ci-local.sh
 --fast` passes.
+## CK. Adversarial co-evolution, series 9 — the post-#283 operator gaps (shifts, Ruby `*`)
+
+One protocol pass ([adversarial-coevolution](adversarial-coevolution.md)), aimed by the
+freshness slot rule at code changed since series 8: the #283-C/D operator narrowings
+(value-model/canonicalizer), the `nose verify` oracle (#317's type-incoherence finding),
+and the #328 enrich-only-emitted perf path. Three blind fresh-subagent attackers, persona-
+rotated (soundness-skeptic, oracle-bail-skeptic, perf-determinism); ledger `s9-*`; tracking
+issue #329; commit `6f61fb3`.
+
+**Two confirmed false merges, both in operators the #283 narrowings did not reach.**
+- **JS bitwise *shifts* were not int32.** #283-D narrowed `& | ^` and `~` for JS via
+  `js_int32_narrow` so they no longer merge with arbitrary-precision Python/Ruby bitwise,
+  but `<<`/`>>` built a bare `Bin(Shl/Shr, [a,b])` identical to Python's — an exact
+  cross-language merge though `1 << 31` is `-2147483648` in JS and `2147483648` in Python
+  (and `(2**32) >> 0` is `0` vs `2**32`; both verified with `node`/`python3`). The in-code
+  comment even *claimed* shifts were "narrowed at their own build sites" — they were not.
+  Fix: `eval_binop_expr` narrows the shifted operand via `js_int32_narrow` for JS `Shl`/
+  `Shr` (a no-op elsewhere; `>>>` was already kept distinct). JS-vs-JS shifts still converge.
+- **Ruby `*` commuted, but it is repetition.** The reorder sites all assumed "`* & | ^` Err
+  on non-numeric regardless of order, so stay safe" — false for Ruby, where `*` is string/
+  array repetition and *asymmetric*: `"ab" * 3` → `"ababab"` but `3 * "ab"` raises
+  (`Integer#*` rejects a String), and `[1,2] * 3` ≠ `3 * [1,2]`. Four sites reordered it:
+  the `algebra` IL pass (constant-fold-to-end **and** hash-sort) and the value graph
+  (AC-chain sort + the 2-operand commutative swap). Fix: one `ac_chain_commutes` predicate
+  threaded through all four — `+` stays gated on non-concat (#283-C), and `*` commutes only
+  when `lang != Ruby || all operands proven-non-concat`. **Largest sound generalization:**
+  only Ruby is held, because Python repetition *is* commutative (`3 * "ab"` == `"ab" * 3`)
+  and JS/TS/Java/Go/C `*` is numeric — so those five languages keep full `*` commutativity
+  and lose no recall.
+
+**Soundness by construction + measured.** Both fixes only ADD distinctions (a `ToInt32`
+node; held operand order) — they can only SPLIT fingerprints, never create a merge, so no
+new false merge is possible. Measured anyway: `nose verify --max-violations 0` clean on 13
+repos across the changed-path languages (Ruby/TS/Python/Java/Go); scan output **byte-
+identical** to `origin/main` on faraday, rack, axios, requests, gson (the merges were
+latent — absent from the corpus, the §AS reason batteries exist); determinism byte-
+identical across `RAYON_NUM_THREADS`. Permanent battery: two `equivalence.rs` tests with
+the cross-language hard negatives and the Python/JS commutativity guards;
+`bench/coevo/false_merges/ruby_star_repetition.rb`.
+
+**Oracle surface — green-with-teeth + a sharpened boundary.** The oracle attacker re-
+confirmed the #317/§7 type-incoherence false-positive class with a 2-line reproducer and
+**sharpened its root**: the trigger is the EQUALITY (`==`/`!=`) canon meeting an `Err`
+operand (relational `<` over the same incoherent subscript is clean, a bare subscript is
+clean), and it is **language-independent** — untyped Python `b[s] == 0` reproduces it — so
+the cause is `collect_file_verify_recs`'s concrete-only canon check not filtering `Err`,
+not the absence of declared-param domain evidence per se. Recorded as `recorded-low-
+prevalence`; the fix stays deferred (the cheap "skip `Err` rows" candidate must first be
+vetted against the cross-unit false-merge check, where `Err`-vs-value IS a distinguishing
+behavior). The bail taxonomy (`battery-bail`/`path-bail`/`uninterpretable`/`empty-
+fingerprint`/`core-missing`) is printed and censused — no silent coverage drop (green).
+
+**Perf surface — green-with-teeth.** The #328 enrich-only-emitted narrowing held under
+attack: 2560 per-family witness comparisons on jedis across `--top {0,5,30}` and a 6-entry
+ignore set spanning near ranks 2..2507 found zero witness loss, and 9/9 byte-identical
+determinism checks across thread counts (the merge-time verification reproduced
+adversarially).
+
+**Verdict.** Two false merges closed at the operator layer the series-6–8 encoding fixes
+never touched — the miss this time was not a lost identity token but an over-broad
+*algebraic law* (commute/int32-equivalence) applied past the language where it holds. The
+defense is the §BA pattern again: gate the law to exactly the languages/domains that prove
+it, no further. Issue #329.
+
+| packet | surface | verdict |
+|---|---|---|
+| s9-vm-shl-int32 | value-model | violation-fixed (JS `<<` int32-narrowed) |
+| s9-vm-shr-int32 | value-model | violation-fixed (JS `>>` int32-narrowed) |
+| s9-vm-ruby-mul-strrep | value-model | violation-fixed (`ac_chain_commutes` Ruby-`*` gate) |
+| s9-oracle-eq-err-incoherent | oracle | recorded-low-prevalence (§7 sharpened; fix deferred) |
+| s9-perf-enrich-narrowing | performance-determinism | green-confirmed |


### PR DESCRIPTION
Adversarial co-evolution **series 9** (issue #329, per `docs/adversarial-coevolution.md`). Three blind fresh-subagent attackers, persona-rotated, aimed by the freshness slot rule at code changed since series 8. Two confirmed exact-channel **false merges**, both in operators the #283-C/D narrowings did not reach.

### 1. JS bitwise shifts were not int32
#283-D narrowed JS `& | ^` (and `~`) to int32 so they fingerprint distinctly from arbitrary-precision Python/Ruby bitwise — but `<<`/`>>` built a bare `Bin(Shl/Shr,[a,b])` identical to Python's. So JS `a << b` false-merged with Python `a << b`, though (verified with `node`/`python3`):
- `1 << 31` = **-2147483648** in JS, **2147483648** in Python
- `(2**32) >> 0` = **0** in JS, **2**32** in Python

**Fix:** `eval_binop_expr` narrows the shifted operand via `js_int32_narrow` for JS `Shl`/`Shr` (a no-op for non-JS; `>>>` was already kept distinct). JS-vs-JS shifts still converge.

### 2. Ruby `*` was reordered, but it is repetition
The reorder sites assumed "`* & | ^` Err on non-numeric regardless of order" — **false for Ruby**, where `*` is string/array repetition and *asymmetric*: `"ab" * 3` → `"ababab"` but `3 * "ab"` **raises** (`Integer#*` rejects a String); likewise `[1,2]*3` ≠ `3*[1,2]`. Four sites reordered it (the `algebra` IL pass's constant-fold-to-end **and** hash-sort, plus the value graph's AC-chain sort and 2-operand commutative swap).

**Fix:** one `ac_chain_commutes` predicate threaded through all four — `+` stays gated on non-concat (#283-C); `*` commutes only when `lang != Ruby || all operands proven-non-concat`. **Largest sound generalization:** Python repetition *is* commutative (`3 * "ab"` == `"ab" * 3`) and JS/TS/Java/Go/C `*` is numeric, so those five keep full `*` commutativity and lose no recall.

### Soundness — by construction + measured
Both fixes only ADD distinctions (a `ToInt32` node; held operand order), so they can only **split** fingerprints, never create a merge → no new false merge is possible. Verified anyway:
- `nose verify --max-violations 0` **clean** on 13 repos across Ruby/TS/Python/Java/Go.
- Scan JSON **byte-identical to `origin/main`** on faraday, rack, axios, requests, gson (the merges were latent — absent from the corpus).
- Determinism byte-identical across `RAYON_NUM_THREADS`.
- Re-validated after rebasing onto #330 (semantic-extraction hot paths): regression tests + fixtures + verify all still hold.

### Battery & record
- Two regression tests in `equivalence.rs` (with cross-language shift hard negatives and the Python/JS commutativity guards) + `bench/coevo/false_merges/ruby_star_repetition.rb`.
- `docs/experiments.md §CK`, `bench/coevo/packets.v1.json` (`s9-*`), CHANGELOG.

**Other surfaces this campaign:** the oracle attacker re-confirmed and *sharpened* the #317/§7 type-incoherence class (trigger is the `==`/`!=` canon over an `Err` operand; language-independent) — `recorded-low-prevalence`, fix deferred. The #328 perf narrowing came back `green-confirmed` (2560 witness comparisons, 9/9 determinism). Closes #329.

Local gates: fmt, clippy `-D warnings`, full workspace tests (18 suites), dup-gate (26/26), docs connectivity — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
