### PR TITLE
Soundness: close semantic false-merge boundaries

### DIFF
--- a/crates/nose-cli/tests/cli/exact_fragments.rs
+++ b/crates/nose-cli/tests/cli/exact_fragments.rs
@@ -392,40 +392,40 @@ fn semantic_scan_reports_exact_safe_conditional_return_fragments_under_opaque_fu
 fn semantic_scan_reports_exact_safe_conditional_throw_fragments_under_opaque_functions() {
     let fixtures = [
         (
-            "square_throw_guard_a.js",
-            "function squareThrowLeft(xs) {\n  if (xs[0] > 0) {\n    throw xs[0] * xs[0];\n  }\n  audit(xs);\n}\n",
+            "square_throw_guard_a.ts",
+            "function squareThrowLeft(xs: number[]) {\n  if (xs[0] > 0) {\n    throw xs[0] * xs[0];\n  }\n  audit(xs);\n}\n",
         ),
         (
-            "square_throw_guard_b.js",
-            "function squareThrowRight(ys) {\n  if (0 < ys[0]) {\n    throw ys[0] * ys[0];\n  }\n  trace(ys);\n}\n",
+            "square_throw_guard_b.ts",
+            "function squareThrowRight(ys: number[]) {\n  if (0 < ys[0]) {\n    throw ys[0] * ys[0];\n  }\n  trace(ys);\n}\n",
         ),
         (
-            "square_throw_guard_neg.js",
-            "function squareThrowWrong(zs) {\n  if (zs[0] > 1) {\n    throw zs[0] * zs[0];\n  }\n  audit(zs);\n}\n",
+            "square_throw_guard_neg.ts",
+            "function squareThrowWrong(zs: number[]) {\n  if (zs[0] > 1) {\n    throw zs[0] * zs[0];\n  }\n  audit(zs);\n}\n",
         ),
         (
-            "sum_throw_guard_a.js",
-            "function sumThrowLeft(xs) {\n  if (xs[0] + xs[1] > 10) {\n    throw xs[0] + xs[1];\n  }\n  audit(xs);\n}\n",
+            "sum_throw_guard_a.ts",
+            "function sumThrowLeft(xs: number[]) {\n  if (xs[0] + xs[1] > 10) {\n    throw xs[0] + xs[1];\n  }\n  audit(xs);\n}\n",
         ),
         (
-            "sum_throw_guard_b.js",
-            "function sumThrowRight(ys) {\n  if (10 < ys[0] + ys[1]) {\n    throw ys[0] + ys[1];\n  }\n  trace(ys);\n}\n",
+            "sum_throw_guard_b.ts",
+            "function sumThrowRight(ys: number[]) {\n  if (10 < ys[0] + ys[1]) {\n    throw ys[0] + ys[1];\n  }\n  trace(ys);\n}\n",
         ),
         (
-            "sum_throw_guard_neg.js",
-            "function sumThrowWrong(zs) {\n  if (zs[0] + zs[1] > 10) {\n    throw zs[0] - zs[1];\n  }\n  audit(zs);\n}\n",
+            "sum_throw_guard_neg.ts",
+            "function sumThrowWrong(zs: number[]) {\n  if (zs[0] + zs[1] > 10) {\n    throw zs[0] - zs[1];\n  }\n  audit(zs);\n}\n",
         ),
         (
-            "both_throw_guard_a.js",
-            "function bothThrowLeft(xs) {\n  if (xs[0] > 0 && xs[1] > 0) {\n    throw xs[0] + xs[1];\n  }\n  audit(xs);\n}\n",
+            "both_throw_guard_a.ts",
+            "function bothThrowLeft(x: number, y: number) {\n  if (x > 0 && y > 0) {\n    throw x + y;\n  }\n  audit(x);\n}\n",
         ),
         (
-            "both_throw_guard_b.js",
-            "function bothThrowRight(ys) {\n  if (ys[1] > 0 && ys[0] > 0) {\n    throw ys[0] + ys[1];\n  }\n  trace(ys);\n}\n",
+            "both_throw_guard_b.ts",
+            "function bothThrowRight(a: number, b: number) {\n  if (b > 0 && a > 0) {\n    throw a + b;\n  }\n  trace(a);\n}\n",
         ),
         (
-            "both_throw_guard_mutated.js",
-            "function bothThrowMutated(zs) {\n  zs.push(1);\n  if (zs[0] > 0 && zs[1] > 0) {\n    throw zs[0] + zs[1];\n  }\n  audit(zs);\n}\n",
+            "both_throw_guard_mutated.ts",
+            "function bothThrowMutated(z: number, w: number) {\n  z = z + 1;\n  if (z > 0 && w > 0) {\n    throw z + w;\n  }\n  audit(z);\n}\n",
         ),
     ];
     let (dir, out, families) =
@@ -448,19 +448,19 @@ fn semantic_scan_reports_exact_safe_conditional_throw_fragments_under_opaque_fun
     };
 
     assert_guard_family(
-        "square_throw_guard_a.js",
-        "square_throw_guard_b.js",
-        "square_throw_guard_neg.js",
+        "square_throw_guard_a.ts",
+        "square_throw_guard_b.ts",
+        "square_throw_guard_neg.ts",
     );
     assert_guard_family(
-        "sum_throw_guard_a.js",
-        "sum_throw_guard_b.js",
-        "sum_throw_guard_neg.js",
+        "sum_throw_guard_a.ts",
+        "sum_throw_guard_b.ts",
+        "sum_throw_guard_neg.ts",
     );
     assert_guard_family(
-        "both_throw_guard_a.js",
-        "both_throw_guard_b.js",
-        "both_throw_guard_mutated.js",
+        "both_throw_guard_a.ts",
+        "both_throw_guard_b.ts",
+        "both_throw_guard_mutated.ts",
     );
     let _ = fs::remove_dir_all(&dir);
 }
@@ -470,40 +470,40 @@ fn semantic_scan_reports_exact_safe_empty_branch_conditional_exit_fragments_unde
 {
     let fixtures = [
         (
-            "empty_else_return_a.js",
-            "function emptyElseReturnLeft(xs) {\n  if (xs[0] > 0) {\n    return xs[0] * xs[0];\n  } else {\n  }\n  audit(xs);\n}\n",
+            "empty_else_return_a.ts",
+            "function emptyElseReturnLeft(xs: number[]) {\n  if (xs[0] > 0) {\n    return xs[0] * xs[0];\n  } else {\n  }\n  audit(xs);\n}\n",
         ),
         (
-            "empty_else_return_b.js",
-            "function emptyElseReturnRight(ys) {\n  if (0 < ys[0]) {\n    return ys[0] * ys[0];\n  } else {\n  }\n  trace(ys);\n}\n",
+            "empty_else_return_b.ts",
+            "function emptyElseReturnRight(ys: number[]) {\n  if (0 < ys[0]) {\n    return ys[0] * ys[0];\n  } else {\n  }\n  trace(ys);\n}\n",
         ),
         (
-            "empty_else_return_neg.js",
-            "function emptyElseReturnWrong(zs) {\n  if (zs[0] > 1) {\n    return zs[0] * zs[0];\n  } else {\n  }\n  audit(zs);\n}\n",
+            "empty_else_return_neg.ts",
+            "function emptyElseReturnWrong(zs: number[]) {\n  if (zs[0] > 1) {\n    return zs[0] * zs[0];\n  } else {\n  }\n  audit(zs);\n}\n",
         ),
         (
-            "empty_else_throw_a.js",
-            "function emptyElseThrowLeft(xs) {\n  if (xs[0] + xs[1] > 10) {\n    throw xs[0] + xs[1];\n  } else {\n  }\n  audit(xs);\n}\n",
+            "empty_else_throw_a.ts",
+            "function emptyElseThrowLeft(xs: number[]) {\n  if (xs[0] + xs[1] > 10) {\n    throw xs[0] + xs[1];\n  } else {\n  }\n  audit(xs);\n}\n",
         ),
         (
-            "empty_else_throw_b.js",
-            "function emptyElseThrowRight(ys) {\n  if (10 < ys[0] + ys[1]) {\n    throw ys[0] + ys[1];\n  } else {\n  }\n  trace(ys);\n}\n",
+            "empty_else_throw_b.ts",
+            "function emptyElseThrowRight(ys: number[]) {\n  if (10 < ys[0] + ys[1]) {\n    throw ys[0] + ys[1];\n  } else {\n  }\n  trace(ys);\n}\n",
         ),
         (
-            "empty_else_throw_neg.js",
-            "function emptyElseThrowWrong(zs) {\n  if (zs[0] + zs[1] > 10) {\n    throw zs[0] - zs[1];\n  } else {\n  }\n  audit(zs);\n}\n",
+            "empty_else_throw_neg.ts",
+            "function emptyElseThrowWrong(zs: number[]) {\n  if (zs[0] + zs[1] > 10) {\n    throw zs[0] - zs[1];\n  } else {\n  }\n  audit(zs);\n}\n",
         ),
         (
-            "empty_then_throw_a.js",
-            "function emptyThenThrowLeft(xs) {\n  if (xs[0] > 0 && xs[1] > 0) {\n  } else {\n    throw xs[0] + xs[1];\n  }\n  audit(xs);\n}\n",
+            "empty_then_throw_a.ts",
+            "function emptyThenThrowLeft(x: number, y: number) {\n  if (x > 0 && y > 0) {\n  } else {\n    throw x + y;\n  }\n  audit(x);\n}\n",
         ),
         (
-            "empty_then_throw_b.js",
-            "function emptyThenThrowRight(ys) {\n  if (ys[1] > 0 && ys[0] > 0) {\n  } else {\n    throw ys[0] + ys[1];\n  }\n  trace(ys);\n}\n",
+            "empty_then_throw_b.ts",
+            "function emptyThenThrowRight(a: number, b: number) {\n  if (b > 0 && a > 0) {\n  } else {\n    throw a + b;\n  }\n  trace(a);\n}\n",
         ),
         (
-            "empty_then_throw_mutated.js",
-            "function emptyThenThrowMutated(zs) {\n  zs.push(1);\n  if (zs[0] > 0 && zs[1] > 0) {\n  } else {\n    throw zs[0] + zs[1];\n  }\n  audit(zs);\n}\n",
+            "empty_then_throw_mutated.ts",
+            "function emptyThenThrowMutated(z: number, w: number) {\n  z = z + 1;\n  if (z > 0 && w > 0) {\n  } else {\n    throw z + w;\n  }\n  audit(z);\n}\n",
         ),
     ];
     let (dir, out, families) =
@@ -526,19 +526,19 @@ fn semantic_scan_reports_exact_safe_empty_branch_conditional_exit_fragments_unde
     };
 
     assert_guard_family(
-        "empty_else_return_a.js",
-        "empty_else_return_b.js",
-        "empty_else_return_neg.js",
+        "empty_else_return_a.ts",
+        "empty_else_return_b.ts",
+        "empty_else_return_neg.ts",
     );
     assert_guard_family(
-        "empty_else_throw_a.js",
-        "empty_else_throw_b.js",
-        "empty_else_throw_neg.js",
+        "empty_else_throw_a.ts",
+        "empty_else_throw_b.ts",
+        "empty_else_throw_neg.ts",
     );
     assert_guard_family(
-        "empty_then_throw_a.js",
-        "empty_then_throw_b.js",
-        "empty_then_throw_mutated.js",
+        "empty_then_throw_a.ts",
+        "empty_then_throw_b.ts",
+        "empty_then_throw_mutated.ts",
     );
     let _ = fs::remove_dir_all(&dir);
 }
@@ -554,40 +554,40 @@ fn semantic_scan_reports_exact_safe_conditional_bare_return_fragments_under_opaq
 
     let fixtures = [
         (
-            "bare_square_a.js",
-            "function bareSquareLeft(xs) {\n  if (xs[0] > 0) {\n    return;\n  }\n  audit(xs);\n}\n",
+            "bare_square_a.ts",
+            "function bareSquareLeft(xs: number[]) {\n  if (xs[0] > 0) {\n    return;\n  }\n  audit(xs);\n}\n",
         ),
         (
-            "bare_square_b.js",
-            "function bareSquareRight(ys) {\n  if (0 < ys[0]) {\n    return;\n  }\n  trace(ys);\n}\n",
+            "bare_square_b.ts",
+            "function bareSquareRight(ys: number[]) {\n  if (0 < ys[0]) {\n    return;\n  }\n  trace(ys);\n}\n",
         ),
         (
-            "bare_square_neg.js",
-            "function bareSquareWrong(zs) {\n  if (zs[0] > 1) {\n    return;\n  }\n  audit(zs);\n}\n",
+            "bare_square_neg.ts",
+            "function bareSquareWrong(zs: number[]) {\n  if (zs[0] > 1) {\n    return;\n  }\n  audit(zs);\n}\n",
         ),
         (
-            "bare_sum_a.js",
-            "function bareSumLeft(xs) {\n  if (xs[0] + xs[1] > 10) {\n    return;\n  }\n  audit(xs);\n}\n",
+            "bare_sum_a.ts",
+            "function bareSumLeft(xs: number[]) {\n  if (xs[0] + xs[1] > 10) {\n    return;\n  }\n  audit(xs);\n}\n",
         ),
         (
-            "bare_sum_b.js",
-            "function bareSumRight(ys) {\n  if (10 < ys[0] + ys[1]) {\n    return;\n  }\n  trace(ys);\n}\n",
+            "bare_sum_b.ts",
+            "function bareSumRight(ys: number[]) {\n  if (10 < ys[0] + ys[1]) {\n    return;\n  }\n  trace(ys);\n}\n",
         ),
         (
-            "bare_sum_mutated.js",
-            "function bareSumMutated(zs) {\n  zs.push(1);\n  if (zs[0] + zs[1] > 10) {\n    return;\n  }\n  audit(zs);\n}\n",
+            "bare_sum_mutated.ts",
+            "function bareSumMutated(zs: number[]) {\n  zs.push(1);\n  if (zs[0] + zs[1] > 10) {\n    return;\n  }\n  audit(zs);\n}\n",
         ),
         (
-            "bare_else_a.js",
-            "function bareElseLeft(xs) {\n  if (xs[0] > 0 && xs[1] > 0) {\n  } else {\n    return;\n  }\n  audit(xs);\n}\n",
+            "bare_else_a.ts",
+            "function bareElseLeft(x: number, y: number) {\n  if (x > 0 && y > 0) {\n  } else {\n    return;\n  }\n  audit(x);\n}\n",
         ),
         (
-            "bare_else_b.js",
-            "function bareElseRight(ys) {\n  if (ys[1] > 0 && ys[0] > 0) {\n  } else {\n    return;\n  }\n  trace(ys);\n}\n",
+            "bare_else_b.ts",
+            "function bareElseRight(a: number, b: number) {\n  if (b > 0 && a > 0) {\n  } else {\n    return;\n  }\n  trace(a);\n}\n",
         ),
         (
-            "bare_else_neg.js",
-            "function bareElseWrong(zs) {\n  if (zs[0] > 0 && zs[1] > 1) {\n  } else {\n    return;\n  }\n  audit(zs);\n}\n",
+            "bare_else_neg.ts",
+            "function bareElseWrong(z: number, w: number) {\n  if (z > 0 && w > 1) {\n  } else {\n    return;\n  }\n  audit(z);\n}\n",
         ),
     ];
     for (name, src) in fixtures {
@@ -636,9 +636,9 @@ fn semantic_scan_reports_exact_safe_conditional_bare_return_fragments_under_opaq
         );
     };
 
-    assert_guard_family("bare_square_a.js", "bare_square_b.js", "bare_square_neg.js");
-    assert_guard_family("bare_sum_a.js", "bare_sum_b.js", "bare_sum_mutated.js");
-    assert_guard_family("bare_else_a.js", "bare_else_b.js", "bare_else_neg.js");
+    assert_guard_family("bare_square_a.ts", "bare_square_b.ts", "bare_square_neg.ts");
+    assert_guard_family("bare_sum_a.ts", "bare_sum_b.ts", "bare_sum_mutated.ts");
+    assert_guard_family("bare_else_a.ts", "bare_else_b.ts", "bare_else_neg.ts");
     let _ = fs::remove_dir_all(&dir);
 }
 
@@ -653,40 +653,40 @@ fn semantic_scan_reports_exact_safe_conditional_expr_effect_fragments_under_opaq
 
     let fixtures = [
         (
-            "push_square_a.js",
-            "function pushSquareLeft(xs, out) {\n  if (xs[0] > 0) {\n    out.push(xs[0] * xs[0]);\n  }\n  audit(xs);\n}\n",
+            "push_square_a.ts",
+            "function pushSquareLeft(xs: number[], out: number[]) {\n  if (xs[0] > 0) {\n    out.push(xs[0] * xs[0]);\n  }\n  audit(xs);\n}\n",
         ),
         (
-            "push_square_b.js",
-            "function pushSquareRight(ys, dst) {\n  if (0 < ys[0]) {\n    dst.push(ys[0] * ys[0]);\n  }\n  trace(ys);\n}\n",
+            "push_square_b.ts",
+            "function pushSquareRight(ys: number[], dst: number[]) {\n  if (0 < ys[0]) {\n    dst.push(ys[0] * ys[0]);\n  }\n  trace(ys);\n}\n",
         ),
         (
-            "push_square_neg.js",
-            "function pushSquareWrong(zs, out) {\n  if (zs[0] > 1) {\n    out.push(zs[0] * zs[0]);\n  }\n  audit(zs);\n}\n",
+            "push_square_neg.ts",
+            "function pushSquareWrong(zs: number[], out: number[]) {\n  if (zs[0] > 1) {\n    out.push(zs[0] * zs[0]);\n  }\n  audit(zs);\n}\n",
         ),
         (
-            "push_sum_a.js",
-            "function pushSumLeft(xs, out) {\n  if (xs[0] + xs[1] > 10) {\n    out.push(xs[0] + xs[1]);\n  }\n  audit(xs);\n}\n",
+            "push_sum_a.ts",
+            "function pushSumLeft(xs: number[], out: number[]) {\n  if (xs[0] + xs[1] > 10) {\n    out.push(xs[0] + xs[1]);\n  }\n  audit(xs);\n}\n",
         ),
         (
-            "push_sum_b.js",
-            "function pushSumRight(ys, dst) {\n  if (10 < ys[0] + ys[1]) {\n    dst.push(ys[0] + ys[1]);\n  }\n  trace(ys);\n}\n",
+            "push_sum_b.ts",
+            "function pushSumRight(ys: number[], dst: number[]) {\n  if (10 < ys[0] + ys[1]) {\n    dst.push(ys[0] + ys[1]);\n  }\n  trace(ys);\n}\n",
         ),
         (
-            "push_sum_neg.js",
-            "function pushSumWrong(zs, out) {\n  if (zs[0] + zs[1] > 10) {\n    out.push(zs[0] - zs[1]);\n  }\n  audit(zs);\n}\n",
+            "push_sum_neg.ts",
+            "function pushSumWrong(zs: number[], out: number[]) {\n  if (zs[0] + zs[1] > 10) {\n    out.push(zs[0] - zs[1]);\n  }\n  audit(zs);\n}\n",
         ),
         (
-            "push_else_a.js",
-            "function pushElseLeft(xs, out) {\n  if (xs[0] > 0 && xs[1] > 0) {\n  } else {\n    out.push(xs[0] + xs[1]);\n  }\n  audit(xs);\n}\n",
+            "push_else_a.ts",
+            "function pushElseLeft(x: number, y: number, out: number[]) {\n  if (x > 0 && y > 0) {\n  } else {\n    out.push(x + y);\n  }\n  audit(x);\n}\n",
         ),
         (
-            "push_else_b.js",
-            "function pushElseRight(ys, dst) {\n  if (ys[1] > 0 && ys[0] > 0) {\n  } else {\n    dst.push(ys[0] + ys[1]);\n  }\n  trace(ys);\n}\n",
+            "push_else_b.ts",
+            "function pushElseRight(a: number, b: number, dst: number[]) {\n  if (b > 0 && a > 0) {\n  } else {\n    dst.push(a + b);\n  }\n  trace(a);\n}\n",
         ),
         (
-            "push_else_mutated.js",
-            "function pushElseMutated(zs, out) {\n  out.push(0);\n  if (zs[0] > 0 && zs[1] > 0) {\n  } else {\n    out.push(zs[0] + zs[1]);\n  }\n  audit(zs);\n}\n",
+            "push_else_mutated.ts",
+            "function pushElseMutated(z: number, w: number, out: number[]) {\n  out.push(0);\n  if (z > 0 && w > 0) {\n  } else {\n    out.push(z + w);\n  }\n  audit(z);\n}\n",
         ),
     ];
     for (name, src) in fixtures {
@@ -735,9 +735,9 @@ fn semantic_scan_reports_exact_safe_conditional_expr_effect_fragments_under_opaq
         );
     };
 
-    assert_guard_family("push_square_a.js", "push_square_b.js", "push_square_neg.js");
-    assert_guard_family("push_sum_a.js", "push_sum_b.js", "push_sum_neg.js");
-    assert_guard_family("push_else_a.js", "push_else_b.js", "push_else_mutated.js");
+    assert_guard_family("push_square_a.ts", "push_square_b.ts", "push_square_neg.ts");
+    assert_guard_family("push_sum_a.ts", "push_sum_b.ts", "push_sum_neg.ts");
+    assert_guard_family("push_else_a.ts", "push_else_b.ts", "push_else_mutated.ts");
     let _ = fs::remove_dir_all(&dir);
 }
 
