### PR TITLE
chore: dogfood nose to remove genuine internal duplication

### DIFF
--- a/crates/nose-detect/src/fragment/conditional_guard.rs
+++ b/crates/nose-detect/src/fragment/conditional_guard.rs
@@ -165,20 +165,12 @@ fn ordered_mixed_effect_sequence(
     node: NodeId,
 ) -> Option<Vec<EffectSite>> {
     let kids = block_children_exact_len(il, node, 2)?;
-    if kids
-        .iter()
-        .filter(|&&kid| il.kind(kid) == NodeKind::Loop)
-        .count()
-        != 1
-    {
+    if !exactly_one_kid(il, kids, |k| k == NodeKind::Loop) {
         return None;
     }
-    if kids
-        .iter()
-        .filter(|&&kid| matches!(il.kind(kid), NodeKind::ExprStmt | NodeKind::Assign))
-        .count()
-        != 1
-    {
+    if !exactly_one_kid(il, kids, |k| {
+        matches!(k, NodeKind::ExprStmt | NodeKind::Assign)
+    }) {
         return None;
     }
     let mut effects = Vec::new();
@@ -216,20 +208,12 @@ fn ordered_conditional_mixed_effect_sequence(
     node: NodeId,
 ) -> Option<Vec<EffectSite>> {
     let kids = block_children_exact_len(il, node, 2)?;
-    if kids
-        .iter()
-        .filter(|&&kid| il.kind(kid) == NodeKind::If)
-        .count()
-        != 1
-    {
+    if !exactly_one_kid(il, kids, |k| k == NodeKind::If) {
         return None;
     }
-    if kids
-        .iter()
-        .filter(|&&kid| matches!(il.kind(kid), NodeKind::ExprStmt | NodeKind::Assign))
-        .count()
-        != 1
-    {
+    if !exactly_one_kid(il, kids, |k| {
+        matches!(k, NodeKind::ExprStmt | NodeKind::Assign)
+    }) {
         return None;
     }
     let mut effects = Vec::new();
@@ -251,20 +235,10 @@ fn ordered_loop_conditional_effect_sequence(
     node: NodeId,
 ) -> Option<Vec<EffectSite>> {
     let kids = block_children_exact_len(il, node, 2)?;
-    if kids
-        .iter()
-        .filter(|&&kid| il.kind(kid) == NodeKind::Loop)
-        .count()
-        != 1
-    {
+    if !exactly_one_kid(il, kids, |k| k == NodeKind::Loop) {
         return None;
     }
-    if kids
-        .iter()
-        .filter(|&&kid| il.kind(kid) == NodeKind::If)
-        .count()
-        != 1
-    {
+    if !exactly_one_kid(il, kids, |k| k == NodeKind::If) {
         return None;
     }
     let mut effects = Vec::new();
@@ -284,28 +258,15 @@ fn ordered_loop_conditional_mixed_effect_sequence(
     node: NodeId,
 ) -> Option<Vec<EffectSite>> {
     let kids = block_children_exact_len(il, node, 3)?;
-    if kids
-        .iter()
-        .filter(|&&kid| il.kind(kid) == NodeKind::Loop)
-        .count()
-        != 1
-    {
+    if !exactly_one_kid(il, kids, |k| k == NodeKind::Loop) {
         return None;
     }
-    if kids
-        .iter()
-        .filter(|&&kid| il.kind(kid) == NodeKind::If)
-        .count()
-        != 1
-    {
+    if !exactly_one_kid(il, kids, |k| k == NodeKind::If) {
         return None;
     }
-    if kids
-        .iter()
-        .filter(|&&kid| matches!(il.kind(kid), NodeKind::ExprStmt | NodeKind::Assign))
-        .count()
-        != 1
-    {
+    if !exactly_one_kid(il, kids, |k| {
+        matches!(k, NodeKind::ExprStmt | NodeKind::Assign)
+    }) {
         return None;
     }
     let mut effects = Vec::new();
@@ -739,6 +700,13 @@ fn append_consumes_chained_temp(
 
 fn block_children_exact_len(il: &Il, node: NodeId, len: usize) -> Option<&[NodeId]> {
     (il.kind(node) == NodeKind::Block && il.children(node).len() == len).then(|| il.children(node))
+}
+
+/// True when exactly one of `kids` is a node whose kind satisfies `pred`. The
+/// `ordered_*_effect_sequence` recognizers use it to assert a block's shape (e.g. "exactly
+/// one loop and exactly one direct statement") without repeating the filter/count/`!= 1`.
+fn exactly_one_kid(il: &Il, kids: &[NodeId], pred: impl Fn(NodeKind) -> bool) -> bool {
+    kids.iter().filter(|&&kid| pred(il.kind(kid))).count() == 1
 }
 
 fn append_call_args(il: &Il, interner: &Interner, node: NodeId) -> Option<(NodeId, NodeId)> {

--- a/crates/nose-il/src/lib.rs
+++ b/crates/nose-il/src/lib.rs
@@ -247,6 +247,18 @@ impl Il {
         }
     }
 
+    /// The bound name symbol of a `Var` node, resolving a `Payload::Cid` through
+    /// `cid_names`. Unlike [`Self::var_name`] (which matches `Payload::Name` only), this
+    /// is the full Var-name lookup several passes need; `None` for a non-`Var` node.
+    #[inline]
+    pub fn var_binding_name(&self, id: NodeId) -> Option<Symbol> {
+        match (self.kind(id), self.node(id).payload) {
+            (NodeKind::Var, Payload::Name(name)) => Some(name),
+            (NodeKind::Var, Payload::Cid(cid)) => self.cid_names.get(cid as usize).copied(),
+            _ => None,
+        }
+    }
+
     #[inline]
     pub fn assignment_parts(&self, id: NodeId) -> Option<(NodeId, NodeId)> {
         if self.kind(id) != NodeKind::Assign {

--- a/crates/nose-normalize/src/library_api_evidence.rs
+++ b/crates/nose-normalize/src/library_api_evidence.rs
@@ -493,17 +493,8 @@ fn binding_symbol_evidence_id(
 }
 
 fn node_name<'a>(il: &Il, interner: &'a Interner, node: NodeId) -> Option<&'a str> {
-    if il.kind(node) != NodeKind::Var {
-        return None;
-    }
-    match il.node(node).payload {
-        Payload::Name(symbol) => Some(interner.resolve(symbol)),
-        Payload::Cid(cid) => il
-            .cid_names
-            .get(cid as usize)
-            .map(|&symbol| interner.resolve(symbol)),
-        _ => None,
-    }
+    il.var_binding_name(node)
+        .map(|symbol| interner.resolve(symbol))
 }
 
 fn node_name_hash(il: &Il, interner: &Interner, node: NodeId) -> Option<u64> {
@@ -511,14 +502,7 @@ fn node_name_hash(il: &Il, interner: &Interner, node: NodeId) -> Option<u64> {
 }
 
 fn binding_node_name(il: &Il, node: NodeId) -> Option<Symbol> {
-    if il.kind(node) != NodeKind::Var {
-        return None;
-    }
-    match il.node(node).payload {
-        Payload::Name(symbol) => Some(symbol),
-        Payload::Cid(cid) => il.cid_names.get(cid as usize).copied(),
-        _ => None,
-    }
+    il.var_binding_name(node)
 }
 
 fn file_defines_name_visible_at(

--- a/crates/nose-normalize/src/value_graph/stdlib.rs
+++ b/crates/nose-normalize/src/value_graph/stdlib.rs
@@ -3,6 +3,22 @@
 use super::*;
 
 impl<'a> Builder<'a> {
+    /// A collection sequence-literal call `Call(0, [callee, Seq(collection)])` → its
+    /// `(callee, seq)`. The shared guard under every collection/map factory recognizer; `None`
+    /// when `value` is not that shape.
+    fn collection_call_callee_seq(&self, value: ValueId) -> Option<(ValueId, ValueId)> {
+        let node = &self.nodes[value as usize];
+        if !matches!(node.op, ValOp::Call(0)) || node.args.len() != 2 {
+            return None;
+        }
+        let (callee, seq) = (node.args[0], node.args[1]);
+        matches!(
+            self.nodes[seq as usize].op,
+            ValOp::Seq(SEQ_VALUE_COLLECTION)
+        )
+        .then_some((callee, seq))
+    }
+
     /// Shared skeleton of the collection-factory recognizers: a collection sequence literal
     /// call `Call(0, [callee, Seq(collection)])`
     /// whose `callee` passes `is_factory` wraps the sequence literal `args[1]`; return it. The
@@ -13,17 +29,7 @@ impl<'a> Builder<'a> {
         value: ValueId,
         is_factory: impl FnOnce(&Self, ValueId) -> bool,
     ) -> Option<ValueId> {
-        let node = &self.nodes[value as usize];
-        if !matches!(node.op, ValOp::Call(0)) || node.args.len() != 2 {
-            return None;
-        }
-        let (callee, seq) = (node.args[0], node.args[1]);
-        if !matches!(
-            self.nodes[seq as usize].op,
-            ValOp::Seq(SEQ_VALUE_COLLECTION)
-        ) {
-            return None;
-        }
+        let (callee, seq) = self.collection_call_callee_seq(value)?;
         is_factory(self, callee).then_some(seq)
     }
 
@@ -361,17 +367,7 @@ impl<'a> Builder<'a> {
     /// 2-element key/value entries. Data-driven by first-party map contracts in `nose-semantics`;
     /// the matched row's `Seq` tag says how each entry is shaped (JS array vs Rust tuple).
     pub(super) fn proven_free_name_map_factory(&mut self, value: ValueId) -> Option<ValueId> {
-        let node = &self.nodes[value as usize];
-        if !matches!(node.op, ValOp::Call(0)) || node.args.len() != 2 {
-            return None;
-        }
-        let (callee, seq) = (node.args[0], node.args[1]);
-        if !matches!(
-            self.nodes[seq as usize].op,
-            ValOp::Seq(SEQ_VALUE_COLLECTION)
-        ) {
-            return None;
-        }
+        let (callee, seq) = self.collection_call_callee_seq(value)?;
         let admitted = admitted_free_name_map_factory_at_call_span(
             self.il,
             self.interner,
@@ -914,14 +910,25 @@ impl<'a> Builder<'a> {
         }
         let receiver = admitted.receiver?;
         let key = self.eval(kids[1], env);
+        let map = self.resolve_receiver_map_value(receiver, env)?;
+        Some(self.mk(ValOp::Bin(Op::In as u32), vec![key, map]))
+    }
+
+    /// The proven map [`ValueId`] a map-method `receiver` denotes: the receiver value itself
+    /// when it is a map parameter, else a proven map value or a proven local map binding.
+    /// `None` when the receiver is not a provable map.
+    fn resolve_receiver_map_value(
+        &mut self,
+        receiver: NodeId,
+        env: &FxHashMap<u32, ValueId>,
+    ) -> Option<ValueId> {
         let receiver_value = self.eval(receiver, env);
-        let map = if self.is_map_param_expr(receiver) {
-            receiver_value
+        if self.is_map_param_expr(receiver) {
+            Some(receiver_value)
         } else {
             self.proven_map_value(receiver_value)
-                .or_else(|| self.proven_local_map_binding_value(receiver, env))?
-        };
-        Some(self.mk(ValOp::Bin(Op::In as u32), vec![key, map]))
+                .or_else(|| self.proven_local_map_binding_value(receiver, env))
+        }
     }
 
     pub(super) fn eval_proven_map_get_default_call(
@@ -945,13 +952,7 @@ impl<'a> Builder<'a> {
             return None;
         }
         let receiver = admitted.receiver?;
-        let receiver_value = self.eval(receiver, env);
-        let map = if self.is_map_param_expr(receiver) {
-            receiver_value
-        } else {
-            self.proven_map_value(receiver_value)
-                .or_else(|| self.proven_local_map_binding_value(receiver, env))?
-        };
+        let map = self.resolve_receiver_map_value(receiver, env)?;
         let key = self.eval(kids[1], env);
         let default = self.eval_map_get_default_arg(result.args, kids[2], env)?;
         Some(self.mk(

--- a/crates/nose-semantics/src/lib.rs
+++ b/crates/nose-semantics/src/lib.rs
@@ -1009,17 +1009,8 @@ fn assignment_parts(il: &Il, stmt: NodeId) -> Option<(NodeId, NodeId)> {
 }
 
 fn node_name<'a>(il: &Il, interner: &'a Interner, node: NodeId) -> Option<&'a str> {
-    if il.kind(node) != NodeKind::Var {
-        return None;
-    }
-    match il.node(node).payload {
-        Payload::Name(symbol) => Some(interner.resolve(symbol)),
-        Payload::Cid(cid) => il
-            .cid_names
-            .get(cid as usize)
-            .map(|&symbol| interner.resolve(symbol)),
-        _ => None,
-    }
+    il.var_binding_name(node)
+        .map(|symbol| interner.resolve(symbol))
 }
 
 fn node_name_hash(il: &Il, interner: &Interner, node: NodeId) -> Option<u64> {


### PR DESCRIPTION
Ran `nose query` / `nose scan` over nose's own `crates/` and extracted shared helpers **only where consolidation genuinely improves clarity** — behavior-preserving, with parallel-by-design and param-heavy parallel code deliberately left alone.

## Extracted (4)
- **`nose-detect` `conditional_guard.rs`** — the `kids.iter().filter(kind).count() != 1 { return None }` block was repeated **9×** across the `ordered_*_effect_sequence` recognizers → `exactly_one_kid(il, kids, pred)`.
- **`nose-il` `Il::var_binding_name`** — the Var-name lookup (resolving `Payload::Cid` through `cid_names`) was independently reimplemented in `nose-normalize` and `nose-semantics` (`node_name`/`binding_node_name`). Moved the logic to one accessor on the IL type (its natural owner); the locals now delegate.
- **`nose-normalize` `value_graph/stdlib.rs`** — the `Call(0, [callee, Seq(collection)])` guard reimplemented inside `proven_free_name_map_factory` → `collection_call_callee_seq` (now also the basis of the existing `collection_factory_seq`).
- **`nose-normalize` `value_graph/stdlib.rs`** — the receiver→proven-map-value resolution duplicated in two map-method evaluators → `resolve_receiver_map_value`.

## Deliberately NOT extracted (quality would not improve)
- **Per-language frontend lowering** (`c.rs`/`java.rs`/`js_ts.rs` `stmt_as_block`, `lower_for`, `lower_while`, …) differs only in tree-sitter grammar strings (`"compound_statement"` vs `"block"`, `"initializer"` vs `"init"`), but is intentionally self-contained per language. A shared helper would couple the frontends and leak grammar names into shared code — worse, not better.
- **Param-heavy parallel recorders** (`record_*_library_api`, several `lower.rs` blocks with 3–11 varying spots) read more clearly as parallel functions than as a higher-order helper taking several closures.

## Checks
- `cargo test --workspace --release` green; `fmt` clean; `cargo +1.96.0 clippy --workspace --all-targets -D warnings` clean.
- Scan output deterministic and `NOSE_THREADS=1`-invariant.
- nose's own default-surface duplication: **324 → 321 families, ~11,318 → ~11,264 lines**. No API or behavior change (no version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)