### PR TITLE
Dataflow: don't inline a temp past a clobbering write or into a lambda (close §7.2 residue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ break.
   vectors. A `NOSE_TIME`-gated `enrich` stage timing was added.
 
 ### Fixed
+- **Dataflow copy-propagation no longer makes two real-semantics-unsound moves (coevo
+  series 9 oracle residue).** The single-use temp inliner (1) moved a temp's read past an
+  indexed store that clobbers it — `t = a[i]; a[i] = a[j]; a[j] = t` became `a[i] = a[j];
+  a[j] = a[i]`, turning a swap into "set both to `a[j]`" — because the hazard check's
+  `collect_writes` ignored that `a[i] = …` mutates `a`; and (2) inlined a possibly-raising
+  read into a comprehension filter lambda, eliding its `Err` when the iterable is empty.
+  `collect_writes` now records the root var of an `Index`/`Field` store target, and the
+  inliner skips uses in a conditional/repeated position (lambda body, `If` branch, `Loop`).
+  This closes every remaining `nose verify` canon-preservation violation across the corpus
+  (netty/sympy/guava → 0); the value-graph fingerprint is essentially unchanged (family
+  delta ≈ 0). The deeper limit that array-element mutation is not modeled (so `swap` ≡
+  `clobber` still share an exact fingerprint) is an oracle-blind value-model gap recorded as
+  OPEN in `docs/oracle-value-model.md` §7.3 and `bench/coevo/false_merges/`.
 - **`nose verify` interpreter propagates `Err` from either operand (coevo series 9 oracle
   follow-up).** A comparison whose erroring operand sat on the *right* (`0 == b[s]` after
   the sound `==`/`!=` operand-ordering canon) read as a concrete `Bool` instead of raising,

--- a/bench/coevo/false_merges/README.md
+++ b/bench/coevo/false_merges/README.md
@@ -20,6 +20,7 @@ moved into the permanent regression battery.
 | ruby_star_repetition.rb | Ruby `*` reorders, but `"ab"*3` ≠ `3*"ab"` (repetition is asymmetric) | yes | FIXED series 9 — `ac_chain_commutes` Ruby-`*` gate |
 | (cross-lang shift) | JS `a<<b`/`a>>b` (int32) ≡ Python arbitrary-precision `<<`/`>>` | n/a (cross-language — no single-file repro) | FIXED series 9 — JS shift operand int32-narrowed |
 | float_assoc.py | `(a+b)+c≡a+(b+c)` for floats | NO — oracle blind | OPEN (C/float) — needs the `Float` value kind (D-div) |
