### PR TITLE
Soundness #337: model in-place array-element mutation (close swap≡clobber)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ break.
   vectors. A `NOSE_TIME`-gated `enrich` stage timing was added.
 
 ### Fixed
+- **False merge closed: in-place array-element mutation is now modeled (#337).** `swap`
+  (`t=a[i]; a[i]=a[j]; a[j]=t`) and `clobber` (`a[i]=a[j]; a[j]=a[i]`) compute different
+  results (`swap([1,2],0,1)` → `[2,1]`, `clobber` → `[2,2]`) but shared one
+  `exact-value-graph` fingerprint: an indexed store was an opaque effect that never updated
+  readable state, so a later `a[i]` read re-derived the pre-write value. Now a `base[index]`
+  READ that follows a write to that exact place FORWARDS to the written value
+  (`value_graph/index_state.rs`), so the two element-write traces — and thus the fingerprints
+  — differ. The element WRITE stays an ordered effect (order-sensitive, sound under index
+  aliasing); forwarding is installed only for an unconditional, top-level, non-loop write and
+  is invalidated by any effect/branch/loop, so it can only cost recall, never soundness. The
+  interpreter mutates the array in place in lockstep (`interp.rs`), so the `nose verify`
+  soundness oracle WITNESSES the difference (a new battery row feeds a list base with two
+  distinct int indices) instead of being blind to it. Split-only: corpus family delta 0
+  (type4 20→20), verify clean. A Lean obligation (cf. `normalize.value_graph.field_writes`)
+  is a tracked follow-up. (oracle-value-model §7.3.)
 - **False merge closed: float-TYPED-param `+`/`*` is no longer reassociated (#283 C-float).**
   A `+`/`*` chain over float-typed params — `: float` (Python), `f64` (Rust), `double` (Java),
   `float64` (Go), `number` (TS) — is now held unassociated even with no syntactic float leaf:

--- a/bench/coevo/false_merges/array_element_mutation.py
+++ b/bench/coevo/false_merges/array_element_mutation.py
@@ -1,12 +1,11 @@
-# The value model treats an indexed store `a[i] = v` as an opaque ordered effect and does
-# NOT update readable state, so a later `a[i]` read re-derives the PRE-write value (fields
-# are versioned via `field_env`; array elements are not). So `swap` and `clobber` below
-# compute the same effect trace and share an exact-value-graph fingerprint — a false merge:
-# swap(a,0,1) on [1,2] gives [2,1], clobber gives [2,2]. OPEN, ORACLE-BLIND: the interpreter
-# shares the no-mutation model, so `nose verify` cannot witness it (no battery row
-# distinguishes them) — the same category as float_assoc.py. Closing it needs in-place
-# element-mutation modeling in the value graph AND the interpreter. See
-# docs/oracle-value-model.md §7.3 (coevo series 9).
+# CLOSED (#337). `swap(a,0,1)` on [1,2] gives [2,1]; `clobber` gives [2,2] — different
+# behavior. They once shared an exact-value-graph fingerprint because an indexed store
+# `a[i] = v` was an opaque effect that did not update readable state, so a later `a[i]` read
+# re-derived the PRE-write value. Now the value graph FORWARDS a post-write read of `base[index]`
+# to the written value (`value_graph/index_state.rs`) and the interpreter mutates the array in
+# place (`interp.rs` `bind` for `Index`), so the two are split AND oracle-witnessed. Kept as a
+# guard; the permanent tests are `array_element_swap_does_not_merge_with_clobber` (equivalence)
+# and `index_store_is_observed_by_later_read` (interp). See docs/oracle-value-model.md §7.3.
 def swap(a, i, j):
     t = a[i]
     a[i] = a[j]

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -1828,8 +1828,18 @@ fn verify_battery(probes: &[nose_normalize::Value]) -> Vec<Vec<nose_normalize::V
     // forwarding (and the interpreter's in-place store) is starved and `swap` reads identical to
     // `clobber`. A list base + small int indices is the NORMAL array shape (unlike a string used
     // as an index), so it does not manufacture canonicalizer-divergent impossible inputs.
-    battery.push(vec![l(&[1, 2, 3, 4]), Value::Int(0), Value::Int(1), Value::Int(2)]);
-    battery.push(vec![l(&[5, 1, 4, 2, 8]), Value::Int(2), Value::Int(0), Value::Int(3)]);
+    battery.push(vec![
+        l(&[1, 2, 3, 4]),
+        Value::Int(0),
+        Value::Int(1),
+        Value::Int(2),
+    ]);
+    battery.push(vec![
+        l(&[5, 1, 4, 2, 8]),
+        Value::Int(2),
+        Value::Int(0),
+        Value::Int(3),
+    ]);
     battery
 }
 

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -1821,6 +1821,15 @@ fn verify_battery(probes: &[nose_normalize::Value]) -> Vec<Vec<nose_normalize::V
         rev.reverse();
         battery.push(rev);
     }
