### PR TITLE
#360: align the extraction proposal across all of a family's copies

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -5271,7 +5271,7 @@ fn print_family_entry(
         print_member_diff(&f.locations[0], &f.locations[1]);
     }
     if proposal && f.locations.len() >= 2 {
-        print_member_proposal(&f.locations[0], &f.locations[1], f.locations.len());
+        print_member_proposal(&f.locations);
     }
 }
 
@@ -5368,59 +5368,80 @@ fn print_member_diff(a: &nose_detect::Loc, b: &nose_detect::Loc) {
     }
 }
 
-/// Synthesize an *extraction proposal* from two representative copies: the lines
-/// they share become the body of the shared helper, and each maximal run of differing
-/// lines collapses to a `⟨param N⟩` placeholder — i.e. anti-unification at line
-/// granularity. Turns "these are similar" into "extract this, parameterize these N
-/// spots." The varying spots are the candidate parameters.
-///
-/// The skeleton is necessarily *pairwise* (the two largest copies). For a family with
-/// more copies that's an upper bound: a third copy that diverges further shrinks the
-/// truly-shared body and adds parameters, which is why the family's one-line summary —
-/// computed as a *majority* intersection across all members — can report fewer shared
-/// lines. `members` lets us say so rather than letting the two counts silently disagree.
-fn print_member_proposal(a: &nose_detect::Loc, b: &nose_detect::Loc, members: usize) {
-    let (Some(la), Some(lb)) = (
-        read_lines(&a.file, a.start_line, a.end_line),
-        read_lines(&b.file, b.start_line, b.end_line),
-    ) else {
+/// Synthesize an *extraction proposal* aligned across **all** the family's copies (#360):
+/// the lines invariant across *every* copy become the body of the shared helper, and each
+/// maximal run that varies in *any* copy collapses to a `⟨param N⟩` placeholder — line-
+/// granularity anti-unification, N-way. Turns "these are similar" into "extract this,
+/// parameterize these N spots", and — unlike a pairwise skeleton — the result is safe to
+/// apply to *every* member, not just the two largest, so it never claims a shared line a
+/// third copy actually diverges on. Bounded to one family, paid only on `--show proposal`.
+fn print_member_proposal(locations: &[nose_detect::Loc]) {
+    // Read every copy's source; align across all of them. A copy whose source can't be
+    // read is dropped, and the count reflects the copies actually aligned.
+    let members: Vec<Vec<String>> = locations
+        .iter()
+        .filter_map(|l| read_lines(&l.file, l.start_line, l.end_line))
+        .collect();
+    if members.len() < 2 {
         return;
-    };
-    let ar: Vec<&str> = la.iter().map(String::as_str).collect();
-    let br: Vec<&str> = lb.iter().map(String::as_str).collect();
-    let (skeleton, shared, params) = anti_unify(&ar, &br);
-    let scope = if members > 2 {
-        format!(" (of the 2 largest of {members} copies; the rest may share fewer)")
-    } else {
-        String::new()
-    };
+    }
+    let (skeleton, shared, params) = anti_unify_all(&members);
+    let copies = members.len();
     println!(
-        "     proposal  extract a shared helper · {shared} shared lines · {params} parameter(s) vary{scope}"
+        "     proposal  extract a shared helper · {shared} shared lines · {params} parameter(s) vary (across all {copies} copies)"
     );
     for line in skeleton.iter().take(40) {
         println!("       │ {line}");
     }
 }
 
-/// Anti-unify two line-blocks at line granularity: the lines they share become the
-/// body of the extracted helper, and each maximal run of differing lines collapses to
-/// one `⟨param N⟩` placeholder (a candidate parameter). Returns the skeleton, the
-/// count of shared (invariant) lines, and the parameter count. Shared by the
-/// `--show proposal` view and by extractability ranking / honest shared-line reporting.
-fn anti_unify(a: &[&str], b: &[&str]) -> (Vec<String>, u32, u32) {
-    let diff = line_diff(a, b);
+/// Anti-unify N line-blocks at line granularity. Anchored on the first (largest) copy,
+/// a line *survives* into the shared body only if it is matched in *every* other copy
+/// (each copy votes via a pairwise `line_diff` against the anchor); any maximal run of
+/// non-surviving anchor lines collapses to one `⟨param N⟩` placeholder. Returns the
+/// skeleton, the count of lines shared across all copies, and the parameter count. With
+/// two copies this is exactly the old pairwise anti-unification; with more, it is the
+/// honest intersection — what the `--show proposal` view renders.
+fn anti_unify_all(members: &[Vec<String>]) -> (Vec<String>, u32, u32) {
+    let anchor: Vec<&str> = members[0].iter().map(String::as_str).collect();
+    let n = anchor.len();
+    // survive[i]: anchor line i is matched in every other copy.
+    let mut survive = vec![true; n];
+    for other in &members[1..] {
+        let b: Vec<&str> = other.iter().map(String::as_str).collect();
+        let mut matched = vec![false; n];
+        let mut ai = 0usize;
+        for (tag, _line) in line_diff(&anchor, &b) {
+            match tag {
+                // matched line — advances the anchor cursor and votes the line in.
+                ' ' => {
+                    if ai < n {
+                        matched[ai] = true;
+                    }
+                    ai += 1;
+                }
+                // anchor-only line — advances the cursor, not voted in.
+                '-' => ai += 1,
+                // other-only line ('+') — does not advance the anchor cursor.
+                _ => {}
+            }
+        }
+        for (s, m) in survive.iter_mut().zip(matched) {
+            *s &= m;
+        }
+    }
     let mut skeleton: Vec<String> = Vec::new();
     let mut shared = 0u32;
     let mut params = 0u32;
     let mut in_hole = false;
     let mut indent = "";
-    for (tag, line) in &diff {
-        if *tag == ' ' {
+    for (line, &kept) in anchor.iter().zip(&survive) {
+        if kept {
             in_hole = false;
             shared += 1;
             // remember the indentation to align the placeholder
             indent = &line[..line.len() - line.trim_start().len()];
-            skeleton.push(line.clone());
+            skeleton.push((*line).to_string());
         } else if !in_hole {
             in_hole = true;
             params += 1;

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1849,6 +1849,43 @@ fn proposal_shows_shared_skeleton_and_parameters() {
 }
 
 #[test]
+fn proposal_aligns_across_all_copies() {
+    // Three near-identical functions (one operator each) form one family of 3. The
+    // proposal must align across ALL three copies (#360), not just a representative
+    // pair — so it says so, and the operator line is a parameter.
+    let dir = std::env::temp_dir().join(format!("nose_prop3_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    for d in ["a", "b", "c"] {
+        fs::create_dir_all(dir.join(d)).unwrap();
+    }
+    let mk = |op: &str| {
+        format!("def f(xs):\n    t = 0\n    for x in xs:\n        if x > 0:\n            t = t {op} x\n    return t\n")
+    };
+    fs::write(dir.join("a/m.py"), mk("+")).unwrap();
+    fs::write(dir.join("b/m.py"), mk("*")).unwrap();
+    fs::write(dir.join("c/m.py"), mk("-")).unwrap();
+    let out = run(&[
+        "scan",
+        dir.to_str().unwrap(),
+        "--mode",
+        "near:0.5",
+        "--show",
+        "proposal",
+        "--min-size",
+        "12",
+    ]);
+    assert!(
+        out.contains("across all 3 copies"),
+        "proposal must align across all 3 copies: {out}"
+    );
+    assert!(
+        out.contains("⟨param 1⟩"),
+        "the varying operator line is a parameter: {out}"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn sort_keys_label_the_ranking_and_reject_garbage() {
     let dir = make_project("sort");
     let p = dir.to_str().unwrap();

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -128,7 +128,7 @@ chance** — see [hazard-ranking](hazard-ranking.md) for the full, honest evalua
 | flag | effect |
 |---|---|
 | `--show diff` | show each family inline as a unified diff between its two representative copies — both versions and exactly what differs |
-| `--show proposal` | show an extraction skeleton per family — the shared structure with the differing parts marked as parameters |
+| `--show proposal` | show an extraction skeleton per family — the structure shared across **all** the family's copies, with the differing parts marked as parameters (so the helper is safe to apply to every copy, not just a representative pair) |
 | `--show hotspots` | after the report, rank directories/modules by total duplicated lines (architecture view) |
 | `--show reinvented` | list **every** [reinvented-helper](reinvented-helpers.md) containment finding (code that reimplements an existing pure helper inline), including the test-container ones the default report excludes — the bare default already lists the non-test findings |
 | `--format human\|json\|markdown\|sarif` | output format (default `human`) |


### PR DESCRIPTION
Implements #360.

## What

`--show proposal` built its extraction skeleton from the **two representative copies** and hedged the count: *"(of the 2 largest of N copies; the rest may share fewer)"*. For a family of 4–12 copies that's a pairwise upper bound — a third copy that diverges further means the helper isn't actually safe to apply to every member.

This replaces the pairwise anti-unification with an **N-way** one:

- `anti_unify_all(members)` — anchored on the largest copy, a line survives into the shared body only if **every other copy matches it** (each copy votes via a pairwise `line_diff` against the anchor); any maximal run that varies in *any* copy collapses to a `⟨param N⟩` placeholder. With two copies it is exactly the old behavior; with more, it is the honest intersection.
- `print_member_proposal(&[Loc])` reads every copy, aligns across all readable ones, and reports `… (across all N copies)` — counts that are safe to act on for every member, not just the pair.

## Why

This is the **act-surface** capability the exploration surface (#359) depends on: browsing must terminate in something you can *safely* apply. The lazy `id=FAM full` drill in #359 will reuse `anti_unify_all`. The pairwise `anti_unify` is removed (subsumed).

## Tests / checks

- New `proposal_aligns_across_all_copies`: a 3-copy family whose operator line varies → it becomes a parameter and the label reads "across all 3 copies".
- Existing `proposal_shows_shared_skeleton_and_parameters` still green (2-copy → "across all 2 copies").
- Full `nose-cli` suite green; `fmt`/`clippy -D warnings` clean (pinned 1.96.0); `awiki lint` clean.
- Byte-deterministic across runs; the default surface (no `--show proposal`) is unchanged — only the opt-in proposal path differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)