### PR TITLE
query expressiveness: set-membership OR (comma) in filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ deprecated.** All changes below are staged; the release is not yet cut.
 
 ### Added
 - **`nose query` is now a complete surface** over the same dataset `scan` computes:
-  - **Explorability (#374):** DSL negation (`field!=value` / `path!~substr`), an `at=FILE:LINE`
-    selector (a stable family handle across edits), a `same_symbol` evidence field + facet (the
-    parallel-variant signal), an `existing_helper` field on `call-existing-helper` families
-    (names the member to call — and marks it `role: "existing-helper"` — so it isn't read as one
-    more copy to fold), and a `spotclass` facet (`leaf-only` vs `structural`) that separates
-    near families whose varying spots are clean value-leaves from those with genuine logic
-    divergence (computed on demand from the graded witness — only when queried, for cost).
+  - **Explorability (#374):** DSL negation (`field!=value` / `path!~substr`), **set-membership
+    OR** (`witness=exact,subdag` matches either; `!=` over a comma-set drops all of them), an
+    `at=FILE:LINE` selector (a stable family handle across edits), a `same_symbol` evidence field
+    + facet (the parallel-variant signal), an `existing_helper` field on `call-existing-helper`
+    families (names the member to call — and marks it `role: "existing-helper"` — so it isn't read
+    as one more copy to fold), and a `spotclass` facet (`leaf-only` vs `structural`) that
+    separates near families whose varying spots are clean value-leaves from those with genuine
+    logic divergence (computed on demand from the graded witness — only when queried, for cost).
   - **Analysis flags:** `--mode`/`--min-*`/`--exclude`/`--cache-dir`/`--ignore-file`/
     `--semantic-pack`/`--config`, configured identically to scan.
   - **CI gate:** `--fail-on any`/`new` with `--baseline`/`--write-baseline`, reusing scan's

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3910,45 +3910,53 @@ fn parse_query(terms: &[String]) -> Result<Query> {
     }
     for flt in &q.filters {
         validate_field(&flt.field, &flt.op)?;
-        // Validate enum *values* too (a value typo must error, not silently match nothing
-        // and read as "no such clones exist").
-        if matches!(flt.op, QOp::Eq) {
-            let valid: Option<&[&str]> = match flt.field.as_str() {
-                "scope" => Some(&["prod", "test", "mixed"]),
-                "witness" => Some(&[
-                    "exact",
-                    "subdag",
-                    "copy-paste",
-                    "similar",
-                    "shared-core",
-                    "copypaste",
-                    "structural",
-                ]),
-                "shape" | "extraction_shape" => Some(&[
-                    "call-existing-helper",
-                    "extract-helper",
-                    "extract-method-from-block",
-                    "consolidate-type",
-                    "extract-base-class",
-                    "consolidate-cross-language",
-                ]),
-                "same_symbol" => Some(&["true", "false"]),
-                "spotclass" => Some(&["leaf-only", "structural"]),
-                _ => None,
-            };
-            if let Some(vals) = valid {
-                if !vals.contains(&flt.value.as_str()) {
-                    anyhow::bail!(
-                        "unknown {} value `{}` — valid: {}",
-                        flt.field,
-                        flt.value,
-                        vals.join(" ")
-                    );
-                }
-            }
-        }
+        validate_filter_values(flt)?;
     }
     Ok(q)
+}
+
+/// Validate an `=`/`!=` filter's value(s) against the field's enum, if it has one — so a value
+/// typo errors instead of silently matching nothing (which reads as "no such clones exist").
+/// Each comma-part is a member of the OR set and is checked independently.
+fn validate_filter_values(flt: &QFilter) -> Result<()> {
+    if !matches!(flt.op, QOp::Eq) {
+        return Ok(());
+    }
+    let valid: Option<&[&str]> = match flt.field.as_str() {
+        "scope" => Some(&["prod", "test", "mixed"]),
+        "witness" => Some(&[
+            "exact",
+            "subdag",
+            "copy-paste",
+            "similar",
+            "shared-core",
+            "copypaste",
+            "structural",
+        ]),
+        "shape" | "extraction_shape" => Some(&[
+            "call-existing-helper",
+            "extract-helper",
+            "extract-method-from-block",
+            "consolidate-type",
+            "extract-base-class",
+            "consolidate-cross-language",
+        ]),
+        "same_symbol" => Some(&["true", "false"]),
+        "spotclass" => Some(&["leaf-only", "structural"]),
+        _ => None,
+    };
+    let Some(vals) = valid else { return Ok(()) };
+    for part in flt.value.split(',') {
+        if !vals.contains(&part) {
+            anyhow::bail!(
+                "unknown {} value `{}` — valid: {}",
+                flt.field,
+                part,
+                vals.join(" ")
+            );
+        }
+    }
+    Ok(())
 }
 
 /// The family whose member span covers `at` (`file:line`) — the `at=` selector's target.
@@ -4061,10 +4069,20 @@ fn family_num(f: &nose_detect::RefactorFamily, field: &str) -> Option<f64> {
 /// Whether a family satisfies one filter.
 fn family_matches(f: &nose_detect::RefactorFamily, ov: &SurfaceOverrides, flt: &QFilter) -> bool {
     let field = flt.field.as_str();
-    let val = flt.value.as_str();
-    // Substring fields.
-    let path_has = || f.locations.iter().any(|l| l.file.contains(val));
-    let lang_eq = |exact: bool| {
+    // The family's value for string fields, computed once. `None` (e.g. `spotclass` on an
+    // unenriched/non-near family) deliberately matches nothing rather than erroring.
+    let fval: Option<String> = match field {
+        "scope" => Some(f.scope.to_string()),
+        "witness" => Some(witness_token(f.witness.as_ref().map(|w| w.kind)).to_string()),
+        "surface" => Some(effective_surface(f, ov).to_string()),
+        "shape" | "extraction_shape" => Some(f.extraction_shape().to_string()),
+        "dir" => Some(family_dir(f)),
+        "same_symbol" => Some(family_same_symbol(f).to_string()),
+        "spotclass" => family_spotclass(f).map(str::to_string),
+        _ => None,
+    };
+    let path_has = |val: &str| f.locations.iter().any(|l| l.file.contains(val));
+    let lang_match = |val: &str, exact: bool| {
         f.locations.iter().any(|l| {
             if exact {
                 l.lang.as_str() == val
@@ -4073,46 +4091,42 @@ fn family_matches(f: &nose_detect::RefactorFamily, ov: &SurfaceOverrides, flt: &
             }
         })
     };
-    let strfield = |field: &str| -> Option<String> {
-        Some(match field {
-            "scope" => f.scope.to_string(),
-            "witness" => witness_token(f.witness.as_ref().map(|w| w.kind)).to_string(),
-            "surface" => effective_surface(f, ov).to_string(),
-            "shape" | "extraction_shape" => f.extraction_shape().to_string(),
-            "dir" => family_dir(f),
-            "same_symbol" => family_same_symbol(f).to_string(),
-            // `None` (witness not enriched / not a near family) deliberately matches no
-            // `spotclass=` filter rather than erroring — the caller widens or drops it.
-            "spotclass" => family_spotclass(f)?.to_string(),
-            _ => return None,
-        })
+    // Match one value (one comma-part). `=`/`~` OR over the comma-separated set (membership);
+    // `>`/`<` are a range, so they take the whole value as a single number.
+    let one = |val: &str| -> bool {
+        match flt.op {
+            QOp::Has => match field {
+                "path" | "file" => path_has(val),
+                "lang" | "language" => lang_match(val, false),
+                _ => fval.as_deref().is_some_and(|s| s.contains(val)),
+            },
+            QOp::Eq => match field {
+                "path" | "file" => path_has(val),
+                "lang" | "language" => lang_match(val, true),
+                "witness" => f.witness.as_ref().map(|w| w.kind) == Some(witness_alias(val)),
+                _ => {
+                    if let Some(s) = &fval {
+                        s == val
+                    } else {
+                        family_num(f, field)
+                            .zip(val.parse::<f64>().ok())
+                            .is_some_and(|(a, b)| (a - b).abs() < f64::EPSILON)
+                    }
+                }
+            },
+            QOp::Gt => family_num(f, field)
+                .zip(val.parse::<f64>().ok())
+                .is_some_and(|(a, b)| a > b),
+            QOp::Lt => family_num(f, field)
+                .zip(val.parse::<f64>().ok())
+                .is_some_and(|(a, b)| a < b),
+        }
     };
     let base = match flt.op {
-        QOp::Has => match field {
-            "path" | "file" => path_has(),
-            "lang" | "language" => lang_eq(false),
-            _ => strfield(field).is_some_and(|s| s.contains(val)),
-        },
-        QOp::Eq => match field {
-            "path" | "file" => path_has(),
-            "lang" | "language" => lang_eq(true),
-            "witness" => f.witness.as_ref().map(|w| w.kind) == Some(witness_alias(val)),
-            _ => {
-                if let Some(s) = strfield(field) {
-                    s == val
-                } else {
-                    family_num(f, field)
-                        .zip(val.parse::<f64>().ok())
-                        .is_some_and(|(a, b)| (a - b).abs() < f64::EPSILON)
-                }
-            }
-        },
-        QOp::Gt => family_num(f, field)
-            .zip(val.parse::<f64>().ok())
-            .is_some_and(|(a, b)| a > b),
-        QOp::Lt => family_num(f, field)
-            .zip(val.parse::<f64>().ok())
-            .is_some_and(|(a, b)| a < b),
+        // Set-membership OR: `witness=exact,subdag` matches either; `!=` (negate) then drops
+        // any family in the set. `>`/`<` stay single-valued.
+        QOp::Has | QOp::Eq => flt.value.split(',').any(one),
+        QOp::Gt | QOp::Lt => one(flt.value.as_str()),
     };
     base ^ flt.negate
 }

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1948,6 +1948,24 @@ fn query_dashboard_filter_and_family() {
     // Negated equality still validates the value (a typo errors, never silently matches).
     assert!(run_fail(&["query", p, "witness!=nonsense"]).contains("unknown witness value"));
 
+    // Set-membership OR: comma is "any of". The fixture family is `similar`, so a set that
+    // includes `similar` keeps it and one that excludes it drops it — and a typo in any
+    // comma-part errors (never silently narrows the set).
+    assert!(
+        run(&["query", p, "witness=exact,similar"]).contains("families"),
+        "witness=exact,similar matches the similar fixture (OR)"
+    );
+    let none = run(&["query", p, "witness=exact,copy-paste"]);
+    assert!(
+        none.contains("0 families") || !none.contains(&format!("nose query {p} id=")),
+        "a set without `similar` excludes the only family"
+    );
+    assert!(
+        run(&["query", p, "witness!=exact,copy-paste"]).contains("families"),
+        "witness!=<set> keeps a family outside the set"
+    );
+    assert!(run_fail(&["query", p, "witness=similar,bogus"]).contains("unknown witness value"));
+
     // `at=FILE:LINE` opens the family whose copy covers that location; a miss errors loudly.
     let at = run(&["query", p, &format!("at={p}/a/m.py:3")]);
     assert!(

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -229,7 +229,7 @@ nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE | reinvented
 
 | part | meaning |
 |---|---|
-| `field=value` | keep families where the field equals the value (AND-ed); `field>N`/`field<N` for numbers; `path~substr` for a path substring; **negate** with `field!=value` / `path!~substr` (e.g. `path!~frontend` drops a whole directory) |
+| `field=value` | keep families where the field equals the value (terms AND-ed); `field>N`/`field<N` for numbers; `path~substr` for a path substring; **set OR** with a comma — `witness=exact,subdag` matches either; **negate** with `field!=value` / `path!~substr` (e.g. `path!~frontend` drops a directory; `witness!=exact,subdag` drops both) |
 | `group=FIELD` | facet the selection by a discrete field (`dir`, `file`, `scope`, `witness`, `lang`, `shape`, `same_symbol`, `spotclass`); each bucket carries its family count **and summed removable lines**, ranked by removable — so `group=dir`/`group=file` is the duplication **hotspot** map |
 | `id=FAM` | open one family (any unambiguous id prefix): its copies, the all-copies extraction skeleton, fold-graph links (`subsumes`/`subsumed_by`), and navigation |
 | `at=FILE:LINE` | open the family whose copy covers that source location — a stable handle across edits (the span-derived `id=` shifts when code moves) |


### PR DESCRIPTION
**Category 2** of the query-improvement plan. One composable primitive — **a comma means "any of"** (set membership) — instead of a boolean-expression language, which would recreate the jq authoring burden the query surface deliberately avoids ([Capabilities over features](https://wiki.g15e.com/pages/Capabilities%20over%20features): maximal capability from a single orthogonal operator).

## What's in
- `witness=exact,subdag` matches either; `path~api,web` matches either substring.
- `!=`/`!~` negate the set (`witness!=exact,subdag` drops both).
- `>`/`<` stay single-valued — a range, not a set.
- Each comma-part is validated against the field's enum, so a typo in *any* part errors loudly (the standing "a typo must not read as no-duplication" rule).

## Notes
- Deliberately **not** added: nested boolean/parenthesised expressions — that's the jq trap the design rejected. OR-within-a-field is the high-value, low-complexity slice.
- `family_matches` now matches one value via a shared closure and ORs over the parts; enum validation extracted to `validate_filter_values` (keeps `parse_query` under the cognitive-complexity bar).

## Tests
End-to-end query walk gains OR assertions: `exact,similar` keeps the `similar` fixture, a set without `similar` drops it, `!=`-set keeps an outsider, and a comma-part typo errors. Local preflight green (fmt, clippy `-D warnings`, full tests, awiki).

Docs: usage grammar, CHANGELOG `[Unreleased]`.

PR 2 of 3 (object model ✓ #383 → expressiveness → decision completeness). Still **0.9.1** — release held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)