### PR TITLE
#283 C-float: hold syntactic-float +/* associativity (close the float-literal/division cases)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ break.
   vectors. A `NOSE_TIME`-gated `enrich` stage timing was added.
 
 ### Fixed
+- **False merge closed: syntactic-float `+`/`*` is no longer reassociated (#283 C-float).**
+  Float `+`/`*` is non-associative (`(1.0 + a) + b ≠ 1.0 + (a + b)`), so a chain with a
+  syntactically-float leaf — a float literal or a `/` (true-division) result — now keeps its
+  source grouping in BOTH the `algebra` IL pass (`chain_has_syntactic_float` → leave the tree
+  intact) and the value graph (`proven_float` → don't flatten the AC chain), so the two
+  groupings fingerprint distinctly. Closes the documented `(a+b)+c ≡ a+(b+c)` float-literal /
+  division cases. Integer reassociation and same-grouping float clones still converge; corpus
+  family delta ≈ 0 (sympy −1, all others 0), verify clean. (The earlier note that this needed
+  the full Float value kind was a misdiagnosis — the fingerprint is structure-sensitive; the
+  grouping was lost at `algebra` reassociation, which is gateable. The float-**typed-param**
+  case with no syntactic marker still flattens — that is the remaining Float-kind work, §3.3.)
 - **False merge closed: float subtraction is no longer reassociated (#283 C-float, partial).**
   A `-` carrying a proven-float operand (a float literal, a `/` true-division result, or a
   float-typed param) is now kept as a literal `Sub` rather than routed through the

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -2611,9 +2611,9 @@ fn float_subtraction_is_not_reassociated_while_integer_subtraction_is() {
     // than routed through the AC `+` normalization (`a - b` ≡ `a + (-b)`), because that
     // reassociation is float-unsound — `(1e100 + x) - 1e100` (= 0.0, the large term swallows
     // x) must not converge with the regrouped `(1e100 - 1e100) + x` (= x). Integer `-` still
-    // normalizes and converges (two's-complement subtraction is associative). The pure-`+`
-    // float case (`(a+b)+c ≡ a+(b+c)` for untyped a,b,c) is NOT closed here — the fingerprint
-    // flattens AC chains, so it needs the `Float` value kind (oracle-value-model §3.3).
+    // normalizes and converges (two's-complement subtraction is associative). Pure `+`/`*`
+    // float associativity is also held now (next test); the fully-untyped `(a+b)+c` with no
+    // float marker still flattens — that is the remaining full Float value kind (§3.3).
     let i = Interner::new();
     let t = |src: &str| value_fp(&i, src, Lang::Python);
     // Float literal: the two groupings compute different floats and must NOT merge.
@@ -2627,6 +2627,44 @@ fn float_subtraction_is_not_reassociated_while_integer_subtraction_is() {
         t("def f(x):\n    return (5 + x) - 5\n"),
         t("def g(x):\n    return (5 - 5) + x\n"),
         "integer subtraction must still reassociate (sound)"
+    );
+}
+
+#[test]
+fn float_addition_and_multiplication_are_held_unassociated() {
+    // #283 C-float: float `+`/`*` is non-associative. A chain with a SYNTACTICALLY-float leaf
+    // — a float literal or a `/` (true-division) result — keeps its source grouping in BOTH
+    // the algebra IL pass (`chain_has_syntactic_float` → don't reassociate) and the value
+    // graph (`proven_float` → don't flatten), so the groupings fingerprint distinctly.
+    let i = Interner::new();
+    let t = |src: &str| value_fp(&i, src, Lang::Python);
+    assert_ne!(
+        t("def f(a, b):\n    return (1.0 + a) + b\n"),
+        t("def g(a, b):\n    return 1.0 + (a + b)\n"),
+        "float-literal `+` must not reassociate"
+    );
+    assert_ne!(
+        t("def f(a, b):\n    return (1.5 * a) * b\n"),
+        t("def g(a, b):\n    return 1.5 * (a * b)\n"),
+        "float-literal `*` must not reassociate"
+    );
+    assert_ne!(
+        t("def f(a, b, c):\n    return (a / b + c) + 1.0\n"),
+        t("def g(a, b, c):\n    return a / b + (c + 1.0)\n"),
+        "true-division (float) `+` must not reassociate"
+    );
+    // Control — integer reassociation is sound and still converges.
+    assert_eq!(
+        t("def p(a, b):\n    return (2 + a) + b\n"),
+        t("def q(a, b):\n    return 2 + (a + b)\n"),
+        "integer `+` still reassociates (sound)"
+    );
+    // Control — the SAME float grouping written twice still converges (the hold is
+    // grouping-sensitive, not a blanket exclusion).
+    assert_eq!(
+        t("def p(a, b):\n    return (1.0 + a) + b\n"),
+        t("def q(x, y):\n    return (1.0 + x) + y\n"),
+        "identical float grouping still converges"
     );
 }
 

--- a/crates/nose-normalize/src/algebra.rs
+++ b/crates/nose-normalize/src/algebra.rs
@@ -152,6 +152,16 @@ impl Rewriter<'_> {
             }
             let mut leaves = Vec::new();
             self.collect_assoc_old(old_id, op, &mut leaves);
+            // Float `+`/`*` is NON-ASSOCIATIVE (`(a+b)+c != a+(b+c)`, #283 C-float). If any
+            // leaf is syntactically float — a float literal or a `/` true-division result —
+            // leave the source tree intact (like the mixed-coercion `+` above) so the
+            // grouping survives into the value graph, which keeps it (its `proven_float`
+            // gate). Folding/reassociating here would erase the grouping the float result
+            // depends on. (Float-typed params with no syntactic marker still flatten — that
+            // needs the full Float value kind, §3.3.)
+            if matches!(op, Op::Add | Op::Mul) && self.chain_has_syntactic_float(&leaves) {
+                return self.generic(old_id, span);
+            }
             // Constant folding + identity elimination (now that C retains literal values):
             // `2 + 3` → `5`, `x + 2 + 3` → `x + 5`, `x + 0` → `x`, `x * 1` → `x`. SOUND —
             // `x` is still evaluated either way. NOT `x * 0 → 0` (would drop `x`'s
@@ -396,5 +406,18 @@ impl Rewriter<'_> {
                 out.push(*c);
             }
         }
