### PR TITLE
#307: recognize globals()[str] / setattr dynamic module rebinds (close false merge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ break.
   vectors. A `NOSE_TIME`-gated `enrich` stage timing was added.
 
 ### Fixed
+- **False merge closed: dynamic module rebind via `globals()['f'] = …` / `setattr` (#307).**
+  Reassigning a module function without a `global` declaration — `globals()['helper'] =
+  other` or `setattr(<module>, 'helper', other)` — left `helper` looking like its `def`
+  body, so callers of `helper()` across files that rebind it differently false-merged. Such
+  rebinds are now recognized structurally and the string-literal key resolved (by content
+  hash) to the module function it names, which then joins the `ModuleRebind` exclusion (no
+  inlining / content-keying / exact channel) the lexical `global f; f = …` form already got.
+  Conservative — it can only split fingerprints, never merge; corpus family delta = 0 (the
+  pattern is absent from the pinned corpus).
 - **Dataflow copy-propagation no longer makes two real-semantics-unsound moves (coevo
   series 9 oracle residue).** The single-use temp inliner (1) moved a temp's read past an
   indexed store that clobbers it — `t = a[i]; a[i] = a[j]; a[j] = t` became `a[i] = a[j];

--- a/crates/nose-frontend/src/python.rs
+++ b/crates/nose-frontend/src/python.rs
@@ -1405,6 +1405,33 @@ mod tests {
     use nose_semantics::source_comprehension_at_node;
 
     #[test]
+    fn dynamic_module_rebind_via_globals_and_setattr_marks_the_named_function() {
+        // #307: `globals()['helper'] = …` and `setattr(<module>, 'other', …)` reassign a
+        // module function with NO `global` declaration to key off. The named function's
+        // runtime binding is no longer its `def`, so it must be excluded from inlining /
+        // content-keying (else callers false-merge across files reassigning it differently).
+        let interner = Interner::new();
+        let il = lower(
+            FileId(0),
+            "t.py",
+            b"def helper(x):\n    return x + 1\ndef other(x):\n    return x * 100\nglobals()['helper'] = other\nsetattr(m, 'other', helper)\n",
+            &interner,
+        )
+        .expect("lower");
+        let rebound = nose_semantics::module_rebound_symbols(&il, &interner);
+        let names: std::collections::HashSet<&str> =
+            rebound.iter().map(|&s| interner.resolve(s)).collect();
+        assert!(
+            names.contains("helper"),
+            "globals()['helper'] = … must mark helper as rebound: {names:?}"
+        );
+        assert!(
+            names.contains("other"),
+            "setattr(m, 'other', …) must mark other as rebound: {names:?}"
+        );
+    }
+
+    #[test]
     fn literal_match_lowers_without_raw_case_nodes() {
         let interner = Interner::new();
         let il = lower(

--- a/crates/nose-normalize/src/call_target_evidence.rs
+++ b/crates/nose-normalize/src/call_target_evidence.rs
@@ -100,7 +100,7 @@ fn unique_direct_function_targets(
     // ...`): the runtime binding is no longer the `def` body, so the name is not a
     // DirectFunction target. Precise — a local `name = x` (no `global`) carries no fact
     // and stays a valid target (#302). Empty for non-Python and the common case.
