### PR TITLE
#375 (Wave A-2b): nose query gains scan's CI gate + baseline + ignores

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -240,6 +240,17 @@ enum Cmd {
         /// Config file (`nose.toml`; same as scan).
         #[arg(long, value_name = "FILE")]
         config: Option<PathBuf>,
+        /// CI gate — exit non-zero when default-surface families are reported: `any`, or
+        /// `new` (only new/changed vs `--baseline`). Same gate as `nose scan --fail-on`.
+        #[arg(long, value_name = "WHAT")]
+        fail_on: Option<FailOn>,
+        /// Accepted-baseline file: hide already-recorded families so only new/changed
+        /// duplication is shown and gated (same as scan).
+        #[arg(long, value_name = "FILE")]
+        baseline: Option<PathBuf>,
+        /// Write the current families to `--baseline` and exit (same as scan).
+        #[arg(long, requires = "baseline")]
+        write_baseline: bool,
     },
     /// Flag a change applied to one clone copy but not its siblings (PR/CI check).
     ///
@@ -4132,6 +4143,9 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
         ignore_file,
         semantic_pack,
         config,
+        fail_on,
+        baseline,
+        write_baseline,
     } = cmd
     else {
         unreachable!("run_query_cmd requires Cmd::Query")
@@ -4152,19 +4166,34 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
         mode,
         show: vec![],
         cache_dir,
-        fail_on: None,
-        baseline: None,
+        fail_on,
+        baseline,
         ignore_file,
         semantic_pack,
-        write_baseline: false,
+        write_baseline,
         format,
         exclude,
         min_size,
         min_lines,
         scope: ScopeFilter::All,
     };
+    if matches!(args.fail_on, Some(FailOn::New)) && args.baseline.is_none() {
+        anyhow::bail!(
+            "--fail-on new requires --baseline (it gates on families new vs the baseline)"
+        );
+    }
     let refs = paths_as_refs(&args.paths);
     let mut dataset = build_scan_dataset(&args, &refs)?;
+    // query is a full surface (#375): prepare the family set exactly as scan does before
+    // rendering — write/apply a baseline, drop ignored families — then run the same CI gate.
+    if args.write_baseline {
+        return write_scan_baseline(&args, &dataset.families);
+    }
+    let baseline_comparison = apply_scan_baseline(&args, &mut dataset.families)?;
+    let ignore_set = dataset.settings.ignore_set.take();
+    let (active, _ignored) =
+        partition_ignored(std::mem::take(&mut dataset.families), ignore_set.as_ref());
+    dataset.families = active;
     let overrides =
         classify_surface_overrides(&mut dataset.families, &refs, &dataset.settings.exclude);
     if let Some(sk) = q.sort {
@@ -4193,9 +4222,7 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
             &path_arg,
             json,
         );
-        return Ok(());
-    }
-    if let Some(at) = &q.at {
+    } else if let Some(at) = &q.at {
         // `at=file:line` → the family whose member span covers that location (stable across
         // edits, unlike the span-derived id). Resolve to an `id=` open.
         let idv = baseline::family_id(family_at(&dataset.families, at, &path_arg)?);
@@ -4208,9 +4235,7 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
             &path_arg,
             json,
         );
-        return Ok(());
-    }
-    if let Some(idv) = &q.id {
+    } else if let Some(idv) = &q.id {
         render_query_family(
             &dataset.families,
             &overrides,
@@ -4220,26 +4245,38 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
             &path_arg,
             json,
         );
-        return Ok(());
+    } else {
+        // Default to the curated default surface (the same families the dashboard counts and
+        // `scan` trusts); `all` or an explicit `surface=` filter widens to the raw universe.
+        let widen = q.all || q.filters.iter().any(|flt| flt.field == "surface");
+        let sel: Vec<&nose_detect::RefactorFamily> = dataset
+            .families
+            .iter()
+            .filter(|f| {
+                (widen || is_default_surface(f, &overrides))
+                    && !opp.is_slice(f)
+                    && q.filters
+                        .iter()
+                        .all(|flt| family_matches(f, &overrides, flt))
+            })
+            .collect();
+        match &q.group {
+            Some(field) => render_query_group(&sel, field, &terms, &path_arg),
+            None => render_query_list(&sel, &overrides, &opp, &q, &terms, &path_arg, widen),
+        }
     }
