### PR TITLE
Release v0.8.0: cut the changelog, bump workspace version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ break.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-14
+
 ### Added
 - **Lean obligation for indexed-element read-forwarding (`normalize.value_graph.index_writes`,
   #343).** The #337 read-forwarding now carries a machine-checked proof (analogous to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nose-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "nose-detect"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "nose-frontend",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "nose-eval"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "rustc-hash",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "nose-frontend"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "nose-il"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "lasso",
  "serde",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "nose-normalize"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "nose-il",
  "nose-semantics",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "nose-semantics"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "nose-il",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/corca-ai/nose"
@@ -25,12 +25,12 @@ rust-version = "1.85"
 [workspace.dependencies]
 # Internal crates carry an explicit `version` (not just `path`) so the tree has no
 # wildcard deps and the crates stay publishable; `path` wins for local builds.
-nose-il = { path = "crates/nose-il", version = "0.7.0" }
-nose-semantics = { path = "crates/nose-semantics", version = "0.7.0" }
-nose-frontend = { path = "crates/nose-frontend", version = "0.7.0" }
-nose-normalize = { path = "crates/nose-normalize", version = "0.7.0" }
-nose-detect = { path = "crates/nose-detect", version = "0.7.0" }
-nose-eval = { path = "crates/nose-eval", version = "0.7.0" }
+nose-il = { path = "crates/nose-il", version = "0.8.0" }
+nose-semantics = { path = "crates/nose-semantics", version = "0.8.0" }
+nose-frontend = { path = "crates/nose-frontend", version = "0.8.0" }
+nose-normalize = { path = "crates/nose-normalize", version = "0.8.0" }
+nose-detect = { path = "crates/nose-detect", version = "0.8.0" }
+nose-eval = { path = "crates/nose-eval", version = "0.8.0" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
A soundness + oracle release that **closes the #283 false-merge cluster in full** and hardens the verify oracle. Standard release mechanics: cut `## [0.8.0]` in the CHANGELOG, bump the workspace + internal-crate versions `0.7.0 → 0.8.0`, regenerate `Cargo.lock`.

## Highlights since v0.7.0
- **#283 C-float / D-div — CLOSED.** The fully-untyped `(a+b)+c ≢ a+(b+c)` false merge is closed by the IEEE-754 `Value::Float` value kind (#342), on top of syntactic-float (#339) and float-typed-param (#340). Commutativity preserved; recall delta 0 on the full 105-repo corpus.
- **#283 D-int32 — CLOSED.** int32 oracle execution shipped (#344); the full fixed-width recall recovery was *measured unnecessary* (0 family delta), so the floor is the stopping point.
- **#337 — CLOSED.** In-place array-element mutation modeled (swap ≢ clobber) in both the value graph (read-forwarding) and the interpreter; machine-checked by the `normalize.value_graph.index_writes` Lean obligation (#343).
- **#317 — falsification search** for `nose verify --falsify`: institutionalizes the adversarial-input discipline; finds 0 new false merges on the corpus.
- Per-language operator gates consolidated into `OperatorSemantics` (#346); docs/comments reconciled with the now-closed cluster.

Every soundness change was priced at **~0 recall on the full pinned corpus**. Remaining float work is breadth (a full Int↔Float coercion lattice), not a soundness gap.

`nose --version` → `nose 0.8.0`. Full suite / clippy / fmt / docs / dup-gate / formal-obligations / MSRV all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)