-    let rebound = nose_semantics::module_rebound_symbols(il);
+    let rebound = nose_semantics::module_rebound_symbols(il, interner);
     for unit in &il.units {
         if unit.kind != UnitKind::Function || !is_top_level_function_root(il, &parents, unit.root) {
             continue;

--- a/crates/nose-normalize/src/value_graph/context.rs
+++ b/crates/nose-normalize/src/value_graph/context.rs
@@ -324,7 +324,7 @@ impl<'a> Builder<'a> {
         // Names rebound at module scope (`global name; name = ...`) — not content-keyable
         // for the same reason as decorated defs: the name's runtime value is not its `def`
         // body (#302).
-        let rebound = nose_semantics::module_rebound_symbols(self.il);
+        let rebound = nose_semantics::module_rebound_symbols(self.il, self.interner);
         // Indexed loop: the body needs `&mut self` but never mutates `units`.
         for i in 0..self.il.units.len() {
             let unit = self.il.units[i];

--- a/crates/nose-semantics/src/evidence.rs
+++ b/crates/nose-semantics/src/evidence.rs
@@ -130,7 +130,7 @@ pub fn decorated_definition_at_node(il: &Il, node: NodeId) -> bool {
 /// content-keyed or admitted to the exact channel (#302). Precise where the series-6
 /// reassigned-anywhere predicate over-fired: a local `name = x` (no `global`) carries no
 /// fact, so the function stays a valid target.
-pub fn module_rebound_symbols(il: &Il) -> rustc_hash::FxHashSet<Symbol> {
+pub fn module_rebound_symbols(il: &Il, interner: &Interner) -> rustc_hash::FxHashSet<Symbol> {
     let mut out = rustc_hash::FxHashSet::default();
     for idx in 0..il.nodes.len() {
         let node = NodeId(idx as u32);
@@ -146,7 +146,69 @@ pub fn module_rebound_symbols(il: &Il) -> rustc_hash::FxHashSet<Symbol> {
             collect_target_names(il, lhs, &mut out);
         }
     }
+    collect_dynamic_module_rebinds(il, interner, &mut out);
     out
+}
+
+/// Dynamic module rebinds with NO `global` declaration to key off: `globals()['name'] = …`
+/// and `setattr(<module>, 'name', …)`. The reassigned name is a STRING LITERAL, so detect
+/// the shape structurally and resolve the key to the module function it names — a `LitStr`
+/// holds `stable_symbol_hash(content)`, the same hash a `Symbol` has, so a function whose
+/// `symbol_hash` matches the key is the rebound target. Closes #307: a caller of `helper()`
+/// must not inline its `def` body once `globals()['helper']` reassigns it. Fail-open — a key
+/// that names no module function adds nothing.
+fn collect_dynamic_module_rebinds(
+    il: &Il,
+    interner: &Interner,
+    out: &mut rustc_hash::FxHashSet<Symbol>,
+) {
+    let by_hash: FxHashMap<u64, Symbol> = il
+        .units
+        .iter()
+        .filter_map(|u| u.name)
+        .map(|s| (interner.symbol_hash(s), s))
+        .collect();
+    if by_hash.is_empty() {
+        return;
+    }
+    let str_lit_hash = |n: NodeId| match il.node(n).payload {
+        Payload::LitStr(h) => Some(h),
+        _ => None,
+    };
+    // A `Call` whose callee is the free name `want` (`globals` / `setattr`).
+    let callee_named = |call: NodeId, want: &str| {
+        il.kind(call) == NodeKind::Call
+            && il
+                .children(call)
+                .first()
+                .and_then(|&c| il.var_name(c))
+                .is_some_and(|s| interner.resolve(s) == want)
+    };
+    for idx in 0..il.nodes.len() {
+        let node = NodeId(idx as u32);
+        let key_hash = match il.kind(node) {
+            // `globals()['name'] = …` → Assign( Index( Call(globals), LitStr ), value )
+            NodeKind::Assign => il.children(node).first().and_then(|&lhs| {
+                if il.kind(lhs) != NodeKind::Index {
+                    return None;
+                }
+                let kids = il.children(lhs);
+                let base = *kids.first()?;
+                let key = *kids.get(1)?;
+                callee_named(base, "globals")
+                    .then(|| str_lit_hash(key))
+                    .flatten()
+            }),
+            // `setattr(<module>, 'name', …)` → Call[callee, module, LitStr, value]
+            NodeKind::Call if callee_named(node, "setattr") => {
+                il.children(node).get(2).copied().and_then(str_lit_hash)
+            }
+            _ => None,
+        };
+        if let Some(sym) = key_hash.and_then(|h| by_hash.get(&h).copied()) {
+            out.insert(sym);
+        }
+    }
 }
 
 fn collect_target_names(il: &Il, target: NodeId, out: &mut rustc_hash::FxHashSet<Symbol>) {

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -273,7 +273,10 @@ downstream value-graph.
   non-top-level `f = x` is indistinguishable from a local declaration, which is why
   a coarse reassigned-anywhere predicate over-fires (it kills valid inlines whose
   name a local merely shadows). A local `f = 5` carries no fact and stays a valid
-  target (#302).
+  target (#302). The same exclusion covers two **dynamic** rebinds that carry no
+  `global` declaration — `globals()['f'] = ...` and `setattr(<module>, 'f', ...)` —
+  recognized structurally and resolved by matching the string-literal key's content
+  hash to the module function it names (#307).
 
   Admission is *generalized*, not whitelisted: the callee body may contain loops,
   branches, builder appends, and nested proven calls — it is evaluated through the


### PR DESCRIPTION
Closes **#307** — a confirmed exact-channel false merge (still reproducing on main).

### The false merge
Reassigning a module function *without* a `global` declaration leaves the name looking like its `def` body, so callers false-merge across files that rebind it differently. Verified on main:
```python
# a/mod.py: globals()['helper'] = other   (other = x*100)  → run(x) == x*100
# b/mod.py: globals()['helper'] = other   (other = x-7)    → run(x) == x-7
```
`run` from a and b shared one `exact-value-graph` fingerprint (both inlined `helper`'s original `def`, `x+1`, ignoring the dynamic rebind).

### Fix
`module_rebound_symbols` (the `ModuleRebind` exclusion that already covers lexical `global f; f = …`, #302/#305) now also detects the two **dynamic** forms structurally:
- `globals()['name'] = …` → `Assign(Index(Call(globals), LitStr), value)`
- `setattr(<module>, 'name', …)` → `Call(setattr, module, LitStr, value)`

The string-literal key carries `stable_symbol_hash(content)` — the same hash a `Symbol` has — so the rebound function is the module unit whose `symbol_hash` matches the key. It then joins the exclusion (no inlining / content-keying / exact channel).

### Why it's safe
- **Sound by construction:** excluding a function from inlining only *splits* fingerprints, never merges — no new false merge is possible.
- The #307 reproducer no longer merges `run` across files (only the genuinely-identical `helper` defs do); an identical-helper-**without**-rebind control still merges (recall preserved).
- `nose verify` SOUND and **corpus family delta = 0** across sympy/flask/requests/httpx/click — the pattern is exotic, absent from the pinned corpus.
- Regression test `dynamic_module_rebind_via_globals_and_setattr_marks_the_named_function`; full workspace suite (18) green; clippy/dup-gate/docs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
