### PR TITLE
query decision completeness: skeleton signature hints + proof depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ deprecated.** All changes below are staged; the release is not yet cut.
     (`subsumes`/`subsumed_by` — the related `id=` handles, not just a count), and a new
     `reinvented` view surfaces the reinvented-helper channel ("call the existing helper") that
     was previously `scan --show reinvented` only.
+  - **Decision completeness — act in one turn:** `full` skeletons annotate each varying spot
+    with a coarse value-class hint (`⟨param N: literal|name|call|expr|block⟩`) for the helper
+    signature (#374 item 6), and the family object carries proof depth — `value_nodes` (the
+    shared value-multiset size an exact family proves identical) and per-location
+    `shared_subdag` spans (where a sub-dag clone's proven shared computation lives).
 
 ### Changed (breaking)
 - **`nose scan` is deprecated** in favour of `nose query`. It still works (an interactive run

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -4193,6 +4193,11 @@ fn query_family_json(
             if helper.is_some_and(|h| std::ptr::eq(h, l)) {
                 o["role"] = serde_json::Value::from("existing-helper");
             }
+            // For a shared-sub-dag (partial) clone, where the proven shared computation lives
+            // at this site — so the caller can see what is provably equal, not just the unit.
+            if let Some((s, e)) = l.shared_subdag {
+                o["shared_subdag"] = serde_json::json!([s, e]);
+            }
             o
         })
         .collect();
@@ -4214,6 +4219,12 @@ fn query_family_json(
         "folds": opp.slices(f).map(<[_]>::len).unwrap_or(0),
         "locations": locations,
     });
+    // Proof depth: for the exact channel, how much is proven identical — the size of the shared
+    // value multiset. Lets a caller act now on the strongest evidence (subdag families carry the
+    // proven span per location instead). Evidence, not a verdict.
+    if let Some(n) = f.witness.as_ref().and_then(|w| w.value_nodes) {
+        obj["value_nodes"] = serde_json::Value::from(n);
+    }
     // Fold-graph navigation: the actual related family ids, not just a count — so a caller can
     // jump to the fuller overlapping family or open the slices it subsumes (HATEOAS).
     let id = baseline::family_id(f);
@@ -6907,22 +6918,61 @@ fn anti_unify_all(members: &[Vec<String>]) -> (Vec<String>, u32, u32) {
     let mut skeleton: Vec<String> = Vec::new();
     let mut shared = 0u32;
     let mut params = 0u32;
-    let mut in_hole = false;
-    let mut indent = "";
+    // The open hole, if any: (the skeleton slot to fill once it closes, the placeholder
+    // indent, and the anchor lines that vary across it — kept so the placeholder can carry a
+    // value-class hint for the helper signature, #374 item 6).
+    let mut hole: Option<(usize, &str, Vec<&str>)> = None;
     for (line, &kept) in anchor.iter().zip(&survive) {
         if kept {
-            in_hole = false;
+            if let Some((slot, indent, lines)) = hole.take() {
+                skeleton[slot] = format!("{indent}⟨param {params}: {}⟩", classify_param(&lines));
+            }
             shared += 1;
-            // remember the indentation to align the placeholder
-            indent = &line[..line.len() - line.trim_start().len()];
             skeleton.push((*line).to_string());
-        } else if !in_hole {
-            in_hole = true;
-            params += 1;
-            skeleton.push(format!("{indent}⟨param {params}⟩"));
+        } else {
+            match &mut hole {
+                Some((_, _, lines)) => lines.push(line),
+                None => {
+                    params += 1;
+                    let indent = &line[..line.len() - line.trim_start().len()];
+                    let slot = skeleton.len();
+                    skeleton.push(String::new());
+                    hole = Some((slot, indent, vec![line]));
+                }
+            }
         }
     }
+    if let Some((slot, indent, lines)) = hole.take() {
+        skeleton[slot] = format!("{indent}⟨param {params}: {}⟩", classify_param(&lines));
+    }
     (skeleton, shared, params)
+}
+
+/// A coarse value-class for one skeleton hole, from its (line-granularity) varying text — a
+/// signature hint for the extracted helper, not a proof: `literal` (a constant → a value
+/// parameter), `name` (a bare identifier), `call` (a call expression → maybe a closure/fn
+/// parameter), `block` (a multi-line region → a large or divergent parameter), or `expr`
+/// (anything else single-line).
+fn classify_param(lines: &[&str]) -> &'static str {
+    if lines.len() > 1 {
+        return "block";
+    }
+    let t = lines.first().map_or("", |s| s.trim());
+    let Some(first) = t.chars().next() else {
+        return "expr";
+    };
+    if first.is_ascii_digit() || matches!(first, '"' | '\'' | '`') {
+        "literal"
+    } else if t.ends_with(')') && t.contains('(') {
+        "call"
+    } else if t
+        .chars()
+        .all(|c| c.is_alphanumeric() || matches!(c, '_' | '.'))
+    {
+        "name"
+    } else {
+        "expr"
+    }
 }
 
 /// The invariant (shared) source lines across a family, plus the parameter count — the