-    // Default to the curated default surface (the same families the dashboard counts and
-    // `scan` trusts); `all` or an explicit `surface=` filter widens to the raw universe.
-    let widen = q.all || q.filters.iter().any(|flt| flt.field == "surface");
-    let sel: Vec<&nose_detect::RefactorFamily> = dataset
+    // CI gate (same as scan): a non-empty default-report family set fails `--fail-on`.
+    let reportable: Vec<&nose_detect::RefactorFamily> = dataset
         .families
         .iter()
-        .filter(|f| {
-            (widen || is_default_surface(f, &overrides))
-                && !opp.is_slice(f)
-                && q.filters
-                    .iter()
-                    .all(|flt| family_matches(f, &overrides, flt))
-        })
+        .filter(|f| is_default_report_family(f, &overrides))
         .collect();
-    match &q.group {
-        Some(field) => render_query_group(&sel, field, &terms, &path_arg),
-        None => render_query_list(&sel, &overrides, &opp, &q, &terms, &path_arg, widen),
-    }
+    enforce_scan_fail_on(
+        &args,
+        dataset.settings.channels,
+        &reportable,
+        baseline_comparison.as_ref(),
+    );
     Ok(())
 }
 

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1975,6 +1975,17 @@ fn query_dashboard_filter_and_family() {
         "query accepts --mode"
     );
 
+    // query gates like scan: `--fail-on any` exits non-zero on a reported family, and
+    // `--fail-on new` without `--baseline` errors (parity with scan).
+    assert!(
+        run_fail(&["query", p, "--fail-on", "any"]).contains("--fail-on any"),
+        "query --fail-on any fires on a reported family"
+    );
+    assert!(
+        run_fail(&["query", p, "--fail-on", "new"]).contains("requires --baseline"),
+        "query --fail-on new requires --baseline"
+    );
+
     let _ = fs::remove_dir_all(&dir);
 }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -244,7 +244,9 @@ A typical loop: `nose query .` → `nose query . witness=exact` → `nose query 
 `nose query` accepts the same **analysis flags** as `scan` — `--mode`, `--min-size`,
 `--min-value`, `--min-members`, `--exclude`, `--cache-dir`, `--ignore-file`,
 `--semantic-pack`, `--config` — so the dataset it explores is configured identically (the
-scope/sort/top knobs are the DSL's `scope=`/`sort=`/`top=` instead).
+scope/sort/top knobs are the DSL's `scope=`/`sort=`/`top=` instead). It also takes the same
+**CI gate** — `--fail-on any` / `--fail-on new` with `--baseline`/`--write-baseline` — and
+drops structured-ignored families, so `nose query <path> --fail-on any` is a drop-in gate.
 
 ## Integrating with nose
 


### PR DESCRIPTION
Next additive slice of #375. **No behavior change** to `scan`/`review`/the JSON contract; query with no gate flags is unchanged.

`nose query` is now a drop-in for scan's **gate** role: `--fail-on any` / `--fail-on new` with `--baseline` / `--write-baseline`, reusing scan's standalone helpers (`enforce_scan_fail_on`, `apply_scan_baseline`, `write_scan_baseline`, `partition_ignored`, `is_default_report_family`) — so the gate verdict, baseline diffing, and **structured-ignore** handling match scan exactly.

`run_query_cmd` now prepares the family set the way `cmd_scan` does (write/apply baseline → drop ignored → classify surfaces) and runs the gate after rendering. The view dispatch (dashboard / `at=` / `id=` / group / list) was refactored from early-returns to a fall-through `if/else` chain so the gate runs for **every** view — `nose query <path> --fail-on any` (no terms) gates on the dashboard. `--fail-on new` without `--baseline` errors, as in scan.

Verified: `--fail-on any` → exit 1 on a reported family, 0 on a clean tree; scan and query exit codes match; `--write-baseline` then `--fail-on new` passes (nothing new); query without gate flags unchanged (apply-baseline / partition-ignored are no-ops without `--baseline` / an ignore file).

`cargo test -p nose-cli` green (incl. the scan-JSON v1 contract test, untouched); `fmt`/`clippy -D warnings`/`awiki` clean.

Remaining Wave A-2: report formats (`markdown`/`sarif`), the **v2 JSON contract**. Then Wave B (deprecate scan) — staged on `main`, **the 0.10.0 release itself is held** per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)