+    }
+
+    /// Whether any leaf of an `Add`/`Mul` chain is SYNTACTICALLY float — a float literal or
+    /// a `/` (true-division) result — so the chain must not be reassociated (#283 C-float;
+    /// float `+`/`*` is non-associative). Float-typed params with no syntactic marker are
+    /// not detected here (the full Float value kind, §3.3).
+    fn chain_has_syntactic_float(&self, leaves: &[NodeId]) -> bool {
+        leaves.iter().any(|&n| {
+            matches!(
+                self.old.node(n).payload,
+                Payload::LitFloat(_) | Payload::Op(Op::TrueDiv)
+            )
+        })
     }
 }

--- a/crates/nose-normalize/src/value_graph/canonicalize.rs
+++ b/crates/nose-normalize/src/value_graph/canonicalize.rs
@@ -478,6 +478,14 @@ impl<'a> Builder<'a> {
                 if o == Op::Add as u32 && !self.add_association_safe(&leaves) {
                     return None;
                 }
+                // Float `+`/`*` is non-associative (`(a+b)+c != a+(b+c)`, #283 C-float): a
+                // chain with a proven-float leaf keeps its source grouping (the value the
+                // eval-time gate already built), so don't flatten it here either.
+                if (o == Op::Add as u32 || o == Op::Mul as u32)
+                    && leaves.iter().any(|&v| self.proven_float(v))
+                {
+                    return None;
+                }
                 // COMMUTATIVITY — sorting the operands — is gated per op (`ac_chain_commutes`):
                 // a concat-possible `+` (#283-C), mixed-coercion `+`, and a Ruby string/list
                 // `*` (series 9) stay ordered, while numeric/typed sums and products still

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -427,6 +427,23 @@ impl<'a> Builder<'a> {
         if let Some(v) = self.c_u32_be_byte_pack_pattern(&operands) {
             return v;
         }
+        // Float `+`/`*` is NON-ASSOCIATIVE (`(a+b)+c != a+(b+c)`, #283 C-float). When the
+        // chain bears a proven-float operand, do NOT flatten/reassociate it — rebuild the
+        // SOURCE grouping from the original operands so the two groupings fingerprint
+        // distinctly (`ac_chain_canon` is gated to not re-flatten a float chain either). The
+        // 2-operand commute (`order_bin_operands`) still applies — float `+`/`*` IS
+        // commutative. Untyped chains stay optimistically reassociated (the i64 oracle is
+        // blind; closing that is the Float value kind, oracle-value-model §3.3).
+        if (op == Op::Add as u32 || op == Op::Mul as u32)
+            && operands.iter().any(|&v| self.proven_float(v))
+        {
+            let mut acc = self.eval(kids[0], env);
+            for &k in &kids[1..] {
+                let v = self.eval(k, env);
+                acc = self.mk(ValOp::Bin(op), vec![acc, v]);
+            }
+            return acc;
+        }
         self.narrow_js_bitwise_leaves(op, &mut operands);
         let do_sort = self.ac_chain_commutes(op, &operands, ValueLaw::AddAssociativity)
             && operands.iter().all(|&v| self.reorder_safe(v));

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -193,24 +193,27 @@ first; promote to the full model only if the priced recall loss justifies it.
   `TrueDiv`, distinct from C-family truncated `Div` and Ruby/Python `FloorDiv`.
   Same-semantics surfaces still converge (`Python /` with JS `/`, Ruby `/` with
   Python `//`).
-- **Subtraction slice (shipped, series-9 follow-up):** a `-` carrying a proven-float
-  operand (float literal / `TrueDiv` result / float-typed param) is kept as a literal
-  `Sub` instead of being routed through the AC `+` normalization (`a - b` ≡ `a + (-b)`),
-  so `(1e100 + x) - 1e100` no longer false-merges with the regrouped `(1e100 - 1e100) + x`
-  (`proven_float` + the `eval_sub_chain` gate; corpus family delta 0). This works only
-  because `Sub` and `Add` are distinct fingerprint nodes.
-- **Why the pure `+`/`*` case still needs the full model (the finding):** gating the
-  *canonicalizer* CANNOT close `(a+b)+c ≡ a+(b+c)` for floats — the exact fingerprint
-  flattens an associative-commutative chain to its **leaf sequence** (grouping-insensitive
-  by design, so loop≡sum and regrouped sums converge), so holding the source tree grouping
-  leaves the leaves identical and the fingerprint unchanged. Closing it requires the
-  fingerprint itself to be **grouping-sensitive for float chains** — i.e. the Float value
-  kind, not a canon gate.
-- **Full model:** add `Value::Float` with IEEE-754 semantics, the per-language
-  Int↔Float coercion lattice, and the float half of C (`+`/`*` non-associativity,
-  `(a+b)+c ≠ a+(b+c)`). Recovers the recall the floor gives up. **Largest single
-  piece in the whole #283 cluster** — its own design doc if pursued.
-- **Cost:** floor paid; remaining High for a real Float interpreter/value-graph model.
+- **Non-associativity — syntactic-float `+`/`*`/`-` (shipped).** Float `+`/`*` is
+  non-associative (`(1.0+a)+b ≠ 1.0+(a+b)`) and a float `-` must not fold into a sum, so a
+  chain with a **syntactically-float** leaf — a float literal or a `/` (true-division)
+  result — keeps its source grouping. Held in BOTH layers: the `algebra` IL pass
+  (`chain_has_syntactic_float` → leave the tree intact, like the mixed-coercion `+` bail) and
+  the value graph (`proven_float` → don't flatten the AC chain; `eval_sub_chain` keeps a
+  float `-` as `Sub`). Closes the documented `(1e100+1)-1e100` and the `(a+b)+c ≡ a+(b+c)`
+  float-literal/division cases. **Corpus family delta ≈ 0** (sympy −1, all others 0 — float
+  clones written in one grouping are unaffected); verify clean. The earlier worry that "the
+  fingerprint flattens AC chains to a leaf sequence so no canon gate can help" was a
+  **misdiagnosis**: the fingerprint is the reachable-**node** multiset (structure-sensitive,
+  `intern_node` hashes args in order); the grouping was lost at the `algebra` reassociation,
+  which IS gateable.
+- **Remaining (the full model):** a chain whose float-ness is ONLY in a type — `def
+  f(a: float, b: float, c: float): (a+b)+c` — has no syntactic float leaf, so it still
+  flattens; and the fully-untyped `(a+b)+c` (`float_assoc.py`) is undecidable without types.
+  Both need `Value::Float` with IEEE-754 semantics + the per-language Int↔Float coercion
+  lattice (so a param's float-ness propagates and the oracle can witness it) — smaller now
+  that the syntactic cases are closed.
+- **Cost:** floor + syntactic non-associativity paid (≈0 recall); remaining Medium for
+  float-typed-param propagation and a real Float interpreter value.
 
 ---
 


### PR DESCRIPTION
Closes the headline **#283 C-float** false-merge class — float `+`/`*` non-associativity — for the **syntactic-float** cases (float literals and `/` true-division results). Previously thought to need the full Float value kind; it doesn't.

### The merge
Float `+`/`*` is non-associative, but the canonicalizer reassociated AC chains, so:
```python
def f(a, b): return (1.0 + a) + b   # one rounding order
def g(a, b): return 1.0 + (a + b)   # a different one
```
shared an `exact-value-graph` fingerprint. (Same for `*` and for `/`-bearing chains.)

### Root cause (correcting an earlier misdiagnosis)
The #336 note claimed a canon gate "can't help — the fingerprint flattens AC chains to a leaf sequence." That was wrong: the fingerprint is the reachable-**node** multiset and `intern_node` hashes args **in order**, so it is structure-sensitive. The grouping was actually lost at the **`algebra` IL reassociation pass** (and the value-graph AC flatten) — both gateable.

### Fix (two layers, the series-9 pattern)
- **`algebra.rs`** — `chain_has_syntactic_float` (a `LitFloat` or `TrueDiv` leaf) → bail to `generic`, leaving the source tree intact (exactly like the mixed-string-coercion `+` bail already there).
- **value graph** — a chain with a `proven_float` operand rebuilds the **source grouping** instead of flattening, and `ac_chain_canon` won't re-flatten it. The 2-operand commute still applies (float `+`/`*` IS commutative).

### Validation
- **Sound by construction**: only splits fingerprints, never merges.
- Headline cases (`(1.0+a)+b`, `(1.5*a)*b`, `(a/b+c)+1.0`) no longer merge; **integer** reassociation and **same-grouping** float clones still converge.
- **Corpus family delta ≈ 0** (sympy −1, all of flask/redis/guava/axios/httpx/click/gson 0); `nose verify` clean (0/0); full workspace suite (18) green; dup-gate 28/28; docs green.
- Regression test `float_addition_and_multiplication_are_held_unassociated`.

### Remaining (the genuine Float value kind, §3.3)
A chain whose float-ness is only in a TYPE (`def f(a: float, …): (a+b)+c`) has no syntactic marker and still flattens; the fully-untyped `float_assoc.py` is undecidable without types. Both need `Value::Float` + the Int↔Float coercion lattice — a smaller remaining piece now that the common syntactic cases are closed. Updated `oracle-value-model §3.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
