### PR TITLE
Soundness #283 C-float: hold float-TYPED-param +/* associativity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ break.
   vectors. A `NOSE_TIME`-gated `enrich` stage timing was added.
 
 ### Fixed
+- **False merge closed: float-TYPED-param `+`/`*` is no longer reassociated (#283 C-float).**
+  A `+`/`*` chain over float-typed params — `: float` (Python), `f64` (Rust), `double` (Java),
+  `float64` (Go), `number` (TS) — is now held unassociated even with no syntactic float leaf:
+  the float-ness comes from the param's type evidence (`proven_float` via the param domain).
+  Held in BOTH layers: the `algebra` IL pass (`chain_has_float` now also matches float-typed
+  param cids, not just float literals / `/`) and the value graph (`proven_float` rebuilds the
+  source grouping). The value-graph fix also covers the **string-coercion `+` path** that
+  JS/TS/Java route through — previously a `double a,b,c` chain was proven non-concat and so
+  flattened+sorted there, leaking `(a+b)+c ≡ a+(b+c)`. Now `def f(a: float,b,c): (a+b)+c`
+  fingerprints distinctly from `a+(b+c)`. Split-only: int-typed and untyped chains still
+  associate, so corpus family delta is **0** (type4 20→20); verify clean. Only the
+  fully-untyped float chain (`float_assoc.py`) remains — undecidable without types, the
+  genuine `Value::Float` kind (§3.3).
 - **False merge closed: syntactic-float `+`/`*` is no longer reassociated (#283 C-float).**
   Float `+`/`*` is non-associative (`(1.0 + a) + b ≠ 1.0 + (a + b)`), so a chain with a
   syntactically-float leaf — a float literal or a `/` (true-division) result — now keeps its
@@ -27,7 +40,7 @@ break.
   family delta ≈ 0 (sympy −1, all others 0), verify clean. (The earlier note that this needed
   the full Float value kind was a misdiagnosis — the fingerprint is structure-sensitive; the
   grouping was lost at `algebra` reassociation, which is gateable. The float-**typed-param**
-  case with no syntactic marker still flattens — that is the remaining Float-kind work, §3.3.)
+  case is now closed too — see the entry above.)
 - **False merge closed: float subtraction is no longer reassociated (#283 C-float, partial).**
   A `-` carrying a proven-float operand (a float literal, a `/` true-division result, or a
   float-typed param) is now kept as a literal `Sub` rather than routed through the

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -2669,6 +2669,64 @@ fn float_addition_and_multiplication_are_held_unassociated() {
 }
 
 #[test]
+fn float_typed_param_addition_is_held_unassociated() {
+    // #283 C-float: a `+`/`*` chain over FLOAT-TYPED params (`: float`, `f64`, `double`,
+    // `float64`) is non-associative even with no syntactic float leaf — the float-ness comes
+    // from the param's type evidence (`proven_float` via the param domain), not a literal. The
+    // grouping is held in BOTH layers: the algebra IL pass (`chain_has_float` over
+    // `float_param_cids` → don't reassociate) and the value graph (`proven_float` → don't
+    // flatten, in the general AND the string-coercion `+` path for Java/TS). Untyped/int-typed
+    // chains keep flattening (sound: integer `+` IS associative; the fully-untyped float case
+    // is the remaining Value::Float kind, §3.3).
+    let i = Interner::new();
+
+    // Python `: float`
+    assert_ne!(
+        value_fp(&i, "def f(a: float, b: float, c: float):\n    return (a + b) + c\n", Lang::Python),
+        value_fp(&i, "def g(a: float, b: float, c: float):\n    return a + (b + c)\n", Lang::Python),
+        "python float-typed `+` must not reassociate"
+    );
+    // Rust `f64`
+    assert_ne!(
+        value_fp(&i, "fn f(a: f64, b: f64, c: f64) -> f64 { (a + b) + c }", Lang::Rust),
+        value_fp(&i, "fn g(a: f64, b: f64, c: f64) -> f64 { a + (b + c) }", Lang::Rust),
+        "rust f64 `+` must not reassociate"
+    );
+    // Java `double` — the value graph routes Java `+` through the string-coercion path, which
+    // must honor the float hold too (the regression this test guards).
+    assert_ne!(
+        value_fp(&i, "class C { static double f(double a, double b, double c) { return (a + b) + c; } }", Lang::Java),
+        value_fp(&i, "class C { static double g(double a, double b, double c) { return a + (b + c); } }", Lang::Java),
+        "java double `+` must not reassociate"
+    );
+    // Go `float64`
+    assert_ne!(
+        value_fp(&i, "package m\nfunc f(a float64, b float64, c float64) float64 { return (a + b) + c }", Lang::Go),
+        value_fp(&i, "package m\nfunc g(a float64, b float64, c float64) float64 { return a + (b + c) }", Lang::Go),
+        "go float64 `+` must not reassociate"
+    );
+
+    // Control — INT-typed params still reassociate (sound): split-only on float evidence.
+    assert_eq!(
+        value_fp(&i, "def p(a: int, b: int, c: int):\n    return (a + b) + c\n", Lang::Python),
+        value_fp(&i, "def q(a: int, b: int, c: int):\n    return a + (b + c)\n", Lang::Python),
+        "python int-typed `+` still reassociates"
+    );
+    assert_eq!(
+        value_fp(&i, "class C { static int p(int a, int b, int c) { return (a + b) + c; } }", Lang::Java),
+        value_fp(&i, "class C { static int q(int a, int b, int c) { return a + (b + c); } }", Lang::Java),
+        "java int `+` still reassociates"
+    );
+    // Control — fully-untyped params still reassociate (the i64 oracle is associative;
+    // distinguishing this is the full Value::Float kind, §3.3).
+    assert_eq!(
+        value_fp(&i, "def p(a, b, c):\n    return (a + b) + c\n", Lang::Python),
+        value_fp(&i, "def q(a, b, c):\n    return a + (b + c)\n", Lang::Python),
+        "untyped `+` still reassociates"
+    );
+}
+
+#[test]
 fn algebra_comparison_direction() {
     let i = Interner::new();
     let gt = "def f(a, b):\n    return a > b\n";

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -2682,46 +2682,102 @@ fn float_typed_param_addition_is_held_unassociated() {
 
     // Python `: float`
     assert_ne!(
-        value_fp(&i, "def f(a: float, b: float, c: float):\n    return (a + b) + c\n", Lang::Python),
-        value_fp(&i, "def g(a: float, b: float, c: float):\n    return a + (b + c)\n", Lang::Python),
+        value_fp(
+            &i,
+            "def f(a: float, b: float, c: float):\n    return (a + b) + c\n",
+            Lang::Python
+        ),
+        value_fp(
+            &i,
+            "def g(a: float, b: float, c: float):\n    return a + (b + c)\n",
+            Lang::Python
+        ),
         "python float-typed `+` must not reassociate"
     );
     // Rust `f64`
     assert_ne!(
-        value_fp(&i, "fn f(a: f64, b: f64, c: f64) -> f64 { (a + b) + c }", Lang::Rust),
-        value_fp(&i, "fn g(a: f64, b: f64, c: f64) -> f64 { a + (b + c) }", Lang::Rust),
+        value_fp(
+            &i,
+            "fn f(a: f64, b: f64, c: f64) -> f64 { (a + b) + c }",
+            Lang::Rust
+        ),
+        value_fp(
+            &i,
+            "fn g(a: f64, b: f64, c: f64) -> f64 { a + (b + c) }",
+            Lang::Rust
+        ),
         "rust f64 `+` must not reassociate"
     );
     // Java `double` — the value graph routes Java `+` through the string-coercion path, which
     // must honor the float hold too (the regression this test guards).
     assert_ne!(
-        value_fp(&i, "class C { static double f(double a, double b, double c) { return (a + b) + c; } }", Lang::Java),
-        value_fp(&i, "class C { static double g(double a, double b, double c) { return a + (b + c); } }", Lang::Java),
+        value_fp(
+            &i,
+            "class C { static double f(double a, double b, double c) { return (a + b) + c; } }",
+            Lang::Java
+        ),
+        value_fp(
+            &i,
+            "class C { static double g(double a, double b, double c) { return a + (b + c); } }",
+            Lang::Java
+        ),
         "java double `+` must not reassociate"
     );
     // Go `float64`
     assert_ne!(
-        value_fp(&i, "package m\nfunc f(a float64, b float64, c float64) float64 { return (a + b) + c }", Lang::Go),
-        value_fp(&i, "package m\nfunc g(a float64, b float64, c float64) float64 { return a + (b + c) }", Lang::Go),
+        value_fp(
+            &i,
+            "package m\nfunc f(a float64, b float64, c float64) float64 { return (a + b) + c }",
+            Lang::Go
+        ),
+        value_fp(
+            &i,
+            "package m\nfunc g(a float64, b float64, c float64) float64 { return a + (b + c) }",
+            Lang::Go
+        ),
         "go float64 `+` must not reassociate"
     );
 
     // Control — INT-typed params still reassociate (sound): split-only on float evidence.
     assert_eq!(
-        value_fp(&i, "def p(a: int, b: int, c: int):\n    return (a + b) + c\n", Lang::Python),
-        value_fp(&i, "def q(a: int, b: int, c: int):\n    return a + (b + c)\n", Lang::Python),
+        value_fp(
+            &i,
+            "def p(a: int, b: int, c: int):\n    return (a + b) + c\n",
+            Lang::Python
+        ),
+        value_fp(
+            &i,
+            "def q(a: int, b: int, c: int):\n    return a + (b + c)\n",
+            Lang::Python
+        ),
         "python int-typed `+` still reassociates"
     );
     assert_eq!(
-        value_fp(&i, "class C { static int p(int a, int b, int c) { return (a + b) + c; } }", Lang::Java),
-        value_fp(&i, "class C { static int q(int a, int b, int c) { return a + (b + c); } }", Lang::Java),
+        value_fp(
+            &i,
+            "class C { static int p(int a, int b, int c) { return (a + b) + c; } }",
+            Lang::Java
+        ),
+        value_fp(
+            &i,
+            "class C { static int q(int a, int b, int c) { return a + (b + c); } }",
+            Lang::Java
+        ),
         "java int `+` still reassociates"
     );
     // Control — fully-untyped params still reassociate (the i64 oracle is associative;
     // distinguishing this is the full Value::Float kind, §3.3).
     assert_eq!(
-        value_fp(&i, "def p(a, b, c):\n    return (a + b) + c\n", Lang::Python),
-        value_fp(&i, "def q(a, b, c):\n    return a + (b + c)\n", Lang::Python),
+        value_fp(
+            &i,
+            "def p(a, b, c):\n    return (a + b) + c\n",
+            Lang::Python
+        ),
+        value_fp(
+            &i,
+            "def q(a, b, c):\n    return a + (b + c)\n",
+            Lang::Python
+        ),
         "untyped `+` still reassociates"
     );
 }

--- a/crates/nose-normalize/src/algebra.rs
+++ b/crates/nose-normalize/src/algebra.rs
@@ -37,12 +37,32 @@ pub(crate) fn run(old: &Il, interner: &Interner) -> Il {
         return old.clone();
     }
     let unit_root_set: FxHashSet<u32> = old.units.iter().map(|u| u.root.0).collect();
+    // Params with FLOAT type evidence (`double`/`f64`/`float64`/`: float`/…): a `+`/`*`
+    // chain over them is non-associative (#283 C-float), so it must not be reassociated.
+    // The value graph already proves these float (`proven_float` via the param domain); the
+    // grouping is lost HERE, in the IL reassociation, unless this pass is float-aware too.
+    let float_param_cids: FxHashSet<u32> = old
+        .nodes
+        .iter()
+        .enumerate()
+        .filter(|(_, node)| node.kind == NodeKind::Param)
+        .filter_map(|(i, node)| match node.payload {
+            Payload::Cid(c)
+                if nose_semantics::domain_evidence_for_param(old, NodeId(i as u32))
+                    .is_some_and(|d| d.is_float()) =>
+            {
+                Some(c)
+            }
+            _ => None,
+        })
+        .collect();
     let mut rw = Rewriter {
         old,
         b: IlBuilder::with_capacity(old.file, old.nodes.len(), old.edges.len()),
         hashes: Vec::with_capacity(old.nodes.len()),
         remap: FxHashMap::default(),
         unit_root_set,
+        float_param_cids,
         interner,
     };
     let (new_root, _) = rw.rewrite(old.root);
@@ -70,6 +90,9 @@ struct Rewriter<'a> {
     hashes: Vec<u64>,
     remap: FxHashMap<u32, NodeId>,
     unit_root_set: FxHashSet<u32>,
+    /// Canonical ids of float-typed params (#283 C-float) — a `+`/`*` chain touching one
+    /// is non-associative and must keep its source grouping.
+    float_param_cids: FxHashSet<u32>,
     interner: &'a Interner,
 }
 
@@ -153,13 +176,13 @@ impl Rewriter<'_> {
             let mut leaves = Vec::new();
             self.collect_assoc_old(old_id, op, &mut leaves);
             // Float `+`/`*` is NON-ASSOCIATIVE (`(a+b)+c != a+(b+c)`, #283 C-float). If any
-            // leaf is syntactically float — a float literal or a `/` true-division result —
-            // leave the source tree intact (like the mixed-coercion `+` above) so the
-            // grouping survives into the value graph, which keeps it (its `proven_float`
-            // gate). Folding/reassociating here would erase the grouping the float result
-            // depends on. (Float-typed params with no syntactic marker still flatten — that
-            // needs the full Float value kind, §3.3.)
-            if matches!(op, Op::Add | Op::Mul) && self.chain_has_syntactic_float(&leaves) {
+            // leaf is provably float — a float literal, a `/` true-division result, or a
+            // float-TYPED param — leave the source tree intact (like the mixed-coercion `+`
+            // above) so the grouping survives into the value graph, which keeps it (its
+            // `proven_float` gate). Folding/reassociating here would erase the grouping the
+            // float result depends on. (The fully-untyped chain with no float evidence still
+            // flattens — that needs the full Float value kind, §3.3.)
+            if matches!(op, Op::Add | Op::Mul) && self.chain_has_float(&leaves) {
                 return self.generic(old_id, span);
             }
             // Constant folding + identity elimination (now that C retains literal values):
@@ -408,16 +431,30 @@ impl Rewriter<'_> {
         }
     }
 
-    /// Whether any leaf of an `Add`/`Mul` chain is SYNTACTICALLY float — a float literal or
-    /// a `/` (true-division) result — so the chain must not be reassociated (#283 C-float;
-    /// float `+`/`*` is non-associative). Float-typed params with no syntactic marker are
-    /// not detected here (the full Float value kind, §3.3).
-    fn chain_has_syntactic_float(&self, leaves: &[NodeId]) -> bool {
-        leaves.iter().any(|&n| {
-            matches!(
-                self.old.node(n).payload,
-                Payload::LitFloat(_) | Payload::Op(Op::TrueDiv)
-            )
-        })
+    /// Whether any leaf of an `Add`/`Mul` chain is FLOAT — a float literal, a `/`
+    /// (true-division) result, a FLOAT-TYPED param (`double`/`f64`/`float64`/`: float`/…), or
+    /// a sign-flip of one — so the chain must not be reassociated (#283 C-float; float
+    /// `+`/`*` is non-associative). Mirrors the value graph's `proven_float` at the IL level
+    /// so the two layers agree. The fully-untyped case (no float evidence anywhere) is
+    /// undecidable here and still flattens (the residual Float value kind, §3.3).
+    fn chain_has_float(&self, leaves: &[NodeId]) -> bool {
+        leaves.iter().any(|&n| self.il_node_is_float(n))
+    }
+
+    fn il_node_is_float(&self, n: NodeId) -> bool {
+        match self.old.node(n).payload {
+            Payload::LitFloat(_) => true,
+            Payload::Op(Op::TrueDiv) => true,
+            Payload::Cid(c) if self.old.kind(n) == NodeKind::Var => {
+                self.float_param_cids.contains(&c)
+            }
+            // `-x` / `+x` is float iff `x` is (mirrors `proven_float`'s unary recursion).
+            Payload::Op(Op::Neg | Op::Pos) => self
+                .old
+                .children(n)
+                .first()
+                .is_some_and(|&child| self.il_node_is_float(child)),
+            _ => false,
+        }
     }
 }

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -385,6 +385,19 @@ impl<'a> Builder<'a> {
             for &value in &direct {
                 self.flatten_into(value, op, &mut leaves);
             }
+            // Float `+` is NON-ASSOCIATIVE even in string-coercion langs (Java `double`,
+            // TS `number`): a float-typed chain is provably non-concat, so the lines below
+            // would happily flatten+sort it — but `(a+b)+c != a+(b+c)` in IEEE-754 (#283
+            // C-float). Hold the SOURCE grouping by rebuilding from the original binop kids,
+            // exactly as the general (non-coercion) path does. Each kid was recursively
+            // eval'd, so any nested float subchain already preserved its own grouping.
+            if leaves.iter().any(|&v| self.proven_float(v)) {
+                let mut acc = direct[0];
+                for &v in &direct[1..] {
+                    acc = self.mk(ValOp::Bin(op), vec![acc, v]);
+                }
+                return acc;
+            }
             if !self.add_association_safe(&leaves) {
                 return self.intern_ac_chain(op, &direct);
             }

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -179,16 +179,18 @@ impl<'a> Builder<'a> {
         }
     }
 
-    /// Whether `v` provably evaluates to a FLOAT (so subtraction over it must not be routed
-    /// through the AC `+` normalization, #283 C-float). Genuine evidence only — a float
-    /// literal, a true-division result (`a / b` is float even of integers, the value-blind
-    /// i64 model notwithstanding), a float-typed parameter, or a sign-flip of one. Fails
-    /// closed: an untyped param is NOT proven float. NOTE: this gates only `eval_sub_chain`
-    /// (subtraction), the one place where the source grouping survives into the fingerprint
-    /// — `Sub` and `Add` are distinct nodes. Pure `+`/`*` associativity (`(a+b)+c ≡ a+(b+c)`)
-    /// CANNOT be gated this way: the fingerprint flattens an AC chain to its leaf sequence,
-    /// so holding the source tree leaves the leaves identical. Closing that needs the `Float`
-    /// value kind (a grouping-sensitive fingerprint for float chains, oracle-value-model §3.3).
+    /// Whether `v` provably evaluates to a FLOAT (so `+`/`*`/`-` over it is non-associative
+    /// and its source grouping must be preserved, #283 C-float). Genuine evidence only — a
+    /// float literal, a true-division result (`a / b` is float even of integers, the
+    /// value-blind i64 model notwithstanding), a float-typed parameter, or a sign-flip of one.
+    /// Fails closed: an untyped param is NOT proven float. This gates `eval_sub_chain` (a float
+    /// `-` stays a literal `Sub`, not `a + (-b)`) AND `eval_assoc_comm_chain` (a float `+`/`*`
+    /// chain rebuilds its SOURCE grouping rather than flatten/sort) — in BOTH the general path
+    /// and the string-coercion `+` path (JS/TS/Java). The fingerprint is structure-sensitive,
+    /// so the held grouping survives. The ONE remaining C-float gap is the fully-untyped chain
+    /// (`(a+b)+c` with no float marker on any operand): nothing proves it float, the i64 oracle
+    /// is associative, so it still flattens — closing it needs the `Float` value kind
+    /// (oracle-value-model §3.3).
     pub(super) fn proven_float(&self, v: ValueId) -> bool {
         match self.nodes[v as usize].op {
             ValOp::Const { kind, .. } => kind == ConstKind::Float,

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -193,27 +193,31 @@ first; promote to the full model only if the priced recall loss justifies it.
   `TrueDiv`, distinct from C-family truncated `Div` and Ruby/Python `FloorDiv`.
   Same-semantics surfaces still converge (`Python /` with JS `/`, Ruby `/` with
   Python `//`).
-- **Non-associativity — syntactic-float `+`/`*`/`-` (shipped).** Float `+`/`*` is
-  non-associative (`(1.0+a)+b ≠ 1.0+(a+b)`) and a float `-` must not fold into a sum, so a
-  chain with a **syntactically-float** leaf — a float literal or a `/` (true-division)
-  result — keeps its source grouping. Held in BOTH layers: the `algebra` IL pass
-  (`chain_has_syntactic_float` → leave the tree intact, like the mixed-coercion `+` bail) and
-  the value graph (`proven_float` → don't flatten the AC chain; `eval_sub_chain` keeps a
-  float `-` as `Sub`). Closes the documented `(1e100+1)-1e100` and the `(a+b)+c ≡ a+(b+c)`
-  float-literal/division cases. **Corpus family delta ≈ 0** (sympy −1, all others 0 — float
-  clones written in one grouping are unaffected); verify clean. The earlier worry that "the
-  fingerprint flattens AC chains to a leaf sequence so no canon gate can help" was a
-  **misdiagnosis**: the fingerprint is the reachable-**node** multiset (structure-sensitive,
-  `intern_node` hashes args in order); the grouping was lost at the `algebra` reassociation,
-  which IS gateable.
-- **Remaining (the full model):** a chain whose float-ness is ONLY in a type — `def
-  f(a: float, b: float, c: float): (a+b)+c` — has no syntactic float leaf, so it still
-  flattens; and the fully-untyped `(a+b)+c` (`float_assoc.py`) is undecidable without types.
-  Both need `Value::Float` with IEEE-754 semantics + the per-language Int↔Float coercion
-  lattice (so a param's float-ness propagates and the oracle can witness it) — smaller now
-  that the syntactic cases are closed.
-- **Cost:** floor + syntactic non-associativity paid (≈0 recall); remaining Medium for
-  float-typed-param propagation and a real Float interpreter value.
+- **Non-associativity — syntactic-float AND float-typed-param `+`/`*`/`-` (shipped).** Float
+  `+`/`*` is non-associative (`(1.0+a)+b ≠ 1.0+(a+b)`) and a float `-` must not fold into a
+  sum, so a chain that is **provably float** keeps its source grouping. Two sources of proof
+  are now honored: a **syntactically-float** leaf (a float literal or a `/` true-division
+  result), and a **float-TYPED param** (`: float`, `f64`, `double`, `float64` — via the param
+  domain evidence, `proven_float(Input)`). Held in BOTH layers: the `algebra` IL pass
+  (`chain_has_float` over the syntactic markers + the float-typed-param cids → leave the tree
+  intact, like the mixed-coercion `+` bail) and the value graph (`proven_float` → rebuild the
+  source grouping instead of flatten/sort, in the general AC path AND the string-coercion `+`
+  path used by JS/TS/Java; `eval_sub_chain` keeps a float `-` as `Sub`). Closes the documented
+  `(1e100+1)-1e100`, the float-literal/division `(a+b)+c ≡ a+(b+c)`, and now the
+  `def f(a: float, b: float, c: float): (a+b)+c` typed-param case across Python/Rust/Java/Go/TS.
+  **Corpus family delta = 0** (type4: 20→20; the typed-param cases are split-only — int-typed
+  and untyped chains still associate); verify clean. The earlier worry that "the fingerprint
+  flattens AC chains to a leaf sequence so no canon gate can help" was a **misdiagnosis**: the
+  fingerprint is the reachable-**node** multiset (structure-sensitive, `intern_node` hashes
+  args in order); the grouping was lost at the `algebra` reassociation and the value-graph
+  flatten, both of which ARE gateable.
+- **Remaining (the full model):** ONLY the fully-untyped `(a+b)+c` (`float_assoc.py`) —
+  nothing proves it float, the i64 oracle is associative, so it still flattens. Closing it is
+  undecidable without types: it needs `Value::Float` with IEEE-754 semantics + the
+  per-language Int↔Float coercion lattice (so the oracle can witness the non-associativity) —
+  much smaller now that both the syntactic and the float-typed-param cases are closed.
+- **Cost:** floor + syntactic + float-typed-param non-associativity paid (0 recall on type4);
+  remaining Medium ONLY for the fully-untyped case (a real Float interpreter value).
 
 ---
 


### PR DESCRIPTION
## What

Closes the **float-TYPED-param** case of the #283 C-float false merge. A `+`/`*` chain over float-typed params — `: float` (Python), `f64` (Rust), `double` (Java), `float64` (Go), `number` (TS) — is non-associative in IEEE-754 (`(a+b)+c != a+(b+c)`) but had **no syntactic float leaf**, so #339's syntactic-float gate did not catch it and the two groupings still shared one `exact-value-graph` fingerprint.

## Fix — both normalization layers learn that a float-TYPED param is provably float

The float-ness now comes from the param's **type/domain evidence** (`proven_float` via the param domain), not only a float literal or `/` result:

- **`algebra` IL pass** (`crates/nose-normalize/src/algebra.rs`): `chain_has_float` now also matches the cids of float-typed params (`float_param_cids`, built from `domain_evidence_for_param`). A float-param `+`/`*` chain bails to `generic`, keeping its source tree so the grouping survives into the value graph.
- **value graph** (`crates/nose-normalize/src/value_graph/eval.rs`): the float guard (rebuild source grouping instead of flatten/sort) lived only in the **general** AC path. JS/TS/Java route `+` through the **string-coercion path**, where a float-typed chain is proven non-concat and so was flattened+sorted — that was the actual leak for Java `double`. The same `proven_float` guard is now applied there.

## Soundness & recall

**Split-only.** Int-typed and untyped chains still associate freely (integer `+` is associative; the i64 oracle agrees). Verified:
- float-typed `(a+b)+c` vs `a+(b+c)` now **splits** in Python / Rust / Java / Go / TS (`+` and `*`).
- int-typed and fully-untyped chains still **merge** (controls).
- **corpus family delta = 0** (type4: 20 → 20).
- `nose verify` on `bench/coevo/false_merges`: the float entry no longer violates; only the pre-existing `array_element_mutation.py` (#337) remains.
- workspace tests green (286 in the equivalence suite incl. the new test); clippy / docs-connectivity / formal-obligations / dup-gate (28/28) all pass.

## Tests & docs

- New regression test `float_typed_param_addition_is_held_unassociated` (Python/Rust/Java/Go float-typed splits + int-typed/untyped controls).
- `docs/oracle-value-model.md` §3.3 and `CHANGELOG.md` updated; stale "can't be gated" / "typed-param still flattens" comments corrected.

## Remaining

Only the **fully-untyped** float chain (`float_assoc.py`) is still open — undecidable without types, the genuine `Value::Float` kind tracked under #283 / §3.3. This PR does **not** close #283 (that case remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)