### PR TITLE
#375 (Wave A-2d): structured, versioned query JSON contract (schema v2)

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -876,6 +876,7 @@ impl ScanScope {
 }
 
 const SCAN_JSON_SCHEMA_VERSION: u32 = 1;
+const QUERY_JSON_SCHEMA_VERSION: u32 = 2;
 const CAPABILITIES_SCHEMA_VERSION: u32 = 1;
 
 #[derive(serde::Serialize)]
@@ -921,6 +922,7 @@ struct CapabilitiesCommands {
 struct CapabilitiesSchemas {
     capabilities: Vec<u32>,
     scan_json: Vec<u32>,
+    query_json: Vec<u32>,
     semantic_packs: Vec<&'static str>,
     semantic_pack_conformance: Vec<u32>,
 }
@@ -990,6 +992,7 @@ impl CapabilitiesReport {
             schemas: CapabilitiesSchemas {
                 capabilities: vec![CAPABILITIES_SCHEMA_VERSION],
                 scan_json: vec![SCAN_JSON_SCHEMA_VERSION],
+                query_json: vec![QUERY_JSON_SCHEMA_VERSION],
                 semantic_packs: vec![nose_semantics::SEMANTIC_PACK_API_VERSION],
                 semantic_pack_conformance: vec![semantic_pack::CONFORMANCE_SCHEMA_VERSION],
             },
@@ -4097,6 +4100,67 @@ fn query_row(f: &nose_detect::RefactorFamily) -> String {
     )
 }
 
+/// One family as the structured `nose query --format json` object (schema_version 2): all
+/// the evidence a consumer needs to triage without re-parsing a human row. `shared`/`params`
+/// are the all-copies counts (the same the human row shows); `skeleton` is the all-copies
+/// extraction proposal, included only on `full`.
+fn query_family_json(
+    f: &nose_detect::RefactorFamily,
+    ov: &SurfaceOverrides,
+    opp: &OpportunityGroups,
+    full: bool,
+) -> serde_json::Value {
+    let (shared, params) = all_copies_shared(f);
+    let removable = u32::try_from(f.members.saturating_sub(1)).unwrap_or(0) * shared;
+    let locations: Vec<_> = f
+        .locations
+        .iter()
+        .map(|l| {
+            serde_json::json!({
+                "file": l.file, "start": l.start_line, "end": l.end_line,
+                "name": l.name, "lang": l.lang.as_str(),
+            })
+        })
+        .collect();
+    let mut obj = serde_json::json!({
+        "id": baseline::family_id(f),
+        "scope": f.scope,
+        "witness": witness_token(f.witness.as_ref().map(|w| w.kind)),
+        "surface": effective_surface(f, ov),
+        "members": f.members,
+        "files": f.files,
+        "dirs": f.modules,
+        "shared": shared,
+        "rep_lines": representative_lines(f),
+        "params": params,
+        "removable": removable,
+        "value": f.value,
+        "extraction_shape": f.extraction_shape(),
+        "same_symbol": family_same_symbol(f),
+        "folds": opp.slices(f).map(<[_]>::len).unwrap_or(0),
+        "locations": locations,
+    });
+    if full {
+        if let Some(skeleton) = family_skeleton(f) {
+            obj["skeleton"] = serde_json::Value::from(skeleton);
+        }
+    }
+    obj
+}
+
+/// The all-copies extraction-skeleton lines (the `--show proposal` artifact) for the `full`
+/// JSON contract. `None` when fewer than two copies read. Capped at the same 8 members as
+/// `all_copies_shared`, so the skeleton and the `shared`/`params` counts agree.
+fn family_skeleton(f: &nose_detect::RefactorFamily) -> Option<Vec<String>> {
+    let members: Vec<Vec<String>> = f
+        .locations
+        .iter()
+        .take(8)
+        .filter_map(|l| read_lines(&l.file, l.start_line, l.end_line))
+        .collect();
+    (members.len() >= 2).then(|| anti_unify_all(&members).0)
+}
+
 /// Shared-line and parameter counts aligned across **all** copies (not the pairwise
 /// representative `shared_lines`, which over-counts a family whose 3rd+ copies diverge —
 /// e.g. 25 serializer methods that pairwise share 11 lines but all-25 share 2). Reads the
@@ -4261,8 +4325,8 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
             })
             .collect();
         match &q.group {
-            Some(field) => render_query_group(&sel, field, &terms, &path_arg),
-            None => render_query_list(&sel, &overrides, &opp, &q, &terms, &path_arg, widen),
+            Some(field) => render_query_group(&sel, field, &terms, &path_arg, json),
+            None => render_query_list(&sel, &overrides, &opp, &q, &terms, &path_arg, widen, json),
         }
     }
     // CI gate (same as scan): a non-empty default-report family set fails `--fail-on`.
