### PR TITLE
Generalize per-language operator gates into OperatorSemantics (+ container move, 2-tier canon doc)

### DIFF
--- a/crates/nose-normalize/src/algebra.rs
+++ b/crates/nose-normalize/src/algebra.rs
@@ -24,7 +24,7 @@
 //! proof-obligation: normalize.value_graph.compare
 
 use crate::combine;
-use nose_il::{Il, IlBuilder, Interner, Lang, NodeId, NodeKind, Op, Payload, Span};
+use nose_il::{Il, IlBuilder, Interner, NodeId, NodeKind, Op, Payload, Span};
 use nose_semantics::{semantics, ComparisonLaw};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -73,13 +73,6 @@ fn is_assoc_comm(op: Op) -> bool {
     matches!(
         op,
         Op::Add | Op::Mul | Op::And | Op::Or | Op::BitAnd | Op::BitOr | Op::BitXor
-    )
-}
-
-fn plus_has_mixed_string_coercion(lang: Lang) -> bool {
-    matches!(
-        lang,
-        Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html | Lang::Java
     )
 }
 
@@ -170,7 +163,11 @@ impl Rewriter<'_> {
             // is observable: `"a" + 2 + 3` is not `"a" + (2 + 3)`. This IL pass has no
             // evidence strong enough to prove a chain numeric; leave the tree intact and
             // let the value graph perform evidence-gated association/commutation.
