### PR TITLE
Soundness #344: int32 oracle execution; full fixed-width canon measured-unneeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ break.
   vectors. A `NOSE_TIME`-gated `enrich` stage timing was added.
 
 ### Fixed
+- **Soundness oracle now witnesses int32 bitwise (#344).** A JS-family `a & b` / `a | b` /
+  `a ^ b` / `~a` coerces its operands to int32, so the interpreter (the `nose verify` oracle)
+  now evaluates them under int32 wrap (`0xF_0000_0003 & 0xF_0000_0005` is `1`, not the bigint
+  `0xF_0000_0001`) instead of arbitrary-precision i64. The scan fingerprint already split JS
+  bitwise from bigint via the `ToInt32` floor (#283-D); this makes the oracle agree with that
+  split rather than be blind to it, widening the verify gate's coverage. Scan unchanged (family
+  delta 0); a `verify_battery` row with high-bit-overlapping ints makes the wrap observable.
+  The deferred **full fixed-width canon** (reconverging JS `a&b` ≡ Java-`int` `a&b`) was
+  **measured unnecessary**: disabling the int32 narrowing changes 0 families on the full 105-repo
+  pinned corpus, so the floor is the correct stopping point. (oracle-value-model §3.2/§6.)
 - **False merge closed: fully-untyped float `+`/`*` associativity — the `Value::Float` kind (#342).**
   `(a+b)+c` and `a+(b+c)` over params with no float marker (`float_assoc.py`) computed different
   floats (`(1e16 + -1e16) + 1 = 1` but `1e16 + (-1e16 + 1) = 0`) yet shared one fingerprint, the

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -1849,6 +1849,18 @@ fn verify_battery(probes: &[nose_normalize::Value]) -> Vec<Vec<nose_normalize::V
     let f = |x: f64| Value::Float(nose_normalize::F64(x));
     battery.push(vec![f(1e16), f(-1e16), f(1.0), f(2.0)]);
     battery.push(vec![f(1.0), f(1e16), f(-1e16), f(2.0)]);
+    // Part 6: int32-WRAP rows (#344). The pool is all small ints (`int32(x) == x`), so a JS
+    // bitwise `a & b` is indistinguishable from an arbitrary-precision one. These rows carry
+    // values whose HIGH bits (≥ 2^32) overlap, so `a & b` differs between int32 (JS) and i64
+    // (Python/etc): `0xF_0000_0003 & 0xF_0000_0005` is `1` under int32 but `0xF_0000_0001` as
+    // bigint. With the oracle now executing JS bitwise as int32, this WITNESSES the split the
+    // `ToInt32` floor fingerprints (#283-D).
+    battery.push(vec![
+        Value::Int(0xF_0000_0003),
+        Value::Int(0xF_0000_0005),
+        Value::Int(0xA_0000_00FF),
+        Value::Int(7),
+    ]);
     battery
 }
 

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -22,8 +22,8 @@ use nose_il::{stable_symbol_hash, Builtin, Il, Interner, LoopKind, NodeId, NodeK
 use nose_semantics::{
     admitted_builtin_semantics_at_call, builtin_demand_profile,
     direct_function_call_target_at_call, exact_java_this_field, exact_java_this_var,
-    exact_self_field_write_assignment, hof_contract, BuiltinDemandProfile, DemandOperation,
-    EagerBuiltinContract, HofDemandProfile,
+    exact_self_field_write_assignment, hof_contract, semantics, BuiltinDemandProfile,
+    DemandOperation, EagerBuiltinContract, HofDemandProfile,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::hash::{Hash, Hasher};
@@ -792,7 +792,14 @@ impl<'a> Interp<'a> {
             NodeKind::UnOp => {
                 let kids = self.il.children(node).to_vec();
                 let a = self.eval(*kids.first().ok_or(Unsupported)?, env)?;
-                Ok(un(op_of(n.payload), &a))
+                let op = op_of(n.payload);
+                // int32 oracle execution (#344): JS-family `~x` is `~ToInt32(x)`, an int32.
+                let a = if matches!(op, Op::BitNot) && self.bitwise_result_is_int32() {
+                    to_int32(a)
+                } else {
+                    a
+                };
+                Ok(un(op, &a))
             }
             NodeKind::Index => self.eval_index(node, env),
             NodeKind::Seq => {
@@ -927,7 +934,24 @@ impl<'a> Interp<'a> {
             return Ok(Value::Err);
         }
         let b = self.eval(kids[1], env)?;
+        // int32 oracle execution (#344): a JS-family bitwise `& | ^` coerces both operands to
+        // int32, so the result is int32 — `(2**40 & 1)` is `0`, not the bigint `2**40 & 1`.
+        // This makes the oracle WITNESS the int32-vs-bigint difference the value graph's
+        // `ToInt32` narrowing fingerprints (it narrows exactly these ops' operands), instead of
+        // computing them as arbitrary-precision i64. Other languages' bitwise stays i64.
+        if matches!(op, Op::BitAnd | Op::BitOr | Op::BitXor) && self.bitwise_result_is_int32() {
+            return Ok(bin(op, &to_int32(a), &to_int32(b)));
+        }
         Ok(bin(op, &a, &b))
+    }
+
+    /// Whether this language's bitwise operators coerce their operands to int32 (the JS family).
+    /// Mirrors the value graph's `is_js_like_lang` gate on the `ToInt32` narrowing, so the
+    /// oracle's bitwise result matches the fingerprint's (#344, #283-D).
+    fn bitwise_result_is_int32(&self) -> bool {
+        semantics(self.il.meta.lang)
+            .modules()
+            .js_like_shadowed_module_bindings()
     }
 
     fn eval_index(&mut self, node: NodeId, env: &mut FxHashMap<u32, Value>) -> R<Value> {
@@ -1668,6 +1692,16 @@ fn range_values(args: &[Value]) -> R<Value> {
         cur = next;
     }
     Ok(Value::List(out))
+}
+
+/// Coerce an integer `Value` to int32 (`x & 0xFFFF_FFFF`, sign-extended), the operand coercion
+/// every JS-family bitwise operator applies (#344). Non-`Int` values pass through (a bitwise op
+/// on them already `Err`s / stays symbolic in `bin`).
+fn to_int32(v: Value) -> Value {
+    match v {
+        Value::Int(i) => Value::Int(i as i32 as i64),
+        other => other,
+    }
 }
 
 fn bin(op: Op, a: &Value, b: &Value) -> Value {
@@ -2412,6 +2446,49 @@ mod tests {
         assert_eq!(Value::Float(F64(f64::NAN)), Value::Float(F64(f64::NAN)));
         assert_eq!(Value::Float(F64(0.0)), Value::Float(F64(-0.0)));
         assert_ne!(Value::Float(F64(1.0)), Value::Float(F64(2.0)));
+    }
+
+    // #344: a JS-family `a & b` coerces operands to int32, so its result is int32 — the oracle
+    // computes `0xF_0000_0003 & 0xF_0000_0005` as `1` (the low-32-bit AND), not the bigint
+    // `0xF_0000_0001`. This is what lets `nose verify` witness the int32-vs-bigint split the
+    // value graph's `ToInt32` floor fingerprints. A non-JS language keeps the i64 result.
+    fn run_bitand(lang: Lang, a: i64, b: i64) -> Value {
+        let sp = Span::synthetic(FileId(0));
+        let mut bld = IlBuilder::new(FileId(0));
+        let pa = bld.add(NodeKind::Param, Payload::Cid(0), sp, &[]);
+        let pb = bld.add(NodeKind::Param, Payload::Cid(1), sp, &[]);
+        let va = bld.add(NodeKind::Var, Payload::Cid(0), sp, &[]);
+        let vb = bld.add(NodeKind::Var, Payload::Cid(1), sp, &[]);
+        let and = bld.add(NodeKind::BinOp, Payload::Op(Op::BitAnd), sp, &[va, vb]);
+        let ret = bld.add(NodeKind::Return, Payload::None, sp, &[and]);
+        let func = bld.add(NodeKind::Func, Payload::None, sp, &[pa, pb, ret]);
+        let il = bld.finish(
+            func,
+            FileMeta {
+                path: "t".into(),
+                lang,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        run_admitted_unit(il, func, &[Value::Int(a), Value::Int(b)])
+            .expect("run_unit")
+            .ret
+    }
+
+    #[test]
+    fn js_bitwise_and_wraps_to_int32_in_the_oracle() {
+        // JS truncates to int32; Python keeps arbitrary precision.
+        assert_eq!(
+            run_bitand(Lang::JavaScript, 0xF_0000_0003, 0xF_0000_0005),
+            Value::Int(1)
+        );
+        assert_eq!(
+            run_bitand(Lang::Python, 0xF_0000_0003, 0xF_0000_0005),
+            Value::Int(0xF_0000_0001)
+        );
+        // Small ints are identical either way (int32(x) == x).
+        assert_eq!(run_bitand(Lang::JavaScript, 6, 3), Value::Int(2));
     }
 
     fn run_foreach_with_iterable_err() -> Option<Value> {

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -19,8 +19,9 @@ finding that opened #283 is [experiments §CE](experiments.md).
 > extension. They decompose into three independent pieces of very different cost:
 > **C's detector-side string/mixed-coercion floor has shipped** (remaining work:
 > oracle input/model coverage and float non-associativity), **D-int32's
-> detector/value-graph floor has shipped** (remaining work: oracle int32 execution
-> plus any full fixed-width recall recovery), and **D-div's fingerprint floor has
+> detector/value-graph floor AND oracle int32 execution have shipped** (#344; the full
+> fixed-width recall recovery was measured unnecessary — 0 family delta on the corpus),
+> and **D-div's fingerprint floor has
 > shipped** while the full `Float` value kind remains deferred. The remaining work
 > is now oracle/model enrichment and priced recall recovery, not one shared
 > foundational rewrite.
@@ -107,7 +108,7 @@ numeric-only rewrites.
 - **Cheapest of the three.** The detector floor is in place; the remaining work
   is oracle coverage/modeling plus recall pricing on larger corpora.
 
-### D-int32 — JS bitwise width *(detector floor shipped; oracle width gap remains)*
+### D-int32 — JS bitwise width *(floor + oracle int32 execution shipped, #344)*
 
 JS bitwise ops coerce operands to int32 (`ToInt32`); Python/Ruby are
 arbitrary-precision. Historically the detector merged JS `a&b` with Python
@@ -180,12 +181,21 @@ first; promote to the full model only if the priced recall loss justifies it.
   distinct `ToInt32` narrowing wrapper, so it stops merging with
   arbitrary-precision bitwise. De Morgan and same-language bitwise recall remain
   green because the wrap lands on leaves rather than replacing the whole operator.
-- **Full model:** a first-class fixed-width bitwise semantics (int32 for JS,
-  type-width for C/Java/Go/Rust) that the whole bitwise canon understands — so
-  JS `a&b` ≡ Java-`int` `a&b` ≡ C-`int32_t` `a&b` reconverge correctly while
-  staying split from bigint and 64-bit. Largest of the three canon surfaces.
-- **Cost:** floor paid; remaining Medium-High for oracle int32 execution and full
-  fixed-width recall recovery.
+- **Oracle int32 execution (shipped, #344):** the interpreter now evaluates a JS-family
+  bitwise `& | ^` / `~` under int32 operand coercion (`to_int32`, gated on the same JS-like
+  predicate as the narrowing), so `nose verify` WITNESSES the int32-vs-bigint difference
+  (`0xF_0000_0003 & 0xF_0000_0005` is `1` under int32, `0xF_0000_0001` as bigint) instead of
+  being blind to it. A `verify_battery` row carries high-bit-overlapping ints so the wrap is
+  observable. Scan fingerprint unchanged (family delta 0); verify clean across type4/coevo and
+  the JS-heavy repos — the oracle agrees with the floor.
+- **Full fixed-width recall recovery — measured NOT needed (#344).** The would-be win is
+  reconverging JS `a&b` ≡ Java-`int` `a&b` ≡ C-`int32_t` `a&b`. But the §6 "promote only if the
+  loss is material" gate is answered: disabling the int32 narrowing changes **0 families on the
+  full 105-repo pinned corpus** (4309 → 4309) — cross-language bitwise clones are too rare to
+  matter — so the floor is the correct stopping point and the full per-type-width canon (the
+  largest canon surface, and risky for platform-dependent C int width) is not built.
+- **Cost:** floor + oracle int32 execution paid (0 recall, scan unchanged). Full fixed-width
+  recall recovery: measured unnecessary.
 
 ### 3.3 D-div — Float value kind
 
@@ -277,7 +287,7 @@ oracle-caught)":
 |---|---|---|
 | C — string/mixed-coercive `+` ordering | `untyped_add_commute.py` (`a+b` vs `b+a`) and JS/TS/Java-style `x+4` / `x+(2+3)` / `x-3` / `-(x+2)` | detector keeps them **split**; oracle witnesses pure string now only after battery enrichment, and mixed string/number after coercion modeling |
 | C — float `+` non-associativity | `float_assoc.py` (`(a+b)+c` vs `a+(b+c)`) | detector keeps them **split** AND oracle witnesses — CLOSED (#342, the `Value::Float` kind, §3.3); guarded by `float_addition_is_non_associative_in_the_oracle` + `algebra_associativity` + `float_typed_param_addition_is_held_unassociated` |
-| D-int32 — JS bitwise vs bigint | cross-language `a & b` (JS vs Python), e.g. the §2 reproducer | detector keeps **split**; oracle int32 execution remains follow-up |
+| D-int32 — JS bitwise vs bigint | cross-language `a & b` (JS vs Python), e.g. the §2 reproducer | detector keeps **split** AND oracle witnesses (int32 execution shipped, #344); guarded by `js_bitwise_and_wraps_to_int32_in_the_oracle`; full fixed-width recall recovery measured-unneeded |
 | D-div — true-float `/` | Python/JS `a/b` vs Ruby `a/b` vs C `a/b` | the three **do not merge**; real Float oracle remains follow-up |
 | in-place element mutation | `array_element_mutation.py` (`swap` vs `clobber`) | detector keeps them **split** AND oracle witnesses — CLOSED (#337, §7.3); guarded by `array_element_swap_does_not_merge_with_clobber` + `index_store_is_observed_by_later_read` |
 
@@ -301,10 +311,11 @@ coarse). Recommended sequence, cheapest-and-highest-confidence first:
    alone (the floor) is worth shipping immediately — it strengthens the oracle for
    *every* future finding and tells us how big the untyped-`+` problem actually
    is before we price the gate.
-2. **D-int32 — floor shipped; defer the full width model.** The distinct
-   narrowing fingerprint is in place. Next work is int32 oracle execution plus
-   measured JS↔C/Java-int recall recovery. Promote to the full fixed-width canon
-   only if that loss is material.
+2. **D-int32 — floor + oracle int32 execution shipped; full width model measured-unneeded
+   (#344).** The narrowing fingerprint splits JS bitwise from bigint, and the interpreter now
+   executes JS bitwise as int32 so the oracle witnesses it. The "promote the full fixed-width
+   canon only if the loss is material" gate is answered: the narrowing changes **0 families on
+   the full 105-repo corpus**, so the recall recovery is not built.
 3. **D-div (Float) — CLOSED.** The true/floored/truncated fingerprints are split, and float
    `+`/`*` non-associativity is held for syntactic-float, float-typed-param (#339/#340) AND
    fully-untyped (#342) chains. The full `Value::Float` model shipped: the interpreter models


### PR DESCRIPTION
The D-int32 floor (#283-D) already splits JS bitwise from arbitrary-precision bigint in the **scan fingerprint** (the `ToInt32` narrowing). This PR adds the remaining **oracle** half and resolves the deferred recall question with a measurement.

## Oracle int32 execution
- The interpreter (the `nose verify` oracle) now evaluates a JS-family `a & b` / `a | b` / `a ^ b` / `~a` under **int32 operand coercion** (`to_int32`, gated on the same JS-like predicate the value-graph narrowing uses), so it **witnesses** the int32-vs-bigint difference (`0xF_0000_0003 & 0xF_0000_0005` = `1` under int32, `0xF_0000_0001` as bigint) instead of computing it as arbitrary-precision i64. The oracle now *agrees* with the floor's split rather than treating it as a missed clone — widening the verify gate's coverage.
- `verify_battery` Part 6 carries high-bit-overlapping ints so the wrap is observable (the pool was all small ints, where `int32(x) == x`).
- **Scan fingerprint unchanged** — oracle-only (family delta 0: type4 20, crates 5). `verify --max-violations 0` clean on type4, coevo, and JS-heavy repos (axios/marked/prettier/rxjs/zod/esbuild/jest): the oracle's int32 result matches the narrowing, so no new violations.

## Full fixed-width recall recovery — measured NOT needed
The §6 gate is "promote the full fixed-width canon **only if the recall loss is material**." Disabling the int32 narrowing changes **0 families on the full 105-repo pinned corpus** (4309 → 4309) — cross-language bitwise clones are too rare to matter. So the floor is the correct stopping point; the full per-type-width canon (the largest canon surface, and risky for platform-dependent C int width) is **not built**. This closes the deferred half of #344 with data, not a guess.

## Tests & docs
- `js_bitwise_and_wraps_to_int32_in_the_oracle` (JS wraps to int32; Python keeps bigint; small ints identical).
- `oracle-value-model.md` §3.2/§5/§6 + BLUF, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)