### PR TITLE
#374 (Wave A residue) + query report formats: existing_helper, spotclass, markdown/sarif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,19 @@ deprecated.** All changes below are staged; the release is not yet cut.
 ### Added
 - **`nose query` is now a complete surface** over the same dataset `scan` computes:
   - **Explorability (#374):** DSL negation (`field!=value` / `path!~substr`), an `at=FILE:LINE`
-    selector (a stable family handle across edits), and a `same_symbol` evidence field +
-    facet (the parallel-variant signal).
+    selector (a stable family handle across edits), a `same_symbol` evidence field + facet (the
+    parallel-variant signal), an `existing_helper` field on `call-existing-helper` families
+    (names the member to call — and marks it `role: "existing-helper"` — so it isn't read as one
+    more copy to fold), and a `spotclass` facet (`leaf-only` vs `structural`) that separates
+    near families whose varying spots are clean value-leaves from those with genuine logic
+    divergence (computed on demand from the graded witness — only when queried, for cost).
   - **Analysis flags:** `--mode`/`--min-*`/`--exclude`/`--cache-dir`/`--ignore-file`/
     `--semantic-pack`/`--config`, configured identically to scan.
   - **CI gate:** `--fail-on any`/`new` with `--baseline`/`--write-baseline`, reusing scan's
     gate/baseline/ignore logic — `nose query <path> --fail-on any` is a drop-in gate.
   - **A structured, versioned JSON contract** ([query-json](docs/query-json.md), schema v2)
-    across every view, advertised as `capabilities.schemas.query_json`.
+    across every view, advertised as `capabilities.schemas.query_json`, plus `--format
+    markdown`/`sarif` report output (reusing scan's formatters over the query selection).
 
 ### Changed (breaking)
 - **`nose scan` is deprecated** in favour of `nose query`. It still works (an interactive run

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3779,6 +3779,7 @@ const STR_FIELDS: &[&str] = &[
     "shape",
     "extraction_shape",
     "same_symbol",
+    "spotclass",
 ];
 /// Numeric filter fields (also the only ones that accept `>`/`<`).
 const NUM_FIELDS: &[&str] = &[
@@ -3927,6 +3928,7 @@ fn parse_query(terms: &[String]) -> Result<Query> {
                     "consolidate-cross-language",
                 ]),
                 "same_symbol" => Some(&["true", "false"]),
+                "spotclass" => Some(&["leaf-only", "structural"]),
                 _ => None,
             };
             if let Some(vals) = valid {
@@ -3995,6 +3997,46 @@ fn family_same_symbol(f: &nose_detect::RefactorFamily) -> bool {
     }
 }
 
+/// The existing helper a `call-existing-helper` family already contains: the lone named
+/// function/method whose body the other (inline) members recompute (#374 item 5). `None`
+/// for every other extraction shape. The `extraction_shape() == "call-existing-helper"`
+/// gate is exactly the predicate `family_hint` uses, so the surfaced helper always matches
+/// the hint — naming *which* member it is stops the agent from reading the helper's own
+/// body as just another copy (the #373 dogfood confusion).
+fn family_existing_helper(f: &nose_detect::RefactorFamily) -> Option<&nose_detect::Loc> {
+    if f.extraction_shape() != "call-existing-helper" {
+        return None;
+    }
+    f.locations.iter().find(|l| {
+        matches!(
+            l.kind,
+            nose_il::UnitKind::Function | nose_il::UnitKind::Method
+        ) && l.name.is_some()
+            && !l.is_fragment
+    })
+}
+
+/// The aggregate value-class of a near family's varying spots, from the #315 graded witness:
+/// `leaf-only` (every hole is a clean value-leaf — a parameterize/extract candidate) vs
+/// `structural` (at least one hole is a shape/arity/unmodeled/decorator divergence, or a
+/// referent mismatch — genuinely different logic, not just parameters). `None` until the
+/// graded witness is attached (near families only, and only when the query asks for it —
+/// the enrichment is the dominant cost, so `query` runs it on demand; see `run_query_cmd`).
+fn family_spotclass(f: &nose_detect::RefactorFamily) -> Option<&'static str> {
+    let g = f.witness.as_ref()?.graded.as_ref()?;
+    let is_structural = |c: &str| {
+        matches!(
+            c,
+            "arity" | "shape" | "unmodeled" | "extra-sink" | "decorator"
+        )
+    };
+    if !g.referent_mismatches.is_empty() || g.spots.iter().any(|s| is_structural(s.class)) {
+        Some("structural")
+    } else {
+        Some("leaf-only")
+    }
+}
+
 /// Numeric value of a family field (for `>`/`<`/`=` on numbers).
 fn family_num(f: &nose_detect::RefactorFamily, field: &str) -> Option<f64> {
     Some(match field {
@@ -4034,6 +4076,9 @@ fn family_matches(f: &nose_detect::RefactorFamily, ov: &SurfaceOverrides, flt: &
             "shape" | "extraction_shape" => f.extraction_shape().to_string(),
             "dir" => family_dir(f),
             "same_symbol" => family_same_symbol(f).to_string(),
+            // `None` (witness not enriched / not a near family) deliberately matches no
+            // `spotclass=` filter rather than erroring — the caller widens or drops it.
+            "spotclass" => family_spotclass(f)?.to_string(),
             _ => return None,
         })
     };
@@ -4115,14 +4160,21 @@ fn query_family_json(
 ) -> serde_json::Value {
     let (shared, params) = all_copies_shared(f);
     let removable = u32::try_from(f.members.saturating_sub(1)).unwrap_or(0) * shared;
+    let helper = family_existing_helper(f);
     let locations: Vec<_> = f
         .locations
         .iter()
         .map(|l| {
-            serde_json::json!({
+            let mut o = serde_json::json!({
                 "file": l.file, "start": l.start_line, "end": l.end_line,
                 "name": l.name, "lang": l.lang.as_str(),
-            })
+            });
+            // Mark the member that is itself the existing helper, so the agent does not read
+            // it as one more copy to fold (#374 item 5).
+            if helper.is_some_and(|h| std::ptr::eq(h, l)) {
+                o["role"] = serde_json::Value::from("existing-helper");
+            }
+            o
         })
         .collect();
     let mut obj = serde_json::json!({
@@ -4143,6 +4195,19 @@ fn query_family_json(
         "folds": opp.slices(f).map(<[_]>::len).unwrap_or(0),
         "locations": locations,
     });
+    // `call-existing-helper` families: name the helper to call (the action is "call it", not
+    // "extract a new one"). Omitted for every other shape (#374 item 5).
+    if let Some(h) = helper {
+        obj["existing_helper"] = serde_json::json!({
+            "name": h.name, "file": h.file, "start": h.start_line, "end": h.end_line,
+        });
+    }
+    // Spot value-class evidence: present only on near families whose graded witness has been
+    // enriched (the query path runs that on demand — see `run_query_cmd`); omitted otherwise
+    // rather than emitted as a misleading null (#374 item 2).
+    if let Some(sc) = family_spotclass(f) {
+        obj["spotclass"] = serde_json::Value::from(sc);
+    }
     if full {
         if let Some(skeleton) = family_skeleton(f) {
             obj["skeleton"] = serde_json::Value::from(skeleton);
@@ -4192,6 +4257,41 @@ fn all_copies_shared(f: &nose_detect::RefactorFamily) -> (u32, u32) {
 
 fn is_default_surface(f: &nose_detect::RefactorFamily, ov: &SurfaceOverrides) -> bool {
     effective_surface(f, ov) == "default"
+}
+
+/// The flat family set a report format (`--format markdown`/`sarif`) emits for a query: the
+/// single addressed family for `at=`/`id=`, otherwise the same default-surface (or `all`/
+/// `surface=`-widened, slice-folded, filtered) selection the list view shows. Report formats
+/// are non-interactive, so they collapse the dashboard/group views to this set.
+fn query_selection<'a>(
+    families: &'a [nose_detect::RefactorFamily],
+    ov: &SurfaceOverrides,
+    opp: &OpportunityGroups,
+    q: &Query,
+    path_arg: &str,
+) -> Result<Vec<&'a nose_detect::RefactorFamily>> {
+    if let Some(at) = &q.at {
+        let idv = baseline::family_id(family_at(families, at, path_arg)?);
+        return Ok(families
+            .iter()
+            .filter(|f| baseline::family_id(f) == idv)
+            .collect());
+    }
+    if let Some(idv) = &q.id {
+        return Ok(families
+            .iter()
+            .filter(|f| baseline::family_id(f).starts_with(idv.as_str()))
+            .collect());
+    }
+    let widen = q.all || q.filters.iter().any(|flt| flt.field == "surface");
+    Ok(families
+        .iter()
+        .filter(|f| {
+            (widen || is_default_surface(f, ov))
+                && !opp.is_slice(f)
+                && q.filters.iter().all(|flt| family_matches(f, ov, flt))
+        })
+        .collect())
 }
 
 #[allow(clippy::too_many_lines)] // a flat command dispatcher: dashboard / at= / id= / group / list
@@ -4263,6 +4363,15 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
     dataset.families = active;
     let overrides =
         classify_surface_overrides(&mut dataset.families, &refs, &dataset.settings.exclude);
+    // `spotclass` reads the #315 graded witness, which `build_scan_dataset` does not compute
+    // (re-deriving it is the dominant scan cost — netty: ~2.8s of a ~4.6s near scan). Run that
+    // enrichment only when the query actually filters or groups by `spotclass`, and before the
+    // filter so the class exists to match on; the common query path stays free of it.
+    let needs_spotclass = q.group.as_deref() == Some("spotclass")
+        || q.filters.iter().any(|flt| flt.field == "spotclass");
+    if needs_spotclass {
+        enrich_graded_witnesses(&mut dataset.families, &dataset.opts);
+    }
     if let Some(sk) = q.sort {
         dataset.families.sort_by(|a, b| {
             sk.score(b)
@@ -4279,57 +4388,78 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
         .filter(|f| is_default_surface(f, &overrides))
         .collect();
     let opp = OpportunityGroups::from_ranked(&default_fams);
-    let json = matches!(format, ReportFormat::Json);
-    if terms.is_empty() {
-        render_query_dashboard(
-            &dataset.families,
-            &overrides,
-            &opp,
-            &dataset.scope,
-            &path_arg,
-            json,
-        );
-    } else if let Some(at) = &q.at {
-        // `at=file:line` → the family whose member span covers that location (stable across
-        // edits, unlike the span-derived id). Resolve to an `id=` open.
-        let idv = baseline::family_id(family_at(&dataset.families, at, &path_arg)?);
-        render_query_family(
-            &dataset.families,
-            &overrides,
-            &opp,
-            &idv,
-            q.id_full,
-            &path_arg,
-            json,
-        );
-    } else if let Some(idv) = &q.id {
-        render_query_family(
-            &dataset.families,
-            &overrides,
-            &opp,
-            idv,
-            q.id_full,
-            &path_arg,
-            json,
-        );
-    } else {
-        // Default to the curated default surface (the same families the dashboard counts and
-        // `scan` trusts); `all` or an explicit `surface=` filter widens to the raw universe.
-        let widen = q.all || q.filters.iter().any(|flt| flt.field == "surface");
-        let sel: Vec<&nose_detect::RefactorFamily> = dataset
-            .families
-            .iter()
-            .filter(|f| {
-                (widen || is_default_surface(f, &overrides))
-                    && !opp.is_slice(f)
-                    && q.filters
-                        .iter()
-                        .all(|flt| family_matches(f, &overrides, flt))
-            })
-            .collect();
-        match &q.group {
-            Some(field) => render_query_group(&sel, field, &terms, &path_arg, json),
-            None => render_query_list(&sel, &overrides, &opp, &q, &terms, &path_arg, widen, json),
+    match format {
+        // Report formats (for PRs / code-scanning, like scan's): non-interactive, so they
+        // ignore dashboard/group navigation and just render the family set the query selects,
+        // reusing scan's own formatters (#374 + scan parity).
+        ReportFormat::Markdown | ReportFormat::Sarif => {
+            let selected = query_selection(&dataset.families, &overrides, &opp, &q, &path_arg)?;
+            let top = q.top.unwrap_or(30);
+            let shown: Vec<&nose_detect::RefactorFamily> =
+                selected.iter().take(top).copied().collect();
+            if matches!(format, ReportFormat::Sarif) {
+                println!("{}", refactor_sarif(&shown, selected.len())?);
+            } else {
+                print_refactor_markdown(
+                    &selected,
+                    &shown,
+                    dataset.settings.channels,
+                    baseline_comparison.as_ref(),
+                    None,
+                    0,
+                    None,
+                );
+            }
+        }
+        _ => {
+            let json = matches!(format, ReportFormat::Json);
+            if terms.is_empty() {
+                render_query_dashboard(
+                    &dataset.families,
+                    &overrides,
+                    &opp,
+                    &dataset.scope,
+                    &path_arg,
+                    json,
+                );
+            } else if let Some(at) = &q.at {
+                // `at=file:line` → the family whose member span covers that location (stable
+                // across edits, unlike the span-derived id). Resolve to an `id=` open.
+                let idv = baseline::family_id(family_at(&dataset.families, at, &path_arg)?);
+                render_query_family(
+                    &dataset.families,
+                    &overrides,
+                    &opp,
+                    &idv,
+                    q.id_full,
+                    &path_arg,
+                    json,
+                );
+            } else if let Some(idv) = &q.id {
+                render_query_family(
+                    &dataset.families,
+                    &overrides,
+                    &opp,
+                    idv,
+                    q.id_full,
+                    &path_arg,
+                    json,
+                );
+            } else {
+                // Default to the curated default surface (the same families the dashboard
+                // counts and `scan` trusts); `all` or an explicit `surface=` filter widens to
+                // the raw universe.
+                let widen = q.all || q.filters.iter().any(|flt| flt.field == "surface");
+                let sel = query_selection(&dataset.families, &overrides, &opp, &q, &path_arg)?;
+                match &q.group {
+                    Some(field) => render_query_group(&sel, field, &terms, &path_arg, json),
+                    None => {
+                        render_query_list(
+                            &sel, &overrides, &opp, &q, &terms, &path_arg, widen, json,
+                        );
+                    }
+                }
+            }
         }
     }
     // CI gate (same as scan): a non-empty default-report family set fails `--fail-on`.
@@ -4610,6 +4740,7 @@ fn render_query_group(
             "dir" => family_dir(f),
             "shape" | "extraction_shape" => f.extraction_shape().to_string(),
             "same_symbol" => family_same_symbol(f).to_string(),
+            "spotclass" => family_spotclass(f).unwrap_or("unwitnessed").to_string(),
             _ => "?".to_string(),
         }
     };
@@ -4726,13 +4857,21 @@ fn render_query_family(
     print!("{fold_note}");
     println!("  → {}", family_hint(f));
     println!("  copies:");
+    let helper = family_existing_helper(f);
     for l in f.locations.iter().take(30) {
         let name = l
             .name
             .as_deref()
             .map(|n| format!("  {n}"))
             .unwrap_or_default();
-        println!("    {}:{}-{}{name}", l.file, l.start_line, l.end_line);
+        // Flag the member that *is* the existing helper, so it isn't mistaken for a copy
+        // to fold — the action is to call it (#374 item 5).
+        let role = if helper.is_some_and(|h| std::ptr::eq(h, l)) {
+            "  ← existing helper (call it)"
+        } else {
+            ""
+        };
+        println!("    {}:{}-{}{name}{role}", l.file, l.start_line, l.end_line);
     }
     // Lead with the decision-grade artifact: the extraction skeleton aligned across ALL
     // copies (#360), with the differing spots as parameters — not a raw 2-copy token diff.
@@ -7561,6 +7700,75 @@ mod tests {
             family_hint(&f),
             "2 sites reimplement `clamp` — call the existing helper (core/math.ts)"
         );
+    }
+
+    #[test]
+    fn existing_helper_names_the_call_target_member() {
+        // A call-existing-helper family: one named function + inline copies that recompute it.
+        let mut f = fam(1, 2, &[None, None, None]);
+        f.locations = vec![
+            {
+                let mut l = loc_at("core/math.ts", 10, 14, nose_il::UnitKind::Function);
+                l.name = Some("clamp".to_string());
+                l
+            },
+            loc_at("ui/model.ts", 80, 84, nose_il::UnitKind::Block),
+            loc_at("worker/job.ts", 33, 37, nose_il::UnitKind::Block),
+        ];
+        let helper = family_existing_helper(&f).expect("call-existing-helper has a helper member");
+        assert_eq!(helper.name.as_deref(), Some("clamp"));
+        assert_eq!(helper.file, "core/math.ts");
+        // A plain multi-function family is a fresh extraction — there is no member to call.
+        assert!(family_existing_helper(&fam(1, 2, &[Some("a"), Some("b")])).is_none());
+    }
+
+    #[test]
+    fn spotclass_grades_near_family_holes() {
+        use nose_detect::{EquivalenceWitness, GradedWitness, WitnessHole};
+        let hole = |class: &'static str| WitnessHole {
+            class,
+            a_lines: None,
+            b_lines: None,
+            effect: false,
+            a_text: String::new(),
+            b_text: String::new(),
+        };
+        let graded = |spots: Vec<WitnessHole>, referent: Vec<String>| {
+            let mut f = fam(1, 2, &[Some("x"), Some("y")]);
+            f.witness = Some(EquivalenceWitness {
+                kind: "structural-similarity",
+                value_nodes: None,
+                mean_value_jaccard: None,
+                mean_shape_jaccard: None,
+                graded: Some(GradedWitness {
+                    holes: spots.len(),
+                    spots,
+                    patterns: Vec::new(),
+                    referent_mismatches: referent,
+                    caveat_names: Vec::new(),
+                    equal_modulo_holes: true,
+                    modeled_caveat: false,
+                }),
+            });
+            f
+        };
+        // Only value-leaf holes → a clean parameterize/extract candidate.
+        assert_eq!(
+            family_spotclass(&graded(vec![hole("literal"), hole("call")], vec![])),
+            Some("leaf-only")
+        );
+        // A shape/arity hole → genuine logic divergence, not just a parameter.
+        assert_eq!(
+            family_spotclass(&graded(vec![hole("literal"), hole("shape")], vec![])),
+            Some("structural")
+        );
+        // A referent mismatch (same name, behaviorally distinct) → structural even with leaf holes.
+        assert_eq!(
+            family_spotclass(&graded(vec![hole("literal")], vec!["equals".into()])),
+            Some("structural")
+        );
+        // No graded witness (not enriched / not a near family) → no class.
+        assert!(family_spotclass(&fam(1, 1, &[Some("a"), Some("b")])).is_none());
     }
 
     #[test]

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -2037,6 +2037,45 @@ fn query_dashboard_filter_and_family() {
         "id=…full json carries skeleton: {opened}"
     );
 
+    // spotclass (#374 item 2): the near family's only varying spot is the operator — a clean
+    // value-leaf — so it grades `leaf-only`. Grouping/filtering by spotclass triggers the
+    // on-demand graded-witness enrichment (skipped on the common path for cost).
+    assert!(
+        run(&["query", p, "group=spotclass"]).contains("by spotclass"),
+        "group=spotclass facets the near families"
+    );
+    let leaf: serde_json::Value = serde_json::from_str(&run(&[
+        "query",
+        p,
+        "spotclass=leaf-only",
+        "--format",
+        "json",
+    ]))
+    .unwrap();
+    assert_eq!(
+        leaf["families"][0]["spotclass"], "leaf-only",
+        "the operator-varying near family grades leaf-only: {leaf}"
+    );
+    assert!(run_fail(&["query", p, "spotclass=bogus"]).contains("unknown spotclass value"));
+
+    // Report formats (#374 + scan parity): query reuses scan's markdown and SARIF formatters
+    // over the selected family set.
+    let md = run(&["query", p, "--format", "markdown"]);
+    assert!(
+        md.contains("duplicated lines"),
+        "markdown report has the header: {md}"
+    );
+    let sarif: serde_json::Value =
+        serde_json::from_str(&run(&["query", p, "--format", "sarif"])).unwrap();
+    assert_eq!(
+        sarif["version"], "2.1.0",
+        "query emits a SARIF 2.1.0 doc: {sarif}"
+    );
+    assert!(
+        sarif["runs"][0]["results"].is_array(),
+        "SARIF has a results array: {sarif}"
+    );
+
     let _ = fs::remove_dir_all(&dir);
 }
 

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -55,8 +55,10 @@ object; with `full`, that object carries `skeleton`.
 | `value` | the raw duplicated-volume score |
 | `extraction_shape` | the decidable fix shape (`extract-helper`, `call-existing-helper`, …) |
 | `same_symbol` | every copy is the same named symbol (the parallel-variant signal) |
+| `existing_helper` | (only for `call-existing-helper`) the member to call — `{name, file, start, end}`; the inline copies recompute it, so the fix is "call it", not a fresh extraction |
+| `spotclass` | (only on enriched near families) `leaf-only` (varying spots are clean value-leaves) \| `structural` (a shape/arity/referent divergence — genuine logic difference). Omitted unless the query filters/groups by `spotclass` (the graded-witness enrichment runs on demand) |
 | `folds` | overlapping slice families folded under this one |
-| `locations[]` | every copy: `{file, start, end, name, lang}` |
+| `locations[]` | every copy: `{file, start, end, name, lang}`; the `existing_helper` member also carries `role: "existing-helper"` |
 | `skeleton` | (only with `full`) the all-copies extraction-skeleton lines, `⟨param N⟩` for varying spots |
 
 Evidence, never a verdict: there is no `worth_it`/`confidence` field — the worthy-vs-parallel

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -230,7 +230,7 @@ nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE] [sort=KEY] 
 | part | meaning |
 |---|---|
 | `field=value` | keep families where the field equals the value (AND-ed); `field>N`/`field<N` for numbers; `path~substr` for a path substring; **negate** with `field!=value` / `path!~substr` (e.g. `path!~frontend` drops a whole directory) |
-| `group=FIELD` | facet the selection by a discrete field (`dir`, `scope`, `witness`, `lang`, `shape`, `same_symbol`), with a count and an exemplar per bucket |
+| `group=FIELD` | facet the selection by a discrete field (`dir`, `scope`, `witness`, `lang`, `shape`, `same_symbol`, `spotclass`), with a count and an exemplar per bucket |
 | `id=FAM` | open one family (any unambiguous id prefix): its copies, the all-copies extraction skeleton, and navigation links |
 | `at=FILE:LINE` | open the family whose copy covers that source location — a stable handle across edits (the span-derived `id=` shifts when code moves) |
 | `sort=KEY` | `extractability` (default), `value`, or `members` |
@@ -240,10 +240,17 @@ nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE] [sort=KEY] 
 
 Fields: `scope` (prod\|test\|mixed), `witness` (exact\|subdag\|copy-paste\|similar),
 `same_symbol` (true\|false — every copy is the same named symbol, the parallel-variant
-signature), `lang`, `path`, `dir`, `members`, `files`, `value`, `params`, `shared`. Every row shows
-the payoff economics — `M/REP shared, Pp · ~N removable` — so a candidate can be triaged
-without opening it. Each result is a pure function of (repo state, command); an unknown
-field or enum value is a hard error (so a typo can't read as "no duplication").
+signature), `spotclass` (leaf-only\|structural — for near families, whether the varying spots
+are clean value-leaves to parameterize or genuine logic divergence), `lang`, `path`, `dir`,
+`members`, `files`, `value`, `params`, `shared`. Every row shows the payoff economics —
+`M/REP shared, Pp · ~N removable` — so a candidate can be triaged without opening it. Each
+result is a pure function of (repo state, command); an unknown field or enum value is a hard
+error (so a typo can't read as "no duplication").
+
+`spotclass` reads the [graded witness](graded-witness.md), which is presentation-layer
+enrichment (the dominant scan cost), so `query` computes it **on demand** — only when a term
+filters or groups by `spotclass`. The common query path pays nothing; a `spotclass=` /
+`group=spotclass` query re-derives the witness for the near families first.
 
 A typical loop: `nose query .` → `nose query . witness=exact` → `nose query . id=<id> full`.
 


### PR DESCRIPTION
Finishes the additive **#374** explorability residue (items 5 and 2) and brings `nose query` to report-format parity with `scan`. All additive, no ranking change, on the now-primary query surface.

## What's in
- **existing_helper (#374 item 5).** `call-existing-helper` families name the member to call: query JSON gains `existing_helper {name,file,start,end}` and marks that member `role: "existing-helper"`; the human family view annotates it `← existing helper (call it)`. Gated on `extraction_shape() == "call-existing-helper"` (the same predicate `family_hint` uses), so it always matches the hint. Resolves the #373 dogfood confusion where the helper's own body read as one more copy to fold.
- **spotclass facet (#374 item 2).** `spotclass=leaf-only|structural` filter + `group=spotclass` + JSON field, from the #315 graded witness — separates near families whose varying spots are clean value-leaves (parameterize) from genuine logic divergence (shape/arity/referent). The graded witness is presentation-layer enrichment (the dominant scan cost) and isn't computed on the query path, so query runs it **on demand** — only when a term filters/groups by `spotclass`, before the filter. The common query path pays nothing.
- **query `--format markdown` / `sarif`.** Reuses scan's formatters over the query selection (single family for `at=`/`id=`, else the list selection) via a new `query_selection` helper. Report formats are non-interactive, so they collapse dashboard/group to that flat set.

## Issue-board context
This is the substantive half of the "hygiene + #374 residue" plan. Also done this round: **#318 closed** (its gate-logic levers shipped via #245/§BV; the ≥0.8 default-on target was measured unreachable by gate logic — residual is family-quality), and #374 status posted (items 1/3/4 shipped in #376/#377; #6 stays last). #6 (skeleton signature hints) is intentionally deferred pending a dogfood/judge pass.

## Tests
- Unit: `family_existing_helper`, `family_spotclass` (incl. referent-mismatch → structural).
- CLI: the end-to-end query walk extended — `group=spotclass`, `spotclass=leaf-only` JSON field, bogus-value rejection, markdown header, SARIF 2.1.0 doc.
- Preflight green locally: fmt, `clippy +1.96.0 -D warnings`, `cargo test --workspace --release`, `awiki lint`.

## Docs
usage grammar (+ on-demand cost note), query-json family-object table (`existing_helper`/`spotclass`/`role`), CHANGELOG `[Unreleased]`.

Release note: still **0.9.1** — the 0.10.0 release stays held per standing instruction; this only stages onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)