-            if op == Op::Add && plus_has_mixed_string_coercion(self.old.meta.lang) {
+            if op == Op::Add
+                && semantics(self.old.meta.lang)
+                    .operators()
+                    .plus_coerces_strings()
+            {
                 return self.generic(old_id, span);
             }
             let mut leaves = Vec::new();
@@ -193,7 +190,10 @@ impl Rewriter<'_> {
             // when `s` is a String but `s * 3` repeats), so folding a constant to the end —
             // a commute — would change behavior. Hold it ordered; the value graph commutes
             // it type-gated (series 9). Numeric Ruby `*` still converges there.
-            let ruby_mul = op == Op::Mul && self.old.meta.lang == Lang::Ruby;
+            let ruby_mul = op == Op::Mul
+                && semantics(self.old.meta.lang)
+                    .operators()
+                    .mul_is_sequence_repetition();
             if matches!(op, Op::Add | Op::Mul) && !ruby_mul {
                 return self.fold_arith(op, span, &leaves);
             }
@@ -321,7 +321,10 @@ impl Rewriter<'_> {
         span: Span,
         mut operands: Vec<(NodeId, u64)>,
     ) -> (NodeId, u64) {
-        let ruby_mul = op == Op::Mul && self.old.meta.lang == Lang::Ruby;
+        let ruby_mul = op == Op::Mul
+            && semantics(self.old.meta.lang)
+                .operators()
+                .mul_is_sequence_repetition();
         if !matches!(op, Op::And | Op::Or | Op::Add) && !ruby_mul {
             operands.sort_by_key(|&(_, h)| h);
         }

--- a/crates/nose-normalize/src/value_graph/control.rs
+++ b/crates/nose-normalize/src/value_graph/control.rs
@@ -960,9 +960,13 @@ impl<'a> Builder<'a> {
                 NodeKind::Func => {
                     let kids = self.il.children(c).to_vec();
                     let mut menv = env.clone();
-                    let saved_param_domain = self.param_domain.clone();
-                    let saved_param_ty = self.param_ty.clone();
-                    self.param_domain.clear();
+                    // The method shadows the container's param scope. MOVE the container maps
+                    // out (leaving them empty, which is what the seed below expects) and move
+                    // them back after — a behavior-identical save/restore that avoids cloning
+                    // both maps per method. `seed_param_value_domains` reassigns `param_ty`
+                    // wholesale, so its emptied start is equivalent to the prior un-cleared one.
+                    let saved_param_domain = std::mem::take(&mut self.param_domain);
+                    let saved_param_ty = std::mem::take(&mut self.param_ty);
                     self.seed_param_domains(c);
                     self.seed_param_value_domains(c);
                     let mut pos = 0u32;

--- a/crates/nose-normalize/src/value_graph/rules.rs
+++ b/crates/nose-normalize/src/value_graph/rules.rs
@@ -1,8 +1,27 @@
 //! Proof-sensitive value-graph rules.
 //!
+//! # Two tiers of canonicalization
+//!
+//! Value-graph rewrites live in one of two places, by whether their soundness depends on a
+//! value-domain *proof*:
+//!
+//! 1. **Value-INDEPENDENT canon — inline in `canonicalize.rs`** (e.g. `order_bin_operands`,
+//!    `unary_canon`'s De Morgan, `bool_and_or_canon`, `ac_chain_canon`'s flattening). These
+//!    hold for *every* operand type — commuting an AC chain, comparison-direction canon,
+//!    De Morgan — so they need no operand evidence and carry no formal obligation. They run
+//!    unconditionally from `mk`.
+//! 2. **Value-DEPENDENT / proof-backed rules — this module tree** (e.g. `clamp`,
+//!    `factor_distribute`, `promise_then`). These fire only when a value-domain precondition
+//!    is *proven* (numeric operands, a bound-order fact, an admitted promise contract), so an
+//!    unproven case must fail closed.
+//!
 //! Any new semantic rewrite in this module tree must have a matching
 //! `formal/obligations/normalize/value_graph/<rule>/meta.toml` entry. The
 //! formal-obligation linter checks that directory/file pairing mechanically.
+//!
+//! Rule of thumb for a NEW rewrite: if it could change behavior on *some* operand type (string
+//! vs number, float vs int, NaN), it is tier 2 and belongs here with a proof obligation; if it
+//! is sound for all types by construction, it is tier 1 and belongs inline in `canonicalize.rs`.
 
 pub(super) mod clamp;
 pub(super) mod factor_distribute;

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -91,22 +91,13 @@ impl<'a> Builder<'a> {
     }
 
     pub(super) fn plus_has_mixed_string_coercion(&self) -> bool {
-        matches!(
-            self.il.meta.lang,
-            Lang::JavaScript
-                | Lang::TypeScript
-                | Lang::Vue
-                | Lang::Svelte
-                | Lang::Html
-                | Lang::Java
-        )
+        semantics(self.il.meta.lang).operators().plus_coerces_strings()
     }
 
     pub(super) fn relational_has_string_ordering(&self) -> bool {
-        matches!(
-            self.il.meta.lang,
-            Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html
-        )
+        semantics(self.il.meta.lang)
+            .operators()
+            .relational_coerces_strings()
     }
 
     /// Whether a `+` chain may be re-associated. In JS/TS/Java, grouping itself is
@@ -137,7 +128,10 @@ impl<'a> Builder<'a> {
         if op == Op::Add as u32 {
             self.add_values_not_concat(add_law, operands)
         } else if op == Op::Mul as u32 {
-            self.il.meta.lang != Lang::Ruby || operands.iter().all(|&v| self.proven_non_concat(v))
+            !semantics(self.il.meta.lang)
+                .operators()
+                .mul_is_sequence_repetition()
+                || operands.iter().all(|&v| self.proven_non_concat(v))
         } else {
             true
         }

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -91,7 +91,9 @@ impl<'a> Builder<'a> {
     }
 
     pub(super) fn plus_has_mixed_string_coercion(&self) -> bool {
-        semantics(self.il.meta.lang).operators().plus_coerces_strings()
+        semantics(self.il.meta.lang)
+            .operators()
+            .plus_coerces_strings()
     }
 
     pub(super) fn relational_has_string_ordering(&self) -> bool {

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -1276,6 +1276,27 @@ impl OperatorSemantics {
         })
     }
 
+    /// Whether `+` can coerce a mixed string/non-string operand pair (so grouping and order
+    /// are observable and the value-graph must not freely associate/commute it). True for the
+    /// JS family and Java (`"a" + 2 + 3` is `"a23"`, not `"a" + 5`). The single source for what
+    /// was duplicated as `plus_has_mixed_string_coercion` in `algebra` and the value graph.
+    pub fn plus_coerces_strings(self) -> bool {
+        js_like_lang(self.lang) || self.lang == Lang::Java
+    }
+
+    /// Whether relational operators (`<`/`>`/…) coerce strings (so their direction/ordering is
+    /// type-observable). The JS family; Java relationals are numeric-only, unlike its `+`.
+    pub fn relational_coerces_strings(self) -> bool {
+        js_like_lang(self.lang)
+    }
+
+    /// Whether `*` is (asymmetric) sequence repetition rather than purely numeric — Ruby only
+    /// (`"ab" * 3` is `"ababab"`, but `3 * "ab"` raises). Gates both the `algebra` constant-fold
+    /// reorder and the value-graph commutation of a `*` chain.
+    pub fn mul_is_sequence_repetition(self) -> bool {
+        self.lang == Lang::Ruby
+    }
+
     pub fn strict_operand_domain(self, op: Op) -> Option<ValueDomain> {
         if self.strict_numeric_operand_operator(op) {
             Some(ValueDomain::Number)


### PR DESCRIPTION
Code-quality pass from the design review (reduce scattered per-language case-enumeration). **Behavior-preserving refactor** — corpus family delta 0 (type4 20→20, nose `crates/` 5→5), `nose verify --max-violations 0` PASS on type4 + coevo (SOUND + PRESERVED), full workspace suite green, dup-gate 28/28, clippy/fmt/docs/formal-obligations all pass.

## Tier 1 — per-language operator gates → single source of truth

`plus_has_mixed_string_coercion` was **duplicated** as a free fn in `algebra.rs` *and* a method in `value_graph/state.rs` (identical `matches!(lang, JS|TS|Vue|Svelte|Html|Java)`). `relational_has_string_ordering` and the Ruby `*`-repetition check (`lang == Ruby`, in both algebra and state) were likewise scattered `matches!(lang, …)`.

Added three capability methods to `OperatorSemantics` (the per-language table that already hosts `comparison_direction`/`value_law`/`membership_operator`), reusing `js_like_lang`:
- `plus_coerces_strings()` — JS family + Java
- `relational_coerces_strings()` — JS family
- `mul_is_sequence_repetition()` — Ruby

The algebra free fn is deleted; the value-graph methods thin-delegate to the table; all call sites read the table. **Lang sets are byte-for-byte identical**, so behavior is unchanged — now one place knows which languages coerce strings on `+`/relationals and repeat on `*`.

## Tier 2 — performance, behavior-identical

`process_container` saved/restored `param_domain` + `param_ty` per class method via `.clone()`; switched to `std::mem::take` (both impl `Default`; `seed_param_value_domains` reassigns `param_ty` wholesale), eliminating two map/vec clones per method and subsuming the `.clear()`.

## Docs

`value_graph/rules.rs` now documents the **two-tier canon split** — value-independent inline canon (`canonicalize.rs`, no obligation) vs proof-backed rules (here, required `formal/obligations/.../meta.toml`) — with a rule-of-thumb for where a new rewrite belongs.

## Investigated & deliberately left (review findings — already clean or out of scope)

- **`intern_node` key clone**: the clean fix needs a `smallvec`/`hashbrown` dep or a custom intern table; a new dep cuts against the self-contained-binary ethos, so deferred rather than forced.
- **`proven_float`/`numeric`/`non_concat`**: the per-`ValOp` arms intentionally differ by op/law and the genuine(`param_domain`)-vs-optimistic(`vty`) split is load-bearing (#283-B) — **not** collapsed into one lattice query.
- **Rust `Vec::new`/`Option::Some`/`None` recognizers** are already thin wrappers over `admitted_rust_*` contracts (table-driven), not inline case-enumeration.
- **`param_domain_scope`** is O(1) for the common `Func` root (early return); the double call is only the rarer non-Func root, so left un-memoized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)