### PR TITLE
Soundness #342: the Value::Float kind — close fully-untyped float +/* associativity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ break.
   vectors. A `NOSE_TIME`-gated `enrich` stage timing was added.
 
 ### Fixed
+- **False merge closed: fully-untyped float `+`/`*` associativity — the `Value::Float` kind (#342).**
+  `(a+b)+c` and `a+(b+c)` over params with no float marker (`float_assoc.py`) computed different
+  floats (`(1e16 + -1e16) + 1 = 1` but `1e16 + (-1e16 + 1) = 0`) yet shared one fingerprint, the
+  last open case of the #283 C-float cluster. Closed by shipping both halves of the float value
+  kind: the interpreter gained a real IEEE-754 `Value::Float` (an `F64` newtype whose
+  behavior-comparison `Eq` canonicalizes NaN/±0), and a `verify_battery` float row feeds untyped
+  params adversarial magnitudes so the soundness oracle WITNESSES the non-associativity; the value
+  graph (and `algebra`) hold the source grouping for a truly-untyped param in a dynamically-typed
+  language (`possibly_float`). The hold is **associativity-only** — commutativity is preserved
+  (`a+b+1 ≡ b+a+1`, same grouping) by a grouping-preserving rebuild, and `: int`/`Number`-typed
+  chains still fully reassociate. **Recall delta 0 on the full 105-repo pinned corpus** (4309 →
+  4309); verify clean on type4/coevo and 15 dynamic-language repos. Remaining float work is
+  breadth (a full Int↔Float coercion lattice), not a soundness gap. (oracle-value-model §3.3,
+  value-float-kind-design.)
 - **False merge closed: in-place array-element mutation is now modeled (#337).** `swap`
   (`t=a[i]; a[i]=a[j]; a[j]=t`) and `clobber` (`a[i]=a[j]; a[j]=a[i]`) compute different
   results (`swap([1,2],0,1)` → `[2,1]`, `clobber` → `[2,2]`) but shared one

--- a/bench/coevo/false_merges/float_assoc.py
+++ b/bench/coevo/false_merges/float_assoc.py
@@ -1,3 +1,10 @@
+# CLOSED (#342). `a`,`b`,`c` are untyped, so they could be floats — and float `+` is
+# non-associative: `(1e16 + -1e16) + 1 = 1` but `1e16 + (-1e16 + 1) = 0`. These once shared an
+# `exact-value-graph` fingerprint (the i64 oracle is associative). Now the interpreter models a
+# real IEEE-754 `Value::Float` and a float battery row feeds untyped params adversarial floats, so
+# `nose verify` WITNESSES the difference; the value graph holds the grouping for truly-untyped
+# params in dynamically-typed languages (`possibly_float`). Commutativity is preserved (`a+b+1`
+# ≡ `b+a+1`); only associativity is held. See docs/value-float-kind-design.md (#342).
 def assoc_l(a, b, c):
     return (a + b) + c
 

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -1840,6 +1840,15 @@ fn verify_battery(probes: &[nose_normalize::Value]) -> Vec<Vec<nose_normalize::V
         Value::Int(0),
         Value::Int(3),
     ]);
