### PR TITLE
#369: canon preservation up to abort — fix impossible-input artifact

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -2675,6 +2675,26 @@ fn push_verify_census(
     });
 }
 
+/// Did a canon pass change a unit's behavior? True iff some battery row's full-IL behavior
+/// is not equivalent to the core-IL behavior. Equivalence (`behavior_equiv`) treats two
+/// ABORTING runs (both `ret == Err`) as equal regardless of the effects recorded before the
+/// abort: an erroring execution has no observable result (the input is out of the unit's
+/// domain), and reordering operations before a guaranteed trap is behavior-preserving.
+/// Without this, impossible inputs (an int bound to an array param of a multi-array-param C
+/// routine like `fe25519_add`, #369) manufacture spurious violations. `Ok→Err`, `Err→Ok`,
+/// and differing successful results still trip (the `ret`s differ, or both are non-`Err` and
+/// compared in full).
+fn canon_changed_behavior(
+    core: &[nose_normalize::Behavior],
+    full: &[nose_normalize::Behavior],
+) -> bool {
+    core.len() != full.len()
+        || core
+            .iter()
+            .zip(full)
+            .any(|(c, f)| !nose_normalize::behavior_equiv(c, f))
+}
+
 #[allow(clippy::too_many_arguments)]
 fn collect_file_verify_recs(
     n: &nose_il::Il,
@@ -2777,7 +2797,7 @@ fn collect_file_verify_recs(
                 && !full_beh.iter().any(nose_normalize::behavior_has_sym);
             if concrete {
                 oracle.canon_checked += 1;
-                if full_beh != beh && oracle.canon_violations.len() < 20 {
+                if canon_changed_behavior(&beh, &full_beh) && oracle.canon_violations.len() < 20 {
                     let s = n.node(root).span;
                     oracle
                         .canon_violations

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -181,6 +181,23 @@ pub fn behavior_has_sym(b: &Behavior) -> bool {
         || b.fields.iter().any(|(_, v)| contains_sym(v))
 }
 
+/// Oracle behavioral equivalence: like `==`, except two ABORTING runs (both `ret ==
+/// Value::Err`) are equal regardless of their `effects`/`fields`. An erroring execution
+/// has no observable result — the input is outside the unit's domain — and the side
+/// effects recorded before a trap are not committed behavior, so a canonicalization that
+/// reorders operations ahead of a guaranteed trap (leaving one IL with a partial effect
+/// trace the other lacks, but BOTH still trapping) has not changed what the unit computes.
+/// A real behavior change — `Ok→Err`, `Err→Ok`, or a differing successful result — is
+/// still unequal: the `ret`s differ, or both are non-`Err` and the full behaviors compare.
+/// Used by the canon-preservation gate, where impossible inputs (e.g. an int bound to an
+/// array parameter) would otherwise manufacture spurious violations.
+pub fn behavior_equiv(a: &Behavior, b: &Behavior) -> bool {
+    if a.ret == Value::Err && b.ret == Value::Err {
+        return true;
+    }
+    a == b
+}
+
 /// Does the value contain a `Sym` anywhere (including inside lists)? Concrete
 /// operations must never run over a hidden symbolic operand — `sum([f(x)])`
 /// collapsing to a concrete `Err` would launder unknownness into the hard
@@ -1930,6 +1947,43 @@ mod tests {
         admit_test_builtin_calls(&mut il);
         let interner = Interner::new();
         run_unit(&il, &interner, root, args)
+    }
+
+    #[test]
+    fn behavior_equiv_treats_both_abort_as_equal() {
+        let beh = |ret: Value, effects: Vec<Value>| Behavior {
+            ret,
+            effects,
+            fields: vec![],
+        };
+        // Both abort (`Err`) with DIFFERENT pre-trap effects → equivalent: an erroring run
+        // has no observable result, so reordering ops before a guaranteed trap preserves
+        // behavior. This is the #-canon-preservation fix for impossible inputs.
+        let abort_a = beh(Value::Err, vec![]);
+        let abort_b = beh(Value::Err, vec![Value::Int(0), Value::Int(2)]);
+        assert!(behavior_equiv(&abort_a, &abort_b));
+        assert!(behavior_equiv(&abort_b, &abort_a));
+        // Real behavior changes still compare unequal:
+        // Ok→Err (the canon made it start/stop erroring)
+        assert!(!behavior_equiv(
+            &beh(Value::Int(1), vec![]),
+            &beh(Value::Err, vec![])
+        ));
+        // two successful runs with different results
+        assert!(!behavior_equiv(
+            &beh(Value::Int(1), vec![]),
+            &beh(Value::Int(2), vec![])
+        ));
+        // two successful runs with different effect traces
+        assert!(!behavior_equiv(
+            &beh(Value::Null, vec![Value::Int(1)]),
+            &beh(Value::Null, vec![Value::Int(2)]),
+        ));
+        // identical successful runs are equal
+        assert!(behavior_equiv(
+            &beh(Value::Int(7), vec![Value::Int(1)]),
+            &beh(Value::Int(7), vec![Value::Int(1)]),
+        ));
     }
 
     fn test_span(offset: u32) -> Span {

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -34,7 +34,8 @@ mod value_graph;
 
 pub use commutative::{node_tag, node_tag_valued, subtree_hashes, valued_tree_hash};
 pub use interp::{
-    behavior_has_sym, run_unit, run_unit_paths, Behavior, Value, F64, MAX_SYM_BRANCH_SITES,
+    behavior_equiv, behavior_has_sym, run_unit, run_unit_paths, Behavior, Value, F64,
+    MAX_SYM_BRANCH_SITES,
 };
 pub use value_graph::{
     anchor_min_weight, containment_anchor_min_weight, value_anchors, value_fingerprint,

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2721,3 +2721,33 @@ So α=1 is shipped: it demotes serde's dud from #1 to #2 (the clean numeric writ
 recall cost. The aggregate P@10 move is within CI: the demotion is a real, validated, safe
 correction of the *visible* failure, not a headline-precision jump — the residual ranking
 loss is judgment-deep (genuinely-ambiguous, parallel-by-design families), confirming §AV.
+
+## CN. Canon preservation up to abort — the impossible-input artifact (#369, 2026-06-14)
+
+The nightly `corpus verify` gate had been red for days on **4 canon-preservation
+violations** — all in libsodium's `fe25519` field arithmetic (`fe25519_add`/`sub`/`neg`,
+`int32_t[10]` / `int64_t[5]` limbs). The exact-claim soundness lane was unaffected
+(`SOUND: no false merges`); this was the stricter pair-free core-vs-full-IL self-check.
+
+Dumping the differing battery rows settled it: **all 279, across all 4 units, had
+`ret == Err` on both the core and the full IL** — zero rows where the return differed or
+either side succeeded. These functions take three array params; the global battery binds
+list/int mixes (e.g. the #337 element-mutation row makes one param a list, the rest ints),
+so `f[i]` indexes a non-list — an input that can never occur. The unit **traps either
+way**; the canonicalizer merely reorders the element-writes recorded *before* the trap,
+so `core = {Err, effects:[]}` vs `full = {Err, effects:[…partial…]}`. The #344 int oracle
+made these limb units interpretable, which is why the check started running on them
+(v0.8.0 shipped with the gate red). This is exactly the impossible-input class
+oracle-value-model.md §7 anticipated ("does not filter `Err`"); it had been masked off-
+corpus (netty 3, sympy 20) but libsodium is pinned.
+
+Fix: judge canon preservation **up to abort** — `behavior_equiv` treats two runs that
+both return `Err` as equivalent regardless of their pre-trap effects, since an erroring
+execution has no observable result and reordering operations ahead of a guaranteed trap is
+behavior-preserving. `Ok→Err`, `Err→Ok`, and differing successful results still trip, so a
+real behavior-changing canon is still caught; scoped to the canon-preservation comparison,
+the soundness/false-merge lane untouched. Full-corpus `nose verify --max-violations 0` then
+reads **PRESERVED ✓** with the soundness lane byte-identical — the benchmark.md "zero
+violations" claim is true again. Lesson: an oracle that models `Err` as an observable
+value must still treat *aborted* executions as resultless, or impossible inputs (which a
+global positional battery cannot avoid) manufacture phantom behavior differences.

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -346,13 +346,19 @@ typed-language array/index params (Java `byte[] bytes`, `int startPos`,
 `String[] a`) carry **none** today, so an incoherent value reaches them uncoerced.
 Feeding, say, a string or a list to a slot a unit uses as an array index manufactures
 an input that **can never occur**, and on it the *interpreter*, not the canonicalizer,
-diverged — producing a spurious **canon-preservation** violation (the check is
-concrete-only but does not filter `Err`).
+diverged — the unit **aborts** (`ret: Err`) either way, differing only in the partial
+effects recorded *before* the trap.
 
-This is not hypothetical, and not new to broadening: the *current* battery already
-trips it. `nose verify` on `netty` reported 3 canon-preservation "violations", all on
-type-incoherent rows, and `sympy` 20 — masked only because the nightly soundness gate's
-pinned corpus includes neither.
+This is not hypothetical: the *current* battery already trips it. It surfaced on the
+pinned corpus as 4 canon-preservation "violations" in libsodium's `fe25519` limb
+arithmetic (`fe25519_add`/`sub`/`neg` take 3 array params, so the #337 element-mutation
+battery row binds a list to one and ints to the rest, and `f[i]` indexes an int — #369),
+and off-corpus on `netty` (3) and `sympy` (20). **Fixed** by judging canon preservation
+*up to abort*: two runs that both return `Err` are equivalent regardless of their pre-trap
+effects (`behavior_equiv`, interp.rs), since an erroring execution has no observable result
+and reordering operations ahead of a guaranteed trap is behavior-preserving. `Ok→Err`,
+`Err→Ok`, and differing successful results still trip; the soundness/false-merge lane is
+untouched.
 
 **The SOUND form shipped — a per-group falsification SEARCH (`nose verify --falsify`, #317).**
 Rather than broaden the global battery (which manufactures the impossible-input rows above),


### PR DESCRIPTION
Closes #369.

The nightly `corpus verify` gate has been **red for days** on 4 canon-preservation violations, all in libsodium's `fe25519` field arithmetic (`fe25519_add`/`sub`/`neg`, `int32_t[10]`/`int64_t[5]` limb arrays). The exact-claim **soundness lane was unaffected** (`SOUND: no false merges`); this is the stricter, pair-free core-vs-full-IL self-check.

## Root cause — impossible-input artifact, not a real canon bug

Dumping **all 279** differing battery rows across the 4 units: every one returns `ret == Err` on **both** the pre-canon core IL and the fully-normalized IL (0 rows where the return differs or either side succeeds).

```
core = Behavior { ret: Err, effects: [] }
full = Behavior { ret: Err, effects: [Int(0), Int(2), Int(1), Int(4), ...] }
```

These functions take three array params, so the global positional verify battery binds list/int mixes (e.g. the #337 element-mutation row makes one param a list, the rest ints) and `f[i]` indexes a non-list — an input that can never occur. The unit **traps either way**; the canonicalizer merely reorders the element-writes recorded *before* the trap. The #344 int oracle (v0.8.0) made these limb units interpretable, which is why the check started running on them — so v0.8.0 shipped with the gate red. This is exactly the impossible-input class `oracle-value-model.md` §7 anticipated ("the check … does not filter `Err`"), previously masked off-corpus (netty 3, sympy 20) but libsodium is pinned.

## Fix — judge canon preservation *up to abort*

`behavior_equiv` (nose-normalize) treats two runs that both return `Err` as equivalent regardless of their pre-trap `effects`/`fields`: an erroring execution has no observable result (the input is out of the unit's domain), and reordering operations ahead of a guaranteed trap is behavior-preserving. **`Ok→Err`, `Err→Ok`, and differing successful results still trip**, so a real behavior-changing canon is still caught. Scoped to the canon-preservation comparison; the soundness/false-merge lane is **byte-identical**.

## Verification

- Full-corpus `nose verify --max-violations 0`: **PRESERVED** (27,087 checked, **0** violations) and **SOUND** (no false merges) — the soundness lane unchanged, the `benchmark.md` "zero violations" claim true again.
- Regression test `behavior_equiv_treats_both_abort_as_equal` (both-abort → equal; Ok→Err, differing results, differing effects → unequal).
- `cargo test --workspace --release` green; `fmt` clean; `cargo +1.96.0 clippy --workspace --all-targets -D warnings` clean; `awiki lint` clean.
- Docs: experiments **§CN**, `oracle-value-model.md` §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)