### PR TITLE
#283 C-float (partial): don't reassociate float subtraction; scope the rest to the Float value kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ break.
   vectors. A `NOSE_TIME`-gated `enrich` stage timing was added.
 
 ### Fixed
+- **False merge closed: float subtraction is no longer reassociated (#283 C-float, partial).**
+  A `-` carrying a proven-float operand (a float literal, a `/` true-division result, or a
+  float-typed param) is now kept as a literal `Sub` rather than routed through the
+  associative `+` normalization (`a - b` ≡ `a + (-b)`) — so `(1e100 + x) - 1e100` (≈ 0.0, the
+  large term swallows `x`) no longer shares an `exact-value-graph` fingerprint with the
+  regrouped `(1e100 - 1e100) + x` (= x). Integer subtraction still normalizes and converges;
+  corpus family delta is 0. The pure-`+`/`*` float case (`(a+b)+c ≡ a+(b+c)`) is NOT closed:
+  the fingerprint flattens AC chains to a leaf sequence, so it is grouping-insensitive by
+  design and needs the Float value kind, not a canon gate (the finding, recorded in
+  [oracle-value-model §3.3](docs/oracle-value-model.md)).
 - **False merge closed: dynamic module rebind via `globals()['f'] = …` / `setattr` (#307).**
   Reassigning a module function without a `global` declaration — `globals()['helper'] =
   other` or `setattr(<module>, 'helper', other)` — left `helper` looking like its `def`

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -2606,6 +2606,31 @@ fn algebra_associativity() {
 }
 
 #[test]
+fn float_subtraction_is_not_reassociated_while_integer_subtraction_is() {
+    // #283 C-float: a `-` carrying a PROVEN-float operand is kept as a literal `Sub` rather
+    // than routed through the AC `+` normalization (`a - b` ≡ `a + (-b)`), because that
+    // reassociation is float-unsound — `(1e100 + x) - 1e100` (= 0.0, the large term swallows
+    // x) must not converge with the regrouped `(1e100 - 1e100) + x` (= x). Integer `-` still
+    // normalizes and converges (two's-complement subtraction is associative). The pure-`+`
+    // float case (`(a+b)+c ≡ a+(b+c)` for untyped a,b,c) is NOT closed here — the fingerprint
+    // flattens AC chains, so it needs the `Float` value kind (oracle-value-model §3.3).
+    let i = Interner::new();
+    let t = |src: &str| value_fp(&i, src, Lang::Python);
+    // Float literal: the two groupings compute different floats and must NOT merge.
+    assert_ne!(
+        t("def f(x):\n    return (1e100 + x) - 1e100\n"),
+        t("def g(x):\n    return (1e100 - 1e100) + x\n"),
+        "float-literal subtraction must not reassociate across groupings"
+    );
+    // Control — the same shape with an integer literal is sound and still converges.
+    assert_eq!(
+        t("def f(x):\n    return (5 + x) - 5\n"),
+        t("def g(x):\n    return (5 - 5) + x\n"),
+        "integer subtraction must still reassociate (sound)"
+    );
+}
+
+#[test]
 fn algebra_comparison_direction() {
     let i = Interner::new();
     let gt = "def f(a, b):\n    return a > b\n";

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -334,7 +334,14 @@ impl<'a> Builder<'a> {
     fn eval_sub_chain(&mut self, kids: &[NodeId], env: &FxHashMap<u32, ValueId>) -> ValueId {
         let a = self.eval(kids[0], env);
         let b = self.eval(kids[1], env);
-        if self.plus_has_mixed_string_coercion() && !self.proven_non_concat(a) {
+        // Routing `a - b` through the AC `+` chain (`a + (-b)`) reassociates it; that is
+        // unsound for a string-coercion `+` (JS/TS/Java) and for float arithmetic
+        // (`(x + a) - x != a` when x is a large float). Keep the literal `Sub` in those
+        // cases so it is not flattened into a reassociated sum (#283 C-float).
+        if (self.plus_has_mixed_string_coercion() && !self.proven_non_concat(a))
+            || self.proven_float(a)
+            || self.proven_float(b)
+        {
             return self.mk(ValOp::Bin(Op::Sub as u32), vec![a, b]);
         }
         let neg_b = self.mk(ValOp::Un(Op::Neg as u32), vec![b]);

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -179,6 +179,32 @@ impl<'a> Builder<'a> {
         }
     }
 
+    /// Whether `v` provably evaluates to a FLOAT (so subtraction over it must not be routed
+    /// through the AC `+` normalization, #283 C-float). Genuine evidence only — a float
+    /// literal, a true-division result (`a / b` is float even of integers, the value-blind
+    /// i64 model notwithstanding), a float-typed parameter, or a sign-flip of one. Fails
+    /// closed: an untyped param is NOT proven float. NOTE: this gates only `eval_sub_chain`
+    /// (subtraction), the one place where the source grouping survives into the fingerprint
+    /// — `Sub` and `Add` are distinct nodes. Pure `+`/`*` associativity (`(a+b)+c ≡ a+(b+c)`)
+    /// CANNOT be gated this way: the fingerprint flattens an AC chain to its leaf sequence,
+    /// so holding the source tree leaves the leaves identical. Closing that needs the `Float`
+    /// value kind (a grouping-sensitive fingerprint for float chains, oracle-value-model §3.3).
+    pub(super) fn proven_float(&self, v: ValueId) -> bool {
+        match self.nodes[v as usize].op {
+            ValOp::Const { kind, .. } => kind == ConstKind::Float,
+            ValOp::Input(cid) => self.param_domain.get(&cid).is_some_and(|d| d.is_float()),
+            ValOp::Bin(o) => op_from_code(o) == Some(Op::TrueDiv),
+            ValOp::Un(o) => {
+                matches!(op_from_code(o), Some(Op::Neg | Op::Pos))
+                    && self.nodes[v as usize]
+                        .args
+                        .first()
+                        .is_some_and(|&a| self.proven_float(a))
+            }
+            _ => false,
+        }
+    }
+
     /// Whether `v` is already an int32-valued node — a JS-family bitwise result (its result
     /// is int32) or an existing `ToInt32`. Such a value needs no further narrowing when it
     /// feeds another bitwise op, which keeps the wrap to the LEAF operands only (#283-D).

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -193,6 +193,19 @@ first; promote to the full model only if the priced recall loss justifies it.
   `TrueDiv`, distinct from C-family truncated `Div` and Ruby/Python `FloorDiv`.
   Same-semantics surfaces still converge (`Python /` with JS `/`, Ruby `/` with
   Python `//`).
+- **Subtraction slice (shipped, series-9 follow-up):** a `-` carrying a proven-float
+  operand (float literal / `TrueDiv` result / float-typed param) is kept as a literal
+  `Sub` instead of being routed through the AC `+` normalization (`a - b` ≡ `a + (-b)`),
+  so `(1e100 + x) - 1e100` no longer false-merges with the regrouped `(1e100 - 1e100) + x`
+  (`proven_float` + the `eval_sub_chain` gate; corpus family delta 0). This works only
+  because `Sub` and `Add` are distinct fingerprint nodes.
+- **Why the pure `+`/`*` case still needs the full model (the finding):** gating the
+  *canonicalizer* CANNOT close `(a+b)+c ≡ a+(b+c)` for floats — the exact fingerprint
+  flattens an associative-commutative chain to its **leaf sequence** (grouping-insensitive
+  by design, so loop≡sum and regrouped sums converge), so holding the source tree grouping
+  leaves the leaves identical and the fingerprint unchanged. Closing it requires the
+  fingerprint itself to be **grouping-sensitive for float chains** — i.e. the Float value
+  kind, not a canon gate.
 - **Full model:** add `Value::Float` with IEEE-754 semantics, the per-language
   Int↔Float coercion lattice, and the float half of C (`+`/`*` non-associativity,
   `(a+b)+c ≠ a+(b+c)`). Recovers the recall the floor gives up. **Largest single


### PR DESCRIPTION
Partially closes the **#283 C-float** item — and records why the rest needs the Float value kind, not a canonicalizer gate.

### Shipped: float subtraction is not reassociated
A `-` carrying a **proven-float** operand (a float literal, a `/` true-division result, or a float-typed param) is kept as a literal `Sub` instead of being routed through the associative `+` normalization (`a - b` ≡ `a + (-b)`). So:
```python
def f(x): return (1e100 + x) - 1e100   # ≈ 0.0  (the large term swallows x)
def g(x): return (1e100 - 1e100) + x   # = x
```
no longer share an `exact-value-graph` fingerprint. **Verified:** this pair merges on `origin/main` and no longer does here; integer subtraction still normalizes/converges; `nose verify` SOUND and corpus family delta **0** across sympy/flask/redis. Regression test `float_subtraction_is_not_reassociated_while_integer_subtraction_is`.

### The finding: pure `+`/`*` float associativity can't be canon-gated
`(a+b)+c ≡ a+(b+c)` for floats (the `float_assoc.py` fixture) is **not** closeable by gating the canonicalizer. The exact fingerprint flattens an associative-commutative chain to its **leaf sequence** — grouping-insensitive *by design* (so loop≡sum and regrouped sums converge) — so holding the source tree grouping leaves the leaf multiset, and thus the fingerprint, unchanged. I confirmed this empirically: an AC-chain gate fired (`anyfloat=true`) yet the 3-operand float chains still merged. Subtraction is closeable only because `Sub` and `Add` are distinct fingerprint nodes.

So closing the pure-`+`/`*` case requires the fingerprint itself to be **grouping-sensitive for float chains** — i.e. the **Float value kind** (the deferred §3.3 epic), not a canon gate. Recorded in `docs/oracle-value-model.md §3.3` and the `proven_float` doc-comment so the canon-gating dead-end isn't re-attempted.

Gates: fmt, clippy `-D warnings`, full workspace suite (18), dup-gate (28/28), docs — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
