### PR TITLE
#390: lower Rust constructor patterns as variant tests (not Raw)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ deprecated.** All changes below are staged; the release is not yet cut.
     copy but not its siblings (a likely un-propagated fix), each item carrying `fire_eligible`
     (the §BV proven-shared-logic verdict); `base=REF --fail-on any` is the CI gate, firing only
     on the proven case. Reuses review's detection verbatim, so the fire precision is identical.
+- **Analysis — Rust constructor patterns now lower as variant tests (#390).** A `match`/`if
+  let`/`while let` test on `Some(v)`/`Ok(_)`/`Point { x, y }` lowered the whole pattern to an
+  opaque `Raw` node (and split copies differing only in binding name); it now lowers to the
+  constructor *path* (the discriminant), parallel to a unit variant like `None`. Measured: corpus
+  Rust `Raw` ratio **2.623% → 1.347%**, soundness clean (0 false merges), gold-set Rust
+  worthy-recall +1 with no regression elsewhere. (The variant *condition* is now Raw-free;
+  whole-family convergence for copies differing only in the bound name needs binding extraction,
+  a follow-up.) See experiments §CP (the coverage worklist) and §CQ.
 - **`nose scan` is deprecated** in favour of `nose query`. It still works (an interactive run
   prints a one-line nudge); `capabilities` moves it from `commands.stable` to
   `commands.deprecated`; docs lead with `query`. Removal is slated for a later release.

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -2106,6 +2106,49 @@ fn query_dashboard_filter_and_family() {
 }
 
 #[test]
+fn rust_binding_patterns_lower_without_raw() {
+    // #390 lowering fidelity: a `match`/`if let`/`while let` test on a binding constructor
+    // pattern (`Some(v)`, `Ok(v)`, `Point { x, y }`) used to lower the whole pattern to an
+    // opaque Raw node. It now lowers to the constructor path, so stats reports no
+    // tuple_struct_pattern / struct_pattern Raw for these sites.
+    let dir = std::env::temp_dir().join(format!("nose_pat_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("p.rs"),
+        "fn a(x: Option<i32>) -> i32 { match x { Some(v) => v + 1, None => 0 } }\n\
+         fn b(x: Option<i32>) -> i32 { if let Some(v) = x { v } else { 0 } }\n\
+         fn c(p: P) -> i32 { match p { Point { x, y } => x + y, _ => 0 } }\n",
+    )
+    .unwrap();
+    let stats: serde_json::Value = serde_json::from_str(&run(&[
+        "stats",
+        dir.to_str().unwrap(),
+        "--json",
+        "--top",
+        "50",
+    ]))
+    .unwrap();
+    let pattern_raw: u64 = stats["top_unhandled"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|u| {
+            matches!(
+                u["surface_kind"].as_str(),
+                Some("tuple_struct_pattern" | "struct_pattern")
+            )
+        })
+        .map(|u| u["count"].as_u64().unwrap())
+        .sum();
+    assert_eq!(
+        pattern_raw, 0,
+        "binding constructor patterns must not lower to Raw: {stats}"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn query_reinvented_view_lists_call_the_helper_findings() {
     // A function that reimplements an existing pure helper inline (the reinvented channel),
     // surfaced as a query view — the action is "call the helper", complementing the clustered

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -5602,6 +5602,23 @@ fn map_default_lookup_keeps_alias_and_guard_boundaries() {
 }
 
 #[test]
+fn rust_constructor_pattern_variant_test_stays_distinct() {
+    let i = Interner::new();
+    // #390: a binding constructor pattern's variant test lowers to the constructor PATH (the
+    // discriminant), not the whole pattern as an opaque Raw node. The discriminant must still
+    // discriminate — matching `Some(_)` vs `Ok(_)` are different variants and stay distinct.
+    // (Full whole-family convergence for copies differing only in the *bound name* additionally
+    // needs binding extraction — a separate lever; here the body bindings still differ.)
+    let some = "pub fn f(x: Option<i32>) -> i32 { match x { Some(a) => a + 1, None => 0 } }\n";
+    let ok = "pub fn f(x: Result<i32, i32>) -> i32 { match x { Ok(a) => a + 1, Err(_) => 0 } }\n";
+    assert_ne!(
+        value_fp(&i, some, Lang::Rust),
+        value_fp(&i, ok, Lang::Rust),
+        "Some(_) and Ok(_) are different variants — must stay distinct"
+    );
+}
+
+#[test]
 fn option_defaulting_converges_with_nullish_default_boundaries() {
     let i = Interner::new();
     let js = "function f(value, fallback, other, otherDefault) { return value ?? fallback; }";

--- a/crates/nose-frontend/src/rust.rs
+++ b/crates/nose-frontend/src/rust.rs
@@ -1111,19 +1111,55 @@ fn lower_match_pattern_condition(
     if pattern.kind() == "range_pattern" {
         return lower_range_pattern_condition(lo, scrutinee, pattern, span);
     }
-    if rust_tuple_struct_wildcard_pattern(lo, pattern) {
+    // `Some(_)`-style single-wildcard patterns are a recognized *presence* test: the source
+    // fact lets a downstream idiom converge `if let Some(_)` with `.is_some()`. Keep their
+    // existing lowering untouched so that convergence holds.
+    let presence_wildcard = rust_tuple_struct_wildcard_pattern(lo, pattern);
+    if presence_wildcard {
         lo.record_source_fact(
             lo.span(pattern),
             SourceFactKind::Pattern(SourcePatternKind::RustTupleStructSingleWildcardPattern),
         );
     }
-    let pat = lower_expr(lo, pattern);
+    // A *binding* constructor pattern (`Some(v)`, `Ok(_)` with payload, `Point { x, y }`) tests
+    // the scrutinee's VARIANT; the inner bindings bind in the arm body and are not part of the
+    // discriminant. Lower the constructor PATH as the comparison value — parallel to a unit
+    // variant like `None` — rather than the whole pattern as an expression, which (a) emits an
+    // opaque `Raw` node (the dominant Rust pattern coverage loss, #390 §CP) and (b) keys the
+    // test on the binding name's subtree hash, splitting two copies that differ only in
+    // `Some(x)` vs `Some(y)`. Lowering the path makes the variant test binding-name-invariant.
+    let pat = if !presence_wildcard
+        && matches!(pattern.kind(), "tuple_struct_pattern" | "struct_pattern")
+    {
+        let target = constructor_path_node(pattern).unwrap_or(pattern);
+        lower_expr(lo, target)
+    } else {
+        lower_expr(lo, pattern)
+    };
     Some(lo.add(
         NodeKind::BinOp,
         Payload::Op(Op::Eq),
         span,
         &[scrutinee, pat],
     ))
+}
+
+/// The constructor path of a tuple-struct / struct pattern (`Some`, `Ok`, `mod::Point`) — the
+/// discriminant a variant test keys on, with the inner bindings dropped. `None` if no path
+/// child is present (the caller then falls back to lowering the whole pattern).
+fn constructor_path_node(pattern: TsNode) -> Option<TsNode> {
+    pattern.child_by_field_name("type").or_else(|| {
+        Lowering::named_children(pattern).into_iter().find(|c| {
+            matches!(
+                c.kind(),
+                "identifier"
+                    | "scoped_identifier"
+                    | "type_identifier"
+                    | "scoped_type_identifier"
+                    | "qualified_type"
+            )
+        })
+    })
 }
 
 fn lower_range_bounds(lo: &mut Lowering, node: TsNode) -> (Option<NodeId>, Option<NodeId>, bool) {

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2788,3 +2788,45 @@ more matching machinery. Method note: the value-graph `Opaque` loss (the collect
 gap, #391) is a *separate* dimension this instrument does not yet attribute — `Opaque` carries
 no construct provenance today, so attributing it needs light instrumentation (tracked on #391),
 not this script. Re-run after each lowering change to watch the ratio fall.
+
+## CQ. Lowering fidelity — Rust constructor patterns as variant tests (#390, 2026-06-15)
+
+The §CP worklist's single biggest, most coherent lever was Rust pattern-destructuring (~40k
+`Raw` nodes, led by `tuple_struct_pattern` at 21.6k). Root cause: `lower_match_pattern_condition`
+lowered a constructor pattern *as an expression* to build `scrutinee == lower_expr(pattern)` —
+and `lower_expr` on `Some(v)`/`Ok(_)`/`Point { x, y }` hits the `Raw` catch-all. Worse, `Raw` is
+keyed by subtree hash, so `Some(x)` and `Some(y)` (differing only in binding name) produced
+*different* conditions and split otherwise-identical copies.
+
+#390 lowers a binding constructor pattern to its **constructor path** (the discriminant) instead
+— `scrutinee == Some`, parallel to how the unit variant `None` already lowered. The inner
+bindings bind in the arm body and are not part of the variant test, so the condition no longer
+splits on the binding name's subtree hash. The recognized `Some(_)`-style single-wildcard
+*presence* pattern is left untouched (a downstream idiom converges `if let Some(_)` with
+`.is_some()`; the fix is scoped to *binding* patterns).
+
+**Measured:**
+- **Coverage:** corpus rust `Raw` ratio **2.623% → 1.347%** (74.7k → 37.6k `Raw` nodes);
+  `tuple_struct_pattern` `Raw` 21.6k → 3.4k (the residue is the preserved wildcard-presence
+  cases). The single largest §CP lever, ~halved.
+- **Soundness:** `nose verify --max-violations 0` clean on nose's crates + alacritty + bat +
+  ripgrep — **0 false merges**. The change makes the variant test *more* specific, not less.
+- **Recall (gold set, `eval_by_language.py --rank extractability`):** Rust worthy-recall **+1**
+  (dev 369→370/411; held-out flat 245/255); every non-Rust language's worthy/recall byte-
+  identical (the change is Rust-only, confirmed). Base (value-order) P@10 identical across all
+  languages including Rust (69%/69%); the extractability re-rank P@10 column fluctuates run-to-
+  run for *all* languages (non-Rust ones move with identical binaries; `n` shifts), so the Rust
+  re-rank wobble (dev 69→72, held-out 64→59) is eval nondeterminism inside wide overlapping CIs,
+  not a ranking change.
+- **Scope honesty:** the variant *condition* is now path-based (Raw-free), but two copies that
+  differ only in the *bound name* (`Some(a)` vs `Some(b)`) still split — the body's `a`/`b` are
+  not alpha-canonicalized because tuple-struct bindings aren't registered as locals. Full
+  whole-family convergence needs binding *extraction* (project the payload into a canonical
+  local), a separate lever; an early test asserting that convergence was *falsified* and the
+  claim dropped. This PR is the coverage fix, not the alpha-convergence fix.
+
+Method: empirical leak isolation (probe each pattern position with `nose stats --json`) pinned
+the leak to the binding cases (match-arm / if-let / while-let), not let-destructuring, before
+any edit. Re-run `coverage_attribution.py` to watch the ratio; next §CP levers: async `await`
+(cross-language), rust `try`/`?`, and tuple-struct binding extraction (the alpha-convergence
+follow-up).


### PR DESCRIPTION
First **lowering-fidelity** lever from the §CP coverage worklist — the biggest single one: Rust pattern-destructuring (~40k `Raw` nodes, `tuple_struct_pattern` 21.6k).

## Root cause
`lower_match_pattern_condition` lowered a constructor pattern *as an expression* to build `scrutinee == lower_expr(pattern)`; `lower_expr` on `Some(v)`/`Ok(_)`/`Point { x, y }` hits the `Raw` catch-all (and keys the test on the binding's subtree hash). It now lowers to the constructor **path** (the discriminant) — `scrutinee == Some`, parallel to how unit variant `None` already lowered. The `Some(_)` single-wildcard *presence* pattern is left untouched (a downstream idiom converges `if let Some(_)` with `.is_some()` — the fix is scoped to binding patterns; that fixture broke until scoped).

## Measured (experiments §CQ)
- **Coverage:** corpus rust `Raw` ratio **2.623% → 1.347%** (74.7k → 37.6k); `tuple_struct_pattern` Raw 21.6k → 3.4k.
- **Soundness:** `nose verify --max-violations 0` clean (nose crates + alacritty + bat + ripgrep) — **0 false merges**.
- **Recall (gold set, old vs new binary):** Rust worthy-recall **+1** (dev 369→370/411; held-out flat 245/255); every non-Rust language byte-identical on the deterministic worthy/recall columns (change is Rust-only ✓). Base P@10 identical across all langs; the re-rank P@10 column is run-to-run noisy (non-Rust langs move with *identical* binaries), so the Rust re-rank wobble is eval nondeterminism, not a ranking change.

## Scope honesty
The variant *condition* is now Raw-free, but copies differing only in the *bound name* still split (tuple-struct bindings aren't registered as locals → body `a`/`b` don't alpha-canonicalize). A test asserting that convergence was **falsified and dropped**; whole-family convergence needs binding *extraction* — a tracked §CP follow-up.

## Tests
equivalence (different variants stay distinct; the preserved `is_some` convergence), a stats-based coverage assertion (binding patterns emit no Raw). Local preflight green: fmt, clippy `-D warnings`, full tests, awiki.

Part of the analysis-quality set (#389 worklist → this is #390's first lever). Still **0.9.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)