### PR TITLE
Default-surface honesty: shallow-extraction demotion + production-first report (#263, #264, #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ break.
 
 ## [Unreleased]
 
+### Added
+- **Default-surface honesty: `shallow-extraction` demotion + production-first human report
+  (#263, #264, #11).** A fresh-repo head-of-ranking audit
+  ([default-surface-noise-audit](docs/default-surface-noise-audit-2026-06-14.md)) measured the
+  bare-default scan surface as ~58% test-scope token-level copy-paste and only 4–5% proven
+  channels. Two measured, principle-respecting levers:
+  - Unproven families whose extracted helper would be mostly parameters (`params` ≥ a third of
+    `shared_lines`) are classified `shallow` (a new `recommended_surface` value / `surface_counts`
+    bucket) and omitted from the default human surface — kept in `--format json --top 0`. The cut
+    labeled at 0.89 precision (−34–36% of the default surface on the audit repos), and never fires
+    on a proven channel.
+  - The human report now leads with production findings and ranks test-scope duplication beneath a
+    `── N test-scope families …` separator (or a `+N more` footer under `--top`). `scope` stays a
+    context tag, never a worthiness penalty: nothing is dropped — test families stay ranked, in
+    JSON, and one `--scope test` away (`--scope prod` hides them).
+
 ## [0.8.0] - 2026-06-14
 
 ### Added

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -1082,6 +1082,10 @@ struct ScanJsonSurfaceCounts {
     /// declarations — real duplication with no extraction action (the human
     /// report omits these from default output too).
     declaration: usize,
+    /// Unproven families whose extracted helper would be mostly parameters
+    /// (`shallow-extraction`) — a decidable non-action class the human report
+    /// omits from default output (kept here and in `--top 0` JSON).
+    shallow: usize,
     fragments: ScanJsonFragmentSurfaceCounts,
 }
 
@@ -1120,6 +1124,7 @@ impl ScanJsonSurfaceCounts {
             "debug" => self.debug += 1,
             "generated" => self.generated += 1,
             "declaration" => self.declaration += 1,
+            "shallow" => self.shallow += 1,
             _ => self.debug += 1,
         }
     }
@@ -3704,12 +3709,8 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
     // the default surface so a diagnostic family can never swallow a default
     // one.
     let opportunities = OpportunityGroups::from_ranked(&reportable_families);
-    let shown_reportable = reportable_families
-        .iter()
-        .filter(|f| !opportunities.is_slice(f))
-        .take(limit)
-        .copied()
-        .collect::<Vec<_>>();
+    let shown_reportable =
+        select_shown_reportable(&reportable_families, &opportunities, args.scope, limit);
     let omitted_note = surface_omission_note(&families, &overrides);
 
     render_scan_report(
@@ -4837,6 +4838,10 @@ fn surface_omission_note(
                 && family_declaration_run(f, overrides)
         })
         .count();
+    let shallow = families
+        .iter()
+        .filter(|f| f.recommended_surface() == "shallow")
+        .count();
     let review = families
         .iter()
         .filter(|f| f.recommended_surface() == "review")
@@ -4849,11 +4854,17 @@ fn surface_omission_note(
         .iter()
         .filter(|f| f.recommended_surface() == "debug")
         .count();
-    let omitted = generated + declaration + review + hidden + debug;
+    let omitted = generated + declaration + shallow + review + hidden + debug;
     if omitted == 0 {
         return None;
     }
-    if generated == 0 && declaration == 0 && review == 0 && hidden == 1 && debug == 0 {
+    if generated == 0
+        && declaration == 0
+        && shallow == 0
+        && review == 0
+        && hidden == 1
+        && debug == 0
+    {
         return Some("omitted 1 hidden proof-only family from default output".to_string());
     }
     let mut parts = Vec::new();
@@ -4862,6 +4873,9 @@ fn surface_omission_note(
     }
     if declaration > 0 {
         parts.push(format!("{declaration} declaration-run"));
+    }
+    if shallow > 0 {
+        parts.push(format!("{shallow} shallow-extraction"));
     }
     if review > 0 {
         parts.push(format!("{review} review"));
@@ -5116,6 +5130,105 @@ fn family_hint(f: &nose_detect::RefactorFamily) -> String {
 /// triage experience: 6+ spots read as scenario-shaped, not helper-shaped).
 const HIGH_PARAM_SPOTS: u32 = 6;
 
+/// The default-surface families to render, in display order: overlapping slices folded
+/// out, then production-scope findings ahead of test-scope, then truncated to `--top`.
+///
+/// §2c default-surface honesty: test duplication is a real smell (never dropped, still
+/// ranked, in `--format json`, one `--scope test` away), but production leads the
+/// bare-default screen so it is not buried — test scope was measured at 60–76% of the
+/// default head ([default-surface-noise-audit](../../../docs/default-surface-noise-audit-2026-06-14.md)).
+/// The reorder is stable (extractability rank preserved within each scope) and only runs
+/// when no `--scope` filter has already narrowed the set to one scope.
+fn select_shown_reportable<'a>(
+    reportable: &[&'a nose_detect::RefactorFamily],
+    opportunities: &OpportunityGroups,
+    scope: ScopeFilter,
+    limit: usize,
+) -> Vec<&'a nose_detect::RefactorFamily> {
+    let mut shown: Vec<_> = reportable
+        .iter()
+        .filter(|f| !opportunities.is_slice(f))
+        .copied()
+        .collect();
+    if matches!(scope, ScopeFilter::All) {
+        shown.sort_by_key(|f| f.scope == "test");
+    }
+    shown.truncate(limit);
+    shown
+}
+
+/// Render one ranked family entry of the human report: headline, hint, folded
+/// opportunity slices, abstraction witness, the (capped) site list, and optional
+/// diff/proposal views.
+fn print_family_entry(
+    i: usize,
+    f: &nose_detect::RefactorFamily,
+    opportunities: &OpportunityGroups,
+    diff: bool,
+    proposal: bool,
+) {
+    // Every site is listed (you can't act on a clone you can't see); only pathological
+    // fanout is capped, with a pointer to the full machine-readable list.
+    const SITE_CAP: usize = 30;
+    println!(
+        "\n#{}  id {} · {}",
+        i + 1,
+        baseline::family_id(f),
+        family_summary(f)
+    );
+    println!("    → {}", family_hint(f));
+    if let Some(slices) = opportunities.slices(f) {
+        let listed = slices
+            .iter()
+            .take(4)
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let more = if slices.len() > 4 { ", …" } else { "" };
+        let (n, noun, verb) = match slices.len() {
+            1 => (1, "family", "folds"),
+            n => (n, "families", "fold"),
+        };
+        println!(
+            "    ↳ {n} overlapping slice {noun} {verb} into this entry (id{} {listed}{more})",
+            if n == 1 { ":" } else { "s:" }
+        );
+    }
+    if let Some(witness) = &f.abstraction_witness {
+        println!("    witness {}", abstraction_witness_summary(witness));
+    }
+    for l in f.locations.iter().take(SITE_CAP) {
+        let name = l
+            .name
+            .as_deref()
+            .map(|n| format!("  {n}"))
+            .unwrap_or_default();
+        // For a partial / sub-DAG clone, point at where the shared computation sits here.
+        let shared = match l.shared_subdag {
+            Some((s, e)) if (s, e) != (l.start_line, l.end_line) => {
+                format!("  (shared computation: lines {s}-{e})")
+            }
+            _ => String::new(),
+        };
+        println!(
+            "    {}:{}-{}{}{}",
+            l.file, l.start_line, l.end_line, name, shared
+        );
+    }
+    if f.locations.len() > SITE_CAP {
+        println!(
+            "    … and {} more sites (--format json lists every one)",
+            f.locations.len() - SITE_CAP
+        );
+    }
+    if diff && f.locations.len() >= 2 {
+        print_member_diff(&f.locations[0], &f.locations[1]);
+    }
+    if proposal && f.locations.len() >= 2 {
+        print_member_proposal(&f.locations[0], &f.locations[1], f.locations.len());
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn print_refactor_human(
     all: &[&nose_detect::RefactorFamily],
@@ -5148,67 +5261,36 @@ fn print_refactor_human(
     if let Some(note) = omitted_note {
         println!("{note}");
     }
-    // Every site is listed (you can't act on a clone you can't see); only pathological
-    // fanout is capped, with a pointer to the full machine-readable list.
-    const SITE_CAP: usize = 30;
+    // Production findings lead; a single separator marks where test-scope duplication
+    // (already sorted beneath, never dropped) begins. Skipped when the list is all one
+    // scope (e.g. under `--scope test`/`prod`).
+    let any_nontest = shown.iter().any(|f| f.scope != "test");
+    let mut test_header_shown = false;
     for (i, f) in shown.iter().enumerate() {
+        if any_nontest && !test_header_shown && f.scope == "test" {
+            let n = shown.iter().filter(|g| g.scope == "test").count();
+            println!(
+                "\n── {n} test-scope {} ranked beneath production · --scope test to focus, --scope prod to hide ──",
+                if n == 1 { "family" } else { "families" }
+            );
+            test_header_shown = true;
+        }
+        print_family_entry(i, f, opportunities, diff, proposal);
+    }
+    // Test-scope duplication is a real smell (never dropped), but production leads the
+    // default screen — so when `--top` cut some test families, say so rather than let
+    // them vanish silently. Skipped under `--scope test`/`prod` (no production above).
+    let test_total = all
+        .iter()
+        .filter(|f| f.scope == "test" && !opportunities.is_slice(f))
+        .count();
+    let test_shown = shown.iter().filter(|f| f.scope == "test").count();
+    if any_nontest && test_total > test_shown {
+        let more = test_total - test_shown;
         println!(
-            "\n#{}  id {} · {}",
-            i + 1,
-            baseline::family_id(f),
-            family_summary(f)
+            "\n+{more} more test-scope {} ranked beneath production (--scope test to focus, --top 0 for all)",
+            if more == 1 { "family" } else { "families" }
         );
-        println!("    → {}", family_hint(f));
-        if let Some(slices) = opportunities.slices(f) {
-            let listed = slices
-                .iter()
-                .take(4)
-                .map(String::as_str)
-                .collect::<Vec<_>>()
-                .join(", ");
-            let more = if slices.len() > 4 { ", …" } else { "" };
-            let (n, noun, verb) = match slices.len() {
-                1 => (1, "family", "folds"),
-                n => (n, "families", "fold"),
-            };
-            println!(
-                "    ↳ {n} overlapping slice {noun} {verb} into this entry (id{} {listed}{more})",
-                if n == 1 { ":" } else { "s:" }
-            );
-        }
-        if let Some(witness) = &f.abstraction_witness {
-            println!("    witness {}", abstraction_witness_summary(witness));
-        }
-        for l in f.locations.iter().take(SITE_CAP) {
-            let name = l
-                .name
-                .as_deref()
-                .map(|n| format!("  {n}"))
-                .unwrap_or_default();
-            // For a partial / sub-DAG clone, point at where the shared computation sits here.
-            let shared = match l.shared_subdag {
-                Some((s, e)) if (s, e) != (l.start_line, l.end_line) => {
-                    format!("  (shared computation: lines {s}-{e})")
-                }
-                _ => String::new(),
-            };
-            println!(
-                "    {}:{}-{}{}{}",
-                l.file, l.start_line, l.end_line, name, shared
-            );
-        }
-        if f.locations.len() > SITE_CAP {
-            println!(
-                "    … and {} more sites (--format json lists every one)",
-                f.locations.len() - SITE_CAP
-            );
-        }
-        if diff && f.locations.len() >= 2 {
-            print_member_diff(&f.locations[0], &f.locations[1]);
-        }
-        if proposal && f.locations.len() >= 2 {
-            print_member_proposal(&f.locations[0], &f.locations[1], f.locations.len());
-        }
     }
     // Discoverability: the report's natural next steps, shown once a real report
     // exists and only when no extra view was already requested.

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1557,14 +1557,17 @@ fn diff_shows_the_differing_line() {
     // are a clear near-duplicate family. (A `+`-loop vs a `*`-loop is deliberately
     // *not* used here: the value graph now treats those as distinct reductions — see
     // §AH — so they are no longer a single family.)
+    // Share enough invariant lines that the one differing literal is a clean,
+    // low-parameter extract — otherwise the family is (correctly) a `shallow`
+    // non-action candidate and leaves the default surface this test reads.
     fs::write(
         dir.join("a/f.py"),
-        "def f(items):\n    t = 0\n    for x in items:\n        t = t + x * 2\n    return t\n",
+        "def f(items):\n    t = 0\n    n = 0\n    s = 0\n    for x in items:\n        t = t + x * 2\n        n = n + 1\n        s = s + x\n    return t\n",
     )
     .unwrap();
     fs::write(
         dir.join("b/f.py"),
-        "def g(items):\n    t = 0\n    for x in items:\n        t = t + x * 3\n    return t\n",
+        "def g(items):\n    t = 0\n    n = 0\n    s = 0\n    for x in items:\n        t = t + x * 3\n        n = n + 1\n        s = s + x\n    return t\n",
     )
     .unwrap();
     let out = run(&[

--- a/crates/nose-detect/src/report.rs
+++ b/crates/nose-detect/src/report.rs
@@ -161,10 +161,51 @@ impl RefactorFamily {
             * self.default_surface_weight()
     }
 
+    /// Decidable, scope-blind actionability reason — a stable code naming WHY a family
+    /// is not a clean default-surface refactor candidate, computed purely from family
+    /// shape (no source, no judgment, no `scope` input). The one measured code today is
+    /// `shallow-extraction`: an **unproven** match (not the exact value-graph or
+    /// shared-sub-dag channel) whose extracted helper would be mostly parameters —
+    /// `params` ≥ a third of the `shared_lines`. Measured 2026-06-14
+    /// ([default-surface-noise-audit](../../../docs/default-surface-noise-audit-2026-06-14.md)):
+    /// this cut labels at 0.89 precision with ~0 worthy loss, and is the dual of
+    /// extractability's `param_penalty`. Proven channels and families with no shared
+    /// lines (cross-language / unreadable) are never shallow. Returns `None` for a clean
+    /// candidate.
+    pub fn actionability_reason(&self) -> Option<&'static str> {
+        const SHALLOW_PARAM_RATIO: f64 = 0.33;
+        let proven = matches!(
+            self.witness.as_ref().map(|w| w.kind),
+            Some("exact-value-graph") | Some("shared-sub-dag")
+        );
+        if !proven
+            && self.shared_lines > 0
+            && self.params as f64 >= SHALLOW_PARAM_RATIO * self.shared_lines as f64
+        {
+            return Some("shallow-extraction");
+        }
+        None
+    }
+
     /// Product placement for the default scan/review/debug surfaces. This is a
     /// presentation/ranking decision, not detector semantics: exact fragments remain
     /// present in `--top 0` JSON even when their default ranking is dampened.
+    ///
+    /// A family that would otherwise reach the **default** head but is a decidable
+    /// non-action shape ([`actionability_reason`](Self::actionability_reason)) is demoted
+    /// to the `shallow` surface, reason-coded and kept in `--top 0` JSON (the §2b
+    /// decidability boundary, measured 2026-06-14). It never overrides a *more specific*
+    /// diagnostic placement (a tiny test-scaffold fragment stays `hidden`), and never
+    /// fires on a proven channel.
     pub fn recommended_surface(&self) -> &'static str {
+        let base = self.recommended_surface_base();
+        if base == "default" && self.actionability_reason().is_some() {
+            return "shallow";
+        }
+        base
+    }
+
+    fn recommended_surface_base(&self) -> &'static str {
         let fragment_sites = self.locations.iter().filter(|l| l.is_fragment).count();
         let all_generated = self.locations.iter().all(is_generated_loc);
         let high_fanout = self.members >= 8;
@@ -248,6 +289,7 @@ impl RefactorFamily {
         match self.recommended_surface() {
             "default" => 1.0,
             "review" => 0.35,
+            "shallow" => 0.05,
             "hidden" => 0.05,
             "debug" => 0.02,
             _ => 1.0,
@@ -1274,6 +1316,91 @@ mod tests {
             fmixed.value, fpure.value,
             "test↔prod duplication is not discounted"
         );
+    }
+
+    fn witnessed(mut f: RefactorFamily, kind: &'static str) -> RefactorFamily {
+        f.witness = Some(crate::EquivalenceWitness {
+            kind,
+            value_nodes: None,
+            mean_value_jaccard: None,
+            mean_shape_jaccard: None,
+            graded: None,
+        });
+        f
+    }
+
+    #[test]
+    fn shallow_extraction_is_demoted_off_default() {
+        // An unproven match whose helper would be mostly parameters (params ≥ a third of
+        // the shared lines) is decidable non-action: demoted to the `shallow` surface,
+        // reason-coded, but never deleted. shared=9, params=4 → ratio 0.44 ≥ 0.33.
+        let shallow = witnessed(
+            fam(
+                500.0,
+                30,
+                9,
+                4,
+                vec![loc("a.go", 1, 30, "go"), loc("b.go", 1, 30, "go")],
+            ),
+            "copy-paste-run",
+        );
+        assert_eq!(shallow.actionability_reason(), Some("shallow-extraction"));
+        assert_eq!(shallow.recommended_surface(), "shallow");
+    }
+
+    #[test]
+    fn clean_low_param_match_stays_default() {
+        // shared=18, params=1 → ratio 0.06 < 0.33: a clean extract, stays on default.
+        let clean = witnessed(
+            fam(
+                500.0,
+                30,
+                18,
+                1,
+                vec![loc("a.go", 1, 30, "go"), loc("b.go", 1, 30, "go")],
+            ),
+            "copy-paste-run",
+        );
+        assert_eq!(clean.actionability_reason(), None);
+        assert_eq!(clean.recommended_surface(), "default");
+    }
+
+    #[test]
+    fn proven_channel_is_never_shallow() {
+        // Same shallow shape (shared=9, params=4) but on the exact value-graph channel:
+        // a proof of equal behavior is never demoted on a parameter-ratio heuristic.
+        let proven = witnessed(
+            fam(
+                500.0,
+                30,
+                9,
+                4,
+                vec![loc("a.go", 1, 30, "go"), loc("b.go", 1, 30, "go")],
+            ),
+            "exact-value-graph",
+        );
+        assert_eq!(proven.actionability_reason(), None);
+        assert_eq!(proven.recommended_surface(), "default");
+    }
+
+    #[test]
+    fn cross_language_no_shared_lines_is_never_shallow() {
+        // shared_lines == 0 (cross-language / unreadable) → ratio undefined → not shallow.
+        let cross = witnessed(
+            fam(
+                500.0,
+                30,
+                0,
+                4,
+                vec![
+                    loc("a.py", 1, 30, "python"),
+                    loc("b.ts", 1, 30, "typescript"),
+                ],
+            ),
+            "structural-similarity",
+        );
+        assert_eq!(cross.actionability_reason(), None);
+        assert_ne!(cross.recommended_surface(), "shallow");
     }
 
     #[test]

--- a/docs/default-surface-noise-audit-2026-06-14.md
+++ b/docs/default-surface-noise-audit-2026-06-14.md
@@ -1,0 +1,128 @@
+# Default-surface noise audit — 2026-06-14
+
+A fresh-repo head-of-ranking audit (the [design](design.md) §2c standing instrument:
+*"field evaluation on unseen neighbours"*) run to re-judge three pieces of user
+feedback against the **current** binary, not the binary the reporters ran:
+[#263](https://github.com/corca-ai/nose/issues/263) (TS/React triage noise),
+[#264](https://github.com/corca-ai/nose/issues/264) (Go-CLI test-scaffolding
+dominance), [#11](https://github.com/corca-ai/nose/issues/11) (refactorability reason
+codes), [#353](https://github.com/corca-ai/nose/issues/353) (JSX declarative shapes).
+
+Most of those issues' *literal* asks had already shipped between filing and this audit
+(opportunity-grouping, the `declaration` surface, `scope`, the reinvented-helper channel,
+the value-vs-shape witness). The open question this audit answers: **does the residual
+"too noisy to triage" complaint still reproduce, and if so, what is the measured,
+principle-respecting lever?**
+
+Two public, unseen (non-corpus) repos, one per reporter shape:
+[goreleaser](https://github.com/goreleaser/goreleaser) (Go CLI, 388 `.go` / 171 `_test.go`)
+and [excalidraw](https://github.com/excalidraw/excalidraw) (React/TSX, 602 TS/TSX, 290 TSX).
+
+## 1. The complaints reproduce on current `main`
+
+`nose scan . --format json --top 0`, HEAD binary:
+
+| | goreleaser | excalidraw |
+|---|---:|---:|
+| default-surface families | 721 | 749 |
+| test scope | 76% | 60% |
+| `copy-paste-run` (weakest witness) | 74% | 83% |
+| **test × copy-paste-run (one bucket)** | **59%** | **58%** |
+| proven moat (`exact-value-graph` + `shared-sub-dag`) | **4%** | **5%** |
+
+The bare-default head is ~60–76% test scope; in goreleaser the first 18 ranked families
+are 14 `*_test.go` pairs, first prod at rank 3. The soundness moat the whole proof program
+defends is 4–5% of what the default surface actually shows. `scope`-weighting (shipped
+2026-06-03) down-weights but does **not** move test off the ranking head. #263 and #264 are
+**live**, not obsolete.
+
+## 2. Method — labeling which *extraction shapes* are non-actionable
+
+A 206-family stratified sample of the two default surfaces (94 `copy-paste-run`, 71
+`structural-similarity`, 34 `shared-sub-dag`, 7 `exact-value-graph`; 107 test / 96 prod / 3
+mixed), labeled by five parallel judge agents that **read the actual source** of each
+family. The rubric encodes nose's standing principle that *test duplication is a real smell
+— `scope` is a context tag, never a worthiness penalty*
+([report.rs](../crates/nose-detect/src/report.rs), [field-evaluation](field-evaluation.md)):
+
+- **KEEP** (belongs on the default head): a cleanly extractable shared helper; a duplicated
+  production block; **test code that reimplements production logic**; a fixture that is one
+  domain concept duplicated and centralizable.
+- **DEMOTE** (intentional / shallow — buries the signal): AAA scaffolding documenting
+  *separate scenarios*; table-test rows; declarative JSX with no named concept; import/type
+  boilerplate; a *shallow* extraction where the shared part is mostly varying spots
+  (params ≈ shared_lines); idiomatic same-file repetition (switch arms, struct fields).
+- **JUDGMENT** only if the source genuinely under-determines it.
+
+Result: **KEEP 71 / DEMOTE 135 / JUDGMENT 0.** No family in the sample reimplemented
+production logic in test code; worthy test *fixtures/helpers* did occur and were KEEP.
+
+## 3. The decisive finding — the noise is two populations
+
+**(a) Decidable-by-shape noise (~43% of DEMOTE).** Separable scope-blind at high precision,
+near-zero worthy loss:
+
+| demotion rule (extraction-shape, scope-agnostic) | precision | KEEP lost | noise recall |
+|---|---:|---:|---:|
+| `unproven ∧ ratio≥0.33` (shallow, the clean cut) | **0.89** | 5 | 0.30 |
+| `structural-similarity ∧ ratio≥0.33` | 0.91 | 2 | 0.15 |
+| `copy-paste-run ∧ same_file ∧ ratio≥0.33` | 0.91 | 1 | 0.07 |
+
+(`ratio` = params / shared_lines; high ratio = "the helper would be almost all
+parameters".) DEMOTE reason tags in this population: `shallow-high-param` (16),
+`idiomatic-same-file` (17), `trivial` (25), `import-type-noise` (7), `jsx-declarative` (4,
+the #353 class), `table-rows` (3).
+
+**(b) AAA test-scaffold bulk (~43% of DEMOTE; 58 of 135).** Long verbatim test-block
+copies documenting separate scenarios. **Not separable from worthy test fixtures/helpers by
+any feature.** Within the `test × copy-paste-run` cell (n=70, 17 KEEP / 53 DEMOTE), the
+KEEP and DEMOTE medians are ~identical (files 2 vs 1, modules 1 vs 1, members 3 vs 3,
+mean_lines 14 vs 13); every structural cut caps at 0.74–0.77 precision — the same as
+demoting the whole cell, which costs 17 worthy KEEP. Only the labeler's *semantic read*
+("one domain concept worth centralizing" vs "AAA documenting separate scenarios")
+separated them. This is **judgment-deep** — §2's consumer-LLM call, not the detector's.
+
+**The `scope` lever is measured-bad.** `scope = test` captures 107, precision 0.74, and
+demotes **28 worthy KEEP** families (worthy fixtures, test-helpers, prod-blocks living in
+test files) — it contradicts the principle *and* loses value. (Corollary: proven channels
+are only keep-rate 0.41, so "proven ⇒ always default" is also false; shape filters apply
+across witnesses but never demote a proven family on shape alone.)
+
+## 4. The lever — one capability, split at the decidability boundary (§2b)
+
+**Shipped** (both arms, this PR — see [CHANGELOG](../CHANGELOG.md) Unreleased):
+
+- **(a) Decidable actionability reason codes** ([#11](https://github.com/corca-ai/nose/issues/11),
+  with [#353](https://github.com/corca-ai/nose/issues/353) as a follow-on code): the first
+  decidable code, **`shallow-extraction`** (unproven match, helper-mostly-parameters), ships as a
+  new `shallow` `recommended_surface` / `surface_counts` bucket — demoted off the default head,
+  **kept in JSON**, never firing on a proven channel. ~0.89 precision; **−36%** (goreleaser) /
+  **−34%** (excalidraw) of the default surface, 0 proven demoted. Touches no `scope`. The further
+  codes (`idiomatic-repetition`, `trivial`, `markup`/JSX) remain queued behind their own
+  measurement.
+- **(b) AAA bulk → scope-aware *rendering*, not penalty.** Collapse/summarize test-scope
+  families beneath prod findings on the human surface (the way overlapping slices already
+  fold into one opportunity); **nothing dropped** — every test family stays in the ranking,
+  in `--format json`, and under `--scope test`. This honors *test-dup-is-a-smell ·
+  nothing-dropped · scope-is-context-not-penalty* while answering #264's "let me see prod
+  first." The worthy-vs-noise call inside the collapsed set is the consumer's, with nose
+  carrying the evidence (§2).
+
+This is **capabilities over features**: a single capability — decidable reason codes plus
+scope-aware rendering — answers #11/#263/#264/#353 together, instead of the issues' literal
+pile of per-category heuristics (role taxonomy, bug-prone weighting, shallow-abstraction
+penalty), most of which are the judgment §2 already delegates to the consumer.
+
+Projection on the two surfaces: the shape cut removes ~35%; with test rendered beneath prod,
+the prod-and-not-shallow head is **105** (goreleaser) / **208** (excalidraw) families —
+converging on #263's *"~20 worth reading"* once the head is what the first screen shows.
+
+## Honest limits
+
+Two repos, two languages (Go, TS/React); single-judge labels (no adversarial refuter pass,
+unlike [experiments §BR](experiments.md)); the sample is stratified, so per-cell precision is
+sound but surface-level fractions are sample-reweighted, not population estimates (the §1
+fractions are the population numbers). The exact `ratio` threshold (0.33) and the rendering
+collapse shape should be re-confirmed on a wider repo set before the default flips, per the
+§2c *measured-before-flipped* discipline. Artifacts: the audit was run from `/tmp` scratch
+(`feats.json`, `labels_*.json`, `analyze.py`); re-runnable from any `--depth 1` clone.

--- a/docs/design.md
+++ b/docs/design.md
@@ -159,7 +159,14 @@ Two consequences:
 - **Determinism** as a sacred invariant — now wanted by *both* consumers.
 - **Default-surface honesty (§2b/§2c).** Decidable non-action classes are filtered
   detector-side with a reason code and JSON preservation; fresh-repo head-of-ranking
-  audits are the recurring instrument that feeds this queue.
+  audits are the recurring instrument that feeds this queue. *Measured 2026-06-14
+  ([default-surface-noise-audit](default-surface-noise-audit-2026-06-14.md)): the bare
+  default was ~58% test-scope token copy-paste, ~4–5% proven. Shipped — the decidable
+  `shallow-extraction` class (unproven, helper-mostly-parameters) demotes off the default
+  at 0.89 precision (−35%), and the human report leads with production, ranking test-scope
+  beneath (never dropped — `scope` stays a context tag). The judgment-deep residue
+  (worthy-fixture vs intentional scaffolding) is feature-inseparable and stays the
+  consumer's call, carried as evidence (§2).*
 
 **Keep / conditional:**
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2569,3 +2569,29 @@ it, no further. Issue #329.
 | s9-vm-ruby-mul-strrep | value-model | violation-fixed (`ac_chain_commutes` Ruby-`*` gate) |
 | s9-oracle-eq-err-incoherent | oracle | recorded-low-prevalence (§7 sharpened; fix deferred) |
 | s9-perf-enrich-narrowing | performance-determinism | green-confirmed |
+
+## CA. Default-surface noise — the #263/#264 triage feedback, re-judged by fresh-repo audit
+
+The triage-noise feedback ([#263](https://github.com/corca-ai/nose/issues/263) TS/React,
+[#264](https://github.com/corca-ai/nose/issues/264) Go-CLI, [#11](https://github.com/corca-ai/nose/issues/11)
+reason codes) was re-judged against the current binary on two public unseen repos
+(goreleaser, excalidraw) — the §2c fresh-repo head-of-ranking instrument. Full record:
+[default-surface-noise-audit-2026-06-14](default-surface-noise-audit-2026-06-14.md).
+
+**Both complaints reproduce**: the bare-default head is 60–76% test scope and 74–83%
+`copy-paste-run`; the proven moat is 4–5% of the default surface. A 206-family
+read-the-source labeling pass (KEEP 71 / DEMOTE 135) found the noise is **two
+populations**: (a) *decidable-by-shape* (shallow `ratio = params/shared ≥ 0.33`, idiomatic
+same-file, trivial, declaration, JSX) — separable scope-blind at **0.89 precision**, and
+(b) the *AAA test-scaffold bulk* — **not separable from worthy test fixtures/helpers by any
+feature** (the `test × copy-paste-run` cell's KEEP/DEMOTE medians are identical; every cut
+caps at 0.76), so it is judgment-deep (§2 consumer-LLM call).
+
+The `scope = test` lever is **measured-bad** (prec 0.74, demotes 28 worthy KEEP) —
+confirming the documented principle that `scope` is a context tag, never a worthiness
+penalty. The lever, split at the §2b decidability boundary: **(a)** decidable actionability
+reason codes (#11 unified with #353) demote the shape-noise codes off the default head
+(kept in JSON, reason-coded; −34–36%); **(b)** the AAA bulk is handled by scope-aware
+*rendering* (collapse test beneath prod, nothing dropped), not a penalty. One capability
+(reason codes + scope-aware rendering) answers #11/#263/#264/#353; the judgment residue
+stays with the consumer.

--- a/docs/home.md
+++ b/docs/home.md
@@ -101,6 +101,7 @@ fundamentals; the rest is grouped by area.
 - [scanjson-agent-audit-2026-06-13](scanjson-agent-audit-2026-06-13.md) — the re-validation after the gap fixes (incl. the graded witness): all five gaps closed, 8/8 decidable from JSON alone.
 - [fragment-quality-audit-2026-06-10](fragment-quality-audit-2026-06-10.md) — labeled Java/Python hidden/review exact-fragment sample and the resulting surface policy.
 - [lawpack-provenance-audit-2026-06-10](lawpack-provenance-audit-2026-06-10.md) — full-corpus and targeted real-repo audit of `nose.value_graph.laws` provenance.
+- [default-surface-noise-audit-2026-06-14](default-surface-noise-audit-2026-06-14.md) — re-judging the #263/#264/#11/#353 triage-noise feedback on fresh repos: the default-surface noise is two populations (decidable-shape vs judgment-deep AAA scaffolding), and the principle-respecting lever.
 
 The contributor workflow and quality gates live in
 [CONTRIBUTING](../CONTRIBUTING.md); release history is in

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -142,7 +142,7 @@ same breakdown for families with at least one exact fragment location. That make
 | `ranking.total_families` | integer | Active families remaining after rank-time pruning, filters, baseline suppression, and structured ignores, before `--top`. |
 | `ranking.shown_families` | integer | Families present in `families`. |
 | `ranking.limit` | integer or null | The `--top` limit; `null` means `--top 0` showed every family. |
-| `ranking.surface_counts` | object | Active family counts by effective surface before `--top`: `default`, `review`, `hidden`, `debug`, `generated` (families wholly in generated-header source), and `declaration` (families whose every member span is only import/include/use/re-export declarations) — the human report omits the last two from default output. Plus `fragments.total/default/review/hidden/debug` for families with exact fragment locations. |
+| `ranking.surface_counts` | object | Active family counts by effective surface before `--top`: `default`, `review`, `hidden`, `debug`, `generated` (families wholly in generated-header source), `declaration` (families whose every member span is only import/include/use/re-export declarations), and `shallow` (unproven families whose extracted helper would be mostly parameters — `params` ≥ a third of `shared_lines`) — the human report omits `generated`, `declaration`, and `shallow` from default output. Plus `fragments.total/default/review/hidden/debug` for families with exact fragment locations. |
 | `baseline` | object, optional | Baseline comparison summary when `--baseline` is active. |
 | `ignore` | object, optional | Structured ignore summary when an ignore file was read. |
 | `families` | array | Active ranked clone families in JSON order, including diagnostic review/hidden families. Empty means no family survived the filters, baseline, and structured ignores. |
@@ -241,7 +241,7 @@ schema version 1:
 | `mean_sem` | number | Mean value-graph size across members. |
 | `scope` | string | `prod`, `test`, or `mixed` test/production classification. |
 | `discount` | number | Refactor-worthiness discount for generated or type-heavy families. |
-| `recommended_surface` | string | Product placement hint. Current detector output uses `default`, `review`, or `hidden`; `debug` is reserved for diagnostics/regression tooling; `generated` marks families whose every location sits in a generated-header source; `declaration` marks families whose every member span consists only of import/include/use/re-export declarations — real duplication the language mandates per file, with no extraction action. The human report omits `generated` and `declaration` from default output. Human-action integrations should keep `default` and treat the others as diagnostic/review surfaces. This is ranking/presentation policy, not detector exactness. |
+| `recommended_surface` | string | Product placement hint. Current detector output uses `default`, `review`, or `hidden`; `debug` is reserved for diagnostics/regression tooling; `generated` marks families whose every location sits in a generated-header source; `declaration` marks families whose every member span consists only of import/include/use/re-export declarations — real duplication the language mandates per file, with no extraction action; `shallow` marks an unproven family (not the `exact-value-graph`/`shared-sub-dag` channel) whose extracted helper would be mostly parameters — `params` ≥ a third of `shared_lines`, the decidable `shallow-extraction` non-action class ([default-surface-noise-audit](default-surface-noise-audit-2026-06-14.md)). The human report omits `generated`, `declaration`, and `shallow` from default output. Human-action integrations should keep `default` and treat the others as diagnostic/review surfaces. This is ranking/presentation policy, not detector exactness. |
 | `overlap_primary_id` | string, optional | Present when this family is an overlapping slice of another default-surface family (≥2 member pairs overlapping on the same file by ≥ half of the shorter span): the `family_id` of that primary. The human report folds slices under their primary as one opportunity; JSON keeps every family so consumers can group or ungroup freely. |
 | `baseline_status` | string, optional | `new` or `changed` when this family is shown because of `--baseline`. |
 | `abstraction_witness` | object, optional | Experimental weak-claim witness emitted only for `--mode abstraction` families that share a normalized template with one supported literal leaf hole. |
@@ -290,11 +290,16 @@ The optional `enclosing_unit` object has:
 | `name` | string, optional | Enclosing symbol name when recoverable. |
 | `unit_key` | string | Stable key built from file, kind, span, and name for grouping/review context. |
 
-Do not confuse fragment `reason_code` with family-level witness reason codes. Fragment
-`reason_code` answers why this sub-function fragment was accepted as exact-safe. Future
-family/actionability reason codes answer why a clone family is worth refactoring or
-reviewing. The experimental `abstraction_witness.reason_code` below is a weak-template
-reason, not exact-fragment proof.
+Do not confuse fragment `reason_code` with family-level actionability reason codes. Fragment
+`reason_code` answers why this sub-function fragment was accepted as exact-safe. Family-level
+actionability reason codes answer why a clone family is, or is not, a clean refactor
+candidate; the first **decidable** one ships as the `shallow` `recommended_surface`
+(`shallow-extraction` — an unproven match whose helper would be mostly parameters). The
+judgment-deep half (worthy-fixture vs intentional scaffolding) is left to the consumer's
+own model and carried as evidence (`witness.kind`, `scope`, `params`/`shared_lines`,
+`varying_spots`), never a verdict — see [design](design.md) §2 and the
+[default-surface-noise-audit](default-surface-noise-audit-2026-06-14.md). The experimental
+`abstraction_witness.reason_code` below is a weak-template reason, not exact-fragment proof.
 
 ### Abstraction witnesses
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -51,11 +51,18 @@ breakdown, scope tags, and the `→` hint — is covered in
 [getting-started → How to read the report](getting-started.md#how-to-read-the-report).
 The default human, Markdown, SARIF, and `--fail-on` surfaces show only
 action-oriented findings. Tiny proof-only fragments, review-only fragments,
-families wholly inside files with generated-code headers, and declaration runs
+families wholly inside files with generated-code headers, declaration runs
 (spans that are only import/include/use/re-export lines — duplication the
-language mandates per file, with nothing to extract) are omitted with a short
-count line; `--format json --top 0` keeps the post-ranking diagnostic families that
-survive rank-time pruning.
+language mandates per file, with nothing to extract), and `shallow-extraction`
+families (unproven matches whose helper would be mostly parameters — `params` ≥ a
+third of the shared lines) are omitted with a short count line; `--format json
+--top 0` keeps the post-ranking diagnostic families that survive rank-time pruning.
+
+Within the human report, **production findings lead and test-scope duplication is
+ranked beneath**, behind a `── N test-scope families …` separator (or a `+N more`
+footer when `--top` cuts them). Test duplication is still a real smell — nothing is
+dropped: the families stay ranked, in `--format json`, and one `--scope test` away.
+`--scope prod` hides them entirely; `--scope test` focuses on them.
 
 A named path that doesn't exist is an error (exit non-zero) — a typo'd path in a
 CI gate must fail loudly. A path that exists but contains no supported source


### PR DESCRIPTION
## Why

A fresh-repo head-of-ranking audit (§2c) on two public unseen repos (goreleaser, excalidraw) re-judged the triage-noise feedback — #263 (TS/React), #264 (Go-CLI test scaffolding), #11 (reason codes) — against the **current** binary. Most of the issues' literal asks had already shipped (opportunity-grouping, `declaration` filter, `scope`, reinvented-helpers, the value-vs-shape witness), but the residual complaint **reproduces**: the bare-default surface is ~58% test-scope token copy-paste and only 4–5% proven channels. Full record: [`docs/default-surface-noise-audit-2026-06-14.md`](docs/default-surface-noise-audit-2026-06-14.md).

A 206-family read-the-source labeling pass (KEEP 71 / DEMOTE 135) found the noise is **two populations**: a *decidable-by-shape* part (separable scope-blind at **0.89 precision**) and an *AAA-test-scaffold bulk* that is **not feature-separable** from worthy test duplication (judgment-deep → the consumer's call, per design §2). The `scope = test` lever is measured-bad (demotes 28 worthy KEEP), so this PR does **not** penalize scope.

## What

Two measured, principle-respecting levers (`scope` stays a context tag; nothing dropped):

- **(a) `shallow-extraction` demotion** (detector-side, scope-blind). An unproven match whose extracted helper would be mostly parameters (`params` ≥ a third of `shared_lines`) is classified `shallow` — a new `recommended_surface` value / `surface_counts` bucket — and omitted from the default human surface, **kept in `--format json --top 0`**. `recommended_surface()` wraps `recommended_surface_base()` so `shallow` only overrides a would-be `default`, never a proven channel or a more-specific `hidden`/`review`. Measured: **goreleaser 721→459** (262 shallow), **excalidraw 749→493** (256 shallow), **0 proven demoted**.
- **(b) production-first human report**. Leads with prod findings; test-scope duplication ranks beneath a `── N test-scope families …` separator (or a `+N more` footer under `--top`). Test families stay ranked, in JSON, and one `--scope test` away (`--scope prod` hides them).

## Verification

- Full workspace tests green (4 new unit tests; 2 pre-existing updated — a fixture that incidentally became `shallow`, and fragment-surface ordering).
- `clippy --all-targets --all-features -- -D warnings` clean.
- Byte-determinism across thread counts: identical.

## Deferred (tracked)

The judgment-deep test residue (worthy-fixture vs intentional scaffolding) and the further decidable codes (`idiomatic-repetition`, `trivial`, JSX `markup` per #353) each behind their own measurement.

Closes #263. Advances #264, #11, #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