+    // Part 4: in-place ELEMENT-MUTATION rows (#337). The combinatorial pool binds slot ≥2 of a
+    // ≥3-arg function to a list (radix `n^2` exceeds COUNT), so a `swap(a,i,j)`/`clobber(a,i,j)`
+    // never sees a list base with TWO distinct int indices — the only input on which in-place
+    // element mutation is observable. Without these rows the value graph's element-write
+    // forwarding (and the interpreter's in-place store) is starved and `swap` reads identical to
+    // `clobber`. A list base + small int indices is the NORMAL array shape (unlike a string used
+    // as an index), so it does not manufacture canonicalizer-divergent impossible inputs.
+    battery.push(vec![l(&[1, 2, 3, 4]), Value::Int(0), Value::Int(1), Value::Int(2)]);
+    battery.push(vec![l(&[5, 1, 4, 2, 8]), Value::Int(2), Value::Int(0), Value::Int(3)]);
     battery
 }
 

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -2783,6 +2783,32 @@ fn float_typed_param_addition_is_held_unassociated() {
 }
 
 #[test]
+fn array_element_swap_does_not_merge_with_clobber() {
+    // #337: in-place element mutation. `swap` (`t=a[i]; a[i]=a[j]; a[j]=t`) and `clobber`
+    // (`a[i]=a[j]; a[j]=a[i]`) differ: clobber's second `a[i]` read observes the FIRST write,
+    // while swap captured the pre-write value in `t`. The value graph forwards a post-write
+    // read of `a[i]` to the written value (`index_env`), so the two element-write traces — and
+    // thus the fingerprints — differ. They previously SHARED a fingerprint (the no-mutation
+    // store model treated every `a[i]` read as the pre-write value): a false merge.
+    let i = Interner::new();
+    let swap = "def swap(a, i, j):\n    t = a[i]\n    a[i] = a[j]\n    a[j] = t\n";
+    let clobber = "def clobber(a, i, j):\n    a[i] = a[j]\n    a[j] = a[i]\n";
+    assert_ne!(
+        value_fp(&i, swap, Lang::Python),
+        value_fp(&i, clobber, Lang::Python),
+        "swap must not merge with clobber (post-write reads forward to the written value)"
+    );
+    // Control — two structurally-identical swaps still converge (read-forwarding is structure-
+    // sensitive, not a blanket exclusion of indexed stores, so genuine clones are unaffected).
+    let swap2 = "def s2(b, m, n):\n    t = b[m]\n    b[m] = b[n]\n    b[n] = t\n";
+    assert_eq!(
+        value_fp(&i, swap, Lang::Python),
+        value_fp(&i, swap2, Lang::Python),
+        "identical swaps still converge"
+    );
+}
+
+#[test]
 fn algebra_comparison_direction() {
     let i = Interner::new();
     let gt = "def f(a, b):\n    return a > b\n";

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -691,20 +691,41 @@ impl<'a> Interp<'a> {
             }
             NodeKind::Index => {
                 let kids = self.il.children(target).to_vec();
-                if let Some(&base) = kids.first() {
-                    let base_value = self.eval(base, env)?;
-                    if matches!(base_value, Value::Err) {
-                        return Ok(true);
-                    }
+                let Some(&base) = kids.first() else {
+                    return Err(Unsupported);
+                };
+                let base_value = self.eval(base, env)?;
+                if matches!(base_value, Value::Err) {
+                    return Ok(true);
                 }
+                let mut iv = None;
                 if let Some(&ix) = kids.get(1) {
-                    let iv = self.eval(ix, env)?;
-                    if matches!(iv, Value::Err) {
+                    let v = self.eval(ix, env)?;
+                    if matches!(v, Value::Err) {
                         return Ok(true);
                     }
-                    self.effects.push(iv);
+                    self.effects.push(v.clone());
+                    iv = Some(v);
                 }
-                self.effects.push(val);
+                self.effects.push(val.clone());
+                // In-place element mutation (#337): when the base is a simple var holding a
+                // `List` and the index is an in-bounds `Int`, update the element so a LATER
+                // `base[i]` read observes the write — this is what distinguishes `swap`
+                // (`t=a[i]; a[i]=a[j]; a[j]=t`) from `clobber` (`a[i]=a[j]; a[j]=a[i]`). The
+                // ordered-effect push above still records the write itself; mutation only
+                // changes what subsequent reads see. Any non-clean shape (computed/aliased
+                // base, out-of-bounds, non-List) leaves the list untouched — the conservative
+                // no-mutation fall-back, matching the value graph's clear-on-write forwarding.
+                if let (NodeKind::Var, Some(Value::Int(i))) = (self.il.kind(base), &iv) {
+                    if let Payload::Cid(c) = self.il.node(base).payload {
+                        if let Some(Value::List(xs)) = env.get_mut(&c) {
+                            let idx = if *i < 0 { *i + xs.len() as i64 } else { *i };
+                            if idx >= 0 && (idx as usize) < xs.len() {
+                                xs[idx as usize] = val;
+                            }
+                        }
+                    }
+                }
                 Ok(false)
             }
             _ => Err(Unsupported),
@@ -2230,6 +2251,48 @@ mod tests {
     #[test]
     fn cstyle_loop_update_err_stops_execution() {
         assert_eq!(run_cstyle_loop_with_update_err(), Value::Err);
+    }
+
+    // #337: `def f(a): a[0] = 5; return a[0]` — the read must observe the WRITTEN 5 (in-place
+    // element mutation), not the pre-write element. Without mutation modeling the oracle was
+    // blind to `swap` vs `clobber`; with it, the value graph's read-forwarding and the oracle
+    // agree, so the two no longer false-merge.
+    fn run_index_store_then_read() -> Value {
+        let sp = Span::synthetic(FileId(0));
+        let mut b = IlBuilder::new(FileId(0));
+        let a_param = b.add(NodeKind::Param, Payload::Cid(0), sp, &[]);
+        let a_var = b.add(NodeKind::Var, Payload::Cid(0), sp, &[]);
+        let zero = b.add(NodeKind::Lit, Payload::LitInt(0), sp, &[]);
+        let target = b.add(NodeKind::Index, Payload::None, sp, &[a_var, zero]);
+        let five = b.add(NodeKind::Lit, Payload::LitInt(5), sp, &[]);
+        let store = b.add(NodeKind::Assign, Payload::None, sp, &[target, five]);
+        let a_var2 = b.add(NodeKind::Var, Payload::Cid(0), sp, &[]);
+        let zero2 = b.add(NodeKind::Lit, Payload::LitInt(0), sp, &[]);
+        let read = b.add(NodeKind::Index, Payload::None, sp, &[a_var2, zero2]);
+        let ret = b.add(NodeKind::Return, Payload::None, sp, &[read]);
+        let block = b.add(NodeKind::Block, Payload::None, sp, &[store, ret]);
+        let func = b.add(NodeKind::Func, Payload::None, sp, &[a_param, block]);
+        let il = b.finish(
+            func,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        run_admitted_unit(
+            il,
+            func,
+            &[Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)])],
+        )
+        .expect("run_unit")
+        .ret
+    }
+
+    #[test]
+    fn index_store_is_observed_by_later_read() {
+        assert_eq!(run_index_store_then_read(), Value::Int(5));
     }
 
     fn run_foreach_with_iterable_err() -> Option<Value> {

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -2284,7 +2284,11 @@ mod tests {
         run_admitted_unit(
             il,
             func,
-            &[Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)])],
+            &[Value::List(vec![
+                Value::Int(1),
+                Value::Int(2),
+                Value::Int(3),
+            ])],
         )
         .expect("run_unit")
         .ret

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -33,6 +33,7 @@ mod context;
 mod control;
 mod eval;
 mod field_state;
+mod index_state;
 mod inline;
 mod model;
 mod ops;
@@ -65,6 +66,7 @@ use crate::module_facts::{
     node_symbol_in_scope, top_level_statements_for,
 };
 use field_state::FieldStateKey;
+use index_state::IndexStateKey;
 use model::sentinel;
 use model::{
     Builder, BuilderCandidate, BuilderKind, ConstKind, FilterMapResult, HofAdmission,

--- a/crates/nose-normalize/src/value_graph/control.rs
+++ b/crates/nose-normalize/src/value_graph/control.rs
@@ -81,6 +81,7 @@ impl<'a> Builder<'a> {
             }
         }
         self.flush_fields();
+        self.index_env.clear();
     }
 
     /// Recognize an existence/universal loop written with an early return, and rewrite it
