### PR TITLE
#375 (Wave B): deprecate nose scan in favour of nose query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ break.
 
 ## [Unreleased]
 
+The 0.10.0 line (breaking): **`nose query` becomes the primary surface and `nose scan` is
+deprecated.** All changes below are staged; the release is not yet cut.
+
+### Added
+- **`nose query` is now a complete surface** over the same dataset `scan` computes:
+  - **Explorability (#374):** DSL negation (`field!=value` / `path!~substr`), an `at=FILE:LINE`
+    selector (a stable family handle across edits), and a `same_symbol` evidence field +
+    facet (the parallel-variant signal).
+  - **Analysis flags:** `--mode`/`--min-*`/`--exclude`/`--cache-dir`/`--ignore-file`/
+    `--semantic-pack`/`--config`, configured identically to scan.
+  - **CI gate:** `--fail-on any`/`new` with `--baseline`/`--write-baseline`, reusing scan's
+    gate/baseline/ignore logic — `nose query <path> --fail-on any` is a drop-in gate.
+  - **A structured, versioned JSON contract** ([query-json](docs/query-json.md), schema v2)
+    across every view, advertised as `capabilities.schemas.query_json`.
+
+### Changed (breaking)
+- **`nose scan` is deprecated** in favour of `nose query`. It still works (an interactive run
+  prints a one-line nudge); `capabilities` moves it from `commands.stable` to
+  `commands.deprecated`; docs lead with `query`. Removal is slated for a later release.
+
+### Deprecated
+- `nose scan` (see above) and the scan-JSON v1 contract — migrate to `nose query` and the
+  query-JSON v2 contract.
+
 ## [0.9.1] - 2026-06-15
 
 Documentation release: lead with `nose query`, and a full code-docs drift sweep. No

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -916,6 +916,9 @@ struct CapabilitiesInterfaces {
 #[derive(serde::Serialize)]
 struct CapabilitiesCommands {
     stable: Vec<&'static str>,
+    /// Commands that still work but are on their way out — integrations should migrate.
+    /// `scan` → `nose query` (same dataset, gate, and a structured `--format json` contract).
+    deprecated: Vec<&'static str>,
 }
 
 #[derive(serde::Serialize)]
@@ -984,10 +987,10 @@ impl CapabilitiesReport {
                     "il",
                     "query",
                     "review",
-                    "scan",
                     "semantic-pack",
                     "stats",
                 ],
+                deprecated: vec!["scan"],
             },
             schemas: CapabilitiesSchemas {
                 capabilities: vec![CAPABILITIES_SCHEMA_VERSION],
@@ -4828,6 +4831,17 @@ fn build_scan_dataset(args: &ScanArgs, refs: &[&std::path::Path]) -> Result<Scan
 }
 
 fn cmd_scan(args: ScanArgs) -> Result<()> {
+    // `nose scan` is deprecated in favour of `nose query` (#375), which reads the same
+    // dataset and now carries the gate, baselines, ignores, and a structured `--format json`
+    // contract. The nudge is interactive-only — gated on a TTY stderr — so machine/CI/test
+    // runs (piped stderr) are never spammed; the `capabilities.commands.deprecated` list and
+    // the docs are the machine-facing deprecation signal.
+    if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        eprintln!(
+            "note: `nose scan` is deprecated — use `nose query` (same dataset; adds slice/filter \
+             navigation, and takes the same --fail-on/--baseline gate). See `nose query --help`."
+        );
+    }
     // `--fail-on new` gates on families that are new/changed vs a baseline, so without
     // `--baseline` the gate could never fire — reject the combination instead of silently
     // passing (a CI gate that always succeeds is the worst failure mode).

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1633,13 +1633,18 @@ fn capabilities_command_lists_stable_commands_and_schemas() {
             "il",
             "query",
             "review",
-            "scan",
             "semantic-pack",
             "stats"
         ]
     );
+    // `scan` is deprecated in favour of `query` (#375) — moved out of `stable`.
+    assert_eq!(
+        json_array_strings(&json["commands"], "deprecated"),
+        vec!["scan"]
+    );
     assert_eq!(json["schemas"]["capabilities"][0], 1);
     assert_eq!(json["schemas"]["scan_json"][0], 1);
