### PR TITLE
Release v0.9.0: cut the changelog, bump workspace version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,21 @@ break.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-14
+
 ### Added
+- **`nose query` — a stateless, self-describing exploration surface for agents (#359).** A new
+  opt-in subcommand over the *same* family dataset `scan` computes: with no terms it prints a
+  landing dashboard, terms slice (`field=value`/`>`/`<`/`path~substr`), facet (`group=FIELD`), or
+  open a family (`id=FAM`, add `full` for the all-copies extraction skeleton). Every result is
+  self-describing and ends in **runnable `nose query …` next-commands**, so an agent navigates by
+  following links — no schema to learn, no `jq` to author. Each row carries the all-copies payoff
+  economics (`M/REP shared, Pp · ~N removable`); the surface is production-first, default-surface-
+  consistent (`all` widens), folds overlapping slices, and is evidence-never-verdict (unknown
+  fields/values error loudly; deterministic). Validated by 4 rounds of LLM-as-judge on 6 corpus
+  repos ("a functional superset of scan, more honest per-family"). `scan`, `--fail-on`, and the
+  scan-JSON v1 contract are unchanged; `build_scan_dataset` is factored out so both share one
+  deterministic family build. MCP is deliberately *not* added (a Skill is the intended packaging).
 - **Family-level actionability vocabulary in scan JSON (#11).** Two new optional fields make a
   family's triage *machine-readable as classification, not a verdict* (no `refactorability_score` /
   `confidence` — that judgment is the consumer's, design §2):
@@ -45,6 +59,41 @@ break.
   hide each scenario's intent. It is a caveat, not a verdict (the worthy fixture-vs-scaffold call
   is the reader's and is not feature-decidable); `mixed` test↔prod leaks get no caveat, and the
   high-parameter caution still wins when both apply.
+- **Scan's `shared`/`removable` headline on the all-copies basis (#366).** `shared_lines` and the
+  derived `~removable` now count lines invariant across **all** of a family's copies (the same
+  all-copies anti-unification `nose query` reports), not just the representative pair — which
+  over-stated families whose 3rd+ copies diverge (serde's 25-copy `serialize_newtype_variant`
+  read `11 shared → ~264 removable`, now `4 → ~96`). Gold-set measured neutral (held-out P@10
+  flat, worthy-recall byte-identical; experiments §CL). `params`/`varying_spots` stay
+  representative-pair (the all-copies hole count regressed held-out, and it keeps the scan-JSON v1
+  `params↔varying_spots` invariant); scan-JSON v1 schema unchanged.
+- **Foldability-aware `extractability` ranking (#365).** The default ranking gains a member-span
+  **heterogeneity** penalty (`× 1/(1+CV)`, same-language): copies that vary widely in length are
+  not one shape, so no single helper folds them — a decidable proxy for signature/arity
+  heterogeneity (on the v5 labelset, not-worthy families carry ~2.7× the span CV of worthy ones).
+  Demotes the low-foldability family that ranked #1 in most corpus repos (serde's 25 heterogeneous
+  `Serializer` methods → #2; the clean numeric writer takes #1). Gold-set measured: held-out P@10
+  flat, worthy-recall invariant (the penalty only reorders); experiments §CM.
+- **Extraction proposal aligns across all copies (#360).** `--show proposal` and `nose query
+  id=FAM full` anti-unify over **all** of a family's copies (not just the two largest), so the
+  drafted helper is safe to apply to every copy — pairwise by default, full alignment on drill.
+- **Directory terminology (#363).** Human-facing output says "directory/directories": nose's
+  spatial unit is the parent directory, not an under-defined "module". The scan-JSON `modules`
+  field name is kept for v1 compatibility.
+
+### Fixed
+- **Canon preservation up to abort (#369).** The soundness oracle's canon-preservation gate
+  flagged 4 spurious violations in libsodium `fe25519` limb arithmetic: on impossible inputs (an
+  int bound to an array parameter), the unit traps (`ret: Err`) on both the core and full IL,
+  differing only in the partial effects recorded before the trap. The gate now judges preservation
+  *up to abort* — two aborting runs are equivalent regardless of pre-trap effects — so `nose verify
+  --max-violations 0` reads PRESERVED on the pinned corpus again. `Ok→Err`/`Err→Ok`/differing
+  results still trip; the soundness/false-merge lane is unchanged. Experiments §CN.
+
+### Notes
+- **Measured NO-GOs** (recorded so they are not re-attempted): JSX-markup detector filtering
+  (#353) and tier-2 sibling-family folding (#358) were both evaluated and rejected on measurement
+  — see the experiment log.
 
 ## [0.8.0] - 2026-06-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nose-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "nose-detect"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "nose-frontend",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "nose-eval"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "rustc-hash",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "nose-frontend"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "nose-il"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "lasso",
  "serde",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "nose-normalize"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "nose-il",
  "nose-semantics",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "nose-semantics"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "nose-il",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/corca-ai/nose"
@@ -25,12 +25,12 @@ rust-version = "1.85"
 [workspace.dependencies]
 # Internal crates carry an explicit `version` (not just `path`) so the tree has no
 # wildcard deps and the crates stay publishable; `path` wins for local builds.
-nose-il = { path = "crates/nose-il", version = "0.8.0" }
-nose-semantics = { path = "crates/nose-semantics", version = "0.8.0" }
-nose-frontend = { path = "crates/nose-frontend", version = "0.8.0" }
-nose-normalize = { path = "crates/nose-normalize", version = "0.8.0" }
-nose-detect = { path = "crates/nose-detect", version = "0.8.0" }
-nose-eval = { path = "crates/nose-eval", version = "0.8.0" }
+nose-il = { path = "crates/nose-il", version = "0.9.0" }
+nose-semantics = { path = "crates/nose-semantics", version = "0.9.0" }
+nose-frontend = { path = "crates/nose-frontend", version = "0.9.0" }
+nose-normalize = { path = "crates/nose-normalize", version = "0.9.0" }
+nose-detect = { path = "crates/nose-detect", version = "0.9.0" }
+nose-eval = { path = "crates/nose-eval", version = "0.9.0" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -34,11 +34,12 @@ anti-unification re-rank columns. The current default `extractability` order is 
 `nose scan --format json` family order; the snapshot below uses that same label matching
 with the native order kept.
 
-**Current reproducible snapshot:** with the current default `extractability` order, an
-audit run over the checked-out `bench/repos` corpus measured overall precision@10 at about
-**65% dev / 58% held-out**. The same scan re-sorted by raw `value` measured about
-**58% dev / 56% held-out**. Worthy-recall in that run was roughly **86% dev / 88%
-held-out**. The per-language CIs are wide (bounded by #repos×10), which is the point —
+**Current reproducible snapshot (v0.9.0):** with the default `extractability` order — after
+the all-copies `shared_lines` (#366, §CL) and the member-span heterogeneity penalty (#365,
+§CM) — an audit run over the checked-out `bench/repos` corpus measured overall precision@10 at
+about **61% dev [56–66] / 59% held-out [54–64]**. Worthy-recall in that run was roughly
+**86% dev / 88% held-out**, and is unchanged by those two ranking edits (they only reorder).
+The per-language CIs are wide (bounded by #repos×10), which is the point —
 they tell you whether a per-language difference is real or noise. The standing finding
 (experiments §AV) is that much residual precision loss is *judgment-deep*
 (genuinely-ambiguous, parallel-by-design families), not a simple detector signal gap.


### PR DESCRIPTION
A surface + ranking-honesty release on top of v0.8.0's soundness work. All ranking changes are gold-set measured (held-out P@10 flat, worthy-recall byte-identical); the soundness gate is green.

## Highlights
- **`nose query` (#359, #364)** — a stateless, self-describing exploration surface for agent loops over the *same* family dataset `scan` computes. Opt-in; `scan`, `--fail-on`, and scan-JSON v1 are unchanged.
- **Honest headline numbers** — scan's `shared`/`~removable` count *all* copies (#366, #367), matching `nose query`; and `extractability` demotes member-span heterogeneity so the least-foldable family stops ranking #1 (#365, #368). Both gold-set measured: held-out P@10 flat, worthy-recall byte-identical (experiments §CL/§CM).
- **Directory terminology** over the under-defined "module" in human output (#363); extraction proposals align across **all** of a family's copies (#360, #362).
- **Soundness — canon preservation up to abort (#369, #370)** — the `corpus verify` gate is green again (PRESERVED on 27,087 units, no false merges); `benchmark.md`'s "zero violations" claim is true. The 4 prior "violations" were an impossible-input artifact (both core and full IL trap), not a real canon bug.

Measured NO-GOs recorded so they aren't re-attempted: JSX detector filtering (#353), tier-2 sibling-family folding (#358).

## Release mechanics
- Bumps `workspace.package.version` and the inter-crate version pins 0.8.0 → 0.9.0; `Cargo.lock` regenerated.
- CHANGELOG `[0.9.0]` section cut from `[Unreleased]`.
- `benchmark.md` snapshot refreshed to the current measured **61% dev / 59% held-out** P@10 (post-#365/#366).
- After merge, tag `v0.9.0` to trigger the cargo-dist release workflow (artifacts + GitHub Release + homebrew) — **pending final go-ahead**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)