@@ -792,7 +792,7 @@ fn semantic_scan_reports_exact_safe_branch_temp_consumption_fragments_under_opaq
         ),
         (
             "temp_effect_b.js",
-            "function tempEffectRight(ys, dst) {\n  if (0 < ys[0]) {\n    dst.push(ys[1] + ys[0] * ys[0]);\n  }\n  trace(ys);\n}\n",
+            "function tempEffectRight(ys, dst) {\n  if (0 < ys[0]) {\n    dst.push(ys[0] * ys[0] + ys[1]);\n  }\n  trace(ys);\n}\n",
         ),
         (
             "temp_effect_neg.js",
@@ -816,7 +816,7 @@ fn semantic_scan_reports_exact_safe_branch_temp_consumption_fragments_under_opaq
         ),
         (
             "temp_chain_throw_b.js",
-            "function tempChainThrowRight(ys) {\n  if (0 < ys[0]) {\n    throw ys[1] + (1 + ys[0]) * (1 + ys[0]);\n  }\n  trace(ys);\n}\n",
+            "function tempChainThrowRight(ys) {\n  if (0 < ys[0]) {\n    throw (ys[0] + 1) * (ys[0] + 1) + ys[1];\n  }\n  trace(ys);\n}\n",
         ),
         (
             "temp_chain_throw_neg.js",
@@ -828,7 +828,7 @@ fn semantic_scan_reports_exact_safe_branch_temp_consumption_fragments_under_opaq
         ),
         (
             "temp_chain_effect_b.js",
-            "function tempChainEffectRight(ys, dst) {\n  if (0 < ys[0]) {\n    dst.push(ys[1] + (1 + ys[0]) * (1 + ys[0]));\n  }\n  trace(ys);\n}\n",
+            "function tempChainEffectRight(ys, dst) {\n  if (0 < ys[0]) {\n    dst.push((ys[0] + 1) * (ys[0] + 1) + ys[1]);\n  }\n  trace(ys);\n}\n",
         ),
         (
             "temp_chain_effect_neg.js",
@@ -1006,40 +1006,40 @@ fn semantic_scan_reports_exact_safe_branch_temp_consumption_fragments_under_opaq
 fn semantic_scan_reports_exact_safe_nested_conditional_effect_fragments_under_opaque_functions() {
     let fixtures = [
         (
-            "nested_push_a.js",
-            "function nestedPushLeft(xs, out) {\n  if (xs[0] > 0 && xs[1] > 0) {\n    out.push(xs[0] + xs[1]);\n  } else {\n    if (xs[2] > 0) {\n      out.push(xs[2] * xs[2]);\n    }\n  }\n  audit(xs);\n}\n",
+            "nested_push_a.ts",
+            "function nestedPushLeft(x: number, y: number, z: number, out: number[]) {\n  if (x > 0 && y > 0) {\n    out.push(x + y);\n  } else {\n    if (z > 0) {\n      out.push(z * z);\n    }\n  }\n  audit(x);\n}\n",
         ),
         (
-            "nested_push_b.js",
-            "function nestedPushRight(ys, dst) {\n  if (ys[1] > 0 && ys[0] > 0) {\n    dst.push(ys[0] + ys[1]);\n  } else {\n    if (0 < ys[2]) {\n      dst.push(ys[2] * ys[2]);\n    }\n  }\n  trace(ys);\n}\n",
+            "nested_push_b.ts",
+            "function nestedPushRight(a: number, b: number, c: number, dst: number[]) {\n  if (b > 0 && a > 0) {\n    dst.push(a + b);\n  } else {\n    if (0 < c) {\n      dst.push(c * c);\n    }\n  }\n  trace(a);\n}\n",
         ),
         (
-            "nested_push_mutated.js",
-            "function nestedPushMutated(zs, out) {\n  out.push(0);\n  if (zs[0] > 0 && zs[1] > 0) {\n    out.push(zs[0] + zs[1]);\n  } else {\n    if (zs[2] > 0) {\n      out.push(zs[2] * zs[2]);\n    }\n  }\n  audit(zs);\n}\n",
+            "nested_push_mutated.ts",
+            "function nestedPushMutated(z: number, w: number, q: number, out: number[]) {\n  out.push(0);\n  if (z > 0 && w > 0) {\n    out.push(z + w);\n  } else {\n    if (q > 0) {\n      out.push(q * q);\n    }\n  }\n  audit(z);\n}\n",
         ),
         (
-            "nested_push_sum_a.js",
-            "function nestedPushSumLeft(xs, out) {\n  if (xs[0] + xs[1] > 10) {\n    out.push(xs[0] + xs[1]);\n  } else {\n    if (xs[2] > 0) {\n      out.push(xs[2] * xs[2]);\n    }\n  }\n  audit(xs);\n}\n",
+            "nested_push_sum_a.ts",
+            "function nestedPushSumLeft(xs: number[], out: number[]) {\n  if (xs[0] + xs[1] > 10) {\n    out.push(xs[0] + xs[1]);\n  } else {\n    if (xs[2] > 0) {\n      out.push(xs[2] * xs[2]);\n    }\n  }\n  audit(xs);\n}\n",
         ),
         (
-            "nested_push_sum_b.js",
-            "function nestedPushSumRight(ys, dst) {\n  if (10 < ys[0] + ys[1]) {\n    dst.push(ys[0] + ys[1]);\n  } else {\n    if (0 < ys[2]) {\n      dst.push(ys[2] * ys[2]);\n    }\n  }\n  trace(ys);\n}\n",
+            "nested_push_sum_b.ts",
+            "function nestedPushSumRight(ys: number[], dst: number[]) {\n  if (10 < ys[0] + ys[1]) {\n    dst.push(ys[0] + ys[1]);\n  } else {\n    if (0 < ys[2]) {\n      dst.push(ys[2] * ys[2]);\n    }\n  }\n  trace(ys);\n}\n",
         ),
         (
-            "nested_push_sum_neg.js",
-            "function nestedPushSumWrong(zs, out) {\n  if (zs[0] + zs[1] > 10) {\n    out.push(zs[0] - zs[1]);\n  } else {\n    if (zs[2] > 0) {\n      out.push(zs[2] * zs[2]);\n    }\n  }\n  audit(zs);\n}\n",
+            "nested_push_sum_neg.ts",
+            "function nestedPushSumWrong(zs: number[], out: number[]) {\n  if (zs[0] + zs[1] > 10) {\n    out.push(zs[0] - zs[1]);\n  } else {\n    if (zs[2] > 0) {\n      out.push(zs[2] * zs[2]);\n    }\n  }\n  audit(zs);\n}\n",
         ),
         (
-            "nested_push_product_a.js",
-            "function nestedPushProductLeft(xs, out) {\n  if ((xs[0] + 1) > 10) {\n    out.push((xs[0] + 1) * 2);\n  } else {\n    if (xs[1] + xs[2] > 0) {\n      out.push(xs[1] + xs[2]);\n    }\n  }\n  audit(xs);\n}\n",
+            "nested_push_product_a.ts",
+            "function nestedPushProductLeft(xs: number[], out: number[]) {\n  if ((xs[0] + 1) > 10) {\n    out.push((xs[0] + 1) * 2);\n  } else {\n    if (xs[1] + xs[2] > 0) {\n      out.push(xs[1] + xs[2]);\n    }\n  }\n  audit(xs);\n}\n",
         ),
         (
-            "nested_push_product_b.js",
-            "function nestedPushProductRight(ys, dst) {\n  if (10 < (1 + ys[0])) {\n    dst.push(2 * (1 + ys[0]));\n  } else {\n    if (ys[1] + ys[2] > 0) {\n      dst.push(ys[1] + ys[2]);\n    }\n  }\n  trace(ys);\n}\n",
+            "nested_push_product_b.ts",
+            "function nestedPushProductRight(ys: number[], dst: number[]) {\n  if (10 < (ys[0] + 1)) {\n    dst.push(2 * (ys[0] + 1));\n  } else {\n    if (ys[1] + ys[2] > 0) {\n      dst.push(ys[1] + ys[2]);\n    }\n  }\n  trace(ys);\n}\n",
         ),
         (
-            "nested_push_product_neg.js",
-            "function nestedPushProductWrong(zs, out) {\n  if ((zs[0] + 2) > 10) {\n    out.push((zs[0] + 2) * 2);\n  } else {\n    if (zs[1] + zs[2] > 0) {\n      out.push(zs[1] + zs[2]);\n    }\n  }\n  audit(zs);\n}\n",
+            "nested_push_product_neg.ts",
+            "function nestedPushProductWrong(zs: number[], out: number[]) {\n  if ((zs[0] + 2) > 10) {\n    out.push((zs[0] + 2) * 2);\n  } else {\n    if (zs[1] + zs[2] > 0) {\n      out.push(zs[1] + zs[2]);\n    }\n  }\n  audit(zs);\n}\n",
         ),
     ];
     let (dir, out, families) =
@@ -1059,19 +1059,19 @@ fn semantic_scan_reports_exact_safe_nested_conditional_effect_fragments_under_op
     };
 
     assert_guard_family(
-        "nested_push_a.js",
-        "nested_push_b.js",
-        "nested_push_mutated.js",
+        "nested_push_a.ts",
+        "nested_push_b.ts",
+        "nested_push_mutated.ts",
     );
     assert_guard_family(
-        "nested_push_sum_a.js",
-        "nested_push_sum_b.js",
-        "nested_push_sum_neg.js",
+        "nested_push_sum_a.ts",
+        "nested_push_sum_b.ts",
+        "nested_push_sum_neg.ts",
     );
     assert_guard_family(
-        "nested_push_product_a.js",
-        "nested_push_product_b.js",
-        "nested_push_product_neg.js",
+        "nested_push_product_a.ts",
+        "nested_push_product_b.ts",
+        "nested_push_product_neg.ts",
     );
     let _ = fs::remove_dir_all(&dir);
 }
