### PR TITLE
#353: record JSX-markup as a measured NO-GO detector filter

### DIFF
--- a/docs/default-surface-noise-audit-2026-06-14.md
+++ b/docs/default-surface-noise-audit-2026-06-14.md
@@ -92,14 +92,14 @@ across witnesses but never demote a proven family on shape alone.)
 
 **Shipped** (both arms, this PR — see [CHANGELOG](../CHANGELOG.md) Unreleased):
 
-- **(a) Decidable actionability reason codes** ([#11](https://github.com/corca-ai/nose/issues/11),
-  with [#353](https://github.com/corca-ai/nose/issues/353) as a follow-on code): the first
-  decidable code, **`shallow-extraction`** (unproven match, helper-mostly-parameters), ships as a
-  new `shallow` `recommended_surface` / `surface_counts` bucket — demoted off the default head,
-  **kept in JSON**, never firing on a proven channel. ~0.89 precision; **−36%** (goreleaser) /
-  **−34%** (excalidraw) of the default surface, 0 proven demoted. Touches no `scope`. The further
-  codes (`idiomatic-repetition`, `trivial`, `markup`/JSX) remain queued behind their own
-  measurement.
+- **(a) Decidable actionability reason codes** ([#11](https://github.com/corca-ai/nose/issues/11)):
+  the first decidable code, **`shallow-extraction`** (unproven match, helper-mostly-parameters),
+  ships as a new `shallow` `recommended_surface` / `surface_counts` bucket — demoted off the
+  default head, **kept in JSON**, never firing on a proven channel. ~0.89 precision; **−36%**
+  (goreleaser) / **−34%** (excalidraw) of the default surface, 0 proven demoted. Touches no
+  `scope`. The further candidate codes (`idiomatic-repetition`, `trivial`) remain queued behind
+  their own measurement; the `markup`/JSX code ([#353](https://github.com/corca-ai/nose/issues/353))
+  was measured a NO-GO — see §5.
 - **(b) AAA bulk → scope-aware *rendering*, not penalty.** Collapse/summarize test-scope
   families beneath prod findings on the human surface (the way overlapping slices already
   fold into one opportunity); **nothing dropped** — every test family stays in the ranking,
@@ -116,6 +116,36 @@ penalty), most of which are the judgment §2 already delegates to the consumer.
 Projection on the two surfaces: the shape cut removes ~35%; with test rendered beneath prod,
 the prod-and-not-shallow head is **105** (goreleaser) / **208** (excalidraw) families —
 converging on #263's *"~20 worth reading"* once the head is what the first screen shows.
+
+## 5. [#353](https://github.com/corca-ai/nose/issues/353) (JSX markup) — measured NO-GO as a detector filter
+
+The follow-on idea was a decidable `markup` class: a family whose every member span is
+**provably behavior-free JSX** (no `subtree_executes` node — no call, arrow, `await`, `new`,
+function, or `yield` anywhere in the JSX subtree), demoted off the default like `declaration`.
+Measured on two React repos before building it:
+
+| repo | default-surface families with all-`.tsx`/`.jsx` locations | JSX-ish span (starts `<`/`{`) | **decidable behavior-free markup** |
+|---|---:|---:|---:|
+| excalidraw | 314 | 18 | **1** (static SVG `<path>` data) |
+| react-bootstrap | 23 | 2 | **0** |
+
+**NO-GO** — the decidable, safe `markup` filter catches ~0–1 families, for structural reasons,
+not a tuning miss:
+
+1. Clone families are whole-component **functions**, so their spans carry `function`/`return`/`=>`
+   code lines — never pure markup (the `declaration` line-grammar would poison them).
+2. Real JSX embeds `clsx(...)`, event handlers, and `{items.map(...)}` — all `subtree_executes`
+   nodes, so a behavior-free JSX span is rare.
+3. Catching the *actual* JSX noise the field reports name (the Homepage `.map` list-render, the
+   `clsx`-wrapped button `<input>`) requires whitelisting list-render / class-helper idioms —
+   which crosses from **decidable** into **judgment** ("is this list-render worth extracting?").
+   §2 puts that on the consumer's model, not the detector.
+
+So JSX/markup-presentational-ness is **not** a detector surface; it becomes one **evidence**
+input for the consumer's own call (the #11 vocabulary), exactly like the AAA-scaffold bulk in §3.
+Shipping a `markup` surface for ~1 family would be dead complexity against *capabilities over
+features*. #353 is closed measured-negligible; the cheap re-run path is the same per-repo
+measurement script if a future component-library corpus suggests otherwise.
 
 ## Honest limits
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2589,9 +2589,19 @@ caps at 0.76), so it is judgment-deep (§2 consumer-LLM call).
 
 The `scope = test` lever is **measured-bad** (prec 0.74, demotes 28 worthy KEEP) —
 confirming the documented principle that `scope` is a context tag, never a worthiness
-penalty. The lever, split at the §2b decidability boundary: **(a)** decidable actionability
-reason codes (#11 unified with #353) demote the shape-noise codes off the default head
-(kept in JSON, reason-coded; −34–36%); **(b)** the AAA bulk is handled by scope-aware
+penalty. The lever, split at the §2b decidability boundary: **(a)** the decidable
+`shallow-extraction` reason code (#11) demotes off the default head (kept in JSON,
+reason-coded; −34–36%, shipped); **(b)** the AAA bulk is handled by scope-aware
 *rendering* (collapse test beneath prod, nothing dropped), not a penalty. One capability
-(reason codes + scope-aware rendering) answers #11/#263/#264/#353; the judgment residue
-stays with the consumer.
+(reason codes + scope-aware rendering) answers #11/#263/#264; the judgment residue stays
+with the consumer.
+
+**#353 (JSX `markup` code) — NO-GO.** A decidable behavior-free-JSX surface (no
+`subtree_executes` node in the JSX subtree) was measured on two React repos before
+building: **1 / 314** qualifying families on excalidraw (a static SVG `<path>`), **0 / 23**
+on react-bootstrap. Structural, not a tuning miss: clone families are whole-component
+functions (spans carry `function`/`return`), and real JSX embeds `clsx`/handlers/`.map`
+(all executing) — catching the field's actual JSX examples needs whitelisting
+list-render/class idioms, which is judgment, not decidable (§2). JSX-presentational-ness
+becomes one **evidence** input for the consumer (the #11 vocabulary), not a detector
+surface — see the audit doc §5.


### PR DESCRIPTION
## Outcome: measured NO-GO (docs only)

#353 proposed a decidable `markup` class — a family whose every member span is provably behavior-free JSX (no `subtree_executes` node anywhere in the JSX subtree), demoted off the default like `declaration`.

**Measured on two React repos before building it:**

| repo | default families, all-`.tsx`/`.jsx` locations | JSX-ish span | decidable behavior-free markup |
|---|---:|---:|---:|
| excalidraw | 314 | 18 | **1** (static SVG `<path>`) |
| react-bootstrap | 23 | 2 | **0** |

**NO-GO**, structural (not a tuning miss): clone families are whole-component **functions** (spans carry `function`/`return`/`=>` lines → never pure markup), and real JSX embeds `clsx(...)`/handlers/`{items.map(...)}` (all `subtree_executes`). Catching the field's *actual* JSX examples (Homepage `.map`, `clsx`-wrapped button) needs whitelisting list-render/class idioms — which crosses from **decidable** into **judgment** ("is this list-render worth extracting?"), which design §2 assigns to the consumer, not the detector.

So JSX-presentational-ness becomes one **evidence** input for the consumer's own call (the #11 vocabulary), not a detector surface. Shipping a `markup` surface for ~1 family would be dead complexity against *capabilities over features*.

Records the measurement in [`default-surface-noise-audit-2026-06-14.md`](docs/default-surface-noise-audit-2026-06-14.md) §5 and experiments §CA. No code change.

Closes #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
