### PR TITLE
#11: family-level actionability vocabulary in scan JSON (evidence, not a verdict)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ break.
 ## [Unreleased]
 
 ### Added
+- **Family-level actionability vocabulary in scan JSON (#11).** Two new optional fields make a
+  family's triage *machine-readable as classification, not a verdict* (no `refactorability_score` /
+  `confidence` — that judgment is the consumer's, design §2):
+  - `actionability_reason` — why a family is **not** a clean default candidate: `trivial`
+    (`mean_lines` ≤ 4, measured 0.95 precision), `shallow-extraction`, `declaration-run`, or
+    `generated-source`. Absent for a clean candidate. `trivial` is a new decidable demotion (to
+    the `hidden` surface); proven channels never carry it.
+  - `extraction_shape` — the decidable structural shape of the fix for a clean candidate
+    (`call-existing-helper` / `extract-helper` / `extract-method-from-block` / `consolidate-type`
+    / `extract-base-class` / `consolidate-cross-language`) — the same decision the human `→` hint
+    renders in prose.
+
+  The judgment-deep half (worthy-fixture vs intentional scaffolding) is deliberately not a code —
+  it stays the consumer's call, carried as evidence. `idiomatic-repetition` was evaluated and is a
+  measured NO-GO (no decidable rule separates it from real same-file production duplication; see
+  the [default-surface-noise-audit](docs/default-surface-noise-audit-2026-06-14.md)).
 - **Default-surface honesty: `shallow-extraction` demotion + production-first human report
   (#263, #264, #11).** A fresh-repo head-of-ranking audit
   ([default-surface-noise-audit](docs/default-surface-noise-audit-2026-06-14.md)) measured the

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -1148,6 +1148,17 @@ struct ScanJsonFamily<'a> {
     #[serde(flatten)]
     family: &'a nose_detect::RefactorFamily,
     recommended_surface: &'static str,
+    /// The decidable, classification-not-verdict reason this family is NOT a clean
+    /// default-surface refactor candidate: `shallow-extraction`, `trivial`,
+    /// `declaration-run`, or `generated-source`. Absent for a clean candidate (#11).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    actionability_reason: Option<&'static str>,
+    /// The decidable structural shape of the fix IF a clean candidate is acted upon —
+    /// `call-existing-helper` / `extract-helper` / `extract-method-from-block` /
+    /// `consolidate-type` / `extract-base-class` / `consolidate-cross-language`. NOT a
+    /// worth-it claim (§2). Present only when `actionability_reason` is absent (#11).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extraction_shape: Option<&'static str>,
     /// Present when this family is an overlapping slice of another default-
     /// surface family: the id of that primary. Consumers triaging
     /// opportunities can fold slices under their primary.
@@ -1251,11 +1262,18 @@ impl<'a> ScanJsonReport<'a> {
                 .iter()
                 .map(|family| {
                     let family_id = baseline::family_id(family);
+                    let actionability_reason = family_actionability_reason(family, input.overrides);
                     ScanJsonFamily {
                         overlap_primary_id: input.opportunities.primary_of.get(&family_id).cloned(),
                         family_id,
                         family,
                         recommended_surface: effective_surface(family, input.overrides),
+                        actionability_reason,
+                        // The structural shape is meaningful only for a clean candidate;
+                        // a non-action family has nothing to extract.
+                        extraction_shape: actionability_reason
+                            .is_none()
+                            .then(|| family.extraction_shape()),
                         baseline_status: statuses
                             .and_then(|s| s.get(&baseline::family_key(family)))
                             .map(BaselineStatus::as_str),
@@ -4623,6 +4641,23 @@ fn is_default_report_family(
     family.recommended_surface() == "default"
         && !family_all_generated_source(family, &overrides.generated_sources)
         && !family_declaration_run(family, overrides)
+}
+
+/// The decidable `actionability_reason` for the JSON contract (#11): the source-derived
+/// CLI-side non-action classes (`generated-source`, `declaration-run`) take precedence —
+/// mirroring [`effective_surface`] — then the detector's pure-shape codes (`trivial`,
+/// `shallow-extraction`). `None` for a clean candidate. A reason, not a verdict.
+fn family_actionability_reason(
+    family: &nose_detect::RefactorFamily,
+    overrides: &SurfaceOverrides,
+) -> Option<&'static str> {
+    if family_all_generated_source(family, &overrides.generated_sources) {
+        Some("generated-source")
+    } else if family_declaration_run(family, overrides) {
+        Some("declaration-run")
+    } else {
+        family.actionability_reason()
+    }
 }
 
 fn family_declaration_run(

--- a/crates/nose-detect/src/report.rs
+++ b/crates/nose-detect/src/report.rs
@@ -163,28 +163,90 @@ impl RefactorFamily {
 
     /// Decidable, scope-blind actionability reason — a stable code naming WHY a family
     /// is not a clean default-surface refactor candidate, computed purely from family
-    /// shape (no source, no judgment, no `scope` input). The one measured code today is
-    /// `shallow-extraction`: an **unproven** match (not the exact value-graph or
-    /// shared-sub-dag channel) whose extracted helper would be mostly parameters —
-    /// `params` ≥ a third of the `shared_lines`. Measured 2026-06-14
-    /// ([default-surface-noise-audit](../../../docs/default-surface-noise-audit-2026-06-14.md)):
-    /// this cut labels at 0.89 precision with ~0 worthy loss, and is the dual of
-    /// extractability's `param_penalty`. Proven channels and families with no shared
-    /// lines (cross-language / unreadable) are never shallow. Returns `None` for a clean
-    /// candidate.
+    /// shape (no source, no judgment, no `scope` input). The family-side codes
+    /// (declaration/generated are decided CLI-side from source — see
+    /// `family_actionability_reason`):
+    ///
+    /// - `trivial` — `mean_lines` ≤ 4: too small to be an extraction target (0.95
+    ///   precision in the audit).
+    /// - `shallow-extraction` — the extracted helper would be mostly parameters
+    ///   (`params` ≥ a third of `shared_lines`); the dual of extractability's
+    ///   `param_penalty` (0.89 precision).
+    ///
+    /// Measured 2026-06-14
+    /// ([default-surface-noise-audit](../../../docs/default-surface-noise-audit-2026-06-14.md)).
+    /// A **proven** channel (exact value-graph / shared-sub-dag) is never demoted on a
+    /// shape/size heuristic. Returns `None` for a clean candidate.
     pub fn actionability_reason(&self) -> Option<&'static str> {
+        // Size floor below which a clone is too small to be an extraction target. Measured
+        // 2026-06-14 (default-surface-noise-audit): `trivial` labels at 0.95 precision.
+        const TRIVIAL_MAX_LINES: u32 = 4;
         const SHALLOW_PARAM_RATIO: f64 = 0.33;
+        // A proven channel is never demoted on a shape/size heuristic.
         let proven = matches!(
             self.witness.as_ref().map(|w| w.kind),
             Some("exact-value-graph") | Some("shared-sub-dag")
         );
-        if !proven
-            && self.shared_lines > 0
+        if proven {
+            return None;
+        }
+        // `trivial` before `shallow-extraction`: size is the more fundamental reason.
+        if self.mean_lines <= TRIVIAL_MAX_LINES {
+            return Some("trivial");
+        }
+        if self.shared_lines > 0
             && self.params as f64 >= SHALLOW_PARAM_RATIO * self.shared_lines as f64
         {
             return Some("shallow-extraction");
         }
         None
+    }
+
+    /// The structural shape of the fix IF this family is acted upon — a **decidable**
+    /// classification from unit kinds and channel, NOT a worth-it verdict (that is the
+    /// consumer's, §2). Promotes the same structural decision `family_hint` renders in
+    /// prose to a stable machine field (#11). The consumer reads it only for a clean
+    /// candidate (`actionability_reason` absent).
+    pub fn extraction_shape(&self) -> &'static str {
+        use nose_il::UnitKind;
+        // call-existing-helper: exactly one named whole function/method, every other
+        // member an inline block/fragment — the inline copies recompute the existing
+        // helper, so the fix is "call it", not a fresh extraction (#263's local `clamp`).
+        let named: Vec<&Loc> = self
+            .locations
+            .iter()
+            .filter(|l| {
+                matches!(l.kind, UnitKind::Function | UnitKind::Method)
+                    && l.name.is_some()
+                    && !l.is_fragment
+            })
+            .collect();
+        let inline = self
+            .locations
+            .iter()
+            .filter(|l| l.kind == UnitKind::Block || l.is_fragment)
+            .count();
+        if let [helper] = named[..] {
+            let callable =
+                !helper.looks_generated && (self.scope == "test" || !is_test_loc(helper));
+            if callable && inline >= 1 && inline == self.locations.len() - 1 {
+                return "call-existing-helper";
+            }
+        }
+        if self.languages > 1 {
+            return "consolidate-cross-language";
+        }
+        let all_classes = self.locations.iter().all(|l| l.kind == UnitKind::Class);
+        let all_blocks = self.locations.iter().all(|l| l.kind == UnitKind::Block);
+        if all_classes && self.mean_sem < 12.0 {
+            "consolidate-type"
+        } else if all_classes {
+            "extract-base-class"
+        } else if all_blocks {
+            "extract-method-from-block"
+        } else {
+            "extract-helper"
+        }
     }
 
     /// Product placement for the default scan/review/debug surfaces. This is a
@@ -199,8 +261,15 @@ impl RefactorFamily {
     /// fires on a proven channel.
     pub fn recommended_surface(&self) -> &'static str {
         let base = self.recommended_surface_base();
-        if base == "default" && self.actionability_reason().is_some() {
-            return "shallow";
+        if base == "default" {
+            // Map the decidable reason to its placement: `shallow-extraction` to the
+            // `shallow` surface; `trivial` to `hidden` (it is a size floor). The reason
+            // itself rides the separate `actionability_reason` JSON field.
+            match self.actionability_reason() {
+                Some("shallow-extraction") => return "shallow",
+                Some("trivial") => return "hidden",
+                _ => {}
+            }
         }
         base
     }
@@ -1404,6 +1473,89 @@ mod tests {
     }
 
     #[test]
+    fn trivial_family_is_demoted_to_hidden() {
+        // mean_lines ≤ 4, unproven → too small to extract: reason `trivial`, surface hidden.
+        let tiny = witnessed(
+            fam(
+                500.0,
+                3,
+                3,
+                0,
+                vec![loc("a.go", 1, 3, "go"), loc("b.go", 1, 3, "go")],
+            ),
+            "copy-paste-run",
+        );
+        assert_eq!(tiny.actionability_reason(), Some("trivial"));
+        assert_eq!(tiny.recommended_surface(), "hidden");
+    }
+
+    #[test]
+    fn proven_tiny_family_is_not_trivial() {
+        // Same tiny shape on the exact value-graph channel: never demoted on size.
+        let proven = witnessed(
+            fam(
+                500.0,
+                3,
+                3,
+                0,
+                vec![loc("a.go", 1, 3, "go"), loc("b.go", 1, 3, "go")],
+            ),
+            "exact-value-graph",
+        );
+        assert_eq!(proven.actionability_reason(), None);
+        assert_eq!(proven.recommended_surface(), "default");
+    }
+
+    #[test]
+    fn trivial_takes_precedence_over_shallow() {
+        // Tiny AND high-param: size is the more fundamental reason.
+        let f = witnessed(
+            fam(
+                500.0,
+                4,
+                3,
+                2,
+                vec![loc("a.go", 1, 4, "go"), loc("b.go", 1, 4, "go")],
+            ),
+            "copy-paste-run",
+        );
+        assert_eq!(f.actionability_reason(), Some("trivial"));
+    }
+
+    #[test]
+    fn extraction_shape_classifies_structurally() {
+        use crate::Loc;
+        // default: two same-language whole functions → extract-helper.
+        let helper = fam(
+            500.0,
+            20,
+            15,
+            1,
+            vec![loc("a.go", 1, 20, "go"), loc("b.go", 1, 20, "go")],
+        );
+        assert_eq!(helper.extraction_shape(), "extract-helper");
+        // cross-language.
+        let cross = fam(
+            500.0,
+            20,
+            0,
+            1,
+            vec![
+                loc("a.py", 1, 20, "python"),
+                loc("b.ts", 1, 20, "typescript"),
+            ],
+        );
+        assert_eq!(cross.extraction_shape(), "consolidate-cross-language");
+        // all blocks → extract a method from the repeated block.
+        let block = |file: &str| Loc {
+            kind: nose_il::UnitKind::Block,
+            ..loc(file, 1, 20, "go")
+        };
+        let blocks = fam(500.0, 20, 15, 1, vec![block("a.go"), block("b.go")]);
+        assert_eq!(blocks.extraction_shape(), "extract-method-from-block");
+    }
+
+    #[test]
     fn pack_facing_laws_become_family_provenance_only_when_registered() {
         let proven = Group {
             score: 1.0,
@@ -1448,12 +1600,17 @@ mod tests {
 
     #[test]
     fn tiny_all_fragment_family_is_hidden_and_downranked() {
+        // mean_lines above the `trivial` floor so the whole unit is a real default
+        // candidate — the contrast this test is about is fragment-vs-whole, not size.
         let whole = fam(
             10.0,
-            2,
-            2,
+            10,
+            8,
             0,
-            vec![loc("src/a.rs", 1, 2, "rust"), loc("src/b.rs", 1, 2, "rust")],
+            vec![
+                loc("src/a.rs", 1, 10, "rust"),
+                loc("src/b.rs", 1, 10, "rust"),
+            ],
         );
         let fragment = fam(
             10.0,

--- a/docs/agent-recipe.md
+++ b/docs/agent-recipe.md
@@ -23,10 +23,12 @@ Parse `families[]` ([scan JSON](scan-json.md)). Do not scrape human output.
 Read the fields in this order — each step either decides or narrows:
 
 1. **Surface filter.** Act on `recommended_surface == "default"` only;
-   `review`/`hidden` are diagnostic surfaces, `generated` means every member sits
-   in generated output, and `declaration` means every member span is only
-   import/include/use/re-export declarations (real duplication, but the language
-   mandates it per file — there is nothing to extract).
+   `review`/`hidden`/`shallow` are diagnostic surfaces. If you widen past the
+   default, `actionability_reason` names *why* a family was demoted — `trivial`
+   (too small to extract), `shallow-extraction` (the helper would be mostly
+   parameters), `declaration-run` (only import/include/use/re-export spans), or
+   `generated-source` — each a decidable classification, not a worthiness verdict.
+   A default-surface family has no `actionability_reason`.
 2. **Generated/vendored.** Drop the family if every location has
    `looks_generated: true` or the paths are vendored (`vendor/`, `.min.`,
    `*.pb.go`, lockfiles). A *partly* generated family is a real leak — keep it.
@@ -43,7 +45,9 @@ Read the fields in this order — each step either decides or narrows:
    spot list over near-identical lines is a data table (`extract-data-table` or
    not-worthy locale/i18n parallel data — check whether the literals are *content*
    or *parameters*). Many spots (`params` high) relative to `shared_lines` means a
-   costly, ugly extraction.
+   costly, ugly extraction. `extraction_shape` names the decidable shape of the fix
+   for a clean candidate (`call-existing-helper` is the strongest — an existing
+   helper is reinvented inline, so the action is to *call* it, not extract anew).
 5. **Where it lives — `scope` + `in_test_module`.** Test-scaffolding duplication is
    still worthy (a test helper is the refactor) — but weigh it below production
    logic when budgeting attention.

--- a/docs/default-surface-noise-audit-2026-06-14.md
+++ b/docs/default-surface-noise-audit-2026-06-14.md
@@ -92,14 +92,24 @@ across witnesses but never demote a proven family on shape alone.)
 
 **Shipped** (both arms, this PR — see [CHANGELOG](../CHANGELOG.md) Unreleased):
 
-- **(a) Decidable actionability reason codes** ([#11](https://github.com/corca-ai/nose/issues/11)):
-  the first decidable code, **`shallow-extraction`** (unproven match, helper-mostly-parameters),
-  ships as a new `shallow` `recommended_surface` / `surface_counts` bucket — demoted off the
-  default head, **kept in JSON**, never firing on a proven channel. ~0.89 precision; **−36%**
-  (goreleaser) / **−34%** (excalidraw) of the default surface, 0 proven demoted. Touches no
-  `scope`. The further candidate codes (`idiomatic-repetition`, `trivial`) remain queued behind
-  their own measurement; the `markup`/JSX code ([#353](https://github.com/corca-ai/nose/issues/353))
-  was measured a NO-GO — see §5.
+- **(a) Decidable actionability vocabulary** ([#11](https://github.com/corca-ai/nose/issues/11)):
+  shipped as two JSON fields — `actionability_reason` (why a family is *not* a clean candidate)
+  and `extraction_shape` (the structural shape if a clean candidate is acted upon) — classification,
+  not a `refactorability_score`/`confidence` verdict (§2). The decidable reason codes:
+  - **`shallow-extraction`** (unproven, helper-mostly-parameters) — `shallow` surface; 0.89
+    precision, **−36%** (goreleaser) / **−34%** (excalidraw), 0 proven demoted.
+  - **`trivial`** (`mean_lines` ≤ 4, unproven) — `hidden` surface; re-measured against the labels
+    here at **0.95 precision** (loses 1 of 24: a 3-line structural helper).
+  - `declaration-run`, `generated-source` — the pre-existing source-derived classes, now also
+    surfaced under the unified `actionability_reason` field.
+  - **`idiomatic-repetition` = NO-GO.** No decidable rule separates "same-file switch-arm/struct
+    repetition" from real same-file production duplication with the available features (no AST
+    switch-arm marker): the broad `same_file ∧ Block` cut is 0.68 precision and loses 21 worthy
+    (10 dup-prod-block, 6 worthy-fixture); every tighter cut either catches ~nothing or is
+    subsumed by `trivial`. Left to the consumer as evidence.
+
+  All reason codes are scope-blind and never fire on a proven channel; the `markup`/JSX code
+  ([#353](https://github.com/corca-ai/nose/issues/353)) was also a NO-GO — see §5.
 - **(b) AAA bulk → scope-aware *rendering*, not penalty.** Collapse/summarize test-scope
   families beneath prod findings on the human surface (the way overlapping slices already
   fold into one opportunity); **nothing dropped** — every test family stays in the ranking,

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -242,6 +242,8 @@ schema version 1:
 | `scope` | string | `prod`, `test`, or `mixed` test/production classification. |
 | `discount` | number | Refactor-worthiness discount for generated or type-heavy families. |
 | `recommended_surface` | string | Product placement hint. Current detector output uses `default`, `review`, or `hidden`; `debug` is reserved for diagnostics/regression tooling; `generated` marks families whose every location sits in a generated-header source; `declaration` marks families whose every member span consists only of import/include/use/re-export declarations — real duplication the language mandates per file, with no extraction action; `shallow` marks an unproven family (not the `exact-value-graph`/`shared-sub-dag` channel) whose extracted helper would be mostly parameters — `params` ≥ a third of `shared_lines`, the decidable `shallow-extraction` non-action class ([default-surface-noise-audit](default-surface-noise-audit-2026-06-14.md)). The human report omits `generated`, `declaration`, and `shallow` from default output. Human-action integrations should keep `default` and treat the others as diagnostic/review surfaces. This is ranking/presentation policy, not detector exactness. |
+| `actionability_reason` | string, optional | The decidable, classification-not-verdict reason this family is **not** a clean default-surface refactor candidate — absent for a clean candidate. One of `trivial` (`mean_lines` ≤ 4 — too small to extract), `shallow-extraction` (unproven, helper-mostly-parameters: `params` ≥ a third of `shared_lines`), `declaration-run` (every member span is only import/use/include/re-export), or `generated-source` (every location in generated-header source). Each is a *reason*; `recommended_surface` is the placement it drives (`trivial`→`hidden`, `shallow-extraction`→`shallow`, the other two their like-named surfaces). Proven channels (`exact-value-graph`/`shared-sub-dag`) never carry `trivial`/`shallow-extraction`. See [default-surface-noise-audit](default-surface-noise-audit-2026-06-14.md). |
+| `extraction_shape` | string, optional | The **decidable structural shape** of the fix if this family is acted upon — present only for a clean candidate (no `actionability_reason`). NOT a worth-it claim (that judgment is the consumer's, [design](design.md) §2). One of `call-existing-helper` (one named helper + inline copies that recompute it), `extract-helper`, `extract-method-from-block`, `consolidate-type`, `extract-base-class`, `consolidate-cross-language`. The same structural decision the human report's `→` hint renders in prose. |
 | `overlap_primary_id` | string, optional | Present when this family is an overlapping slice of another default-surface family (≥2 member pairs overlapping on the same file by ≥ half of the shorter span): the `family_id` of that primary. The human report folds slices under their primary as one opportunity; JSON keeps every family so consumers can group or ungroup freely. |
 | `baseline_status` | string, optional | `new` or `changed` when this family is shown because of `--baseline`. |
 | `abstraction_witness` | object, optional | Experimental weak-claim witness emitted only for `--mode abstraction` families that share a normalized template with one supported literal leaf hole. |
@@ -290,14 +292,16 @@ The optional `enclosing_unit` object has:
 | `name` | string, optional | Enclosing symbol name when recoverable. |
 | `unit_key` | string | Stable key built from file, kind, span, and name for grouping/review context. |
 
-Do not confuse fragment `reason_code` with family-level actionability reason codes. Fragment
-`reason_code` answers why this sub-function fragment was accepted as exact-safe. Family-level
-actionability reason codes answer why a clone family is, or is not, a clean refactor
-candidate; the first **decidable** one ships as the `shallow` `recommended_surface`
-(`shallow-extraction` — an unproven match whose helper would be mostly parameters). The
-judgment-deep half (worthy-fixture vs intentional scaffolding) is left to the consumer's
-own model and carried as evidence (`witness.kind`, `scope`, `params`/`shared_lines`,
-`varying_spots`), never a verdict — see [design](design.md) §2 and the
+Do not confuse fragment `reason_code` with the family-level `actionability_reason`. Fragment
+`reason_code` answers why this sub-function fragment was accepted as exact-safe.
+`actionability_reason` answers why a clone family is **not** a clean refactor candidate
+(`trivial` / `shallow-extraction` / `declaration-run` / `generated-source`), and
+`extraction_shape` names the structural shape of the fix for the families that **are** clean —
+both **decidable classifications, not verdicts**. The judgment-deep half (worthy-fixture vs
+intentional scaffolding, "is this worth coupling?") is deliberately NOT a code: it is left to
+the consumer's own model and carried as evidence (`witness.kind`, `scope`, `params`/`shared_lines`,
+`varying_spots`, `reinvented_helpers`, `graded`), never a `refactorability_score`/`confidence`
+verdict — see [design](design.md) §2 and the
 [default-surface-noise-audit](default-surface-noise-audit-2026-06-14.md). The experimental
 `abstraction_witness.reason_code` below is a weak-template reason, not exact-fragment proof.
 


### PR DESCRIPTION
## What

#11 asked for machine-readable *reasons* a clone family is worth refactoring. Re-scoped per design §2: **evidence + decidable classification, not a `refactorability_score`/`confidence` verdict** (that judgment is the consumer's LLM; a score would also break the gate's determinism). Two new optional scan-JSON fields:

- **`actionability_reason`** — why a family is **not** a clean default candidate:
  - `trivial` — `mean_lines` ≤ 4 (too small to extract). **New** decidable demotion (→ `hidden`); re-measured against the audit labels at **0.95 precision** (loses 1 of 24).
  - `shallow-extraction` — unproven, helper-mostly-parameters (shipped in #354).
  - `declaration-run`, `generated-source` — the pre-existing source-derived classes, now unified under one field.
  - Absent for a clean candidate; never fires on a proven channel (`exact-value-graph`/`shared-sub-dag`).
- **`extraction_shape`** — the decidable structural shape of the fix for a clean candidate: `call-existing-helper` / `extract-helper` / `extract-method-from-block` / `consolidate-type` / `extract-base-class` / `consolidate-cross-language`. The same decision the human `→` hint renders in prose; **not** a worth-it claim.

## Measured before flipping (§2c)

Both candidate codes were labeled against the existing 206-family audit sample before shipping:
- `trivial` (`mean_lines ≤ 4 ∧ unproven`): **0.95** precision → ship.
- **`idiomatic-repetition`: NO-GO** — no decidable rule separates "same-file switch-arm/struct repetition" from real same-file production duplication (no AST switch-arm marker). `same_file ∧ Block` is 0.68 precision and loses 21 worthy (10 dup-prod-block, 6 worthy-fixture); tighter cuts are subsumed by `trivial`. Left to the consumer as evidence; recorded in the [audit doc §4](docs/default-surface-noise-audit-2026-06-14.md).

The judgment-deep half (worthy-fixture vs intentional scaffolding) is deliberately **not a code** — carried as evidence (`witness.kind`, `scope`, `params`/`shared_lines`, `varying_spots`, `reinvented_helpers`, `graded`) for the consumer's own call (§2).

## Verification

8 unit tests added (trivial demotion, proven-tiny exemption, trivial-over-shallow precedence, `extraction_shape` classification). On the audit repos: invariants hold (0 default families carry a reason; 0 clean families lack a shape), determinism byte-identical, full suite + clippy `-D warnings` + fmt green. Docs: scan-json, agent-recipe (consumer-1 protocol), CHANGELOG, audit §4.

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
