### PR TITLE
query base=<ref>: the divergent-edit (review) view under query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ deprecated.** All changes below are staged; the release is not yet cut.
     `status=new` filter, `group=status` facet, `status` in JSON. Unlike `--baseline` (which
     hides accepted families for the gate), `since=` hides nothing; `since=B status=new
     --fail-on any` is the composable equivalent of `--baseline B --fail-on new`.
-
-### Changed (breaking)
+  - **Divergent-edit view — `base=<git-ref>`:** the [`nose review`](docs/review.md) pipeline
+    surfaced under query. Detects families at the ref and flags the ones a diff changed in one
+    copy but not its siblings (a likely un-propagated fix), each item carrying `fire_eligible`
+    (the §BV proven-shared-logic verdict); `base=REF --fail-on any` is the CI gate, firing only
+    on the proven case. Reuses review's detection verbatim, so the fire precision is identical
+    — the first step of folding `review` into `query` (deprecation to follow once at parity).
 - **`nose scan` is deprecated** in favour of `nose query`. It still works (an interactive run
   prints a one-line nudge); `capabilities` moves it from `commands.stable` to
   `commands.deprecated`; docs lead with `query`. Removal is slated for a later release.

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3755,6 +3755,10 @@ struct Query {
     /// `since=<baseline>` — compare the dataset to a saved snapshot and expose each family's
     /// `status` (new/changed/unchanged) as a queryable field (temporal lens, not a gate).
     since: Option<String>,
+    /// `base=<git-ref>` — the divergent-edit view: detect families at that ref and flag the
+    /// ones a diff changed in one copy but not its siblings (the `nose review` pipeline,
+    /// surfaced in query). A distinct entity (a divergence), so it's its own view.
+    base: Option<String>,
 }
 
 enum QOp {
@@ -3887,6 +3891,8 @@ fn parse_query(terms: &[String]) -> Result<Query> {
             q.at = Some(v.to_string());
         } else if let Some(v) = t.strip_prefix("since=") {
             q.since = Some(v.to_string());
+        } else if let Some(v) = t.strip_prefix("base=") {
+            q.base = Some(v.to_string());
         } else if let Some(v) = t.strip_prefix("sort=") {
             q.sort = Some(parse_sort_key(v).ok_or_else(|| {
                 anyhow::anyhow!("unknown sort key `{v}` (extractability|value|sites|hazard)")
@@ -4356,6 +4362,124 @@ fn query_selection<'a>(
         .collect())
 }
 
+/// The `base=<git-ref>` view: divergent edits (a clone changed in one copy but not its
+/// siblings) detected at the ref by the `nose review` pipeline, surfaced under query. Reuses
+/// review's detection verbatim — so the §BV fire precision is preserved by construction — and
+/// gates with the same conservative shared-logic policy.
+fn run_query_base(args: &ScanArgs, base_ref: &str, q: &Query, path_arg: &str) -> Result<()> {
+    // `base=` gates on a diff against a ref, not a saved baseline — `--fail-on new` (which
+    // needs `--baseline`) is meaningless here.
+    if matches!(args.fail_on, Some(FailOn::New)) {
+        anyhow::bail!(
+            "`base=` gates on a diff, not a baseline — use `--fail-on any` (fires on a proven divergence)"
+        );
+    }
+    let review_args = review::ReviewArgs {
+        paths: args.paths.clone(),
+        base: base_ref.to_string(),
+        mode: args.mode.clone(),
+        min_size: args.min_size,
+        min_lines: args.min_lines,
+        exclude: args.exclude.clone(),
+        config: args.config.clone(),
+        ignore_file: args.ignore_file.clone(),
+        format: args.format,
+        top: q.top,
+        fail: false,
+        fail_on: review::ReviewFailOn::default(),
+    };
+    let (flagged, changed_files) = review::detect_divergences(&review_args)?.unwrap_or_default();
+    let json = matches!(args.format, ReportFormat::Json);
+    render_query_base(&flagged, changed_files, base_ref, path_arg, q.top, json);
+    // The gate fires on the §BV conservative policy (a proven shared-logic divergence) — the
+    // only sane CI default — reused verbatim from review so the fire decision is identical.
+    if matches!(args.fail_on, Some(FailOn::Any))
+        && review::divergences_fire(&flagged, review::ReviewFailOn::SharedLogic)
+    {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Render the `base=` divergence view: query's v2 envelope around review's shared finding
+/// JSON, or a concise human report keyed on which copy changed and whether the edit touched
+/// shared logic (the propagation hazard).
+fn render_query_base(
+    flagged: &[review::Divergence],
+    changed_files: usize,
+    base_ref: &str,
+    path: &str,
+    top: Option<usize>,
+    json: bool,
+) {
+    let limit = top.unwrap_or(30);
+    let fire_eligible = flagged.iter().filter(|d| d.fire_eligible).count();
+    if json {
+        let items: Vec<_> = review::divergence_items_json(flagged)
+            .into_iter()
+            .take(limit)
+            .collect();
+        println!(
+            "{}",
+            serde_json::json!({
+                "schema_version": QUERY_JSON_SCHEMA_VERSION,
+                "tool": "nose",
+                "view": "base",
+                "path": path,
+                "base": base_ref,
+                "summary": {
+                    "changed_files": changed_files,
+                    "divergences": flagged.len(),
+                    "fire_eligible": fire_eligible,
+                },
+                "items": items,
+                "next": [format!("nose query {path} base={base_ref} --fail-on any")],
+            })
+        );
+        return;
+    }
+    if flagged.is_empty() {
+        println!("no divergent edits vs `{base_ref}` ({changed_files} files changed).");
+        return;
+    }
+    println!(
+        "{} divergent {} vs `{base_ref}` ({changed_files} files changed; {fire_eligible} touch shared logic):",
+        flagged.len(),
+        if flagged.len() == 1 { "family" } else { "families" },
+    );
+    let site = |s: &review::Site| {
+        let name = s
+            .name
+            .as_deref()
+            .map(|n| format!("  {n}"))
+            .unwrap_or_default();
+        format!("{}:{}-{}{name}", s.file, s.start_line, s.end_line)
+    };
+    for d in flagged.iter().take(limit) {
+        let propagation = if d.fire_eligible {
+            "shared-logic (likely missed propagation)"
+        } else {
+            "span-only (edit stayed in the varying spots)"
+        };
+        println!(
+            "  {}  {} · {} · {propagation}",
+            short_id(&d.family_id),
+            witness_token(d.witness_kind),
+            d.scope,
+        );
+        for s in &d.changed {
+            println!("    changed:      {}", site(s));
+        }
+        for s in &d.not_updated {
+            println!("    not updated:  {}", site(s));
+        }
+    }
+    println!("\nnext:");
+    println!(
+        "  nose query {path} base={base_ref} --fail-on any   # fail CI on a proven divergence"
+    );
+}
+
 #[allow(clippy::too_many_lines)] // a flat command dispatcher: dashboard / at= / id= / group / list
 fn run_query_cmd(cmd: Cmd) -> Result<()> {
     let Cmd::Query {
@@ -4410,6 +4534,11 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
         anyhow::bail!(
             "--fail-on new requires --baseline (it gates on families new vs the baseline)"
         );
+    }
+    // `base=<git-ref>` is the divergent-edit view (the `nose review` pipeline): it detects at
+    // the ref, not the working tree, so it short-circuits the working-tree dataset entirely.
+    if let Some(base_ref) = &q.base {
+        return run_query_base(&args, base_ref, &q, &path_arg);
     }
     let refs = paths_as_refs(&args.paths);
     let mut dataset = build_scan_dataset(&args, &refs)?;

--- a/crates/nose-cli/src/review.rs
+++ b/crates/nose-cli/src/review.rs
@@ -50,72 +50,70 @@ pub(crate) enum ReviewFailOn {
 }
 
 /// A flagged family: a clone whose copies were edited apart in this change set. Locations
-/// are repo-relative (the report navigates the real working tree).
-struct Divergence {
-    family_id: String,
-    similarity: f64,
-    hazard: f64,
-    review_priority: u8,
-    complexity: usize,
+/// are repo-relative (the report navigates the real working tree). `pub(crate)` so the
+/// `nose query <paths> base=<ref>` view renders the same findings (the review/query
+/// unification): query reuses this exact detection, preserving §BV fire precision.
+pub(crate) struct Divergence {
+    pub(crate) family_id: String,
+    pub(crate) similarity: f64,
+    pub(crate) hazard: f64,
+    pub(crate) review_priority: u8,
+    pub(crate) complexity: usize,
     /// Family scope: `prod` / `test` / `mixed` (test scaffolding fires differently).
-    scope: &'static str,
+    pub(crate) scope: &'static str,
     /// The family's equivalence-witness kind (`exact-value-graph`,
     /// `copy-paste-run`, `shared-sub-dag`, `structural-similarity`).
-    witness_kind: Option<&'static str>,
+    pub(crate) witness_kind: Option<&'static str>,
     /// The #245 conservative gate verdict: some changed member PROVABLY touches
     /// lines it shares with an un-updated sibling. `--fail` fires only on these;
     /// `--fail-on any` restores span-overlap firing.
-    fire_eligible: bool,
+    pub(crate) fire_eligible: bool,
     /// The near family's graded equivalence witness (#315), when present — evidence
     /// for the consumer to judge a fire: a clean `equal_modulo_holes` family is a
     /// strong missed-propagation candidate, while `referent_mismatches` /
     /// `decorator-differs` mark a family whose copies are not really the same logic
     /// (a likely false fire). It does NOT gate `fire_eligible` (that would risk
     /// dropping a genuine shared-body propagation).
-    graded: Option<nose_detect::GradedWitness>,
+    pub(crate) graded: Option<nose_detect::GradedWitness>,
     /// Members whose base span was changed by the diff (the edit landed here).
-    changed: Vec<Site>,
+    pub(crate) changed: Vec<Site>,
     /// Sibling members the change did *not* touch (where it may be missing).
-    not_updated: Vec<Site>,
+    pub(crate) not_updated: Vec<Site>,
 }
 
 #[derive(Clone)]
-struct Site {
-    file: String,
-    name: Option<String>,
-    start_line: u32,
-    end_line: u32,
-    lang: String,
-    kind: nose_il::UnitKind,
-    span_lines: u32,
-    span_tokens: usize,
-    is_fragment: bool,
-    fragment_kind: Option<FragmentKind>,
-    reason_code: Option<&'static str>,
-    enclosing_unit: Option<EnclosingUnit>,
+pub(crate) struct Site {
+    pub(crate) file: String,
+    pub(crate) name: Option<String>,
+    pub(crate) start_line: u32,
+    pub(crate) end_line: u32,
+    pub(crate) lang: String,
+    pub(crate) kind: nose_il::UnitKind,
+    pub(crate) span_lines: u32,
+    pub(crate) span_tokens: usize,
+    pub(crate) is_fragment: bool,
+    pub(crate) fragment_kind: Option<FragmentKind>,
+    pub(crate) reason_code: Option<&'static str>,
+    pub(crate) enclosing_unit: Option<EnclosingUnit>,
     /// For CHANGED sites: does the diff touch lines this member shares with an
     /// un-updated sibling? `Some(false)` = the edit stayed inside this member's
     /// varying spots; `None` = unprovable (unreadable source / capped diff) or a
     /// not-updated site.
-    touches_shared: Option<bool>,
+    pub(crate) touches_shared: Option<bool>,
 }
 
-pub(crate) fn cmd_review(args: ReviewArgs) -> Result<()> {
+/// The detection half of `review`, split out so the `nose query base=<ref>` view reuses it
+/// verbatim (the unification). Returns the flagged divergences plus how many files changed;
+/// `None` when there is nothing to review (an adds-only / empty diff). The temporary base
+/// worktree is created and torn down inside — the returned `Divergence`s own their data.
+pub(crate) fn detect_divergences(args: &ReviewArgs) -> Result<Option<(Vec<Divergence>, usize)>> {
     let root = git_repo_root().context(
-        "nose review needs a git repository — it compares the working tree to a git ref",
+        "nose needs a git repository to compare the working tree to a git ref (`base=`/`--base`)",
     )?;
     let changed = git_changed_ranges(&root, &args.base, &args.paths)?;
     if changed.is_empty() {
-        // Nothing reviewable (e.g. an adds-only diff), but the machine formats
-        // must still emit their contract — a JSON consumer parses stdout.
-        match args.format {
-            ReportFormat::Json => println!("{}", review_json(&[], &args.base, 0)?),
-            ReportFormat::Sarif => println!("{}", review_sarif(&[])?),
-            _ => println!("no changes vs `{}` — nothing to review.", args.base),
-        }
-        return Ok(());
+        return Ok(None);
     }
-
     // Detect clone families at the base, where every copy is still intact. A temporary
     // worktree gives the base tree on disk without disturbing the user's working tree.
     let base_tree = BaseWorktree::create(&root, &args.base)?;
@@ -128,7 +126,7 @@ pub(crate) fn cmd_review(args: ReviewArgs) -> Result<()> {
     let families = crate::detect_families(
         &base_paths,
         &exclude,
-        args.mode,
+        args.mode.clone(),
         cfg.mode,
         min_tokens,
         min_lines,
@@ -159,22 +157,37 @@ pub(crate) fn cmd_review(args: ReviewArgs) -> Result<()> {
 
     // base_tree is removed by Drop after we finish reading families.
     drop(base_tree);
+    Ok(Some((flagged, changed.len())))
+}
 
-    let changed_files = changed.len();
+/// Whether a flagged set fires the gate under the given policy — shared by `review --fail`
+/// and `query base=<ref> --fail-on` so both gate identically.
+pub(crate) fn divergences_fire(flagged: &[Divergence], fail_on: ReviewFailOn) -> bool {
+    match fail_on {
+        ReviewFailOn::SharedLogic => flagged.iter().any(|d| d.fire_eligible),
+        ReviewFailOn::Any => !flagged.is_empty(),
+    }
+}
+
+pub(crate) fn cmd_review(args: ReviewArgs) -> Result<()> {
+    let Some((flagged, changed_files)) = detect_divergences(&args)? else {
+        // Nothing reviewable (e.g. an adds-only diff), but the machine formats
+        // must still emit their contract — a JSON consumer parses stdout.
+        match args.format {
+            ReportFormat::Json => println!("{}", review_json(&[], &args.base, 0)?),
+            ReportFormat::Sarif => println!("{}", review_sarif(&[])?),
+            _ => println!("no changes vs `{}` — nothing to review.", args.base),
+        }
+        return Ok(());
+    };
     match args.format {
         ReportFormat::Json => println!("{}", review_json(&flagged, &args.base, changed_files)?),
         ReportFormat::Sarif => println!("{}", review_sarif(&flagged)?),
         _ => print_review_human(&flagged, &args.base, changed_files, args.top.unwrap_or(30)),
     }
 
-    if args.fail {
-        let fires = match args.fail_on {
-            ReviewFailOn::SharedLogic => flagged.iter().any(|d| d.fire_eligible),
-            ReviewFailOn::Any => !flagged.is_empty(),
-        };
-        if fires {
-            std::process::exit(1);
-        }
+    if args.fail && divergences_fire(&flagged, args.fail_on) {
+        std::process::exit(1);
     }
     Ok(())
 }
@@ -697,7 +710,10 @@ fn print_review_human(flagged: &[Divergence], base: &str, changed_files: usize, 
     }
 }
 
-fn review_json(flagged: &[Divergence], base: &str, changed_files: usize) -> Result<String> {
+/// The flagged divergences as JSON objects — shared by `review --format json` and the
+/// `nose query base=<ref>` view, so the two serialize each finding identically (one contract,
+/// reachable from either surface during the unification).
+pub(crate) fn divergence_items_json(flagged: &[Divergence]) -> Vec<serde_json::Value> {
     use serde_json::json;
     let site = |s: &Site| {
         json!({
@@ -713,7 +729,7 @@ fn review_json(flagged: &[Divergence], base: &str, changed_files: usize) -> Resu
             "touches_shared": s.touches_shared,
         })
     };
-    let items: Vec<_> = flagged
+    flagged
         .iter()
         .map(|d| {
             json!({
@@ -728,14 +744,18 @@ fn review_json(flagged: &[Divergence], base: &str, changed_files: usize) -> Resu
                 "not_updated": d.not_updated.iter().map(&site).collect::<Vec<_>>(),
             })
         })
-        .collect();
+        .collect()
+}
+
+fn review_json(flagged: &[Divergence], base: &str, changed_files: usize) -> Result<String> {
+    use serde_json::json;
     Ok(serde_json::to_string_pretty(&json!({
         "schema_version": 1,
         "tool_version": env!("CARGO_PKG_VERSION"),
         "base": base,
         "changed_files": changed_files,
         "inconsistent_families": flagged.len(),
-        "findings": items,
+        "findings": divergence_items_json(flagged),
     }))?)
 }
 

--- a/crates/nose-cli/tests/cli/review.rs
+++ b/crates/nose-cli/tests/cli/review.rs
@@ -42,6 +42,68 @@ fn nose_review(dir: &Path, extra: &[&str]) -> std::process::Output {
         .expect("run nose review")
 }
 
+fn nose_query_in(dir: &Path, extra: &[&str]) -> std::process::Output {
+    let mut args = vec!["query", "."];
+    args.extend_from_slice(extra);
+    Command::new(bin())
+        .current_dir(dir)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .env_remove("GIT_COMMON_DIR")
+        .args(&args)
+        .output()
+        .expect("run nose query")
+}
+
+#[test]
+fn query_base_flags_divergent_edits_like_review() {
+    // `nose query . base=<ref>` is the review pipeline surfaced under query: detect at the
+    // ref, flag a clone changed in one copy but not its siblings, gate on the proven case.
+    let dir = make_project("query_base");
+    init_git_repo(&dir);
+    let a = dir.join("a/f.py");
+    let src = fs::read_to_string(&a).unwrap();
+    fs::write(
+        &a,
+        src.replace(
+            "    return total",
+            "    total = total + 1\n    return total",
+        ),
+    )
+    .unwrap();
+
+    let out = nose_query_in(&dir, &["base=main", "--min-size", "8"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("divergent") && stdout.contains("a/f.py") && stdout.contains("b/f.py"),
+        "base= names the changed copy and the un-updated sibling: {stdout}"
+    );
+
+    let jout = nose_query_in(&dir, &["base=main", "--min-size", "8", "--format", "json"]);
+    let j: serde_json::Value = serde_json::from_slice(&jout.stdout).unwrap();
+    assert_eq!(j["view"], "base", "v2 envelope, base view: {j}");
+    assert_eq!(j["base"], "main");
+    assert!(
+        j["summary"]["divergences"].as_u64().unwrap() >= 1,
+        "at least one divergence: {j}"
+    );
+    assert!(
+        j["items"][0]["fire_eligible"].is_boolean(),
+        "items carry the §BV fire verdict: {j}"
+    );
+
+    // `--fail-on any` over base= fires on the conservative (shared-logic) policy.
+    let gated = nose_query_in(&dir, &["base=main", "--min-size", "8", "--fail-on", "any"]);
+    assert!(
+        !gated.status.success(),
+        "base= --fail-on any exits non-zero on a proven divergence"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn review_flags_a_clone_changed_in_one_copy_only() {
     let dir = make_project("review_flag");

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -43,6 +43,13 @@ object; with `full`, that object carries `skeleton`.
 `{helper {name,file,start,end}, site {file,container,container_start,container_end,start,end},
 value, approximate}` — code that reimplements an existing helper; the action is "call it".
 
+**`base`** (`base=<git-ref>`) — the divergent-edit view (the [`nose review`](review.md)
+pipeline). `base` (the ref), `summary` (`changed_files`, `divergences`, `fire_eligible`), and
+`items[]` of `{family_id, similarity, scope, witness_kind, fire_eligible, graded, changed[],
+not_updated[]}` — each `changed`/`not_updated` site carries `{file, name, start_line, end_line,
+…, touches_shared}`. `fire_eligible` is the §BV proven-shared-logic verdict the gate fires on.
+This is the same per-finding shape as `review --format json`.
+
 ## The family object
 
 | field | meaning |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -224,7 +224,7 @@ unchanged. With `--format json` every view emits the structured, versioned
 [query-JSON v2 contract](query-json.md).
 
 ```text
-nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE | reinvented] [since=FILE] [sort=KEY] [top=N] [full] [all]
+nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE | reinvented | base=REF] [since=FILE] [sort=KEY] [top=N] [full] [all]
 ```
 
 | part | meaning |
@@ -234,6 +234,7 @@ nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE | reinvented
 | `id=FAM` | open one family (any unambiguous id prefix): its copies, the all-copies extraction skeleton, fold-graph links (`subsumes`/`subsumed_by`), and navigation |
 | `at=FILE:LINE` | open the family whose copy covers that source location — a stable handle across edits (the span-derived `id=` shifts when code moves) |
 | `reinvented` | the **reinvented-helper** view: code that reimplements an existing helper inline (the action is "call it"). Complements `shape=call-existing-helper` (those are the cases the family clusterer caught; these are the ones it did not) |
+| `base=REF` | the **divergent-edit** view (the [`nose review`](review.md) pipeline, surfaced in query): detect families at the git ref, flag the ones a diff changed in one copy but not its siblings — a likely un-propagated fix. Each item carries `fire_eligible` (the §BV proven-shared-logic verdict); `base=REF --fail-on any` is the CI gate (fires only on the proven case) |
 | `since=FILE` | compare to a saved snapshot (written with `--baseline FILE --write-baseline`) and expose each family's **`status`** (`new`/`changed`/`unchanged`) as a queryable field — the temporal lens. Hides nothing (unlike `--baseline`); `since=B status=new --fail-on any` is the composable gate |
 | `sort=KEY` | `extractability` (default), `value`, or `members` |
 | `top=N` | show the first N rows (default 30) |


### PR DESCRIPTION
**Step 2 of the query/review unification (Axis B).** `nose query <paths> base=<git-ref>` runs the `nose review` pipeline — detect families at the ref, flag the ones a diff changed in one copy but not its siblings — under query's banner, with the v2 envelope and the gate.

## What's in
- **Reuses review's detection verbatim.** `review.rs::cmd_review` is split into `detect_divergences` (returns the flagged `Divergence`s) + rendering; query's `base=` calls the same `detect_divergences` and `divergences_fire`, so the **§BV fire precision is preserved by construction** — not re-implemented. `divergence_items_json` is shared, so `review --format json` and `query base= --format json` serialize each finding identically.
- **A distinct view** (like `reinvented`): a divergence is *a family + which copy changed*, not a `RefactorFamily`, so `base=` is its own `view: "base"`. Detection runs at the ref (not the working tree), so `base=` short-circuits the working-tree dataset.
- **Gate:** `base=REF --fail-on any` fires on the conservative shared-logic policy (a proven divergence — the only sane CI default); `--fail-on new` is rejected (needs a baseline, not a diff).

## Why a view, not a filter axis
Divergences aren't families, so they don't compose with `witness=`/`spotclass=` etc. — forcing them through the family object would be false plumbing. A dedicated view is the honest shape (matches the `reinvented` precedent).

## Unification status
`nose review` still works unchanged; its deprecation (now that `query base=` subsumes it) is **Step 3**, with a parity test. The detection refactor is behavior-preserving — all existing review tests pass.

## Tests
`query_base_flags_divergent_edits_like_review` (git fixture: edit one clone copy → base= flags the changed copy + un-updated sibling, JSON v2 `base` view, `--fail-on any` exits non-zero). Existing review suite still green. Local preflight: fmt, clippy `-D warnings`, full tests, awiki.

## Docs
usage grammar (`base=`), query-json (`base` view), CHANGELOG `[Unreleased]`.

Still **0.9.1** — release held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)