### PR TITLE
Soundness oracle: propagate Err from either operand (close the ==/!=-over-Err false positive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ break.
   vectors. A `NOSE_TIME`-gated `enrich` stage timing was added.
 
 ### Fixed
+- **`nose verify` interpreter propagates `Err` from either operand (coevo series 9 oracle
+  follow-up).** A comparison whose erroring operand sat on the *right* (`0 == b[s]` after
+  the sound `==`/`!=` operand-ordering canon) read as a concrete `Bool` instead of raising,
+  because `eval_bin_op` short-circuited `Err` only on the left and `bin`'s fallthrough took
+  `0 == Err` as `Bool(false)`. That made the canon look like a behavior change on
+  type-incoherent battery rows — a spurious canon-preservation false positive. `bin` now
+  propagates `Err` symmetrically (the twin of `un`'s `Not`-of-`Err`); the left short-circuit
+  stays for laziness. Verify-only (`interp.rs`), so scan output is byte-identical. Closes the
+  equality-over-`Err` false-positive class: **sympy 20 → 2 canon-preservation violations,
+  netty 3 → 2**, no false merges. The narrower effect-trace and comprehension-context residue
+  is scoped in [oracle-value-model §7](docs/oracle-value-model.md).
 - **Two cross-/intra-language false merges closed (adversarial co-evolution series 9).**
   - **JS bitwise *shifts* are now int32.** #283-D narrowed JS `& | ^` (and `~`) to int32 so
     they fingerprint distinctly from arbitrary-precision Python/Ruby bitwise, but `<<`/`>>`

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -865,6 +865,9 @@ impl<'a> Interp<'a> {
                 },
             );
         }
+        // Left operand short-circuits Err here (not in `bin`) so a raising left side never
+        // evaluates the right — preserving laziness and effect order. The right operand's
+        // Err is handled symmetrically inside `bin`.
         if matches!(a, Value::Err) {
             return Ok(Value::Err);
         }