@@ -1196,7 +1197,24 @@ impl<'a> Builder<'a> {
         if self.try_record_index_assign(stmt, rhs, env) {
             return;
         }
-        // store into an index / computed target → an ordered effect
+        // store into an index / computed target → an ordered effect. Element WRITES stay
+        // ORDERED effects (order-sensitive — sound even when two indices alias at runtime).
+        // Additionally version the `(base, index)` place for READ-forwarding (#337): a later
+        // `base[index]` read in the same straight-line run sees `rhs`, distinguishing `swap`
+        // from `clobber`. The write TARGET is built directly from base+index (NOT via `eval`,
+        // which would forward a prior write into the place itself).
+        if self.il.kind(kids[0]) == NodeKind::Index {
+            let ik = self.il.children(kids[0]).to_vec();
+            if ik.len() == 2 {
+                let base = self.eval(ik[0], env);
+                let index = self.eval(ik[1], env);
+                let place = self.mk(ValOp::Index, vec![base, index]);
+                let st = self.mk(ValOp::Call(0), vec![place, rhs]);
+                self.push_effect(st);
+                self.record_index_write(base, index, rhs);
+                return;
+            }
+        }
         let target = self.eval(kids[0], env);
         let st = self.mk(ValOp::Call(0), vec![target, rhs]);
         self.push_effect(st);
@@ -1300,9 +1318,14 @@ impl<'a> Builder<'a> {
         // Bracket the whole loop processing in a depth counter so an inline return
         // capture can tell a return executed *inside* a callee loop (poison) from one
         // merely written after it (fine).
+        // A loop is an effect/aliasing barrier for indexed read-forwarding (#337): a forward
+        // valid before the loop is invalid inside it (the array may be rewritten each
+        // iteration), and a forward installed inside is invalid after. Clear on both edges.
+        self.index_env.clear();
         self.loop_depth += 1;
         self.process_loop_inner(stmt, env);
         self.loop_depth -= 1;
+        self.index_env.clear();
     }
 
     fn process_loop_inner(&mut self, stmt: NodeId, env: &mut FxHashMap<u32, ValueId>) {

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -554,6 +554,13 @@ impl<'a> Builder<'a> {
         let kids = self.il.children(expr).to_vec();
         let a: Vec<ValueId> = kids.iter().map(|&k| self.eval(k, env)).collect();
         if a.len() == 2 {
+            // #337: a read of an element written earlier in this straight-line run forwards to
+            // the written value, so `clobber`'s post-write `a[i]` read (= the value just put in
+            // `a[j]`) differs from `swap`'s pre-write read. Only fires for a place that was the
+            // most recent indexed write with no intervening effect (see `record_index_write`).
+            if let Some(forwarded) = self.forwarded_index_read(a[0], a[1]) {
+                return forwarded;
+            }
             if let Some((map, default)) = self.proven_go_literal_zero_map_value(a[0]) {
                 return self.mk(
                     ValOp::Call(builtin_tag(Builtin::GetOrDefault)),

--- a/crates/nose-normalize/src/value_graph/index_state.rs
+++ b/crates/nose-normalize/src/value_graph/index_state.rs
@@ -1,0 +1,61 @@
+//! Same-unit indexed-element read-forwarding for value-graph construction (#337).
+//!
+//! Unlike field state (`field_state.rs`), which is keyed by a non-aliasable `this`/`self`
+//! receiver and flushed as order-INSENSITIVE place sinks, array indices CAN alias (two
+//! distinct value nodes `i` and `j` may be equal at runtime), so a place-keyed, order-
+//! insensitive model is UNSOUND for `a[i]`. The element WRITE therefore stays an ordered
+//! effect (`push_effect`, order-sensitive — already sound). This module adds only READ-
+//! FORWARDING: a `base[index]` read evaluated AFTER a write to that exact (base, index) place
+//! returns the written value, so `clobber` (`a[i]=a[j]; a[j]=a[i]`) — whose second read sees
+//! the first write — fingerprints distinctly from `swap` (`t=a[i]; a[i]=a[j]; a[j]=t`).
+//!
+//! Soundness under aliasing is conservative: ANY indexed write clears the entire forwarding
+//! map before recording the just-written place, so a read only forwards when its place was
+//! the most recent write with no intervening (possibly-aliasing) write. This errs toward
+//! FEWER forwards (more distinct nodes), which can only cost recall, never soundness.
+//!
+//! A Lean obligation analogous to `normalize.value_graph.field_writes` (last-write-wins, write
+//! order matters) is a tracked follow-up; for now the argument is conservative-by-construction
+//! (the gates above) plus the `nose verify` soundness oracle, which interprets in-place element
+//! mutation in lockstep (`interp.rs` `bind` for `Index`) and would witness any false merge.
+
+use super::*;
+
+/// A forwardable indexed place: the base value and the index value (both `ValueId`s in the
+/// value graph). Two reads share a place only when base AND index are the SAME value node —
+/// distinct nodes are treated as possibly-aliasing and never forwarded across.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct IndexStateKey {
+    pub(super) base: ValueId,
+    pub(super) index: ValueId,
+}
+
+impl Builder<'_> {
+    /// Record an indexed element write `base[index] = value` for read-forwarding. The write
+    /// itself is captured separately as an ordered effect; this only updates what a LATER
+    /// read of the same place sees. Conservative on two axes:
+    /// - clear all prior forwards first (any write may alias any outstanding place);
+    /// - only INSTALL a forward for an UNCONDITIONAL (top-level, `path` empty) write. A write
+    ///   under a branch condition would otherwise forward unconditionally to a later read
+    ///   (`if c { a[i]=w } ; a[i]` must not become `w`), so a conditional write only
+    ///   invalidates — never forwards. Combined with `push_effect` clearing `index_env`, this
+    ///   confines forwarding to straight-line, effect-free runs, which is sound by construction.
+    pub(super) fn record_index_write(&mut self, base: ValueId, index: ValueId, value: ValueId) {
+        self.index_env.clear();
+        // Only install a forward for an UNCONDITIONAL, top-level write — `path` empty (not under
+        // a branch) and `loop_depth == 0` (not inside a loop body, where the "last write" is an
+        // iteration-relative symbolic value, not the concrete post-loop element). Either way the
+        // write itself is still recorded as an ordered effect; only the forward is suppressed.
+        if self.path.is_empty() && self.loop_depth == 0 {
+            self.index_env.insert(IndexStateKey { base, index }, value);
+        }
+    }
+
+    /// The forwarded value for a `base[index]` read, if that exact place was the most recent
+    /// indexed write (see `record_index_write`). `None` → no forward; emit a fresh `Index`.
+    pub(super) fn forwarded_index_read(&self, base: ValueId, index: ValueId) -> Option<ValueId> {
+        self.index_env
+            .get(&IndexStateKey { base, index })
+            .copied()
+    }
+}

--- a/crates/nose-normalize/src/value_graph/index_state.rs
+++ b/crates/nose-normalize/src/value_graph/index_state.rs
@@ -54,8 +54,6 @@ impl Builder<'_> {
     /// The forwarded value for a `base[index]` read, if that exact place was the most recent
     /// indexed write (see `record_index_write`). `None` → no forward; emit a fresh `Index`.
     pub(super) fn forwarded_index_read(&self, base: ValueId, index: ValueId) -> Option<ValueId> {
-        self.index_env
-            .get(&IndexStateKey { base, index })
-            .copied()
+        self.index_env.get(&IndexStateKey { base, index }).copied()
     }
 }

--- a/crates/nose-normalize/src/value_graph/model.rs
+++ b/crates/nose-normalize/src/value_graph/model.rs
@@ -180,6 +180,11 @@ pub(super) struct Builder<'a> {
     /// by `Place(SelfField)` and `Effect(SelfFieldWrite)`. Raw dynamic attribute writes stay
     /// ordered effects because selector spelling alone is not place/effect proof.
     pub(super) field_env: FxHashMap<FieldStateKey, ValueId>,
+    /// Same-unit indexed-element read-forwarding (#337): the value most recently written to a
+    /// `(base, index)` place, so a later `base[index]` read observes the write. Cleared on any
+    /// indexed write (conservative aliasing). The write itself stays an ordered effect — this
+    /// only versions READS. See `index_state.rs`.
+    pub(super) index_env: FxHashMap<IndexStateKey, ValueId>,
     /// Lazily-computed subtree hash per IL node (kind + payload + children), used to
     /// key unlowered `Raw` constructs and lambda bodies by content. Computed once per
     /// graph (the whole-IL pass is O(n)); `None` until first needed.

--- a/crates/nose-normalize/src/value_graph/sinks.rs
+++ b/crates/nose-normalize/src/value_graph/sinks.rs
@@ -8,6 +8,11 @@ impl<'a> Builder<'a> {
     /// Push an effect sink, tagged with the current path condition — so a *conditional*
     /// effect (`if c { append(x) }`) carries `c`, the way a guarded return does.
     pub(super) fn push_effect(&mut self, v: ValueId) {
+        // Any ordered effect — a method call, an opaque store, a function call taking an array
+        // — may mutate an array's elements (`a.insert`, `a.sort`, `f(a)`), so it INVALIDATES
+        // all outstanding indexed-element read-forwards (#337). The just-emitted indexed write
+        // re-installs its own forward AFTER this, via `record_index_write`.
+        self.index_env.clear();
         let ord = self.next_effect_ordinal();
         let g = self.guarded(v);
         self.sinks.push(Sink::ordered_effect(g, ord));

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -25,6 +25,7 @@ impl<'a> Builder<'a> {
             sinks: Vec::new(),
             opaque_ctr: 0,
             field_env: FxHashMap::default(),
+            index_env: FxHashMap::default(),
             subtree_hash: None,
             shared_subtree_hashes: None,
             valued_subtree_hash: None,

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -271,6 +271,7 @@ oracle-caught)":
 | C — float `+` non-associativity | `float_assoc.py` (`(a+b)+c` vs `a+(b+c)`) | oracle witnesses (needs §3.3 float) or detector keeps split |
 | D-int32 — JS bitwise vs bigint | cross-language `a & b` (JS vs Python), e.g. the §2 reproducer | detector keeps **split**; oracle int32 execution remains follow-up |
 | D-div — true-float `/` | Python/JS `a/b` vs Ruby `a/b` vs C `a/b` | the three **do not merge**; real Float oracle remains follow-up |
+| in-place element mutation | `array_element_mutation.py` (`swap` vs `clobber`) | detector keeps them **split** AND oracle witnesses — CLOSED (#337, §7.3); guarded by `array_element_swap_does_not_merge_with_clobber` + `index_store_is_observed_by_later_read` |
 
 New permanent regression tests follow the pattern of
 `crates/nose-cli/tests/equivalence.rs`
@@ -374,54 +375,56 @@ oracle stays clean. Canon-preservation violations are now **zero** across netty/
 and the wider sweep — together with `bin`'s symmetric `Err` (§7.1), every
 canon-preservation violation the corpus surfaced is closed.
 
-### 7.3 The deeper limit: in-place element mutation is not modeled (oracle-blind, OPEN)
+### 7.3 In-place element mutation — CLOSED (#337)
 
-The value model treats an indexed/collection store `a[i] = v` as an ordered, opaque effect
-and does NOT update readable state — so a later `a[i]` read re-derives the *pre-write*
-value (`field` stores ARE versioned via `field_env`; array elements are not). Under that
-model `swap` (`t=a[i]; a[i]=a[j]; a[j]=t`) and `clobber` (`a[i]=a[j]; a[j]=a[i]`) compute
-the same effect trace, so they share an `exact-value-graph` fingerprint — a latent false
-merge. It is **oracle-blind**: the interpreter shares the same no-mutation model, so the
-false-merge check sees them as behavior-equal too (no battery row distinguishes them). This
-is the same category as float non-associativity (`bench/coevo/false_merges/float_assoc.py`):
-a known value-model gap the oracle cannot witness, not a regression. Closing it needs
-in-place element-mutation modeling (version `a[i]` reads by the array's write state) in
-BOTH the value graph and the interpreter — a value-model extension on the scale of the
-`Float` kind (§3.3), tracked in **#337**. Until then it is recorded in
-`bench/coevo/false_merges/array_element_mutation.py` as an OPEN, oracle-blind class.
+The value model treated an indexed store `a[i] = v` as an ordered, opaque effect that did
+NOT update readable state — so a later `a[i]` read re-derived the *pre-write* value (`field`
+stores were versioned via `field_env`; array elements were not). Under that model `swap`
+(`t=a[i]; a[i]=a[j]; a[j]=t`) and `clobber` (`a[i]=a[j]; a[j]=a[i]`) produced the same
+element-write trace and shared an `exact-value-graph` fingerprint — a false merge (`swap`
+on `[1,2]` gives `[2,1]`, `clobber` gives `[2,2]`).
 
-**Why there is no canon-gate slice (design assessment).** Unlike the float *subtraction*
-case (§3.3), which had a clean `Sub`-vs-`Add` node distinction, closing the swap/clobber
-SCAN merge requires the **fingerprint itself** to distinguish a pre-write from a post-write
-`a[i]` read — i.e. versioning the read value node. Four blockers, found while scoping this,
-make it the epic and not a patch:
-1. **`ValOp::Index` is assumed 2-ary.** Several passes match it positionally — the
-   dict-builder lookup `node.args == [map, key]` (`collections.rs`) and the getter shape
-   `args.len() == 2` (`canonicalize.rs`) — so adding a third "generation" arg silently
-   disables them for versioned reads. A versioned read needs a distinct representation, not
-   an extra arg.
-2. **`eval` is memoised (hash-consed).** The same `a[i]` IL node evaluated before and after
-   a write must yield DIFFERENT value nodes, so the write generation has to enter the eval
-   cache key — today reads are cached by node id alone.
-3. **Aliasing forces a conservative generation.** A per-base counter is unsound when two
-   params alias the same list (`f(xs, xs)`); soundness needs a global per-unit generation
-   bumped on ANY element write, versioning even unrelated array reads after a write — the
-   recall cost.
-4. **Two models must move together.** The value graph (fingerprint) AND the interpreter
-   (oracle) both use the no-mutation model; versioning only one makes them disagree, so the
-   change spans both — exactly the `Float`-kind shape.
+**The fix is READ-FORWARDING, not a versioned read node — which dissolves the blockers.**
+The earlier scoping framed this as needing a third "generation" arg on every `a[i]` read
+node (an epic with four blockers). That framing was wrong. The element WRITE is kept an
+ordered effect (`push_effect`, order-sensitive — already sound even when indices alias);
+the only new behavior is that a `base[index]` READ evaluated after a write to that exact
+place FORWARDS to the written value (`index_env`, `value_graph/index_state.rs`). So
+`clobber`'s second `a[i]` read becomes the value just stored in `a[j]`, while `swap`'s `t`
+holds the pre-write value — distinct write traces, distinct fingerprints. The four "blockers":
+1. **`ValOp::Index` 2-arity** — preserved. Forwarding returns the stored *value node*; it
+   never adds an arg, so the dict-builder/getter positional matches are untouched.
+2. **`eval` hash-consing** — irrelevant. `eval` is not traversal-memoised, and pre/post-write
+   reads are distinct IL nodes anyway; forwarding consults `index_env` at eval time.
+3. **Aliasing** — handled conservatively. A forward is installed only for an UNCONDITIONAL,
+   top-level, non-loop write (`path` empty, `loop_depth == 0`), and ANY ordered effect
+   (`push_effect` — a method call, `f(a)`, an opaque store), branch, or loop CLEARS the
+   forwarding map. So a forward survives only across a straight-line, effect-free run with no
+   possibly-aliasing write — sound by construction; errs toward fewer forwards (recall, never
+   soundness). Conditional base reassignment becomes a `Phi` (a different value node), so its
+   key never matches.
+4. **Two models move together** — done. The interpreter (`interp.rs` `bind` for `Index`) now
+   mutates the array in place (clean Var-holding-`List` + in-bounds-`Int` case; everything
+   else falls back to the opaque no-mutation effect), so the soundness oracle WITNESSES the
+   `swap`/`clobber` difference instead of being blind to it. This is essential: value-graph
+   forwarding *without* interpreter mutation would false-merge `a[0]=5; return a[0]` with
+   `a[0]=5; return 5` against the old non-mutating oracle.
 
-The exact-channel-eligibility route (exclude read-after-write units, like the `ModuleRebind`
-exclusion) does NOT help: it changes only verify's gating, not the scan fingerprint, so the
-product would still merge swap with clobber. The merge is latent (corpus family delta from
-any partial attempt is 0), so this stays the deferred Float-kind-scale epic rather than a
-recall-costly partial gate.
+`verify_battery` Part 4 adds `(list, int, int, int)` rows so a `swap(a,i,j)`/`clobber(a,i,j)`
+sees a list base with two distinct int indices — the combinatorial pool binds slot ≥2 of a
+≥3-arg function to a list, so without these rows the distinguishing input never occurs. (A
+list base with int indices is the normal array shape, NOT a type-incoherent string-as-index
+row, so it does not manufacture the spurious canon-preservation divergence §7 warns about —
+verified clean on type4 and coevo.) Recorded outcome: **corpus family delta 0** (type4
+20→20), verify clean, swap/clobber split AND oracle-witnessed. A Lean obligation analogous
+to `normalize.value_graph.field_writes` is a tracked follow-up (the argument today is
+conservative-by-construction plus the oracle).
 
-**Net:** the equality-over-`Err` class (§7.1) and the dataflow unsoundness (§7.2) are
-closed, so the verify soundness gate can widen toward dynamic-language repos. The
-array-mutation modeling gap (§7.3) and type-domain-aware input feeding remain the
-floor-then-model follow-ups (§3); `verify_battery`'s Part 3 stays hand-curated **on
-purpose** (a guard comment there points here).
+**Net:** the equality-over-`Err` class (§7.1), the dataflow unsoundness (§7.2), and the
+in-place element-mutation gap (§7.3) are all closed, so the verify soundness gate can widen
+toward dynamic-language repos. Type-domain-aware input feeding remains the floor-then-model
+follow-up (§3); the rest of `verify_battery` stays hand-curated **on purpose** (the guard
+comment there points here).
 
 ---
 


### PR DESCRIPTION
## What

Closes #337. `swap` (`t=a[i]; a[i]=a[j]; a[j]=t`) and `clobber` (`a[i]=a[j]; a[j]=a[i]`) compute different results — `swap([1,2],0,1)` → `[2,1]`, `clobber` → `[2,2]` — but shared one `exact-value-graph` fingerprint. An indexed store `a[i]=v` was an opaque ordered effect that never updated readable state, so a later `a[i]` read re-derived the **pre-write** value (fields were versioned via `field_env`; array elements were not).

## The fix is read-forwarding, not a versioned read node

The prior scoping (§7.3) framed this as needing a 3-ary "generation" arg on every `a[i]` read — an epic with four blockers. That framing was wrong; the four blockers dissolve:

- **Value graph** (`value_graph/index_state.rs`, new): a `base[index]` READ that follows a write to that exact place **forwards** to the written value (`index_env`). So `clobber`'s second `a[i]` read becomes the value just stored in `a[j]`, while `swap`'s `t` holds the pre-write value — distinct element-write traces, distinct fingerprints. The element WRITE stays an **ordered effect** (order-sensitive — already sound even when two indices alias at runtime). `ValOp::Index` stays **2-ary** (dict-builder/getter positional matches untouched).
- **Soundness under aliasing** — conservative by construction. A forward is installed only for an **unconditional, top-level, non-loop** write (`path` empty, `loop_depth == 0`), and is invalidated by **any** ordered effect (`push_effect` clears `index_env` — a method call, `f(a)`, an opaque store), branch, or loop. So a forward survives only across a straight-line, effect-free run with no possibly-aliasing write. Conditional base reassignment becomes a `Phi` (different value node), so its key never matches. This errs toward **fewer** forwards — recall cost, never soundness.
- **Interpreter** (`interp.rs` `bind` for `Index`): mutates the array in place (clean Var-holding-`List` + in-bounds-`Int` case; everything else falls back to the opaque no-mutation effect). **Required**: value-graph forwarding *alone* would false-merge `a[0]=5; return a[0]` with `a[0]=5; return 5` against a non-mutating oracle. With it, the two models move together and `nose verify` **witnesses** the swap/clobber difference.
- **Battery** (`verify_battery` Part 4): adds `(list, int, int, int)` rows so a 3-arg `swap`/`clobber` sees a list base with two distinct int indices — the combinatorial pool binds slot ≥2 to a list, starving the distinguishing input. A list + int-indices row is the normal array shape (not a type-incoherent string-as-index row, §7), so it does **not** manufacture spurious canon-preservation divergence.

## Soundness & recall

**Split-only.** Verified:
- `swap`/`clobber` now **split** in `nose scan` and are **behavior-distinct** in the oracle (witnessed).
- **corpus family delta = 0** (type4 20 → 20).
- `nose verify --max-violations 0`: **PASS** on type4 and coevo (0 false merges, canon-preservation PRESERVED).
- full workspace tests pass; clippy / fmt / docs-connectivity / formal-obligations / dup-gate (28/28) all green.

## Tests & docs

- New regression tests: `array_element_swap_does_not_merge_with_clobber` (equivalence, value-graph half) and `index_store_is_observed_by_later_read` (interp, mutation half).
- `docs/oracle-value-model.md` §7.3 rewritten (OPEN→CLOSED, blockers dissolved), §5 table row added; `CHANGELOG.md` and the `array_element_mutation.py` fixture comment updated.

## Follow-up

A Lean obligation analogous to `normalize.value_graph.field_writes` (last-write-wins, write order matters) is a tracked follow-up; today's argument is conservative-by-construction plus the `nose verify` soundness oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)