+| array_element_mutation.py | `swap` ≡ `clobber` — `a[i]` read after an indexed write re-derives the pre-write value | NO — oracle blind | OPEN — needs in-place element-mutation modeling (value graph + interp), see oracle-value-model §7.3 |
 
 FIXED rows are now covered by permanent regression tests (effect cases in the
 value-graph suite; `-(-a)`/`a&a`/`a+b` in `crates/nose-cli/tests/equivalence.rs`,
@@ -27,6 +28,9 @@ value-graph suite; `-(-a)`/`a&a`/`a+b` in `crates/nose-cli/tests/equivalence.rs`
 `bitwise_self_idempotence_gates_on_proven_numeric` +
 `untyped_add_commute_gates_on_proven_numeric`; the series-9 shift and Ruby-`*` cases in
 `js_shift_is_int32_and_distinct_from_arbitrary_precision` +
-`ruby_star_repetition_is_ordered_but_other_multiply_commutes`). The reproducer files stay
-until #283 fully closes (the remaining OPEN row, `float_assoc.py`, is oracle-blind — its
-float non-associativity needs the `Float` value kind, D-div — see #283-D).
+`ruby_star_repetition_is_ordered_but_other_multiply_commutes`; the series-9 dataflow
+inline-soundness cases in `dataflow_does_not_unsoundly_inline_a_temp_past_a_write_or_into_a_lambda`).
+The OPEN rows are oracle-blind value-model gaps: `float_assoc.py` needs the `Float` value
+kind (D-div, #283-D); `array_element_mutation.py` needs in-place element-mutation modeling
+(oracle-value-model §7.3). Both share the limitation that the interpreter cannot witness
+them, so no battery row distinguishes the merged pair.

--- a/bench/coevo/false_merges/array_element_mutation.py
+++ b/bench/coevo/false_merges/array_element_mutation.py
@@ -1,0 +1,18 @@
+# The value model treats an indexed store `a[i] = v` as an opaque ordered effect and does
+# NOT update readable state, so a later `a[i]` read re-derives the PRE-write value (fields
+# are versioned via `field_env`; array elements are not). So `swap` and `clobber` below
+# compute the same effect trace and share an exact-value-graph fingerprint — a false merge:
+# swap(a,0,1) on [1,2] gives [2,1], clobber gives [2,2]. OPEN, ORACLE-BLIND: the interpreter
+# shares the no-mutation model, so `nose verify` cannot witness it (no battery row
+# distinguishes them) — the same category as float_assoc.py. Closing it needs in-place
+# element-mutation modeling in the value graph AND the interpreter. See
+# docs/oracle-value-model.md §7.3 (coevo series 9).
+def swap(a, i, j):
+    t = a[i]
+    a[i] = a[j]
+    a[j] = t
+
+
+def clobber(a, i, j):
+    a[i] = a[j]
+    a[j] = a[i]

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -6796,6 +6796,48 @@ fn js_nullish_assignment_desugars_to_nullish_coalescing() {
 }
 
 #[test]
+fn dataflow_does_not_unsoundly_inline_a_temp_past_a_write_or_into_a_lambda() {
+    // series 9 oracle residue: the copy-propagation inliner must not move a temp's
+    // (possibly-raising) read into a position evaluated under a different condition.
+    // Two cases, both verified to keep the temp's `Var` binding after normalization:
+    //   - `t = a[i]; a[i] = a[j]; a[j] = t` — inlining `t` past the indexed write that
+    //     clobbers `a[i]` would silently turn a swap into "set both to a[j]".
+    //   - `ind = nodes[k]; [x for x in d if nodes[x] == ind]` — inlining `ind` into the
+    //     filter lambda elides its `Err` when `d` is empty (the lambda never runs).
+    use nose_il::NodeKind;
+    let i = Interner::new();
+    let binds_a_var_temp = |il: &nose_il::Il| -> bool {
+        let mut stack = vec![first_func(il)];
+        while let Some(n) = stack.pop() {
+            if il.kind(n) == NodeKind::Assign {
+                if let Some(&lhs) = il.children(n).first() {
+                    if il.kind(lhs) == NodeKind::Var {
+                        return true;
+                    }
+                }
+            }
+            stack.extend(il.children(n).iter().copied());
+        }
+        false
+    };
+    let normalized = |src: &str, lang: Lang| {
+        let il = nose_frontend::lower_source(FileId(0), "t", src.as_bytes(), lang, &i).unwrap();
+        normalize(&il, &i, &NormalizeOptions::default())
+    };
+    let swap = "def swap(a, i, j):\n    t = a[i]\n    a[i] = a[j]\n    a[j] = t\n";
+    assert!(
+        binds_a_var_temp(&normalized(swap, Lang::Python)),
+        "swap's `t = a[i]` must survive — inlining it past `a[i] = a[j]` is unsound",
+    );
+    let comp =
+        "def f(d, nodes, k):\n    ind = nodes[k]\n    return [x for x in d if nodes[x] == ind]\n";
+    assert!(
+        binds_a_var_temp(&normalized(comp, Lang::Python)),
+        "comprehension's `ind = nodes[k]` must not inline into the filter lambda",
+    );
+}
+
+#[test]
 fn js_strict_null_ternary_stays_distinct_from_nullish_coalescing() {
     // `x ?? d` and `x == null ? d : x` both default null AND undefined — they are
     // the same computation. `x === null ? d : x` passes undefined through, so it

--- a/crates/nose-normalize/src/dataflow.rs
+++ b/crates/nose-normalize/src/dataflow.rs
@@ -147,9 +147,10 @@ fn find_inlines(
         // lookup and the hazard check into cheap set tests — without it a single
         // huge block is O(stmts² · subtree) (e.g. comfy/sd.py: 84ms → ~3ms).
         let mut owner: FxHashMap<u32, usize> = FxHashMap::default();
+        let mut lazy: FxHashSet<u32> = FxHashSet::default();
         let mut writes: Vec<FxHashSet<u32>> = Vec::with_capacity(stmts.len());
         for (idx, &s) in stmts.iter().enumerate() {
-            mark_owner(il, s, idx, &mut owner);
+            mark_owner(il, s, idx, false, &mut owner, &mut lazy);
             let mut w = FxHashSet::default();
             collect_writes(il, s, &mut w);
             writes.push(w);
@@ -178,7 +179,12 @@ fn find_inlines(
                 Some(&u) => u,
                 None => continue,
             };
-            // The single use must live in a later statement of this same block.
+            // The single use must be UNCONDITIONALLY evaluated relative to the def: in a
+            // later statement of this same block, and not inside a lambda/branch/loop where
+            // it might evaluate zero times or many (which would move the RHS's `Err`/eval).
+            if lazy.contains(&u.0) {
+                continue;
+            }
             let use_idx = match owner.get(&u.0) {
                 Some(&j) if j > idx => j,
                 _ => continue, // use is nested elsewhere / before — skip conservatively
@@ -210,11 +216,31 @@ fn read_cids(il: &Il, node: NodeId, out: &mut FxHashSet<u32>) {
     }
 }
 
-/// Record `idx` as the owning statement for every node in `node`'s subtree.
-fn mark_owner(il: &Il, node: NodeId, idx: usize, owner: &mut FxHashMap<u32, usize>) {
+/// Record `idx` as the owning statement for every node in `node`'s subtree, and collect into
+/// `lazy` the nodes whose evaluation is CONDITIONAL or REPEATED relative to that statement —
+/// a lambda body (run 0+ times), a non-condition branch of an `If`/ternary, or anything under
+/// a `Loop`. Inlining a possibly-raising temp into such a position would change *when* (or
+/// whether) it evaluates: e.g. inlining `t = nodes[node_ind]` into a comprehension filter
+/// elides its `Err` when the iterable is empty. Such uses are skipped by the inliner.
+fn mark_owner(
+    il: &Il,
+    node: NodeId,
+    idx: usize,
+    in_lazy: bool,
+    owner: &mut FxHashMap<u32, usize>,
+    lazy: &mut FxHashSet<u32>,
+) {
     owner.insert(node.0, idx);
-    for &c in il.children(node) {
-        mark_owner(il, c, idx, owner);
+    if in_lazy {
+        lazy.insert(node.0);
+    }
+    let kind = il.kind(node);
+    for (ci, &c) in il.children(node).iter().enumerate() {
+        let child_lazy = in_lazy
+            || kind == NodeKind::Lambda
+            || kind == NodeKind::Loop
+            || (kind == NodeKind::If && ci > 0);
+        mark_owner(il, c, idx, child_lazy, owner, lazy);
     }
 }
 
@@ -222,10 +248,33 @@ fn mark_owner(il: &Il, node: NodeId, idx: usize, owner: &mut FxHashMap<u32, usiz
 fn collect_writes(il: &Il, node: NodeId, out: &mut FxHashSet<u32>) {
     if il.kind(node) == NodeKind::Assign {
         if let Some(&lhs) = il.children(node).first() {
-            if il.kind(lhs) == NodeKind::Var {
-                if let Payload::Cid(c) = il.node(lhs).payload {
-                    out.insert(c);
+            match il.kind(lhs) {
+                NodeKind::Var => {
+                    if let Payload::Cid(c) = il.node(lhs).payload {
+                        out.insert(c);
+                    }
                 }
+                // An indexed/field store `a[i] = v` / `a.f = v` MUTATES the base object, so
+                // a later read of `a` (e.g. `a[k]`) observes it. Record the base's root var
+                // as written so the inliner's hazard check does not move a temp that reads
+                // `a` past the mutation — without this, `t = a[i]; a[i] = a[j]; a[j] = t`
+                // inlined `t` to `a[j] = a[i]`, reading the already-clobbered `a[i]` and
+                // silently turning a swap into "set both to a[j]".
+                NodeKind::Index | NodeKind::Field => {
+                    let mut base = lhs;
+                    while matches!(il.kind(base), NodeKind::Index | NodeKind::Field) {
+                        match il.children(base).first() {
+                            Some(&c) => base = c,
+                            None => break,
+                        }
+                    }
+                    if il.kind(base) == NodeKind::Var {
+                        if let Payload::Cid(c) = il.node(base).payload {
+                            out.insert(c);
+                        }
+                    }
+                }
+                _ => {}
             }
         }
     }

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -165,3 +165,14 @@ the whole-impl span (8 varying spots, ~7 of ~270 lines shared), but the two impl
 (value-DAG referent resolution vs the value-graph builder's dict-entry/index-write methods) — there
 is nothing extractable. Another spurious whole-impl-span match, not new avoidable duplication; the
 budget is re-baselined to 26.
+
+## Budget 26 → 27 and the series-9 dataflow fix
+
+The series-9 dataflow inline-soundness fix (oracle-value-model §7.2 — `collect_writes` records
+indexed/field-store base mutations, and the inliner skips uses in conditional/repeated positions) is
+fingerprint-neutral on the corpus (family delta ≈ 0), but the small structural shift pushed one
+**pre-existing** test near-family over the substantial line: the two table-driven decidability-filter
+tests in nose-cli's inline `tests` module, `declaration_spans_fail_open_per_language` ↔
+`declaration_spans_classify_per_language`. They are near-identical by construction — a
+`&[(&str, &str)]` case table plus an `assert!(…ast_classifies…)` loop, differing only in the asserted
+direction — benign test scaffolding with nothing extractable. The budget is re-baselined to 27.

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -322,30 +322,55 @@ short-circuit stays for laziness/effect order. This is pure interpreter fidelity
 wherever it arises: **sympy 20 → 2 canon violations, netty 3 → 2**, every other checked
 repo unchanged at 0, zero false merges throughout.
 
-### 7.2 Residue (same spurious type-incoherence root, different interpreter paths)
+### 7.2 The remaining violations were real dataflow bugs — fixed (coevo series 9)
 
-Two narrower sub-classes survive, both still only on type-incoherent rows (so still
-unrealizable, not real canon bugs — every realizable battery row agrees):
+The two narrower sub-classes that survived §7.1 turned out NOT to be spurious: the
+canon-preservation check was correctly catching the copy-propagation inliner
+(`dataflow.rs`) make **real-semantics-unsound** moves, surfaced via type-incoherent rows
+only because the value model doesn't track in-place mutation (§7.3).
 
-- **Effect-trace on the `Err` path** (`ret_diff=false, eff_diff=true`): array-swap
-  writes — netty `swap`/`swapElements`, guava `ObjectArrays`/`Quantiles` — where the
-  canon reorders effect-producing index writes relative to an erroring index *read*, so
-  the two record different `effects` before both still return `Err`.
-- **Comprehension/reduction context** (`ret_diff=true, eff_diff=false`): sympy
-  `_matches_get_other_nodes` / `unit_propagate_int_repr`, where the erroring comparison
-  lives inside a list/set comprehension filter (`nodes[ind] == ind_node`) evaluated via
-  the `Elem`/reduce path, which does not reach the `bin` guard above.
+- **Inline past a clobbering indexed write** (netty/guava `swap`/`swapElements`/
+  `ObjectArrays`): `t = a[i]; a[i] = a[j]; a[j] = t` was inlined to `a[i] = a[j]; a[j] =
+  a[i]` — reading the *already-overwritten* `a[i]`, turning a swap into "set both to
+  `a[j]`". The inliner's hazard check missed it because `collect_writes` only recorded
+  `Var` assignments, not that an indexed store `a[i] = …` MUTATES the base `a`.
+- **Inline into a lambda body** (sympy `_matches_get_other_nodes` /
+  `unit_propagate_int_repr`): `ind = nodes[k]` (a possibly-raising read) was inlined into
+  a comprehension filter — evaluated zero times on an empty iterable, eliding the `Err`
+  the eager read raises. The inliner mapped the lambda-internal use to its top-level
+  statement and saw it as "a later statement of the same block."
 
-Both share the root and could be closed the same way (faithful `Err` propagation on
-those paths) or by **type-domain-aware input feeding**: infer a param's domain from its
-*usage* (index operand → Integer, base / `len` / iteration → Collection, arithmetic →
-Number) and coerce battery rows so impossible inputs never arise. The latter is
-behavior-affecting for *every* verify run (per-unit coercion can feed different values to
-two units in a fingerprint group), so it stays a separately-priced PR with corpus-wide
-re-validation — the floor-then-model discipline of §3. **The pinned soundness gate can
-widen toward dynamic-language repos now that the dominant (equality) class is closed, but
-full netty/guava/sympy inclusion waits on this residue.** `verify_battery`'s Part 3 stays
-hand-curated **on purpose** (a guard comment there points here).
+**Fix:** `collect_writes` records the root var of an `Index`/`Field` store target as a
+write (so the hazard check blocks the swap inline), and the inliner skips any use in a
+CONDITIONAL/REPEATED position — a lambda body, an `If` branch, or under a `Loop` — so it
+never moves a read into a context evaluated under a different condition. Both are
+real-semantics soundness fixes; the value-graph FINGERPRINT is essentially unchanged (the
+value graph does its own env substitution, corpus family delta ≈ 0) and the soundness
+oracle stays clean. Canon-preservation violations are now **zero** across netty/sympy/guava
+and the wider sweep — together with `bin`'s symmetric `Err` (§7.1), every
+canon-preservation violation the corpus surfaced is closed.
+
+### 7.3 The deeper limit: in-place element mutation is not modeled (oracle-blind, OPEN)
+
+The value model treats an indexed/collection store `a[i] = v` as an ordered, opaque effect
+and does NOT update readable state — so a later `a[i]` read re-derives the *pre-write*
+value (`field` stores ARE versioned via `field_env`; array elements are not). Under that
+model `swap` (`t=a[i]; a[i]=a[j]; a[j]=t`) and `clobber` (`a[i]=a[j]; a[j]=a[i]`) compute
+the same effect trace, so they share an `exact-value-graph` fingerprint — a latent false
+merge. It is **oracle-blind**: the interpreter shares the same no-mutation model, so the
+false-merge check sees them as behavior-equal too (no battery row distinguishes them). This
+is the same category as float non-associativity (`bench/coevo/false_merges/float_assoc.py`):
+a known value-model gap the oracle cannot witness, not a regression. Closing it needs
+in-place element-mutation modeling (version `a[i]` reads by the array's write state) in
+BOTH the value graph and the interpreter — a value-model extension on the scale of the
+`Float` kind (§3.3), tracked separately. Until then it is recorded in
+`bench/coevo/false_merges/` as an OPEN, oracle-blind class.
+
+**Net:** the equality-over-`Err` class (§7.1) and the dataflow unsoundness (§7.2) are
+closed, so the verify soundness gate can widen toward dynamic-language repos. The
+array-mutation modeling gap (§7.3) and type-domain-aware input feeding remain the
+floor-then-model follow-ups (§3); `verify_battery`'s Part 3 stays hand-curated **on
+purpose** (a guard comment there points here).
 
 ---
 

--- a/scripts/check-duplication.sh
+++ b/scripts/check-duplication.sh
@@ -49,7 +49,15 @@ MIN_VALUE=40   # ignore small/incidental similarity; gate only on substantial fa
 # (the `impl<'a>` header + a `for u in &il.units { def_*.entry(..) }` skeleton) with
 # value_graph/builders.rs's `impl Builder` — 8 varying spots, nothing extractable (the
 # two impls do unrelated work). A spurious whole-impl span, not new duplication.
-BUDGET=26      # accepted substantial families today (see docs/dogfooding.md)
+#
+# +1 (series 9): the two table-driven decidability-filter tests in nose-cli's inline
+# `tests` module — `declaration_spans_fail_open_per_language` and
+# `declaration_spans_classify_per_language` — are genuinely near-identical by construction
+# (a `&[(&str,&str)]` case table + an `assert!(…ast_classifies…)` loop, differing only in
+# the asserted direction). The series-9 dataflow inline-soundness fix shifted enough
+# structure to push the pair over the near threshold. Benign test scaffolding, nothing to
+# extract; the production change it rode in on is fingerprint-neutral (family delta ≈ 0).
+BUDGET=27      # accepted substantial families today (see docs/dogfooding.md)
 BIN="${NOSE_BIN:-./target/release/nose}"
 GATE_ARGS=(scan crates --exclude tests --mode near --min-value "$MIN_VALUE")
 


### PR DESCRIPTION
The §7.2 residue from the symmetric-`Err` oracle fix (#332). Investigation showed the remaining `nose verify` canon-preservation violations were **not spurious** — the copy-propagation inliner (`dataflow.rs`) was making two **real-semantics-unsound** moves, surfaced only via type-incoherent rows because the value model doesn't track in-place mutation.

### 1. Inline *past* a clobbering indexed write
`t = a[i]; a[i] = a[j]; a[j] = t` was inlined to `a[i] = a[j]; a[j] = a[i]` — reading the **already-overwritten** `a[i]`, turning a swap into "set both to `a[j]`". The hazard check missed it because `collect_writes` recorded only `Var` assignments, not that an indexed store `a[i] = …` **mutates** the base `a`.
**Fix:** record the root var of an `Index`/`Field` store target as a write.

### 2. Inline *into* a lambda body
`ind = nodes[k]` (a possibly-raising read) was inlined into a comprehension filter — evaluated zero times on an empty iterable, **eliding the `Err`** the eager read raises. The inliner mapped the lambda-internal use to its top-level statement.
**Fix:** skip inlining when the use is in a conditional/repeated position — a lambda body, an `If` branch, or under a `Loop`.

### Validation
- Both are real-semantics soundness fixes; the value-graph **fingerprint is essentially unchanged** (the value graph does its own env substitution — corpus family delta ≈ 0, scan output verified), so only the genuinely-buggy units change.
- Canon-preservation violations now **zero** across netty/sympy/guava and the wider 17-repo sweep; **no false merges**; full workspace suite (18) green; clippy/docs clean.
- Regression test `dataflow_does_not_unsoundly_inline_a_temp_past_a_write_or_into_a_lambda`.
- dup-gate re-baselined 26 → 27 — a benign pre-existing test near-family (`declaration_spans_fail_open_per_language` ↔ `…classify_per_language`, table-driven tests) surfaced by the fingerprint shift; nothing extractable (`docs/dogfooding.md`).

### Honest scoping — a deeper gap uncovered (OPEN)
Fixing the dataflow inline does **not** close the underlying `swap` ≡ `clobber` exact-value-graph merge: the value model treats `a[i] = v` as an opaque ordered effect and doesn't update readable state, so a later `a[i]` read re-derives the pre-write value (fields are versioned; array elements are not). This is a **latent false merge the oracle is blind to** — the interpreter shares the no-mutation model, so no battery row distinguishes them, same category as float non-associativity. Recorded as OPEN in `docs/oracle-value-model.md §7.3` and `bench/coevo/false_merges/array_element_mutation.py`. Closing it needs in-place element-mutation modeling in **both** the value graph and the interpreter (a value-model extension on the scale of the `Float` kind) — tracked for a dedicated PR.

**Net:** the equality-over-`Err` class (#332) and the dataflow unsoundness (this PR) close every canon-preservation violation the corpus surfaces; the verify soundness gate can widen toward dynamic-language repos. The array-mutation modeling gap remains the documented floor-then-model follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