@@ -4313,15 +4377,21 @@ fn render_query_dashboard(
         let top: Vec<_> = def
             .iter()
             .take(5)
-            .map(|f| serde_json::json!({"id": baseline::family_id(f), "where": query_row(f)}))
+            .map(|f| query_family_json(f, ov, opp, false))
             .collect();
         println!(
             "{}",
             serde_json::json!({
+                "schema_version": QUERY_JSON_SCHEMA_VERSION,
+                "tool": "nose",
                 "view": "dashboard",
-                "families": def.len(),
-                "by_confidence": {"exact": count("exact"), "subdag": count("subdag"),
-                    "copy_paste": count("copy-paste"), "similar": count("similar")},
+                "path": path,
+                "summary": {
+                    "scanned_files": scope.files,
+                    "families": def.len(),
+                    "by_confidence": {"exact": count("exact"), "subdag": count("subdag"),
+                        "copy_paste": count("copy-paste"), "similar": count("similar")},
+                },
                 "top_candidates": top,
                 "next": [format!("nose query {path} sort=extractability"), format!("nose query {path} group=dir"),
                     format!("nose query {path} scope=prod"), format!("nose query {path} witness=exact")],
@@ -4429,6 +4499,7 @@ fn render_query_dashboard(
 
 /// A ranked list of the current selection: each row carries its own `id=` drill link,
 /// plus a reasoned `next:`.
+#[allow(clippy::too_many_arguments)] // dataset + view + selection state for one list render
 fn render_query_list(
     sel: &[&nose_detect::RefactorFamily],
     ov: &SurfaceOverrides,
@@ -4437,9 +4508,30 @@ fn render_query_list(
     terms: &[String],
     path: &str,
     widen: bool,
+    json: bool,
 ) {
     let top = q.top.unwrap_or(30);
     let shown = sel.len().min(top);
+    if json {
+        let fams: Vec<_> = sel
+            .iter()
+            .take(top)
+            .map(|f| query_family_json(f, ov, opp, q.id_full))
+            .collect();
+        println!(
+            "{}",
+            serde_json::json!({
+                "schema_version": QUERY_JSON_SCHEMA_VERSION,
+                "tool": "nose",
+                "view": "list",
+                "path": path,
+                "summary": { "families": sel.len(), "shown": shown, "widened": widen },
+                "families": fams,
+                "next": [format!("nose query {path} group=dir"), format!("nose query {path} group=witness")],
+            })
+        );
+        return;
+    }
     println!(
         "{} families{}{}:",
         sel.len(),
@@ -4500,6 +4592,7 @@ fn render_query_group(
     field: &str,
     terms: &[String],
     path: &str,
+    json: bool,
 ) {
     use std::collections::HashMap;
     let key = |f: &nose_detect::RefactorFamily| -> String {
@@ -4517,6 +4610,31 @@ fn render_query_group(
             _ => "?".to_string(),
         }
     };
+    if json {
+        let mut counts: HashMap<String, (usize, String)> = HashMap::new();
+        for f in sel {
+            let e = counts.entry(key(f)).or_insert((0, String::new()));
+            if e.0 == 0 {
+                e.1 = baseline::family_id(f);
+            }
+            e.0 += 1;
+        }
+        let mut rows: Vec<(String, usize, String)> =
+            counts.into_iter().map(|(k, (n, ex))| (k, n, ex)).collect();
+        rows.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        let groups: Vec<_> = rows
+            .into_iter()
+            .map(|(k, n, ex)| serde_json::json!({"key": k, "count": n, "exemplar_id": ex}))
+            .collect();
+        println!(
+            "{}",
+            serde_json::json!({
+                "schema_version": QUERY_JSON_SCHEMA_VERSION, "tool": "nose", "view": "group", "path": path,
+                "field": field, "groups": groups,
+            })
+        );
+        return;
+    }
     let mut buckets: HashMap<String, (usize, String)> = HashMap::new();
     for f in sel {
         let e = buckets.entry(key(f)).or_insert((0, String::new()));
@@ -4548,7 +4666,7 @@ fn render_query_group(
 /// with `full` — the all-copies extraction skeleton (#360). Plus navigation links.
 fn render_query_family(
     families: &[nose_detect::RefactorFamily],
-    _ov: &SurfaceOverrides,
+    ov: &SurfaceOverrides,
     opp: &OpportunityGroups,
     idv: &str,
     full: bool,
@@ -4576,18 +4694,15 @@ fn render_query_family(
         String::new()
     };
     if json {
-        let locs: Vec<_> = f
-            .locations
-            .iter()
-            .map(|l| serde_json::json!({"file": l.file, "start": l.start_line, "end": l.end_line, "name": l.name}))
-            .collect();
         println!(
             "{}",
             serde_json::json!({
-                "view": "family", "id": id, "scope": f.scope,
-                "witness": witness_token(f.witness.as_ref().map(|w| w.kind)),
-                "members": f.members, "shared_lines": f.shared_lines, "params": f.params,
-                "extraction_shape": f.extraction_shape(), "hint": family_hint(f), "locations": locs,
+                "schema_version": QUERY_JSON_SCHEMA_VERSION,
+                "tool": "nose",
+                "view": "family",
+                "path": path,
+                "hint": family_hint(f),
+                "family": query_family_json(f, ov, opp, full),
             })
         );
         return;

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1887,6 +1887,7 @@ fn proposal_aligns_across_all_copies() {
 }
 
 #[test]
+#[allow(clippy::too_many_lines, clippy::cognitive_complexity)] // one end-to-end walk of the query surface
 fn query_dashboard_filter_and_family() {
     // A sizeable 3-copy near family (one operator each) survives the default size floor.
     let dir = std::env::temp_dir().join(format!("nose_query_{}", std::process::id()));
@@ -1984,6 +1985,51 @@ fn query_dashboard_filter_and_family() {
     assert!(
         run_fail(&["query", p, "--fail-on", "new"]).contains("requires --baseline"),
         "query --fail-on new requires --baseline"
+    );
+
+    // The JSON form is the structured, versioned query-v2 contract (every view).
+    let dash: serde_json::Value =
+        serde_json::from_str(&run(&["query", p, "--format", "json"])).unwrap();
+    assert_eq!(
+        dash["schema_version"], 2,
+        "dashboard json is schema v2: {dash}"
+    );
+    assert_eq!(dash["view"], "dashboard");
+    assert!(dash["summary"]["families"].is_number());
+    // A filtered list emits structured family objects (not human `where` strings).
+    let list: serde_json::Value =
+        serde_json::from_str(&run(&["query", p, "members>1", "--format", "json"])).unwrap();
+    assert_eq!(list["view"], "list");
+    let fam = &list["families"][0];
+    for k in [
+        "id",
+        "scope",
+        "witness",
+        "members",
+        "shared",
+        "params",
+        "removable",
+        "locations",
+        "extraction_shape",
+        "same_symbol",
+    ] {
+        assert!(!fam[k].is_null(), "query-json family.{k} present: {list}");
+    }
+    // `full` carries the all-copies extraction skeleton on the family object.
+    let famid = fam["id"].as_str().unwrap().to_string();
+    let opened: serde_json::Value = serde_json::from_str(&run(&[
+        "query",
+        p,
+        &format!("id={famid}"),
+        "full",
+        "--format",
+        "json",
+    ]))
+    .unwrap();
+    assert_eq!(opened["view"], "family");
+    assert!(
+        opened["family"]["skeleton"].is_array(),
+        "id=…full json carries skeleton: {opened}"
     );
 
     let _ = fs::remove_dir_all(&dir);

--- a/docs/home.md
+++ b/docs/home.md
@@ -50,6 +50,7 @@ of nose's machine-readable output.
 - [capabilities](capabilities.md) — the `nose capabilities` JSON contract: what an installed binary supports, so a wrapper never has to scrape `--help`.
 - [agent-recipe](agent-recipe.md) — the validated protocol for an LLM agent: explore interactively with `nose query` (follow the emitted next-commands), then read the `nose scan --format json` contract for the batch/gate path.
 - [scan-json](scan-json.md) — the versioned `nose scan --format json` contract for downstream tooling and CI (the batch surface; `nose query` is its interactive companion).
+- [query-json](query-json.md) — the versioned `nose query --format json` contract (schema v2): the structured, view-shaped machine form of the exploration surface.
 
 ## Contributing
 

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -1,0 +1,64 @@
+# nose query JSON (schema v2)
+
+`nose query <path> [terms…] --format json` emits a structured, versioned contract over the
+same family dataset [`scan`](scan-json.md) computes — the **machine** form of the
+[exploration surface](usage.md#nose-query). Unlike scan-JSON v1 (a one-shot `families[]`
+dump), the query contract is *view-shaped*: it mirrors what the human surface shows, so a
+caller drives the same dashboard → slice → open-family loop programmatically.
+
+Discover support with [`nose capabilities`](capabilities.md): `schemas.query_json` lists the
+versions the installed binary emits (currently `[2]`).
+
+## Envelope
+
+Every response is an object with:
+
+| field | meaning |
+|---|---|
+| `schema_version` | `2` |
+| `tool` | `"nose"` |
+| `view` | which surface produced it: `dashboard` \| `list` \| `group` \| `family` |
+| `path` | the scanned path, as given |
+
+plus the view-specific body below. Like the human surface, a result is a pure function of
+(repo state, command); an unknown field or enum value is a hard error.
+
+## Views
+
+**`dashboard`** (no terms) — `summary` (`scanned_files`, `families`, `by_confidence`
+`{exact,subdag,copy_paste,similar}`), `top_candidates[]` (curated production-first families,
+each a *family object*), and `next[]` (runnable follow-up commands).
+
+**`list`** (filters / `sort=` / `top=`) — `summary` (`families`, `shown`, `widened`),
+`families[]` (the selection, each a *family object*), `next[]`.
+
+**`group`** (`group=FIELD`) — `field` and `groups[]` of `{key, count, exemplar_id}`,
+ranked by count.
+
+**`family`** (`id=` / `at=`) — `hint` (the prose `→` recommendation) and a single `family`
+object; with `full`, that object carries `skeleton`.
+
+## The family object
+
+| field | meaning |
+|---|---|
+| `id` | family id (the `id=` handle; any unique prefix opens it) |
+| `scope` | `prod` \| `test` \| `mixed` (context, never a worthiness penalty) |
+| `witness` | why the copies merged: `exact` \| `subdag` (behavior-proven) \| `copy-paste` \| `similar` |
+| `surface` | `default` \| `review` \| `hidden` \| `shallow` \| `generated` \| `declaration` (curation tier) |
+| `members` | number of copies |
+| `files` / `dirs` | distinct files / directories the copies span |
+| `shared` | lines invariant across **all** copies (the all-copies anti-unification count) |
+| `rep_lines` | the representative copy's line count (`shared` of `rep_lines` are shared) |
+| `params` | varying spots the extracted helper would parameterize |
+| `removable` | `(members − 1) × shared` — lines a clean extraction would delete |
+| `value` | the raw duplicated-volume score |
+| `extraction_shape` | the decidable fix shape (`extract-helper`, `call-existing-helper`, …) |
+| `same_symbol` | every copy is the same named symbol (the parallel-variant signal) |
+| `folds` | overlapping slice families folded under this one |
+| `locations[]` | every copy: `{file, start, end, name, lang}` |
+| `skeleton` | (only with `full`) the all-copies extraction-skeleton lines, `⟨param N⟩` for varying spots |
+
+Evidence, never a verdict: there is no `worth_it`/`confidence` field — the worthy-vs-parallel
+judgment is the caller's ([design §2](design.md)). See the [agent-recipe](agent-recipe.md) for
+the loop, and [usage › nose query](usage.md#nose-query) for the grammar.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -215,7 +215,8 @@ runnable `nose query …` next-commands, so an agent navigates by following link
 than re-reading a schema or hand-writing `jq`.
 
 It is **opt-in and additive** — `nose scan`, `--fail-on`, and the scan-JSON contract are
-unchanged.
+unchanged. With `--format json` every view emits the structured, versioned
+[query-JSON v2 contract](query-json.md).
 
 ```text
 nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE] [sort=KEY] [top=N] [full] [all]


### PR DESCRIPTION
The machine half of making `nose query` the primary surface (#375). **No change** to `scan`/scan-JSON v1.

`nose query --format json` now emits a **structured, versioned** contract across **all** views. Previously only the dashboard/family views emitted JSON — and as a thin `{id, where:"<human string>"}` shape; `list`/`group` were human-only (a real machine-path gap). Per the resolved #375 decision, this is a *restructured* (not scan-v1-cloned) contract.

- **Envelope** `{schema_version: 2, tool, view, path, …}` for `dashboard` / `list` / `group` / `family`.
- **`query_family_json`** serializes one family fully: `id, scope, witness, surface, members, files, dirs, shared, rep_lines, params, removable, value, extraction_shape, same_symbol, folds, locations[{file,start,end,name,lang}]`, and on `full` the all-copies `skeleton`.
- `list`/`group` gained `--format json`; dashboard/family restructured onto the same family object.
- Advertised via **`capabilities.schemas.query_json = [2]`** (new `QUERY_JSON_SCHEMA_VERSION`).
- Evidence-not-verdict — no `worth_it`/`confidence`; the judgment stays the caller's ([design §2](../docs/design.md)).

Docs: new [`query-json.md`](../docs/query-json.md) reference, linked from `home.md`/`usage.md`. Test extended (v2 envelope, structured family fields, `full` skeleton). `cargo test -p nose-cli` green; `fmt`/`clippy -D warnings`/`awiki` (50 docs, connected) clean.

This completes **Wave A-2** (query gained analysis flags, the gate, and now the contract). Remaining: report formats (`markdown`/`sarif`, optional until scan removal) and **Wave B** (deprecate scan) — staged on `main`, **the 0.10.0 release held** per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)