@@ -7875,6 +7925,49 @@ mod tests {
             jb["subsumed_by"],
             serde_json::Value::from(short_id(&baseline::family_id(&a))),
             "slice points at its primary: {jb}"
+        );
+    }
+
+    #[test]
+    fn classify_param_hints_value_class() {
+        assert_eq!(classify_param(&["  42"]), "literal");
+        assert_eq!(classify_param(&["\"hello\""]), "literal");
+        assert_eq!(classify_param(&["foo.bar"]), "name");
+        assert_eq!(classify_param(&["compute(x, y)"]), "call");
+        assert_eq!(classify_param(&["a + b * c"]), "expr");
+        assert_eq!(classify_param(&["line one", "line two"]), "block");
+        assert_eq!(classify_param(&[]), "expr");
+    }
+
+    #[test]
+    fn query_family_json_carries_proof_depth() {
+        let ov = SurfaceOverrides {
+            generated_sources: std::collections::HashSet::new(),
+            declaration_run_ids: std::collections::HashSet::new(),
+        };
+        let empty = OpportunityGroups::default();
+        // Exact channel: how much is proven identical (the shared value-multiset size).
+        let mut exact = fam(1, 2, &[Some("a"), Some("b")]);
+        exact.witness = Some(nose_detect::EquivalenceWitness {
+            kind: "exact-value-graph",
+            value_nodes: Some(12),
+            mean_value_jaccard: None,
+            mean_shape_jaccard: None,
+            graded: None,
+        });
+        let je = query_family_json(&exact, &ov, &empty, false);
+        assert_eq!(
+            je["value_nodes"], 12,
+            "exact family carries value_nodes: {je}"
+        );
+        // Sub-dag channel: the proven shared-computation span per location.
+        let mut sub = fam(1, 2, &[Some("c"), Some("d")]);
+        sub.locations[0].shared_subdag = Some((10, 14));
+        let js = query_family_json(&sub, &ov, &empty, false);
+        assert_eq!(
+            js["locations"][0]["shared_subdag"],
+            serde_json::json!([10, 14]),
+            "location carries the proven shared-subdag span: {js}"
         );
     }
 

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1848,8 +1848,8 @@ fn proposal_shows_shared_skeleton_and_parameters() {
         "should report parameters: {out}"
     );
     assert!(
-        out.contains("⟨param 1⟩"),
-        "should show a parameter placeholder: {out}"
+        out.contains("⟨param 1:"),
+        "should show a parameter placeholder with a value-class hint: {out}"
     );
     let _ = fs::remove_dir_all(&dir);
 }
