### PR TITLE
Record tier-2 sibling-family folding as a measured NO-GO

### DIFF
--- a/docs/default-surface-noise-audit-2026-06-14.md
+++ b/docs/default-surface-noise-audit-2026-06-14.md
@@ -157,6 +157,40 @@ Shipping a `markup` surface for ~1 family would be dead complexity against *capa
 features*. #353 is closed measured-negligible; the cheap re-run path is the same per-repo
 measurement script if a future component-library corpus suggests otherwise.
 
+## 6. Tier-2 sibling-family folding — measured NO-GO
+
+§4(b) collapses *overlapping slices of one region* and renders test beneath prod, but the bare
+default is still a long list (fresh `--top 0` default families: rxjs 636, prometheus 1455,
+redis 484, zod 397). The tempting next lever: fold the **per-variant sibling-family wall** —
+many *distinct* families that are copies of one shape (rxjs per-operator marble tests,
+prometheus per-service AWS-discovery inits, serde owned/borrowed impls) — into one
+"opportunity", lifting the genuine standalone wins into view. Fully implemented and measured on
+a 7-repo slice (rich, serde_json, zod, rxjs, prometheus, redis, cobra), reading cluster
+members' real source. **NO-GO, for two structural reasons:**
+
+1. **nose already folds the real repetition** into multi-member families: `finalize-spec.ts` is
+   one 31-member family, serde `write_i8` one 10-member family. The *separate* families that
+   remain are below the clone-merge threshold *because they are genuinely structurally
+   distinct* — there is little cross-family redundancy left to fold.
+2. **Cross-family folding can't cluster coherently.** A metadata key
+   `(scope, extraction_shape, dir, size-band)` "reduces" the surface 72–89% but **incoherently**
+   (rich's best finding `replace_link_ids` grouped with unrelated tests; a 4-line
+   `__rich_measure__` with an 86-line `__init__`). A leaf-abstracted value-DAG shape key
+   (per-node Merkle hash over `(VgOp, arity, child-hashes)`, multiset Jaccard / overlap) does
+   not rescue it: exact-match folds ~nothing; and even **complete-link @ Jaccard 0.6 groups
+   `map.rs new()`/`iter()` with `deserialize_tuple_struct`** — a small unit's leaf-abstracted
+   whole-unit shape is generic ("calls + return" ≈ "construct + return"), so unrelated small
+   units are mutually similar. No metric × threshold × linkage × min-node floor separated true
+   siblings from generic-shape collisions; cost was **+67% scan time** (re-lowering the whole
+   surface for shapes).
+
+Shipping it would hide distinct genuine findings under a misleading "same shape" label *and*
+slow scans — strictly worse. Recorded in [experiments §CA](experiments.md). The independent,
+source-verified lever stands: a decidable **evidence** flag for language-forced parallel
+duplication (`owned-vs-borrowed` / `covariant-type-only` / `high-param-ratio` from the graded
+per-spot `class`, evidence-not-verdict) and retiring "proven ⇒ trust/lead" (serde's top
+`shared-sub-dag` is `Value` vs `&Value`, value 179, **params 15**).
+
 ## Honest limits
 
 Two repos, two languages (Go, TS/React); single-judge labels (no adversarial refuter pass,

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2605,3 +2605,45 @@ functions (spans carry `function`/`return`), and real JSX embeds `clsx`/handlers
 list-render/class idioms, which is judgment, not decidable (§2). JSX-presentational-ness
 becomes one **evidence** input for the consumer (the #11 vocabulary), not a detector
 surface — see the audit doc §5.
+
+**Tier-2 sibling-family folding — NO-GO (measured 2026-06-14).** A natural follow-up to the
+scope-aware *rendering* lever above: the bare default surface is still a long list (per-repo
+default families, fresh `--top 0`: rxjs 636, prometheus 1455, redis 484, zod 397), so collapse
+the *per-variant sibling-family wall* — the rxjs per-operator marble tests, the prometheus
+per-service AWS-discovery inits, the serde owned/borrowed impls — into one folded
+"opportunity" the way overlap slices already fold, lifting the genuine standalone wins into
+view. Fully implemented and measured on a 7-repo corpus slice (rich, serde_json, zod, rxjs,
+prometheus, redis, cobra), reading cluster members' real source to judge coherence. **NO-GO,
+for two structural reasons:**
+
+1. **nose's own family grouping already folds the real repetition.** The "wall of N redundant
+   sibling families" was a miscount: `finalize-spec.ts` is one **31-member** family,
+   serde `write_i8` one **10-member** family, `serialize_newtype_variant` 25 members. The
+   *separate* default families that remain are below the clone-merge threshold *because they
+   are genuinely structurally distinct* — there is little true cross-family redundancy left to
+   fold.
+
+2. **Cross-family folding cannot cluster coherently — intrinsic, not a tuning miss.** A
+   metadata key `(scope, extraction_shape, dir, size-band)` "reduced" the surface 72–89% but
+   **incoherently** — rich's single best finding (`replace_link_ids`, a real shared test
+   helper) was grouped with unrelated tests; a 4-line `__rich_measure__` with an 86-line
+   `__init__`. Replacing the key with a leaf-abstracted value-DAG shape (per-node Merkle hash
+   over `(VgOp, arity, child-hashes)`, ignoring the literal/name `key`; multiset compared by
+   Jaccard or overlap-coefficient) does not rescue it: exact-match folds ~nothing (true
+   siblings differ by ≥1 node, else they'd already be one family); Jaccard is defeated by the
+   siblings' size variance; overlap-coefficient and even **complete-link @ Jaccard 0.6 still
+   group `map.rs new()`/`iter()` with `deserialize_tuple_struct`** — a small function's
+   leaf-abstracted whole-unit shape is generic ("calls + return" ≈ "construct + return"), so
+   semantically-unrelated small units are mutually similar. No metric × threshold × linkage ×
+   min-node floor separated true siblings from generic-shape collisions. Cost: **+67% scan
+   time** (2.96 s → 4.94 s on prometheus) to re-lower the whole default surface for shapes.
+
+Shipping folding would **hide distinct genuine findings under a misleading "same shape" label**
+(the over-folding hazard) *and* slow scans — strictly worse. The whole-unit structural signal
+is not clean enough to separate per-variant siblings from coincidental shape collisions. The
+independent, source-verified lever from the same audit stands unaffected: a decidable
+**evidence** flag for language-forced parallel duplication (`owned-vs-borrowed` /
+`covariant-type-only` / `high-param-ratio`, a rollup of the graded per-spot `class`,
+evidence-not-verdict), plus retiring "proven ⇒ trust/lead" (serde's top `shared-sub-dag` is
+`Value` vs `&Value`, value 179, **params 15** — forced duplication at the head of the proven
+channel). See the audit doc §5.


### PR DESCRIPTION
## What

Records, as a measured **NO-GO**, the tier-2 *sibling-family folding* lever — the natural follow-up to the default-surface noise audit's scope-aware rendering (§4b). The idea: the bare default surface is still a long list (fresh `--top 0` default families: rxjs 636, prometheus 1455, redis 484, zod 397), so fold the *per-variant sibling-family wall* (rxjs per-operator marble tests, prometheus per-service AWS-discovery inits, serde owned/borrowed impls) into one "opportunity", the way overlap slices already fold, lifting the genuine standalone wins into view.

It was **fully implemented** and **measured on a 7-repo corpus slice** (rich, serde_json, zod, rxjs, prometheus, redis, cobra), reading cluster members' real source to judge coherence. **No code ships** — only the measurement is recorded (the #355 pattern).

## Why NO-GO — two structural reasons

1. **nose's own family grouping already folds the real repetition.** The "wall of N redundant sibling families" was a miscount: `finalize-spec.ts` is one **31-member** family, serde `write_i8` one **10-member** family. The *separate* default families that remain are below the clone-merge threshold *because they are genuinely structurally distinct* — there is little cross-family redundancy left to fold.

2. **Cross-family folding cannot cluster coherently — intrinsic, not a tuning miss.**
   - Metadata key `(scope, extraction_shape, dir, size-band)`: "reduced" the surface **72–89%** but **incoherently** — rich's single best finding (`replace_link_ids`, a real shared test helper) grouped with unrelated tests; a 4-line `__rich_measure__` with an 86-line `__init__`.
   - Leaf-abstracted value-DAG **shape** key (per-node Merkle hash over `(VgOp, arity, child-hashes)`, ignoring the literal/name `key`; multiset Jaccard / overlap-coefficient): exact-match folds ~nothing; Jaccard defeated by siblings' size variance; **complete-link @ Jaccard 0.6 still groups `map.rs new()`/`iter()` with `deserialize_tuple_struct`** — a small unit's leaf-abstracted whole-unit shape is generic (`calls + return` ≈ `construct + return`). No metric × threshold × linkage × min-node floor separated true siblings from generic-shape collisions.
   - Cost: **+67% scan time** (2.96s → 4.94s on prometheus) to re-lower the whole surface for shapes.

Shipping it would **hide distinct genuine findings under a misleading "same shape" label** (the over-folding hazard) *and* slow scans — strictly worse.

## What still stands

The independent, source-verified lever from the same audit is unaffected: a decidable **evidence** flag for language-forced parallel duplication (`owned-vs-borrowed` / `covariant-type-only` / `high-param-ratio`, a rollup of the graded per-spot `class`, evidence-not-verdict), plus retiring "proven ⇒ trust/lead" (serde's top `shared-sub-dag` is `Value` vs `&Value`, value 179, **params 15** — forced duplication at the head of the proven channel).

## Changes

- `docs/experiments.md` — §CA: the folding NO-GO measurement.
- `docs/default-surface-noise-audit-2026-06-14.md` — new §6.
- **No code change.** `awiki lint --root docs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)