### PR TITLE
docs: reconcile doc↔code inconsistencies after the #283-cluster / #317 / #343 closes

### DIFF
--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -2613,8 +2613,8 @@ fn float_subtraction_is_not_reassociated_while_integer_subtraction_is() {
     // reassociation is float-unsound — `(1e100 + x) - 1e100` (= 0.0, the large term swallows
     // x) must not converge with the regrouped `(1e100 - 1e100) + x` (= x). Integer `-` still
     // normalizes and converges (two's-complement subtraction is associative). Pure `+`/`*`
-    // float associativity is also held now (next test); the fully-untyped `(a+b)+c` with no
-    // float marker still flattens — that is the remaining full Float value kind (§3.3).
+    // float associativity is also held now (next test), including the fully-untyped `(a+b)+c`
+    // case via the `Value::Float` kind (#342).
     let i = Interner::new();
     let t = |src: &str| value_fp(&i, src, Lang::Python);
     // Float literal: the two groupings compute different floats and must NOT merge.
@@ -2679,9 +2679,9 @@ fn float_typed_param_addition_is_held_unassociated() {
     // from the param's type evidence (`proven_float` via the param domain), not a literal. The
     // grouping is held in BOTH layers: the algebra IL pass (`chain_has_float` over
     // `float_param_cids` → don't reassociate) and the value graph (`proven_float` → don't
-    // flatten, in the general AND the string-coercion `+` path for Java/TS). Untyped/int-typed
-    // chains keep flattening (sound: integer `+` IS associative; the fully-untyped float case
-    // is the remaining Value::Float kind, §3.3).
+    // flatten, in the general AND the string-coercion `+` path for Java/TS). INT-typed chains
+    // keep flattening (sound: integer `+` IS associative); fully-untyped chains are now ALSO
+    // held — an untyped param could be float — via the `Value::Float` kind (#342).
     let i = Interner::new();
 
     // Python `: float`

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -745,9 +745,10 @@ pub enum Op {
     /// `/` (`7 / 2 == 3.5`). DISTINCT from [`Op::Div`] (C/Go/Java/Rust truncated-int,
     /// `7 / 2 == 3`) and [`Op::FloorDiv`] (Ruby `/` and Python `//`, floored-int) —
     /// the three disagree (`7/2` is `3.5`, `3`, `3`; `-7/2` is `-3.5`, `-3`, `-4`), so
-    /// one `Op::Div` for all of them is a false merge (#283-D). The i64 interpreter
-    /// cannot represent the float result, so it stays blind here (consistent within
-    /// the op — no cross-language merge); modeling it needs the `Float` value kind.
+    /// one `Op::Div` for all of them is a false merge (#283-D). `Value::Float` now models float
+    /// arithmetic (#342), but an Int÷Int `TrueDiv` is not promoted to it in the interpreter — it
+    /// stays i64-truncated (consistent within the op, no cross-language merge); the Int→Float
+    /// division promotion is the remaining Int↔Float breadth.
     TrueDiv,
 }
 

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -1784,11 +1784,11 @@ fn int_bin(op: Op, x: i64, y: i64) -> Value {
                 Int(x.wrapping_div(*y))
             }
         }
-        // True (float) division. The i64 model cannot represent `3.5`, so it is
-        // modeled like truncated `Div` here — BLIND to the float result but CONSISTENT
-        // within `TrueDiv`, which only ever compares with itself (a distinct op from
-        // `Div`/`FloorDiv`), so no false merge. An honest float result needs the `Float`
-        // value kind (#283-D, deferred). Div-by-zero still Errs.
+        // True (float) division. `Value::Float` models float arithmetic now (#342), but an
+        // Int÷Int `TrueDiv` is NOT promoted to it here — it stays truncated `Div` (BLIND to the
+        // float result but CONSISTENT within `TrueDiv`, a distinct op that only compares with
+        // itself, so no false merge). Promoting Int÷Int to a float result is the remaining
+        // Int↔Float breadth (oracle-value-model §3.2). Div-by-zero still Errs.
         Op::TrueDiv => {
             if *y == 0 {
                 Value::Err

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -440,13 +440,13 @@ impl<'a> Builder<'a> {
         if let Some(v) = self.c_u32_be_byte_pack_pattern(&operands) {
             return v;
         }
-        // Float `+`/`*` is NON-ASSOCIATIVE (`(a+b)+c != a+(b+c)`, #283 C-float). When the
-        // chain bears a proven-float operand, do NOT flatten/reassociate it — rebuild the
-        // SOURCE grouping from the original operands so the two groupings fingerprint
-        // distinctly (`ac_chain_canon` is gated to not re-flatten a float chain either). The
-        // 2-operand commute (`order_bin_operands`) still applies — float `+`/`*` IS
-        // commutative. Untyped chains stay optimistically reassociated (the i64 oracle is
-        // blind; closing that is the Float value kind, oracle-value-model §3.3).
+        // Float `+`/`*` is NON-ASSOCIATIVE (`(a+b)+c != a+(b+c)`, #283 C-float). When the chain
+        // bears a POSSIBLY-float operand — proven float, OR (in a dynamically-typed language) a
+        // truly-untyped param that could be float at runtime (#342) — do NOT flatten/reassociate
+        // it; rebuild the SOURCE grouping so the two groupings fingerprint distinctly
+        // (`ac_chain_canon` is gated to not re-flatten such a chain either). Commutativity is
+        // preserved (the rebuild below sorts non-concat operands), and `: int`-typed chains stay
+        // associative — only their float-possible siblings are held.
         if (op == Op::Add as u32 || op == Op::Mul as u32)
             && operands.iter().any(|&v| self.possibly_float(v))
         {

--- a/docs/design.md
+++ b/docs/design.md
@@ -259,11 +259,11 @@ defender bounded to the largest **sound** generalization — is the
 packet ledger is also the measuring instrument for §4's e-graph revisit conditions.
 
 A worked instance of "strengthen the oracle as part of the loop" is
-[oracle-value-model](oracle-value-model.md): the go/no-go scoping for the
-remaining #283 false-merge sub-findings, which separates an input-battery gap
-(C), a canonicalization-width problem (D-int32), and the single genuine `Float`
-value-kind gap (D-div) — each with a sound fail-closed floor and a recall-pricing
-protocol, rather than one monolithic "extend the value model" bet.
+[oracle-value-model](oracle-value-model.md): it scoped the #283 false-merge cluster
+into an input-battery gap (C), a canonicalization-width problem (D-int32), and the
+single genuine `Float` value-kind gap (D-div), each with a sound fail-closed floor and
+a recall-pricing protocol — rather than one monolithic "extend the value model" bet.
+All three are now closed (each priced at ~0 recall on the pinned corpus).
 
 ## 5. Decisive measurements (run before betting heavily)
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -63,8 +63,8 @@ fundamentals; the rest is grouped by area.
 - [graded-witness](graded-witness.md) — the anti-unification grade for near families: "equal except *k* holes", each hole a candidate parameter, with the soundness-relevant referent check.
 - [fragment-contracts](fragment-contracts.md) — how exact sub-function fragments are modeled: classification, contract, the wrapper-synthesis behavior oracle, the effect algebra, and fail-closed receiver identity.
 - [reinvented-helpers](reinvented-helpers.md) — the containment channel: code that reimplements an existing pure helper inline, and the surface policy promoting non-test findings to the default report.
-- [oracle-value-model](oracle-value-model.md) — the verify oracle's value model (Int/Bool/Str-monoid/List/Sym), what it can and cannot witness, and the go/no-go plan to close #283's remaining false-merge sub-findings (C battery gap, D-int32 width, D-div float).
-- [value-float-kind-design](value-float-kind-design.md) — design & go/no-go for the last C-float gap (#342): the IEEE-754 `Value::Float` kind for fully-untyped float associativity, with the recall measurement that flips it from NO-GO to GO-phased.
+- [oracle-value-model](oracle-value-model.md) — the verify oracle's value model (Int/Bool/Str-monoid/List/Float/Sym), what it witnesses, and the outcomes that closed the #283 false-merge cluster (C string/`+`-non-assoc, D-int32 width, D-div float) plus the `--falsify` search.
+- [value-float-kind-design](value-float-kind-design.md) — the IEEE-754 `Value::Float` kind (#342, SHIPPED): how fully-untyped float associativity was closed in both the oracle and the scan, with the full-corpus recall measurement (delta 0).
 - [formal-soundness](formal-soundness.md) — Lean 4 proof-obligation registry for proof-sensitive IL, normalization, fragment, and oracle contracts.
 
 ### Semantic kernel & packs

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -1,11 +1,11 @@
 # The verify oracle's value model — scope, gaps, and the extension plan
 
-Design / go-no-go document for closing the three remaining sub-findings of the
-P0 false-merge cluster ([#283](https://github.com/corca-ai/nose/issues/283) C,
-D-div, D-int32). It scopes *what the oracle's value model is today*, *what each
-finding actually needs* (which is **not** one shared "extend i64" prerequisite),
-the **minimum** change per finding, the **recall-pricing protocol**, the
-**regression targets**, and a **go/no-go** recommendation.
+Design / outcome document for the three sub-findings of the P0 false-merge cluster
+([#283](https://github.com/corca-ai/nose/issues/283) C, D-div, D-int32) — **all now
+closed**. It scopes *what the oracle's value model is today*, *what each finding
+needed* (which was **not** one shared "extend i64" prerequisite), the change made per
+finding, the **recall-pricing protocol** (each priced at ~0 on the full pinned corpus),
+and the **regression targets** that now guard them.
 
 Companion to [design §1 (the sound core is the moat)](design.md),
 [formal-soundness](formal-soundness.md), [normalization](normalization.md), the
@@ -13,18 +13,21 @@ Companion to [design §1 (the sound core is the moat)](design.md),
 [adversarial co-evolution runbook](adversarial-coevolution.md). The series-5
 finding that opened #283 is [experiments §CE](experiments.md).
 
-> **Bottom line up front.** The oracle's value model is richer than #283's prose
-> implies — it already models strings as an order-sensitive free monoid. The
-> three findings do **not** share a single "i64 → {int, float, string}"
-> extension. They decompose into three independent pieces of very different cost:
-> **C's detector-side string/mixed-coercion floor has shipped** (remaining work:
-> oracle input/model coverage and float non-associativity), **D-int32's
-> detector/value-graph floor AND oracle int32 execution have shipped** (#344; the full
-> fixed-width recall recovery was measured unnecessary — 0 family delta on the corpus),
-> and **D-div's fingerprint floor has
-> shipped** while the full `Float` value kind remains deferred. The remaining work
-> is now oracle/model enrichment and priced recall recovery, not one shared
-> foundational rewrite.
+> **Bottom line up front — the #283 cluster is CLOSED.** The oracle's value model is richer
+> than #283's prose implied — it already models strings as an order-sensitive free monoid — and
+> the three findings did **not** share a single "i64 → {int, float, string}" extension; they
+> were three independent pieces, each now closed:
+> - **C (string/mixed-coercion + `+` non-associativity):** the detector-side string/coercion
+>   floor, plus float `+`/`*` non-associativity for syntactic-float (#339), float-typed-param
+>   (#340) and fully-untyped (#342) chains; the falsification search (#317) institutionalizes
+>   the adversarial input coverage the fixed battery used to hand-curate.
+> - **D-int32:** the value-graph `ToInt32` floor plus oracle int32 execution (#344); the full
+>   fixed-width recall recovery was measured unnecessary (0 family delta on the corpus).
+> - **D-div (Float):** the true/floored/truncated `/` floor plus the full IEEE-754 `Value::Float`
+>   value kind (#342).
+>
+> Each was priced at ~0 recall on the full 105-repo pinned corpus. The remaining float work is
+> breadth (a full Int↔Float coercion lattice, float literals), not a soundness gap.
 
 ---
 
@@ -288,7 +291,7 @@ oracle-caught)":
 | C — string/mixed-coercive `+` ordering | `untyped_add_commute.py` (`a+b` vs `b+a`) and JS/TS/Java-style `x+4` / `x+(2+3)` / `x-3` / `-(x+2)` | detector keeps them **split**; oracle witnesses pure string now only after battery enrichment, and mixed string/number after coercion modeling |
 | C — float `+` non-associativity | `float_assoc.py` (`(a+b)+c` vs `a+(b+c)`) | detector keeps them **split** AND oracle witnesses — CLOSED (#342, the `Value::Float` kind, §3.3); guarded by `float_addition_is_non_associative_in_the_oracle` + `algebra_associativity` + `float_typed_param_addition_is_held_unassociated` |
 | D-int32 — JS bitwise vs bigint | cross-language `a & b` (JS vs Python), e.g. the §2 reproducer | detector keeps **split** AND oracle witnesses (int32 execution shipped, #344); guarded by `js_bitwise_and_wraps_to_int32_in_the_oracle`; full fixed-width recall recovery measured-unneeded |
-| D-div — true-float `/` | Python/JS `a/b` vs Ruby `a/b` vs C `a/b` | the three **do not merge**; real Float oracle remains follow-up |
+| D-div — true-float `/` | Python/JS `a/b` vs Ruby `a/b` vs C `a/b` | the three **do not merge**; the real IEEE-754 `Value::Float` oracle shipped (#342) |
 | in-place element mutation | `array_element_mutation.py` (`swap` vs `clobber`) | detector keeps them **split** AND oracle witnesses — CLOSED (#337, §7.3); guarded by `array_element_swap_does_not_merge_with_clobber` + `index_store_is_observed_by_later_read` |
 
 New permanent regression tests follow the pattern of
@@ -299,18 +302,18 @@ still merges.
 
 ---
 
-## 6. Go / no-go recommendation
+## 6. Outcomes — all three closed
 
-The findings are **decoupled** — there is no forced ordering and no shared
-foundational blocker (the original "extend the value model" framing was too
-coarse). Recommended sequence, cheapest-and-highest-confidence first:
+The findings were **decoupled** — no forced ordering, no shared foundational blocker (the
+original "extend the value model" framing was too coarse). Each was closed independently:
 
-1. **C (battery + `+`-gate) — GO first.** The value model already supports it;
-   the only new code is battery rows plus a `proven_numeric`-style gate we have a
-   proven template for. Highest soundness-per-effort. The battery enrichment
-   alone (the floor) is worth shipping immediately — it strengthens the oracle for
-   *every* future finding and tells us how big the untyped-`+` problem actually
-   is before we price the gate.
+1. **C (string/coercion + `+`-non-associativity) — CLOSED.** The detector-side
+   string/mixed-coercion floor shipped, then float `+`/`*` non-associativity was held for
+   syntactic-float (#339), float-typed-param (#340) and fully-untyped (#342) chains via a
+   `proven_float`/`possibly_float` gate in both the `algebra` pass and the value graph.
+   Commutativity is preserved; recall delta 0 on the full corpus. The falsification search
+   (`--falsify`, #317) institutionalizes the adversarial input coverage the fixed battery used
+   to hand-curate, and finds 0 new false merges on the corpus.
 2. **D-int32 — floor + oracle int32 execution shipped; full width model measured-unneeded
    (#344).** The narrowing fingerprint splits JS bitwise from bigint, and the interpreter now
    executes JS bitwise as int32 so the oracle witnesses it. The "promote the full fixed-width


### PR DESCRIPTION
The #283 false-merge cluster (C, D-int32, D-div) and the #337 work are all closed now, but several docs + code comments still framed them as open/deferred. This reconciles them — **docs + comments only, no behavior change**.

## Docs
- **oracle-value-model**: intro, BLUF, §5 regression table (D-div row), and §6 (now "Outcomes — all three closed") rewritten. C = string/coercion floor + `+`-non-assoc (#339/#340/#342) + `--falsify` (#317); D-int32 = floor + oracle int32 execution (#344), full-width recovery measured-unneeded; D-div = the IEEE-754 `Value::Float` kind (#342). Each ~0 recall on the pinned corpus.
- **home.md**: the oracle-value-model + value-float-kind-design entries now say SHIPPED (not "NO-GO → GO-phased").
- **design.md**: the §4b oracle-loop worked instance reads "all three closed".

## Code comments
- `interp.rs` / `node.rs` `TrueDiv`: the `Value::Float` kind shipped (#342); only the **Int÷Int division→float promotion** is the remaining Int↔Float breadth.
- `value_graph/eval.rs` float-hold: `possibly_float` = proven-float **OR** a truly-untyped param in a dynamically-typed language; untyped chains are **held** now, not "optimistically reassociated".
- two `equivalence.rs` test comments: the fully-untyped case is **held** (#342), not "still flattens".

`awiki lint` clean (orphan_rate 0); full suite / clippy / fmt / dup-gate / formal-obligations all green. No renamed-symbol references leak into docs (verified by grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)