### PR TITLE
#361: human output says "directories", not "modules"

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -765,7 +765,7 @@ enum ShowView {
     Diff,
     /// An extraction skeleton per family: the shared structure with varying spots as ⟨param N⟩.
     Proposal,
-    /// After the report, directories/modules ranked by total duplicated lines.
+    /// After the report, directories ranked by total duplicated lines.
     Hotspots,
     /// Reinvented-helper containment findings: code that reimplements an existing pure
     /// helper inline instead of calling it (exact-grade; experimental surface).
@@ -4404,7 +4404,7 @@ fn enforce_scan_fail_on(
 
 fn print_hotspots_refs(families: &[&nose_detect::RefactorFamily]) {
     use std::collections::{HashMap, HashSet};
-    // module -> (lines residing here that are in a family, distinct families touching it)
+    // directory -> (lines residing here that are in a family, distinct families touching it)
     let mut lines: HashMap<&str, u32> = HashMap::new();
     let mut fams: HashMap<&str, HashSet<usize>> = HashMap::new();
     for (fi, f) in families.iter().enumerate() {
@@ -4426,10 +4426,10 @@ fn print_hotspots_refs(families: &[&nose_detect::RefactorFamily]) {
         .collect();
     // Most duplicated lines first; ties by family count, then path for determinism.
     ranked.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)).then(a.0.cmp(b.0)));
-    println!("\nduplication hotspots (modules by lines that sit in a clone family):");
+    println!("\nduplication hotspots (directories by lines that sit in a clone family):");
     for (m, dup, n) in ranked.iter().take(10) {
-        let module = if m.is_empty() { "." } else { m };
-        println!("  ~{dup:>5} dup lines · {n:>3} families  {module}");
+        let dir = if m.is_empty() { "." } else { m };
+        println!("  ~{dup:>5} dup lines · {n:>3} families  {dir}");
     }
 }
 
@@ -5140,12 +5140,12 @@ fn family_hint(f: &nose_detect::RefactorFamily) -> String {
     let base = match (shared_name, f.modules) {
         (Some(name), _) => format!("consolidate `{name}` — {} copies{cross}", f.members),
         (None, m) if m >= 3 && all_classes => {
-            format!("repeated across {m} modules — {extract}{cross}")
+            format!("repeated across {m} directories — {extract}{cross}")
         }
         (None, m) if m >= 3 => {
-            format!("repeated across {m} modules — extract a shared abstraction{cross}")
+            format!("repeated across {m} directories — extract a shared abstraction{cross}")
         }
-        (None, m) if m >= 2 => format!("duplicated across {m} modules — {extract}{cross}"),
+        (None, m) if m >= 2 => format!("duplicated across {m} directories — {extract}{cross}"),
         (None, _) => format!("local duplication — {extract}{cross}"),
     };
     // "Extract a method" overclaims when the helper would take many parameters
@@ -5834,7 +5834,7 @@ fn print_refactor_markdown(
             s => format!(" · cross-language: {s}"),
         };
         println!(
-            "## {}. `{}` — {} sites, {} files, {} modules — ~{} dup lines ({}){}",
+            "## {}. `{}` — {} sites, {} files, {} directories — ~{} dup lines ({}){}",
             i + 1,
             baseline::family_id(f),
             f.members,
@@ -6269,7 +6269,7 @@ mod tests {
         let f = fam(1, 3, &[Some("replace"), Some("replaceOrAppend"), None]);
         assert_eq!(
             family_hint(&f),
-            "repeated across 3 modules — extract a shared abstraction"
+            "repeated across 3 directories — extract a shared abstraction"
         );
     }
 
@@ -6312,7 +6312,7 @@ mod tests {
         let f = fam_kind(1, 3, &[None, None, None], nose_il::UnitKind::Class);
         assert_eq!(
             family_hint(&f),
-            "repeated across 3 modules — extract a shared base class / mixin"
+            "repeated across 3 directories — extract a shared base class / mixin"
         );
     }
 

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -229,7 +229,7 @@ schema version 1:
 | `value` | number | Raw refactoring value: duplicated volume scaled by similarity and spread. |
 | `members` | integer | Number of duplicated sites. |
 | `files` | integer | Distinct files spanned by the family. |
-| `modules` | integer | Distinct directories/modules spanned by the family. |
+| `modules` | integer | Distinct directories spanned by the family (design-level spread). The field name is historical; nose's spatial unit is the directory, and human output says "directories". |
 | `languages` | integer | Distinct languages spanned by the family. |
 | `mean_score` | number | Mean pairwise clone similarity. |
 | `mean_lines` | integer | Mean source-line span per member. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -129,7 +129,7 @@ chance** — see [hazard-ranking](hazard-ranking.md) for the full, honest evalua
 |---|---|
 | `--show diff` | show each family inline as a unified diff between its two representative copies — both versions and exactly what differs |
 | `--show proposal` | show an extraction skeleton per family — the structure shared across **all** the family's copies, with the differing parts marked as parameters (so the helper is safe to apply to every copy, not just a representative pair) |
-| `--show hotspots` | after the report, rank directories/modules by total duplicated lines (architecture view) |
+| `--show hotspots` | after the report, rank directories by total duplicated lines (architecture view) |
 | `--show reinvented` | list **every** [reinvented-helper](reinvented-helpers.md) containment finding (code that reimplements an existing pure helper inline), including the test-container ones the default report excludes — the bare default already lists the non-test findings |
 | `--format human\|json\|markdown\|sarif` | output format (default `human`) |
 


### PR DESCRIPTION
Implements #361 (the part that's actionable on the current CLI; the `path~` / `group=dir` *selectors* land with the query surface #359).

## What

nose has no "module" concept — its spatial unit is the **directory** (the `modules` metric counts distinct parent directories). Human output used "modules" inconsistently:
- the `--show hotspots` header ("duplication hotspots (modules by lines …)"),
- the family hint ("repeated/duplicated across N modules"),
- the Markdown family header ("… N modules …"),
- and `--show hotspots`'s help/docs said "directories/modules".

All of that now says **"directories"**. The scan-JSON **`modules` count field keeps its name** (v1 contract); only its *description* is clarified to "distinct directories".

## Checks

- `nose-cli` suite green (the two `family_hint` unit tests updated to "directories"); `top.modules == 3` JSON-field assertion unchanged.
- `fmt`/`clippy -D warnings` clean (pinned 1.96.0); `awiki lint` clean.
- No JSON contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)