### PR TITLE
#375 (Wave A-2a): nose query takes scan's analysis flags

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -210,6 +210,36 @@ enum Cmd {
         /// Output format (`human` or `json`).
         #[arg(long, default_value = "human")]
         format: ReportFormat,
+        /// Detection channels (same as `nose scan --mode`); omit for `syntax,semantic,near`.
+        #[arg(long, value_delimiter = ',')]
+        mode: Vec<ScanMode>,
+        /// Minimum IL-token size for a unit to be considered (same as scan).
+        #[arg(long)]
+        min_size: Option<usize>,
+        /// Minimum invariant-line floor (advanced; same as scan).
+        #[arg(long, hide = true)]
+        min_lines: Option<u32>,
+        /// Minimum family value to keep (same as scan).
+        #[arg(long, value_parser = parse_min_value)]
+        min_value: Option<f64>,
+        /// Minimum copies per family (same as scan).
+        #[arg(long)]
+        min_members: Option<usize>,
+        /// Exclude paths by glob (repeatable; same as scan).
+        #[arg(long)]
+        exclude: Vec<String>,
+        /// Cache per-file analysis under this directory (same as scan).
+        #[arg(long, value_name = "DIR")]
+        cache_dir: Option<PathBuf>,
+        /// Structured-ignore file (same as scan); auto-read `nose.ignore.json` when present.
+        #[arg(long, value_name = "FILE")]
+        ignore_file: Option<PathBuf>,
+        /// Local semantic-pack manifest(s) (same as scan).
+        #[arg(long = "semantic-pack", value_name = "FILE_OR_DIR")]
+        semantic_pack: Vec<PathBuf>,
+        /// Config file (`nose.toml`; same as scan).
+        #[arg(long, value_name = "FILE")]
+        config: Option<PathBuf>,
     },
     /// Flag a change applied to one clone copy but not its siblings (PR/CI check).
     ///
@@ -4092,6 +4122,16 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
         path,
         terms,
         format,
+        mode,
+        min_size,
+        min_lines,
+        min_value,
+        min_members,
+        exclude,
+        cache_dir,
+        ignore_file,
+        semantic_pack,
+        config,
     } = cmd
     else {
         unreachable!("run_query_cmd requires Cmd::Query")
@@ -4105,22 +4145,22 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
     let args = ScanArgs {
         paths: vec![path],
         top: Some(0),
-        min_members: None,
-        min_value: None,
+        min_members,
+        min_value,
         sort: None,
-        config: None,
-        mode: vec![],
+        config,
+        mode,
         show: vec![],
-        cache_dir: None,
+        cache_dir,
         fail_on: None,
         baseline: None,
-        ignore_file: None,
-        semantic_pack: vec![],
+        ignore_file,
+        semantic_pack,
         write_baseline: false,
         format,
-        exclude: vec![],
-        min_size: None,
-        min_lines: None,
+        exclude,
+        min_size,
+        min_lines,
         scope: ScopeFilter::All,
     };
     let refs = paths_as_refs(&args.paths);

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1964,6 +1964,17 @@ fn query_dashboard_filter_and_family() {
     );
     assert!(run_fail(&["query", p, "same_symbol=oops"]).contains("unknown same_symbol value"));
 
+    // query takes scan's analysis flags (dataset parity): `--min-members 99` floors out the
+    // 3-copy family, and `--mode syntax` is accepted (different channel mix).
+    assert!(
+        run(&["query", p, "--min-members", "99"]).contains("0 duplicated-code families"),
+        "query respects --min-members"
+    );
+    assert!(
+        run(&["query", p, "--mode", "syntax"]).contains("families"),
+        "query accepts --mode"
+    );
+
     let _ = fs::remove_dir_all(&dir);
 }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -241,6 +241,11 @@ field or enum value is a hard error (so a typo can't read as "no duplication").
 
 A typical loop: `nose query .` → `nose query . witness=exact` → `nose query . id=<id> full`.
 
+`nose query` accepts the same **analysis flags** as `scan` — `--mode`, `--min-size`,
+`--min-value`, `--min-members`, `--exclude`, `--cache-dir`, `--ignore-file`,
+`--semantic-pack`, `--config` — so the dataset it explores is configured identically (the
+scope/sort/top knobs are the DSL's `scope=`/`sort=`/`top=` instead).
+
 ## Integrating with nose
 
 Use `nose capabilities` when another tool needs to decide what this installed


### PR DESCRIPTION
First additive slice of #375 (make `nose query` the primary surface). **No behavior change** to `scan`/`review`/the JSON contract.

`nose query` now accepts the same dataset/analysis flags as `nose scan` — `--mode`, `--min-size`, `--min-lines`, `--min-value`, `--min-members`, `--exclude`, `--cache-dir`, `--ignore-file`, `--semantic-pack`, `--config` — threaded into the shared `build_scan_dataset`. So the dataset query explores is configured identically to scan; the scope/sort/top knobs stay the DSL's `scope=`/`sort=`/`top=` (no redundant flags).

Verified: scan and query report the same file count under `--exclude '*nose-frontend*'` (137→122); `--mode syntax` and `--min-members` change the family set as expected.

Remaining Wave A-2: the gate (`--fail-on`/`--baseline`), report formats (`markdown`/`sarif`), and the **v2 JSON contract** (restructured per the resolved #375 decisions). Then Wave B (breaking): deprecate `scan`, move it to `capabilities.deprecated`, 0.10.0.

`fmt`/`clippy -D warnings`/`awiki` clean; query test extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)