@@ -1619,6 +1622,17 @@ fn bin(op: Op, a: &Value, b: &Value) -> Value {
     // an impure callee), and branching on the result bails at the truthiness gate.
     if contains_sym(a) || contains_sym(b) {
         return Value::Sym(sym_id(0x00B1_0911, &[hashed(&op), vhash(a), vhash(b)]));
+    }
+    // Err propagates from EITHER operand — an erroring sub-expression raises the whole
+    // expression regardless of its position. Without this the fallthrough arm below read
+    // `0 == Err` as `Bool(false)` (and `!=` as `Bool(true)`), so the SOUND `==`/`!=`
+    // operand-ordering canon (algebra sorts commutative comparison operands by hash) looked
+    // like a behavior change the moment it moved an erroring operand to the right — a
+    // spurious canon-preservation violation on type-incoherent battery rows (coevo series 9
+    // oracle finding). The `eval_bin_op` left short-circuit still fires first so laziness is
+    // preserved; this is the symmetric twin of `un`'s `(Op::Not, Err) => Err`.
+    if matches!(a, Value::Err) || matches!(b, Value::Err) {
+        return Value::Err;
     }
     match (a, b) {
         (Int(x), Int(y)) => match op {
@@ -3836,6 +3850,33 @@ mod tests {
             Value::Sym(_)
         ));
         assert!(contains_sym(&Value::List(vec![Value::Int(1), s])));
+    }
+
+    /// Err propagates from EITHER operand, so the SOUND `==`/`!=` operand-ordering canon
+    /// (which can move an erroring operand from left to right) does not look like a behavior
+    /// change. The fallthrough comparison arm would otherwise read `0 == Err` as a concrete
+    /// `Bool(false)` instead of raising (coevo series 9 oracle finding).
+    #[test]
+    fn err_propagates_from_either_operand() {
+        for op in [Op::Eq, Op::Ne, Op::Lt, Op::Add, Op::Mul, Op::BitAnd] {
+            assert!(
+                matches!(bin(op, &Value::Int(0), &Value::Err), Value::Err),
+                "{op:?}: right-operand Err must propagate"
+            );
+            assert!(
+                matches!(bin(op, &Value::Err, &Value::Int(0)), Value::Err),
+                "{op:?}: left-operand Err must propagate"
+            );
+        }
+        // The pre-fix bug: `0 == Err` and `0 != Err` collapsed to concrete Bools.
+        assert!(matches!(
+            bin(Op::Eq, &Value::Int(0), &Value::Err),
+            Value::Err
+        ));
+        assert!(matches!(
+            bin(Op::Ne, &Value::Int(0), &Value::Err),
+            Value::Err
+        ));
     }
 
     /// `g(x) = x*x` and `f(x) = g(x) + 1` in one file — running `f(3)` must interpret the

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -296,28 +296,56 @@ when it has **declared domain evidence** (`coerce_to_declared_domain`, interp.rs
 typed-language array/index params (Java `byte[] bytes`, `int startPos`,
 `String[] a`) carry **none** today, so an incoherent value reaches them uncoerced.
 Feeding, say, a string or a list to a slot a unit uses as an array index manufactures
-an input that **can never occur**, and the canonicalizer legitimately differs on it —
-producing a spurious **canon-preservation** violation (the check is concrete-only but
-does not filter `Err`).
+an input that **can never occur**, and on it the *interpreter*, not the canonicalizer,
+diverged — producing a spurious **canon-preservation** violation (the check is
+concrete-only but does not filter `Err`).
 
 This is not hypothetical, and not new to broadening: the *current* battery already
-trips it. `nose verify` on `netty` reports 3 canon-preservation "violations", all on
-type-incoherent rows — e.g. `isZeroSafe(byte[],int,int)` fed three lists gives
-core `Err` vs full `Bool(false)`; `swap(String[],int,int)` fed a probe row gives
-core `Err,[]` vs full `Err, effects=[…]`. They are masked only because the nightly
-soundness gate's pinned corpus does not include `netty`. **The verify soundness gate
-cannot safely widen its corpus to typed-language repos until this is fixed.**
+trips it. `nose verify` on `netty` reported 3 canon-preservation "violations", all on
+type-incoherent rows, and `sympy` 20 — masked only because the nightly soundness gate's
+pinned corpus includes neither.
 
-The sound fix is **type-domain-aware input feeding**: infer each param's domain from
-its *usage* (index operand → Integer, index base / `len` / iteration → Collection,
-arithmetic operand → Number) when no declaration exists, and coerce battery rows
-through it — so the search can broaden without manufacturing impossible inputs. That
-is a behavior-affecting change to the interpreter's binding for *every* verify run
-(per-unit coercion can feed different values to two units in a fingerprint group), so
-it needs corpus-wide re-validation (pinned corpus stays sound, no new false merges,
-completeness stable) and is a separately-priced PR — the same floor-then-model
-discipline as §3. Until then `verify_battery`'s Part 3 stays hand-curated **on
-purpose** (a guard comment there points here).
+### 7.1 The equality-over-`Err` mechanism — fixed (coevo series 9)
+
+The series-9 oracle attacker sharpened the dominant class: the trigger was the
+**`==`/`!=` canon meeting an `Err` operand**, and it was **language-independent**
+(untyped Python `def f(b,s): return b[s]==0` reproduced the typed-Java `bytes[i] != 0`).
+The root was an **interpreter asymmetry**, not a canon bug: `eval_bin_op` short-circuited
+`Err` on the *left* operand only, and `bin`'s comparison fallthrough read `0 == Err` as a
+concrete `Bool(false)` (and `!=` as `Bool(true)`). So the moment the sound `==`/`!=`
+operand-ordering canon (algebra sorts commutative comparison operands by hash) moved the
+erroring operand to the right, the full IL returned a `Bool` while the pre-canon core
+returned `Err` — a spurious violation. **Fix: `bin` propagates `Err` from *either*
+operand** (the symmetric twin of `un`'s existing `(Op::Not, Err) => Err`); the left
+short-circuit stays for laziness/effect order. This is pure interpreter fidelity —
+`interp.rs` is verify-only, so scan output is byte-identical — and it closes the class
+wherever it arises: **sympy 20 → 2 canon violations, netty 3 → 2**, every other checked
+repo unchanged at 0, zero false merges throughout.
+
+### 7.2 Residue (same spurious type-incoherence root, different interpreter paths)
+
+Two narrower sub-classes survive, both still only on type-incoherent rows (so still
+unrealizable, not real canon bugs — every realizable battery row agrees):
+
+- **Effect-trace on the `Err` path** (`ret_diff=false, eff_diff=true`): array-swap
+  writes — netty `swap`/`swapElements`, guava `ObjectArrays`/`Quantiles` — where the
+  canon reorders effect-producing index writes relative to an erroring index *read*, so
+  the two record different `effects` before both still return `Err`.
+- **Comprehension/reduction context** (`ret_diff=true, eff_diff=false`): sympy
+  `_matches_get_other_nodes` / `unit_propagate_int_repr`, where the erroring comparison
+  lives inside a list/set comprehension filter (`nodes[ind] == ind_node`) evaluated via
+  the `Elem`/reduce path, which does not reach the `bin` guard above.
+
+Both share the root and could be closed the same way (faithful `Err` propagation on
+those paths) or by **type-domain-aware input feeding**: infer a param's domain from its
+*usage* (index operand → Integer, base / `len` / iteration → Collection, arithmetic →
+Number) and coerce battery rows so impossible inputs never arise. The latter is
+behavior-affecting for *every* verify run (per-unit coercion can feed different values to
+two units in a fingerprint group), so it stays a separately-priced PR with corpus-wide
+re-validation — the floor-then-model discipline of §3. **The pinned soundness gate can
+widen toward dynamic-language repos now that the dominant (equality) class is closed, but
+full netty/guava/sympy inclusion waits on this residue.** `verify_battery`'s Part 3 stays
+hand-curated **on purpose** (a guard comment there points here).
 
 ---
 


### PR DESCRIPTION
The deferred half of the series-9 oracle finding (issue #329): close the `==`/`!=`-over-`Err` canon-preservation **false positive** in `nose verify`, the one blocking the soundness gate from widening to dynamic/typed-language repos (`docs/oracle-value-model.md §7`).

### The bug — an interpreter asymmetry, not a canon bug
On a type-incoherent battery row (e.g. a List fed to a slot used as an index), `b[s]` raises. The pre-canon core IL evaluates `b[s] == 0` left-to-right → `Err`. But the sound `==`/`!=` operand-ordering canon (algebra sorts commutative comparison operands by hash) can move the erroring operand to the **right** — `0 == b[s]` — and then:
- `eval_bin_op` short-circuited `Err` only on the **left** operand;
- `bin`'s comparison fallthrough computed `Int(0) == Err` as `Bool(0 == Err)` = **`Bool(false)`** (and `!=` as `Bool(true)`).

So the fully-normalized IL returned a `Bool` while the core returned `Err`, and a behavior-**preserving** canon looked like a behavior change. The attacker showed this is **language-independent** (untyped Python `b[s]==0` reproduces typed-Java `bytes[i] != 0`).

### The fix
`bin` propagates `Err` from **either** operand — the symmetric twin of `un`'s existing `(Op::Not, Err) => Err` (which fixed exactly this class for unary negation). `eval_bin_op` keeps its left short-circuit so laziness/effect order is preserved (a raising left side never evaluates the right). An erroring sub-expression raises the whole expression regardless of position — pure interpreter fidelity.

### Why it's safe
- **Verify-only.** `interp.rs` is the oracle interpreter, not the scan fingerprint — scan output is **byte-identical** (verified on faraday/requests).
- **No oracle weakening.** It does not *filter* `Err` (the attacker's "cheap" suggestion, which I rejected — canon-preservation is the sole core-vs-full guardian, and blanket `Err`-filtering would let a canon that erases a realizable-input error cause an undetected false merge). It makes the interpreter model `Err` *more faithfully*, which strengthens both checks.
- **Result:** equality-over-`Err` class closed — **sympy 20 → 2** canon-preservation violations, **netty 3 → 2**, every other checked repo unchanged at 0, **zero false merges** throughout. Unit test `err_propagates_from_either_operand`; full workspace suite (18 suites) green; dup-gate/clippy/docs clean.

### Scoped residue (§7.2)
Two narrower sub-classes survive, both **only on type-incoherent (unrealizable) rows** — every realizable battery row agrees, so they are not real canon bugs: effect-trace on the `Err` path (array swaps — netty/guava, `eff_diff` only) and comprehension/reduction context (sympy, via the `Elem`/reduce path that doesn't reach the `bin` guard). Same spurious root; closed by the same `Err`-fidelity principle on those paths or by type-domain-aware input feeding (a separately-priced, behavior-affecting PR). The pinned gate can widen toward dynamic-language repos now that the dominant class is closed; full netty/guava/sympy inclusion waits on the residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
