### PR TITLE
Release v0.9.1: docs lead with nose query + code-docs drift sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ break.
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-15
+
+Documentation release: lead with `nose query`, and a full code-docs drift sweep. No
+behavior change to `scan`/`query`/`review`/`--fail-on` or the scan-JSON v1 contract.
+
+### Changed
+- **Docs lead with `nose query`.** README, [home](docs/home.md),
+  [getting-started](docs/getting-started.md), [agent-recipe](docs/agent-recipe.md), and
+  [design](docs/design.md) §2 now present `nose query` as the interactive/agent exploration
+  entry point, with `nose scan` framed as the one-shot report plus the frozen JSON contract and
+  the `--fail-on` CI gate — both over the same dataset. `nose scan` is **not** deprecated.
+
+### Fixed (code-docs drift)
+- **Default scan mode** in [configuration](docs/configuration.md) said `["syntax","semantic"]`;
+  the real default is `["syntax","semantic","near"]` (matches the CLI and `README`).
+- **The verify oracle now models IEEE-754 floats** ([oracle-value-model](docs/oracle-value-model.md)
+  §1 still said "there is no Float", contradicting #342 and its own §3.3/§6); the input battery's
+  "starved `Str` model" narrative was stale (Parts 3–6 ship distinct-string/list, element-mutation,
+  float, and int32 rows); the canon-preservation baseline was corrected to 0 and the #369
+  up-to-abort attribution untangled from the series-9 cases.
+- **"directory" not "module"** in the `getting-started` report-reading guide and the
+  `architecture` ranking formula (#363); **all-copies** (not "a pair") shared-line wording.
+- **Benchmark reproducer** ([benchmark](docs/benchmark.md)) now passes `--rank extractability`
+  (the no-flag default sorts by `value` and won't reproduce the headline P@10); canon-preservation
+  described "up to abort" (#369); `extractability` description gains the member-span heterogeneity
+  penalty (#365) in [field-evaluation](docs/field-evaluation.md); `clone-types` near threshold
+  `0.70`; `scan-json` example `surface_counts` includes the always-emitted `generated`/`declaration`/`shallow`.
+- **Hazard re-calibration checklist** ([hazard-release-checklist](docs/hazard-release-checklist.md))
+  quick-check no longer over-triggers on display-only/reorder changes (e.g. #365/#366) — it compares
+  the calibrated feature fields sort-independently, with a display-vs-feature note (`shared_lines` ≠
+  `shared_weight`).
+- **scan-JSON v1 contract test** now asserts the always-emitted `shallow` surface count (fixture
+  + `support.rs` had drifted); `--show` help lists the `reinvented` view; a stale `family_hint`
+  doc-comment said "modules". Experiments log: the duplicate `§CA` anchor was disambiguated
+  (default-surface-noise is now `§CO`).
+
 ## [0.9.0] - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nose-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "nose-detect"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "criterion",
  "nose-frontend",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "nose-eval"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "rustc-hash",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "nose-frontend"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "ignore",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "nose-il"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "lasso",
  "serde",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "nose-normalize"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "nose-il",
  "nose-semantics",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "nose-semantics"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "nose-il",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/corca-ai/nose"
@@ -25,12 +25,12 @@ rust-version = "1.85"
 [workspace.dependencies]
 # Internal crates carry an explicit `version` (not just `path`) so the tree has no
 # wildcard deps and the crates stay publishable; `path` wins for local builds.
-nose-il = { path = "crates/nose-il", version = "0.9.0" }
-nose-semantics = { path = "crates/nose-semantics", version = "0.9.0" }
-nose-frontend = { path = "crates/nose-frontend", version = "0.9.0" }
-nose-normalize = { path = "crates/nose-normalize", version = "0.9.0" }
-nose-detect = { path = "crates/nose-detect", version = "0.9.0" }
-nose-eval = { path = "crates/nose-eval", version = "0.9.0" }
+nose-il = { path = "crates/nose-il", version = "0.9.1" }
+nose-semantics = { path = "crates/nose-semantics", version = "0.9.1" }
+nose-frontend = { path = "crates/nose-frontend", version = "0.9.1" }
+nose-normalize = { path = "crates/nose-normalize", version = "0.9.1" }
+nose-detect = { path = "crates/nose-detect", version = "0.9.1" }
+nose-eval = { path = "crates/nose-eval", version = "0.9.1" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -18,35 +18,45 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/corca-ai/nose/releases/
 
 ## Quick start
 
-Point `nose scan` at a directory. It groups duplicated code into clone families
-and ranks them by how cleanly each folds into one shared helper, so the report
-reads top-down as a refactoring to-do list:
+Point `nose query` at a directory to **explore** its duplication. It prints a landing
+dashboard, and every result suggests the next command to run — so you (or an agent) navigate
+by following links instead of memorizing flags:
 
 ```
-$ nose scan src
+$ nose query src
+nose — finds duplicated & refactorable code across languages.
 scanned 23 files · python 14 · typescript 9
-4 clone families, ranked by extractability (cleanest to fold into one helper)  ·  ~118 duplicated lines  (showing 4)
 
-#1  id b221962180c09063 · 2 copies · 8 of 10 lines shared, 2 spots differ · ~8 lines removable
-    → local duplication — extract a method from the repeated block
-    src/loaders/users.py:1-10  load_users
-    src/loaders/orders.py:12-21  load_orders
-…
+4 duplicated-code families on the default surface.
+  by confidence: exact 1 · subdag 0 · copy-paste 1 · similar 2
+
+cleanest to extract (production first):
+  src/loaders/users.py:1  2 copies · 8/10 shared, 2p · ~8 removable · similar   nose query src id=b221962180
+  …
+grammar:  nose query <path> [field=value | field>N | field~substr …] [group=FIELD | id=FAM] [sort=KEY] [top=N] [full] [all]
 ```
 
-The everyday commands:
+Then drill: `nose query src witness=exact` (only behavior-proven families), `nose query src
+group=dir` (by directory), `nose query src id=b221962180 full` (open one family with its
+all-copies extraction skeleton).
+
+For a **one-shot ranked report** — to read top-down, paste into a PR, or gate CI — use
+`nose scan`:
 
 ```sh
+nose scan src                              # the ranked report, cleanest-to-fold first
 nose scan src --show diff                  # also show exactly what differs inside each family
 nose scan src --format markdown            # a report to paste into a PR or issue
 nose review --base origin/main             # PR check: a change applied to one clone copy but not its siblings
 nose scan src --mode syntax --fail-on any  # jscpd-style copy-paste gate for CI
-nose scan src --format json                # machine-readable output for tooling and agents
+nose scan src --format json                # the versioned machine-readable contract for batch tooling and CI
 ```
 
-By default `nose scan` runs all three channels — `syntax` (copy-paste runs),
-`semantic` (exact same-logic Type-4 clones), and `near` (fuzzy near-duplicates) —
-and respects `.gitignore`. Pass `--mode` to run exactly the channels you list.
+`query` and `scan` read the **same** dataset: `query` is the interactive/agent surface,
+`scan` is the one-shot report plus the frozen JSON contract and the `--fail-on` CI gate. By
+default both run all three channels — `syntax` (copy-paste runs), `semantic` (exact
+same-logic Type-4 clones), and `near` (fuzzy near-duplicates) — and respect `.gitignore`.
+Pass `--mode` to run exactly the channels you list.
 
 ## Documentation
 

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -140,8 +140,9 @@ enum Cmd {
         )]
         mode: Vec<ScanMode>,
         /// Extra views (repeatable / comma-list): `diff` (each family as a unified
-        /// diff of its two copies), `proposal` (an extraction skeleton), `hotspots`
-        /// (directories ranked by duplicated lines). e.g. `--show diff,hotspots`.
+        /// diff of its two copies), `proposal` (an extraction skeleton over all copies),
+        /// `hotspots` (directories ranked by duplicated lines), `reinvented` (helpers
+        /// reimplemented inline instead of called). e.g. `--show diff,hotspots`.
         #[arg(long, value_delimiter = ',', value_name = "VIEW")]
         show: Vec<ShowView>,
         /// Cache per-file analysis under this directory. Re-runs reuse the cache for
@@ -5953,7 +5954,7 @@ fn family_langs(f: &nose_detect::RefactorFamily) -> String {
 
 /// A short, fact-grounded refactoring hint for a family — only from signals the
 /// report already establishes (a shared symbol name, cross-language spread, the
-/// number of modules), never a guess about semantics.
+/// number of directories), never a guess about semantics.
 fn family_hint(f: &nose_detect::RefactorFamily) -> String {
     use nose_il::UnitKind;
     // Exactly one member is a whole named function/method while every other

--- a/crates/nose-cli/tests/cli/support.rs
+++ b/crates/nose-cli/tests/cli/support.rs
@@ -396,6 +396,7 @@ fn assert_scan_json_surface_counts_contract(
         "debug",
         "generated",
         "declaration",
+        "shallow",
         "fragments",
     ] {
         assert!(

--- a/crates/nose-cli/tests/fixtures/scan-json-v1.json
+++ b/crates/nose-cli/tests/fixtures/scan-json-v1.json
@@ -92,6 +92,7 @@
       "debug": 0,
       "generated": 0,
       "declaration": 0,
+      "shallow": 0,
       "fragments": {
         "total": 0,
         "default": 0,

--- a/docs/agent-recipe.md
+++ b/docs/agent-recipe.md
@@ -1,30 +1,55 @@
-# Agent recipe — triaging nose scan JSON
+# Agent recipe — exploring & triaging nose findings
 
 [design](design.md) §2: nose's primary consumer is an LLM coding agent that **calls
 nose and applies its own judgment on top**. nose surfaces candidates with
 deterministic, machine-readable evidence; the judgment-deep question — *worth
 refactoring, or parallel-by-design?* — belongs in the caller (experiments §AV/§AY
 measured that ceiling; an internal LLM would be redundant for agents and harmful for
-gates). This page is the protocol for that caller: which fields to read, in what
-order, and what to do with each verdict. It was validated by replaying it against
-the human-audited v5 labels (see *Validation* below).
+gates). This page is the protocol for that caller: how to **explore** the findings, which
+fields to read, in what order, and what to do with each verdict. It was validated by
+replaying it against the human-audited v5 labels (see *Validation* below).
 
-## Inputs
+## Explore: the `nose query` loop (start here)
+
+`nose query <path>` is the interactive entry point — a stateless, self-describing surface
+over the same family dataset, built for an agent loop. Start with no terms for a landing
+dashboard, then **follow the runnable `next:` command on each result** rather than
+pre-scripting field reads:
 
 ```sh
-nose scan <path> --format json --top 30        # the ranked triage surface
+nose query <path>                      # landing dashboard: counts by confidence + cleanest candidates
+nose query <path> witness=exact        # slice: only the behavior-proven families
+nose query <path> scope=prod           # slice: production-scope only
+nose query <path> group=dir            # facet: by directory, with a count + exemplar
+nose query <path> id=<fam> full        # open one family: copies + all-copies extraction skeleton
+```
+
+Each result is a pure function of (repo state, command); an unknown field or enum value is a
+hard error (so a typo can't read as "no duplication"). Use `--format json` on any query for
+the same rows structured. This surface is delivered as the agent's primary path; it is *not*
+an MCP server (a Skill is the intended packaging).
+
+## Inputs for the batch / gate path
+
+For non-interactive consumption — a CI gate, a one-shot triage of the whole tree, or feeding
+the versioned contract to other tooling — read the JSON directly:
+
+```sh
+nose scan <path> --format json --top 30        # the ranked triage surface (versioned contract)
 nose review --base origin/main --format json   # PR-time divergence findings
 ```
 
-Parse `families[]` ([scan JSON](scan-json.md)). Do not scrape human output.
+Parse `families[]` ([scan JSON](scan-json.md)). Do not scrape human output. The per-family
+decision procedure below applies to both a `nose query` row and a `scan` JSON family — they
+carry the same evidence fields.
 
 ## Per-family decision procedure
 
 Read the fields in this order — each step either decides or narrows:
 
 1. **Surface filter.** Act on `recommended_surface == "default"` only;
-   `review`/`hidden`/`shallow` are diagnostic surfaces. If you widen past the
-   default, `actionability_reason` names *why* a family was demoted — `trivial`
+   `review`/`hidden`/`shallow`/`generated`/`declaration` are diagnostic surfaces. If you
+   widen past the default, `actionability_reason` names *why* a family was demoted — `trivial`
    (too small to extract), `shallow-extraction` (the helper would be mostly
    parameters), `declaration-run` (only import/include/use/re-export spans), or
    `generated-source` — each a decidable classification, not a worthiness verdict.
@@ -99,5 +124,5 @@ following this page over a deterministic top-K sample of v5-labeled families
 reproduced the human-audited worthy/not-worthy verdicts — see
 [experiments §BX](experiments.md) for the run and its agreement numbers.
 
-*See also: [scan JSON](scan-json.md) · [review](review.md) ·
-[structured-ignores](structured-ignores.md) · [design](design.md).*
+*See also: [usage › nose query](usage.md#nose-query) · [scan JSON](scan-json.md) ·
+[review](review.md) · [structured-ignores](structured-ignores.md) · [design](design.md).*

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,8 +74,9 @@ source ──tree-sitter──▶ raw IL ──normalize──▶ canonical IL �
    ([graded-witness](graded-witness.md)).
 6. **Cluster & rank**: union-find over accepted pairs/runs forms clone groups, which
    are grouped into **families** and sorted by refactoring value (removable lines
-   × similarity × cross-module/-file/-language spread). See [usage](usage.md) for how the
-   ranked report reads.
+   × similarity × cross-directory/-file/-language spread). See [usage](usage.md) for how the
+   ranked report reads — and [`nose query`](usage.md#nose-query) for exploring the same
+   families dataset interactively.
 
 ## Crates
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -26,7 +26,7 @@ so a change has to generalize, not just fit the dev repos; tune only on dev.
 ```sh
 bench/setup_repos.sh                      # clone the pinned corpus into bench/repos
 python3 bench/prune_corpus.py --check-manifest  # verify the recorded prune digest
-python3 bench/labels/eval_by_language.py  # P@10 + worthy-recall, per language, dev/held-out, 95% CIs
+python3 bench/labels/eval_by_language.py --rank extractability  # P@10 + worthy-recall, per language, dev/held-out, 95% CIs
 ```
 
 `eval_by_language.py` still prints its historical `value` baseline and
@@ -51,7 +51,9 @@ nose's value-graph fingerprint is **sound by intent**: equal fingerprint ⟹ equ
 an input battery and flags any fingerprint-equal pair whose behavior differs. It interprets
 the *pre-canonicalization* IL (so a behavior-changing canon can't mask itself), and a
 **canon-preservation** check requires each unit's core-IL behavior to equal its full-IL
-behavior. The core canonicalizations are additionally machine-checked in Lean (`formal/`).
+behavior *up to abort* — two runs that both error are equivalent regardless of the effects
+recorded before the trap, so an impossible input can't manufacture a phantom violation
+(experiments §CN). The core canonicalizations are additionally machine-checked in Lean (`formal/`).
 Both currently report **zero** violations on the characterized gates. `verify` is bounded:
 units whose estimated work (`IL nodes × battery rows`) exceeds the oracle budget fail closed as
 `battery-bail` and appear in the exclusion census instead of monopolizing the run.
@@ -77,7 +79,8 @@ experiments §T for the throughput work.
 
 ## The research commands
 
-The everyday surface is `nose scan` ([usage](usage.md)). The default mix is
+The everyday surfaces are `nose query` (interactive exploration) and `nose scan` (one-shot
+report + CI gate) — both over the same dataset ([usage](usage.md)). The default mix is
 `syntax,semantic,near` (experiments §BM priced the flip); benchmark runs that need the
 pre-flip exact-only surface pin `--mode syntax,semantic` explicitly. The benchmark also
 uses a hidden research surface:

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -132,7 +132,7 @@ release so it can't drift.
 | `interfaces.capabilities_json` | boolean | Whether `nose capabilities` is the supported capability query interface. |
 | `interfaces.version_json` | boolean | Whether `nose --version --json` is supported. Version 1 reports `false`. |
 | `interfaces.doctor_json` | boolean | Whether `nose doctor --json` is supported. Version 1 reports `false`. |
-| `commands.stable` | array | Stable user-facing commands that integrations may invoke. Hidden research commands are intentionally omitted. |
+| `commands.stable` | array | Stable user-facing commands that integrations may invoke (incl. `query`, the interactive exploration surface — see [usage › nose query](usage.md#nose-query); it has no versioned sub-contract of its own yet). Hidden research commands are intentionally omitted. |
 | `schemas.capabilities` | array | Supported capabilities schema versions. |
 | `schemas.scan_json` | array | Supported `nose scan --format json` schema versions. |
 | `schemas.semantic_packs` | array | Supported semantic-pack manifest API versions, currently `nose.semantic-pack.v0`. |

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -190,7 +190,7 @@ separately with `recommended_surface`: default, review, or hidden. See
 Each type maps to a detection channel by evidence surface: **Type-1 and token-level
 copy floors → `syntax`**, identifier/type-normalized **Type-2 → `semantic` or `near`**,
 literal-varied Type-2 and **Type-3 → `near`** (fuzzy; the threshold rides on the mode,
-`near:0.8`), and exact **Type-4 → `semantic`**. The experimental
+`near:0.70` by default), and exact **Type-4 → `semantic`**. The experimental
 `abstraction[:T]` mode is a weak family-wide witness layer over a narrow `near` subset;
 it does not feed `semantic` or `verify`. The default is `syntax,semantic,near`; see
 [usage → Scan modes](usage.md#scan-modes) for the full table and how to compose channels.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,7 @@ the built-in default". Keys are kebab-case and live under the `[scan]` table.
 | key | type | default | same as flag |
 |---|---|---|---|
 | `exclude` | list of globs | `[]` | `--exclude` |
-| `mode` | list of `syntax`\|`semantic`\|`near[:T]` | `["syntax", "semantic"]` | `--mode` |
+| `mode` | list of `syntax`\|`semantic`\|`near[:T]` | `["syntax", "semantic", "near"]` | `--mode` |
 | `sort` | `extractability`\|`value`\|`sites`\|`hazard` | `extractability` | `--sort` |
 | `min-value` | finite non-negative float | `0.0` | `--min-value` |
 | `min-members` | int | `2` | `--min-members` |
@@ -51,9 +51,9 @@ the built-in default". Keys are kebab-case and live under the `[scan]` table.
 
 ```toml
 [scan]
-mode = ["syntax"]                  # jscpd-style gate
-# mode = ["syntax", "semantic"]    # same as omitting mode
-# mode = ["syntax", "semantic", "near"]
+mode = ["syntax"]                          # jscpd-style gate (exact copy-paste only)
+# mode = ["syntax", "semantic"]            # exact channels only, no fuzzy near
+# mode = ["syntax", "semantic", "near"]    # same as omitting mode (the default)
 ```
 
 `min-size` (and the advanced `min-lines`) apply to both structural units and the syntax

--- a/docs/default-surface-noise-audit-2026-06-14.md
+++ b/docs/default-surface-noise-audit-2026-06-14.md
@@ -185,7 +185,7 @@ members' real source. **NO-GO, for two structural reasons:**
    surface for shapes).
 
 Shipping it would hide distinct genuine findings under a misleading "same shape" label *and*
-slow scans — strictly worse. Recorded in [experiments §CA](experiments.md). The independent,
+slow scans — strictly worse. Recorded in [experiments §CO](experiments.md). The independent,
 source-verified lever stands: a decidable **evidence** flag for language-forced parallel
 duplication (`owned-vs-borrowed` / `covariant-type-only` / `high-param-ratio` from the graded
 per-spot `class`, evidence-not-verdict) and retiring "proven ⇒ trust/lead" (serde's top

--- a/docs/design.md
+++ b/docs/design.md
@@ -68,6 +68,12 @@ What nose owes consumer 1:
 - **Rich machine-readable evidence** — the [scan JSON](scan-json.md) output should carry
   *why* two units are equivalent, *what* differs, exact locations, and the behavior contract,
   so the agent can decide and act without re-deriving the analysis.
+- **A navigable, self-describing surface** — [`nose query`](usage.md#nose-query) lets the
+  agent *explore* the same dataset interactively: a landing dashboard, sliceable
+  filters/facets, drill-into-one-family, and a runnable next-command on every result, so the
+  agent navigates by following links instead of re-reading a schema or hand-writing `jq`. This
+  is consumer 1's interactive entry point; the one-shot scan JSON is the batch/contract form of
+  the same dataset. (Packaged as a Skill, deliberately not as an MCP server.)
 - **Speed.**
 
 Implication: **perfectly separating parallel-by-design is not specially important here** — the
@@ -95,7 +101,7 @@ diff — is a natural high-precision, actionable gate trigger.
 |---|---|---|
 | recall | higher is better (agent filters) | low is fine |
 | precision | good enough (deep judgment outsourced) | **must be extremely high** |
-| output | rich JSON + equivalence evidence | pass / block + `--fail-on` |
+| output | interactive `nose query` + one-shot rich JSON, both with equivalence evidence | pass / block + `--fail-on` |
 | ranking | triage aid (saves agent tokens) | mostly irrelevant (gates don't rank) |
 | LLM | in the *caller* (external) | none (determinism required) |
 | shared | **soundness · determinism · speed** | same |
@@ -126,9 +132,10 @@ is held to proof discipline (§1). Actionability splits by **decidability, not c
 
 ### 2c. The bare default is the product
 
-`nose scan <path>` with **no flags** is the first-user experience and the calling agent's
-default invocation; the top of that report is nose's one chance to demonstrate value.
-Two consequences:
+A no-flags invocation is the first-user experience: `nose query <path>` (the interactive
+landing dashboard) for an exploring agent or human, `nose scan <path>` (the one-shot report)
+for a batch read or CI. Both render the **same default surface**, and its head is nose's one
+chance to demonstrate value. Two consequences:
 
 - The default surface must be **dominated by actionable findings**. A finding class leaves
   the default surface only when its non-actionability is *decidable* (§2b) or *measured*
@@ -204,7 +211,7 @@ engine over a single formal IL semantics was evaluated in depth. The current evi
   measured: 6/7 phase-ordering-stressing equivalences already converge, the 7th closed by
   *one* new rule, not an engine ("the lever is new sound rules, not a better engine");
 - the fingerprint is a whole-DAG node-hash multiset (`fingerprint_lits` in
-  `crates/nose-normalize/src/value_graph.rs`); cost-based extraction from two non-isomorphic
+  `crates/nose-normalize/src/value_graph/output.rs`); cost-based extraction from two non-isomorphic
   e-graphs could pick different representatives and **break currently-converging matches**,
   and threatens the byte-determinism invariant;
 - behavioral equivalence is **not a congruence** under the IL's ordered effects (the oracle

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2570,7 +2570,7 @@ it, no further. Issue #329.
 | s9-oracle-eq-err-incoherent | oracle | recorded-low-prevalence (§7 sharpened; fix deferred) |
 | s9-perf-enrich-narrowing | performance-determinism | green-confirmed |
 
-## CA. Default-surface noise — the #263/#264 triage feedback, re-judged by fresh-repo audit
+## CO. Default-surface noise — the #263/#264 triage feedback, re-judged by fresh-repo audit
 
 The triage-noise feedback ([#263](https://github.com/corca-ai/nose/issues/263) TS/React,
 [#264](https://github.com/corca-ai/nose/issues/264) Go-CLI, [#11](https://github.com/corca-ai/nose/issues/11)
@@ -2677,7 +2677,7 @@ principled (it correctly demotes the low-foldability serde family — the standi
 target) but **regressed held-out** (59→57, Java −9): the all-copies hole count over-fires
 `shallow-extraction` on dev-shaped families that don't generalize. So `params` deliberately
 stays representative-pair (also keeping it tied to `varying_spots` and the frozen scan-JSON
-v1 contract). The lesson repeats §AV/§CA: the residual ranking loss is judgment-deep, not a
+v1 contract). The lesson repeats §AV/§CO: the residual ranking loss is judgment-deep, not a
 number-basis bug — #365 needs its own signal (signature/arity heterogeneity), not a more
 honest parameter count. Scan and query now print one shared/removable headline per family;
 the `params`/`spots-differ` count stays each surface's own (scan = representative pair,

--- a/docs/field-evaluation.md
+++ b/docs/field-evaluation.md
@@ -118,7 +118,8 @@ over-rewarded a big block whose copies share little -- a 384-line family sharing
 22 lines across 14 varying spots topped the list at a misleading `sim 1.00`,
 above a tight `15/15`-shared pair. The default sort is now **extractability** --
 how cleanly a family folds into one helper (invariant lines × copies × spread,
-weighted by tightness and penalized by parameter count), with the report's
+weighted by tightness and penalized by parameter count and member-span heterogeneity —
+#365/§CM), with the report's
 similarity cell replaced by an honest `N/M shared · Pp`. Same-language families
 that share *no* invariant lines (a language idiom, or two unrelated type literals
 of the same shape) now sink instead of topping the list. `--sort value` retains

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,37 @@ Silicon + Intel) and Linux (x86_64 + arm64) are attached to every
 [release](https://github.com/corca-ai/nose/releases). To build from source
 instead, see [usage → Install](usage.md#install).
 
+## Explore interactively: `nose query`
+
+The quickest way in is `nose query <path>`. It prints a **landing dashboard** of what nose
+found, and every result suggests the next command to run — so you (or an agent) navigate by
+following links instead of memorizing flags:
+
+```
+$ nose query examples
+nose — finds duplicated & refactorable code across languages.
+scanned 3 files · go 1 · python 1 · typescript 1
+
+1 duplicated-code families on the default surface.
+  by confidence: exact 0 · subdag 1 · copy-paste 0 · similar 0
+
+cleanest to extract (production first):
+  examples/sum.go:3  6 copies · same logic in 3 languages · ~30 removable · subdag   nose query examples id=b658f483dc
+  …
+grammar:  nose query <path> [field=value | field>N | field~substr …] [group=FIELD | id=FAM] [sort=KEY] [top=N] [full] [all]
+```
+
+From there you **slice** (`nose query examples witness=exact`, `scope=prod`, `params<2`),
+**facet** (`group=dir`), or **open one family** (`nose query examples id=b658f483dc full`
+shows its copies and the all-copies extraction skeleton). Each result is a pure function of
+(repo state, command), and an unknown field or value is a hard error — so a typo can never
+read as "no duplication." It explores the *same* dataset `nose scan` computes; nothing is
+written and `nose scan` / CI are unaffected.
+
 ## Your first scan
+
+For a **one-shot ranked report** — to read top-down, paste into a PR, or gate CI —
+use `nose scan`.
 
 Run `nose scan` on any file or directory. It recurses, respects `.gitignore` files inside
 the scanned tree, and prints the duplication it found, most worth-refactoring first:
@@ -70,12 +100,12 @@ shared helper, base class, or data table). Read it left to right:
 - `3 copies` — how many places this code appears.
 - `same logic in 2 languages …` — what's shared. For copies in one language this
   instead reads `N of M lines identical` (or `… shared, K spots differ`) — the
-  *honest* overlap, so a pair that looks identical but really shares few lines is
-  obvious. Cross-language copies have no shared *source* lines, so they report the
-  language list instead.
+  *honest* overlap counted across **all** the copies (not just two), so a family that
+  looks identical but really shares few lines is obvious. Cross-language copies have no
+  shared *source* lines, so they report the language list instead.
 - `~134 lines removable` — roughly how much code you'd delete by consolidating.
 - The **`→` line is a hint**, grounded in facts (a shared symbol name, how many
-  modules it spans), never a guess about what the code means.
+  directories it spans), never a guess about what the code means.
 - Then **every site is listed** with its exact `file:line-range` — you can't act on
   a clone you can't see.
 
@@ -108,6 +138,8 @@ nose scan src --show proposal   # show the extracted helper skeleton, varying sp
 
 | You want… | Command |
 |---|---|
+| Explore interactively (or drive from an agent loop) | `nose query src` → follow the next-commands |
+| Only the behavior-proven families, interactively | `nose query src witness=exact` |
 | A report to paste into a PR or issue | `nose scan src --format markdown > REFACTOR.md` |
 | Only the biggest, cleanest wins | `nose scan src --min-value 300 --min-members 3` |
 | A copy-paste gate for CI (jscpd-style) | `nose scan src --mode syntax --fail-on any` |
@@ -138,6 +170,8 @@ gate policy, and CI wiring.
 
 ## Where to go next
 
+- **[usage › nose query](usage.md#nose-query)** — the full query grammar: filters,
+  facets, drill-into-one-family, and the agent loop.
 - **[usage](usage.md)** — every command and flag, the ranking keys, and the scan
   modes in full.
 - **[review](review.md)** — the git-aware companion command: catch a clone

--- a/docs/hazard-release-checklist.md
+++ b/docs/hazard-release-checklist.md
@@ -29,8 +29,21 @@ miss.
 
 **How to tell if detection output changed**, if unsure: scan a fixed fixture corpus with
 the old and new binary and diff the JSON `families` (`nose scan <fixtures> --mode
-semantic,near --format json --top 0`). No diff → ranking-only, skip. Any diff → refresh.
-When in doubt, refresh — it costs minutes (cached clones).
+semantic,near --format json --top 0`), comparing **sort-independently** and looking only at
+the calibrated inputs — family identity, member sets, fingerprints, and the feature values in
+the row above (`mean_sem`, `shared_weight`, `params`, `mean_lines`, `modules`, `scope`). A
+change there → refresh. **Ignore** pure-display fields and ordering: a reorder of the
+extractability-sorted `families` array, or a changed `shared_lines`/`dup_lines`/`~removable`
+value, is *not* a hazard input (e.g. v0.9.0's #365 reorder and #366 all-copies `shared_lines`
+both moved the JSON without touching any hazard feature — see the note below). When a real
+feature value moved, refresh — it costs minutes (cached clones).
+
+> **Display vs feature.** The display field `shared_lines` (#366; computed CLI-side, feeds
+> `extractability` via the shallow-extraction gate) is **not** the calibrated hazard feature
+> `shared_weight` (the IDF-weighted majority-vote count, byte-identical across #366). `hazard()`
+> consumes `shared_weight`/`mean_lines`/`spread`/`scope` — never `shared_lines` — so a
+> #366-style change is "Nothing" for hazard even though it alters scan JSON and extractability
+> order.
 
 ## The refresh procedure
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -18,7 +18,10 @@ where relevant. The pages are grouped by what you're here to do.
 ## Fast paths
 
 - **Trying nose locally:** install from [getting-started](getting-started.md), then run
-  `nose scan <path>` and read the first few ranked families.
+  `nose query <path>` to explore interactively (follow the suggested next-commands), or
+  `nose scan <path>` for a one-shot ranked report.
+- **Driving nose from an agent:** run `nose query <path>` and follow the runnable `next:`
+  links — see [usage › nose query](usage.md#nose-query) and the [agent-recipe](agent-recipe.md).
 - **Adding a repo gate:** start with [continuous integration](continuous-integration.md),
   then commit shared defaults from [configuration](configuration.md).
 - **Building an integration:** use [capabilities](capabilities.md) before invoking a binary
@@ -28,7 +31,8 @@ where relevant. The pages are grouped by what you're here to do.
 
 You want to *run* nose on a codebase and act on what it finds.
 
-- [usage](usage.md) — the complete command and flag reference (`scan`, `review`, `stats`, `il`, `capabilities`), the ranking keys, and the scan modes.
+- [usage](usage.md) — the complete command and flag reference (`query`, `scan`, `review`, `stats`, `il`, `capabilities`, `semantic-pack`), the ranking keys, and the scan modes.
+- [usage › nose query](usage.md#nose-query) — `nose query`: the stateless, self-describing **exploration surface** over the same dataset `scan` computes — a landing dashboard, sliceable filters/facets, drill-into-one-family, and a runnable next-command on every result. The interactive/agent entry point.
 - [review](review.md) — `nose review`: flag clones changed inconsistently in a diff (a copy fixed, its siblings missed) — a PR/CI check on top of git.
 - [configuration](configuration.md) — the `nose.toml` file: excludes, modes, ranking, thresholds, and structured-ignore defaults.
 - [continuous-integration](continuous-integration.md) — the `--fail-on any` gate, baseline-driven incremental adoption, SARIF, and fast re-runs.
@@ -44,8 +48,8 @@ You're building tooling — an installer, CI wrapper, or editor integration — 
 of nose's machine-readable output.
 
 - [capabilities](capabilities.md) — the `nose capabilities` JSON contract: what an installed binary supports, so a wrapper never has to scrape `--help`.
-- [scan-json](scan-json.md) — the versioned `nose scan --format json` contract for downstream tooling.
-- [agent-recipe](agent-recipe.md) — the validated protocol for an LLM agent triaging scan JSON: which fields to read, in what order, and what to do with each verdict.
+- [agent-recipe](agent-recipe.md) — the validated protocol for an LLM agent: explore interactively with `nose query` (follow the emitted next-commands), then read the `nose scan --format json` contract for the batch/gate path.
+- [scan-json](scan-json.md) — the versioned `nose scan --format json` contract for downstream tooling and CI (the batch surface; `nose query` is its interactive companion).
 
 ## Contributing
 

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -40,7 +40,8 @@ on a battery of inputs and compares observable behavior. Its value type is
 
 | kind | models | notes |
 |---|---|---|
-| `Int(i64)` | every integer | **all numbers** — there is no float (see §3.3) |
+| `Int(i64)` | every integer | i64 arithmetic, with JS int32 bitwise execution where typed (#344) |
+| `Float(F64)` | IEEE-754 doubles | full IEEE-754 `Add`/`Sub`/`Mul`/`Div`/`FloorDiv`/`Mod`/`Pow` (#342, see §3.3); float *literals* stay opaque (`LitFloat`) |
 | `Bool(bool)` | booleans | |
 | `Str(Vec<u64>)` | strings as a **free monoid** over appended token hashes | **order-sensitive**: `"x"+"y"` = `[hx,hy]` ≠ `[hy,hx]` = `"y"+"x"`. No char content; length/index stay `Err`. |
 | `List(Vec<Value>)` | sequences | |
@@ -53,11 +54,11 @@ Two facts matter for everything below:
 - **Strings are already order-sensitive.** The free-monoid `Str` was built
   precisely so that an unsound commutative treatment of `+` on strings is
   *witnessable* — the model is not the gap for finding C.
-- **There is no `Float`.** Every numeric literal and result is an `i64`. Float
-  *literals* are kept distinct in the value graph (`LitFloat`, a hash of the
-  source text, so `3.14 ≠ 2.71` — `crates/nose-il/src/node.rs`), but the
-  interpreter has no float arithmetic, so any *computation* whose result depends
-  on float semantics is invisible to the oracle.
+- **The oracle now models IEEE-754 floats** (`Value::Float(F64)`, #342 — see §3.3/§6).
+  Float *literals* are still kept opaque in the value graph (`LitFloat`, a hash of the
+  source text, so `3.14 ≠ 2.71` — `crates/nose-il/src/node.rs`), but float *arithmetic* is
+  interpreted, so the fully-untyped float associativity gap that motivated this doc is
+  closed in both the detector and the oracle.
 
 ### 1.1 The input battery (the other half of the oracle)
 
@@ -73,16 +74,22 @@ production battery is `verify_battery` / `verify_probes`
   corpus actually branches on, each injected at **one** position with the other
   slots filled by `pool[0]` (the list `[1,2,3,4]`).
 
-The `wide` ("leap-3") battery widens the integer/list domain but follows the same
-shape: still no strings in the combinatorial core, still one-position string
-probes.
+Beyond the combinatorial core and the literal probes, the battery carries targeted
+order/kind rows (`verify_battery` Parts 3–6) added as each gap was closed:
 
-**Consequence:** the battery never binds **two distinct strings to two
-parameters simultaneously**. So `f(a,b)=a+b` and `g(a,b)=b+a` are only ever
-compared on integer/list rows (where `+` is commutative or both `Err`) and on
-single-string probe rows (`"x" + [1,2,3,4]` → `Err`, same as the swap) — never on
-`("x","y")`, the one input on which they differ. The order-sensitive `Str` model
-is present but **starved of the input that would exercise it**.
+- **Part 3 — distinct-pair rows (#283-C):** two *distinct* strings (and two distinct lists)
+  bound to adjacent params, forward and reversed — the input on which `a+b` and `b+a` differ.
+- **Part 4 — element-mutation rows (#337):** a list base with two distinct int indices, so
+  `swap(a,i,j)` is observably ≠ `clobber`.
+- **Part 5 — adversarial float rows (#342):** magnitudes like `1e16 ± 1e16` that expose
+  non-associative float `+`.
+- **Part 6 — int32-overlap rows (#344):** ints straddling the 2³² boundary for JS bitwise width.
+
+**Consequence:** the order-sensitive `Str`/`List` model is **no longer starved** — Part 3
+binds `("x","y")` to two params, so `f(a,b)=a+b` and `g(a,b)=b+a` are now distinguished by the
+oracle, not only by the detector gate. The remaining genuine gap is *mixed* string/number
+**coercion** rows (a string and a number to the same family of params), which need
+type-domain-aware feeding to avoid manufacturing impossible inputs (§7).
 
 ---
 
@@ -104,10 +111,11 @@ numeric-only rewrites.
   numeric-to-string coercion for `string + number`, so mixed-coercion regressions
   rely on external-language witnesses plus detector fingerprint splits until that
   model exists. The **float** half of C overlaps D-div; see there.
-- **Remaining gap:** the **battery** (§1.1) never feeds two distinct strings/lists
-  to two params at once, and it has no mixed string/number coercion rows. The
-  detector no longer merges the known C string/mixed cases, but `nose verify`
-  remains too weak to witness all of them by itself.
+- **Remaining gap:** the **battery** (§1.1) now feeds two distinct strings/lists to two
+  params at once (Part 3), so pure string/list ordering is oracle-witnessed; what it still
+  lacks is mixed string/number **coercion** rows. The detector no longer merges the known C
+  string/mixed cases, and `nose verify` now witnesses the pure-string half itself — only the
+  mixed-coercion half still relies on detector splits.
 - **Cheapest of the three.** The detector floor is in place; the remaining work
   is oracle coverage/modeling plus recall pricing on larger corpora.
 
@@ -168,11 +176,11 @@ first; promote to the full model only if the priced recall loss justifies it.
   add/sub/negation rewrites on a *proven-not-concat* predicate: reorder only when
   every operand is proven numeric/non-string. Untyped `+` stays ordered in
   string-coercive languages, while typed numeric `+` still converges.
-- **Oracle coverage:** add battery rows that bind **two distinct strings** (and
-  two distinct lists) to multiple positions — e.g. probe pairs `("α","β")` drawn
-  from the mined string set, plus a couple of distinct-list rows. Add mixed
-  string/number rows only after the interpreter has explicit JS/Java coercion
-  semantics. *Effect:* `verify` can witness `a+b ≠ b+a` for strings and later
+- **Oracle coverage (distinct-pair rows shipped, Part 3):** the battery now binds **two
+  distinct strings** (and two distinct lists) to adjacent positions, forward and reversed —
+  so `verify` witnesses `a+b ≠ b+a` for strings directly. The remaining piece is mixed
+  string/number rows, to be added only after the interpreter has explicit JS/Java coercion
+  semantics. *Effect:* `verify` witnesses pure-string `a+b ≠ b+a` today, and later
   `"a"+2+3 ≠ "a"+(2+3)` for coercive languages, instead of relying only on
   detector fingerprint splits and external-language witnesses.
 - **Cost:** Medium detector gate already paid; remaining Low-Medium oracle
@@ -256,7 +264,8 @@ For each candidate fix, record **before → after**:
 1. **Soundness (must improve or hold).**
    `nose verify bench/repos` → `SOUND: no false merges ✓`, and the reproducer in
    §5 must flip from merged to split. Canon-preservation violations must not rise
-   above the standing baseline (currently **20**, sympy/nushell).
+   above the standing baseline (currently **0** on the pinned corpus — the last
+   spurious cases were resolved by the up-to-abort gate, §7.2 / experiments §CN).
 2. **Recall delta (the price).**
    `nose scan bench/repos --mode semantic --top 0` family count, **dev split and
    heldout split separately**. A change that holds family count on dev but drops
@@ -288,7 +297,7 @@ oracle-caught)":
 
 | target | file / repro | must become |
 |---|---|---|
-| C — string/mixed-coercive `+` ordering | `untyped_add_commute.py` (`a+b` vs `b+a`) and JS/TS/Java-style `x+4` / `x+(2+3)` / `x-3` / `-(x+2)` | detector keeps them **split**; oracle witnesses pure string now only after battery enrichment, and mixed string/number after coercion modeling |
+| C — string/mixed-coercive `+` ordering | `untyped_add_commute.py` (`a+b` vs `b+a`) and JS/TS/Java-style `x+4` / `x+(2+3)` / `x-3` / `-(x+2)` | detector keeps them **split** AND oracle witnesses pure string/list ordering (battery Part 3 shipped); mixed string/number still awaits coercion modeling |
 | C — float `+` non-associativity | `float_assoc.py` (`(a+b)+c` vs `a+(b+c)`) | detector keeps them **split** AND oracle witnesses — CLOSED (#342, the `Value::Float` kind, §3.3); guarded by `float_addition_is_non_associative_in_the_oracle` + `algebra_associativity` + `float_typed_param_addition_is_held_unassociated` |
 | D-int32 — JS bitwise vs bigint | cross-language `a & b` (JS vs Python), e.g. the §2 reproducer | detector keeps **split** AND oracle witnesses (int32 execution shipped, #344); guarded by `js_bitwise_and_wraps_to_int32_in_the_oracle`; full fixed-width recall recovery measured-unneeded |
 | D-div — true-float `/` | Python/JS `a/b` vs Ruby `a/b` vs C `a/b` | the three **do not merge**; the real IEEE-754 `Value::Float` oracle shipped (#342) |
@@ -352,8 +361,10 @@ effects recorded *before* the trap.
 This is not hypothetical: the *current* battery already trips it. It surfaced on the
 pinned corpus as 4 canon-preservation "violations" in libsodium's `fe25519` limb
 arithmetic (`fe25519_add`/`sub`/`neg` take 3 array params, so the #337 element-mutation
-battery row binds a list to one and ints to the rest, and `f[i]` indexes an int — #369),
-and off-corpus on `netty` (3) and `sympy` (20). **Fixed** by judging canon preservation
+battery row binds a list to one and ints to the rest, and `f[i]` indexes an int — #369).
+(Earlier off-corpus `netty`/`sympy` violations were a *related but distinct* class — the
+`==`/`Err`-operand canon — resolved separately by the series-9 `bin`/dataflow fixes, §7.1/§7.2.)
+**Fixed** by judging canon preservation
 *up to abort*: two runs that both return `Err` are equivalent regardless of their pre-trap
 effects (`behavior_equiv`, interp.rs), since an erroring execution has no observable result
 and reordering operations ahead of a guaranteed trap is behavior-preserving. `Ok→Err`,

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -6,7 +6,9 @@ For the command context see [usage](usage.md); for CI-oriented formats see
 [continuous-integration](continuous-integration.md). Tools can discover supported
 scan JSON schema versions with [capabilities](capabilities.md). An LLM agent
 consuming this schema should follow the validated triage protocol in
-[agent-recipe](agent-recipe.md).
+[agent-recipe](agent-recipe.md). This is the one-shot batch contract; for *interactive*
+exploration of the same dataset, [`nose query`](usage.md#nose-query) is its companion
+surface (also `--format json`).
 
 ## Version 1
 
@@ -80,6 +82,9 @@ The top-level value is always an object:
       "review": 1,
       "hidden": 7,
       "debug": 0,
+      "generated": 0,
+      "declaration": 0,
+      "shallow": 0,
       "fragments": {
         "total": 8,
         "default": 1,


### PR DESCRIPTION
A documentation release. **No behavior change** to `scan`/`query`/`review`/`--fail-on` or the scan-JSON v1 contract; the only non-doc edits are doc-comments/help text and a contract-test fixture that had drifted.

## Lead with `nose query`
README, [home](docs/home.md), [getting-started](docs/getting-started.md), [agent-recipe](docs/agent-recipe.md), and [design](docs/design.md) §2 now present `nose query` as the **interactive / agent exploration** entry point, with `nose scan` framed as the one-shot report + the frozen JSON contract + the `--fail-on` CI gate — both over the same dataset. **`scan` is not deprecated**: it owns the gate and the versioned JSON contract (design §2's two consumers); query is the navigational surface for consumer 1.

## Code-docs drift fixed (verified by a 5-agent audit against the source)
- **configuration.md** default `mode` `["syntax","semantic"]` → `["syntax","semantic","near"]` (matched CLI/README).
- **oracle-value-model.md** §1 still said "there is no Float" (contradicting #342 and its own §3.3/§6); the input-battery "starved `Str` model" narrative was stale (Parts 3–6 ship distinct-string/list, element-mutation, float, int32 rows); canon-preservation baseline 20 → 0; the #369 up-to-abort fix was untangled from the series-9 cases it had been conflated with.
- **#363 terminology** "module" → "directory" (getting-started report guide, architecture ranking formula); **all-copies** (not "a pair") shared-line wording (#366).
- **benchmark.md** reproducer now passes `--rank extractability` (the no-flag default sorts by `value`, won't reproduce the headline P@10); canon "up to abort" (#369); **field-evaluation** extractability description gains the #365 member-span heterogeneity penalty; **clone-types** `near:0.70`; **scan-json** example `surface_counts` includes the always-emitted `generated`/`declaration`/`shallow`.
- **hazard-release-checklist** quick-check no longer over-triggers on display-only/reorder changes (#365/#366) — compares calibrated feature fields sort-independently, with a display-vs-feature note (`shared_lines` ≠ `shared_weight`).
- **scan-JSON v1 contract test + fixture** now assert the always-emitted `shallow` surface count (both had drifted); `--show` help lists the `reinvented` view; a stale `family_hint` doc-comment said "modules"; the duplicate experiments `§CA` anchor is disambiguated (default-surface-noise → `§CO`).

## Checks
- `cargo test --workspace --release` green (incl. the scan-JSON v1 contract test); `fmt` clean; `cargo +1.96.0 clippy --workspace --all-targets -D warnings` clean; `awiki lint --root docs` clean (connected graph, 0 orphans).
- Version bumped 0.9.0 → 0.9.1. After merge, tag `v0.9.1` to publish (cargo-dist) — **pending final go-ahead**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)