### PR TITLE
deprecate nose review in favour of query base= (unification complete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,15 +46,17 @@ deprecated.** All changes below are staged; the release is not yet cut.
     surfaced under query. Detects families at the ref and flags the ones a diff changed in one
     copy but not its siblings (a likely un-propagated fix), each item carrying `fire_eligible`
     (the §BV proven-shared-logic verdict); `base=REF --fail-on any` is the CI gate, firing only
-    on the proven case. Reuses review's detection verbatim, so the fire precision is identical
-    — the first step of folding `review` into `query` (deprecation to follow once at parity).
+    on the proven case. Reuses review's detection verbatim, so the fire precision is identical.
 - **`nose scan` is deprecated** in favour of `nose query`. It still works (an interactive run
   prints a one-line nudge); `capabilities` moves it from `commands.stable` to
   `commands.deprecated`; docs lead with `query`. Removal is slated for a later release.
+- **`nose review` is deprecated** in favour of `nose query <paths> base=<ref>` (which runs the
+  same detection — a parity test holds them identical). It still works (interactive nudge);
+  `capabilities` moves it to `commands.deprecated`. Removal is slated for a later release.
 
 ### Deprecated
-- `nose scan` (see above) and the scan-JSON v1 contract — migrate to `nose query` and the
-  query-JSON v2 contract.
+- `nose scan` (and the scan-JSON v1 contract) and `nose review` — migrate to `nose query`
+  (`query <path>`, `query <path> base=<ref>`) and the query-JSON v2 contract.
 
 ## [0.9.1] - 2026-06-15
 

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -982,15 +982,8 @@ impl CapabilitiesReport {
                 doctor_json: false,
             },
             commands: CapabilitiesCommands {
-                stable: vec![
-                    "capabilities",
-                    "il",
-                    "query",
-                    "review",
-                    "semantic-pack",
-                    "stats",
-                ],
-                deprecated: vec!["scan"],
+                stable: vec!["capabilities", "il", "query", "semantic-pack", "stats"],
+                deprecated: vec!["review", "scan"],
             },
             schemas: CapabilitiesSchemas {
                 capabilities: vec![CAPABILITIES_SCHEMA_VERSION],
@@ -1820,6 +1813,20 @@ fn run_review_cmd(cmd: Cmd) -> Result<()> {
         paths
     };
     require_paths_exist(&paths)?;
+    // `nose review` is deprecated in favour of `nose query <paths> base=<ref>` (#375), which
+    // runs this exact detection under the unified query surface (same findings, same gate).
+    // The nudge is interactive-only — gated on a TTY stderr — so machine/CI/test runs (piped
+    // stderr) are never spammed; `capabilities.commands.deprecated` is the machine signal.
+    if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        eprintln!(
+            "note: `nose review` is deprecated — use `nose query {} base={}` (same divergent-edit \
+             detection; add --fail-on any for the gate). See `nose query --help`.",
+            paths
+                .first()
+                .map_or(".".into(), |p| p.display().to_string()),
+            base,
+        );
+    }
     review::cmd_review(review::ReviewArgs {
         paths,
         base,

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1628,19 +1628,13 @@ fn capabilities_command_lists_stable_commands_and_schemas() {
 
     assert_eq!(
         json_array_strings(&json["commands"], "stable"),
-        vec![
-            "capabilities",
-            "il",
-            "query",
-            "review",
-            "semantic-pack",
-            "stats"
-        ]
+        vec!["capabilities", "il", "query", "semantic-pack", "stats"]
     );
-    // `scan` is deprecated in favour of `query` (#375) — moved out of `stable`.
+    // `scan` and `review` are deprecated in favour of `query` (#375): `query <path>` and
+    // `query <path> base=<ref>` subsume them — moved out of `stable`.
     assert_eq!(
         json_array_strings(&json["commands"], "deprecated"),
-        vec!["scan"]
+        vec!["review", "scan"]
     );
     assert_eq!(json["schemas"]["capabilities"][0], 1);
     assert_eq!(json["schemas"]["scan_json"][0], 1);

--- a/crates/nose-cli/tests/cli/review.rs
+++ b/crates/nose-cli/tests/cli/review.rs
@@ -105,6 +105,56 @@ fn query_base_flags_divergent_edits_like_review() {
 }
 
 #[test]
+fn query_base_matches_review_findings() {
+    // The deprecation is earned: `nose query base=<ref>` and `nose review` run the same
+    // detection, so they report the same findings (family_id + fire verdict) on one diff.
+    let dir = make_project("query_base_parity");
+    init_git_repo(&dir);
+    let a = dir.join("a/f.py");
+    let src = fs::read_to_string(&a).unwrap();
+    fs::write(
+        &a,
+        src.replace(
+            "    return total",
+            "    total = total + 1\n    return total",
+        ),
+    )
+    .unwrap();
+
+    let rev: serde_json::Value =
+        serde_json::from_slice(&nose_review(&dir, &["--format", "json"]).stdout).unwrap();
+    let qry: serde_json::Value = serde_json::from_slice(
+        &nose_query_in(&dir, &["base=main", "--min-size", "8", "--format", "json"]).stdout,
+    )
+    .unwrap();
+
+    let key = |v: &serde_json::Value, arr: &str| {
+        let mut ks: Vec<(String, bool)> = v[arr]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|f| {
+                (
+                    f["family_id"].as_str().unwrap().to_string(),
+                    f["fire_eligible"].as_bool().unwrap(),
+                )
+            })
+            .collect();
+        ks.sort();
+        ks
+    };
+    let rev_keys = key(&rev, "findings");
+    assert!(!rev_keys.is_empty(), "review found a divergence: {rev}");
+    assert_eq!(
+        rev_keys,
+        key(&qry, "items"),
+        "query base= reports the same family ids + fire verdicts as review"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn review_flags_a_clone_changed_in_one_copy_only() {
     let dir = make_project("review_flag");
     init_git_repo(&dir);

--- a/docs/review.md
+++ b/docs/review.md
@@ -1,5 +1,11 @@
 # Review — catch un-propagated changes
 
+> **Deprecated (0.10.0).** `nose review --base <ref>` is now `nose query <paths> base=<ref>`
+> — the same detection and the same `fire_eligible` gate, under the unified
+> [query](usage.md#nose-query) surface (`base=REF --fail-on any` is the gate). `review` still
+> works and `capabilities` lists it under `commands.deprecated`; it is slated for removal in a
+> later release. The mechanics below are unchanged and describe both spellings.
+
 `nose review` flags clone families that were **edited inconsistently** in a change set:
 some copies changed, sibling copies not. That is the classic way a duplicated bug fix
 slips through — you fix one copy and never learn the others exist, because they were

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -28,7 +28,7 @@ from-source `./target/release/nose`.
 |---|---|
 | Find refactoring candidates in a tree | `nose scan <paths...>` |
 | Explore the duplication interactively (agent loop) | `nose query <path> [terms...]` |
-| Catch a missed sibling edit in a diff or PR | `nose review --base <ref>` |
+| Catch a missed sibling edit in a diff or PR | `nose query <path> base=<ref>` (was `nose review --base`, now deprecated) |
 | Ask what an installed binary supports | `nose capabilities` |
 | Check a local semantic-pack manifest | `nose semantic-pack check <file-or-dir>` |
 | Inspect lowering coverage for a language | `nose stats <paths...>` |
@@ -283,10 +283,10 @@ and may change to improve readability. The stable contract is documented in
 
 ## Other commands
 
-- `nose review [paths…] [--base <ref>]` — flag clones changed inconsistently in a diff (a
-  copy edited, its siblings missed). Defaults to `HEAD` for uncommitted local changes;
-  use `--base origin/main` for a PR branch. The git-aware companion to `scan`; full guide in
-  [review](review.md).
+- `nose review [paths…] [--base <ref>]` — **deprecated** in favour of
+  [`nose query <paths> base=<ref>`](#nose-query) (same detection + gate). Flags clones changed
+  inconsistently in a diff (a copy edited, its siblings missed); defaults to `HEAD`, use
+  `base=origin/main` for a PR branch. Full guide in [review](review.md).
 - `nose stats <paths…> [--top N] [--json]` — per-language IL lowering coverage (the
   Raw-node ratio), with the top unhandled surface kinds (`--top`, default 30; `--json`
   for machine output). Use it to spot a language/construct that isn't lowering well; see


### PR DESCRIPTION
**Step 3 (final) of the query/review unification.** Now that `nose query <paths> base=<ref>` runs review's exact detection (#387), `nose review` is deprecated — same scan-deprecation playbook (#375): it still works, but `query` is the one surface.

## What's in
- **TTY-gated nudge** on `nose review` → `nose query <paths> base=<ref>` (interactive-only; piped/CI/test runs never spammed).
- **`capabilities`** moves `review` from `commands.stable` to `commands.deprecated` (joining `scan`); stable is now `[capabilities, il, query, semantic-pack, stats]`.
- **Parity test** `query_base_matches_review_findings`: on one git fixture, `review --format json` and `query base= --format json` report the identical set of `(family_id, fire_eligible)` — the deprecation is *earned*, not asserted. (Holds by construction: both call `detect_divergences`.)

## Docs
review.md deprecation banner; usage.md task-table + command-list point at `query base=`; CHANGELOG (review under Changed-breaking + Deprecated). Capabilities test asserts `deprecated = [review, scan]`.

## The unification, complete
One verb (`query`) with orthogonal composable axes — **filters × OR × negate × group × since × base × views × gate**. `scan` and `review` are now both deprecated aliases over the same dataset/detection. This is the [Capabilities over features](https://wiki.g15e.com/pages/Capabilities%20over%20features) end-state: maximal capability, minimal surface.

Closes the 4 & 5 design+build (Axis A #386 temporality → Axis B #387 diff-scope → this). Local preflight green: fmt, clippy `-D warnings`, full tests, awiki. Still **0.9.1** — release held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)