@@ -1885,8 +1885,8 @@ fn proposal_aligns_across_all_copies() {
         "proposal must align across all 3 copies: {out}"
     );
     assert!(
-        out.contains("⟨param 1⟩"),
-        "the varying operator line is a parameter: {out}"
+        out.contains("⟨param 1:"),
+        "the varying operator line is a parameter (with a class hint): {out}"
     );
     let _ = fs::remove_dir_all(&dir);
 }

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -62,11 +62,12 @@ value, approximate}` — code that reimplements an existing helper; the action i
 | `same_symbol` | every copy is the same named symbol (the parallel-variant signal) |
 | `existing_helper` | (only for `call-existing-helper`) the member to call — `{name, file, start, end}`; the inline copies recompute it, so the fix is "call it", not a fresh extraction |
 | `spotclass` | (only on enriched near families) `leaf-only` (varying spots are clean value-leaves) \| `structural` (a shape/arity/referent divergence — genuine logic difference). Omitted unless the query filters/groups by `spotclass` (the graded-witness enrichment runs on demand) |
+| `value_nodes` | (exact families) the size of the shared value multiset proven identical — *how much* is proven, not just that it is |
 | `folds` | count of overlapping slice families folded under this one |
 | `subsumes` | (in the `family` view) the `id=` handles of the slice families this one subsumes — open any to inspect |
 | `subsumed_by` | (in the `family` view) the `id=` handle of the fuller overlapping family this one is a slice of |
-| `locations[]` | every copy: `{file, start, end, name, lang}`; the `existing_helper` member also carries `role: "existing-helper"` |
-| `skeleton` | (only with `full`) the all-copies extraction-skeleton lines, `⟨param N⟩` for varying spots |
+| `locations[]` | every copy: `{file, start, end, name, lang}`; the `existing_helper` member also carries `role: "existing-helper"`; a sub-dag clone's member carries `shared_subdag: [start, end]` — where the proven shared computation lives at that site |
+| `skeleton` | (only with `full`) the all-copies extraction-skeleton lines, each varying spot a `⟨param N: class⟩` placeholder (`class` = `literal`/`name`/`call`/`expr`/`block` — a coarse value-class hint for the helper signature) |
 
 Evidence, never a verdict: there is no `worth_it`/`confidence` field — the worthy-vs-parallel
 judgment is the caller's ([design §2](design.md)). See the [agent-recipe](agent-recipe.md) for

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -236,7 +236,7 @@ nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE | reinvented
 | `reinvented` | the **reinvented-helper** view: code that reimplements an existing helper inline (the action is "call it"). Complements `shape=call-existing-helper` (those are the cases the family clusterer caught; these are the ones it did not) |
 | `sort=KEY` | `extractability` (default), `value`, or `members` |
 | `top=N` | show the first N rows (default 30) |
-| `full` | on `id=` or a list, render the all-copies extraction skeletons inline (batched) |
+| `full` | on `id=` or a list, render the all-copies extraction skeletons inline (batched); each varying spot is `⟨param N: class⟩` — a coarse value-class hint (`literal`/`name`/`call`/`expr`/`block`) for the helper signature |
 | `all` | widen past the curated default surface to the full raw universe (demoted families labeled) |
 
 Fields: `scope` (prod\|test\|mixed), `witness` (exact\|subdag\|copy-paste\|similar),


### PR DESCRIPTION
**Category 3** (final) of the query-improvement plan — make each family decision-complete so the agent acts in one turn instead of opening it and reading source. Both additions build on data nose already computes; evidence-not-verdict (no `worth_it`/`confidence`).

## What's in
- **Skeleton signature hints (#374 item 6).** Each `full` skeleton placeholder carries a coarse value-class — `⟨param N: literal|name|call|expr|block⟩` — classified from the hole's varying text, so the agent can size the helper signature (a `literal` → value param, a `call` → maybe a closure, a `block` → large/divergent) without diffing copies. A hint, not a codemod — nose stays a finder. (Line-granularity, so it's coarse; documented as such.)
- **Proof depth.** The family object surfaces *how strong / where* the proof is, for the proven channels: `value_nodes` (the shared value-multiset size an **exact** family proves identical) and per-location `shared_subdag` spans (where a **sub-dag** clone's proven shared computation lives at each site). Lets a caller act now on the strongest evidence.

## Tests
- Unit: `classify_param_hints_value_class`, `query_family_json_carries_proof_depth` (value_nodes on exact, shared_subdag per location).
- The two `⟨param 1⟩` proposal assertions updated to the `⟨param 1:` class form.
- Local preflight green: fmt, clippy `-D warnings`, full tests, awiki.

## Docs
usage grammar (`full`), query-json family object (`value_nodes`, `shared_subdag`, skeleton class), CHANGELOG `[Unreleased]`.

**Final PR of the 3-PR sequence** (object model #383 → expressiveness #384 → decision completeness). Next: the design of **4 (temporality)** and **5 (diff-scope / review unification)** through the capabilities lens, as requested. Still **0.9.1** — release held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)