@@ -1111,7 +1111,7 @@ fn semantic_scan_reports_exact_safe_foreach_append_effect_fragments_under_opaque
         ),
         (
             "loop_push_product_b.ts",
-            "function loopPushProductRight(ys: number[], dst: number[]): void {\n  for (const y of ys) {\n    dst.push(2 * (1 + y));\n  }\n  trace(ys);\n}\n",
+            "function loopPushProductRight(ys: number[], dst: number[]): void {\n  for (const y of ys) {\n    dst.push(2 * (y + 1));\n  }\n  trace(ys);\n}\n",
         ),
         (
             "loop_push_product_neg.ts",
@@ -1123,7 +1123,7 @@ fn semantic_scan_reports_exact_safe_foreach_append_effect_fragments_under_opaque
         ),
         (
             "loop_push_guard_b.ts",
-            "function loopPushGuardRight(ys: number[], dst: number[]): void {\n  for (const y of ys) {\n    if (0 < y) dst.push(1 + y);\n  }\n  trace(ys);\n}\n",
+            "function loopPushGuardRight(ys: number[], dst: number[]): void {\n  for (const y of ys) {\n    if (0 < y) dst.push(y + 1);\n  }\n  trace(ys);\n}\n",
         ),
         (
             "loop_push_guard_neg.ts",
@@ -1159,7 +1159,7 @@ fn semantic_scan_reports_exact_safe_foreach_append_effect_fragments_under_opaque
         ),
         (
             "loop_temp_chain_push_b.ts",
-            "function loopTempChainPushRight(ys: number[], dst: number[]): void {\n  for (const y of ys) {\n    const offset = 1 + y;\n    const result = offset * offset;\n    dst.push(result);\n  }\n  trace(ys);\n}\n",
+            "function loopTempChainPushRight(ys: number[], dst: number[]): void {\n  for (const y of ys) {\n    const offset = y + 1;\n    const result = offset * offset;\n    dst.push(result);\n  }\n  trace(ys);\n}\n",
         ),
         (
             "loop_temp_chain_push_wrong.ts",
@@ -1593,11 +1593,11 @@ fn semantic_scan_reports_exact_safe_conditional_foreach_append_effect_fragments_
         ),
         (
             "cond_loop_else_b.ts",
-            "function condLoopElseRight(flag: boolean, ys: number[], dst: number[]): void {\n  if (flag) {\n  } else {\n    for (const y of ys) {\n      dst.push(1 + y);\n    }\n  }\n  trace(flag);\n}\n",
+            "function condLoopElseRight(flag: boolean, ys: number[], dst: number[]): void {\n  if (flag) {\n  } else {\n    for (const y of ys) {\n      dst.push(y + 1);\n    }\n  }\n  trace(flag);\n}\n",
         ),
         (
             "cond_loop_else_wrong_receiver.ts",
-            "function condLoopElseWrongReceiver(flag: boolean, ys: number[], dst: number[]): void {\n  if (flag) {\n  } else {\n    for (const y of ys) {\n      ys.push(1 + y);\n    }\n  }\n  trace(flag);\n}\n",
+            "function condLoopElseWrongReceiver(flag: boolean, ys: number[], dst: number[]): void {\n  if (flag) {\n  } else {\n    for (const y of ys) {\n      ys.push(y + 1);\n    }\n  }\n  trace(flag);\n}\n",
         ),
         (
             "cond_loop_guard_a.ts",
@@ -1605,11 +1605,11 @@ fn semantic_scan_reports_exact_safe_conditional_foreach_append_effect_fragments_
         ),
         (
             "cond_loop_guard_b.ts",
-            "function condLoopGuardRight(flag: boolean, ys: number[], dst: number[]): void {\n  if (flag) {\n    for (const y of ys) {\n      if (0 < y) dst.push(1 + y);\n    }\n  }\n  trace(flag);\n}\n",
+            "function condLoopGuardRight(flag: boolean, ys: number[], dst: number[]): void {\n  if (flag) {\n    for (const y of ys) {\n      if (0 < y) dst.push(y + 1);\n    }\n  }\n  trace(flag);\n}\n",
         ),
         (
             "cond_loop_guard_wrong_value.ts",
-            "function condLoopGuardWrongValue(flag: boolean, ys: number[], dst: number[]): void {\n  if (flag) {\n    for (const y of ys) {\n      if (0 < y) dst.push(2 + y);\n    }\n  }\n  trace(flag);\n}\n",
+            "function condLoopGuardWrongValue(flag: boolean, ys: number[], dst: number[]): void {\n  if (flag) {\n    for (const y of ys) {\n      if (0 < y) dst.push(y + 2);\n    }\n  }\n  trace(flag);\n}\n",
         ),
         (
             "cond_loop_mutated.ts",
@@ -1697,7 +1697,7 @@ fn semantic_scan_reports_exact_safe_ordered_foreach_effect_branch_fragments() {
         ),
         (
             "cond_two_loops_b.ts",
-            "function condTwoLoopsRight(flag: boolean, as: number[], bs: number[], dst: number[]): void {\n  if (flag) {\n    for (const a of as) {\n      dst.push(1 + a);\n    }\n    for (const b of bs) {\n      dst.push(b * b);\n    }\n  }\n  trace(flag);\n}\n",
+            "function condTwoLoopsRight(flag: boolean, as: number[], bs: number[], dst: number[]): void {\n  if (flag) {\n    for (const a of as) {\n      dst.push(a + 1);\n    }\n    for (const b of bs) {\n      dst.push(b * b);\n    }\n  }\n  trace(flag);\n}\n",
         ),
         (
             "cond_two_loops_wrong_order.ts",
@@ -1891,23 +1891,23 @@ fn semantic_scan_reports_exact_safe_ordered_mixed_effect_branch_fragments() {
         ),
         (
             "mixed_loop_append_b.ts",
-            "function mixedLoopAppendRight(flag: boolean, ys: number[], dst: number[], base: number): void {\n  if (flag) {\n    for (const y of ys) {\n      dst.push(1 + y);\n    }\n    dst.push(base * base);\n  }\n  trace(flag);\n}\n",
+            "function mixedLoopAppendRight(flag: boolean, ys: number[], dst: number[], base: number): void {\n  if (flag) {\n    for (const y of ys) {\n      dst.push(y + 1);\n    }\n    dst.push(base * base);\n  }\n  trace(flag);\n}\n",
         ),
         (
             "mixed_loop_append_wrong_order.ts",
-            "function mixedLoopAppendWrongOrder(flag: boolean, ys: number[], dst: number[], base: number): void {\n  if (flag) {\n    dst.push(base * base);\n    for (const y of ys) {\n      dst.push(1 + y);\n    }\n  }\n  trace(flag);\n}\n",
+            "function mixedLoopAppendWrongOrder(flag: boolean, ys: number[], dst: number[], base: number): void {\n  if (flag) {\n    dst.push(base * base);\n    for (const y of ys) {\n      dst.push(y + 1);\n    }\n  }\n  trace(flag);\n}\n",
         ),
         (
             "mixed_loop_append_wrong_receiver.ts",
-            "function mixedLoopAppendWrongReceiver(flag: boolean, ys: number[], dst: number[], base: number): void {\n  if (flag) {\n    for (const y of ys) {\n      dst.push(1 + y);\n    }\n    ys.push(base * base);\n  }\n  trace(flag);\n}\n",
+            "function mixedLoopAppendWrongReceiver(flag: boolean, ys: number[], dst: number[], base: number): void {\n  if (flag) {\n    for (const y of ys) {\n      dst.push(y + 1);\n    }\n    ys.push(base * base);\n  }\n  trace(flag);\n}\n",
         ),
         (
             "mixed_loop_append_mutated.ts",
-            "function mixedLoopAppendMutated(flag: boolean, ys: number[], dst: number[], base: number): void {\n  dst.push(0);\n  if (flag) {\n    for (const y of ys) {\n      dst.push(1 + y);\n    }\n    dst.push(base * base);\n  }\n  trace(flag);\n}\n",
+            "function mixedLoopAppendMutated(flag: boolean, ys: number[], dst: number[], base: number): void {\n  dst.push(0);\n  if (flag) {\n    for (const y of ys) {\n      dst.push(y + 1);\n    }\n    dst.push(base * base);\n  }\n  trace(flag);\n}\n",
         ),
         (
             "mixed_loop_append_third_effect.ts",
-            "function mixedLoopAppendThirdEffect(flag: boolean, ys: number[], dst: number[], base: number): void {\n  if (flag) {\n    for (const y of ys) {\n      dst.push(1 + y);\n    }\n    dst.push(base * base);\n    dst.push(base + 1);\n  }\n  trace(flag);\n}\n",
+            "function mixedLoopAppendThirdEffect(flag: boolean, ys: number[], dst: number[], base: number): void {\n  if (flag) {\n    for (const y of ys) {\n      dst.push(y + 1);\n    }\n    dst.push(base * base);\n    dst.push(base + 1);\n  }\n  trace(flag);\n}\n",
         ),
         (
             "mixed_append_loop_a.py",
@@ -2550,27 +2550,27 @@ fn semantic_scan_reports_exact_safe_ordered_loop_conditional_effect_branch_fragm
         ),
         (
             "loop_cond_append_b.ts",
-            "function loopCondAppendRight(flag: boolean, ys: number[], b: number, dst: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(1 + a);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n  }\n  trace(flag);\n}\n",
+            "function loopCondAppendRight(flag: boolean, ys: number[], b: number, dst: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(a + 1);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n  }\n  trace(flag);\n}\n",
         ),
         (
             "loop_cond_append_wrong_order.ts",
-            "function loopCondAppendWrongOrder(flag: boolean, ys: number[], b: number, dst: number[]): void {\n  if (flag) {\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    for (const a of ys) {\n      dst.push(1 + a);\n    }\n  }\n  trace(flag);\n}\n",
+            "function loopCondAppendWrongOrder(flag: boolean, ys: number[], b: number, dst: number[]): void {\n  if (flag) {\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    for (const a of ys) {\n      dst.push(a + 1);\n    }\n  }\n  trace(flag);\n}\n",
         ),
         (
             "loop_cond_append_wrong_guard.ts",
-            "function loopCondAppendWrongGuard(flag: boolean, ys: number[], b: number, dst: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(1 + a);\n    }\n    if (b >= 0) {\n      dst.push(b * b);\n    }\n  }\n  trace(flag);\n}\n",
+            "function loopCondAppendWrongGuard(flag: boolean, ys: number[], b: number, dst: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(a + 1);\n    }\n    if (b >= 0) {\n      dst.push(b * b);\n    }\n  }\n  trace(flag);\n}\n",
         ),
         (
             "loop_cond_append_wrong_receiver.ts",
-            "function loopCondAppendWrongReceiver(flag: boolean, ys: number[], b: number, dst: number[], other: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(1 + a);\n    }\n    if (b > 0) {\n      other.push(b * b);\n    }\n  }\n  trace(flag);\n}\n",
+            "function loopCondAppendWrongReceiver(flag: boolean, ys: number[], b: number, dst: number[], other: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(a + 1);\n    }\n    if (b > 0) {\n      other.push(b * b);\n    }\n  }\n  trace(flag);\n}\n",
         ),
         (
             "loop_cond_append_mutated.ts",
-            "function loopCondAppendMutated(flag: boolean, ys: number[], b: number, dst: number[]): void {\n  dst.push(0);\n  if (flag) {\n    for (const a of ys) {\n      dst.push(1 + a);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n  }\n  trace(flag);\n}\n",
+            "function loopCondAppendMutated(flag: boolean, ys: number[], b: number, dst: number[]): void {\n  dst.push(0);\n  if (flag) {\n    for (const a of ys) {\n      dst.push(a + 1);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n  }\n  trace(flag);\n}\n",
         ),
         (
             "loop_cond_append_third.ts",
-            "function loopCondAppendThird(flag: boolean, ys: number[], b: number, c: number, dst: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(1 + a);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    dst.push(c + 3);\n  }\n  trace(flag);\n}\n",
+            "function loopCondAppendThird(flag: boolean, ys: number[], b: number, c: number, dst: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(a + 1);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    dst.push(c + 3);\n  }\n  trace(flag);\n}\n",
         ),
         (
             "loop_cond_append_a.py",
@@ -2780,27 +2780,27 @@ fn semantic_scan_reports_exact_safe_ordered_loop_conditional_mixed_effect_branch
         ),
         (
             "loop_cond_mixed_append_b.ts",
-            "function loopCondMixedRight(flag: boolean, ys: number[], b: number, c: number, dst: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(1 + a);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    dst.push(3 + c);\n  }\n  trace(flag);\n}\n",
+            "function loopCondMixedRight(flag: boolean, ys: number[], b: number, c: number, dst: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(a + 1);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    dst.push(c + 3);\n  }\n  trace(flag);\n}\n",
         ),
         (
             "loop_cond_mixed_append_wrong_order.ts",
-            "function loopCondMixedWrongOrder(flag: boolean, ys: number[], b: number, c: number, dst: number[]): void {\n  if (flag) {\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    for (const a of ys) {\n      dst.push(1 + a);\n    }\n    dst.push(3 + c);\n  }\n  trace(flag);\n}\n",
+            "function loopCondMixedWrongOrder(flag: boolean, ys: number[], b: number, c: number, dst: number[]): void {\n  if (flag) {\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    for (const a of ys) {\n      dst.push(a + 1);\n    }\n    dst.push(c + 3);\n  }\n  trace(flag);\n}\n",
         ),
         (
             "loop_cond_mixed_append_wrong_guard.ts",
-            "function loopCondMixedWrongGuard(flag: boolean, ys: number[], b: number, c: number, dst: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(1 + a);\n    }\n    if (b >= 0) {\n      dst.push(b * b);\n    }\n    dst.push(3 + c);\n  }\n  trace(flag);\n}\n",
+            "function loopCondMixedWrongGuard(flag: boolean, ys: number[], b: number, c: number, dst: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(a + 1);\n    }\n    if (b >= 0) {\n      dst.push(b * b);\n    }\n    dst.push(c + 3);\n  }\n  trace(flag);\n}\n",
         ),
         (
             "loop_cond_mixed_append_wrong_receiver.ts",
-            "function loopCondMixedWrongReceiver(flag: boolean, ys: number[], b: number, c: number, dst: number[], other: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(1 + a);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    other.push(3 + c);\n  }\n  trace(flag);\n}\n",
+            "function loopCondMixedWrongReceiver(flag: boolean, ys: number[], b: number, c: number, dst: number[], other: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(a + 1);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    other.push(c + 3);\n  }\n  trace(flag);\n}\n",
         ),
         (
             "loop_cond_mixed_append_mutated.ts",
-            "function loopCondMixedMutated(flag: boolean, ys: number[], b: number, c: number, dst: number[]): void {\n  dst.push(0);\n  if (flag) {\n    for (const a of ys) {\n      dst.push(1 + a);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    dst.push(3 + c);\n  }\n  trace(flag);\n}\n",
+            "function loopCondMixedMutated(flag: boolean, ys: number[], b: number, c: number, dst: number[]): void {\n  dst.push(0);\n  if (flag) {\n    for (const a of ys) {\n      dst.push(a + 1);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    dst.push(c + 3);\n  }\n  trace(flag);\n}\n",
         ),
         (
             "loop_cond_mixed_append_fourth.ts",
-            "function loopCondMixedFourth(flag: boolean, ys: number[], b: number, c: number, d: number, dst: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(1 + a);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    dst.push(3 + c);\n    dst.push(d + 4);\n  }\n  trace(flag);\n}\n",
+            "function loopCondMixedFourth(flag: boolean, ys: number[], b: number, c: number, d: number, dst: number[]): void {\n  if (flag) {\n    for (const a of ys) {\n      dst.push(a + 1);\n    }\n    if (b > 0) {\n      dst.push(b * b);\n    }\n    dst.push(c + 3);\n    dst.push(d + 4);\n  }\n  trace(flag);\n}\n",
         ),
         (
             "loop_cond_mixed_append_a.py",
@@ -3958,7 +3958,7 @@ fn semantic_scan_reports_exact_safe_throw_fragments_under_opaque_functions() {
         ),
         (
             "throw_squares_b.js",
-            "function throwSquaresRight(ys) {\n  throw ys[1] * ys[1] + ys[0] * ys[0];\n  trace(ys);\n}\n",
+            "function throwSquaresRight(ys) {\n  throw ys[0] * ys[0] + ys[1] * ys[1];\n  trace(ys);\n}\n",
         ),
         (
             "throw_squares_neg.js",
@@ -3970,7 +3970,7 @@ fn semantic_scan_reports_exact_safe_throw_fragments_under_opaque_functions() {
         ),
         (
             "throw_product_b.js",
-            "function throwProductRight(ys) {\n  throw (4 + ys[2]) * (ys[0] + ys[1]);\n  trace(ys);\n}\n",
+            "function throwProductRight(ys) {\n  throw (ys[2] + 4) * (ys[0] + ys[1]);\n  trace(ys);\n}\n",
         ),
         (
             "throw_product_mutated.js",

--- a/crates/nose-cli/tests/cli/semantic_idioms.rs
+++ b/crates/nose-cli/tests/cli/semantic_idioms.rs
@@ -439,7 +439,7 @@ fn scan_mode_semantic_proves_rust_integer_methods() {
     fs::create_dir_all(&dir).unwrap();
     fs::write(
         dir.join("abs_conditional.py"),
-        "def magnitude(value, other):\n    magnitude = value if value >= 0 else -value\n    return magnitude + other\n",
+        "def magnitude(value: int, other: int):\n    magnitude = value if value >= 0 else -value\n    return magnitude + other\n",
     )
     .unwrap();
     fs::write(
@@ -2954,6 +2954,11 @@ fn scan_mode_semantic_allows_named_namespace_import_identity() {
     )
     .unwrap();
     fs::write(
+        dir.join("typed_named.ts"),
+        "import { helper } from \"./shared-math\";\n\nfunction report(input: number): number {\n  return helper(input + 1);\n}\n",
+    )
+    .unwrap();
+    fs::write(
         dir.join("typed_namespace.ts"),
         "import * as mathOps from \"./shared-math\";\n\nfunction build(input: number): number {\n  return mathOps.helper(input + 1);\n}\n",
     )
@@ -2968,12 +2973,14 @@ fn scan_mode_semantic_allows_named_namespace_import_identity() {
     let semantic_json: serde_json::Value =
         serde_json::from_str(&semantic).expect("semantic scan should emit JSON");
     let semantic_text = semantic_json.to_string();
-    for expected in ["named.js", "namespace.js", "typed_namespace.ts"] {
-        assert!(
-            semantic_text.contains(expected),
-            "semantic mode should include static import member positive {expected}: {semantic}"
-        );
-    }
+    assert!(
+        family_contains_all(&semantic_json, &["named.js", "namespace.js"]),
+        "semantic mode should include untyped JS static import member positives: {semantic}"
+    );
+    assert!(
+        family_contains_all(&semantic_json, &["typed_named.ts", "typed_namespace.ts"]),
+        "semantic mode should include typed TS static import member positives: {semantic}"
+    );
     assert!(
         !semantic_text.contains("wrong_member.js"),
         "semantic mode must preserve imported member coordinate boundaries: {semantic}"

--- a/crates/nose-cli/tests/detection.rs
+++ b/crates/nose-cli/tests/detection.rs
@@ -133,8 +133,11 @@ fn sub_dag_family_annotates_each_site_with_shared_computation_lines() {
 #[test]
 fn cross_language_family_groups_proven_foreach_languages() {
     // The same guarded-accumulator loop, written idiomatically in languages with proven foreach
-    // semantics, must land in ONE cross-language family. Ruby `.each` is present as a hard
-    // negative: it stays closed until a pack supplies receiver/protocol proof for `items`.
+    // semantics and numeric element proof, must land in ONE cross-language family. TypeScript
+    // `number[]` proves the receiver is an array, but the current domain evidence does not carry
+    // numeric element proof for `for...of`, so it stays closed under JS relational coercion rules.
+    // Ruby `.each` is present as a hard negative: it stays closed until a pack supplies
+    // receiver/protocol proof for `items`.
     let py = "def f(items):\n    total = 0\n    for x in items:\n        if x > 0:\n            total = total + x\n    return total\n";
     let ts = "function g(xs: number[]): number {\n    let acc = 0;\n    for (const v of xs) {\n        if (v > 0) {\n            acc = acc + v;\n        }\n    }\n    return acc;\n}\n";
     let go = "package m\nfunc H(items []int) int {\n\tsum := 0\n\tfor _, e := range items {\n\t\tif e > 0 {\n\t\t\tsum = sum + e\n\t\t}\n\t}\n\treturn sum\n}\n";
@@ -167,8 +170,8 @@ fn cross_language_family_groups_proven_foreach_languages() {
         .find(|f| f.languages >= 2)
         .expect("a cross-language family must exist");
     assert!(
-        xlang.languages == 5 && xlang.members == 5,
-        "py/ts/go/rust/java accumulators form one 5-language, 5-site family (got {} langs, {} sites)",
+        xlang.languages == 4 && xlang.members == 4,
+        "py/go/rust/java accumulators form one 4-language, 4-site family (got {} langs, {} sites)",
         xlang.languages,
         xlang.members
     );
@@ -176,8 +179,8 @@ fn cross_language_family_groups_proven_foreach_languages() {
         xlang
             .locations
             .iter()
-            .all(|l| l.file != "decoy.py" && l.file != "acc.rb"),
-        "ruby each and the decoy must not join the proven foreach family"
+            .all(|l| l.file != "decoy.py" && l.file != "acc.ts" && l.file != "acc.rb"),
+        "typescript without element-domain proof, ruby each, and the decoy must not join the proven foreach family"
     );
 }
 

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -403,10 +403,10 @@ fn filtered_method_reduce_converges_with_guarded_loop() {
         value_fp(&i, reduce_js, Lang::TypeScript),
         "JS filter().reduce(sum) should converge with the guarded loop"
     );
-    assert_eq!(
+    assert_ne!(
         loop_fp,
         value_fp(&i, reduce_rs, Lang::Rust),
-        "Rust filter().fold(sum) should converge through the same value graph"
+        "TypeScript number[] element domains are not yet numeric proof for cross-language relational predicates"
     );
     assert_ne!(
         loop_fp,
@@ -434,10 +434,10 @@ fn filtered_count_aggregates_converge_with_count_loop() {
         return_fp(&i, len_js, Lang::TypeScript),
         "JS filter().length should converge with a guarded count loop"
     );
-    assert_eq!(
+    assert_ne!(
         loop_fp,
         return_fp(&i, count_rs, Lang::Rust),
-        "Rust filter().count() should converge through the same count reduce"
+        "TypeScript number[] element domains are not yet numeric proof for cross-language relational predicates"
     );
     assert_ne!(
         loop_fp,
@@ -1242,8 +1242,16 @@ fn selection_reduction_loops_converge_cross_language() {
     let bad_min = "def f(xs):\n    best = 0\n    for x in xs:\n        if x < best:\n            best = x\n    return best\n";
 
     let max_fp = value_fp(&i, py_max, Lang::Python);
-    assert_eq!(max_fp, value_fp(&i, js_max, Lang::JavaScript));
-    assert_eq!(max_fp, value_fp(&i, reduce_js, Lang::TypeScript));
+    assert_ne!(
+        max_fp,
+        value_fp(&i, js_max, Lang::JavaScript),
+        "untyped JS relational comparison can be string-ordered and must stay closed"
+    );
+    assert_ne!(
+        max_fp,
+        value_fp(&i, reduce_js, Lang::TypeScript),
+        "TypeScript number[] callback elements are not yet numeric proof for relational predicates"
+    );
     assert_eq!(max_fp, value_fp(&i, rust_max, Lang::Rust));
     assert_eq!(max_fp, value_fp(&i, rust_fold_max, Lang::Rust));
     let min_fp = value_fp(&i, py_min, Lang::Python);
@@ -1343,22 +1351,29 @@ fn enumerate_converges_with_range_index() {
 
 #[test]
 fn abs_idiom_converges() {
-    // `abs(x)` and the `x if x>=0 else -x` idiom canonicalize to one Abs value (§AI).
+    // Integer `abs(x)` and the `x if x>=0 else -x` idiom canonicalize to one Abs value (§AI).
     let i = Interner::new();
-    let call = "def f(x):\n    return abs(x)\n";
-    let tern = "def g(x):\n    return x if x >= 0 else -x\n";
+    let call = "def f(x: int):\n    return abs(x)\n";
+    let tern = "def g(x: int):\n    return x if x >= 0 else -x\n";
     assert_eq!(
         value_fp(&i, call, Lang::Python),
         value_fp(&i, tern, Lang::Python),
-        "abs(x) should converge with the conditional-negate idiom"
+        "integer abs(x) should converge with the conditional-negate idiom"
+    );
+    let untyped_call = "def f(x):\n    return abs(x)\n";
+    let untyped_tern = "def g(x):\n    return x if x >= 0 else -x\n";
+    assert_ne!(
+        value_fp(&i, untyped_call, Lang::Python),
+        value_fp(&i, untyped_tern, Lang::Python),
+        "untyped Python abs must not merge with the signed-zero-sensitive ternary idiom"
     );
 }
 
 #[test]
 fn scalar_abs_axis_converges_with_unused_alternate_param() {
     let i = Interner::new();
-    let call = "def f(value, other):\n    return abs(value)\n";
-    let tern = "def g(value, other):\n    return value if value >= 0 else -value\n";
+    let call = "def f(value: int, other: int):\n    return abs(value)\n";
+    let tern = "def g(value: int, other: int):\n    return value if value >= 0 else -value\n";
     assert_eq!(
         value_fp(&i, call, Lang::Python),
         value_fp(&i, tern, Lang::Python)
@@ -1368,12 +1383,13 @@ fn scalar_abs_axis_converges_with_unused_alternate_param() {
 #[test]
 fn scalar_abs_builtins_converge_cross_language_with_shadow_boundary() {
     let i = Interner::new();
-    let py = "def f(value, other):\n    magnitude = value if value >= 0 else -value\n    return magnitude + other\n";
+    let py = "def f(value: int, other: int):\n    magnitude = value if value >= 0 else -value\n    return magnitude + other\n";
     let js =
         "function f(value, other) { const magnitude = Math.abs(value); return magnitude + other; }";
     let ts = "function f(value: number, other: number): number { const magnitude = Math.abs(value); return magnitude + other; }";
     let go = "package p\n\nimport \"math\"\n\nfunc F(value float64, other float64) float64 { magnitude := math.Abs(value); return magnitude + other }\n";
     let java = "class C { static int f(int value, int other) { int magnitude = Math.abs(value); return magnitude + other; } }\n";
+    let java_double = "class C { static double f(double value, double other) { double magnitude = Math.abs(value); return magnitude + other; } }\n";
     let ruby_abs = "def f(value, other)\n  magnitude = value.abs\n  magnitude + other\nend\n";
     let rust_abs =
         "pub fn f(value: i64, other: i64) -> i64 { let magnitude = value.abs(); magnitude + other }\n";
@@ -1384,10 +1400,23 @@ fn scalar_abs_builtins_converge_cross_language_with_shadow_boundary() {
     let rust_float_abs = "pub fn f(value: f64, other: f64) -> f64 { let magnitude = value.abs(); magnitude + other }\n";
     let custom_rust_abs = "struct Wrap(i64);\nimpl Wrap { fn abs(&self) -> i64 { 0 } }\npub fn f(value: Wrap) -> i64 { let magnitude = value.abs(); magnitude + 1 }\n";
     let fp = value_fp(&i, py, Lang::Python);
-    assert_eq!(fp, value_fp(&i, js, Lang::JavaScript));
-    assert_eq!(fp, value_fp(&i, ts, Lang::TypeScript));
-    assert_eq!(fp, value_fp(&i, go, Lang::Go));
+    assert_ne!(fp, value_fp(&i, js, Lang::JavaScript));
+    assert_ne!(
+        fp,
+        value_fp(&i, ts, Lang::TypeScript),
+        "TypeScript Math.abs over number keeps the signed-zero boundary closed"
+    );
+    assert_ne!(
+        fp,
+        value_fp(&i, go, Lang::Go),
+        "Go math.Abs over float64 keeps the signed-zero boundary closed"
+    );
     assert_eq!(fp, value_fp(&i, java, Lang::Java));
+    assert_ne!(
+        fp,
+        value_fp(&i, java_double, Lang::Java),
+        "Java Math.abs over double keeps the signed-zero boundary closed"
+    );
     assert_ne!(fp, value_fp(&i, ruby_abs, Lang::Ruby));
     assert_eq!(fp, value_fp(&i, rust_abs, Lang::Rust));
     assert_ne!(fp, value_fp(&i, shadowed_js, Lang::JavaScript));
@@ -1413,6 +1442,7 @@ fn scalar_minmax_builtins_converge_cross_language() {
         "function f(left, right, other) { const selected = min(left, right); return selected + other; }";
     let go_min = "package p\n\nimport \"math\"\n\nfunc F(left float64, right float64, other float64) float64 { selected := math.Min(left, right); return selected + other }\n";
     let java_min = "class C { static int f(int left, int right, int other) { int selected = Math.min(left, right); return selected + other; } }\n";
+    let java_double_min = "class C { static double f(double left, double right, double other) { double selected = Math.min(left, right); return selected + other; } }\n";
     let c_min = "#include <math.h>\n\ndouble f(double left, double right, double other) { double selected = fmin(left, right); return selected + other; }\n";
     let ruby_min =
         "def f(left, right, other)\n  selected = [left, right].min\n  selected + other\nend\n";
@@ -1426,11 +1456,28 @@ fn scalar_minmax_builtins_converge_cross_language() {
 
     let fp = value_fp(&i, py_min, Lang::Python);
     assert_eq!(fp, value_fp(&i, py_min_call, Lang::Python));
-    assert_eq!(fp, value_fp(&i, js_min, Lang::JavaScript));
-    assert_eq!(fp, value_fp(&i, ts_min, Lang::TypeScript));
+    assert_ne!(
+        fp,
+        value_fp(&i, js_min, Lang::JavaScript),
+        "JS Math.min returns NaN when any argument is NaN, unlike the ternary min idiom"
+    );
+    assert_ne!(
+        fp,
+        value_fp(&i, ts_min, Lang::TypeScript),
+        "TypeScript Math.min over number keeps the same NaN boundary as JS"
+    );
     assert_ne!(fp, value_fp(&i, js_free_min, Lang::JavaScript));
-    assert_eq!(fp, value_fp(&i, go_min, Lang::Go));
+    assert_ne!(
+        fp,
+        value_fp(&i, go_min, Lang::Go),
+        "Go math.Min is a float64 API and keeps the NaN boundary closed"
+    );
     assert_eq!(fp, value_fp(&i, java_min, Lang::Java));
+    assert_ne!(
+        fp,
+        value_fp(&i, java_double_min, Lang::Java),
+        "Java Math.min over double keeps the NaN boundary closed"
+    );
     assert_ne!(fp, value_fp(&i, c_min, Lang::C));
     assert_ne!(fp, value_fp(&i, ruby_min, Lang::Ruby));
     assert_eq!(fp, value_fp(&i, rust_min, Lang::Rust));
@@ -1589,12 +1636,13 @@ fn numeric_clamp_surface_bridge_requires_bound_proof() {
 }
 
 #[test]
-fn conditional_abs_reduction_converges_with_aggregate() {
+fn conditional_abs_reduction_keeps_unproved_abs_aggregate_closed() {
     // A branch in the per-element contribution is still a single reduction:
-    // `total += (x < 0 ? -x : x)` must converge with aggregate `sum(abs(x))`.
+    // `total += (x < 0 ? -x : x)` can converge across proven integer surfaces, but
+    // Python `sum(abs(x) for x in xs)` stays closed until element-domain proof exists.
     let i = Interner::new();
-    let py_loop = "def f(xs):\n    total = 0\n    for x in xs:\n        if x < 0:\n            total += -x\n        else:\n            total += x\n    return total\n";
-    let py_sum = "def f(xs):\n    return sum(abs(x) for x in xs)\n";
+    let py_loop = "def f(xs: list[int]):\n    total = 0\n    for x in xs:\n        if x < 0:\n            total += -x\n        else:\n            total += x\n    return total\n";
+    let py_abs_sum = "def f(xs: list[int]):\n    return sum(abs(x) for x in xs)\n";
     let js_reduce =
         "function f(xs: number[]): number { return xs.reduce((total, x) => total + (x < 0 ? -x : x), 0); }";
     let rust_fold =
@@ -1603,10 +1651,26 @@ fn conditional_abs_reduction_converges_with_aggregate() {
     let bad_sum =
         "def f(xs):\n    total = 0\n    for x in xs:\n        total += x\n    return total\n";
     let fp = value_fp(&i, py_loop, Lang::Python);
-    assert_eq!(fp, value_fp(&i, py_sum, Lang::Python));
-    assert_eq!(fp, value_fp(&i, js_reduce, Lang::TypeScript));
-    assert_eq!(fp, value_fp(&i, rust_fold, Lang::Rust));
-    assert_eq!(fp, value_fp(&i, c_loop, Lang::C));
+    assert_ne!(
+        fp,
+        value_fp(&i, py_abs_sum, Lang::Python),
+        "Python list[int] does not yet prove generator element integer domains for abs"
+    );
+    assert_ne!(
+        fp,
+        value_fp(&i, js_reduce, Lang::TypeScript),
+        "TypeScript number[] callback elements are not yet numeric proof for relational predicates"
+    );
+    assert_eq!(
+        fp,
+        value_fp(&i, rust_fold, Lang::Rust),
+        "Rust i32 slice elements provide integer-domain proof for abs-pattern lowering"
+    );
+    assert_eq!(
+        fp,
+        value_fp(&i, c_loop, Lang::C),
+        "C int pointer elements provide integer-domain proof for abs-pattern lowering"
+    );
     assert_ne!(fp, value_fp(&i, bad_sum, Lang::Python));
 }
 
@@ -1688,15 +1752,15 @@ int h(const void *pa, const void *pb) {
 }
 "#;
     let fp = value_fp(&i, less_first, Lang::C);
-    assert_eq!(
+    assert_ne!(
         fp,
         value_fp(&i, greater_first, Lang::C),
-        "strict comparator guard order should not affect the fingerprint"
+        "C pointer-loaded comparator locals do not yet prove total-order guard inversion"
     );
-    assert_eq!(
+    assert_ne!(
         fp,
         value_fp(&i, ternary, Lang::C),
-        "strict if-return comparator should converge with the ternary sign form"
+        "C pointer-loaded comparator ternaries stay closed without total-order proof"
     );
 }
 
@@ -1980,38 +2044,47 @@ fn conjoined_guard_merges() {
 }
 
 #[test]
-fn continue_guard_unwraps() {
-    // `for x: if c: continue; body` ≡ `for x: if not c: body` (continue-guard unwrap).
+fn continue_guard_unwraps_requires_total_order_proof() {
+    // `for x: if c: continue; body` ≡ `for x: if not c: body` needs proof that
+    // the inverted guard is a total-order dual. Untyped collection elements stay closed.
     let i = Interner::new();
     let cont = "def f(xs):\n    for x in xs:\n        if x < 0:\n            continue\n        process(x)\n";
     let guard = "def g(xs):\n    for x in xs:\n        if x >= 0:\n            process(x)\n";
-    assert_eq!(
+    assert_ne!(
         unit_hash(&i, cont, Lang::Python),
         unit_hash(&i, guard, Lang::Python),
-        "continue-guard ≡ inverted nested body"
+        "continue-guard inversion over untyped elements must keep the NaN boundary closed"
     );
 }
 
 #[test]
 fn branch_orientation_inverts_comparison_canonically() {
-    // `if a < b { X } else { Y }` ≡ `if a >= b { Y } else { X }`: branch orientation
-    // must invert the comparison into the *canonical* (Lt/Le) operand order, else the
-    // two forms never converge. Regression for the Ge/Le canonicalization bug.
+    // Untyped order-comparison branch inversion is not sound in the behavioral
+    // fingerprint: NaN makes `!(a < b)` differ from `a >= b`.
     let i = Interner::new();
     let lt = "def f(a, b, x, y):\n    if a < b:\n        r = x\n    else:\n        r = y\n    return r\n";
     let ge = "def g(a, b, x, y):\n    if a >= b:\n        r = y\n    else:\n        r = x\n    return r\n";
-    assert_eq!(
-        unit_hash(&i, lt, Lang::Python),
-        unit_hash(&i, ge, Lang::Python),
-        "a<b/else ≡ a>=b/swapped"
+    assert_ne!(
+        value_fp(&i, lt, Lang::Python),
+        value_fp(&i, ge, Lang::Python),
+        "untyped a<b/else must not merge with a>=b/swapped"
     );
 
-    let le = "def f(a, b, x, y):\n    if a <= b:\n        r = x\n    else:\n        r = y\n    return r\n";
-    let gt = "def g(a, b, x, y):\n    if a > b:\n        r = y\n    else:\n        r = x\n    return r\n";
+    // Integer-proven operands can still use the total-order dual and should converge.
+    let int_lt = "def f(a: int, b: int, x: int, y: int):\n    if a < b:\n        r = x\n    else:\n        r = y\n    return r\n";
+    let int_ge = "def g(a: int, b: int, x: int, y: int):\n    if a >= b:\n        r = y\n    else:\n        r = x\n    return r\n";
     assert_eq!(
-        unit_hash(&i, le, Lang::Python),
-        unit_hash(&i, gt, Lang::Python),
-        "a<=b/else ≡ a>b/swapped"
+        value_fp(&i, int_lt, Lang::Python),
+        value_fp(&i, int_ge, Lang::Python),
+        "integer a<b/else should converge with a>=b/swapped"
+    );
+
+    let int_le = "def f(a: int, b: int, x: int, y: int):\n    if a <= b:\n        r = x\n    else:\n        r = y\n    return r\n";
+    let int_gt = "def g(a: int, b: int, x: int, y: int):\n    if a > b:\n        r = y\n    else:\n        r = x\n    return r\n";
+    assert_eq!(
+        value_fp(&i, int_le, Lang::Python),
+        value_fp(&i, int_gt, Lang::Python),
+        "integer a<=b/else should converge with a>b/swapped"
     );
 }
 
@@ -2487,11 +2560,11 @@ fn cfg_nested_guard_equals_conjunction() {
 }
 
 #[test]
-fn cfg_continue_guard_equals_nested() {
+fn cfg_continue_guard_requires_total_order_proof() {
     let i = Interner::new();
     let cont = "def f(xs):\n    total = 0\n    for x in xs:\n        if x < 0:\n            continue\n        total = total + x\n    return total\n";
     let nested = "def g(ys):\n    total = 0\n    for y in ys:\n        if y >= 0:\n            total = total + y\n    return total\n";
-    assert_eq!(
+    assert_ne!(
         unit_hash(&i, cont, Lang::Python),
         unit_hash(&i, nested, Lang::Python)
     );
@@ -2832,9 +2905,9 @@ fn filtered_flat_map_sum_converges_with_nested_guarded_reduction() {
         filtered_sum_gen, filtered_sum_loop,
         "filtered flat-map sums should match equivalent nested guarded reductions"
     );
-    assert_eq!(
+    assert_ne!(
         filtered_sum_gen, filtered_sum_js,
-        "filtered flatMap().reduce() should preserve carried outer and inner predicates"
+        "TypeScript number[] callback elements are not yet numeric proof for relational predicates"
     );
     assert_ne!(
         filtered_sum_gen, filtered_sum_outer_changed,
@@ -2890,9 +2963,9 @@ fn filtered_flat_map_any_all_converge_with_nested_guarded_loops() {
         Lang::TypeScript,
     );
 
-    assert_eq!(
+    assert_ne!(
         filtered_any_gen, filtered_any_js,
-        "method terminal predicates over filtered flatMap should preserve carried predicates"
+        "TypeScript number[] callback elements are not yet numeric proof for relational predicates"
     );
     assert_eq!(
         filtered_any_gen, filtered_any_loop,
@@ -2902,9 +2975,9 @@ fn filtered_flat_map_any_all_converge_with_nested_guarded_loops() {
         filtered_any_gen, filtered_any_terminal_changed,
         "changing the terminal method predicate changes behavior"
     );
-    assert_eq!(
+    assert_ne!(
         filtered_all_gen, filtered_all_js,
-        "method universal predicates over filtered flatMap should preserve carried predicates"
+        "TypeScript number[] callback elements are not yet numeric proof for relational predicates"
     );
     assert_eq!(
         filtered_all_gen, filtered_all_loop,
@@ -2916,9 +2989,10 @@ fn filtered_flat_map_any_all_converge_with_nested_guarded_loops() {
     );
 }
 
-/// Cross-language `any`/`all` predicate reductions converge to one fingerprint: Python
-/// `any(p(x) for x in xs)`, JS `xs.some(p)`, Rust `xs.iter().any(p)` — and likewise
-/// `all`/`every`. `any` and `all` stay DISTINCT (different short-circuit behavior).
+/// Cross-language `any`/`all` predicate reductions converge when the predicate is proven in the
+/// same primitive domain. Rust iterator predicates still converge with Python generators; TS
+/// `number[]` callbacks stay closed until element-domain proof exists. `any` and `all` stay
+/// DISTINCT (different short-circuit behavior).
 #[test]
 fn cross_language_any_all_converges() {
     let i = Interner::new();
@@ -2947,9 +3021,15 @@ fn cross_language_any_all_converges() {
         "function g(xs: number[]): boolean { return xs.every(x => x > 0); }",
         Lang::TypeScript,
     );
-    assert_eq!(any_py, any_js, "Python any ≡ JS some");
+    assert_ne!(
+        any_py, any_js,
+        "TypeScript number[] callback elements are not yet numeric proof for relational predicates"
+    );
     assert_eq!(any_py, any_rs, "Python any ≡ Rust any");
-    assert_eq!(all_py, all_js, "Python all ≡ JS every");
+    assert_ne!(
+        all_py, all_js,
+        "TypeScript number[] callback elements are not yet numeric proof for relational predicates"
+    );
     assert_ne!(any_py, all_py, "any and all must stay distinct");
     assert!(!any_py.is_empty());
 }
@@ -3006,21 +3086,21 @@ fn rust_filter_map_converges_with_filtered_map_and_guarded_builder() {
         filtered_py, filtered_js,
         "untyped JS parameter method calls lack a receiver proof and must stay opaque"
     );
-    assert_eq!(
+    assert_ne!(
         filtered_py, filtered_ts,
-        "TypeScript filter+map surface should agree"
+        "TypeScript number[] callback elements are not yet numeric proof for relational predicates"
     );
     assert_eq!(
         filtered_py, filter_map_rs,
-        "Rust filter_map Some/None should become the same filtered-map value"
+        "Rust i32 slice callback elements provide total-order proof for filter_map"
     );
     assert_eq!(
         filtered_py, match_option_rs,
-        "Rust filter_map match guards should become the same filtered-map value"
+        "Rust filter_map match guards should use the same total-order proof"
     );
     assert_eq!(
         filtered_py, and_then_rs,
-        "Rust filter_map pure Option::and_then chains should become the same filtered-map value"
+        "Rust Option::and_then filter_map chains should use the same total-order proof"
     );
     assert_eq!(
         filtered_py, guarded_builder_rs,
@@ -3072,11 +3152,11 @@ fn rust_filter_map_keeps_falsey_and_none_payload_boundaries() {
 
     assert_eq!(
         falsey_py, falsey_rs,
-        "Some(0) is an emitted value, not an absence sentinel"
+        "Rust filter_map emits falsey payloads rather than treating them as absence"
     );
     assert_eq!(
         filtered_none_py, wrapped_none_rs,
-        "Some(None) is an emitted Null payload, not a dropped item"
+        "Rust filter_map emits wrapped None payloads rather than dropping them"
     );
     assert_ne!(
         filtered_py, wrapped_none_rs,
@@ -3993,6 +4073,7 @@ fn import_named_and_namespace_member_coordinates_converge() {
     let js_named = "import { helper } from \"./shared-math\";\nfunction f(value) { return helper(value + 1); }\n";
     let js_namespace = "import * as mathOps from \"./shared-math\";\nfunction f(value) { return mathOps.helper(value + 1); }\n";
     let js_wrong_member = "import * as mathOps from \"./shared-math\";\nfunction f(value) { return mathOps.otherHelper(value + 1); }\n";
+    let ts_named = "import { helper } from \"./shared-math\";\nfunction f(value: number): number { return helper(value + 1); }\n";
     let ts_namespace = "import * as mathOps from \"./shared-math\";\nfunction f(value: number): number { return mathOps.helper(value + 1); }\n";
     let ts_type_only =
         "import type { helper } from \"./shared-math\";\nfunction f(value: number): number { return helper(value + 1); }\n";
@@ -4006,8 +4087,11 @@ fn import_named_and_namespace_member_coordinates_converge() {
 
     let fp = value_fp(&i, js_named, Lang::JavaScript);
     assert_eq!(fp, value_fp(&i, js_namespace, Lang::JavaScript));
-    assert_eq!(fp, value_fp(&i, ts_namespace, Lang::TypeScript));
     assert_ne!(fp, value_fp(&i, js_wrong_member, Lang::JavaScript));
+
+    let ts_fp = value_fp(&i, ts_named, Lang::TypeScript);
+    assert_eq!(ts_fp, value_fp(&i, ts_namespace, Lang::TypeScript));
+    assert_ne!(fp, ts_fp);
     assert_ne!(fp, value_fp(&i, ts_type_only, Lang::TypeScript));
     assert_ne!(fp, value_fp(&i, ts_mixed_type_only, Lang::TypeScript));
 
@@ -5380,19 +5464,26 @@ fn value_graph_distinguishes_boolean_literals() {
     // `if x>0: return True else False` and its negation (booleans swapped) compute
     // opposite results and must not collapse. The bool *value* was abstracted away.
     let i = Interner::new();
-    let p = "def f(x):\n    if x > 0:\n        return True\n    return False\n";
-    let q = "def g(x):\n    if x > 0:\n        return False\n    return True\n";
+    let p = "def f(x: int):\n    if x > 0:\n        return True\n    return False\n";
+    let q = "def g(x: int):\n    if x > 0:\n        return False\n    return True\n";
     assert_ne!(
         value_fp(&i, p, Lang::Python),
         value_fp(&i, q, Lang::Python),
         "a predicate and its boolean-swapped negation must not fingerprint identically"
     );
-    // Cross-language: the same predicate in TS converges with Python.
-    let ts = "function f(x) { if (x > 0) { return true; } return false; }";
+    // Cross-language: the same integer predicate in Java converges with Python.
+    let java = "class C { static boolean f(int x) { if (x > 0) { return true; } return false; } }";
     assert_eq!(
         value_fp(&i, p, Lang::Python),
+        value_fp(&i, java, Lang::Java),
+        "same integer predicate should converge across languages"
+    );
+    // TypeScript `number` keeps its NaN comparison boundary closed.
+    let ts = "function f(x: number): boolean { if (x > 0) { return true; } return false; }";
+    assert_ne!(
+        value_fp(&i, p, Lang::Python),
         value_fp(&i, ts, Lang::TypeScript),
-        "same predicate should converge across languages"
+        "TS number predicates must not merge with integer-only predicates"
     );
 }
 
@@ -5686,8 +5777,8 @@ u32 q(const int *a) {
 fn value_graph_cross_language_reorder() {
     // Same computation, different statement order, different language.
     let i = Interner::new();
-    let py = "def f(a, b):\n    p = a * b\n    q = a + b\n    return p + q + p\n";
-    let ts = "function g(a, b){ const q = a + b; const p = a * b; return p + q + p; }";
+    let py = "def f(a: int, b: int):\n    p = a * b\n    q = a + b\n    return p + q + p\n";
+    let ts = "function g(a: number, b: number): number { const q = a + b; const p = a * b; return p + q + p; }";
     assert_eq!(
         value_fp(&i, py, Lang::Python),
         value_fp(&i, ts, Lang::TypeScript)
@@ -5838,7 +5929,7 @@ fn lattice_strict_comparison_converges_and_separates() {
     // SOUND lattice canon on a total order: `(x ≤ y) ∧ (x ≠ y) ≡ x < y` and the dual
     // `(x < y) ∨ (x = y) ≡ x ≤ y`. Declaring the one `∧` rule composes through the
     // recursive `mk` fixpoint (De Morgan + comparison-direction canon) to also close
-    // `not (a > b or a == b) ≡ a < b`, cross-language.
+    // `not (a > b or a == b) ≡ a < b` for integer-proven operands.
     let i = Interner::new();
     let lt = value_fp(&i, "def f(a,b):\n    return a<b\n", Lang::Python);
     assert_eq!(
@@ -5851,22 +5942,32 @@ fn lattice_strict_comparison_converges_and_separates() {
         value_fp(&i, "def g(a,b):\n    return a!=b and a<=b\n", Lang::Python),
         "operand order of the conjunction must not matter"
     );
+    let lt_int = value_fp(&i, "def f(a: int,b: int):\n    return a<b\n", Lang::Python);
     assert_eq!(
+        lt_int,
+        value_fp(
+            &i,
+            "def g(a: int,b: int):\n    return not (a>b or a==b)\n",
+            Lang::Python
+        ),
+        "De Morgan + comparison-direction must compose into the lattice canon"
+    );
+    assert_ne!(
         lt,
         value_fp(
             &i,
             "def g(a,b):\n    return not (a>b or a==b)\n",
             Lang::Python
         ),
-        "De Morgan + comparison-direction must compose into the lattice canon"
+        "untyped De Morgan plus order negation must keep the NaN boundary closed"
     );
-    // Cross-language: a JS strict-less written as the conjunction.
+    // Cross-language: a typed TS strict-less written as the conjunction.
     assert_eq!(
         lt,
         value_fp(
             &i,
-            "function g(a,b){ return a<=b && a!=b; }",
-            Lang::JavaScript
+            "function g(a: number, b: number): boolean { return a <= b && a !== b; }",
+            Lang::TypeScript
         ),
         "the lattice canon is language-agnostic"
     );
@@ -6067,8 +6168,8 @@ fn class_value_law_domains_use_method_parameter_evidence() {
 
 /// FILTER FUSION: `filter(q, filter(p, xs))` ≡ `filter(p∧q, xs)`. The value graph carries a
 /// filter's element so nested filters fuse (`value_graph.rs` `HoFKind::Filter` arm, Lean
-/// `normalize.value_graph.functor`). A two-filter comprehension, an explicitly nested one, and
-/// (cross-language) a JS `.filter().filter()` all converge to one filtered stream.
+/// `normalize.value_graph.functor`). A two-filter comprehension and an explicitly nested one
+/// converge; TS `number[]` callbacks stay closed until element-domain proof exists.
 #[test]
 fn filter_fusion_converges() {
     let i = Interner::new();
@@ -6085,7 +6186,7 @@ fn filter_fusion_converges() {
         ),
         "two stacked filters should fuse with an explicitly nested filter"
     );
-    assert_eq!(
+    assert_ne!(
         value_fp(
             &i,
             "def f(xs):\n    return [x for x in xs if x>0 if x<10]\n",
@@ -6096,7 +6197,7 @@ fn filter_fusion_converges() {
             "function g(xs: number[]): number[] { return xs.filter(x=>x>0).filter(x=>x<10); }",
             Lang::TypeScript
         ),
-        "Python two-filter comprehension should converge with JS chained .filter().filter()"
+        "TypeScript number[] callback elements are not yet numeric proof for relational predicates"
     );
 }
 
@@ -6294,7 +6395,7 @@ fn convergence_probe_xlang() {
          "def f(a,b):\n    if a>0:\n        return b+1\n    return b+2\n", Lang::Python,
          "package p\nfunc f(a,b int) int {\n\tif a>0 {\n\t\treturn b+1\n\t}\n\treturn b+2\n}\n", Lang::Go),
         ("x*2 vs x+x", "def f(x):\n    return x*2\n", Lang::Python, "def g(x):\n    return x+x\n", Lang::Python),
-        ("abs idioms Py", "def f(x):\n    return x if x>=0 else -x\n", Lang::Python, "def g(x):\n    return abs(x)\n", Lang::Python),
+        ("abs idioms Py", "def f(x: int):\n    return x if x>=0 else -x\n", Lang::Python, "def g(x: int):\n    return abs(x)\n", Lang::Python),
         ("compound assign", "def f(a,b):\n    a += b\n    a *= 2\n    return a\n", Lang::Python, "def g(a,b):\n    return (a+b)*2\n", Lang::Python),
         ("min idioms", "def f(a,b):\n    return a if a<b else b\n", Lang::Python, "def g(a,b):\n    return min(a,b)\n", Lang::Python),
         ("count loop vs sum-1", "def f(xs):\n    c=0\n    for x in xs:\n        if x>0:\n            c+=1\n    return c\n", Lang::Python, "def g(xs):\n    return sum(1 for x in xs if x>0)\n", Lang::Python),
@@ -6469,15 +6570,15 @@ fn tail_recursion_converges_with_while_loop() {
 
 #[test]
 fn tail_recursion_converges_cross_language() {
-    // Python accumulator recursion ≡ a JavaScript while loop — the shared IL makes the
+    // Python accumulator recursion ≡ a typed TypeScript while loop — the shared IL makes the
     // recursion→iteration rewrite cross-language for free.
     let i = Interner::new();
     let py = "def f(n, acc):\n    if n == 0:\n        return acc\n    return f(n - 1, acc + n)\n";
-    let js = "function g(n, acc){ while(n != 0){ acc = acc + n; n = n - 1; } return acc; }";
+    let ts = "function g(n: number, acc: number): number { while (n !== 0) { acc = acc + n; n = n - 1; } return acc; }";
     assert_eq!(
         value_fp(&i, py, Lang::Python),
-        value_fp(&i, js, Lang::JavaScript),
-        "Python tail recursion and JS while loop should converge"
+        value_fp(&i, ts, Lang::TypeScript),
+        "Python tail recursion and typed TypeScript while loop should converge"
     );
 }
 
@@ -6733,6 +6834,217 @@ fn js_shift_is_int32_and_distinct_from_arbitrary_precision() {
         value_fp(&i, py_shl, Lang::Python),
         value_fp(&i, py_shl2, Lang::Python),
         "two Python `<<` must still converge"
+    );
+}
+
+#[test]
+fn js_mixed_string_addition_keeps_grouping_ordered() {
+    // JS `+` is not just numeric add or string concat: when a string participates,
+    // later numeric operands are coerced to strings in left-to-right order.
+    // `"a" + 2 + 3` is `"a23"`, while `"a" + (2 + 3)` / `"a" + 5` is `"a5"`.
+    // Flattening/folding an untyped JS `+` chain therefore false-merges real code.
+    let i = Interner::new();
+    let left_assoc = "function f(x) { return x + 2 + 3; }";
+    let grouped = "function g(x) { return x + (2 + 3); }";
+    let folded = "function h(x) { return x + 5; }";
+    assert_ne!(
+        value_fp(&i, left_assoc, Lang::JavaScript),
+        value_fp(&i, grouped, Lang::JavaScript),
+        "untyped JS `x + 2 + 3` must not merge with `x + (2 + 3)`"
+    );
+    assert_ne!(
+        value_fp(&i, left_assoc, Lang::JavaScript),
+        value_fp(&i, folded, Lang::JavaScript),
+        "untyped JS `x + 2 + 3` must not merge with `x + 5`"
+    );
+
+    let typed_left = "function f(x: number): number { return x + 2 + 3; }";
+    let typed_grouped = "function g(x: number): number { return x + (2 + 3); }";
+    assert_eq!(
+        value_fp(&i, typed_left, Lang::TypeScript),
+        value_fp(&i, typed_grouped, Lang::TypeScript),
+        "TypeScript number evidence should preserve numeric associativity recall"
+    );
+
+    let sub = "function f(x) { return x - 3; }";
+    let add_neg = "function g(x) { return x + (-3); }";
+    assert_ne!(
+        value_fp(&i, sub, Lang::JavaScript),
+        value_fp(&i, add_neg, Lang::JavaScript),
+        "untyped JS `x - 3` must not merge with `x + (-3)`"
+    );
+
+    let neg_grouped = "function f(x) { return -(x + 2); }";
+    let distributed = "function g(x) { return -x - 2; }";
+    assert_ne!(
+        value_fp(&i, neg_grouped, Lang::JavaScript),
+        value_fp(&i, distributed, Lang::JavaScript),
+        "untyped JS `-(x + 2)` must not distribute over potentially-string `+`"
+    );
+
+    let typed_sub = "function f(x: number): number { return x - 3; }";
+    let typed_add_neg = "function g(x: number): number { return x + (-3); }";
+    assert_eq!(
+        value_fp(&i, typed_sub, Lang::TypeScript),
+        value_fp(&i, typed_add_neg, Lang::TypeScript),
+        "TypeScript number evidence should preserve subtraction/add-negation recall"
+    );
+}
+
+#[test]
+fn js_value_returning_logical_operators_keep_operand_order() {
+    // JS `||`/`&&` return one of the operand values, not a coerced Bool. With
+    // `a = "left"` and `b = "right"`, `a || b` returns `a` while `b || a` returns `b`;
+    // `a && b` returns `b` while `b && a` returns `a`.
+    let i = Interner::new();
+    let or_ab = "function f(a, b) { return a || b; }";
+    let or_ba = "function g(a, b) { return b || a; }";
+    let and_ab = "function h(a, b) { return a && b; }";
+    let and_ba = "function k(a, b) { return b && a; }";
+    assert_ne!(
+        value_fp(&i, or_ab, Lang::JavaScript),
+        value_fp(&i, or_ba, Lang::JavaScript),
+        "untyped JS `a || b` must not merge with `b || a`"
+    );
+    assert_ne!(
+        value_fp(&i, and_ab, Lang::JavaScript),
+        value_fp(&i, and_ba, Lang::JavaScript),
+        "untyped JS `a && b` must not merge with `b && a`"
+    );
+
+    let bool_or_ab = "function f(a: boolean, b: boolean): boolean { return a || b; }";
+    let bool_or_ba = "function g(a: boolean, b: boolean): boolean { return b || a; }";
+    let bool_and_ab = "function h(a: boolean, b: boolean): boolean { return a && b; }";
+    let bool_and_ba = "function k(a: boolean, b: boolean): boolean { return b && a; }";
+    assert_eq!(
+        value_fp(&i, bool_or_ab, Lang::TypeScript),
+        value_fp(&i, bool_or_ba, Lang::TypeScript),
+        "typed boolean `||` should keep commutative recall"
+    );
+    assert_eq!(
+        value_fp(&i, bool_and_ab, Lang::TypeScript),
+        value_fp(&i, bool_and_ba, Lang::TypeScript),
+        "typed boolean `&&` should keep commutative recall"
+    );
+}
+
+#[test]
+fn js_loose_equality_stays_distinct_from_strict_equality() {
+    // JS loose equality coerces (`false == 0`, `"0" == 0`, `[] == 0`), so it is not
+    // semantically interchangeable with strict equality except for the intentionally modeled
+    // nullish check (`x == null`) that backs `??`.
+    let i = Interner::new();
+    let loose_zero = "function f(x) { return x == 0; }";
+    let loose_zero_swapped = "function g(y) { return 0 == y; }";
+    let strict_zero = "function h(x) { return x === 0; }";
+    assert_eq!(
+        value_fp(&i, loose_zero, Lang::JavaScript),
+        value_fp(&i, loose_zero_swapped, Lang::JavaScript),
+        "loose equality itself is symmetric and should still converge across operand order"
+    );
+    assert_ne!(
+        value_fp(&i, loose_zero, Lang::JavaScript),
+        value_fp(&i, strict_zero, Lang::JavaScript),
+        "loose `x == 0` must not merge with strict `x === 0`"
+    );
+
+    let loose_ne_zero = "function f(x) { return x != 0; }";
+    let strict_ne_zero = "function h(x) { return x !== 0; }";
+    assert_ne!(
+        value_fp(&i, loose_ne_zero, Lang::JavaScript),
+        value_fp(&i, strict_ne_zero, Lang::JavaScript),
+        "loose `x != 0` must not merge with strict `x !== 0`"
+    );
+
+    let nullish = "function f(x, d) { return x ?? d; }";
+    let loose_null = "function g(x, d) { return x == null ? d : x; }";
+    let strict_null = "function h(x, d) { return x === null ? d : x; }";
+    assert_eq!(
+        value_fp(&i, nullish, Lang::JavaScript),
+        value_fp(&i, loose_null, Lang::JavaScript),
+        "loose `== null` remains the modeled nullish check"
+    );
+    assert_ne!(
+        value_fp(&i, loose_null, Lang::JavaScript),
+        value_fp(&i, strict_null, Lang::JavaScript),
+        "strict null equality must stay separate from the nullish loose check"
+    );
+}
+
+#[test]
+fn js_instanceof_stays_distinct_from_equality() {
+    // `instanceof` tests a value's prototype chain. It is not equality:
+    // `[] instanceof Array` is true, while `[] === Array` is false.
+    let i = Interner::new();
+    let membership = "function f(x, C) { return x instanceof C; }";
+    let renamed_membership = "function h(value, Type) { return value instanceof Type; }";
+    let equality = "function g(x, C) { return x === C; }";
+    assert_eq!(
+        value_fp(&i, membership, Lang::JavaScript),
+        value_fp(&i, renamed_membership, Lang::JavaScript),
+        "`instanceof` should still converge with the same directional source surface"
+    );
+    assert_ne!(
+        value_fp(&i, membership, Lang::JavaScript),
+        value_fp(&i, equality, Lang::JavaScript),
+        "`x instanceof C` must not merge with `x === C`"
+    );
+
+    let not_membership = "function f(x, C) { return !(x instanceof C); }";
+    let not_renamed_membership = "function h(value, Type) { return !(value instanceof Type); }";
+    let strict_inequality = "function g(x, C) { return x !== C; }";
+    assert_eq!(
+        value_fp(&i, not_membership, Lang::JavaScript),
+        value_fp(&i, not_renamed_membership, Lang::JavaScript),
+        "negated `instanceof` should still converge with the same source surface"
+    );
+    assert_ne!(
+        value_fp(&i, not_membership, Lang::JavaScript),
+        value_fp(&i, strict_inequality, Lang::JavaScript),
+        "`!(x instanceof C)` must not merge with `x !== C`"
+    );
+}
+
+#[test]
+fn js_relational_comparison_stays_distinct_from_typed_numeric_comparison() {
+    // JS relational comparison is not purely numeric for untyped operands:
+    // `"2" < "10"` is false because both operands are strings, while `2 < 10` is true.
+    let i = Interner::new();
+    let js_lt = "function f(a, b) { return a < b; }";
+    let ts_lt = "function g(a: number, b: number): boolean { return a < b; }";
+    let ts_gt = "function h(a: number, b: number): boolean { return b > a; }";
+    assert_eq!(
+        value_fp(&i, ts_lt, Lang::TypeScript),
+        value_fp(&i, ts_gt, Lang::TypeScript),
+        "typed numeric TS comparison should keep primitive comparison laws"
+    );
+    assert_ne!(
+        value_fp(&i, js_lt, Lang::JavaScript),
+        value_fp(&i, ts_lt, Lang::TypeScript),
+        "untyped JS `<` must not merge with typed numeric `<`"
+    );
+
+    let not_lt = "function f(a, b) { return !(a < b); }";
+    let ge = "function g(a, b) { return a >= b; }";
+    assert_ne!(
+        value_fp(&i, not_lt, Lang::JavaScript),
+        value_fp(&i, ge, Lang::JavaScript),
+        "JS `!(a < b)` must not merge with `a >= b` because NaN makes them differ"
+    );
+
+    let py_not_lt = "def f(a, b):\n    return not (a < b)\n";
+    let py_ge = "def g(a, b):\n    return a >= b\n";
+    assert_ne!(
+        value_fp(&i, py_not_lt, Lang::Python),
+        value_fp(&i, py_ge, Lang::Python),
+        "Python `not (a < b)` must not merge with `a >= b` because NaN makes them differ"
+    );
+    let py_int_not_lt = "def f(a: int, b: int):\n    return not (a < b)\n";
+    let py_int_ge = "def g(a: int, b: int):\n    return a >= b\n";
+    assert_eq!(
+        value_fp(&i, py_int_not_lt, Lang::Python),
+        value_fp(&i, py_int_ge, Lang::Python),
+        "integer-proven Python order negation can use total-order duals"
     );
 }
 
@@ -7147,14 +7459,15 @@ fn effectful_commutative_operands_do_not_reorder() {
 
 #[test]
 fn sound_recall_rules_converge_with_hard_negatives() {
-    // #284 (coevo §CE / S5-C4): three behaviorally-equal forms that nose now
-    // converges. Each is sound for ALL inputs because the error behavior is
-    // preserved on both sides (unlike the §BA identity rewrites), so no type gate.
+    // #284 (coevo §CE / S5-C4): behaviorally-equal forms that nose now converges.
+    // The abs law is integer-gated; the bitwise laws preserve error behavior on
+    // both sides for non-integer inputs.
     let i = Interner::new();
 
-    // abs(abs x) ≡ abs x — abs is idempotent; a non-orderable input Errs on both.
-    let abs_nested = "def f(x):\n    a = x if x >= 0 else -x\n    return a if a >= 0 else -a\n";
-    let abs_once = "def g(x):\n    return x if x >= 0 else -x\n";
+    // abs(abs x) ≡ abs x for integer-proven operands.
+    let abs_nested =
+        "def f(x: int):\n    a = x if x >= 0 else -x\n    return a if a >= 0 else -a\n";
+    let abs_once = "def g(x: int):\n    return x if x >= 0 else -x\n";
     assert_eq!(
         value_fp(&i, abs_nested, Lang::Python),
         value_fp(&i, abs_once, Lang::Python),

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -1957,7 +1957,8 @@ fn js_bin_op(text: &str) -> Option<Op> {
         "===" => Some(Op::Eq),
         "!==" => Some(Op::Ne),
         // `x in obj` is a directional membership/key test — its own non-commutative op.
-        // `instanceof` is a type-identity check; equality-shaped is an acceptable approx.
+        // `instanceof` is structurally equality-shaped but carries a source-operator fact;
+        // the value graph salts it so prototype-chain type membership never merges with equality.
         "in" => Some(Op::In),
         "instanceof" => Some(Op::Eq),
         _ => None,

--- a/crates/nose-normalize/src/algebra.rs
+++ b/crates/nose-normalize/src/algebra.rs
@@ -9,10 +9,11 @@
 //!   grouping/ordering of `a + b + c` converges.
 //! - **comparison direction**: `a > b` → `b < a`, `a >= b` → `b <= a`, so only
 //!   `<`/`<=`/`==`/`!=` remain.
-//! - **negation / De Morgan**: `!(a && b)` → `!a || !b`, `!(a == b)` → `a != b`,
-//!   `!(a < b)` → `b <= a`. The value-DEPENDENT cancellations `!!x → x` (bool
-//!   coercion) and `-(-x) → x` (numeric only) are NOT done here — this pass has no
-//!   operand type, so they are deferred to the value graph's proof-gated canon.
+//! - **negation / De Morgan**: `!(a && b)` → `!a || !b`, `!(a == b)` → `a != b`.
+//!   Order-comparison duals such as `!(a < b)` → `a >= b`, plus value-DEPENDENT
+//!   cancellations `!!x → x` (bool coercion) and `-(-x) → x` (numeric only), are
+//!   NOT done here — this pass has no operand type, so they are deferred to the
+//!   value graph's proof-gated canon.
 //!
 //! Value-dependent identities (`x + 0` → `x`) are deferred — they need literal
 //! values, which are abstracted to classes. Full distribution (where the
@@ -52,6 +53,13 @@ fn is_assoc_comm(op: Op) -> bool {
     matches!(
         op,
         Op::Add | Op::Mul | Op::And | Op::Or | Op::BitAnd | Op::BitOr | Op::BitXor
+    )
+}
+
+fn plus_has_mixed_string_coercion(lang: Lang) -> bool {
+    matches!(
+        lang,
+        Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html | Lang::Java
     )
 }
 
@@ -135,6 +143,13 @@ impl Rewriter<'_> {
             _ => return self.generic(old_id, span),
         };
         if is_assoc_comm(op) {
+            // JS/TS/Java `+` can coerce mixed string/non-string operands, so grouping itself
+            // is observable: `"a" + 2 + 3` is not `"a" + (2 + 3)`. This IL pass has no
+            // evidence strong enough to prove a chain numeric; leave the tree intact and
+            // let the value graph perform evidence-gated association/commutation.
+            if op == Op::Add && plus_has_mixed_string_coercion(self.old.meta.lang) {
+                return self.generic(old_id, span);
+            }
             let mut leaves = Vec::new();
             self.collect_assoc_old(old_id, op, &mut leaves);
             // Constant folding + identity elimination (now that C retains literal values):
@@ -320,14 +335,13 @@ impl Rewriter<'_> {
                             olds.into_iter().map(|o| self.rewrite_negated(o)).collect();
                         self.build_assoc(flip, span, negated)
                     }
-                    // Negate an order comparison on a total order, canonicalized to `<`/`<=`:
-                    //   !(x < y)  = y <= x   !(x <= y) = y < x    (operands reflect)
-                    //   !(x > y)  = x <= y   !(x >= y) = x < y     (operands stay)
-                    // The strict/non-strict polarity flips (`<`,`>` → `<=`; `<=`,`>=` → `<`),
-                    // and only the already-reflected `<`/`<=` cases swap operands so the result
-                    // points the canonical way. Lean obligation: `normalize.value_graph.compare`,
-                    // `not_le_eq_gt`+`gt_eq_lt_swap`, `not_gt_eq_le`, `not_ge_eq_lt`.
                     Op::Eq | Op::Ne | Op::Lt | Op::Le | Op::Gt | Op::Ge => {
+                        // Equality negation is value-independent. Order-comparison duals
+                        // need total-order proof because NaN makes `!(a < b)` differ from
+                        // `a >= b`; the value graph handles those when operands prove integer.
+                        if matches!(op, Op::Lt | Op::Le | Op::Gt | Op::Ge) {
+                            return self.negate_wrap(old, span);
+                        }
                         let Some(contract) = operators.canonical_negated_comparison(op) else {
                             return self.negate_wrap(old, span);
                         };

--- a/crates/nose-normalize/src/cfg_norm.rs
+++ b/crates/nose-normalize/src/cfg_norm.rs
@@ -6,8 +6,10 @@
 //!   produces are then canonicalized by `algebra` (flatten, De Morgan), so nested
 //!   and flattened control styles converge.
 //! - [`run`] (in-place, run last): **branch orientation** — when an `if`'s two
-//!   branches could be swapped, orient them canonically by inverting a comparison
-//!   condition. `if a < b { X } else { Y }` ≡ `if a >= b { Y } else { X }`.
+//!   branches could be swapped, orient equality comparisons canonically by
+//!   inverting the condition. Order-comparison branch orientation is value-domain
+//!   dependent (`NaN` breaks `!(a < b)` ≡ `a >= b`), so the value graph performs
+//!   that rewrite only after integer-domain proof.
 //!
 //! proof-obligation: normalize.control_flow.guard_returns
 
@@ -216,22 +218,19 @@ pub(crate) fn run(il: &mut Il, interner: &Interner) {
     }
 }
 
-/// If `cond` is a comparison `BinOp`, return its canonical negation as
-/// `(operator, swap_operands)`. Only the post-`algebra` canonical comparisons
-/// (`Lt`/`Le`/`Eq`/`Ne`) are produced: `a < b` negates to `a >= b` ≡ `b <= a`
-/// (`Le`, operands swapped); `a <= b` to `b < a` (`Lt`, swapped).
+/// If `cond` is an equality comparison `BinOp`, return its canonical negation as
+/// `(operator, swap_operands)`. Order comparisons are deliberately excluded here:
+/// they need total-order proof, which is only available in the value graph.
 fn invert_comparison(il: &Il, cond: NodeId) -> Option<(Op, bool)> {
     let n = il.node(cond);
     if n.kind != NodeKind::BinOp {
         return None;
     }
     match n.payload {
-        Payload::Op(op) if matches!(op, Op::Eq | Op::Ne | Op::Lt | Op::Le) => {
-            semantics(il.meta.lang)
-                .operators()
-                .canonical_negated_comparison(op)
-                .map(|contract| (contract.output, contract.swap_operands))
-        }
+        Payload::Op(op) if matches!(op, Op::Eq | Op::Ne) => semantics(il.meta.lang)
+            .operators()
+            .canonical_negated_comparison(op)
+            .map(|contract| (contract.output, contract.swap_operands)),
         Payload::Op(_) => None,
         _ => None,
     }

--- a/crates/nose-normalize/src/idioms.rs
+++ b/crates/nose-normalize/src/idioms.rs
@@ -1908,17 +1908,11 @@ mod tests {
     }
 
     #[test]
-    fn go_stdlib_method_requires_import_namespace_proof() {
+    fn go_math_abs_stays_closed_even_with_import_namespace_proof() {
         let (il, interner, call) = go_math_abs_il(false);
         assert!(matches!(canon_call(&il, &interner, call), CallCanon::None));
 
         let (il, interner, call) = go_math_abs_il(true);
-        assert!(matches!(
-            canon_call(&il, &interner, call),
-            CallCanon::Builtin {
-                op: Builtin::Abs,
-                arg_olds
-            } if arg_olds.len() == 1
-        ));
+        assert!(matches!(canon_call(&il, &interner, call), CallCanon::None));
     }
 }

--- a/crates/nose-normalize/src/value_graph/canonicalize.rs
+++ b/crates/nose-normalize/src/value_graph/canonicalize.rs
@@ -114,10 +114,8 @@ impl<'a> Builder<'a> {
 
     fn unary_canon(&mut self, op: &ValOp, args: &[ValueId]) -> Option<ValueId> {
         let ValOp::Un(o) = *op else { return None };
-        // ABS IDEMPOTENCE: `abs(abs x) → abs x` (#284). `abs` is always ≥ 0 so the
-        // outer is a no-op; on a non-orderable input both sides Err identically
-        // (the inner `abs` Errs, propagating), so it is sound for ALL inputs — no
-        // type gate. `ABS_CODE` is synthesized from a ternary by `minmax_pattern`.
+        // ABS IDEMPOTENCE: `abs(abs x) → abs x` (#284). `ABS_CODE` is synthesized
+        // only from integer-proven calls or sign ternaries, so the outer Abs is a no-op.
         if o == ABS_CODE && !args.is_empty() {
             if let ValOp::Un(io) = self.nodes[args[0] as usize].op {
                 if io == ABS_CODE {
@@ -153,9 +151,16 @@ impl<'a> Builder<'a> {
                 }
             }
         }
-        // NEGATED COMPARISON: `!(a<=b) → a>b`, `!(a<b) → a>=b`, `!(a==b) → a!=b`, etc.
-        // Sound for a total order, and on non-numeric operands both sides Err
-        // (`!(Err)` propagates — see interp `un`), so the rewrite preserves behavior.
+        // Boolean double negation: unlike truthiness `!!x`, `!!b == b` when the
+        // inner value is already proven Boolean (comparisons, boolean params, etc.).
+        if o == Op::Not as u32 && !args.is_empty() {
+            if let Some(inner) = self.boolean_double_negation(args[0]) {
+                return Some(inner);
+            }
+        }
+        // NEGATED COMPARISON: `!(a==b) → a!=b` is value-independent. Order duals
+        // such as `!(a<b) → a>=b` require integer-domain proof because NaN makes
+        // the apparent dual false while the negated comparison is true.
         // This canonicalizes the residual `Not` the algebra pass leaves on a pushed
         // double-negation (`!!(a<b)` → `!(b<=a)` → `a<b`), converging it with the bare
         // comparison without the unsound untyped `!!x → x`.
@@ -163,11 +168,8 @@ impl<'a> Builder<'a> {
             && !args.is_empty()
             && self.comparison_law_enabled(ComparisonLaw::Negation)
         {
-            if let ValOp::Bin(bo) = self.nodes[args[0] as usize].op {
-                if let Some(neg) = negate_cmp_code(self.il.meta.lang, bo) {
-                    let cargs = self.nodes[args[0] as usize].args.clone();
-                    return Some(self.mk(ValOp::Bin(neg), cargs));
-                }
+            if let Some(negated) = self.negated_comparison(args[0]) {
+                return Some(negated);
             }
         }
         if o == Op::Neg as u32 && !args.is_empty() {
@@ -187,6 +189,13 @@ impl<'a> Builder<'a> {
             if let ValOp::Bin(bo) = self.nodes[args[0] as usize].op {
                 if bo == Op::Add as u32 {
                     let inner = self.nodes[args[0] as usize].args.clone();
+                    let mut leaves = Vec::new();
+                    for &value in &inner {
+                        self.flatten_into(value, Op::Add as u32, &mut leaves);
+                    }
+                    if !self.add_association_safe(&leaves) {
+                        return None;
+                    }
                     let negs: Vec<ValueId> = inner
                         .iter()
                         .map(|&t| self.mk(ValOp::Un(Op::Neg as u32), vec![t]))
@@ -200,6 +209,31 @@ impl<'a> Builder<'a> {
             }
         }
         None
+    }
+
+    fn boolean_double_negation(&self, value: ValueId) -> Option<ValueId> {
+        let ValOp::Un(op) = self.nodes[value as usize].op else {
+            return None;
+        };
+        let inner = self.nodes[value as usize].args[0];
+        (op == Op::Not as u32 && self.vty(inner) == ValueDomain::Boolean).then_some(inner)
+    }
+
+    fn negated_comparison(&mut self, comparison: ValueId) -> Option<ValueId> {
+        let ValOp::Bin(op) = self.nodes[comparison as usize].op else {
+            return None;
+        };
+        let negated = negate_cmp_code(self.il.meta.lang, op)?;
+        let args = self.nodes[comparison as usize].args.clone();
+        if matches!(op_from_code(op), Some(Op::Lt | Op::Le | Op::Gt | Op::Ge))
+            && !args
+                .iter()
+                .copied()
+                .all(|arg| self.is_integer_domain_value(arg))
+        {
+            return None;
+        }
+        Some(self.mk(ValOp::Bin(negated), args))
     }
 
     fn bin_idempotence_and_factor(&mut self, op: &ValOp, args: &[ValueId]) -> Option<ValueId> {
@@ -297,7 +331,8 @@ impl<'a> Builder<'a> {
     // Recognize select idioms on EVERY branch merge — `Phi(cond, then, els)` is built
     // both by a ternary (`a if c else b`) and by an if/else that assigns a variable, so
     // doing this here (not just at the ternary) keeps the two forms convergent:
-    //   `x if x>=0 else -x` → Abs(x) ;  `x if x<y else y` → Min(x,y) / Max(x,y).
+    //   integer-proven `x if x>=0 else -x` → Abs(x);
+    //   `x if x<y else y` → Min(x,y) / Max(x,y).
     fn phi_select_idioms(&mut self, op: &ValOp, args: &[ValueId]) -> Option<ValueId> {
         if !matches!(*op, ValOp::Phi) || args.len() != 3 {
             return None;
@@ -307,6 +342,9 @@ impl<'a> Builder<'a> {
         }
         if self.bool_const(args[1]) == Some(false) && self.bool_const(args[2]) == Some(true) {
             return Some(self.mk(ValOp::Un(Op::Not as u32), vec![args[0]]));
+        }
+        if let Some(v) = self.phi_branch_orientation(args[0], args[1], args[2]) {
+            return Some(v);
         }
         if let Some(v) = self.boolean_guarded_identity_phi(args[0], args[1], args[2]) {
             return Some(v);
@@ -333,6 +371,19 @@ impl<'a> Builder<'a> {
             return Some(v);
         }
         None
+    }
+
+    fn phi_branch_orientation(
+        &mut self,
+        cond: ValueId,
+        then_v: ValueId,
+        else_v: ValueId,
+    ) -> Option<ValueId> {
+        if self.vhash[then_v as usize] <= self.vhash[else_v as usize] {
+            return None;
+        }
+        let negated = self.negated_comparison(cond)?;
+        Some(self.mk(ValOp::Phi, vec![negated, else_v, then_v]))
     }
 
     // Boolean logical `and`/`or` is associative and commutative only when both sides are
@@ -421,13 +472,16 @@ impl<'a> Builder<'a> {
             }
             if leaves.len() > 2 && leaves.iter().all(|&v| self.reorder_safe(v)) {
                 // ASSOCIATIVITY — re-grouping a flat chain into one canonical left-leaning
-                // shape — is sound for ALL types, string/list concat included
-                // (`"a"+"b"+"c"` is `"abc"` however parenthesized). So ALWAYS flatten and
-                // rebuild, converging `(a+b)+c` with `a+(b+c)` even for untyped params.
+                // shape — is sound for Python/Ruby string/list concat, but not for JS/TS/Java
+                // mixed string coercion (`"a"+2+3` != `"a"+(2+3)`). Gate `+` association
+                // in those languages on proof that every leaf is non-concat.
+                if o == Op::Add as u32 && !self.add_association_safe(&leaves) {
+                    return None;
+                }
                 // COMMUTATIVITY — sorting the operands — is gated per op (`ac_chain_commutes`):
-                // a concat-possible `+` (#283-C) and a Ruby string/list `*` (series 9) stay
-                // ordered, so `c+(a+b)` and `3*"ab"` keep their source order, while numeric/
-                // typed sums and products still fully canonicalize.
+                // a concat-possible `+` (#283-C), mixed-coercion `+`, and a Ruby string/list
+                // `*` (series 9) stay ordered, while numeric/typed sums and products still
+                // fully canonicalize.
                 let commute = self.ac_chain_commutes(o, &leaves, ValueLaw::AddCommutativity);
                 if commute {
                     leaves.sort_unstable_by_key(|&v| self.vhash[v as usize]);
@@ -679,8 +733,8 @@ impl<'a> Builder<'a> {
         self.lattice_pair_canon(a, b, Op::Lt as u32, Op::Eq as u32, Op::Le as u32)
     }
 
-    /// Recognize the absolute-value idiom `x if x>=0 else -x` (and its mirror
-    /// `-x if x<0 else x`) as `Un(ABS_CODE, [x])`, so it converges with `abs(x)`.
+    /// Recognize integer absolute-value idioms `x if x>=0 else -x` (and mirrors)
+    /// as `Un(ABS_CODE, [x])`, so they converge with integer-proven `abs(x)`.
     pub(super) fn abs_pattern(
         &mut self,
         cond: ValueId,
@@ -702,6 +756,9 @@ impl<'a> Builder<'a> {
         } else {
             return None;
         };
+        if !self.is_integer_domain_value(v) {
+            return None;
+        }
         let cn = &self.nodes[cond as usize];
         let opc = match cn.op {
             ValOp::Bin(o) => o,

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -3,14 +3,15 @@ use super::*;
 const LARGE_AC_EXPR_OPERANDS: usize = 64;
 
 impl<'a> Builder<'a> {
-    /// JS strict (in)equality. The value model conflates `null`/`undefined` into
-    /// ONE constant, so the model's Eq-against-null means the LOOSE check
-    /// (`x == null`, true for both) — which is also what `x ?? d` desugars to. A
-    /// strict `x === null` (false for undefined) cannot be expressed in that
-    /// model: keep it a distinct shape keyed by the spelled operand, so strict
-    /// checks converge only with the same strict spelling and never feed the
-    /// nullish-default fold (`null_condition` → `ValueOrDefault`).
-    fn eval_strict_equality_comparison(
+    /// JS equality with source-operator semantics. The value model conflates
+    /// `null`/`undefined` into ONE constant, so the model's Eq-against-null means
+    /// the LOOSE check (`x == null`, true for both) — which is also what `x ?? d`
+    /// desugars to. A strict `x === null` (false for undefined) cannot be expressed
+    /// in that model: keep it a distinct shape keyed by the spelled operand.
+    ///
+    /// Outside the nullish special case, JS loose equality uses coercions (`false == 0`,
+    /// `"0" == 0`, `[] == 0`) and must not merge with strict equality.
+    fn eval_js_equality_comparison(
         &mut self,
         expr: NodeId,
         op: u32,
@@ -20,14 +21,32 @@ impl<'a> Builder<'a> {
         if (op != Op::Eq as u32 && op != Op::Ne as u32) || kids.len() != 2 {
             return None;
         }
+        let source = source_operator_at_node(self.il, expr);
+        if matches!(source, Some(nose_il::SourceOperatorKind::TypeMembership)) {
+            let a = self.eval(kids[0], env);
+            let b = self.eval(kids[1], env);
+            let membership = self.mk(ValOp::Opaque(JS_INSTANCEOF_CMP_TAG), vec![a, b]);
+            return Some(if op == Op::Ne as u32 {
+                self.mk(ValOp::Un(Op::Not as u32), vec![membership])
+            } else {
+                membership
+            });
+        }
         let strict = matches!(
-            source_operator_at_node(self.il, expr),
+            source,
             Some(
                 nose_il::SourceOperatorKind::StrictEquality
                     | nose_il::SourceOperatorKind::StrictInequality
             )
         );
-        if !strict {
+        let loose = matches!(
+            source,
+            Some(
+                nose_il::SourceOperatorKind::LooseEquality
+                    | nose_il::SourceOperatorKind::LooseInequality
+            )
+        );
+        if !strict && !loose {
             return None;
         }
         let a = self.eval(kids[0], env);
@@ -40,6 +59,9 @@ impl<'a> Builder<'a> {
             None
         };
         if let Some((null_kid, value_side)) = null_kid {
+            if !strict {
+                return Some(self.mk(ValOp::Bin(op), vec![a, b]));
+            }
             // Exception: `=== undefined` against a value that provably cannot be
             // null IS the faithful absence check — a typed `Map.get` result is
             // `V | undefined`. Keep the model's Eq shape there so the map-default
@@ -58,6 +80,21 @@ impl<'a> Builder<'a> {
                     eq
                 });
             }
+        }
+        if loose {
+            let tag = if op == Op::Ne as u32 {
+                JS_LOOSE_NE_CMP_TAG
+            } else {
+                JS_LOOSE_EQ_CMP_TAG
+            };
+            let mut args = vec![a, b];
+            if self.reorder_safe(args[0])
+                && self.reorder_safe(args[1])
+                && self.vhash[args[0] as usize] > self.vhash[args[1] as usize]
+            {
+                args.swap(0, 1);
+            }
+            return Some(self.mk(ValOp::Opaque(tag), args));
         }
         // Strict comparison the model expresses faithfully: the model's Eq IS
         // strict. Operands are already evaluated — don't evaluate them twice.
@@ -246,10 +283,24 @@ impl<'a> Builder<'a> {
                 return v;
             }
         }
-        if let Some(v) = self.eval_strict_equality_comparison(expr, op, &kids, env) {
+        if let Some(v) = self.eval_js_equality_comparison(expr, op, &kids, env) {
             return v;
         }
-        if op == Op::Add as u32 || op == Op::Sub as u32 {
+        if self.relational_has_string_ordering()
+            && matches!(op_from_code(op), Some(Op::Lt | Op::Le | Op::Gt | Op::Ge))
+            && kids.len() == 2
+        {
+            let args: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+            if args.iter().all(|&v| self.proven_numeric(v)) {
+                return self.mk(ValOp::Bin(op), args);
+            }
+            return self.mk(
+                ValOp::Opaque(combine(JS_RELATIONAL_CMP_TAG, op as u64)),
+                args,
+            );
+        }
+        if (op == Op::Add as u32 || op == Op::Sub as u32) && !self.plus_has_mixed_string_coercion()
+        {
             let mut operands = Vec::new();
             self.collect_add_sub_expr_operands(expr, false, &mut operands);
             if operands.len() >= LARGE_AC_EXPR_OPERANDS {
@@ -283,6 +334,9 @@ impl<'a> Builder<'a> {
     fn eval_sub_chain(&mut self, kids: &[NodeId], env: &FxHashMap<u32, ValueId>) -> ValueId {
         let a = self.eval(kids[0], env);
         let b = self.eval(kids[1], env);
+        if self.plus_has_mixed_string_coercion() && !self.proven_non_concat(a) {
+            return self.mk(ValOp::Bin(Op::Sub as u32), vec![a, b]);
+        }
         let neg_b = self.mk(ValOp::Un(Op::Neg as u32), vec![b]);
         let mut operands = Vec::new();
         self.flatten_into(a, Op::Add as u32, &mut operands);
@@ -318,6 +372,24 @@ impl<'a> Builder<'a> {
         // Very large generated formulas can arrive as deeply nested binary ASTs.
         // For those, collect same-op source operands first so one giant expression
         // pays for flatten/sort/rebuild once instead of once per nested pair.
+        if op == Op::Add as u32 && self.plus_has_mixed_string_coercion() {
+            let direct: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
+            let mut leaves = Vec::new();
+            for &value in &direct {
+                self.flatten_into(value, op, &mut leaves);
+            }
+            if !self.add_association_safe(&leaves) {
+                return self.intern_ac_chain(op, &direct);
+            }
+            let mut operands = leaves;
+            let do_sort = self.ac_chain_commutes(op, &operands, ValueLaw::AddAssociativity)
+                && operands.iter().all(|&v| self.reorder_safe(v));
+            if do_sort {
+                operands.sort_by_key(|&v| self.vhash[v as usize]);
+            }
+            return self.intern_ac_chain(op, &operands);
+        }
+
         let mut expr_operands = Vec::new();
         for &k in kids {
             self.collect_ac_expr_operands(k, op, &mut expr_operands);
@@ -535,7 +607,7 @@ impl<'a> Builder<'a> {
         // the explicit accumulator loop (§AI representation axis).
         if let Payload::Builtin(Builtin::Abs) = payload {
             if let Some(&arg) = kids.first() {
-                let v = self.eval(arg, env);
+                let v = self.eval_proven_integer_expr(arg, env)?;
                 return Some(self.mk(ValOp::Un(ABS_CODE), vec![v]));
             }
         }

--- a/crates/nose-normalize/src/value_graph/ops.rs
+++ b/crates/nose-normalize/src/value_graph/ops.rs
@@ -281,6 +281,20 @@ pub(super) const TO_INT32_CODE: u32 = 0x132;
 /// the null/undefined-conflating value model cannot express as `Bin(Eq)` without
 /// merging it with the loose check (see `eval`'s strict-null handling).
 pub(super) const JS_STRICT_NULL_CMP_TAG: u64 = 0x4A53_534E_4351;
+/// Salt for JS loose equality outside the nullish special case. `x == null` is modeled
+/// by the null/undefined-conflating `Eq` because that is exactly the nullish-default
+/// check; other loose equality uses JS coercions and must not merge with `===`.
+pub(super) const JS_LOOSE_EQ_CMP_TAG: u64 = 0x4A53_4C45_4351;
+pub(super) const JS_LOOSE_NE_CMP_TAG: u64 = 0x4A53_4C4E_4351;
+/// Salt for JS `instanceof`. The frontend lowers it through an equality-shaped
+/// BinOp so structural consumers can still see a binary predicate, but the
+/// value graph must keep prototype-chain type membership distinct from equality.
+pub(super) const JS_INSTANCEOF_CMP_TAG: u64 = 0x4A53_494F_4351;
+/// Salt for JS-family relational comparison (`< <= > >=`) when operands are not
+/// proven numeric. JS compares two strings lexicographically but otherwise applies
+/// numeric coercion, so untyped relational predicates cannot share the primitive
+/// numeric comparison node safely.
+pub(super) const JS_RELATIONAL_CMP_TAG: u64 = 0x4A53_5243_4D50;
 pub(super) const C_U16_BE_BYTE_PACK_CODE: u32 = 0x4331_3642;
 pub(super) const C_U32_BE_BYTE_PACK_CODE: u32 = 0x4333_3242;
 pub(super) const EFFECT_ORDINAL_SINK_TAG: u64 = 0xEFFE_C701;

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -71,25 +71,56 @@ impl<'a> Builder<'a> {
             })
     }
 
-    /// Whether a `+` chain may be treated as commutative (so its operands can be reordered)
-    /// rather than as ordered string/list concat. `value_law_satisfied` alone accepts an
-    /// UNKNOWN operand optimistically — which false-merges `a+b` with `b+a` for two untyped
-    /// params that are actually strings (`"x"+"y" != "y"+"x"`, now witnessed by the oracle,
-    /// #283-C). The exact condition is that AT LEAST ONE operand is PROVEN non-concat (never
-    /// a string/list): if one operand is numeric, then for any other operand the sum either
-    /// stays numeric (commutes) or hits `num + str` → `Err` in EVERY order (Err propagates
-    /// symmetrically), so the chain is permutation-invariant. Only when NO operand is proven
-    /// non-concat could they all be strings/lists, where order matters. So `x + 4`,
-    /// `x*x + y*y`, and any sum touching a number still commute; only `a + b` with two
-    /// concat-possible operands stays ordered.
+    /// Whether a `+` chain may be treated as numeric/non-concat rather than ordered
+    /// string/list concat. `value_law_satisfied` alone accepts an UNKNOWN operand
+    /// optimistically, which false-merges `a+b` with `b+a` for two untyped params that are
+    /// actually strings (`"x"+"y" != "y"+"x"`, #283-C).
+    ///
+    /// Non-coercive languages can commute when at least one operand is proven non-concat:
+    /// `num + str` errors regardless of order. JS/TS/Java are stricter because their `+`
+    /// coerces mixed string/non-string operands instead of erroring, so `x + 4` is ordered
+    /// unless every leaf is proven non-concat.
     pub(super) fn add_values_not_concat(&self, law: ValueLaw, values: &[ValueId]) -> bool {
-        self.value_law_satisfied(law, values) && values.iter().any(|&v| self.proven_non_concat(v))
+        self.value_law_satisfied(law, values)
+            && if self.plus_has_mixed_string_coercion() {
+                values.iter().all(|&v| self.proven_non_concat(v))
+            } else {
+                values.iter().any(|&v| self.proven_non_concat(v))
+            }
+    }
+
+    pub(super) fn plus_has_mixed_string_coercion(&self) -> bool {
+        matches!(
+            self.il.meta.lang,
+            Lang::JavaScript
+                | Lang::TypeScript
+                | Lang::Vue
+                | Lang::Svelte
+                | Lang::Html
+                | Lang::Java
+        )
+    }
+
+    pub(super) fn relational_has_string_ordering(&self) -> bool {
+        matches!(
+            self.il.meta.lang,
+            Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html
+        )
+    }
+
+    /// Whether a `+` chain may be re-associated. In JS/TS/Java, grouping itself is
+    /// observable under mixed string coercion (`"a"+2+3` vs `"a"+(2+3)`), so association
+    /// needs the same all-leaves non-concat proof as commutation.
+    pub(super) fn add_association_safe(&self, values: &[ValueId]) -> bool {
+        !self.plus_has_mixed_string_coercion()
+            || self.add_values_not_concat(ValueLaw::AddAssociativity, values)
     }
 
     /// Whether an associative-commutative chain's operands may be COMMUTED (reordered).
     /// Associativity — regrouping a flat chain — is sound for every type and handled by the
     /// caller; this gates only the SORT. Commutativity is op- and language-specific:
-    /// - `+` is ordered string/list concat unless proven non-concat (#283-C, via `add_law`).
+    /// - `+` is ordered string/list concat unless proven non-concat (#283-C, via `add_law`);
+    ///   in JS/TS/Java mixed string coercion requires every operand to be proven non-concat.
     /// - `*` is string/list REPETITION in Ruby, and there it is asymmetric: `"ab" * 3` →
     ///   "ababab" but `3 * "ab"` raises (`Integer#*` rejects a String). Python repetition
     ///   commutes (`3 * "ab"` == `"ab" * 3`), and JS/TS/Java/Go/C `*` is always numeric — so

--- a/crates/nose-normalize/src/value_graph/stdlib.rs
+++ b/crates/nose-normalize/src/value_graph/stdlib.rs
@@ -1001,26 +1001,49 @@ impl<'a> Builder<'a> {
     ) -> Option<ValueId> {
         let admitted = admitted_scalar_integer_method_at_call(self.il, self.interner, call)?;
         let contract = admitted.contract;
-        if contract.result.receiver != MethodReceiverContract::ExactInteger {
-            return None;
-        }
-        let receiver = admitted.receiver?;
-        let receiver_value = self.eval_proven_integer_expr(receiver, env)?;
-        match contract.result.semantic {
-            ScalarIntegerMethod::Abs => Some(self.mk(ValOp::Un(ABS_CODE), vec![receiver_value])),
-            ScalarIntegerMethod::Min => {
-                let rhs = self.eval(*kids.get(1)?, env);
-                self.eval_proven_integer_minmax_method_call(MIN_CODE, receiver_value, rhs)
+        match contract.result.receiver {
+            MethodReceiverContract::ExactInteger => {
+                let receiver = admitted.receiver?;
+                let receiver_value = self.eval_proven_integer_expr(receiver, env)?;
+                match contract.result.semantic {
+                    ScalarIntegerMethod::Abs => {
+                        Some(self.mk(ValOp::Un(ABS_CODE), vec![receiver_value]))
+                    }
+                    ScalarIntegerMethod::Min => {
+                        let rhs = self.eval(*kids.get(1)?, env);
+                        self.eval_proven_integer_minmax_method_call(MIN_CODE, receiver_value, rhs)
+                    }
+                    ScalarIntegerMethod::Max => {
+                        let rhs = self.eval(*kids.get(1)?, env);
+                        self.eval_proven_integer_minmax_method_call(MAX_CODE, receiver_value, rhs)
+                    }
+                    ScalarIntegerMethod::Clamp => {
+                        let lo = self.eval(*kids.get(1)?, env);
+                        let hi = self.eval(*kids.get(2)?, env);
+                        self.eval_proven_integer_clamp_method_call(receiver_value, lo, hi)
+                    }
+                }
             }
-            ScalarIntegerMethod::Max => {
-                let rhs = self.eval(*kids.get(1)?, env);
-                self.eval_proven_integer_minmax_method_call(MAX_CODE, receiver_value, rhs)
+            MethodReceiverContract::UnshadowedGlobal("Math") if self.il.meta.lang == Lang::Java => {
+                match contract.result.semantic {
+                    ScalarIntegerMethod::Abs => {
+                        let value = self.eval_proven_integer_expr(*kids.get(1)?, env)?;
+                        Some(self.mk(ValOp::Un(ABS_CODE), vec![value]))
+                    }
+                    ScalarIntegerMethod::Min | ScalarIntegerMethod::Max => {
+                        let left = self.eval_proven_integer_expr(*kids.get(1)?, env)?;
+                        let right = self.eval_proven_integer_expr(*kids.get(2)?, env)?;
+                        let op = match contract.result.semantic {
+                            ScalarIntegerMethod::Min => MIN_CODE,
+                            ScalarIntegerMethod::Max => MAX_CODE,
+                            _ => unreachable!(),
+                        };
+                        Some(self.mk(ValOp::Bin(op), vec![left, right]))
+                    }
+                    ScalarIntegerMethod::Clamp => None,
+                }
             }
-            ScalarIntegerMethod::Clamp => {
-                let lo = self.eval(*kids.get(1)?, env);
-                let hi = self.eval(*kids.get(2)?, env);
-                self.eval_proven_integer_clamp_method_call(receiver_value, lo, hi)
-            }
+            _ => None,
         }
     }
 
@@ -1054,6 +1077,9 @@ impl<'a> Builder<'a> {
         };
         let left = self.eval(kids[1], env);
         let right = self.eval(kids[2], env);
+        if !self.is_integer_domain_value(left) || !self.is_integer_domain_value(right) {
+            return None;
+        }
         Some(self.mk(ValOp::Bin(op), vec![left, right]))
     }
 

--- a/crates/nose-normalize/src/value_graph/tests/clamp.rs
+++ b/crates/nose-normalize/src/value_graph/tests/clamp.rs
@@ -49,8 +49,8 @@ fn push_canonical_java_minmax_builtin_evidence(il: &mut Il, first_id: u32) {
             Builtin::Max => "max",
             _ => continue,
         };
-        let contract = library_method_call_contract(il.meta.lang, method, arg_count)
-            .expect("min/max contract");
+        let contract = library_scalar_integer_method_contract(il.meta.lang, method, arg_count)
+            .expect("min/max integer contract");
         il.evidence.push(library_api_contract_evidence(
             next_id,
             il.node(node).span,

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -2117,19 +2117,20 @@ fn scalar_integer_method_contract_shape(
     name: &str,
     arg_count: usize,
 ) -> Option<ScalarIntegerMethodContract> {
+    use MethodReceiverContract as Receiver;
     use ScalarIntegerMethod as Method;
 
-    let semantic = match (lang, name, arg_count) {
-        (Lang::Rust, "abs", 0) => Method::Abs,
-        (Lang::Rust, "min", 1) => Method::Min,
-        (Lang::Rust, "max", 1) => Method::Max,
-        (Lang::Rust, "clamp", 2) => Method::Clamp,
+    let (semantic, receiver) = match (lang, name, arg_count) {
+        (Lang::Rust, "abs", 0) => (Method::Abs, Receiver::ExactInteger),
+        (Lang::Rust, "min", 1) => (Method::Min, Receiver::ExactInteger),
+        (Lang::Rust, "max", 1) => (Method::Max, Receiver::ExactInteger),
+        (Lang::Rust, "clamp", 2) => (Method::Clamp, Receiver::ExactInteger),
+        (Lang::Java, "abs", 1) => (Method::Abs, Receiver::UnshadowedGlobal("Math")),
+        (Lang::Java, "min", 2) => (Method::Min, Receiver::UnshadowedGlobal("Math")),
+        (Lang::Java, "max", 2) => (Method::Max, Receiver::UnshadowedGlobal("Math")),
         _ => return None,
     };
-    Some(ScalarIntegerMethodContract {
-        semantic,
-        receiver: MethodReceiverContract::ExactInteger,
-    })
+    Some(ScalarIntegerMethodContract { semantic, receiver })
 }
 
 pub fn scalar_integer_method_contract(
@@ -2257,11 +2258,8 @@ fn method_namespace_call_contract_shape(
             Receiver::ImportedNamespace("fmt"),
             Args::All,
         ),
-        (Lang::Go, "Abs", 1) => (
-            Builtin::Abs,
-            Receiver::ImportedNamespace("math"),
-            Args::First,
-        ),
+        // Go math.Abs is a float64 API and differs from the ternary abs idiom on -0.0.
+        // Keep it closed until a signed-zero-aware float model exists.
         (Lang::Go, "HasPrefix", 2) => (
             Builtin::StartsWith,
             Receiver::ImportedNamespace("strings"),
@@ -2467,28 +2465,15 @@ fn method_numeric_contract_shape(
             Receiver::ImportedNamespace("functools"),
             Args::All,
         ),
-        (Lang::Go, "Min", 2) => (Builtin::Min, Receiver::ImportedNamespace("math"), Args::All),
-        (Lang::Go, "Max", 2) => (Builtin::Max, Receiver::ImportedNamespace("math"), Args::All),
-        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "abs", 1) => {
-            (
-                Builtin::Abs,
-                Receiver::UnshadowedGlobal("Math"),
-                Args::First,
-            )
-        }
-        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "min", 2) => {
-            (Builtin::Min, Receiver::UnshadowedGlobal("Math"), Args::All)
-        }
-        (Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html, "max", 2) => {
-            (Builtin::Max, Receiver::UnshadowedGlobal("Math"), Args::All)
-        }
-        (Lang::Java, "abs", 1) => (
-            Builtin::Abs,
-            Receiver::UnshadowedGlobal("Math"),
-            Args::First,
-        ),
-        (Lang::Java, "min", 2) => (Builtin::Min, Receiver::UnshadowedGlobal("Math"), Args::All),
-        (Lang::Java, "max", 2) => (Builtin::Max, Receiver::UnshadowedGlobal("Math"), Args::All),
+        // Go math.Min/math.Max are float64 APIs and return NaN if either argument is NaN.
+        // Keep them closed until a NaN-aware float model exists. Java Math.abs/min/max
+        // use scalar-integer method contracts instead, so only integer-overload calls
+        // lower to the modeled Abs/Min/Max value nodes.
+        // JS-family Math.abs differs from `x >= 0 ? x : -x` on -0.
+        // Keep it closed until a signed-zero-aware numeric model exists.
+        // JS-family Math.min/Math.max return NaN if any argument is NaN. The value
+        // graph's Min/Max nodes model the ternary selection idiom instead, so these
+        // calls stay ordinary calls until a NaN-aware numeric model exists.
         (Lang::Rust, "zip", 1) => (
             Builtin::Zip,
             Receiver::ExactProtocolPairArgument,

--- a/crates/nose-semantics/src/tests/library_api_contracts.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts.rs
@@ -990,24 +990,11 @@ fn method_call_contracts_carry_receiver_and_resolution_obligations() {
             args: MethodBuiltinArgs::All,
         })
     );
-    assert_eq!(
-        method_call_contract(Lang::JavaScript, "min", 2),
-        Some(MethodCallContract {
-            semantic: MethodSemanticContract::Builtin(Builtin::Min),
-            receiver: MethodReceiverContract::UnshadowedGlobal("Math"),
-            args: MethodBuiltinArgs::All,
-        })
-    );
+    assert_eq!(method_call_contract(Lang::JavaScript, "min", 2), None);
+    assert_eq!(method_call_contract(Lang::TypeScript, "max", 2), None);
     assert_eq!(method_call_contract(Lang::JavaScript, "min", 1), None);
     assert_eq!(method_call_contract(Lang::Python, "min", 2), None);
-    assert_eq!(
-        method_call_contract(Lang::Go, "Abs", 1),
-        Some(MethodCallContract {
-            semantic: MethodSemanticContract::Builtin(Builtin::Abs),
-            receiver: MethodReceiverContract::ImportedNamespace("math"),
-            args: MethodBuiltinArgs::First,
-        })
-    );
+    assert_eq!(method_call_contract(Lang::Go, "Abs", 1), None);
     assert_eq!(
         method_call_contract(Lang::Go, "Contains", 2),
         Some(MethodCallContract {
@@ -1016,22 +1003,8 @@ fn method_call_contracts_carry_receiver_and_resolution_obligations() {
             args: MethodBuiltinArgs::GoSliceContains,
         })
     );
-    assert_eq!(
-        method_call_contract(Lang::Java, "abs", 1),
-        Some(MethodCallContract {
-            semantic: MethodSemanticContract::Builtin(Builtin::Abs),
-            receiver: MethodReceiverContract::UnshadowedGlobal("Math"),
-            args: MethodBuiltinArgs::First,
-        })
-    );
-    assert_eq!(
-        method_call_contract(Lang::Java, "min", 2),
-        Some(MethodCallContract {
-            semantic: MethodSemanticContract::Builtin(Builtin::Min),
-            receiver: MethodReceiverContract::UnshadowedGlobal("Math"),
-            args: MethodBuiltinArgs::All,
-        })
-    );
+    assert_eq!(method_call_contract(Lang::Java, "abs", 1), None);
+    assert_eq!(method_call_contract(Lang::Java, "min", 2), None);
 }
 
 #[test]
@@ -1104,7 +1077,22 @@ fn scalar_integer_methods_are_language_and_signature_constrained() {
             receiver: MethodReceiverContract::ExactInteger,
         })
     );
+    assert_eq!(
+        scalar_integer_method_contract(Lang::Java, "abs", 1),
+        Some(ScalarIntegerMethodContract {
+            semantic: ScalarIntegerMethod::Abs,
+            receiver: MethodReceiverContract::UnshadowedGlobal("Math"),
+        })
+    );
+    assert_eq!(
+        scalar_integer_method_contract(Lang::Java, "min", 2),
+        Some(ScalarIntegerMethodContract {
+            semantic: ScalarIntegerMethod::Min,
+            receiver: MethodReceiverContract::UnshadowedGlobal("Math"),
+        })
+    );
     assert_eq!(scalar_integer_method_contract(Lang::Rust, "clamp", 1), None);
+    assert_eq!(scalar_integer_method_contract(Lang::Java, "abs", 0), None);
     assert_eq!(
         scalar_integer_method_contract(Lang::TypeScript, "clamp", 2),
         None

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -119,11 +119,39 @@ core canonicalizations, but not a per-scan or whole-pipeline proof. See
   carry no per-pair behavioral proof.
 - Type-4 coverage is a **growing set of modeled equivalences**, not a guarantee about any
   given pair of semantically-equal fragments.
-- **The value model is coarser than full JS semantics for loose equality on non-null
-  operands**: `a == b` and `a === b` over arbitrary values share a fingerprint (the model's
-  equality is strict/structural; coercion is not modeled). Null-ish checks are handled
-  precisely — `x === null` never merges with `x == null` / `x ?? d`, and `null` and
-  `undefined` spellings stay distinct in strict checks.
+- **JS loose equality is fail-closed outside the null-ish contract**: `a == b` over
+  non-null operands does not merge with `a === b`, because the value model does not
+  implement JS coercions such as `false == 0`, `"0" == 0`, or `[] == 0`. Loose
+  equality still converges with the same loose surface, including symmetric operand
+  order. Null-ish checks are handled precisely — `x == null` remains the modeled
+  nullish check that can converge with `x ?? d`, while `x === null` never merges
+  with `x == null` / `x ?? d`, and `null` and `undefined` spellings stay distinct
+  in strict checks.
+- **JS `instanceof` is exact-closed rather than equality-modeled**: `x instanceof C`
+  and `!(x instanceof C)` can converge with the same membership surface, but they
+  do not merge with `x === C` or `x !== C`. The value model does not attempt to
+  prove prototype-chain type membership equivalent to other predicates.
+- **JS-family relational comparisons need numeric proof**: untyped `<`, `<=`, `>`,
+  and `>=` stay exact-closed because JS compares two strings lexicographically but
+  otherwise coerces toward numeric comparison (`"2" < "10"` differs from `2 < 10`).
+  Scalar/literal/operator-proven numeric TypeScript comparisons still use the
+  primitive comparison laws. TypeScript `number[]` callback or loop elements are
+  not yet treated as numeric proof, so those higher-order relational predicates
+  stay closed until element-domain facts are modeled. Negated order comparisons
+  such as `!(a < b)` and branch-swapped order conditionals lower to the apparent
+  dual (`a >= b`) only with integer-domain proof, because `NaN` makes the two differ.
+- **Float-sensitive min/max APIs stay exact-closed**: the modeled Min/Max value
+  nodes represent integer/ternary selection idioms. JS-family `Math.min`/`Math.max`
+  and Go `math.Min`/`math.Max` return `NaN` if any argument is `NaN`; Java
+  `Math.min`/`Math.max` lower only with unshadowed `Math` plus integer-domain
+  proof for their value arguments. Free `min`/`max` lowering needs integer-domain
+  proof before it can use the modeled Min/Max node.
+- **Float-sensitive abs APIs stay exact-closed**: JS-family `Math.abs` and Go
+  `math.Abs` differ from ternary absolute-value idioms on signed zero; Java
+  `Math.abs` likewise lowers only with unshadowed `Math` plus integer-domain
+  proof. Python free `abs(...)` and sign-test ternary absolute-value idioms also
+  need integer-domain proof before they use the modeled Abs node. Float overloads
+  need a signed-zero-aware numeric model before entering exact matching.
 - Sub-function semantic coverage is intentionally bounded: nose extracts control-flow
   blocks and exact-safe single-statement fragments (return/throw expressions and simple
   conditional return/throw/effect guards, including bare returns, explicit empty no-op

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -176,3 +176,19 @@ tests in nose-cli's inline `tests` module, `declaration_spans_fail_open_per_lang
 `declaration_spans_classify_per_language`. They are near-identical by construction — a
 `&[(&str, &str)]` case table plus an `assert!(…ast_classifies…)` loop, differing only in the asserted
 direction — benign test scaffolding with nothing extractable. The budget is re-baselined to 27.
+
+## Budget 27 → 28 and semantic false-merge boundaries
+
+The semantic false-merge boundary fix moves order-comparison orientation behind integer-domain
+evidence and keeps NaN/signed-zero-sensitive APIs fail-closed. That changes canonicalized value
+fingerprints enough that this branch's release binary reports the same 28 substantial families even
+when pointed at an unmodified `origin/main` worktree: the count increase is detector behavior, not
+new copy-paste in the PR tree.
+
+The extra counted family is the pre-existing overlap slice
+`body_depends_on_iter` ↔ `foreach_effect_body_depends_on_iter` ↔ `single_branch_statement`, folded
+under the broader loop-effect family in the human report. It shares the recursive "recognized
+statement body" skeleton, but the two loop-effect paths deliberately differ in their effect-site
+recording and recognizer contracts while `single_branch_statement` belongs to conditional-guard
+summarization. Extracting it would be a high-parameter helper that couples separate detector
+responsibilities, so the family is recorded as design debt and the budget is re-baselined to 28.

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -38,7 +38,8 @@ experiments that validated these passes are in [experiments](experiments.md).
 > changed flattened predicates; filtered Sum/Reduce FlatMap aggregates, method-terminal
 > Any/All predicates, and filtered nested early-return any/all loops preserve carried
 > outer/inner predicates), full **AC flatten+sort in the value graph itself** (not
-> only the `algebra` IL pass), **operator-law contracts** from the semantic kernel
+> only the `algebra` IL pass), with `+` association/reorder kept domain-gated in
+> string-coercive languages, **operator-law contracts** from the semantic kernel
 > gate comparison transforms, comparison-lattice rewrites, static cardinality
 > thresholds, and source membership operators, while source-fact gates protect
 > JS-like constructor factories, regex literal `.test(...)`, and static
@@ -115,11 +116,27 @@ Guiding constraints for every pass:
   hunt fixed seven false merges; §AX, using the now-independent oracle, fixed a whole
   further class of *treating-a-non-commutative-op-as-commutative* bugs (value `and`/`or`,
   `!!x`, `not(Err)`, `x+0`/`x*1`, string-`+` operand sort). The core canons are also
-  **Lean-proven** (`formal/`). Operations whose commutativity/identity depends on value
-  domain are **domain-gated**, never assumed: `+` commutes only on non-concat operands
-  (string/list `+`
-  is ordered concatenation), and `and`/`or` commute only on Bool (else they are the
-  value-returning short-circuit `Phi`). Identity elimination `x+0`/`x*1`→`x` is dropped
+  **Lean-proven** (`formal/`). Operations whose commutativity, associativity, or
+  identity depends on value domain are **domain-gated**, never assumed: `+`
+  commutes and associates only on non-concat operands. String/list `+` is ordered
+  concatenation, and JS/TS/Vue/Svelte/HTML/Java mixed string coercion also makes
+  grouping observable (`"a"+2+3` vs. `"a"+(2+3)`). In those languages the value
+  graph flattens or reorders `+`, rewrites `x-y` as `x+(-y)`, or distributes
+  unary negation over addition only after every `+` leaf is proven non-concat.
+  JS loose equality over non-null operands and positive/negated JS `instanceof`
+  are also exact-closed behind their source operator facts; JS-family relational
+  comparisons stay exact-closed until both operands carry numeric proof, because
+  string/string comparison is lexicographic. Scalar/literal/operator-proven
+  TypeScript operands can use primitive comparison laws; `number[]` callback or
+  loop elements do not yet provide element-domain numeric proof. Negated order
+  comparisons use the `!(a < b)` -> `a >= b` dual only with integer-domain proof
+  because `NaN` breaks that equivalence. `x == null` remains the modeled nullish
+  check, while strict null equality stays separate.
+  Python free `abs(...)` and sign-test ternary absolute-value idioms lower to
+  the modeled Abs node only with integer-domain proof; untyped or element-derived
+  operands stay closed because signed zero and non-integer domains are observable.
+  `and`/`or` commute only on Bool (else they are the value-returning
+  short-circuit `Phi`). Identity elimination `x+0`/`x*1`→`x` is dropped
   entirely — it is unsound for non-number domains (`"a"+0` Errs), and value-domain
   inference is optimistic (it would infer `Number` from the `*1` itself), so even a
   number-domain gate can't make it safe.
@@ -284,7 +301,8 @@ via bounded equality saturation over a fixed rule set:
   unsound for non-number domains and untypeable here (the optimistic inference would
   self-justify it).
   negation normalization (De Morgan,
-  double-negation `!!x` cancelled only on Bool, negated-comparison `!(a<=b)`→`a>b`);
+  double-negation `!!x` cancelled only on Bool, equality negation, and order-comparison
+  negation only after integer-domain proof);
   comparison-direction canonicalization; short-circuit `and`/`or` to the value-`Phi`.
   Distribution/factoring (e.g. `a*c+b*c -> (a+b)*c`) is applied only through the
   value-graph rule when the operands are proven numeric. String/list repetition and other
@@ -295,7 +313,8 @@ canonical extraction, integer/float/overflow caveats (kept approximate).
 
 ## Track 3 — Control-flow graph normalization
 
-Beyond today's local rewrites (else-after-return, branch orientation): build a
+Beyond today's local rewrites (else-after-return, equality branch orientation, and
+value-graph order branch orientation after integer-domain proof): build a
 structured CFG and canonicalize equivalent shapes — flag-variable loop ↔ `break`,
 nested guards ↔ flattened guards, `continue`-skip ↔ wrapped body, redundant-jump
 elimination. Hard parts: structuring

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -228,7 +228,7 @@ For each candidate fix, record **before → after**:
    pathologically (a fix that merges *nothing* trivially has "no false merges");
    the pre-gate guards against measuring a degenerate detector.
 4. **No silent regressions elsewhere.**
-   dup-gate (`scripts/check-duplication.sh`, budget 25) and the byte-identical
+   dup-gate (`scripts/check-duplication.sh`, budget 28) and the byte-identical
    `cmp` fingerprint-stability gate must stay green; build a `main` worktree
    baseline for the family count so the delta is apples-to-apples (see the perf
    tooling notes in the repo memory / [dogfooding](dogfooding.md)).

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -17,11 +17,13 @@ finding that opened #283 is [experiments §CE](experiments.md).
 > implies — it already models strings as an order-sensitive free monoid. The
 > three findings do **not** share a single "i64 → {int, float, string}"
 > extension. They decompose into three independent pieces of very different cost:
-> **C is an input-battery gap** (the value model already suffices), **D-int32 is
-> a canonicalization-width problem** (no new value kind), and **D-div is the only
-> one that needs a genuinely new value kind (Float)**. Each has a cheap, sound
-> *fail-closed floor* that can ship first, with a measured recall cost, ahead of
-> any full model.
+> **C's detector-side string/mixed-coercion floor has shipped** (remaining work:
+> oracle input/model coverage and float non-associativity), **D-int32's
+> detector/value-graph floor has shipped** (remaining work: oracle int32 execution
+> plus any full fixed-width recall recovery), and **D-div's fingerprint floor has
+> shipped** while the full `Float` value kind remains deferred. The remaining work
+> is now oracle/model enrichment and priced recall recovery, not one shared
+> foundational rewrite.
 
 ---
 
@@ -82,47 +84,50 @@ is present but **starved of the input that would exercise it**.
 
 ## 2. The three findings, re-scoped
 
-### C — untyped `+` commutativity / associativity *(input-battery gap)*
+### C — untyped `+` commutativity / associativity *(detector gate shipped; oracle coverage gap remains)*
 
-`a+b ≡ b+a` and `(a+b)+c ≡ a+(b+c)` are merged for untyped params. Wrong for
-strings (`"x"+"y" ≠ "y"+"x"`) and for floats (`(1e100+1)-1e100`). The detector
-commutes/reorders `+` whenever an operand is not *proven* concat
-(`order_bin_operands`, `eval_sub_chain` in
-`crates/nose-normalize/src/value_graph/`); for untyped params nothing is proven,
-so it reorders optimistically.
+Historically, `a+b ≡ b+a` and `(a+b)+c ≡ a+(b+c)` merged for untyped params. That
+is wrong for strings (`"x"+"y" ≠ "y"+"x"`), for JS/Java-style mixed string
+coercion (`"a"+2+3` differs from `"a"+(2+3)`), and for floats
+(`(1e100+1)-1e100`). The detector now fails closed for this family: in
+JS/TS/Vue/Svelte/HTML/Java it only flattens/reorders `+`, rewrites `x-y` to
+`x+(-y)`, or distributes `-(x+y)` when every `+` leaf is proven non-concat.
+Untyped mixed forms such as `x+4`, `x+(2+3)`, `x-3`, and `-(x+2)` stay split from
+numeric-only rewrites.
 
-- **Value model:** already sufficient for the **string** half — the `Str` monoid
-  is order-sensitive. (The **float** half of C overlaps D-div; see there.)
-- **Real gap:** the **battery** (§1.1) never feeds two distinct strings/lists to
-  two params at once, so the oracle cannot witness the divergence — it reads
-  SOUND while the detector merges. This is the §AS "green corpus, latent false
-  merge" scenario, in the *oracle's own inputs* rather than the corpus.
-- **Cheapest of the three.** No new value kind.
+- **Value model:** sufficient for the pure **string + string** half — the `Str`
+  monoid is order-sensitive. The oracle still does not model JS/Java
+  numeric-to-string coercion for `string + number`, so mixed-coercion regressions
+  rely on external-language witnesses plus detector fingerprint splits until that
+  model exists. The **float** half of C overlaps D-div; see there.
+- **Remaining gap:** the **battery** (§1.1) never feeds two distinct strings/lists
+  to two params at once, and it has no mixed string/number coercion rows. The
+  detector no longer merges the known C string/mixed cases, but `nose verify`
+  remains too weak to witness all of them by itself.
+- **Cheapest of the three.** The detector floor is in place; the remaining work
+  is oracle coverage/modeling plus recall pricing on larger corpora.
 
-### D-int32 — JS bitwise width *(canonicalization-width problem)*
+### D-int32 — JS bitwise width *(detector floor shipped; oracle width gap remains)*
 
 JS bitwise ops coerce operands to int32 (`ToInt32`); Python/Ruby are
-arbitrary-precision. The detector merges JS `a&b` with Python `a&b` (same
-`Bin(BitAnd,[a,b])` fingerprint) and the oracle reads SOUND (both modeled as i64
-`x & y`). They differ for operands outside int32 range (`2^40 & 2^40` → JS `0`,
-Python `2^40`). **Confirmed active false merge** (verified 2026-06-12; reproducer
-below).
+arbitrary-precision. Historically the detector merged JS `a&b` with Python
+`a&b` (same `Bin(BitAnd,[a,b])` fingerprint) and the oracle read SOUND (both
+modeled as i64 `x & y`). They differ for operands outside int32 range (`2^40 &
+2^40` → JS `0`, Python `2^40`).
 
 - **Value kind:** none new — int32 is representable inside `Int(i64)` via
   `x as i32 as i64`.
-- **Real gap:** the *fingerprint* must differ (an oracle-only fix would make
-  `verify` flag the merge but leave the detector merging, and risk reddening the
-  corpus gate). The clean way — narrow JS bitwise operands — **collides with the
-  existing bitwise canonicalizations**: De Morgan `~(a&b)→~a|~b`
-  ([#284](https://github.com/corca-ai/nose/issues/284)) stops firing when `~`'s
-  operand is a narrowing node instead of a `BitAnd`; the `a&a→a` idempotence
-  (gated in [#283-B](https://github.com/corca-ai/nose/issues/283)) is itself
-  **unsound for JS** (`x&x` = ToInt32(x) ≠ x for `x ≥ 2³¹`); the u16/u32
-  byte-pack patterns no longer recognize wrapped operands. Width-awareness has to
-  be threaded **through the bitwise canon**, not bolted on. This is canon
-  surgery, not a value-model extension.
+- **Detector floor (shipped):** JS-family bitwise leaves now carry a `ToInt32`
+  wrapper in the value graph. That makes JS `& | ^ ~ << >>` fingerprints distinct
+  from arbitrary-precision Python/Ruby while preserving within-JS commutativity
+  and De Morgan recall (`~(a&b)` still converges with `~a|~b`). `>>>` remains a
+  distinct raw/operator surface.
+- **Remaining gap:** the independent interpreter still executes bitwise over
+  i64, so `nose verify` cannot yet witness the JS-vs-bigint difference by itself.
+  A full fixed-width model must thread width through bitwise canon and interpreter
+  execution, then price any JS↔C/Java-int recall recovery.
 
-### D-div — true-float division *(the only genuine value-kind gap)*
+### D-div — true-float division *(fingerprint floor shipped; Float value gap remains)*
 
 Three-way split: `/` is **true-float** in Python 3 / JS (`7/2 == 3.5`),
 **floored-int** in Ruby (`7/2 == 3`), **truncated-int** in C/Go/Java/Rust
@@ -133,6 +138,14 @@ The true-float result `3.5` is **unrepresentable in `Int(i64)`**.
 
 - **Value kind:** genuinely needs **`Float`** (plus the float semantics of
   `+ - * / %` and the per-language Int↔Float coercion rules).
+- **Detector floor (shipped):** Python and JS `/` now lower to `Op::TrueDiv`,
+  Ruby `/` and Python `//` lower to `Op::FloorDiv`, and C-family integer `/`
+  remains `Op::Div`. The value graph no longer merges true-float, floored, and
+  truncated division.
+- **Remaining gap:** the interpreter still maps `TrueDiv` integer inputs through
+  i64 truncation internally. That is safe for the detector floor because
+  `TrueDiv` has a distinct fingerprint, but it is not a real float model and
+  cannot witness `7 / 2 == 3.5` or NaN/±0 behavior.
 - **Most expensive.** Float drags in NaN (`NaN != NaN`), `±0`, non-associativity
   (the float half of C), and equality quirks — a large new surface in both the
   interpreter and the canonicalizer.
@@ -145,54 +158,46 @@ Each finding has a **fail-closed floor** (sound, cheap, with a measured recall
 cost) and a **full model** (recovers the recall, larger surface). Ship the floor
 first; promote to the full model only if the priced recall loss justifies it.
 
-### 3.1 C — battery enrichment (+ a detector gate)
+### 3.1 C — battery/model enrichment after the detector gate
 
-- **Floor (measure-only):** add battery rows that bind **two distinct strings**
-  (and two distinct lists) to multiple positions — e.g. probe pairs `("α","β")`
-  drawn from the mined string set, plus a couple of distinct-list rows. No model
-  change. *Effect:* `verify` now witnesses `a+b ≠ b+a` for strings and **flags
-  the existing false merge** — turning a latent hole into a measured one. Expect
-  `nose verify bench/repos` to surface new false merges if the corpus contains
-  untyped `+` reorders (this is the safety net working; it tells us the size of
-  the problem before we touch the detector).
-- **Fix:** gate the untyped `+` commute/reorder (`order_bin_operands`,
-  `eval_sub_chain`) on a *proven-not-concat* predicate (analogous to
-  [#283-B](https://github.com/corca-ai/nose/issues/283)'s `proven_numeric`):
-  reorder only when every operand is proven numeric/non-string. Untyped `+`
-  stays ordered. **This is the recall-priced step** — many real clones are
-  untyped numeric `+` that we must keep converging, so the predicate has to admit
-  the genuine numeric case (via the same genuine-evidence channel as
-  `proven_numeric`) without admitting untyped.
-- **Cost:** Low (battery) + Medium (the gate + its recall pricing).
+- **Detector floor (shipped):** gate untyped `+` commute/reorder and related
+  add/sub/negation rewrites on a *proven-not-concat* predicate: reorder only when
+  every operand is proven numeric/non-string. Untyped `+` stays ordered in
+  string-coercive languages, while typed numeric `+` still converges.
+- **Oracle coverage:** add battery rows that bind **two distinct strings** (and
+  two distinct lists) to multiple positions — e.g. probe pairs `("α","β")` drawn
+  from the mined string set, plus a couple of distinct-list rows. Add mixed
+  string/number rows only after the interpreter has explicit JS/Java coercion
+  semantics. *Effect:* `verify` can witness `a+b ≠ b+a` for strings and later
+  `"a"+2+3 ≠ "a"+(2+3)` for coercive languages, instead of relying only on
+  detector fingerprint splits and external-language witnesses.
+- **Cost:** Medium detector gate already paid; remaining Low-Medium oracle
+  enrichment/modeling plus recall pricing.
 
-### 3.2 D-int32 — width-aware bitwise canon (or fail-closed)
+### 3.2 D-int32 — width-aware bitwise canon
 
-- **Floor (fail-closed):** lower JS bitwise (`& | ^ ~ << >> >>>`) to a distinct
-  **opaque/narrowing op** that (a) fingerprints differently from
-  arbitrary-precision bitwise and (b) the interpreter models with int32
-  narrowing. JS bitwise stops merging with Python/Ruby (and, conservatively, with
-  C/Java-int — a recall loss to price). *Risk:* interacts with De Morgan /
-  idempotence / byte-pack (§2) — those rules must be made width-aware **or**
-  disabled for the narrowed op (recall loss).
+- **Floor (shipped):** JS bitwise (`& | ^ ~ << >>`) fingerprints through a
+  distinct `ToInt32` narrowing wrapper, so it stops merging with
+  arbitrary-precision bitwise. De Morgan and same-language bitwise recall remain
+  green because the wrap lands on leaves rather than replacing the whole operator.
 - **Full model:** a first-class fixed-width bitwise semantics (int32 for JS,
   type-width for C/Java/Go/Rust) that the whole bitwise canon understands — so
   JS `a&b` ≡ Java-`int` `a&b` ≡ C-`int32_t` `a&b` reconverge correctly while
   staying split from bigint and 64-bit. Largest of the three canon surfaces.
-- **Cost:** Medium (floor) → High (full).
+- **Cost:** floor paid; remaining Medium-High for oracle int32 execution and full
+  fixed-width recall recovery.
 
-### 3.3 D-div — Float value kind (or fail-closed)
+### 3.3 D-div — Float value kind
 
-- **Floor (fail-closed):** lower Python/JS `/` (true-float division) to an op the
-  interpreter **bails on** (`Sym`/`Err`, so it never feeds the SOUND gate) and
-  that fingerprints distinctly from integer division. True-float `/` units stop
-  merging across the int/float boundary. *Recall cost:* every true-float `/` unit
-  becomes oracle-opaque (no longer eligible for the exact behavioral claim) —
-  potentially significant in float-heavy corpora; **must be priced**.
+- **Floor (shipped):** Python/JS `/` (true-float division) fingerprints as
+  `TrueDiv`, distinct from C-family truncated `Div` and Ruby/Python `FloorDiv`.
+  Same-semantics surfaces still converge (`Python /` with JS `/`, Ruby `/` with
+  Python `//`).
 - **Full model:** add `Value::Float` with IEEE-754 semantics, the per-language
   Int↔Float coercion lattice, and the float half of C (`+`/`*` non-associativity,
   `(a+b)+c ≠ a+(b+c)`). Recovers the recall the floor gives up. **Largest single
   piece in the whole #283 cluster** — its own design doc if pursued.
-- **Cost:** Low–Medium (floor) → High (full).
+- **Cost:** floor paid; remaining High for a real Float interpreter/value-graph model.
 
 ---
 
@@ -242,10 +247,10 @@ oracle-caught)":
 
 | target | file / repro | must become |
 |---|---|---|
-| C — string `+` non-commutativity | `untyped_add_commute.py` (`a+b` vs `b+a`) | oracle **witnesses** the difference; detector keeps them **split** |
+| C — string/mixed-coercive `+` ordering | `untyped_add_commute.py` (`a+b` vs `b+a`) and JS/TS/Java-style `x+4` / `x+(2+3)` / `x-3` / `-(x+2)` | detector keeps them **split**; oracle witnesses pure string now only after battery enrichment, and mixed string/number after coercion modeling |
 | C — float `+` non-associativity | `float_assoc.py` (`(a+b)+c` vs `a+(b+c)`) | oracle witnesses (needs §3.3 float) or detector keeps split |
-| D-int32 — JS bitwise vs bigint | cross-language `a & b` (JS vs Python), e.g. the §2 reproducer — **add to the battery** | detector keeps **split**; oracle models int32 |
-| D-div — true-float `/` | Python/JS `a/b` vs Ruby `a/b` vs C `a/b` | the three **do not merge**; oracle models float (or fails closed) |
+| D-int32 — JS bitwise vs bigint | cross-language `a & b` (JS vs Python), e.g. the §2 reproducer | detector keeps **split**; oracle int32 execution remains follow-up |
+| D-div — true-float `/` | Python/JS `a/b` vs Ruby `a/b` vs C `a/b` | the three **do not merge**; real Float oracle remains follow-up |
 
 New permanent regression tests follow the pattern of
 `crates/nose-cli/tests/equivalence.rs`
@@ -267,16 +272,15 @@ coarse). Recommended sequence, cheapest-and-highest-confidence first:
    alone (the floor) is worth shipping immediately — it strengthens the oracle for
    *every* future finding and tells us how big the untyped-`+` problem actually
    is before we price the gate.
-2. **D-int32 — GO as a fail-closed floor; defer the full width model.** Ship the
-   distinct narrowing op + int32 interpreter semantics, price the JS↔C/Java-int
-   recall loss. Promote to the full fixed-width canon only if that loss is
-   material. The canon interactions (§3.2) are the real work and should be a
-   separate PR from the floor.
-3. **D-div (Float) — NO-GO for now; floor-only.** Ship the fail-closed floor
-   (true-float `/` bails + fingerprints distinctly) and **measure** the recall
-   cost. The full `Value::Float` model is the largest single surface in the
-   cluster and should not be started until (a) the floor's recall price proves it
-   necessary and (b) it gets its own design doc covering NaN/±0/coercion.
+2. **D-int32 — floor shipped; defer the full width model.** The distinct
+   narrowing fingerprint is in place. Next work is int32 oracle execution plus
+   measured JS↔C/Java-int recall recovery. Promote to the full fixed-width canon
+   only if that loss is material.
+3. **D-div (Float) — floor shipped; full model remains NO-GO for now.** The
+   true/floored/truncated fingerprints are split. The full `Value::Float` model
+   is the largest single surface in the cluster and should not be started until
+   (a) the floor's recall price proves it necessary and (b) it gets its own
+   design doc covering NaN/±0/coercion.
 
 This converts "one big scary foundational extension" into **three independently
 priced, independently shippable fixes**, each with a sound floor — exactly the

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -165,8 +165,9 @@ and pack ecosystem.
 - Python `math.prod` product-reduction recognition moved behind an imported
   namespace function contract with missing-import and overwritten-binding hard
   negatives.
-- Java `Math.abs`/`Math.min`/`Math.max` moved out of frontend text-only lowering
-  and into method contracts that require an unshadowed `Math` receiver.
+- Java integer `Math.abs`/`Math.min`/`Math.max` moved out of frontend text-only
+  lowering and into scalar-integer method contracts that require an unshadowed
+  `Math` receiver plus integer-domain proof for value arguments.
 - JS-like `undefined` moved from unconditional frontend null lowering to an
   unshadowed-global nullish contract, preserving shadowed binding hard negatives.
 - Strict exact gates now consume the same nullish-global proof, so temp-bound
@@ -180,15 +181,18 @@ and pack ecosystem.
 - Normalize idiom receiver admission for iterator identity adapters and Rust
   `zip` now consumes the same semantic contracts as value-graph/detect paths,
   closing language-blind `iter`/`zip` selector bypasses.
-- JS-like `Math.abs`/`Math.min`/`Math.max` now consume method contracts with an
-  unshadowed `Math` receiver, and JS record-shape guards using `Boolean(...)`
-  consume a static-global function contract with an unshadowed `Boolean`
-  requirement.
+- JS-like `Math.abs`/`Math.min`/`Math.max` stay exact-closed until a signed-zero
+  and NaN-aware numeric model exists; Go `math.Abs`/`math.Min`/`math.Max` and
+  Java floating `Math.abs`/`Math.min`/`Math.max` stay closed for the same reason.
+  JS record-shape guards using `Boolean(...)` consume a static-global function
+  contract with an unshadowed `Boolean` requirement.
 - Generic Python/Go free-function builtins now have `LibraryApi` occurrence
   rows. Early idiom canonicalization and value-graph two-argument
-  `min(...)`/`max(...)` require admitted occurrence evidence instead of raw
-  callee spelling, closing unqualified JS `min(...)`, local-shadowing, and
-  missing-producer bypasses.
+  `min(...)`/`max(...)` require admitted occurrence evidence plus integer-domain
+  proof instead of raw callee spelling. Python free `abs(...)` and sign-test
+  absolute-value ternaries use the same integer-domain proof gate, closing
+  unqualified JS `min(...)`, local-shadowing, missing-producer bypasses, and
+  float/signed-zero/NaN false merges.
 - Ruby `fetch(key) { fallback }` map-default handling now consumes an explicit
   zero-arg-lambda fallback argument contract, and Go `slices.Contains` value-graph
   membership proof consumes the imported namespace carried by the method contract

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -555,14 +555,21 @@ migrated.
 - Imported namespace function contracts now cover Python `math.prod` as a product
   reduction only when the receiver is proven to be the imported `math` namespace.
   Bare globals named `math` and overwritten module bindings stay exact-closed.
-- Java and JS-like `Math.abs`/`Math.min`/`Math.max` now lower through method
-  contracts with an unshadowed `Math` receiver requirement instead of frontend
-  text-only builtin lowering.
+- Java integer `Math.abs`/`Math.min`/`Math.max` now lower through scalar-integer
+  method contracts with an unshadowed `Math` receiver requirement plus
+  integer-domain proof for value arguments instead of frontend text-only builtin
+  lowering. JS-like `Math.abs`/`Math.min`/`Math.max` stay exact-closed until a
+  signed-zero and NaN-aware numeric model exists; Go `math.Abs`/`math.Min`/
+  `math.Max` and Java floating `Math.abs`/`Math.min`/`Math.max` stay closed for
+  the same reason.
 - Two-argument free `min(...)`/`max(...)` normalization consumes the Python
-  free-function builtin `LibraryApi` occurrence contract. Same-named functions
-  from other languages, including JS `min(...)`, locally shadowed Python names,
-  and manually constructed calls without admitted occurrence evidence stay
-  exact-closed.
+  free-function builtin `LibraryApi` occurrence contract plus integer-domain
+  proof. Same-named functions from other languages, including JS `min(...)`,
+  locally shadowed Python names, manually constructed calls without admitted
+  occurrence evidence, and float/NaN-sensitive operands stay exact-closed. Python
+  free `abs(...)` and sign-test absolute-value ternaries also require
+  integer-domain proof before they use the modeled Abs node, so untyped and
+  element-derived operands keep the signed-zero boundary closed.
 - User-defined and imported opaque call identity now consume `CallTarget`
   evidence. The first-party producer admits `DirectFunction` records for unique
   top-level in-file function targets with no current or enclosing lexical

--- a/docs/source-facts.md
+++ b/docs/source-facts.md
@@ -139,7 +139,10 @@ fall back to a side-table mirror when source evidence is missing.
   closed.
 - JS-like static membership callbacks such as `x => x === value` consume source
   operator facts and require strict equality/inequality. Loose equality and
-  `instanceof` stay closed for those exact contracts.
+  `instanceof` stay closed for those exact contracts. The value graph also keeps
+  non-null loose equality and positive/negated JS `instanceof` exact-closed
+  instead of treating them as strict equality/inequality; only the `x == null`
+  source contract feeds the modeled nullish check.
 - Rust full-index range recognition consumes `Source::Range` evidence for the
   half-open `0..len(collection)` source surface. A raw `Seq(0, Len(C), 0)` shape,
   or an inclusive `0..=len(collection)` source fact, does not prove that loop

--- a/docs/type4-benchmark.md
+++ b/docs/type4-benchmark.md
@@ -228,8 +228,9 @@ generated as hard negatives.
 The current C total-order comparator contract is similarly narrow: generated comparator
 callbacks dereference two scalar coordinates and return `-1`, `1`, or `0` for ascending
 less, greater, and equal cases. Guard-return order and nested ternary sign forms may
-converge only when the comparison operators are primitive ordered comparisons; overloadable
-or effectful receiver comparisons remain hard negatives.
+converge only when the value graph has total-order proof for the compared values; pointer-loaded
+locals without that proof, overloadable comparisons, and effectful receiver comparisons remain
+hard negatives.
 
 The current C byte-pack contract is narrower still. Generated `u16` big-endian decoders may
 converge only when the receiver is proven to be a byte buffer (`unsigned char *`, `uint8_t *`,

--- a/scripts/check-duplication.sh
+++ b/scripts/check-duplication.sh
@@ -57,7 +57,15 @@ MIN_VALUE=40   # ignore small/incidental similarity; gate only on substantial fa
 # the asserted direction). The series-9 dataflow inline-soundness fix shifted enough
 # structure to push the pair over the near threshold. Benign test scaffolding, nothing to
 # extract; the production change it rode in on is fingerprint-neutral (family delta ≈ 0).
-BUDGET=27      # accepted substantial families today (see docs/dogfooding.md)
+#
+# +1 (semantic false-merge boundaries): the value-graph order-orientation soundness fix shifts
+# canonicalized value fingerprints enough for this branch's binary to report the same 28-family
+# count even when scanning an unmodified origin/main tree. The extra counted family is the
+# pre-existing high-parameter overlap slice
+# `body_depends_on_iter` / `foreach_effect_body_depends_on_iter` / `single_branch_statement`,
+# folded under the loop-effect family in human output. It is tracked design debt, not code
+# introduced here.
+BUDGET=28      # accepted substantial families today (see docs/dogfooding.md)
 BIN="${NOSE_BIN:-./target/release/nose}"
 GATE_ARGS=(scan crates --exclude tests --mode near --min-value "$MIN_VALUE")
 


### PR DESCRIPTION
## Summary
- fail-closed JS/TS/Java string-coercive `+`, JS loose equality/instanceof/relational comparisons, and NaN-sensitive order negation unless integer proof exists
- gate abs/min/max and clamp-style canonical forms on integer-domain evidence, preserving signed-zero/NaN-sensitive APIs
- move order branch orientation into value-graph Phi canonicalization behind integer proof while keeping equality branch orientation in CFG
- update semantic-kernel/oracle docs for the shipped detector floors and remaining oracle/model gaps

## Tests
- `awiki lint --root docs`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`