### PR TITLE
#359: nose query — a stateless, self-describing exploration surface for agents

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -937,6 +937,7 @@ impl CapabilitiesReport {
                 stable: vec![
                     "capabilities",
                     "il",
+                    "query",
                     "review",
                     "scan",
                     "semantic-pack",

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3670,6 +3670,10 @@ struct Query {
     group: Option<String>,
     id: Option<String>,
     id_full: bool,
+    /// Widen from the curated default surface to the full raw universe (shallow/hidden/
+    /// declaration/generated families too) — the `all` token. Default queries stay on the
+    /// default surface so `query`'s counts and curation match `scan`'s.
+    all: bool,
     sort: Option<SortKey>,
     top: Option<usize>,
 }
@@ -3685,6 +3689,58 @@ struct QFilter {
     field: String,
     op: QOp,
     value: String,
+}
+
+/// String-valued (or substring) filter fields.
+const STR_FIELDS: &[&str] = &[
+    "scope",
+    "witness",
+    "lang",
+    "language",
+    "path",
+    "file",
+    "dir",
+    "surface",
+    "shape",
+    "extraction_shape",
+];
+/// Numeric filter fields (also the only ones that accept `>`/`<`).
+const NUM_FIELDS: &[&str] = &[
+    "members",
+    "copies",
+    "sites",
+    "files",
+    "modules",
+    "dirs",
+    "value",
+    "params",
+    "lines",
+    "mean_lines",
+    "shared",
+    "shared_lines",
+    "dup",
+    "dup_lines",
+    "languages",
+];
+
+/// Reject an unknown field (so a typo errors loudly instead of silently matching nothing
+/// and reading as "this repo is clean"), and a non-numeric `>`/`<`.
+fn validate_field(field: &str, op: &QOp) -> Result<()> {
+    let numeric = NUM_FIELDS.contains(&field);
+    if matches!(op, QOp::Gt | QOp::Lt) && !numeric {
+        anyhow::bail!(
+            "`{field}` is not numeric — `>`/`<` take one of: {}",
+            NUM_FIELDS.join(" ")
+        );
+    }
+    if !numeric && !STR_FIELDS.contains(&field) {
+        anyhow::bail!(
+            "unknown field `{field}` — valid: {} {}",
+            STR_FIELDS.join(" "),
+            NUM_FIELDS.join(" ")
+        );
+    }
+    Ok(())
 }
 
 /// Canonical `witness.kind` for a friendly filter token (`exact`→`exact-value-graph`, …).
@@ -3726,6 +3782,8 @@ fn parse_query(terms: &[String]) -> Result<Query> {
     for t in terms {
         if t == "full" {
             q.id_full = true;
+        } else if t == "all" {
+            q.all = true;
         } else if let Some(v) = t.strip_prefix("group=") {
             q.group = Some(v.to_string());
         } else if let Some(v) = t.strip_prefix("id=") {
@@ -3768,6 +3826,9 @@ fn parse_query(terms: &[String]) -> Result<Query> {
                 "unrecognized term `{t}` — try field=value, group=FIELD, id=FAM, sort=KEY, top=N"
             );
         }
+    }
+    for flt in &q.filters {
+        validate_field(&flt.field, &flt.op)?;
     }
     Ok(q)
 }
@@ -3861,7 +3922,9 @@ fn short_id(id: &str) -> &str {
     &id[..id.len().min(10)]
 }
 
-/// One concise list/preview row: where the largest copy is + what it is.
+/// One concise list/preview row: where the largest copy is, what it is, and the **payoff
+/// economics** an agent needs to triage without opening the family — how much is shared,
+/// how many spots vary, how many lines an extraction removes (counts, not a verdict).
 fn query_row(f: &nose_detect::RefactorFamily) -> String {
     let l = &f.locations[0];
     let name = l
@@ -3870,10 +3933,14 @@ fn query_row(f: &nose_detect::RefactorFamily) -> String {
         .map(|n| format!("  {n}"))
         .unwrap_or_default();
     format!(
-        "{}:{}{name}  ({} copies · {})",
+        "{}:{}{name}  {} copies · {}/{} shared, {}p · ~{} removable · {}",
         l.file,
         l.start_line,
         f.members,
+        f.shared_lines,
+        representative_lines(f),
+        f.params,
+        removable_lines(f),
         witness_token(f.witness.as_ref().map(|w| w.kind))
     )
 }
@@ -3893,6 +3960,9 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
     };
     require_paths_exist(std::slice::from_ref(&path))?;
     let q = parse_query(&terms)?;
+    // The path as the user typed it — every suggested next-command echoes it so the links
+    // are runnable verbatim (the surface takes the path positionally).
+    let path_arg = path.to_string_lossy().into_owned();
     // Build the full dataset (all families); query filters/views work in-memory over it.
     let args = ScanArgs {
         paths: vec![path],
@@ -3929,25 +3999,42 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
     }
     let json = matches!(format, ReportFormat::Json);
     if terms.is_empty() {
-        render_query_dashboard(&dataset.families, &overrides, &dataset.scope, json);
+        render_query_dashboard(
+            &dataset.families,
+            &overrides,
+            &dataset.scope,
+            &path_arg,
+            json,
+        );
         return Ok(());
     }
     if let Some(idv) = &q.id {
-        render_query_family(&dataset.families, &overrides, idv, q.id_full, json);
+        render_query_family(
+            &dataset.families,
+            &overrides,
+            idv,
+            q.id_full,
+            &path_arg,
+            json,
+        );
         return Ok(());
     }
+    // Default to the curated default surface (the same families the dashboard counts and
+    // `scan` trusts); `all` or an explicit `surface=` filter widens to the raw universe.
+    let widen = q.all || q.filters.iter().any(|flt| flt.field == "surface");
     let sel: Vec<&nose_detect::RefactorFamily> = dataset
         .families
         .iter()
         .filter(|f| {
-            q.filters
-                .iter()
-                .all(|flt| family_matches(f, &overrides, flt))
+            (widen || is_default_surface(f, &overrides))
+                && q.filters
+                    .iter()
+                    .all(|flt| family_matches(f, &overrides, flt))
         })
         .collect();
     match &q.group {
-        Some(field) => render_query_group(&sel, field, &terms),
-        None => render_query_list(&sel, &q, &terms),
+        Some(field) => render_query_group(&sel, field, &terms, &path_arg),
+        None => render_query_list(&sel, &overrides, &q, &terms, &path_arg, widen),
     }
     Ok(())
 }
@@ -3955,21 +4042,26 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
 /// The landing dashboard: what nose is, the dataset's shape, a few real candidates per
 /// slice with `id=` links, and the grammar — all self-describing so a nose-naive agent
 /// can act from this output alone.
+#[allow(clippy::too_many_lines)]
 fn render_query_dashboard(
     families: &[nose_detect::RefactorFamily],
     ov: &SurfaceOverrides,
     scope: &ScanScope,
+    path: &str,
     json: bool,
 ) {
-    let def: Vec<&nose_detect::RefactorFamily> = families
+    let mut def: Vec<&nose_detect::RefactorFamily> = families
         .iter()
         .filter(|f| is_default_surface(f, ov))
         .collect();
+    // Production leads, test-scope ranked beneath — scan's #263/#264 ordering.
+    def.sort_by_key(|f| f.scope == "test");
     let count = |k: &str| {
         def.iter()
             .filter(|f| witness_token(f.witness.as_ref().map(|w| w.kind)) == k)
             .count()
     };
+    let n_test = def.iter().filter(|f| f.scope == "test").count();
     if json {
         let top: Vec<_> = def
             .iter()
@@ -3984,7 +4076,8 @@ fn render_query_dashboard(
                 "by_confidence": {"exact": count("exact"), "subdag": count("subdag"),
                     "copy_paste": count("copy-paste"), "similar": count("similar")},
                 "top_candidates": top,
-                "next": ["nose query sort=value", "nose query group=dir", "nose query witness=exact"],
+                "next": [format!("nose query {path} sort=value"), format!("nose query {path} group=dir"),
+                    format!("nose query {path} scope=prod"), format!("nose query {path} witness=exact")],
             })
         );
         return;
@@ -3992,26 +4085,38 @@ fn render_query_dashboard(
     println!("nose — finds duplicated & refactorable code across languages.");
     println!("{}", scope.summary());
     println!(
-        "\n{} duplicated-code families on the default surface.\n  by confidence: exact {} · subdag {} · copy-paste {} · similar {}\n                 (exact = proven-identical, value-graph-verified · similar = fuzzy match)",
+        "\n{} duplicated-code families on the default surface.\n  by confidence: exact {} · subdag {} · copy-paste {} · similar {}\n                 (exact/subdag = behavior-proven, value-graph-verified · copy-paste = token-identical · similar = fuzzy)",
         def.len(),
         count("exact"),
         count("subdag"),
         count("copy-paste"),
         count("similar"),
     );
-    println!("\ncleanest to extract:");
+    println!("\ncleanest to extract (production first):");
     for f in def.iter().take(3) {
         println!(
-            "  {}   nose query id={}",
+            "  {}   nose query {path} id={}",
             query_row(f),
             short_id(&baseline::family_id(f))
         );
     }
     println!(
-        "  nose query sort=value                # all {}, ranked",
+        "  nose query {path} sort=value                # all {} (default surface), ranked",
         def.len()
     );
+    if n_test > 0 && n_test < def.len() {
+        println!(
+            "  nose query {path} scope=prod                # production only ({n_test} test-scope ranked beneath)"
+        );
+    }
 
+    let kind_of = |k: &str| {
+        def.iter()
+            .filter(|f| f.witness.as_ref().map(|w| w.kind) == Some(k))
+            .count()
+    };
+    let n_exact = kind_of("exact-value-graph");
+    let n_subdag = kind_of("shared-sub-dag");
     let proven: Vec<_> = def
         .iter()
         .filter(|f| {
@@ -4023,17 +4128,23 @@ fn render_query_dashboard(
         .collect();
     if !proven.is_empty() {
         println!(
-            "\nproven-identical / shared-core ({}, highest confidence):",
-            proven.len()
+            "\nhighest confidence — exact {n_exact} (proven-identical) + shared-core {n_subdag}:"
         );
         for f in proven.iter().take(3) {
             println!(
-                "  {}   nose query id={}",
+                "  {}   nose query {path} id={}",
                 query_row(f),
                 short_id(&baseline::family_id(f))
             );
         }
-        println!("  nose query witness=exact             # the proven core");
+        if n_exact > 0 {
+            println!(
+                "  nose query {path} witness=exact             # the {n_exact} proven-identical"
+            );
+        }
+        if n_subdag > 0 {
+            println!("  nose query {path} witness=subdag            # the {n_subdag} shared-core");
+        }
     }
 
     // Most-duplicated directories.
@@ -4049,23 +4160,31 @@ fn render_query_dashboard(
     if !dirs.is_empty() {
         println!("\nmost-duplicated directories:");
         for (d, (_dup, n)) in dirs.iter().take(3) {
-            println!("  nose query path~{d:<28}   # {n} families");
+            println!("  nose query {path} path~{d}   # {n} families");
         }
-        println!("  nose query group=dir                 # full breakdown");
+        println!("  nose query {path} group=dir                 # full breakdown");
     }
     println!(
-        "\ngrammar:  nose query [field=value ...] [group=FIELD | id=FAM]\n          filter fields: scope witness lang path members files value params shared dir  ·  add `full` to id= to align all copies"
+        "\ngrammar:  nose query <path> [field=value | field>N | field~substr ...] [group=FIELD | id=FAM]\n          fields: scope(prod|test) witness(exact|subdag|copy-paste|similar) lang path members files value params shared dir\n          · sort=value|members  · top=N  · `full` after id= aligns all copies  · `all` widens past the default surface"
     );
 }
 
 /// A ranked list of the current selection: each row carries its own `id=` drill link,
 /// plus a reasoned `next:`.
-fn render_query_list(sel: &[&nose_detect::RefactorFamily], q: &Query, terms: &[String]) {
+fn render_query_list(
+    sel: &[&nose_detect::RefactorFamily],
+    ov: &SurfaceOverrides,
+    q: &Query,
+    terms: &[String],
+    path: &str,
+    widen: bool,
+) {
     let top = q.top.unwrap_or(30);
     let shown = sel.len().min(top);
     println!(
-        "{} families{}:",
+        "{} families{}{}:",
         sel.len(),
+        if widen { " (full surface)" } else { "" },
         if shown < sel.len() {
             format!(" (showing {shown})")
         } else {
@@ -4073,8 +4192,17 @@ fn render_query_list(sel: &[&nose_detect::RefactorFamily], q: &Query, terms: &[S
         }
     );
     for f in sel.iter().take(top) {
+        // When widened past the default surface, label why a demoted family is here.
+        let surf = if widen {
+            match effective_surface(f, ov) {
+                "default" => String::new(),
+                s => format!(" [{s}]"),
+            }
+        } else {
+            String::new()
+        };
         println!(
-            "  {}   nose query id={}",
+            "  {}{surf}   nose query {path} id={}",
             query_row(f),
             short_id(&baseline::family_id(f))
         );
@@ -4083,15 +4211,23 @@ fn render_query_list(sel: &[&nose_detect::RefactorFamily], q: &Query, terms: &[S
     if !terms.iter().any(|t| t.starts_with("group=")) {
         println!(
             "  {} group=dir       # where this selection concentrates",
-            base_cmd(terms)
+            base_cmd(terms, path)
         );
     }
-    println!("  {} group=witness   # by confidence", base_cmd(terms));
+    println!(
+        "  {} group=witness   # by confidence",
+        base_cmd(terms, path)
+    );
 }
 
 /// Facet the current selection by a discrete field, with a top exemplar per bucket and
 /// the "see all" command for each.
-fn render_query_group(sel: &[&nose_detect::RefactorFamily], field: &str, terms: &[String]) {
+fn render_query_group(
+    sel: &[&nose_detect::RefactorFamily],
+    field: &str,
+    terms: &[String],
+    path: &str,
+) {
     use std::collections::HashMap;
     let key = |f: &nose_detect::RefactorFamily| -> String {
         match field {
@@ -4124,9 +4260,9 @@ fn render_query_group(sel: &[&nose_detect::RefactorFamily], field: &str, terms: 
         .map(String::as_str)
         .collect();
     let base = if other.is_empty() {
-        "nose query".to_string()
+        format!("nose query {path}")
     } else {
-        format!("nose query {}", other.join(" "))
+        format!("nose query {path} {}", other.join(" "))
     };
     for (k, (n, ex)) in &rows {
         println!("  {k:<16} ({n:>3})  e.g. {ex}");
@@ -4141,6 +4277,7 @@ fn render_query_family(
     _ov: &SurfaceOverrides,
     idv: &str,
     full: bool,
+    path: &str,
     json: bool,
 ) {
     let Some(f) = families
@@ -4169,11 +4306,15 @@ fn render_query_family(
         return;
     }
     println!(
-        "{} — {} · {} · {} copies",
+        "{} — {} · {} · {} copies · {}/{} shared, {}p · ~{} removable",
         short_id(&id),
         witness_token(f.witness.as_ref().map(|w| w.kind)),
         f.scope,
-        f.members
+        f.members,
+        f.shared_lines,
+        representative_lines(f),
+        f.params,
+        removable_lines(f),
     );
     println!("  → {}", family_hint(f));
     println!("  copies:");
@@ -4192,34 +4333,34 @@ fn render_query_family(
         print_member_proposal(&f.locations);
     } else if f.locations.len() > 2 {
         println!(
-            "    nose query id={} full   # align the extraction across all {} copies",
+            "    nose query {path} id={} full   # align the extraction across all {} copies",
             short_id(&id),
             f.members
         );
     }
     println!("\nnext:");
     println!(
-        "  nose query path~{}   # other duplication in this directory",
+        "  nose query {path} path~{}   # other duplication in this directory",
         family_dir(f)
     );
     println!(
-        "  nose query witness={}   # other families of the same confidence",
+        "  nose query {path} witness={}   # other families of the same confidence",
         witness_token(f.witness.as_ref().map(|w| w.kind))
     );
 }
 
 /// `nose query` with the current selection's terms minus any view term — the prefix the
 /// `next:` links extend.
-fn base_cmd(terms: &[String]) -> String {
+fn base_cmd(terms: &[String], path: &str) -> String {
     let keep: Vec<&str> = terms
         .iter()
         .filter(|t| !t.starts_with("group=") && !t.starts_with("id=") && *t != "full")
         .map(String::as_str)
         .collect();
     if keep.is_empty() {
-        "nose query".to_string()
+        format!("nose query {path}")
     } else {
-        format!("nose query {}", keep.join(" "))
+        format!("nose query {path} {}", keep.join(" "))
     }
 }
 

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -193,6 +193,22 @@ enum Cmd {
         #[arg(long, value_enum, default_value_t = ScopeFilter::All)]
         scope: ScopeFilter,
     },
+    /// Explore the duplication dataset (#359) — a stateless, self-describing query
+    /// surface for an agent loop. `nose query <path>` prints a landing dashboard; add
+    /// terms to slice, facet, or open one family. Every result suggests runnable next
+    /// commands. Opt-in: it does not change `nose scan`.
+    Query {
+        /// Path to a file or directory (recursively scanned).
+        #[arg(required = true)]
+        path: PathBuf,
+        /// Query terms (none → the dashboard): `field=value` `field>N` `field<N`
+        /// `path~substr` filter (AND-ed); `group=FIELD` facet; `id=FAM` (add `full` to
+        /// align all copies); `sort=KEY`; `top=N`.
+        terms: Vec<String>,
+        /// Output format (`human` or `json`).
+        #[arg(long, default_value = "human")]
+        format: ReportFormat,
+    },
     /// Flag a change applied to one clone copy but not its siblings (PR/CI check).
     ///
     /// Compares the working tree to a git ref and reports clone families changed
@@ -1601,6 +1617,7 @@ fn run() -> Result<()> {
             corpus,
         } => cmd_eval(gold, predictions, hard_negatives, corpus),
         cmd @ Cmd::Scan { .. } => run_scan_cmd(cmd),
+        cmd @ Cmd::Query { .. } => run_query_cmd(cmd),
         cmd @ Cmd::Review { .. } => run_review_cmd(cmd),
         Cmd::Ceiling {
             gold,
@@ -3644,22 +3661,586 @@ fn semantic_pack_summary_line(packs: &nose_semantics::SemanticPackSet) -> Option
     })
 }
 
-fn cmd_scan(args: ScanArgs) -> Result<()> {
-    // `--fail-on new` gates on families that are new/changed vs a baseline, so without
-    // `--baseline` the gate could never fire — reject the combination instead of silently
-    // passing (a CI gate that always succeeds is the worst failure mode).
-    if matches!(args.fail_on, Some(FailOn::New)) && args.baseline.is_none() {
-        anyhow::bail!(
-            "--fail-on new requires --baseline (it gates on families new vs the baseline)"
+// ===================== `nose query`: the exploration surface (#359) =====================
+
+/// A parsed query: in-memory filters over the family dataset, plus the chosen view.
+#[derive(Default)]
+struct Query {
+    filters: Vec<QFilter>,
+    group: Option<String>,
+    id: Option<String>,
+    id_full: bool,
+    sort: Option<SortKey>,
+    top: Option<usize>,
+}
+
+enum QOp {
+    Eq,
+    Gt,
+    Lt,
+    Has,
+}
+
+struct QFilter {
+    field: String,
+    op: QOp,
+    value: String,
+}
+
+/// Canonical `witness.kind` for a friendly filter token (`exact`→`exact-value-graph`, …).
+fn witness_alias(v: &str) -> &str {
+    match v {
+        "exact" => "exact-value-graph",
+        "subdag" | "shared-core" => "shared-sub-dag",
+        "copy-paste" | "copypaste" => "copy-paste-run",
+        "similar" | "structural" => "structural-similarity",
+        other => other,
+    }
+}
+
+/// The friendly token for a `witness.kind` (for display / `group=witness`).
+fn witness_token(kind: Option<&str>) -> &'static str {
+    match kind {
+        Some("exact-value-graph") => "exact",
+        Some("shared-sub-dag") => "subdag",
+        Some("copy-paste-run") => "copy-paste",
+        Some("structural-similarity") => "similar",
+        _ => "?",
+    }
+}
+
+fn parse_sort_key(v: &str) -> Option<SortKey> {
+    match v {
+        "extractability" | "extract" => Some(SortKey::Extractability),
+        "value" => Some(SortKey::Value),
+        "sites" | "members" | "copies" => Some(SortKey::Sites),
+        "hazard" => Some(SortKey::Hazard),
+        _ => None,
+    }
+}
+
+/// Parse free-form query terms. Unknown terms are an error (a typo must not silently
+/// widen the result to everything).
+fn parse_query(terms: &[String]) -> Result<Query> {
+    let mut q = Query::default();
+    for t in terms {
+        if t == "full" {
+            q.id_full = true;
+        } else if let Some(v) = t.strip_prefix("group=") {
+            q.group = Some(v.to_string());
+        } else if let Some(v) = t.strip_prefix("id=") {
+            q.id = Some(v.to_string());
+        } else if let Some(v) = t.strip_prefix("sort=") {
+            q.sort = Some(parse_sort_key(v).ok_or_else(|| {
+                anyhow::anyhow!("unknown sort key `{v}` (extractability|value|sites|hazard)")
+            })?);
+        } else if let Some(v) = t.strip_prefix("top=") {
+            q.top = Some(
+                v.parse()
+                    .map_err(|_| anyhow::anyhow!("top= needs a number, got `{v}`"))?,
+            );
+        } else if let Some((f, v)) = t.split_once('~') {
+            q.filters.push(QFilter {
+                field: f.into(),
+                op: QOp::Has,
+                value: v.into(),
+            });
+        } else if let Some((f, v)) = t.split_once('>') {
+            q.filters.push(QFilter {
+                field: f.into(),
+                op: QOp::Gt,
+                value: v.into(),
+            });
+        } else if let Some((f, v)) = t.split_once('<') {
+            q.filters.push(QFilter {
+                field: f.into(),
+                op: QOp::Lt,
+                value: v.into(),
+            });
+        } else if let Some((f, v)) = t.split_once('=') {
+            q.filters.push(QFilter {
+                field: f.into(),
+                op: QOp::Eq,
+                value: v.into(),
+            });
+        } else {
+            anyhow::bail!(
+                "unrecognized term `{t}` — try field=value, group=FIELD, id=FAM, sort=KEY, top=N"
+            );
+        }
+    }
+    Ok(q)
+}
+
+/// The directory a family lives in (the parent of its largest copy) — nose's spatial unit.
+fn family_dir(f: &nose_detect::RefactorFamily) -> String {
+    f.locations
+        .first()
+        .and_then(|l| {
+            std::path::Path::new(&l.file)
+                .parent()
+                .and_then(|p| p.to_str())
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or(".")
+        .to_string()
+}
+
+/// Numeric value of a family field (for `>`/`<`/`=` on numbers).
+fn family_num(f: &nose_detect::RefactorFamily, field: &str) -> Option<f64> {
+    Some(match field {
+        "members" | "copies" | "sites" => f.members as f64,
+        "files" => f.files as f64,
+        "modules" | "dirs" => f.modules as f64,
+        "value" => f.value,
+        "params" => f.params as f64,
+        "lines" | "mean_lines" => f.mean_lines as f64,
+        "shared" | "shared_lines" => f.shared_lines as f64,
+        "dup" | "dup_lines" => f.dup_lines as f64,
+        "languages" => f.languages as f64,
+        _ => return None,
+    })
+}
+
+/// Whether a family satisfies one filter.
+fn family_matches(f: &nose_detect::RefactorFamily, ov: &SurfaceOverrides, flt: &QFilter) -> bool {
+    let field = flt.field.as_str();
+    let val = flt.value.as_str();
+    // Substring fields.
+    let path_has = || f.locations.iter().any(|l| l.file.contains(val));
+    let lang_eq = |exact: bool| {
+        f.locations.iter().any(|l| {
+            if exact {
+                l.lang.as_str() == val
+            } else {
+                l.lang.as_str().contains(val)
+            }
+        })
+    };
+    let strfield = |field: &str| -> Option<String> {
+        Some(match field {
+            "scope" => f.scope.to_string(),
+            "witness" => witness_token(f.witness.as_ref().map(|w| w.kind)).to_string(),
+            "surface" => effective_surface(f, ov).to_string(),
+            "shape" | "extraction_shape" => f.extraction_shape().to_string(),
+            "dir" => family_dir(f),
+            _ => return None,
+        })
+    };
+    match flt.op {
+        QOp::Has => match field {
+            "path" | "file" => path_has(),
+            "lang" | "language" => lang_eq(false),
+            _ => strfield(field).is_some_and(|s| s.contains(val)),
+        },
+        QOp::Eq => match field {
+            "path" | "file" => path_has(),
+            "lang" | "language" => lang_eq(true),
+            "witness" => f.witness.as_ref().map(|w| w.kind) == Some(witness_alias(val)),
+            _ => {
+                if let Some(s) = strfield(field) {
+                    s == val
+                } else {
+                    family_num(f, field)
+                        .zip(val.parse::<f64>().ok())
+                        .is_some_and(|(a, b)| (a - b).abs() < f64::EPSILON)
+                }
+            }
+        },
+        QOp::Gt => family_num(f, field)
+            .zip(val.parse::<f64>().ok())
+            .is_some_and(|(a, b)| a > b),
+        QOp::Lt => family_num(f, field)
+            .zip(val.parse::<f64>().ok())
+            .is_some_and(|(a, b)| a < b),
+    }
+}
+
+/// A short, git-style family handle for `id=` links (the full id accepts any prefix).
+fn short_id(id: &str) -> &str {
+    &id[..id.len().min(10)]
+}
+
+/// One concise list/preview row: where the largest copy is + what it is.
+fn query_row(f: &nose_detect::RefactorFamily) -> String {
+    let l = &f.locations[0];
+    let name = l
+        .name
+        .as_deref()
+        .map(|n| format!("  {n}"))
+        .unwrap_or_default();
+    format!(
+        "{}:{}{name}  ({} copies · {})",
+        l.file,
+        l.start_line,
+        f.members,
+        witness_token(f.witness.as_ref().map(|w| w.kind))
+    )
+}
+
+fn is_default_surface(f: &nose_detect::RefactorFamily, ov: &SurfaceOverrides) -> bool {
+    effective_surface(f, ov) == "default"
+}
+
+fn run_query_cmd(cmd: Cmd) -> Result<()> {
+    let Cmd::Query {
+        path,
+        terms,
+        format,
+    } = cmd
+    else {
+        unreachable!("run_query_cmd requires Cmd::Query")
+    };
+    require_paths_exist(std::slice::from_ref(&path))?;
+    let q = parse_query(&terms)?;
+    // Build the full dataset (all families); query filters/views work in-memory over it.
+    let args = ScanArgs {
+        paths: vec![path],
+        top: Some(0),
+        min_members: None,
+        min_value: None,
+        sort: None,
+        config: None,
+        mode: vec![],
+        show: vec![],
+        cache_dir: None,
+        fail_on: None,
+        baseline: None,
+        ignore_file: None,
+        semantic_pack: vec![],
+        write_baseline: false,
+        format,
+        exclude: vec![],
+        min_size: None,
+        min_lines: None,
+        scope: ScopeFilter::All,
+    };
+    let refs = paths_as_refs(&args.paths);
+    let mut dataset = build_scan_dataset(&args, &refs)?;
+    let overrides =
+        classify_surface_overrides(&mut dataset.families, &refs, &dataset.settings.exclude);
+    if let Some(sk) = q.sort {
+        dataset.families.sort_by(|a, b| {
+            sk.score(b)
+                .total_cmp(&sk.score(a))
+                .then(b.value.total_cmp(&a.value))
+                .then_with(|| family_anchor(a).cmp(&family_anchor(b)))
+        });
+    }
+    let json = matches!(format, ReportFormat::Json);
+    if terms.is_empty() {
+        render_query_dashboard(&dataset.families, &overrides, &dataset.scope, json);
+        return Ok(());
+    }
+    if let Some(idv) = &q.id {
+        render_query_family(&dataset.families, &overrides, idv, q.id_full, json);
+        return Ok(());
+    }
+    let sel: Vec<&nose_detect::RefactorFamily> = dataset
+        .families
+        .iter()
+        .filter(|f| {
+            q.filters
+                .iter()
+                .all(|flt| family_matches(f, &overrides, flt))
+        })
+        .collect();
+    match &q.group {
+        Some(field) => render_query_group(&sel, field, &terms),
+        None => render_query_list(&sel, &q, &terms),
+    }
+    Ok(())
+}
+
+/// The landing dashboard: what nose is, the dataset's shape, a few real candidates per
+/// slice with `id=` links, and the grammar — all self-describing so a nose-naive agent
+/// can act from this output alone.
+fn render_query_dashboard(
+    families: &[nose_detect::RefactorFamily],
+    ov: &SurfaceOverrides,
+    scope: &ScanScope,
+    json: bool,
+) {
+    let def: Vec<&nose_detect::RefactorFamily> = families
+        .iter()
+        .filter(|f| is_default_surface(f, ov))
+        .collect();
+    let count = |k: &str| {
+        def.iter()
+            .filter(|f| witness_token(f.witness.as_ref().map(|w| w.kind)) == k)
+            .count()
+    };
+    if json {
+        let top: Vec<_> = def
+            .iter()
+            .take(5)
+            .map(|f| serde_json::json!({"id": baseline::family_id(f), "where": query_row(f)}))
+            .collect();
+        println!(
+            "{}",
+            serde_json::json!({
+                "view": "dashboard",
+                "families": def.len(),
+                "by_confidence": {"exact": count("exact"), "subdag": count("subdag"),
+                    "copy_paste": count("copy-paste"), "similar": count("similar")},
+                "top_candidates": top,
+                "next": ["nose query sort=value", "nose query group=dir", "nose query witness=exact"],
+            })
+        );
+        return;
+    }
+    println!("nose — finds duplicated & refactorable code across languages.");
+    println!("{}", scope.summary());
+    println!(
+        "\n{} duplicated-code families on the default surface.\n  by confidence: exact {} · subdag {} · copy-paste {} · similar {}\n                 (exact = proven-identical, value-graph-verified · similar = fuzzy match)",
+        def.len(),
+        count("exact"),
+        count("subdag"),
+        count("copy-paste"),
+        count("similar"),
+    );
+    println!("\ncleanest to extract:");
+    for f in def.iter().take(3) {
+        println!(
+            "  {}   nose query id={}",
+            query_row(f),
+            short_id(&baseline::family_id(f))
         );
     }
+    println!(
+        "  nose query sort=value                # all {}, ranked",
+        def.len()
+    );
 
-    let refs = paths_as_refs(&args.paths);
-    let settings = resolve_scan_settings(&args)?;
+    let proven: Vec<_> = def
+        .iter()
+        .filter(|f| {
+            matches!(
+                f.witness.as_ref().map(|w| w.kind),
+                Some("exact-value-graph") | Some("shared-sub-dag")
+            )
+        })
+        .collect();
+    if !proven.is_empty() {
+        println!(
+            "\nproven-identical / shared-core ({}, highest confidence):",
+            proven.len()
+        );
+        for f in proven.iter().take(3) {
+            println!(
+                "  {}   nose query id={}",
+                query_row(f),
+                short_id(&baseline::family_id(f))
+            );
+        }
+        println!("  nose query witness=exact             # the proven core");
+    }
+
+    // Most-duplicated directories.
+    use std::collections::HashMap;
+    let mut by_dir: HashMap<String, (u32, usize)> = HashMap::new();
+    for f in &def {
+        let e = by_dir.entry(family_dir(f)).or_default();
+        e.0 += f.dup_lines;
+        e.1 += 1;
+    }
+    let mut dirs: Vec<_> = by_dir.into_iter().collect();
+    dirs.sort_by(|a, b| b.1 .0.cmp(&a.1 .0).then(a.0.cmp(&b.0)));
+    if !dirs.is_empty() {
+        println!("\nmost-duplicated directories:");
+        for (d, (_dup, n)) in dirs.iter().take(3) {
+            println!("  nose query path~{d:<28}   # {n} families");
+        }
+        println!("  nose query group=dir                 # full breakdown");
+    }
+    println!(
+        "\ngrammar:  nose query [field=value ...] [group=FIELD | id=FAM]\n          filter fields: scope witness lang path members files value params shared dir  ·  add `full` to id= to align all copies"
+    );
+}
+
+/// A ranked list of the current selection: each row carries its own `id=` drill link,
+/// plus a reasoned `next:`.
+fn render_query_list(sel: &[&nose_detect::RefactorFamily], q: &Query, terms: &[String]) {
+    let top = q.top.unwrap_or(30);
+    let shown = sel.len().min(top);
+    println!(
+        "{} families{}:",
+        sel.len(),
+        if shown < sel.len() {
+            format!(" (showing {shown})")
+        } else {
+            String::new()
+        }
+    );
+    for f in sel.iter().take(top) {
+        println!(
+            "  {}   nose query id={}",
+            query_row(f),
+            short_id(&baseline::family_id(f))
+        );
+    }
+    println!("\nnext:");
+    if !terms.iter().any(|t| t.starts_with("group=")) {
+        println!(
+            "  {} group=dir       # where this selection concentrates",
+            base_cmd(terms)
+        );
+    }
+    println!("  {} group=witness   # by confidence", base_cmd(terms));
+}
+
+/// Facet the current selection by a discrete field, with a top exemplar per bucket and
+/// the "see all" command for each.
+fn render_query_group(sel: &[&nose_detect::RefactorFamily], field: &str, terms: &[String]) {
+    use std::collections::HashMap;
+    let key = |f: &nose_detect::RefactorFamily| -> String {
+        match field {
+            "scope" => f.scope.to_string(),
+            "witness" => witness_token(f.witness.as_ref().map(|w| w.kind)).to_string(),
+            "lang" | "language" => f
+                .locations
+                .first()
+                .map(|l| l.lang.as_str().to_string())
+                .unwrap_or_default(),
+            "dir" => family_dir(f),
+            "shape" | "extraction_shape" => f.extraction_shape().to_string(),
+            _ => "?".to_string(),
+        }
+    };
+    let mut buckets: HashMap<String, (usize, String)> = HashMap::new();
+    for f in sel {
+        let e = buckets.entry(key(f)).or_insert((0, String::new()));
+        if e.0 == 0 {
+            e.1 = query_row(f);
+        }
+        e.0 += 1;
+    }
+    let mut rows: Vec<_> = buckets.into_iter().collect();
+    rows.sort_by(|a, b| b.1 .0.cmp(&a.1 .0).then(a.0.cmp(&b.0)));
+    println!("{} families by {field}:", sel.len());
+    let other: Vec<&str> = terms
+        .iter()
+        .filter(|t| !t.starts_with("group="))
+        .map(String::as_str)
+        .collect();
+    let base = if other.is_empty() {
+        "nose query".to_string()
+    } else {
+        format!("nose query {}", other.join(" "))
+    };
+    for (k, (n, ex)) in &rows {
+        println!("  {k:<16} ({n:>3})  e.g. {ex}");
+        println!("        {base} {field}={k}");
+    }
+}
+
+/// Open one family: its copies, the extraction hint, the representative-pair diff, and —
+/// with `full` — the all-copies extraction skeleton (#360). Plus navigation links.
+fn render_query_family(
+    families: &[nose_detect::RefactorFamily],
+    _ov: &SurfaceOverrides,
+    idv: &str,
+    full: bool,
+    json: bool,
+) {
+    let Some(f) = families
+        .iter()
+        .find(|f| baseline::family_id(f).starts_with(idv))
+    else {
+        println!("no family whose id starts with `{idv}` — run `nose query` for the dashboard");
+        return;
+    };
+    let id = baseline::family_id(f);
+    if json {
+        let locs: Vec<_> = f
+            .locations
+            .iter()
+            .map(|l| serde_json::json!({"file": l.file, "start": l.start_line, "end": l.end_line, "name": l.name}))
+            .collect();
+        println!(
+            "{}",
+            serde_json::json!({
+                "view": "family", "id": id, "scope": f.scope,
+                "witness": witness_token(f.witness.as_ref().map(|w| w.kind)),
+                "members": f.members, "shared_lines": f.shared_lines, "params": f.params,
+                "extraction_shape": f.extraction_shape(), "hint": family_hint(f), "locations": locs,
+            })
+        );
+        return;
+    }
+    println!(
+        "{} — {} · {} · {} copies",
+        short_id(&id),
+        witness_token(f.witness.as_ref().map(|w| w.kind)),
+        f.scope,
+        f.members
+    );
+    println!("  → {}", family_hint(f));
+    println!("  copies:");
+    for l in f.locations.iter().take(30) {
+        let name = l
+            .name
+            .as_deref()
+            .map(|n| format!("  {n}"))
+            .unwrap_or_default();
+        println!("    {}:{}-{}{name}", l.file, l.start_line, l.end_line);
+    }
+    if f.locations.len() >= 2 {
+        print_member_diff(&f.locations[0], &f.locations[1]);
+    }
+    if full {
+        print_member_proposal(&f.locations);
+    } else if f.locations.len() > 2 {
+        println!(
+            "    nose query id={} full   # align the extraction across all {} copies",
+            short_id(&id),
+            f.members
+        );
+    }
+    println!("\nnext:");
+    println!(
+        "  nose query path~{}   # other duplication in this directory",
+        family_dir(f)
+    );
+    println!(
+        "  nose query witness={}   # other families of the same confidence",
+        witness_token(f.witness.as_ref().map(|w| w.kind))
+    );
+}
+
+/// `nose query` with the current selection's terms minus any view term — the prefix the
+/// `next:` links extend.
+fn base_cmd(terms: &[String]) -> String {
+    let keep: Vec<&str> = terms
+        .iter()
+        .filter(|t| !t.starts_with("group=") && !t.starts_with("id=") && *t != "full")
+        .map(String::as_str)
+        .collect();
+    if keep.is_empty() {
+        "nose query".to_string()
+    } else {
+        format!("nose query {}", keep.join(" "))
+    }
+}
+
+/// The ranked family dataset shared by `nose scan` and `nose query`: detect, rank,
+/// filter (min-members / min-value / scope), relativize paths, weight shared lines, and
+/// sort. It stops before the scan-only surface policy (baseline, structured ignores,
+/// surface classification, rendering, the gate) so `query` can apply its own views over
+/// exactly the same deterministic set.
+struct ScanDataset {
+    families: Vec<nose_detect::RefactorFamily>,
+    scope: ScanScope,
+    settings: ScanSettings,
+    reinvented: Vec<nose_detect::ReinventedHelper>,
+    opts: nose_detect::DetectOptions,
+}
+
+fn build_scan_dataset(args: &ScanArgs, refs: &[&std::path::Path]) -> Result<ScanDataset> {
+    let settings = resolve_scan_settings(args)?;
     let opts = scan_detect_options(settings.channels, settings.min_tokens, settings.min_lines);
     let detector = scan_detector(settings.channels, &opts);
-    let (mut report, scope) =
-        scan_report(&args, &refs, &settings.exclude, &opts, detector.as_ref());
+    let (mut report, scope) = scan_report(args, refs, &settings.exclude, &opts, detector.as_ref());
 
     let mut families = nose_detect::rank_families(&report);
     if settings.channels.abstraction_only() {
@@ -3681,7 +4262,7 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
             r.container_file = relativize(&r.container_file, &cwd);
         }
     }
-    weight_shared_lines(&mut families, &refs, &settings.exclude);
+    weight_shared_lines(&mut families, refs, &settings.exclude);
     let sort = settings.sort;
     families.sort_by(|a, b| {
         sort.score(b)
@@ -3690,6 +4271,33 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
             .then(b.value.total_cmp(&a.value))
             .then_with(|| family_anchor(a).cmp(&family_anchor(b)))
     });
+    Ok(ScanDataset {
+        families,
+        scope,
+        settings,
+        reinvented,
+        opts,
+    })
+}
+
+fn cmd_scan(args: ScanArgs) -> Result<()> {
+    // `--fail-on new` gates on families that are new/changed vs a baseline, so without
+    // `--baseline` the gate could never fire — reject the combination instead of silently
+    // passing (a CI gate that always succeeds is the worst failure mode).
+    if matches!(args.fail_on, Some(FailOn::New)) && args.baseline.is_none() {
+        anyhow::bail!(
+            "--fail-on new requires --baseline (it gates on families new vs the baseline)"
+        );
+    }
+
+    let refs = paths_as_refs(&args.paths);
+    let ScanDataset {
+        mut families,
+        scope,
+        settings,
+        reinvented,
+        opts,
+    } = build_scan_dataset(&args, &refs)?;
     // Baseline: write the current state, or hide already-accepted families so only
     // new/changed duplication is reported and gated.
     if args.write_baseline {

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3829,6 +3829,41 @@ fn parse_query(terms: &[String]) -> Result<Query> {
     }
     for flt in &q.filters {
         validate_field(&flt.field, &flt.op)?;
+        // Validate enum *values* too (a value typo must error, not silently match nothing
+        // and read as "no such clones exist").
+        if matches!(flt.op, QOp::Eq) {
+            let valid: Option<&[&str]> = match flt.field.as_str() {
+                "scope" => Some(&["prod", "test", "mixed"]),
+                "witness" => Some(&[
+                    "exact",
+                    "subdag",
+                    "copy-paste",
+                    "similar",
+                    "shared-core",
+                    "copypaste",
+                    "structural",
+                ]),
+                "shape" | "extraction_shape" => Some(&[
+                    "call-existing-helper",
+                    "extract-helper",
+                    "extract-method-from-block",
+                    "consolidate-type",
+                    "extract-base-class",
+                    "consolidate-cross-language",
+                ]),
+                _ => None,
+            };
+            if let Some(vals) = valid {
+                if !vals.contains(&flt.value.as_str()) {
+                    anyhow::bail!(
+                        "unknown {} value `{}` — valid: {}",
+                        flt.field,
+                        flt.value,
+                        vals.join(" ")
+                    );
+                }
+            }
+        }
     }
     Ok(q)
 }
@@ -3932,17 +3967,42 @@ fn query_row(f: &nose_detect::RefactorFamily) -> String {
         .as_deref()
         .map(|n| format!("  {n}"))
         .unwrap_or_default();
+    let (shared, params) = all_copies_shared(f);
+    let removable = u32::try_from(f.members.saturating_sub(1)).unwrap_or(0) * shared;
     format!(
         "{}:{}{name}  {} copies · {}/{} shared, {}p · ~{} removable · {}",
         l.file,
         l.start_line,
         f.members,
-        f.shared_lines,
+        shared,
         representative_lines(f),
-        f.params,
-        removable_lines(f),
+        params,
+        removable,
         witness_token(f.witness.as_ref().map(|w| w.kind))
     )
+}
+
+/// Shared-line and parameter counts aligned across **all** copies (not the pairwise
+/// representative `shared_lines`, which over-counts a family whose 3rd+ copies diverge —
+/// e.g. 25 serializer methods that pairwise share 11 lines but all-25 share 2). Reads the
+/// copies and runs the N-way anti-unification (#360); only ever called on the rows
+/// actually displayed, so it is bounded. The honest `~removable` is then `(copies − 1) ×
+/// all-copies-shared`, which is never more than is truly shared and `0` when nothing is.
+/// Cross-language or unreadable families fall back to the detector's structural estimate.
+fn all_copies_shared(f: &nose_detect::RefactorFamily) -> (u32, u32) {
+    if f.languages != 1 {
+        return (f.shared_lines, f.params);
+    }
+    let members: Vec<Vec<String>> = f
+        .locations
+        .iter()
+        .filter_map(|l| read_lines(&l.file, l.start_line, l.end_line))
+        .collect();
+    if members.len() < 2 {
+        return (f.shared_lines, f.params);
+    }
+    let (_skeleton, shared, params) = anti_unify_all(&members);
+    (shared, params)
 }
 
 fn is_default_surface(f: &nose_detect::RefactorFamily, ov: &SurfaceOverrides) -> bool {
@@ -4206,6 +4266,16 @@ fn render_query_list(
             query_row(f),
             short_id(&baseline::family_id(f))
         );
+        // `full` on a list/filter batches the extraction skeletons — triage N candidates
+        // in one stateless call (no per-family id= round-trip).
+        if q.id_full {
+            print_member_proposal(&f.locations);
+        }
+    }
+    if !q.id_full {
+        println!(
+            "  nose query {path} ... full   # add `full` to show the extraction skeletons inline"
+        );
     }
     println!("\nnext:");
     if !terms.iter().any(|t| t.starts_with("group=")) {
@@ -4305,16 +4375,18 @@ fn render_query_family(
         );
         return;
     }
+    let (shared, params) = all_copies_shared(f);
+    let removable = u32::try_from(f.members.saturating_sub(1)).unwrap_or(0) * shared;
     println!(
         "{} — {} · {} · {} copies · {}/{} shared, {}p · ~{} removable",
         short_id(&id),
         witness_token(f.witness.as_ref().map(|w| w.kind)),
         f.scope,
         f.members,
-        f.shared_lines,
+        shared,
         representative_lines(f),
-        f.params,
-        removable_lines(f),
+        params,
+        removable,
     );
     println!("  → {}", family_hint(f));
     println!("  copies:");
@@ -4326,16 +4398,17 @@ fn render_query_family(
             .unwrap_or_default();
         println!("    {}:{}-{}{name}", l.file, l.start_line, l.end_line);
     }
+    // Lead with the decision-grade artifact: the extraction skeleton aligned across ALL
+    // copies (#360), with the differing spots as parameters — not a raw 2-copy token diff.
     if f.locations.len() >= 2 {
-        print_member_diff(&f.locations[0], &f.locations[1]);
-    }
-    if full {
         print_member_proposal(&f.locations);
-    } else if f.locations.len() > 2 {
+    }
+    if full && f.locations.len() >= 2 {
+        print_member_diff(&f.locations[0], &f.locations[1]);
+    } else if !full && f.locations.len() >= 2 {
         println!(
-            "    nose query {path} id={} full   # align the extraction across all {} copies",
-            short_id(&id),
-            f.members
+            "    nose query {path} id={} full   # also show the raw token diff of two copies",
+            short_id(&id)
         );
     }
     println!("\nnext:");

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3969,8 +3969,14 @@ fn query_row(f: &nose_detect::RefactorFamily) -> String {
         .unwrap_or_default();
     let (shared, params) = all_copies_shared(f);
     let removable = u32::try_from(f.members.saturating_sub(1)).unwrap_or(0) * shared;
+    // Flag non-production scope inline so a test/mixed family isn't mistaken for prod.
+    let scope = if f.scope == "prod" {
+        String::new()
+    } else {
+        format!(" · {}", f.scope)
+    };
     format!(
-        "{}:{}{name}  {} copies · {}/{} shared, {}p · ~{} removable · {}",
+        "{}:{}{name}  {} copies · {}/{} shared, {}p · ~{} removable · {}{scope}",
         l.file,
         l.start_line,
         f.members,
@@ -4057,11 +4063,20 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
                 .then_with(|| family_anchor(a).cmp(&family_anchor(b)))
         });
     }
+    // Fold overlapping slice families under their best-ranked primary (scan's #263/#264
+    // grouping) so query doesn't double-count or under-report the same region vs scan.
+    let default_fams: Vec<&nose_detect::RefactorFamily> = dataset
+        .families
+        .iter()
+        .filter(|f| is_default_surface(f, &overrides))
+        .collect();
+    let opp = OpportunityGroups::from_ranked(&default_fams);
     let json = matches!(format, ReportFormat::Json);
     if terms.is_empty() {
         render_query_dashboard(
             &dataset.families,
             &overrides,
+            &opp,
             &dataset.scope,
             &path_arg,
             json,
@@ -4072,6 +4087,7 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
         render_query_family(
             &dataset.families,
             &overrides,
+            &opp,
             idv,
             q.id_full,
             &path_arg,
@@ -4087,6 +4103,7 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
         .iter()
         .filter(|f| {
             (widen || is_default_surface(f, &overrides))
+                && !opp.is_slice(f)
                 && q.filters
                     .iter()
                     .all(|flt| family_matches(f, &overrides, flt))
@@ -4094,7 +4111,7 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
         .collect();
     match &q.group {
         Some(field) => render_query_group(&sel, field, &terms, &path_arg),
-        None => render_query_list(&sel, &overrides, &q, &terms, &path_arg, widen),
+        None => render_query_list(&sel, &overrides, &opp, &q, &terms, &path_arg, widen),
     }
     Ok(())
 }
@@ -4106,13 +4123,15 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
 fn render_query_dashboard(
     families: &[nose_detect::RefactorFamily],
     ov: &SurfaceOverrides,
+    opp: &OpportunityGroups,
     scope: &ScanScope,
     path: &str,
     json: bool,
 ) {
+    // Default surface, slice-folds removed (shown under their primary) — matches scan.
     let mut def: Vec<&nose_detect::RefactorFamily> = families
         .iter()
-        .filter(|f| is_default_surface(f, ov))
+        .filter(|f| is_default_surface(f, ov) && !opp.is_slice(f))
         .collect();
     // Production leads, test-scope ranked beneath — scan's #263/#264 ordering.
     def.sort_by_key(|f| f.scope == "test");
@@ -4122,6 +4141,10 @@ fn render_query_dashboard(
             .count()
     };
     let n_test = def.iter().filter(|f| f.scope == "test").count();
+    let fold = |f: &nose_detect::RefactorFamily| match opp.slices(f) {
+        Some(s) if !s.is_empty() => format!("\n       ↳ +{} overlapping slice folds", s.len()),
+        _ => String::new(),
+    };
     if json {
         let top: Vec<_> = def
             .iter()
@@ -4136,7 +4159,7 @@ fn render_query_dashboard(
                 "by_confidence": {"exact": count("exact"), "subdag": count("subdag"),
                     "copy_paste": count("copy-paste"), "similar": count("similar")},
                 "top_candidates": top,
-                "next": [format!("nose query {path} sort=value"), format!("nose query {path} group=dir"),
+                "next": [format!("nose query {path} sort=extractability"), format!("nose query {path} group=dir"),
                     format!("nose query {path} scope=prod"), format!("nose query {path} witness=exact")],
             })
         );
@@ -4155,13 +4178,14 @@ fn render_query_dashboard(
     println!("\ncleanest to extract (production first):");
     for f in def.iter().take(3) {
         println!(
-            "  {}   nose query {path} id={}",
+            "  {}   nose query {path} id={}{}",
             query_row(f),
-            short_id(&baseline::family_id(f))
+            short_id(&baseline::family_id(f)),
+            fold(f)
         );
     }
     println!(
-        "  nose query {path} sort=value                # all {} (default surface), ranked",
+        "  nose query {path} sort=extractability       # all {} (default surface), cleanest first",
         def.len()
     );
     if n_test > 0 && n_test < def.len() {
@@ -4192,9 +4216,10 @@ fn render_query_dashboard(
         );
         for f in proven.iter().take(3) {
             println!(
-                "  {}   nose query {path} id={}",
+                "  {}   nose query {path} id={}{}",
                 query_row(f),
-                short_id(&baseline::family_id(f))
+                short_id(&baseline::family_id(f)),
+                fold(f)
             );
         }
         if n_exact > 0 {
@@ -4224,8 +4249,17 @@ fn render_query_dashboard(
         }
         println!("  nose query {path} group=dir                 # full breakdown");
     }
+    // Repo-level magnitude + what the default surface omitted (scan's honesty footer).
+    let omitted = surface_omission_note(families, ov);
     println!(
-        "\ngrammar:  nose query <path> [field=value | field>N | field~substr ...] [group=FIELD | id=FAM]\n          fields: scope(prod|test) witness(exact|subdag|copy-paste|similar) lang path members files value params shared dir\n          · sort=value|members  · top=N  · `full` after id= aligns all copies  · `all` widens past the default surface"
+        "\n~{} duplicated lines on the default surface.{}",
+        total_dup_lines_refs(&def),
+        omitted
+            .map(|n| format!(" {n} — add `all` to include them"))
+            .unwrap_or_default()
+    );
+    println!(
+        "\ngrammar:  nose query <path> [field=value | field>N | field~substr ...] [group=FIELD | id=FAM]\n          fields: scope(prod|test) witness(exact|subdag|copy-paste|similar) lang path members files value(=duplicated volume) params shared dir\n          · sort=extractability(default)|value|members  · top=N  · `full` after id= or a list expands the all-copies skeleton  · `all` widens past the default surface"
     );
 }
 
@@ -4234,6 +4268,7 @@ fn render_query_dashboard(
 fn render_query_list(
     sel: &[&nose_detect::RefactorFamily],
     ov: &SurfaceOverrides,
+    opp: &OpportunityGroups,
     q: &Query,
     terms: &[String],
     path: &str,
@@ -4261,8 +4296,12 @@ fn render_query_list(
         } else {
             String::new()
         };
+        let fold = match opp.slices(f) {
+            Some(s) if !s.is_empty() => format!("\n       ↳ +{} overlapping slice folds", s.len()),
+            _ => String::new(),
+        };
         println!(
-            "  {}{surf}   nose query {path} id={}",
+            "  {}{surf}   nose query {path} id={}{fold}",
             query_row(f),
             short_id(&baseline::family_id(f))
         );
@@ -4345,6 +4384,7 @@ fn render_query_group(
 fn render_query_family(
     families: &[nose_detect::RefactorFamily],
     _ov: &SurfaceOverrides,
+    opp: &OpportunityGroups,
     idv: &str,
     full: bool,
     path: &str,
@@ -4358,6 +4398,18 @@ fn render_query_family(
         return;
     };
     let id = baseline::family_id(f);
+    // Overlap-fold provenance: a slice points at its richer primary; a primary lists what
+    // it subsumes (so the agent doesn't triage the same region twice).
+    let fold_note = if let Some(primary) = opp.primary_of.get(&id) {
+        format!(
+            "  ↳ subsumed by id={} (the fuller overlapping family)\n",
+            short_id(primary)
+        )
+    } else if let Some(s) = opp.slices(f).filter(|s| !s.is_empty()) {
+        format!("  ↳ subsumes {} overlapping slice families\n", s.len())
+    } else {
+        String::new()
+    };
     if json {
         let locs: Vec<_> = f
             .locations
@@ -4388,6 +4440,7 @@ fn render_query_family(
         params,
         removable,
     );
+    print!("{fold_note}");
     println!("  → {}", family_hint(f));
     println!("  copies:");
     for l in f.locations.iter().take(30) {

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1886,6 +1886,49 @@ fn proposal_aligns_across_all_copies() {
 }
 
 #[test]
+fn query_dashboard_filter_and_family() {
+    // A sizeable 3-copy near family (one operator each) survives the default size floor.
+    let dir = std::env::temp_dir().join(format!("nose_query_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    for d in ["a", "b", "c"] {
+        fs::create_dir_all(dir.join(d)).unwrap();
+    }
+    let mk = |op: &str| {
+        format!(
+            "def process(items):\n    total = 0\n    count = 0\n    best = None\n    for it in items:\n        v = it.value\n        total = total {op} v\n        count = count + 1\n        if best is None or v > best:\n            best = v\n    avg = total / count\n    return total, count, best, avg\n"
+        )
+    };
+    fs::write(dir.join("a/m.py"), mk("+")).unwrap();
+    fs::write(dir.join("b/m.py"), mk("*")).unwrap();
+    fs::write(dir.join("c/m.py"), mk("-")).unwrap();
+    let p = dir.to_str().unwrap();
+
+    // Dashboard: self-describing, with a real candidate carrying a runnable drill link.
+    let dash = run(&["query", p]);
+    assert!(
+        dash.contains("duplicated-code families"),
+        "dashboard names the dataset: {dash}"
+    );
+    assert!(
+        dash.contains("nose query"),
+        "dashboard teaches the grammar: {dash}"
+    );
+    assert!(
+        dash.contains("nose query id="),
+        "dashboard shows a real candidate with a drill link: {dash}"
+    );
+
+    // A filter narrows to a ranked list; a facet groups it.
+    assert!(run(&["query", p, "members>1"]).contains("families"));
+    assert!(run(&["query", p, "group=dir"]).contains("families by dir"));
+
+    // An unknown term is a hard error (a typo must not silently widen the result).
+    assert!(run_fail(&["query", p, "wat"]).contains("unrecognized term"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn sort_keys_label_the_ranking_and_reject_garbage() {
     let dir = make_project("sort");
     let p = dir.to_str().unwrap();

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1913,9 +1913,11 @@ fn query_dashboard_filter_and_family() {
         dash.contains("nose query"),
         "dashboard teaches the grammar: {dash}"
     );
+    // Suggested commands echo the path so they're runnable verbatim (the surface takes
+    // the path positionally) — every drill link is `nose query <path> id=…`.
     assert!(
-        dash.contains("nose query id="),
-        "dashboard shows a real candidate with a drill link: {dash}"
+        dash.contains(&format!("nose query {p} id=")),
+        "dashboard's drill links carry the path: {dash}"
     );
 
     // A filter narrows to a ranked list; a facet groups it.

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1631,6 +1631,7 @@ fn capabilities_command_lists_stable_commands_and_schemas() {
         vec![
             "capabilities",
             "il",
+            "query",
             "review",
             "scan",
             "semantic-pack",

--- a/crates/nose-cli/tests/cli/support.rs
+++ b/crates/nose-cli/tests/cli/support.rs
@@ -121,6 +121,17 @@ pub(crate) fn run(args: &[&str]) -> String {
     String::from_utf8(out.stdout).unwrap()
 }
 
+/// Like [`run`] but expects a non-zero exit; returns stderr (where errors print).
+#[allow(dead_code)]
+pub(crate) fn run_fail(args: &[&str]) -> String {
+    let out = Command::new(bin()).args(args).output().expect("run nose");
+    assert!(
+        !out.status.success(),
+        "expected nose to fail, but it succeeded"
+    );
+    String::from_utf8(out.stderr).unwrap()
+}
+
 /// `nose scan <dir> --mode <mode> --format json --top 0` with the tiny-fixture
 /// floors (`--min-lines 1 --min-size 1`) — the standard invocation for the
 /// one-function fixtures the semantic CLI tests are built from.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -42,7 +42,7 @@ nose capabilities
     "doctor_json": false
   },
   "commands": {
-    "stable": ["capabilities", "il", "review", "scan", "semantic-pack", "stats"]
+    "stable": ["capabilities", "il", "query", "review", "scan", "semantic-pack", "stats"]
   },
   "schemas": {
     "capabilities": [1],

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,6 +27,7 @@ from-source `./target/release/nose`.
 | You want to... | Use |
 |---|---|
 | Find refactoring candidates in a tree | `nose scan <paths...>` |
+| Explore the duplication interactively (agent loop) | `nose query <path> [terms...]` |
 | Catch a missed sibling edit in a diff or PR | `nose review --base <ref>` |
 | Ask what an installed binary supports | `nose capabilities` |
 | Check a local semantic-pack manifest | `nose semantic-pack check <file-or-dir>` |
@@ -198,6 +199,42 @@ field writes. General statement windows, dynamic receiver writes, mixed unproven
 and arbitrary field/property mutation stay closed. The exact fragment contract and JSON
 metadata are documented in [fragment-contracts](fragment-contracts.md) and
 [scan-json](scan-json.md#fragment-metadata).
+
+## `nose query`
+
+`nose query <path> [terms…]` is the **exploration surface** (#359): a stateless,
+self-describing query over the same family dataset `scan` computes, designed for an LLM
+agent loop. With no terms it prints a **landing dashboard** — what nose is, the family
+count by confidence, the cleanest production candidates (each with its own runnable drill
+link), the highest-confidence families, the most-duplicated directories, and a one-line
+omission footer. Add terms to slice, facet, or open one family; every result ends in
+runnable `nose query …` next-commands, so an agent navigates by following links rather
+than re-reading a schema or hand-writing `jq`.
+
+It is **opt-in and additive** — `nose scan`, `--fail-on`, and the scan-JSON contract are
+unchanged.
+
+```text
+nose query <path> [FILTER … | group=FIELD | id=FAM] [sort=KEY] [top=N] [full] [all]
+```
+
+| part | meaning |
+|---|---|
+| `field=value` | keep families where the field equals the value (AND-ed); `field>N`/`field<N` for numbers; `path~substr` for a path substring |
+| `group=FIELD` | facet the selection by a discrete field (`dir`, `scope`, `witness`, `lang`, `shape`), with a count and an exemplar per bucket |
+| `id=FAM` | open one family (any unambiguous id prefix): its copies, the all-copies extraction skeleton, and navigation links |
+| `sort=KEY` | `extractability` (default), `value`, or `members` |
+| `top=N` | show the first N rows (default 30) |
+| `full` | on `id=` or a list, render the all-copies extraction skeletons inline (batched) |
+| `all` | widen past the curated default surface to the full raw universe (demoted families labeled) |
+
+Fields: `scope` (prod\|test\|mixed), `witness` (exact\|subdag\|copy-paste\|similar),
+`lang`, `path`, `dir`, `members`, `files`, `value`, `params`, `shared`. Every row shows
+the payoff economics — `M/REP shared, Pp · ~N removable` — so a candidate can be triaged
+without opening it. Each result is a pure function of (repo state, command); an unknown
+field or enum value is a hard error (so a typo can't read as "no duplication").
+
+A typical loop: `nose query .` → `nose query . witness=exact` → `nose query . id=<id> full`.
 
 ## Integrating with nose
 


### PR DESCRIPTION
Implements **#359** — the `nose query` exploration surface.

## What

A stateless, self-describing **`nose query`** subcommand: an agent-facing query/navigation surface over the *same* family dataset `scan` computes. With no terms it prints a landing dashboard; terms slice (`field=value`/`>`/`<`/`path~`), facet (`group=FIELD`), or open a family (`id=FAM`, `full` for the all-copies skeleton). Every result is self-describing and ends in **runnable `nose query …` next-commands**, so an agent navigates by following links — no schema to learn, no `jq` to author.

**Opt-in and additive**: `nose scan`, `--fail-on`, baselines, and the scan-JSON v1 contract are unchanged. `build_scan_dataset` was factored out of `cmd_scan` so both commands share one deterministic family build.

Key properties (all validated below):
- **Self-describing cold** — a nose-naive agent acts from the output alone (what nose is, a confidence legend, curated candidates, the grammar).
- **Payoff economics on every row** — `M/REP shared, Pp · ~N removable`, aligned across **all** copies (reuses #360), so candidates triage without opening them — and *more honest than scan's pairwise headline* for diverging-copy families.
- **Default-surface-consistent** — filters/facets default to scan's curated default surface (counts reconcile); `all` widens, demoted families labeled.
- **Folded & production-first** — overlapping slices fold under their primary (`↳ +N`, reusing `OpportunityGroups`); production leads, test/mixed tagged inline.
- **Evidence, never verdict** — no worth-it claims; unknown fields/values error loudly; deterministic.

## Validation — 4 rounds of LLM-as-judge on 6 corpus repos (rust/py/go/js/java/c)

Each round, an agent drove `nose query` turn-by-turn with zero prior knowledge and compared it to `nose scan`; gaps fed the next round:

| round | verdict |
|---|---|
| 1 | 3/5 "partly" — better explorer, worse decider (no payoff economics, surface inconsistency, links missing the path) |
| 2 | 4/5 "mostly" — economics + consistency + prod-first + runnable links + field validation landed |
| 3 | 5/6 "mostly" (redis "partly") — honest all-copies economics, batched proposals, proposal-by-default, enum validation |
| 4 | **6/6 "mostly" — "a functional superset of scan, more honest per-family, can replace scan today for a careful agent"** (redis blocker cleared by slice folding) |

Every judge reached a concrete, source-verified refactor candidate in 2–4 turns on every repo.

## Deferred (filed as follow-ups, deliberately *not* in this PR)

The two remaining round-4 items are about the **shared** ranking / scan's estimator, not query's design — changing them touches `scan`'s output and the calibrated benchmark, so they belong in their own measured (§2c/§5) PRs:
- ranking quality: `extractability` sometimes surfaces a low-foldability #1 (shared with scan).
- unifying scan's headline numbers onto query's honest all-copies basis (query is already the honest one).

## Checks

- `nose-cli` suite green incl. a new `query_dashboard_filter_and_family` test and the capabilities stable-command test (now lists `query`); `fmt`/`clippy -D warnings` clean (1.96.0); `awiki lint` clean.
- `nose scan`, `--fail-on`, scan-JSON v1 unchanged. Docs: a `nose query` section in `usage.md`, advertised in `capabilities`.

Built on #360 (all-copies proposal) and #361 (directory terminology), both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