+    assert_eq!(json["schemas"]["query_json"][0], 2);
     assert_eq!(
         json["schemas"]["semantic_packs"][0],
         "nose.semantic-pack.v0"

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -42,7 +42,8 @@ nose capabilities
     "doctor_json": false
   },
   "commands": {
-    "stable": ["capabilities", "il", "query", "review", "scan", "semantic-pack", "stats"]
+    "stable": ["capabilities", "il", "query", "review", "semantic-pack", "stats"],
+    "deprecated": ["scan"]
   },
   "schemas": {
     "capabilities": [1],
@@ -132,7 +133,8 @@ release so it can't drift.
 | `interfaces.capabilities_json` | boolean | Whether `nose capabilities` is the supported capability query interface. |
 | `interfaces.version_json` | boolean | Whether `nose --version --json` is supported. Version 1 reports `false`. |
 | `interfaces.doctor_json` | boolean | Whether `nose doctor --json` is supported. Version 1 reports `false`. |
-| `commands.stable` | array | Stable user-facing commands that integrations may invoke (incl. `query`, the interactive exploration surface — see [usage › nose query](usage.md#nose-query); it has no versioned sub-contract of its own yet). Hidden research commands are intentionally omitted. |
+| `commands.stable` | array | Stable user-facing commands that integrations may invoke (incl. `query`, the interactive exploration surface — see [usage › nose query](usage.md#nose-query), with its versioned [query-JSON](query-json.md) contract). Hidden research commands are intentionally omitted. |
+| `commands.deprecated` | array | Commands that still work but are being retired; integrations should migrate. `scan` → `nose query` (same dataset + gate + a structured `--format json` contract). |
 | `schemas.capabilities` | array | Supported capabilities schema versions. |
 | `schemas.scan_json` | array | Supported `nose scan --format json` schema versions. |
 | `schemas.semantic_packs` | array | Supported semantic-pack manifest API versions, currently `nose.semantic-pack.v0`. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,6 +36,11 @@ from-source `./target/release/nose`.
 
 ## `nose scan`
 
+> **Deprecated** (since 0.10.0) in favour of [`nose query`](#nose-query), which reads the
+> same dataset and now carries the analysis flags, the `--fail-on`/`--baseline` gate, and a
+> structured versioned [`--format json`](query-json.md) contract. `scan` still works (an
+> interactive run prints a one-line nudge); it will be removed in a later release.
+
 `nose scan <paths…>` scans one or more files/directories (recursively, respecting
 `.gitignore` files inside each scanned tree), groups duplicated code into **families**, and
 ranks them by **extractability** — how cleanly each family folds into one shared helper — so the


### PR DESCRIPTION
The flip for #375. With `nose query` now a complete surface (analysis flags + the `--fail-on`/`--baseline` gate + the structured v2 JSON contract), `nose scan` is **deprecated**.

- **Interactive nudge:** an interactive `nose scan` (TTY stderr) prints a one-line "use `nose query`" note. Gated on `IsTerminal` so machine/CI/test runs (piped stderr) are never spammed — the `capabilities.commands.deprecated` list and the docs are the machine-facing signal.
- **capabilities:** `scan` moves from `commands.stable` → a new `commands.deprecated` list.
- **Docs:** lead with query; `usage.md`'s scan section gets a deprecation banner; `CHANGELOG [Unreleased]` records the breaking 0.10.0 line (query-primary + scan deprecated).

`scan` still works fully; removal is a later release.

> **The 0.10.0 release (version bump + tag + publish) is intentionally NOT cut** — per request, this only **stages** the change on `main`. When you're ready to release, the remaining step is: bump 0.9.1 → 0.10.0, cut the CHANGELOG `[Unreleased]` → `[0.10.0]`, tag `v0.10.0`.

`cargo test -p nose-cli` green (TTY-gated nudge leaves the piped scan tests untouched; capabilities contract test updated); `fmt`/`clippy -D warnings`/`awiki` clean.

Optional follow-up (not blocking, deferrable to scan removal): query `--format markdown`/`sarif` parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)