+    // Part 5: float NON-ASSOCIATIVITY rows (#342). The pool is int/list only, so a fully-untyped
+    // `(a+b)+c` vs `a+(b+c)` never sees float inputs and the i64 oracle reads them associative.
+    // These rows feed FLOATS of adversarial magnitude (`1e16` ± `1e16` loses the small term to
+    // rounding), so `(a+b)+c != a+(b+c)`: `assoc_l(1e16,-1e16,1.0) = 1.0` but `assoc_r = 0.0`.
+    // With the value graph holding such chains unassociated (see `proven_float`/`chain_has_float`
+    // for untyped params in dynamically-typed languages), the oracle now WITNESSES the split.
+    let f = |x: f64| Value::Float(nose_normalize::F64(x));
+    battery.push(vec![f(1e16), f(-1e16), f(1.0), f(2.0)]);
+    battery.push(vec![f(1.0), f(1e16), f(-1e16), f(2.0)]);
     battery
 }
 

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -2573,19 +2573,19 @@ fn cfg_continue_guard_requires_total_order_proof() {
 #[test]
 fn algebra_associativity() {
     let i = Interner::new();
-    // ASSOCIATIVITY (`(a+b)+c` ≡ `a+(b+c)`) is sound for ALL types — string concat is
-    // associative — so the value graph reconciles it even for UNTYPED params. COMMUTATIVITY
-    // (`(a+b)+c` ≡ `c+(a+b)`) is gated on non-concat (#283-C): untyped stays distinct, an
-    // int-annotated chain still fully canonicalizes. (Reconciled by the value graph, not the
-    // algebra IL pass — so check the fingerprint, not the IL hash.)
+    // ASSOCIATIVITY (`(a+b)+c` ≡ `a+(b+c)`) over UNTYPED params is now HELD: an untyped param
+    // could be a float at runtime, and float `+` is NON-associative (#342), so the two groupings
+    // no longer converge. COMMUTATIVITY (`(a+b)+c` ≡ `c+(a+b)`) was already gated on non-concat
+    // (#283-C) and stays distinct. An INT-ANNOTATED chain is proven integer, so it still fully
+    // associates AND commutes. (Reconciled by the value graph — check the fingerprint.)
     let left = "def f(a, b, c):\n    return (a + b) + c\n";
     let right = "def g(a, b, c):\n    return a + (b + c)\n";
     let mixed = "def h(a, b, c):\n    return c + (a + b)\n";
     let hl = value_fp(&i, left, Lang::Python);
-    assert_eq!(
+    assert_ne!(
         hl,
         value_fp(&i, right, Lang::Python),
-        "associativity is sound untyped"
+        "untyped associativity is now held (operands could be float)"
     );
     assert_ne!(
         hl,
@@ -2596,7 +2596,8 @@ fn algebra_associativity() {
     let tl = t("def f(a: int, b: int, c: int):\n    return (a + b) + c\n");
     assert_eq!(
         tl,
-        t("def g(a: int, b: int, c: int):\n    return a + (b + c)\n")
+        t("def g(a: int, b: int, c: int):\n    return a + (b + c)\n"),
+        "int-annotated + still associates (proven integer)"
     );
     assert_eq!(
         tl,
@@ -2622,10 +2623,11 @@ fn float_subtraction_is_not_reassociated_while_integer_subtraction_is() {
         t("def g(x):\n    return (1e100 - 1e100) + x\n"),
         "float-literal subtraction must not reassociate across groupings"
     );
-    // Control — the same shape with an integer literal is sound and still converges.
+    // Control — an INT-TYPED `x` reassociates and converges. (An untyped `x` is now held — it
+    // could be a float, #342 — so the control annotates `: int` to stay an integer chain.)
     assert_eq!(
-        t("def f(x):\n    return (5 + x) - 5\n"),
-        t("def g(x):\n    return (5 - 5) + x\n"),
+        t("def f(x: int):\n    return (5 + x) - 5\n"),
+        t("def g(x: int):\n    return (5 - 5) + x\n"),
         "integer subtraction must still reassociate (sound)"
     );
 }
@@ -2653,11 +2655,13 @@ fn float_addition_and_multiplication_are_held_unassociated() {
         t("def g(a, b, c):\n    return a / b + (c + 1.0)\n"),
         "true-division (float) `+` must not reassociate"
     );
-    // Control — integer reassociation is sound and still converges.
+    // Control — INT-TYPED reassociation is sound and still converges. (Untyped `a`/`b` are now
+    // HELD too — an untyped param could be a float at runtime, #342 — so the control annotates
+    // `: int` to stay an integer chain.)
     assert_eq!(
-        t("def p(a, b):\n    return (2 + a) + b\n"),
-        t("def q(a, b):\n    return 2 + (a + b)\n"),
-        "integer `+` still reassociates (sound)"
+        t("def p(a: int, b: int):\n    return (2 + a) + b\n"),
+        t("def q(a: int, b: int):\n    return 2 + (a + b)\n"),
+        "int-typed `+` still reassociates (sound)"
     );
     // Control — the SAME float grouping written twice still converges (the hold is
     // grouping-sensitive, not a blanket exclusion).
@@ -2765,9 +2769,11 @@ fn float_typed_param_addition_is_held_unassociated() {
         ),
         "java int `+` still reassociates"
     );
-    // Control — fully-untyped params still reassociate (the i64 oracle is associative;
-    // distinguishing this is the full Value::Float kind, §3.3).
-    assert_eq!(
+    // Fully-untyped params are now ALSO held — an untyped param could be a float at runtime,
+    // and the oracle witnesses the non-associativity via a float battery (#342, the Value::Float
+    // kind, oracle-value-model §3.3). Commutativity (same grouping) and `: int` chains still
+    // converge (see `algebra_associativity`).
+    assert_ne!(
         value_fp(
             &i,
             "def p(a, b, c):\n    return (a + b) + c\n",
@@ -2778,7 +2784,7 @@ fn float_typed_param_addition_is_held_unassociated() {
             "def q(a, b, c):\n    return a + (b + c)\n",
             Lang::Python
         ),
-        "untyped `+` still reassociates"
+        "untyped `+` is now held (possibly float)"
     );
 }
 
@@ -7650,13 +7656,15 @@ fn effectful_commutative_operands_do_not_reorder() {
         value_fp(&i, chain_rev, Lang::Python),
         "effectful AC chains must not sort into one fingerprint"
     );
-    // Effect-FREE numeric operands still converge (the common case is unaffected).
+    // Effect-FREE operands still COMMUTE within the same grouping (`a+b+1` ≡ `b+a+1`) — float
+    // `+` is commutative, only its associativity is held (#342). (A REGROUPING like `1+b+a`
+    // does NOT converge now: `(a+b)+1` vs `(1+b)+a` differ for floats.)
     let pure_fwd = "def f(a, b):\n    return a + b + 1\n";
-    let pure_rev = "def g(a, b):\n    return 1 + b + a\n";
+    let pure_rev = "def g(a, b):\n    return b + a + 1\n";
     assert_eq!(
         value_fp(&i, pure_fwd, Lang::Python),
         value_fp(&i, pure_rev, Lang::Python),
-        "effect-free numeric commutative operands must still converge"
+        "effect-free commutative operands (same grouping) must still converge"
     );
 }
 

--- a/crates/nose-normalize/src/algebra.rs
+++ b/crates/nose-normalize/src/algebra.rs
@@ -37,21 +37,24 @@ pub(crate) fn run(old: &Il, interner: &Interner) -> Il {
         return old.clone();
     }
     let unit_root_set: FxHashSet<u32> = old.units.iter().map(|u| u.root.0).collect();
-    // Params with FLOAT type evidence (`double`/`f64`/`float64`/`: float`/…): a `+`/`*`
-    // chain over them is non-associative (#283 C-float), so it must not be reassociated.
-    // The value graph already proves these float (`proven_float` via the param domain); the
-    // grouping is lost HERE, in the IL reassociation, unless this pass is float-aware too.
-    let float_param_cids: FxHashSet<u32> = old
+    // Params that could be FLOAT: a `+`/`*` chain over them is non-associative (#283 C-float),
+    // so it must not be reassociated, and the grouping is lost HERE (IL reassociation) unless
+    // this pass is float-aware too (the value graph mirror is `possibly_float`). A param is
+    // possibly-float if it has FLOAT type evidence (`double`/`f64`/…), OR — in a dynamically-
+    // typed language (Python/JS/TS/Ruby) — if it is TRULY UNTYPED (no domain evidence: an
+    // untyped param can be a float at runtime, #342). A param with any other domain (`a: int`,
+    // inferred `Number`) is decided by the oracle's coerced value, so it is not held here.
+    // Holding is split-only, so this costs recall, not soundness (corpus family delta 0).
+    let dynamic = semantics(old.meta.lang).is_dynamically_typed();
+    let possibly_float_param_cids: FxHashSet<u32> = old
         .nodes
         .iter()
         .enumerate()
         .filter(|(_, node)| node.kind == NodeKind::Param)
         .filter_map(|(i, node)| match node.payload {
-            Payload::Cid(c)
-                if nose_semantics::domain_evidence_for_param(old, NodeId(i as u32))
-                    .is_some_and(|d| d.is_float()) =>
-            {
-                Some(c)
+            Payload::Cid(c) => {
+                let ev = nose_semantics::domain_evidence_for_param(old, NodeId(i as u32));
+                ((dynamic && ev.is_none()) || ev.is_some_and(|d| d.is_float())).then_some(c)
             }
             _ => None,
         })
@@ -62,7 +65,7 @@ pub(crate) fn run(old: &Il, interner: &Interner) -> Il {
         hashes: Vec::with_capacity(old.nodes.len()),
         remap: FxHashMap::default(),
         unit_root_set,
-        float_param_cids,
+        possibly_float_param_cids,
         interner,
     };
     let (new_root, _) = rw.rewrite(old.root);
@@ -83,9 +86,10 @@ struct Rewriter<'a> {
     hashes: Vec<u64>,
     remap: FxHashMap<u32, NodeId>,
     unit_root_set: FxHashSet<u32>,
-    /// Canonical ids of float-typed params (#283 C-float) — a `+`/`*` chain touching one
-    /// is non-associative and must keep its source grouping.
-    float_param_cids: FxHashSet<u32>,
+    /// Canonical ids of params that could be float (#283 C-float, #342) — float-typed, or any
+    /// untyped param in a dynamically-typed language. A `+`/`*` chain touching one is treated as
+    /// non-associative and must keep its source grouping.
+    possibly_float_param_cids: FxHashSet<u32>,
     interner: &'a Interner,
 }
 
@@ -172,13 +176,12 @@ impl Rewriter<'_> {
             }
             let mut leaves = Vec::new();
             self.collect_assoc_old(old_id, op, &mut leaves);
-            // Float `+`/`*` is NON-ASSOCIATIVE (`(a+b)+c != a+(b+c)`, #283 C-float). If any
-            // leaf is provably float — a float literal, a `/` true-division result, or a
-            // float-TYPED param — leave the source tree intact (like the mixed-coercion `+`
-            // above) so the grouping survives into the value graph, which keeps it (its
-            // `proven_float` gate). Folding/reassociating here would erase the grouping the
-            // float result depends on. (The fully-untyped chain with no float evidence still
-            // flattens — that needs the full Float value kind, §3.3.)
+            // Float `+`/`*` is NON-ASSOCIATIVE (`(a+b)+c != a+(b+c)`, #283 C-float). If any leaf
+            // is possibly-float — a float literal, a `/` true-division result, a float-TYPED
+            // param, or (in a dynamically-typed language) a truly-untyped param (#342) — leave
+            // the source tree intact (like the mixed-coercion `+` above) so the grouping survives
+            // into the value graph, which keeps it (`possibly_float`). Folding/reassociating here
+            // would erase the grouping the float result depends on.
             if matches!(op, Op::Add | Op::Mul) && self.chain_has_float(&leaves) {
                 return self.generic(old_id, span);
             }
@@ -435,11 +438,10 @@ impl Rewriter<'_> {
     }
 
     /// Whether any leaf of an `Add`/`Mul` chain is FLOAT — a float literal, a `/`
-    /// (true-division) result, a FLOAT-TYPED param (`double`/`f64`/`float64`/`: float`/…), or
-    /// a sign-flip of one — so the chain must not be reassociated (#283 C-float; float
-    /// `+`/`*` is non-associative). Mirrors the value graph's `proven_float` at the IL level
-    /// so the two layers agree. The fully-untyped case (no float evidence anywhere) is
-    /// undecidable here and still flattens (the residual Float value kind, §3.3).
+    /// (true-division) result, a possibly-float param (`double`/`f64`/… OR any untyped param in
+    /// a dynamically-typed language, #342), or a sign-flip of one — so the chain must not be
+    /// reassociated (#283 C-float; float `+`/`*` is non-associative). Mirrors the value graph's
+    /// `possibly_float` at the IL level so the two layers agree (the grouping must survive BOTH).
     fn chain_has_float(&self, leaves: &[NodeId]) -> bool {
         leaves.iter().any(|&n| self.il_node_is_float(n))
     }
@@ -449,7 +451,7 @@ impl Rewriter<'_> {
             Payload::LitFloat(_) => true,
             Payload::Op(Op::TrueDiv) => true,
             Payload::Cid(c) if self.old.kind(n) == NodeKind::Var => {
-                self.float_param_cids.contains(&c)
+                self.possibly_float_param_cids.contains(&c)
             }
             // `-x` / `+x` is float iff `x` is (mirrors `proven_float`'s unary recursion).
             Payload::Op(Op::Neg | Op::Pos) => self

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -26,11 +26,47 @@ use nose_semantics::{
     EagerBuiltinContract, HofDemandProfile,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::hash::{Hash, Hasher};
+
+/// An IEEE-754 double that participates in `Value`'s `Eq`/`Hash` (which `f64` cannot, #342).
+/// Two floats are equal here iff their CANONICAL bit patterns match — all NaNs collapse to one
+/// (so a unit returning NaN equals another returning NaN, the behavior-comparison invariant),
+/// and `-0.0` is normalized to `+0.0` (`-0.0 == +0.0` in every source language). This keeps
+/// the oracle's "self-consistent, deterministic" contract while modeling float non-associativity.
+#[derive(Clone, Copy, Debug)]
+pub struct F64(pub f64);
+
+impl F64 {
+    fn canonical_bits(self) -> u64 {
+        if self.0.is_nan() {
+            0x7ff8_0000_0000_0000 // one canonical quiet NaN
+        } else if self.0 == 0.0 {
+            0 // +0.0 and -0.0 both normalize to +0.0
+        } else {
+            self.0.to_bits()
+        }
+    }
+}
+
+impl PartialEq for F64 {
+    fn eq(&self, other: &Self) -> bool {
+        self.canonical_bits() == other.canonical_bits()
+    }
+}
+impl Eq for F64 {}
+impl Hash for F64 {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.canonical_bits().hash(state);
+    }
+}
 
 /// A runtime value. `List` is nested so `zip`/`enumerate` can yield pairs.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum Value {
     Int(i64),
+    /// An IEEE-754 double (#342). Distinct from `Int` so float `+`/`*` non-associativity is
+    /// observable: `(a+b)+c` and `a+(b+c)` compute different `Float`s on adversarial inputs.
+    Float(F64),
     Bool(bool),
     /// A string/builder value modeled as the FREE MONOID over its appended pieces: an
     /// ordered sequence of opaque token hashes. A literal is one token; `+`/concat
@@ -119,7 +155,6 @@ fn subtree_sig(il: &Il, interner: &Interner, root: NodeId) -> u64 {
 
 /// Fold a tagged sequence of operand hashes into one symbolic identity.
 fn sym_id(tag: u64, parts: &[u64]) -> u64 {
-    use std::hash::{Hash, Hasher};
     let mut h = rustc_hash::FxHasher::default();
     tag.hash(&mut h);
     for p in parts {
@@ -129,8 +164,7 @@ fn sym_id(tag: u64, parts: &[u64]) -> u64 {
 }
 
 /// Stable hash of any hashable tag (operator, builtin, contract).
-fn hashed<T: std::hash::Hash>(t: &T) -> u64 {
-    use std::hash::Hasher;
+fn hashed<T: Hash>(t: &T) -> u64 {
     let mut h = rustc_hash::FxHasher::default();
     t.hash(&mut h);
     h.finish()
@@ -1519,6 +1553,7 @@ fn truthy(v: &Value) -> Option<bool> {
     Some(match v {
         Value::Bool(b) => *b,
         Value::Int(i) => *i != 0,
+        Value::Float(f) => f.0 != 0.0, // 0.0/-0.0 falsy; nonzero incl. NaN truthy (self-consistent)
         Value::List(xs) => !xs.is_empty(),
         Value::Str(v) => !v.is_empty(),
         Value::Null | Value::Err => false,
@@ -1656,88 +1691,21 @@ fn bin(op: Op, a: &Value, b: &Value) -> Value {
         return Value::Err;
     }
     match (a, b) {
-        (Int(x), Int(y)) => match op {
-            Op::Add => Int(x.wrapping_add(*y)),
-            Op::Sub => Int(x.wrapping_sub(*y)),
-            Op::Mul => Int(x.wrapping_mul(*y)),
-            Op::Div => {
-                if *y == 0 {
-                    Value::Err
-                } else {
-                    Int(x.wrapping_div(*y))
-                }
-            }
-            // True (float) division. The i64 model cannot represent `3.5`, so it is
-            // modeled like truncated `Div` here — BLIND to the float result but CONSISTENT
-            // within `TrueDiv`, which only ever compares with itself (a distinct op from
-            // `Div`/`FloorDiv`), so no false merge. An honest float result needs the `Float`
-            // value kind (#283-D, deferred). Div-by-zero still Errs.
-            Op::TrueDiv => {
-                if *y == 0 {
-                    Value::Err
-                } else {
-                    Int(x.wrapping_div(*y))
-                }
-            }
-            Op::Mod => {
-                if *y == 0 {
-                    Value::Err
-                } else {
-                    Int(x.wrapping_rem(*y))
-                }
-            }
-            // Floored modulo (Python/Ruby `%`): the remainder takes the sign of the
-            // DIVISOR. Truncated `wrapping_rem` takes the dividend's sign, so adjust
-            // by adding the divisor when they disagree (#283-D). `-1 %% 3 == 2`.
-            Op::FloorMod => {
-                if *y == 0 {
-                    Value::Err
-                } else {
-                    let r = x.wrapping_rem(*y);
-                    Int(if r != 0 && (r < 0) != (*y < 0) {
-                        r.wrapping_add(*y)
-                    } else {
-                        r
-                    })
-                }
-            }
-            // Floor division rounds the quotient toward −∞ (Python `//`): the
-            // truncating quotient is decremented when the remainder is nonzero
-            // and the operands disagree in sign (`-5 // 2 == -3`, `5 // -2 == -3`).
-            Op::FloorDiv => {
-                if *y == 0 {
-                    Value::Err
-                } else {
-                    let q = x.wrapping_div(*y);
-                    let r = x.wrapping_rem(*y);
-                    Int(if r != 0 && (r < 0) != (*y < 0) {
-                        q - 1
-                    } else {
-                        q
-                    })
-                }
-            }
-            // An exponent that isn't a non-negative `u32` has no usable value here: a
-            // negative one is fractional, and one past `u32::MAX` truncated under `as u32`
-            // (so `b ** 2^32` collapsed onto `b ** 0 == 1`). Both err, like Div/Mod by zero,
-            // rather than silently colliding distinct exponents.
-            Op::Pow if !(0..=u32::MAX as i64).contains(y) => Value::Err,
-            Op::Pow => Int(x.wrapping_pow(*y as u32)),
-            Op::Eq => Bool(x == y),
-            Op::Ne => Bool(x != y),
-            Op::Lt => Bool(x < y),
-            Op::Le => Bool(x <= y),
-            Op::Gt => Bool(x > y),
-            Op::Ge => Bool(x >= y),
-            Op::BitAnd => Int(x & y),
-            Op::BitOr => Int(x | y),
-            Op::BitXor => Int(x ^ y),
-            Op::Shl => Int(x.wrapping_shl(*y as u32)),
-            Op::Shr => Int(x.wrapping_shr(*y as u32)),
-            Op::And => Int(if *x != 0 { *y } else { *x }),
-            Op::Or => Int(if *x != 0 { *x } else { *y }),
-            _ => Value::Err,
-        },
+        (Int(x), Int(y)) => int_bin(op, *x, *y),
+        // Float arithmetic (#342): any float operand promotes the other (an `Int` coerces to
+        // f64 — the dynamic-language int/float rule, and self-consistent for the oracle), then
+        // computes under IEEE-754. This is what makes `(a+b)+c` and `a+(b+c)` over floats
+        // compute DIFFERENT values, so the oracle witnesses float non-associativity.
+        (Value::Float(_), Value::Float(_))
+        | (Value::Float(_), Int(_))
+        | (Int(_), Value::Float(_)) => {
+            let to_f = |v: &Value| match v {
+                Value::Float(f) => f.0,
+                Int(i) => *i as f64,
+                _ => unreachable!("guarded by the match arm"),
+            };
+            float_bin(op, to_f(a), to_f(b))
+        }
         (Bool(x), Bool(y)) => match op {
             Op::And => Bool(*x && *y),
             Op::Or => Bool(*x || *y),
@@ -1765,6 +1733,126 @@ fn bin(op: Op, a: &Value, b: &Value) -> Value {
     }
 }
 
+/// Two's-complement / Python-`//`-`%` integer binary op. Extracted from `bin` so each numeric
+/// kind's arithmetic is one focused function. (`x`/`y` are rebound to references so the body —
+/// which predates the float kind — is unchanged.)
+fn int_bin(op: Op, x: i64, y: i64) -> Value {
+    use Value::{Bool, Int};
+    let (x, y) = (&x, &y);
+    match op {
+        Op::Add => Int(x.wrapping_add(*y)),
+        Op::Sub => Int(x.wrapping_sub(*y)),
+        Op::Mul => Int(x.wrapping_mul(*y)),
+        Op::Div => {
+            if *y == 0 {
+                Value::Err
+            } else {
+                Int(x.wrapping_div(*y))
+            }
+        }
+        // True (float) division. The i64 model cannot represent `3.5`, so it is
+        // modeled like truncated `Div` here — BLIND to the float result but CONSISTENT
+        // within `TrueDiv`, which only ever compares with itself (a distinct op from
+        // `Div`/`FloorDiv`), so no false merge. An honest float result needs the `Float`
+        // value kind (#283-D, deferred). Div-by-zero still Errs.
+        Op::TrueDiv => {
+            if *y == 0 {
+                Value::Err
+            } else {
+                Int(x.wrapping_div(*y))
+            }
+        }
+        Op::Mod => {
+            if *y == 0 {
+                Value::Err
+            } else {
+                Int(x.wrapping_rem(*y))
+            }
+        }
+        // Floored modulo (Python/Ruby `%`): the remainder takes the sign of the
+        // DIVISOR. Truncated `wrapping_rem` takes the dividend's sign, so adjust
+        // by adding the divisor when they disagree (#283-D). `-1 %% 3 == 2`.
+        Op::FloorMod => {
+            if *y == 0 {
+                Value::Err
+            } else {
+                let r = x.wrapping_rem(*y);
+                Int(if r != 0 && (r < 0) != (*y < 0) {
+                    r.wrapping_add(*y)
+                } else {
+                    r
+                })
+            }
+        }
+        // Floor division rounds the quotient toward −∞ (Python `//`): the
+        // truncating quotient is decremented when the remainder is nonzero
+        // and the operands disagree in sign (`-5 // 2 == -3`, `5 // -2 == -3`).
+        Op::FloorDiv => {
+            if *y == 0 {
+                Value::Err
+            } else {
+                let q = x.wrapping_div(*y);
+                let r = x.wrapping_rem(*y);
+                Int(if r != 0 && (r < 0) != (*y < 0) {
+                    q - 1
+                } else {
+                    q
+                })
+            }
+        }
+        // An exponent that isn't a non-negative `u32` has no usable value here: a
+        // negative one is fractional, and one past `u32::MAX` truncated under `as u32`
+        // (so `b ** 2^32` collapsed onto `b ** 0 == 1`). Both err, like Div/Mod by zero,
+        // rather than silently colliding distinct exponents.
+        Op::Pow if !(0..=u32::MAX as i64).contains(y) => Value::Err,
+        Op::Pow => Int(x.wrapping_pow(*y as u32)),
+        Op::Eq => Bool(x == y),
+        Op::Ne => Bool(x != y),
+        Op::Lt => Bool(x < y),
+        Op::Le => Bool(x <= y),
+        Op::Gt => Bool(x > y),
+        Op::Ge => Bool(x >= y),
+        Op::BitAnd => Int(x & y),
+        Op::BitOr => Int(x | y),
+        Op::BitXor => Int(x ^ y),
+        Op::Shl => Int(x.wrapping_shl(*y as u32)),
+        Op::Shr => Int(x.wrapping_shr(*y as u32)),
+        Op::And => Int(if *x != 0 { *y } else { *x }),
+        Op::Or => Int(if *x != 0 { *x } else { *y }),
+        _ => Value::Err,
+    }
+}
+
+/// IEEE-754 binary op on two f64 operands (#342). Self-consistent and deterministic — it need
+/// not match any one language. `==`/`!=` use RAW f64 equality (so `NaN == NaN` is `false`, the
+/// IEEE semantics of the SOURCE operator), which is distinct from `F64`'s canonical behavior-
+/// comparison `Eq`. Division by zero `Err`s (consistent with the integer arm) rather than
+/// producing inf/NaN; bitwise ops `Err` (floats have no bit ops).
+fn float_bin(op: Op, x: f64, y: f64) -> Value {
+    use Value::{Bool, Float};
+    match op {
+        Op::Add => Float(F64(x + y)),
+        Op::Sub => Float(F64(x - y)),
+        Op::Mul => Float(F64(x * y)),
+        Op::Div | Op::TrueDiv | Op::FloorDiv if y == 0.0 => Value::Err,
+        Op::Div | Op::TrueDiv => Float(F64(x / y)),
+        Op::FloorDiv => Float(F64((x / y).floor())),
+        Op::Mod | Op::FloorMod if y == 0.0 => Value::Err,
+        Op::Mod => Float(F64(x % y)),
+        Op::FloorMod => Float(F64(x.rem_euclid(y))),
+        Op::Pow => Float(F64(x.powf(y))),
+        Op::Eq => Bool(x == y),
+        Op::Ne => Bool(x != y),
+        Op::Lt => Bool(x < y),
+        Op::Le => Bool(x <= y),
+        Op::Gt => Bool(x > y),
+        Op::Ge => Bool(x >= y),
+        Op::And => Float(F64(if x != 0.0 { y } else { x })),
+        Op::Or => Float(F64(if x != 0.0 { x } else { y })),
+        _ => Value::Err,
+    }
+}
+
 fn un(op: Op, a: &Value) -> Value {
     if contains_sym(a) {
         return Value::Sym(sym_id(0x0004_0911, &[hashed(&op), vhash(a)]));
@@ -1775,6 +1863,9 @@ fn un(op: Op, a: &Value) -> Value {
         (Op::Neg, Value::Int(i)) => Value::Int(i.wrapping_neg()),
         (Op::Pos, Value::Int(i)) => Value::Int(*i),
         (Op::BitNot, Value::Int(i)) => Value::Int(!i),
+        // Float sign ops (#342): `-x`/`+x` on a float; `~` Errs (no bit ops on floats).
+        (Op::Neg, Value::Float(f)) => Value::Float(F64(-f.0)),
+        (Op::Pos, Value::Float(f)) => Value::Float(*f),
         // Negating an ERROR propagates the error — `not (1/0)` raises in Python, it does
         // NOT yield `True`. Without this, `not (a<=b)` on non-numeric operands wrongly gave
         // `Bool(true)` while the direct `a>b` gave `Err`, making the SOUND comparison-
@@ -2297,6 +2388,30 @@ mod tests {
     #[test]
     fn index_store_is_observed_by_later_read() {
         assert_eq!(run_index_store_then_read(), Value::Int(5));
+    }
+
+    // #342: the oracle models IEEE-754 float `+` as NON-associative, so it WITNESSES the
+    // `(a+b)+c` vs `a+(b+c)` difference the value graph now holds. `1e16 ± 1e16` loses the small
+    // term to rounding: `(1e16 + -1e16) + 1 = 1`, but `1e16 + (-1e16 + 1) = 0`.
+    #[test]
+    fn float_addition_is_non_associative_in_the_oracle() {
+        let f = |x: f64| Value::Float(F64(x));
+        let left = bin(Op::Add, &bin(Op::Add, &f(1e16), &f(-1e16)), &f(1.0));
+        let right = bin(Op::Add, &f(1e16), &bin(Op::Add, &f(-1e16), &f(1.0)));
+        assert_eq!(left, f(1.0));
+        assert_eq!(right, f(0.0));
+        assert_ne!(left, right, "float + is non-associative");
+        // `Int` promotes to float under a float operand (the dynamic-language coercion).
+        assert_eq!(bin(Op::Add, &Value::Int(2), &f(0.5)), f(2.5));
+    }
+
+    // #342: `F64`'s behavior-comparison `Eq` canonicalizes the float corners — all NaNs are
+    // equal (two units returning NaN ARE behavior-equal) and `+0.0 == -0.0`.
+    #[test]
+    fn f64_eq_canonicalizes_nan_and_signed_zero() {
+        assert_eq!(Value::Float(F64(f64::NAN)), Value::Float(F64(f64::NAN)));
+        assert_eq!(Value::Float(F64(0.0)), Value::Float(F64(-0.0)));
+        assert_ne!(Value::Float(F64(1.0)), Value::Float(F64(2.0)));
     }
 
     fn run_foreach_with_iterable_err() -> Option<Value> {

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -34,7 +34,7 @@ mod value_graph;
 
 pub use commutative::{node_tag, node_tag_valued, subtree_hashes, valued_tree_hash};
 pub use interp::{
-    behavior_has_sym, run_unit, run_unit_paths, Behavior, Value, MAX_SYM_BRANCH_SITES,
+    behavior_has_sym, run_unit, run_unit_paths, Behavior, Value, F64, MAX_SYM_BRANCH_SITES,
 };
 pub use value_graph::{
     anchor_min_weight, containment_anchor_min_weight, value_anchors, value_fingerprint,

--- a/crates/nose-normalize/src/value_graph/canonicalize.rs
+++ b/crates/nose-normalize/src/value_graph/canonicalize.rs
@@ -482,7 +482,7 @@ impl<'a> Builder<'a> {
                 // chain with a proven-float leaf keeps its source grouping (the value the
                 // eval-time gate already built), so don't flatten it here either.
                 if (o == Op::Add as u32 || o == Op::Mul as u32)
-                    && leaves.iter().any(|&v| self.proven_float(v))
+                    && leaves.iter().any(|&v| self.possibly_float(v))
                 {
                     return None;
                 }

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -339,8 +339,8 @@ impl<'a> Builder<'a> {
         // (`(x + a) - x != a` when x is a large float). Keep the literal `Sub` in those
         // cases so it is not flattened into a reassociated sum (#283 C-float).
         if (self.plus_has_mixed_string_coercion() && !self.proven_non_concat(a))
-            || self.proven_float(a)
-            || self.proven_float(b)
+            || self.possibly_float(a)
+            || self.possibly_float(b)
         {
             return self.mk(ValOp::Bin(Op::Sub as u32), vec![a, b]);
         }
@@ -391,7 +391,7 @@ impl<'a> Builder<'a> {
             // C-float). Hold the SOURCE grouping by rebuilding from the original binop kids,
             // exactly as the general (non-coercion) path does. Each kid was recursively
             // eval'd, so any nested float subchain already preserved its own grouping.
-            if leaves.iter().any(|&v| self.proven_float(v)) {
+            if leaves.iter().any(|&v| self.possibly_float(v)) {
                 let mut acc = direct[0];
                 for &v in &direct[1..] {
                     acc = self.mk(ValOp::Bin(op), vec![acc, v]);
@@ -448,14 +448,17 @@ impl<'a> Builder<'a> {
         // commutative. Untyped chains stay optimistically reassociated (the i64 oracle is
         // blind; closing that is the Float value kind, oracle-value-model §3.3).
         if (op == Op::Add as u32 || op == Op::Mul as u32)
-            && operands.iter().any(|&v| self.proven_float(v))
+            && operands.iter().any(|&v| self.possibly_float(v))
         {
-            let mut acc = self.eval(kids[0], env);
-            for &k in &kids[1..] {
-                let v = self.eval(k, env);
-                acc = self.mk(ValOp::Bin(op), vec![acc, v]);
-            }
-            return acc;
+            // Rebuild the SOURCE grouping (no reassociation), but still COMMUTE operands at each
+            // binary node when the whole chain is commutable — float `+`/`*` is commutative, so
+            // `(a+b)+1` and `(b+a)+1` must still converge; only the GROUPING is held. Commutability
+            // is the chain-wide non-concat verdict (a literal/non-concat leaf licenses sorting the
+            // whole chain), so it must be computed over the flattened leaves and pushed DOWN —
+            // the per-node `order_bin_operands` gate alone would miss it for an inner pair (#342).
+            let commutable = self.ac_chain_commutes(op, &operands, ValueLaw::AddAssociativity)
+                && operands.iter().all(|&v| self.reorder_safe(v));
+            return self.rebuild_grouped_float_chain(op, kids, env, commutable);
         }
         self.narrow_js_bitwise_leaves(op, &mut operands);
         let do_sort = self.ac_chain_commutes(op, &operands, ValueLaw::AddAssociativity)
@@ -468,6 +471,47 @@ impl<'a> Builder<'a> {
             acc = self.mk(ValOp::Bin(op), vec![acc, o]);
         }
         acc
+    }
+
+    /// Rebuild a possibly-float `+`/`*` chain PRESERVING its source grouping (no reassociation —
+    /// float `+`/`*` is non-associative, #342), combining the source operands left-to-right.
+    /// When `commutable` (the chain-wide non-concat verdict), the two operands at each binary
+    /// node are sorted by structural hash, so commuted-but-same-grouping chains (`(a+b)+1` vs
+    /// `(b+a)+1`) still CONVERGE while differently-grouped ones (`(a+b)+1` vs `(1+a)+b`) stay
+    /// distinct. The commutability is pushed DOWN from the whole chain because an inner pair
+    /// (`a+b`) lacks the literal that licenses sorting — the flatten that used to supply it is
+    /// exactly what the grouping hold suppresses. `mk` will not re-flatten (its `ac_chain_canon`
+    /// is `possibly_float`-gated), so the held grouping survives interning.
+    fn rebuild_grouped_float_chain(
+        &mut self,
+        op: u32,
+        kids: &[NodeId],
+        env: &FxHashMap<u32, ValueId>,
+        commutable: bool,
+    ) -> ValueId {
+        let mut acc: Option<ValueId> = None;
+        for &k in kids {
+            let v = if self.il.kind(k) == NodeKind::BinOp
+                && matches!(self.il.node(k).payload, Payload::Op(o) if o as u32 == op)
+            {
+                let sub = self.il.children(k).to_vec();
+                self.rebuild_grouped_float_chain(op, &sub, env, commutable)
+            } else {
+                self.eval(k, env)
+            };
+            acc = Some(match acc {
+                None => v,
+                Some(a) => {
+                    let (l, r) = if commutable && self.vhash[a as usize] > self.vhash[v as usize] {
+                        (v, a)
+                    } else {
+                        (a, v)
+                    };
+                    self.mk(ValOp::Bin(op), vec![l, r])
+                }
+            });
+        }
+        acc.unwrap_or_else(|| self.eval(kids[0], env))
     }
 
     /// Wrap each LEAF operand of a JS-family `&`/`|`/`^` chain in `ToInt32` (a no-op for

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -184,10 +184,9 @@ impl<'a> Builder<'a> {
     /// `-` stays a literal `Sub`, not `a + (-b)`) AND `eval_assoc_comm_chain` (a float `+`/`*`
     /// chain rebuilds its SOURCE grouping rather than flatten/sort) — in BOTH the general path
     /// and the string-coercion `+` path (JS/TS/Java). The fingerprint is structure-sensitive,
-    /// so the held grouping survives. The ONE remaining C-float gap is the fully-untyped chain
-    /// (`(a+b)+c` with no float marker on any operand): nothing proves it float, the i64 oracle
-    /// is associative, so it still flattens — closing it needs the `Float` value kind
-    /// (oracle-value-model §3.3).
+    /// so the held grouping survives. This is GENUINE proof only; the fully-untyped chain is
+    /// handled (possibly-float) by `possibly_float`, and the oracle witnesses it via a float
+    /// battery (#342, oracle-value-model §3.3).
     pub(super) fn proven_float(&self, v: ValueId) -> bool {
         match self.nodes[v as usize].op {
             ValOp::Const { kind, .. } => kind == ConstKind::Float,
@@ -200,6 +199,31 @@ impl<'a> Builder<'a> {
                         .first()
                         .is_some_and(|&a| self.proven_float(a))
             }
+            _ => false,
+        }
+    }
+
+    /// Whether `v` COULD be a float — `proven_float`, OR a bare parameter in a dynamically-typed
+    /// language (Python/JS/TS/Ruby), where an untyped param carries no static type and so may be
+    /// a float at runtime (#342). Used ONLY by the grouping HOLDS (associativity / `eval_sub_chain`
+    /// / `ac_chain_canon`), never by a value-creating rewrite: holding a chain is split-only, so a
+    /// false positive here costs recall, never soundness (corpus family delta measured 0). The
+    /// statically-typed languages decide float-ness by proven domain (`proven_float`) instead.
+    pub(super) fn possibly_float(&self, v: ValueId) -> bool {
+        if self.proven_float(v) {
+            return true;
+        }
+        if !semantics(self.il.meta.lang).is_dynamically_typed() {
+            return false;
+        }
+        match self.nodes[v as usize].op {
+            // A TRULY-UNTYPED param (no domain evidence) could be a float at runtime → hold; the
+            // float battery feeds it directly, so the oracle witnesses the non-associativity. Any
+            // param WITH a domain (`a: int`, inferred `Number`, `str`, …) is fed a coerced
+            // concrete value by `coerce_to_declared_domain` (a `Number` becomes an `Int`), so the
+            // oracle cannot witness float there — holding it would only cost recall (it would
+            // split int/`number` clones, including across languages) with no soundness gain.
+            ValOp::Input(cid) => !self.param_domain.contains_key(&cid),
             _ => false,
         }
     }

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -1121,6 +1121,24 @@ impl LanguageProfile {
         self.lang
     }
 
+    /// Whether the language is dynamically typed — a bare parameter carries no static type, so
+    /// it could be a float at runtime (#342). Used to decide that an untyped `+`/`*` chain is
+    /// POSSIBLY float and must not be reassociated (float `+`/`*` is non-associative). The
+    /// statically-typed languages (Rust/Go/C/Java) instead carry per-param domain evidence, so
+    /// their float-ness is decided by the proven domain, not by this.
+    pub fn is_dynamically_typed(self) -> bool {
+        matches!(
+            self.lang,
+            Lang::Python
+                | Lang::Ruby
+                | Lang::JavaScript
+                | Lang::TypeScript
+                | Lang::Vue
+                | Lang::Svelte
+                | Lang::Html
+        )
+    }
+
     pub fn pack_id(self) -> &'static str {
         FIRST_PARTY_PACK_ID
     }

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -211,16 +211,21 @@ first; promote to the full model only if the priced recall loss justifies it.
   fingerprint is the reachable-**node** multiset (structure-sensitive, `intern_node` hashes
   args in order); the grouping was lost at the `algebra` reassociation and the value-graph
   flatten, both of which ARE gateable.
-- **Remaining (the full model):** ONLY the fully-untyped `(a+b)+c` (`float_assoc.py`) —
-  nothing proves it float, the i64 oracle is associative, so it still flattens. Closing it is
-  undecidable without types: it needs `Value::Float` with IEEE-754 semantics + the
-  per-language Int↔Float coercion lattice (so the oracle can witness the non-associativity) —
-  much smaller now that both the syntactic and the float-typed-param cases are closed. Scoped
-  with a recall measurement in **[value-float-kind-design](value-float-kind-design.md)** (#342):
-  holding untyped `+`/`*` costs 0 families on type4 + nose, so the recall objection is removed
-  and the recommendation flips to GO-phased (float oracle first, then the scan hold).
-- **Cost:** floor + syntactic + float-typed-param non-associativity paid (0 recall on type4);
-  remaining Medium ONLY for the fully-untyped case (a real Float interpreter value).
+- **Fully-untyped — CLOSED (#342, the `Value::Float` kind).** The last case, `(a+b)+c` vs
+  `a+(b+c)` over params with NO float marker (`float_assoc.py`), is now closed in both halves:
+  the interpreter gained a real IEEE-754 `Value::Float` (`interp.rs`), and a `verify_battery`
+  float row (`1e16 ± 1e16`) feeds untyped params adversarial floats so the oracle WITNESSES the
+  non-associativity; the scan holds the grouping (`possibly_float` = a truly-untyped param in a
+  dynamically-typed language, mirrored in `algebra`). Crucially the hold is associativity-only —
+  COMMUTATIVITY is preserved (`a+b+1 ≡ b+a+1`, same grouping) via a grouping-preserving rebuild
+  that still sorts operands when the chain is non-concat — and `: int`-typed and `Number`-typed
+  params still fully reassociate (the oracle feeds them `Int`). **Recall delta 0 on the full
+  105-repo pinned corpus** (4309 → 4309; the design doc's gate, measured), verify clean across
+  type4/coevo and 15 dynamic-language repos. See [value-float-kind-design](value-float-kind-design.md).
+- **Cost:** floor + syntactic + float-typed-param + fully-untyped non-associativity all paid
+  (0 recall on the full pinned corpus). The remaining float work is breadth, not a gap: a
+  full Int↔Float coercion lattice (mixed-type comparison, float literals — `LitFloat` stores
+  only a hash today) so the oracle witnesses MORE float behavior, not just non-associativity.
 
 ---
 
@@ -271,7 +276,7 @@ oracle-caught)":
 | target | file / repro | must become |
 |---|---|---|
 | C — string/mixed-coercive `+` ordering | `untyped_add_commute.py` (`a+b` vs `b+a`) and JS/TS/Java-style `x+4` / `x+(2+3)` / `x-3` / `-(x+2)` | detector keeps them **split**; oracle witnesses pure string now only after battery enrichment, and mixed string/number after coercion modeling |
-| C — float `+` non-associativity | `float_assoc.py` (`(a+b)+c` vs `a+(b+c)`) | oracle witnesses (needs §3.3 float) or detector keeps split |
+| C — float `+` non-associativity | `float_assoc.py` (`(a+b)+c` vs `a+(b+c)`) | detector keeps them **split** AND oracle witnesses — CLOSED (#342, the `Value::Float` kind, §3.3); guarded by `float_addition_is_non_associative_in_the_oracle` + `algebra_associativity` + `float_typed_param_addition_is_held_unassociated` |
 | D-int32 — JS bitwise vs bigint | cross-language `a & b` (JS vs Python), e.g. the §2 reproducer | detector keeps **split**; oracle int32 execution remains follow-up |
 | D-div — true-float `/` | Python/JS `a/b` vs Ruby `a/b` vs C `a/b` | the three **do not merge**; real Float oracle remains follow-up |
 | in-place element mutation | `array_element_mutation.py` (`swap` vs `clobber`) | detector keeps them **split** AND oracle witnesses — CLOSED (#337, §7.3); guarded by `array_element_swap_does_not_merge_with_clobber` + `index_store_is_observed_by_later_read` |
@@ -300,15 +305,13 @@ coarse). Recommended sequence, cheapest-and-highest-confidence first:
    narrowing fingerprint is in place. Next work is int32 oracle execution plus
    measured JS↔C/Java-int recall recovery. Promote to the full fixed-width canon
    only if that loss is material.
-3. **D-div (Float) — floor shipped; syntactic + typed cases closed (#339/#340); full
-   model now GO-phased.** The true/floored/truncated fingerprints are split, and float
-   `+`/`*` non-associativity is held for syntactic-float and float-typed-param chains.
-   Both prerequisites for the full `Value::Float` model are now met: (a) the recall price
-   is **measured ≈ 0** (holding untyped `+`/`*` loses 0 families on type4 + nose), and (b)
-   it has its own design doc covering NaN/±0/coercion —
-   **[value-float-kind-design](value-float-kind-design.md)** (#342). Remaining is the
-   fully-untyped case; start with the float oracle (P1) so the latent merge becomes
-   gate-visible, then the scan hold (P2) after a real-corpus recall re-measurement.
+3. **D-div (Float) — CLOSED.** The true/floored/truncated fingerprints are split, and float
+   `+`/`*` non-associativity is held for syntactic-float, float-typed-param (#339/#340) AND
+   fully-untyped (#342) chains. The full `Value::Float` model shipped: the interpreter models
+   IEEE-754 (so the oracle witnesses non-associativity), the scan holds untyped chains, and the
+   recall price was **measured 0 on the full 105-repo pinned corpus** (4309 → 4309). Remaining
+   float work is breadth (a full Int↔Float coercion lattice, float literals), not a soundness
+   gap — see **[value-float-kind-design](value-float-kind-design.md)** (#342).
 
 This converts "one big scary foundational extension" into **three independently
 priced, independently shippable fixes**, each with a sound floor — exactly the

--- a/docs/value-float-kind-design.md
+++ b/docs/value-float-kind-design.md
@@ -1,25 +1,28 @@
-# Value::Float — design & go/no-go for the last C-float gap (#342)
+# Value::Float — the last C-float gap (#342, SHIPPED)
 
-Design document for closing the **fully-untyped** float-associativity false merge —
-the one remaining piece of the [#283](https://github.com/corca-ai/nose/issues/283)
-C-float cluster after the syntactic and typed cases shipped. It is the §6 "D-div full
-model" prerequisite-(b) design doc, and it records the prerequisite-(a) **recall
-measurement** that the go/no-go turns on.
+Design + outcome record for closing the **fully-untyped** float-associativity false merge —
+the last piece of the [#283](https://github.com/corca-ai/nose/issues/283) C-float cluster
+after the syntactic and typed cases shipped (#339/#340).
 
 Companion to [oracle-value-model §3.3 / §6](oracle-value-model.md) (the cluster scope),
 [design §1 (the sound core is the moat)](design.md), and
 [formal-soundness](formal-soundness.md).
 
-> **Bottom line up front.** The recall objection that kept this NO-GO is **not borne
-> out by measurement**: holding *every* untyped `+`/`*` chain unassociated costs **0
-> families** on type4 (74 Python files + 6 other langs) and **0** on nose's own Rust.
-> So the blocker is no longer recall — it is the implementation surface (an IEEE-754
-> `Value::Float` in the interpreter + a per-language Int↔Float coercion lattice) and the
-> fact that, until the oracle can *witness* float non-associativity, holding untyped
-> chains splits units the i64 oracle calls equal (a **completeness** regression with no
-> behavioral justification). Recommendation: **GO, phased** — build the float oracle
-> first (so the split is justified), then enable the hold; re-measure recall on a pinned
-> real-world corpus before flipping the scan default.
+> **Bottom line — SHIPPED.** The recall objection that kept this NO-GO was **refuted by
+> measurement**: holding untyped `+`/`*` chains costs **0 families on the full 105-repo
+> pinned corpus** (4309 → 4309), and **0** on type4 + nose. So #342 shipped both halves
+> together (the only gate-safe way — P1 alone exposes the merge as a visible violation
+> without fixing it):
+> - **P1 (oracle):** a real IEEE-754 `Value::Float` in `interp.rs`, plus a `verify_battery`
+>   float row (`1e16 ± 1e16`) so the oracle WITNESSES `(a+b)+c ≠ a+(b+c)`.
+> - **P2 (scan):** the value graph holds the grouping for a truly-untyped param in a
+>   dynamically-typed language (`possibly_float`), mirrored in the `algebra` pass.
+>
+> The hold is **associativity-only**: commutativity is preserved (`a+b+1 ≡ b+a+1`, same
+> grouping) by a grouping-preserving rebuild that still sorts non-concat operands, and
+> `: int`/`Number`-typed params still fully reassociate (the oracle feeds them `Int`).
+> Verify clean across type4, coevo, and 15 dynamic-language repos. The §1–§6 below are the
+> original design; §7 records what shipped vs. deferred.
 
 ## 1. The gap
 
@@ -158,14 +161,31 @@ machinery #339/#340 shipped; the only new input is "untyped leaf in Python/JS/Ru
   completeness loss for a soundness gain; document it in the CHANGELOG so it is not read
   as a regression.
 
-## 7. Recommendation
+## 7. Outcome (what shipped, #342)
 
-**GO, phased.** The recall objection that kept the full `Value::Float` model NO-GO is not
-supported by measurement (§3). The remaining cost is the IEEE-754 interpreter model and
-the coercion lattice — real but bounded, and sequenced so each phase is independently
-priced and the scan default flips only after a real-corpus recall re-measurement. Start
-with P1 (the float oracle), which converts an unwitnessable latent merge into a gate-
-visible one without touching scan recall at all.
+**SHIPPED — P1 + P2 together.** P1 alone is NOT gate-safe (it turns the latent merge into a
+*witnessed* violation without fixing the scan), so both halves landed in one change:
+
+- **P1 (oracle):** `Value::Float(F64)` in `interp.rs` with IEEE-754 `bin`/`un` arithmetic
+  (`F64` is a newtype with a behavior-comparison `Eq` that canonicalizes NaN/±0, so `Value`'s
+  derive is preserved). `verify_battery` Part 5 feeds adversarial floats (`1e16 ± 1e16`) so the
+  oracle witnesses non-associativity. Float *literals* stay opaque (`LitFloat` carries only a
+  hash) — only battery-fed params are concrete, which bounds the new interpretable surface.
+- **P2 (scan):** `possibly_float` = `proven_float` OR a **truly-untyped** (`None`-domain) param
+  in a dynamically-typed language, used by the grouping holds (`eval_assoc_comm_chain`,
+  `eval_sub_chain`, `ac_chain_canon`) and mirrored in `algebra`. A grouping-preserving rebuild
+  (`rebuild_grouped_float_chain`) keeps the source grouping while still sorting non-concat
+  operands, so **commutativity is preserved** (`a+b+1 ≡ b+a+1`) and only **associativity** is
+  held. `Number`-typed params are NOT held — the oracle feeds them `Int`, so it cannot witness
+  float there, and holding would split int/`number` clones (incl. cross-language) for no
+  soundness gain.
+
+**Recall: 0** on the full 105-repo pinned corpus (4309 → 4309) — the design's gate, measured
+on real code, not just type4. Verify clean on type4, coevo, and 15 dynamic-language repos.
+
+**Deferred (breadth, not a gap):** a full Int↔Float coercion lattice (mixed-type `==`, float
+literals once `LitFloat` retains a value, `Number`-param float witnessing). These widen what
+the oracle witnesses; none is a known false merge today.
 
 ---
 


### PR DESCRIPTION
Closes #342 — the last open case of the #283 C-float cluster. `(a+b)+c` vs `a+(b+c)` over params with **no float marker** (`float_assoc.py`) computed different floats (`(1e16 + -1e16) + 1 = 1` but `1e16 + (-1e16 + 1) = 0`) yet shared one `exact-value-graph` fingerprint (the i64 oracle treats `+` as associative).

Shipped as the full **`Value::Float` value kind**, both halves together — P1 alone isn't gate-safe (it turns the latent merge into a *witnessed* violation without fixing the scan).

## P1 — oracle (`interp.rs`)
- New `Value::Float(F64)`. `F64` is an f64 newtype whose behavior-comparison `Eq`/`Hash` canonicalizes the corners (all NaNs equal; `+0.0 == -0.0`), so `Value`'s derive is preserved. IEEE-754 arithmetic in a new `float_bin` (`Int` promotes to f64 under a float operand); `bin`'s integer arm extracted to `int_bin`.
- `verify_battery` Part 5 feeds untyped params adversarial floats (`1e16 ± 1e16`) so the soundness oracle **witnesses** `(a+b)+c ≠ a+(b+c)`. Float *literals* stay opaque (`LitFloat` holds only a hash), bounding the new interpretable surface to battery-fed params.

## P2 — scan (value graph + `algebra`)
- `possibly_float` = `proven_float` OR a **truly-untyped** (`None`-domain) param in a dynamically-typed language (`LanguageProfile::is_dynamically_typed`), used by the grouping holds and mirrored in the `algebra` pass (both layers, or the grouping is lost).
- **Associativity-only hold:** a new `rebuild_grouped_float_chain` preserves the source grouping while still sorting non-concat operands, so **commutativity is preserved** (`a+b+1 ≡ b+a+1`, same grouping). `: int`- and `Number`-typed params still fully reassociate — the oracle feeds `Number` an `Int`, so it can't witness float there, and holding would split int/`number` clones (incl. cross-language) for no soundness gain.

## Soundness & recall
- **Recall delta 0 on the full 105-repo pinned corpus** (4309 → 4309 families) — the design doc's exact gate, measured on real code (`bench/repos` reconstructed via `bench/setup_repos.sh`), not just type4.
- `verify --max-violations 0` **PASS** on type4, coevo, and 15 dynamic-language repos (requests/flask/scrapy/sympy/httpx/axios/marked/prettier/rxjs/zod/rack/sinatra/rubocop…). `Value::Float` + the float battery expose no new false merge beyond `float_assoc`, which the hold closes.
- Full workspace suite green; clippy / fmt (pinned 1.96.0) / docs-connectivity / formal-obligations / dup-gate all pass.

## Tests & docs
- New: `float_addition_is_non_associative_in_the_oracle`, `f64_eq_canonicalizes_nan_and_signed_zero`. Updated `algebra_associativity` / `float_typed_param_addition_is_held_unassociated` / `effectful_commutative_operands_do_not_reorder` (untyped now held; commutativity preserved; `: int` still reassociates).
- `oracle-value-model.md` §3.3/§5/§6, `value-float-kind-design.md` (SHIPPED outcome), `CHANGELOG.md`, `float_assoc.py` fixture comment.

## Remaining (breadth, not a gap)
A full Int↔Float coercion lattice (mixed-type `==`, float literals once `LitFloat` retains a value, `Number`-param float witnessing) — widens what the oracle witnesses; none is a known false merge today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)