### PR TITLE
#374: query same_symbol evidence field (parallel-variant signal)

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3731,6 +3731,7 @@ const STR_FIELDS: &[&str] = &[
     "surface",
     "shape",
     "extraction_shape",
+    "same_symbol",
 ];
 /// Numeric filter fields (also the only ones that accept `>`/`<`).
 const NUM_FIELDS: &[&str] = &[
@@ -3878,6 +3879,7 @@ fn parse_query(terms: &[String]) -> Result<Query> {
                     "extract-base-class",
                     "consolidate-cross-language",
                 ]),
+                "same_symbol" => Some(&["true", "false"]),
                 _ => None,
             };
             if let Some(vals) = valid {
@@ -3934,6 +3936,18 @@ fn family_dir(f: &nose_detect::RefactorFamily) -> String {
         .to_string()
 }
 
+/// Whether every copy is the **same named symbol** in a different place — the decidable
+/// signature of a parallel-variant family (e.g. one `lower_for`/`stmt_as_block` per language
+/// frontend). Evidence, not a verdict: combine with negation (`same_symbol!=true`) to drop the
+/// parallel-by-design class, or `same_symbol=true` to review it.
+fn family_same_symbol(f: &nose_detect::RefactorFamily) -> bool {
+    let mut names = f.locations.iter().map(|l| l.name.as_deref());
+    match names.next().flatten() {
+        Some(first) if f.locations.len() > 1 => names.all(|n| n == Some(first)),
+        _ => false,
+    }
+}
+
 /// Numeric value of a family field (for `>`/`<`/`=` on numbers).
 fn family_num(f: &nose_detect::RefactorFamily, field: &str) -> Option<f64> {
     Some(match field {
@@ -3972,6 +3986,7 @@ fn family_matches(f: &nose_detect::RefactorFamily, ov: &SurfaceOverrides, flt: &
             "surface" => effective_surface(f, ov).to_string(),
             "shape" | "extraction_shape" => f.extraction_shape().to_string(),
             "dir" => family_dir(f),
+            "same_symbol" => family_same_symbol(f).to_string(),
             _ => return None,
         })
     };
@@ -4331,7 +4346,7 @@ fn render_query_dashboard(
             .unwrap_or_default()
     );
     println!(
-        "\ngrammar:  nose query <path> [field=value | field>N | field~substr | field!=value | field!~substr ...] [group=FIELD | id=FAM | at=FILE:LINE]\n          fields: scope(prod|test) witness(exact|subdag|copy-paste|similar) lang path members files value(=duplicated volume) params shared dir\n          · sort=extractability(default)|value|members  · top=N  · `full` after id= or a list expands the all-copies skeleton  · `all` widens past the default surface"
+        "\ngrammar:  nose query <path> [field=value | field>N | field~substr | field!=value | field!~substr ...] [group=FIELD | id=FAM | at=FILE:LINE]\n          fields: scope(prod|test) witness(exact|subdag|copy-paste|similar) same_symbol(true|false) lang path members files value(=duplicated volume) params shared dir\n          · sort=extractability(default)|value|members  · top=N  · `full` after id= or a list expands the all-copies skeleton  · `all` widens past the default surface"
     );
 }
 
@@ -4421,6 +4436,7 @@ fn render_query_group(
                 .unwrap_or_default(),
             "dir" => family_dir(f),
             "shape" | "extraction_shape" => f.extraction_shape().to_string(),
+            "same_symbol" => family_same_symbol(f).to_string(),
             _ => "?".to_string(),
         }
     };

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1953,6 +1953,17 @@ fn query_dashboard_filter_and_family() {
         "a location with no family errors"
     );
 
+    // same_symbol: the three `process` copies share a name → the parallel-variant signal.
+    assert!(
+        run(&["query", p, "same_symbol=true"]).contains("families"),
+        "same_symbol=true matches the same-named family"
+    );
+    assert!(
+        run(&["query", p, "group=same_symbol"]).contains("by same_symbol"),
+        "group=same_symbol facets"
+    );
+    assert!(run_fail(&["query", p, "same_symbol=oops"]).contains("unknown same_symbol value"));
+
     let _ = fs::remove_dir_all(&dir);
 }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -224,7 +224,7 @@ nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE] [sort=KEY] 
 | part | meaning |
 |---|---|
 | `field=value` | keep families where the field equals the value (AND-ed); `field>N`/`field<N` for numbers; `path~substr` for a path substring; **negate** with `field!=value` / `path!~substr` (e.g. `path!~frontend` drops a whole directory) |
-| `group=FIELD` | facet the selection by a discrete field (`dir`, `scope`, `witness`, `lang`, `shape`), with a count and an exemplar per bucket |
+| `group=FIELD` | facet the selection by a discrete field (`dir`, `scope`, `witness`, `lang`, `shape`, `same_symbol`), with a count and an exemplar per bucket |
 | `id=FAM` | open one family (any unambiguous id prefix): its copies, the all-copies extraction skeleton, and navigation links |
 | `at=FILE:LINE` | open the family whose copy covers that source location — a stable handle across edits (the span-derived `id=` shifts when code moves) |
 | `sort=KEY` | `extractability` (default), `value`, or `members` |
@@ -233,7 +233,8 @@ nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE] [sort=KEY] 
 | `all` | widen past the curated default surface to the full raw universe (demoted families labeled) |
 
 Fields: `scope` (prod\|test\|mixed), `witness` (exact\|subdag\|copy-paste\|similar),
-`lang`, `path`, `dir`, `members`, `files`, `value`, `params`, `shared`. Every row shows
+`same_symbol` (true\|false — every copy is the same named symbol, the parallel-variant
+signature), `lang`, `path`, `dir`, `members`, `files`, `value`, `params`, `shared`. Every row shows
 the payoff economics — `M/REP shared, Pp · ~N removable` — so a candidate can be triaged
 without opening it. Each result is a pure function of (repo state, command); an unknown
 field or enum value is a hard error (so a typo can't read as "no duplication").


### PR DESCRIPTION
Next additive slice of #374. A decidable evidence dimension, **no behavior change** to scan/review/contract.

## `same_symbol`
A family is `same_symbol=true` when **every copy is the same named symbol** in a different place (computed from `Loc.name`) — the signature of a parallel-variant family (one `lower_for` / `stmt_as_block` per language frontend, one per-backend handler, …). Evidence, not a verdict (the "is this parallel-by-design?" call stays the caller's, §2b).

Combined with the negation from #376, this is the direct fix for the dogfood friction "the per-language lowering dominated the ranking and I couldn't exclude the class":
- `nose query crates same_symbol=true` — review the parallel-named families
- `nose query crates witness=subdag same_symbol!=true` — drop them
- `nose query crates group=same_symbol` — the split (verified on nose: 5 true / 316 false on the default surface)

Filter + `group=` facet + value validation (`same_symbol=oops` errors). Grammar footer, `usage.md`, and the query test updated. `fmt`/`clippy -D warnings`/`awiki` clean.

Remaining #374 (spot-class facet, reinvented-helper join, skeleton hints) tracked in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)