### PR TITLE
#264: test-scope findings carry a scaffolding triage caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ break.
     context tag, never a worthiness penalty: nothing is dropped — test families stay ranked, in
     JSON, and one `--scope test` away (`--scope prod` hides them).
 
+### Changed
+- **Test-scope findings carry a scaffolding triage caveat (#264).** A test-scope family's `→`
+  hint now appends "test scaffolding: consolidate only a genuinely shared fixture/helper, not
+  per-scenario setup" — Arrange/Act/Assert setup is often duplicated on purpose, so extraction can
+  hide each scenario's intent. It is a caveat, not a verdict (the worthy fixture-vs-scaffold call
+  is the reader's and is not feature-decidable); `mixed` test↔prod leaks get no caveat, and the
+  high-parameter caution still wins when both apply.
+
 ## [0.8.0] - 2026-06-14
 
 ### Added

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -5123,6 +5123,17 @@ fn family_hint(f: &nose_detect::RefactorFamily) -> String {
             f.params
         );
     }
+    // Test-scope duplication is a real smell, but Arrange/Act/Assert setup is often
+    // duplicated on purpose — extracting it can hide each scenario's intent (issue
+    // #264). Flag that triage caveat without asserting a verdict; the worthy
+    // fixture-vs-scaffold call is the reader's (and is not feature-decidable — see the
+    // default-surface-noise-audit). `mixed` (a test↔prod leak) is a real extract, no caveat.
+    if f.scope == "test" {
+        return format!(
+            "{base} — test scaffolding: consolidate only a genuinely shared fixture/helper, \
+             not per-scenario setup"
+        );
+    }
     base
 }
 
@@ -6203,6 +6214,34 @@ mod tests {
         assert_eq!(
             family_hint(&f),
             "repeated across 3 modules — extract a shared abstraction"
+        );
+    }
+
+    #[test]
+    fn hint_test_scope_flags_scaffolding_caveat() {
+        let mut f = fam(1, 2, &[None, None]);
+        f.scope = "test";
+        let h = family_hint(&f);
+        assert!(h.contains("extract a helper"), "{h}");
+        assert!(h.ends_with("not per-scenario setup"), "{h}");
+    }
+
+    #[test]
+    fn hint_prod_scope_has_no_test_caveat() {
+        let f = fam(1, 2, &[None, None]); // scope defaults to prod
+        assert!(!family_hint(&f).contains("test scaffolding"));
+    }
+
+    #[test]
+    fn hint_high_param_caution_wins_over_test_caveat() {
+        let mut f = fam(1, 2, &[None, None]);
+        f.scope = "test";
+        f.params = 8; // >= HIGH_PARAM_SPOTS
+        let h = family_hint(&f);
+        assert!(h.contains("high-parameter"), "{h}");
+        assert!(
+            !h.contains("test scaffolding"),
+            "high-param branch wins: {h}"
         );
     }
 


### PR DESCRIPTION
## What

A test-scope family's `→` hint now appends *"test scaffolding: consolidate only a genuinely shared fixture/helper, not per-scenario setup"*:

```
#1  id … · 11 copies · 18 of 21 lines shared, 1 spot differs · ~180 lines removable · near-duplicate  · in test code
    → consolidate `TestSkip` — 11 copies — test scaffolding: consolidate only a genuinely shared fixture/helper, not per-scenario setup
```

Arrange/Act/Assert setup is often duplicated *on purpose*, so extraction can hide each scenario's intent — #264's core experience. This is a **caveat, not a verdict**: the worthy fixture-vs-scaffold call is the reader's, and the [default-surface-noise-audit](docs/default-surface-noise-audit-2026-06-14.md) measured it **feature-inseparable** (within the `test × copy-paste-run` cell, worthy and noise have identical structural medians), so a detector verdict would be wrong (design §2). `mixed` test↔prod leaks (a real extract) get no caveat; the high-parameter caution still wins when both apply.

## Why #264 is complete

The rest of #264 already shipped:
- **prod vs test, prod first** + `shallow` demotion — #354.
- **overlapping families grouped** into one opportunity.
- **high-parameter wording** ("extract a method" softened at ≥6 varying spots).
- **"could use an existing helper"** — the reinvented-helper channel + "call the existing helper" hint.
- **shared-decision vs shared-shape** — the value-vs-shape equivalence witness, surfaced in the summary.

What remains of "distinguish extractable behavior from test scaffolding" is exactly the judgment the audit measured as not feature-decidable — so nose carries the evidence (`scope`, `witness.kind`, `params`/`shared_lines`) and this caveat, and leaves the verdict to the consumer (§2).

## Verification

3 hint tests added (caveat present for test scope; absent for prod; high-param precedence). Full suite + clippy `-D warnings` + fmt green.

Closes #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
