### PR TITLE
query temporality: since=<snapshot> + status field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ deprecated.** All changes below are staged; the release is not yet cut.
     signature (#374 item 6), and the family object carries proof depth — `value_nodes` (the
     shared value-multiset size an exact family proves identical) and per-location
     `shared_subdag` spans (where a sub-dag clone's proven shared computation lives).
+  - **Temporality — query the loop, not a snapshot:** `since=<baseline>` exposes each family's
+    `status` (`new`/`changed`/`unchanged`) against a saved snapshot as a queryable field —
+    `status=new` filter, `group=status` facet, `status` in JSON. Unlike `--baseline` (which
+    hides accepted families for the gate), `since=` hides nothing; `since=B status=new
+    --fail-on any` is the composable equivalent of `--baseline B --fail-on new`.
 
 ### Changed (breaking)
 - **`nose scan` is deprecated** in favour of `nose query`. It still works (an interactive run

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3752,6 +3752,9 @@ struct Query {
     /// The `reinvented` view — code that reimplements an existing helper (the `reinvented`
     /// channel, surfaced in query), distinct from `shape=call-existing-helper` families.
     reinvented: bool,
+    /// `since=<baseline>` — compare the dataset to a saved snapshot and expose each family's
+    /// `status` (new/changed/unchanged) as a queryable field (temporal lens, not a gate).
+    since: Option<String>,
 }
 
 enum QOp {
@@ -3783,6 +3786,7 @@ const STR_FIELDS: &[&str] = &[
     "extraction_shape",
     "same_symbol",
     "spotclass",
+    "status",
 ];
 /// Numeric filter fields (also the only ones that accept `>`/`<`).
 const NUM_FIELDS: &[&str] = &[
@@ -3881,6 +3885,8 @@ fn parse_query(terms: &[String]) -> Result<Query> {
             q.id = Some(v.to_string());
         } else if let Some(v) = t.strip_prefix("at=") {
             q.at = Some(v.to_string());
+        } else if let Some(v) = t.strip_prefix("since=") {
+            q.since = Some(v.to_string());
         } else if let Some(v) = t.strip_prefix("sort=") {
             q.sort = Some(parse_sort_key(v).ok_or_else(|| {
                 anyhow::anyhow!("unknown sort key `{v}` (extractability|value|sites|hazard)")
@@ -3943,6 +3949,7 @@ fn validate_filter_values(flt: &QFilter) -> Result<()> {
         ]),
         "same_symbol" => Some(&["true", "false"]),
         "spotclass" => Some(&["leaf-only", "structural"]),
+        "status" => Some(&["new", "changed", "unchanged"]),
         _ => None,
     };
     let Some(vals) = valid else { return Ok(()) };
@@ -4067,10 +4074,16 @@ fn family_num(f: &nose_detect::RefactorFamily, field: &str) -> Option<f64> {
 }
 
 /// Whether a family satisfies one filter.
-fn family_matches(f: &nose_detect::RefactorFamily, ov: &SurfaceOverrides, flt: &QFilter) -> bool {
+fn family_matches(
+    f: &nose_detect::RefactorFamily,
+    ov: &SurfaceOverrides,
+    flt: &QFilter,
+    since: Option<&BaselineComparison>,
+) -> bool {
     let field = flt.field.as_str();
     // The family's value for string fields, computed once. `None` (e.g. `spotclass` on an
-    // unenriched/non-near family) deliberately matches nothing rather than erroring.
+    // unenriched/non-near family, or `status` without `since=`) deliberately matches nothing
+    // rather than erroring.
     let fval: Option<String> = match field {
         "scope" => Some(f.scope.to_string()),
         "witness" => Some(witness_token(f.witness.as_ref().map(|w| w.kind)).to_string()),
@@ -4079,6 +4092,7 @@ fn family_matches(f: &nose_detect::RefactorFamily, ov: &SurfaceOverrides, flt: &
         "dir" => Some(family_dir(f)),
         "same_symbol" => Some(family_same_symbol(f).to_string()),
         "spotclass" => family_spotclass(f).map(str::to_string),
+        "status" => since.map(|c| family_status(f, c).to_string()),
         _ => None,
     };
     let path_has = |val: &str| f.locations.iter().any(|l| l.file.contains(val));
@@ -4176,6 +4190,7 @@ fn query_family_json(
     ov: &SurfaceOverrides,
     opp: &OpportunityGroups,
     full: bool,
+    since: Option<&BaselineComparison>,
 ) -> serde_json::Value {
     let (shared, params) = all_copies_shared(f);
     let removable = u32::try_from(f.members.saturating_sub(1)).unwrap_or(0) * shared;
@@ -4224,6 +4239,10 @@ fn query_family_json(
     // proven span per location instead). Evidence, not a verdict.
     if let Some(n) = f.witness.as_ref().and_then(|w| w.value_nodes) {
         obj["value_nodes"] = serde_json::Value::from(n);
+    }
+    // Temporal status against a `since=` snapshot (new/changed/unchanged), when one was given.
+    if let Some(cmp) = since {
+        obj["status"] = serde_json::Value::from(family_status(f, cmp));
     }
     // Fold-graph navigation: the actual related family ids, not just a count — so a caller can
     // jump to the fuller overlapping family or open the slices it subsumes (HATEOAS).
@@ -4309,6 +4328,7 @@ fn query_selection<'a>(
     opp: &OpportunityGroups,
     q: &Query,
     path_arg: &str,
+    since: Option<&BaselineComparison>,
 ) -> Result<Vec<&'a nose_detect::RefactorFamily>> {
     if let Some(at) = &q.at {
         let idv = baseline::family_id(family_at(families, at, path_arg)?);
@@ -4329,7 +4349,9 @@ fn query_selection<'a>(
         .filter(|f| {
             (widen || is_default_surface(f, ov))
                 && !opp.is_slice(f)
-                && q.filters.iter().all(|flt| family_matches(f, ov, flt))
+                && q.filters
+                    .iter()
+                    .all(|flt| family_matches(f, ov, flt, since))
         })
         .collect())
 }
@@ -4412,6 +4434,19 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
     if needs_spotclass {
         enrich_graded_witnesses(&mut dataset.families, &dataset.opts);
     }
+    // `since=<snapshot>` annotates each family with a temporal `status` (new/changed/unchanged)
+    // — an exploration lens over the baseline machinery, not a gate (it hides nothing). The
+    // `status` field is unresolvable without it, so reject the combination loudly.
+    let uses_status =
+        q.group.as_deref() == Some("status") || q.filters.iter().any(|flt| flt.field == "status");
+    if uses_status && q.since.is_none() {
+        anyhow::bail!("`status` needs a snapshot — add `since=<baseline-file>` (write one with `--write-baseline`)");
+    }
+    let since_cmp = match &q.since {
+        Some(p) => Some(compare_since(p, &dataset.families)?),
+        None => None,
+    };
+    let since = since_cmp.as_ref();
     if let Some(sk) = q.sort {
         dataset.families.sort_by(|a, b| {
             sk.score(b)
@@ -4433,7 +4468,8 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
         // ignore dashboard/group navigation and just render the family set the query selects,
         // reusing scan's own formatters (#374 + scan parity).
         ReportFormat::Markdown | ReportFormat::Sarif => {
-            let selected = query_selection(&dataset.families, &overrides, &opp, &q, &path_arg)?;
+            let selected =
+                query_selection(&dataset.families, &overrides, &opp, &q, &path_arg, since)?;
             let top = q.top.unwrap_or(30);
             let shown: Vec<&nose_detect::RefactorFamily> =
                 selected.iter().take(top).copied().collect();
@@ -4473,6 +4509,7 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
                     &path_arg,
                     reinvented_prod,
                     json,
+                    since,
                 );
             } else if let Some(at) = &q.at {
                 // `at=file:line` → the family whose member span covers that location (stable
@@ -4486,6 +4523,7 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
                     q.id_full,
                     &path_arg,
                     json,
+                    since,
                 );
             } else if let Some(idv) = &q.id {
                 render_query_family(
@@ -4496,18 +4534,20 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
                     q.id_full,
                     &path_arg,
                     json,
+                    since,
                 );
             } else {
                 // Default to the curated default surface (the same families the dashboard
                 // counts and `scan` trusts); `all` or an explicit `surface=` filter widens to
                 // the raw universe.
                 let widen = q.all || q.filters.iter().any(|flt| flt.field == "surface");
-                let sel = query_selection(&dataset.families, &overrides, &opp, &q, &path_arg)?;
+                let sel =
+                    query_selection(&dataset.families, &overrides, &opp, &q, &path_arg, since)?;
                 match &q.group {
-                    Some(field) => render_query_group(&sel, field, &terms, &path_arg, json),
+                    Some(field) => render_query_group(&sel, field, &terms, &path_arg, json, since),
                     None => {
                         render_query_list(
-                            &sel, &overrides, &opp, &q, &terms, &path_arg, widen, json,
+                            &sel, &overrides, &opp, &q, &terms, &path_arg, widen, json, since,
                         );
                     }
                 }
@@ -4542,6 +4582,7 @@ fn render_query_dashboard(
     path: &str,
     reinvented_prod: usize,
     json: bool,
+    since: Option<&BaselineComparison>,
 ) {
     // Default surface, slice-folds removed (shown under their primary) — matches scan.
     let mut def: Vec<&nose_detect::RefactorFamily> = families
@@ -4564,7 +4605,7 @@ fn render_query_dashboard(
         let top: Vec<_> = def
             .iter()
             .take(5)
-            .map(|f| query_family_json(f, ov, opp, false))
+            .map(|f| query_family_json(f, ov, opp, false, since))
             .collect();
         println!(
             "{}",
@@ -4784,6 +4825,7 @@ fn render_query_list(
     path: &str,
     widen: bool,
     json: bool,
+    since: Option<&BaselineComparison>,
 ) {
     let top = q.top.unwrap_or(30);
     let shown = sel.len().min(top);
@@ -4791,7 +4833,7 @@ fn render_query_list(
         let fams: Vec<_> = sel
             .iter()
             .take(top)
-            .map(|f| query_family_json(f, ov, opp, q.id_full))
+            .map(|f| query_family_json(f, ov, opp, q.id_full, since))
             .collect();
         println!(
             "{}",
@@ -4831,8 +4873,14 @@ fn render_query_list(
             Some(s) if !s.is_empty() => format!("\n       ↳ +{} overlapping slice folds", s.len()),
             _ => String::new(),
         };
+        // With `since=`, tag the actionable changes (new/changed) so the diff against the
+        // snapshot is visible inline; unchanged families stay untagged (the common case).
+        let status = match since.map(|c| family_status(f, c)) {
+            Some(s @ ("new" | "changed")) => format!(" [{s}]"),
+            _ => String::new(),
+        };
         println!(
-            "  {}{surf}   nose query {path} id={}{fold}",
+            "  {}{surf}{status}   nose query {path} id={}{fold}",
             query_row(f),
             short_id(&baseline::family_id(f))
         );
@@ -4879,6 +4927,7 @@ fn render_query_group(
     terms: &[String],
     path: &str,
     json: bool,
+    since: Option<&BaselineComparison>,
 ) {
     use std::collections::HashMap;
     let key = |f: &nose_detect::RefactorFamily| -> String {
@@ -4899,6 +4948,7 @@ fn render_query_group(
             "shape" | "extraction_shape" => f.extraction_shape().to_string(),
             "same_symbol" => family_same_symbol(f).to_string(),
             "spotclass" => family_spotclass(f).unwrap_or("unwitnessed").to_string(),
+            "status" => since.map_or_else(|| "?".to_string(), |c| family_status(f, c).to_string()),
             _ => "?".to_string(),
         }
     };
@@ -4964,6 +5014,7 @@ fn render_query_group(
 
 /// Open one family: its copies, the extraction hint, the representative-pair diff, and —
 /// with `full` — the all-copies extraction skeleton (#360). Plus navigation links.
+#[allow(clippy::too_many_arguments)] // dataset + view + selection state for one family render
 fn render_query_family(
     families: &[nose_detect::RefactorFamily],
     ov: &SurfaceOverrides,
@@ -4972,6 +5023,7 @@ fn render_query_family(
     full: bool,
     path: &str,
     json: bool,
+    since: Option<&BaselineComparison>,
 ) {
     let Some(f) = families
         .iter()
@@ -5013,7 +5065,7 @@ fn render_query_family(
                 "view": "family",
                 "path": path,
                 "hint": family_hint(f),
-                "family": query_family_json(f, ov, opp, full),
+                "family": query_family_json(f, ov, opp, full, since),
             })
         );
         return;
@@ -5672,6 +5724,31 @@ fn apply_scan_baseline(
     let comparison = BaselineComparison::new(path, &accepted, families);
     families.retain(|f| !accepted.keys.contains(&baseline::family_key(f)));
     Ok(Some(comparison))
+}
+
+/// `since=<baseline>`: compare to a saved snapshot WITHOUT hiding anything — the temporal
+/// exploration lens. Unlike `--baseline` (which drops accepted families for the gate), this
+/// keeps every family and lets the caller slice by the `status` field. `nose query <path>
+/// since=B status=new --fail-on any` is the composable equivalent of `--baseline B --fail-on
+/// new`; the two baseline paths converge as the gate folds into query (the review-unification).
+fn compare_since(
+    path: &str,
+    families: &[nose_detect::RefactorFamily],
+) -> Result<BaselineComparison> {
+    let snapshot = baseline::load(std::path::Path::new(path))?;
+    Ok(BaselineComparison::new(
+        std::path::Path::new(path),
+        &snapshot,
+        families,
+    ))
+}
+
+/// A family's status against a `since=` snapshot: `new`/`changed` (in the comparison) or
+/// `unchanged` (present in the snapshot, so absent from the changed/new map).
+fn family_status(f: &nose_detect::RefactorFamily, cmp: &BaselineComparison) -> &'static str {
+    cmp.statuses
+        .get(&baseline::family_key(f))
+        .map_or("unchanged", BaselineStatus::as_str)
 }
 
 fn partition_ignored(
@@ -7912,7 +7989,7 @@ mod tests {
             declaration_run_ids: std::collections::HashSet::new(),
         };
         // The primary lists the slice ids it subsumes (navigable id= handles).
-        let ja = query_family_json(&a, &ov, &opp, false);
+        let ja = query_family_json(&a, &ov, &opp, false, None);
         assert_eq!(
             ja["subsumes"],
             serde_json::json!([short_id(&baseline::family_id(&b))]),
@@ -7920,7 +7997,7 @@ mod tests {
         );
         assert!(ja.get("subsumed_by").is_none(), "a primary is not subsumed");
         // The slice points back at its primary.
-        let jb = query_family_json(&b, &ov, &opp, false);
+        let jb = query_family_json(&b, &ov, &opp, false, None);
         assert_eq!(
             jb["subsumed_by"],
             serde_json::Value::from(short_id(&baseline::family_id(&a))),
@@ -7955,7 +8032,7 @@ mod tests {
             mean_shape_jaccard: None,
             graded: None,
         });
-        let je = query_family_json(&exact, &ov, &empty, false);
+        let je = query_family_json(&exact, &ov, &empty, false, None);
         assert_eq!(
             je["value_nodes"], 12,
             "exact family carries value_nodes: {je}"
@@ -7963,7 +8040,7 @@ mod tests {
         // Sub-dag channel: the proven shared-computation span per location.
         let mut sub = fam(1, 2, &[Some("c"), Some("d")]);
         sub.locations[0].shared_subdag = Some((10, 14));
-        let js = query_family_json(&sub, &ov, &empty, false);
+        let js = query_family_json(&sub, &ov, &empty, false, None);
         assert_eq!(
             js["locations"][0]["shared_subdag"],
             serde_json::json!([10, 14]),

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -2165,6 +2165,97 @@ fn query_reinvented_view_lists_call_the_helper_findings() {
 }
 
 #[test]
+#[allow(clippy::too_many_lines)] // one end-to-end walk of the since= temporal lens
+fn query_since_status_classifies_against_a_snapshot() {
+    // Family X (3 near copies of `process`, one operator each) exists at snapshot time; a
+    // structurally distinct family Y (3 exact `banner` copies) is added after — so `since=`
+    // grades X unchanged and Y new. (Y must be distinct: a near-identical Y would *merge*
+    // into X, which would correctly read as `changed`, not a second family.)
+    let dir = std::env::temp_dir().join(format!("nose_since_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    for d in ["a", "b", "c", "d", "e", "f"] {
+        fs::create_dir_all(dir.join(d)).unwrap();
+    }
+    let process = |op: &str| {
+        format!(
+            "def process(items):\n    total = 0\n    count = 0\n    best = None\n    for it in items:\n        v = it.value\n        total = total {op} v\n        count = count + 1\n        if best is None or v > best:\n            best = v\n    return total, count, best\n"
+        )
+    };
+    fs::write(dir.join("a/m.py"), process("+")).unwrap();
+    fs::write(dir.join("b/m.py"), process("*")).unwrap();
+    fs::write(dir.join("c/m.py"), process("-")).unwrap();
+    let p = dir.to_str().unwrap();
+    let bl = dir.join("base.json");
+    let bls = bl.to_str().unwrap();
+
+    // Snapshot the current state (only family X).
+    run(&["query", p, "--baseline", bls, "--write-baseline"]);
+
+    // Add a structurally distinct family Y (exact copies) after the snapshot.
+    let banner = "def banner(title):\n    line = \"=\" * 40\n    print(line)\n    print(\"  \" + title)\n    print(line)\n    print(\"done\")\n    return title\n";
+    fs::write(dir.join("d/n.py"), banner).unwrap();
+    fs::write(dir.join("e/n.py"), banner).unwrap();
+    fs::write(dir.join("f/n.py"), banner).unwrap();
+
+    // `status` without `since=` is a hard error (the field is unresolvable).
+    assert!(
+        run_fail(&["query", p, "status=new"]).contains("needs a snapshot"),
+        "status without since= errors"
+    );
+
+    // group=status facets the diff against the snapshot.
+    let grouped = run(&["query", p, &format!("since={bls}"), "group=status"]);
+    assert!(
+        grouped.contains("by status"),
+        "group=status facets the snapshot diff: {grouped}"
+    );
+
+    // status=new keeps the family added after the snapshot; the JSON family carries status.
+    let newj: serde_json::Value = serde_json::from_str(&run(&[
+        "query",
+        p,
+        &format!("since={bls}"),
+        "status=new",
+        "--format",
+        "json",
+    ]))
+    .unwrap();
+    let newfams = newj["families"].as_array().unwrap();
+    assert!(
+        !newfams.is_empty() && newfams.iter().all(|f| f["status"] == "new"),
+        "status=new selects only new families, each tagged: {newj}"
+    );
+    // The new family is Y (the post-snapshot `banner` copy-paste family in d/e/f), not the
+    // snapshotted `process` family (which is the `similar` witness in a/b/c).
+    assert!(
+        newfams.iter().all(|f| f["witness"] == "copy-paste"
+            && f["locations"][0]["file"].as_str().unwrap().contains("/d/")),
+        "the post-snapshot family (Y) is flagged new, not the snapshotted X: {newj}"
+    );
+
+    // status=unchanged keeps the snapshotted family X (`process`, the `similar` witness).
+    let unchanged: serde_json::Value = serde_json::from_str(&run(&[
+        "query",
+        p,
+        &format!("since={bls}"),
+        "status=unchanged",
+        "--format",
+        "json",
+    ]))
+    .unwrap();
+    assert!(
+        unchanged["families"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|f| f["locations"][0]["name"] == "process" && f["status"] == "unchanged"),
+        "the snapshotted family grades unchanged: {unchanged}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn sort_keys_label_the_ranking_and_reject_garbage() {
     let dir = make_project("sort");
     let p = dir.to_str().unwrap();

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -63,6 +63,7 @@ value, approximate}` — code that reimplements an existing helper; the action i
 | `existing_helper` | (only for `call-existing-helper`) the member to call — `{name, file, start, end}`; the inline copies recompute it, so the fix is "call it", not a fresh extraction |
 | `spotclass` | (only on enriched near families) `leaf-only` (varying spots are clean value-leaves) \| `structural` (a shape/arity/referent divergence — genuine logic difference). Omitted unless the query filters/groups by `spotclass` (the graded-witness enrichment runs on demand) |
 | `value_nodes` | (exact families) the size of the shared value multiset proven identical — *how much* is proven, not just that it is |
+| `status` | (only with `since=`) `new` \| `changed` \| `unchanged` against the snapshot — the temporal lens |
 | `folds` | count of overlapping slice families folded under this one |
 | `subsumes` | (in the `family` view) the `id=` handles of the slice families this one subsumes — open any to inspect |
 | `subsumed_by` | (in the `family` view) the `id=` handle of the fuller overlapping family this one is a slice of |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -224,16 +224,17 @@ unchanged. With `--format json` every view emits the structured, versioned
 [query-JSON v2 contract](query-json.md).
 
 ```text
-nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE | reinvented] [sort=KEY] [top=N] [full] [all]
+nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE | reinvented] [since=FILE] [sort=KEY] [top=N] [full] [all]
 ```
 
 | part | meaning |
 |---|---|
 | `field=value` | keep families where the field equals the value (terms AND-ed); `field>N`/`field<N` for numbers; `path~substr` for a path substring; **set OR** with a comma — `witness=exact,subdag` matches either; **negate** with `field!=value` / `path!~substr` (e.g. `path!~frontend` drops a directory; `witness!=exact,subdag` drops both) |
-| `group=FIELD` | facet the selection by a discrete field (`dir`, `file`, `scope`, `witness`, `lang`, `shape`, `same_symbol`, `spotclass`); each bucket carries its family count **and summed removable lines**, ranked by removable — so `group=dir`/`group=file` is the duplication **hotspot** map |
+| `group=FIELD` | facet the selection by a discrete field (`dir`, `file`, `scope`, `witness`, `lang`, `shape`, `same_symbol`, `spotclass`, `status`); each bucket carries its family count **and summed removable lines**, ranked by removable — so `group=dir`/`group=file` is the duplication **hotspot** map |
 | `id=FAM` | open one family (any unambiguous id prefix): its copies, the all-copies extraction skeleton, fold-graph links (`subsumes`/`subsumed_by`), and navigation |
 | `at=FILE:LINE` | open the family whose copy covers that source location — a stable handle across edits (the span-derived `id=` shifts when code moves) |
 | `reinvented` | the **reinvented-helper** view: code that reimplements an existing helper inline (the action is "call it"). Complements `shape=call-existing-helper` (those are the cases the family clusterer caught; these are the ones it did not) |
+| `since=FILE` | compare to a saved snapshot (written with `--baseline FILE --write-baseline`) and expose each family's **`status`** (`new`/`changed`/`unchanged`) as a queryable field — the temporal lens. Hides nothing (unlike `--baseline`); `since=B status=new --fail-on any` is the composable gate |
 | `sort=KEY` | `extractability` (default), `value`, or `members` |
 | `top=N` | show the first N rows (default 30) |
 | `full` | on `id=` or a list, render the all-copies extraction skeletons inline (batched); each varying spot is `⟨param N: class⟩` — a coarse value-class hint (`literal`/`name`/`call`/`expr`/`block`) for the helper signature |
@@ -242,7 +243,8 @@ nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE | reinvented
 Fields: `scope` (prod\|test\|mixed), `witness` (exact\|subdag\|copy-paste\|similar),
 `same_symbol` (true\|false — every copy is the same named symbol, the parallel-variant
 signature), `spotclass` (leaf-only\|structural — for near families, whether the varying spots
-are clean value-leaves to parameterize or genuine logic divergence), `lang`, `path`, `dir`,
+are clean value-leaves to parameterize or genuine logic divergence), `status`
+(new\|changed\|unchanged — vs the `since=` snapshot), `lang`, `path`, `dir`,
 `members`, `files`, `value`, `params`, `shared`. Every row shows the payoff economics —
 `M/REP shared, Pp · ~N removable` — so a candidate can be triaged without opening it. Each
 result is a pure function of (repo state, command); an unknown field or enum value is a hard


### PR DESCRIPTION
**Step 1 of the query/review unification (Axis A — temporality).** `since=<baseline>` makes the dataset diff-valued against a saved snapshot, exposing each family's `status` as a queryable field — the temporal lens the agent's find→fix→re-scan loop needs. [Capabilities over features](https://wiki.g15e.com/pages/Capabilities%20over%20features): this *exposes the existing baseline machinery* (previously gate-only) as a composable dimension, not a parallel feature.

## What's in
- `since=FILE` loads a snapshot (written with `--baseline FILE --write-baseline`) and **annotates — hides nothing**, unlike `--baseline` (which drops accepted families for the gate). `status` ∈ {new, changed, unchanged} is a filter (`status=new`), a facet (`group=status`), and a JSON/human field; composes with set-OR (`status=new,changed`).
- `status` without `since=` is a hard error (unresolvable field).
- The gate composes: `since=B status=new --fail-on any` ≡ `--baseline B --fail-on new`. The two baseline paths converge as the unification proceeds.

## Why this shape
The end state (per your Option-1 choice) is one verb (`query`) with orthogonal composable axes. This is the first axis: temporality. Next: **Axis B `base=`** (git-diff scope), then folding **`nose review`** in behind a measured `propagation` field — at which point `--baseline`/`--fail-on new` and `review` get reconciled/deprecated.

## Tests
`query_since_status_classifies_against_a_snapshot`: snapshot X (`process` near-family); add a structurally distinct Y (`banner` exact copies); assert `group=status`, `status=new` selects Y, `status=unchanged` keeps X, and status-without-since errors. (Notes the merge subtlety: a near-identical Y would fold into X and read as `changed`, not a new family.) Local preflight green: fmt, clippy `-D warnings`, full tests, awiki.

## Docs
usage grammar (`since=`, `status`), query-json family object (`status`), CHANGELOG `[Unreleased]`.

Still **0.9.1** — release held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)