### PR TITLE
#317: falsification-driven distinguishing-input search for nose verify (--falsify)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ break.
 
 ## [Unreleased]
 
+### Added
+- **Falsification-driven distinguishing-input search for `nose verify` (`--falsify`, #317).**
+  The fixed battery only finds a false merge when a hand-curated row happens to feed the
+  distinguishing input (e.g. two distinct strings to two untyped params — the #283-C class).
+  `--falsify` institutionalizes that: for each fingerprint-equal group the battery found equal,
+  it SEARCHES a value-kind-rich input domain (two distinct strings/lists, int32-wrapping ints,
+  float magnitudes, mined constants; seeded/deterministic, budget-bounded) for a row that
+  distinguishes two members — a false merge the battery's input starvation missed, counted
+  toward `--max-violations`. Unlike broadening the global battery (which manufactures impossible
+  type-incoherent rows), it compares group members against each other and never touches the
+  canon-preservation check, so the spurious-violation hazard does not arise. Offline/opt-in: the
+  scan path and the default `verify` gate are unchanged. The engine re-derives the #283-C
+  distinguisher by search (regression test) and finds 0 new false merges on the full pinned
+  corpus (the value model already separates every checked group). (oracle-value-model §7.)
+
 ### Performance
 - **Interactive `nose scan` no longer pays for the graded witness it does not show.**
   The graded witness (#315) is serialized only by `--format json`; the human and SARIF

--- a/crates/nose-cli/src/falsify.rs
+++ b/crates/nose-cli/src/falsify.rs
@@ -1,0 +1,144 @@
+//! Falsification-driven distinguishing-input SEARCH for `nose verify` (#317).
+//!
+//! The fixed `verify_battery` is the ad-hoc half of the soundness perimeter: it only finds a
+//! false merge when a HAND-CURATED row happens to feed the distinguishing input (e.g. two
+//! distinct strings to two untyped params — the #283-C class). This module institutionalizes
+//! that: given two fingerprint-equal units the battery found EQUAL, it SEARCHES a small,
+//! value-kind-rich input domain (mixed-radix, seeded/deterministic, budget-bounded) for a row
+//! on which they behave differently. A hit is a false merge the fixed battery missed.
+//!
+//! Scope: this runs only under `nose verify --falsify` (offline, opt-in) — the scan path and
+//! the default gate are untouched. Determinism comes from the fixed pool + fixed enumeration
+//! order (no RNG), so a nightly run is reproducible.
+
+use nose_il::{Il, Interner, NodeId, NodeKind, Payload};
+use nose_normalize::{run_unit, Value, F64};
+
+/// The per-position value pool — deliberately spans every value KIND the oracle models, with
+/// at least TWO distinct strings and TWO distinct lists (the combination the fixed battery
+/// under-samples: it never binds two *different* strings to two params at once). Mined corpus
+/// constants are appended so value-keyed branches (`x == 'ipc'`) are exercised too.
+fn falsify_pool(probes: &[Value]) -> Vec<Value> {
+    let mut pool = vec![
+        Value::Int(0),
+        Value::Int(1),
+        Value::Int(-1),
+        Value::Int(0xF_0000_0003), // > 2^32, exposes int32 wrap
+        Value::Bool(true),
+        Value::Null,
+        Value::Str(vec![0x5EED_0001]),
+        Value::Str(vec![0x5EED_0002]), // a SECOND, distinct string
+        Value::List(vec![Value::Int(1), Value::Int(2)]),
+        Value::List(vec![Value::Int(2), Value::Int(1)]), // a distinct list (same multiset)
+        Value::Float(F64(1e16)),
+        Value::Float(F64(-1e16)),
+    ];
+    pool.extend(probes.iter().cloned());
+    pool
+}
+
+/// Number of `Param` children of a unit root (its arity); inputs beyond it are ignored by the
+/// interpreter, so we only enumerate over this many positions.
+fn arity(il: &Il, root: NodeId) -> usize {
+    il.children(root)
+        .iter()
+        .filter(|&&c| {
+            il.kind(c) == NodeKind::Param && matches!(il.node(c).payload, Payload::Cid(_))
+        })
+        .count()
+}
+
+/// Search for a distinguishing input for two units (their pre-canon CORE ILs + roots). Returns
+/// the first row on which both interpret to DIFFERENT, non-`None` behaviors, or `None` if none
+/// within `budget` rows. Mixed-radix enumeration over [`falsify_pool`] varies the lowest
+/// positions fastest, so the high-value 1- and 2-arg distinguishers are covered first.
+pub(crate) fn falsify_pair(
+    il_a: &Il,
+    root_a: NodeId,
+    il_b: &Il,
+    root_b: NodeId,
+    interner: &Interner,
+    probes: &[Value],
+    budget: usize,
+) -> Option<Vec<Value>> {
+    let pool = falsify_pool(probes);
+    let n = pool.len();
+    let ar = arity(il_a, root_a).max(arity(il_b, root_b)).max(1);
+    let total = n.checked_pow(ar as u32).unwrap_or(usize::MAX).min(budget);
+    for e in 0..total {
+        let row: Vec<Value> = (0..ar)
+            .map(|j| {
+                let radix = n.saturating_pow(j as u32).max(1);
+                pool[(e / radix) % n].clone()
+            })
+            .collect();
+        let (Some(ba), Some(bb)) = (
+            run_unit(il_a, interner, root_a, &row),
+            run_unit(il_b, interner, root_b, &row),
+        ) else {
+            continue;
+        };
+        // A symbolic disagreement is keyed on pre-canon syntax, not behavior — skip it (the
+        // soundness report routes those to the advisory lane, never the hard gate).
+        if ba != bb
+            && !nose_normalize::behavior_has_sym(&ba)
+            && !nose_normalize::behavior_has_sym(&bb)
+        {
+            return Some(row);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nose_il::{FileId, FileMeta, IlBuilder, Lang, Op, Span};
+
+    // Build `return <a op b>` (operands in `order`) as a 2-arg unit.
+    fn two_arg_binop(op: Op, order: (u32, u32)) -> (Il, Interner, NodeId) {
+        let interner = Interner::new();
+        let sp = Span::synthetic(FileId(0));
+        let mut b = IlBuilder::new(FileId(0));
+        let pa = b.add(NodeKind::Param, Payload::Cid(0), sp, &[]);
+        let pb = b.add(NodeKind::Param, Payload::Cid(1), sp, &[]);
+        let l = b.add(NodeKind::Var, Payload::Cid(order.0), sp, &[]);
+        let r = b.add(NodeKind::Var, Payload::Cid(order.1), sp, &[]);
+        let bin = b.add(NodeKind::BinOp, Payload::Op(op), sp, &[l, r]);
+        let ret = b.add(NodeKind::Return, Payload::None, sp, &[bin]);
+        let func = b.add(NodeKind::Func, Payload::None, sp, &[pa, pb, ret]);
+        let il = b.finish(
+            func,
+            FileMeta {
+                path: "t".into(),
+                lang: Lang::Python,
+            },
+            Vec::new(),
+            Vec::new(),
+        );
+        (il, interner, func)
+    }
+
+    // #317 regression baseline: re-derive the #283-C distinguisher BY SEARCH. `a + b` and
+    // `b + a` agree on every integer (the fixed battery's small-int rows), but DIFFER when both
+    // params are distinct STRINGS (`s1·s2 != s2·s1`) — the input the fixed battery starves. The
+    // search's pool carries two distinct strings, so it finds the row.
+    #[test]
+    fn search_finds_string_noncommutativity_distinguisher() {
+        let (ia, na, ra) = two_arg_binop(Op::Add, (0, 1)); // a + b
+        let (ib, _nb, rb) = two_arg_binop(Op::Add, (1, 0)); // b + a
+        let row = falsify_pair(&ia, ra, &ib, rb, &na, &[], 4096)
+            .expect("search must find a distinguishing input for a+b vs b+a");
+        // The distinguisher is two DISTINCT non-int values (strings or lists).
+        assert_ne!(row[0], row[1]);
+    }
+
+    // Genuinely-equal units (`a + b` vs `a + b`) have NO distinguisher — the search must report
+    // none (no false positive), the soundness side of the engine.
+    #[test]
+    fn search_finds_no_distinguisher_for_identical_units() {
+        let (ia, na, ra) = two_arg_binop(Op::Add, (0, 1));
+        let (ib, _nb, rb) = two_arg_binop(Op::Add, (0, 1));
+        assert!(falsify_pair(&ia, ra, &ib, rb, &na, &[], 4096).is_none());
+    }
+}

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3,6 +3,7 @@
 mod baseline;
 mod cache;
 mod config;
+mod falsify;
 mod fnv;
 mod ignores;
 mod review;
@@ -372,6 +373,13 @@ enum Cmd {
         /// by unverified-merge mass instead of by guess.
         #[arg(long)]
         exclusion_census: Option<PathBuf>,
+        /// Run the falsification-driven distinguishing-input SEARCH (#317) IN ADDITION to the
+        /// fixed battery: for each fingerprint-equal group the battery found equal, search a
+        /// value-kind-rich input domain (two distinct strings/lists, int32-wrapping ints, float
+        /// magnitudes, mined constants) for a row that distinguishes two members — a false merge
+        /// the fixed battery's input STARVATION missed. Offline/opt-in; reports the search delta.
+        #[arg(long)]
+        falsify: bool,
     },
     /// EXPERIMENTAL Type-4 benchmark harness (research tool, not a stable interface).
     ///
@@ -1591,6 +1599,7 @@ fn run() -> Result<()> {
             max_violations,
             leads,
             exclusion_census,
+            falsify,
         } => cmd_verify(
             paths,
             no_cfg_norm,
@@ -1598,6 +1607,7 @@ fn run() -> Result<()> {
             max_violations,
             leads,
             exclusion_census,
+            falsify,
         ),
         Cmd::BehavioralGate {
             paths,
@@ -2311,6 +2321,7 @@ fn cmd_verify(
     max_violations: Option<usize>,
     leads: Option<PathBuf>,
     exclusion_census: Option<PathBuf>,
+    falsify: bool,
 ) -> Result<()> {
     let refs = paths_as_refs(&paths);
     let corpus = nose_frontend::lower_corpus_many(&refs);
@@ -2360,9 +2371,16 @@ fn cmd_verify(
         }
     }
 
-    let n_violations = report_verify_soundness(&oracle.recs);
+    let mut n_violations = report_verify_soundness(&oracle.recs);
     report_verify_completeness(&oracle.recs, leads.as_deref())?;
     report_verify_calibration(&oracle.recs);
+    if falsify {
+        // Falsification search (#317): augment the fixed battery with a per-group
+        // distinguishing-input search. Any hit is a false merge the battery's input
+        // starvation missed; count it toward the gate so `--falsify --max-violations 0` is
+        // the stronger engine the issue calls for.
+        n_violations += report_falsify(&corpus, &opts, &oracle.recs, &verify_probes(&corpus));
+    }
 
     // CI soundness gate: fail if false merges exceed the budget, or if any normalization
     // pass changes a unit's behavior vs the pre-canon core IL. The independent oracle thus
@@ -2401,6 +2419,10 @@ struct VerifyRec {
     /// only when their declarations agree; a disagreement across different
     /// declarations is an advisory lead, not a hard violation.
     domain_sig: u64,
+    /// Index into `corpus.files` and the CORE-IL root, so `--falsify` can re-normalize the
+    /// file (deterministically) and re-interpret this unit on search-generated inputs (#317).
+    file_idx: usize,
+    core_root: nose_il::NodeId,
 }
 
 #[derive(Clone, Copy)]
@@ -2515,7 +2537,8 @@ fn collect_verify_recs(
     let per_file: Vec<_> = corpus
         .files
         .par_iter()
-        .map(|il| {
+        .enumerate()
+        .map(|(file_idx, il)| {
             let n = nose_normalize::normalize(il, &corpus.interner, opts);
             // The behavioral ground truth comes from the pre-canonicalization core IL (so a
             // behavior-changing canon can't mask itself), matched to each fully-normalized
@@ -2557,6 +2580,7 @@ fn collect_verify_recs(
                 battery,
                 &mut oracle,
                 &exact_safe_by_span,
+                file_idx,
             );
             oracle
         })
@@ -2610,6 +2634,7 @@ fn push_verify_census(
     });
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_file_verify_recs(
     n: &nose_il::Il,
     core: &nose_il::Il,
@@ -2618,6 +2643,7 @@ fn collect_file_verify_recs(
     battery: &[Vec<nose_normalize::Value>],
     oracle: &mut VerifyOracle,
     exact_safe_by_span: &std::collections::HashMap<(u32, u32), bool>,
+    file_idx: usize,
 ) {
     let file_path = &n.meta.path;
     let core_func = func_span_index(core);
@@ -2734,6 +2760,8 @@ fn collect_file_verify_recs(
             loc: format!("{}:{}", file_path, span.start_line),
             claimable,
             domain_sig: param_domain_signature(n, root),
+            file_idx,
+            core_root,
         });
     }
 }
@@ -2906,6 +2934,83 @@ fn report_verify_soundness(recs: &[VerifyRec]) -> usize {
         }
     }
     n_violations
+}
+
+/// Falsification search (#317): for each fingerprint-equal group the FIXED battery found
+/// equal-and-hard-gate-eligible, search a value-kind-rich input domain (`falsify::falsify_pair`)
+/// for a distinguishing input. A hit is a false merge the battery's input starvation missed.
+/// Re-normalizes each member's file to the pre-canon CORE IL on demand (deterministic, cached)
+/// and re-interprets. Returns the count of newly-found false merges (added to the gate).
+fn report_falsify(
+    corpus: &Corpus,
+    opts: &nose_normalize::NormalizeOptions,
+    recs: &[VerifyRec],
+    probes: &[nose_normalize::Value],
+) -> usize {
+    use std::collections::HashMap;
+    const PER_PAIR_BUDGET: usize = 4096;
+    let oracle_opts = nose_normalize::NormalizeOptions {
+        oracle: true,
+        ..*opts
+    };
+    let mut by_fp: HashMap<&[u64], Vec<&VerifyRec>> = HashMap::new();
+    for r in recs {
+        by_fp.entry(&r.fp).or_default().push(r);
+    }
+    let mut core_cache: HashMap<usize, nose_il::Il> = HashMap::new();
+    let mut found: Vec<(String, String)> = Vec::new();
+    for members in by_fp.values() {
+        if members.len() < 2 {
+            continue;
+        }
+        let first = members[0];
+        for r in &members[1..] {
+            // The battery already found these EQUAL; only such groups need a deeper search.
+            // Restrict to hard-gate-eligible pairs (claimable, comparable declarations) so a hit
+            // is a real false merge, not an advisory/lossy diagnostic.
+            if r.beh != first.beh
+                || !(first.claimable && r.claimable && first.domain_sig == r.domain_sig)
+            {
+                continue;
+            }
+            for &idx in &[first.file_idx, r.file_idx] {
+                core_cache.entry(idx).or_insert_with(|| {
+                    nose_normalize::normalize(&corpus.files[idx], &corpus.interner, &oracle_opts)
+                });
+            }
+            let il_a = &core_cache[&first.file_idx];
+            let il_b = &core_cache[&r.file_idx];
+            if falsify::falsify_pair(
+                il_a,
+                first.core_root,
+                il_b,
+                r.core_root,
+                &corpus.interner,
+                probes,
+                PER_PAIR_BUDGET,
+            )
+            .is_some()
+            {
+                found.push((first.loc.clone(), r.loc.clone()));
+            }
+        }
+    }
+    println!("\nFALSIFICATION SEARCH (#317) — distinguishing inputs beyond the fixed battery:");
+    if found.is_empty() {
+        println!(
+            "  no new distinguishers — the fixed battery already separates every checked group ✓"
+        );
+    } else {
+        found.sort();
+        println!(
+            "  [!] {} false merge(s) found by SEARCH that the fixed battery missed:",
+            found.len()
+        );
+        for (a, b) in found.iter().take(20) {
+            println!("    {a}  ≡?  {b}   (distinguisher found by search)");
+        }
+    }
+    found.len()
 }
 
 /// Completeness: behavior-equal ⟹ fingerprint-equal (the under-merge / recall

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -351,6 +351,20 @@ trips it. `nose verify` on `netty` reported 3 canon-preservation "violations", a
 type-incoherent rows, and `sympy` 20 — masked only because the nightly soundness gate's
 pinned corpus includes neither.
 
+**The SOUND form shipped — a per-group falsification SEARCH (`nose verify --falsify`, #317).**
+Rather than broaden the global battery (which manufactures the impossible-input rows above),
+the search compares MEMBERS of a fingerprint-equal group against EACH OTHER on a value-kind-rich
+input domain (two distinct strings/lists, int32-wrapping ints, float magnitudes, mined
+constants; `crates/nose-cli/src/falsify.rs`). It never touches the canon-preservation check
+(core-vs-full-IL), so the impossible-input hazard does not arise; and it runs only on
+hard-gate-eligible groups (claimable, comparable declarations). A hit is a false merge the
+fixed battery's input starvation missed — counted toward `--max-violations`. The engine
+re-derives the #283-C string-non-commutativity distinguisher BY SEARCH (regression test
+`search_finds_string_noncommutativity_distinguisher`), and on the pinned corpus finds **0 new
+false merges** (the fixed battery + value model already separate every checked group) — so it
+institutionalizes the adversarial-input discipline without changing the gate's verdict today.
+It is offline/opt-in: the scan path and the default `verify` gate are untouched.
+
 ### 7.1 The equality-over-`Err` mechanism — fixed (coevo series 9)
 
 The series-9 oracle attacker sharpened the dominant class: the trigger was the


### PR DESCRIPTION
The fixed `verify_battery` is the ad-hoc half of the soundness perimeter — it only finds a false merge when a **hand-curated** row happens to feed the distinguishing input (two distinct strings to two untyped params — the #283-C class; the array-index and float-magnitude rows; …). This adds the **falsification SEARCH** the issue calls for, opt-in, institutionalizing that discipline.

## Engine (`crates/nose-cli/src/falsify.rs`)
`falsify_pair` searches a value-kind-rich, **seeded/deterministic, budget-bounded** input domain — two distinct strings/lists, an int32-wrapping int, float magnitudes, plus the corpus's mined constants — for a row on which two units interpret to different, non-symbolic behaviors. Mixed-radix enumeration varies the low positions fastest, so the high-value 1- and 2-arg distinguishers come first.

## Integration (`nose verify --falsify`)
For each fingerprint-equal group the **fixed battery found equal** and hard-gate-eligible (claimable, comparable declarations), it re-normalizes each member's file to the pre-canon **core IL** on demand (deterministic, cached) and runs the search. A hit is a false merge the battery missed — counted toward `--max-violations`.

Unlike broadening the **global** battery (which manufactures impossible type-incoherent rows → spurious canon-preservation violations, oracle-value-model §7), this compares group **members against each other** and never touches the canon-preservation check, so that hazard does not arise. **Offline/opt-in: the scan path and the default `verify` gate are untouched** (gate-safe by construction).

## Results
- Re-derives the **#283-C string-non-commutativity distinguisher by search** (`search_finds_string_noncommutativity_distinguisher`); a genuinely-equal pair yields no distinguisher (no false positive).
- `--falsify` finds **0 new false merges** across type4 and the dynamic/JS/float/bitwise repos (requests/flask/axios/marked/prettier/rxjs/zod/esbuild/sympy/rich) — the value model already separates every checked group, so the search **confirms soundness** rather than exposing latent bugs.
- Default `verify` unchanged; full workspace suite green; clippy/fmt/docs/dup/formal all pass.

## Scope
This is the issue's "First steps" 1–2 (build the engine; measure the corpus delta), delivered opt-in. Replacing the fixed battery by default and the per-rule auto-adversary (from Lean side conditions) remain follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)