### PR TITLE
Release v0.10.0: nose query is the primary surface; docs lead with query + drift sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ break.
 
 ## [Unreleased]
 
-The 0.10.0 line (breaking): **`nose query` becomes the primary surface and `nose scan` is
-deprecated.** All changes below are staged; the release is not yet cut.
+## [0.10.0] - 2026-06-15
+
+Breaking: **`nose query` becomes the primary surface and `nose scan`/`nose review` are
+deprecated** (both still work, with an interactive one-line nudge; removal is slated for a
+later release).
 
 ### Added
 - **`nose query` is now a complete surface** over the same dataset `scan` computes:
@@ -73,6 +76,23 @@ deprecated.** All changes below are staged; the release is not yet cut.
 ### Deprecated
 - `nose scan` (and the scan-JSON v1 contract) and `nose review` — migrate to `nose query`
   (`query <path>`, `query <path> base=<ref>`) and the query-JSON v2 contract.
+
+### Documentation
+- **The docs lead with `nose query`.** README, the wiki [home](docs/home.md),
+  [getting-started](docs/getting-started.md), and the full [usage](docs/usage.md) reference now
+  present `nose query` as the everyday command — explore, one-shot report (`--format markdown`),
+  PR check (`base=<ref>`), CI gate (`--fail-on`), and the versioned JSON contract. `nose
+  scan`/`nose review` are documented as deprecated aliases, and usage is reordered so the
+  primary command and the shared Ranking / detection-mode sections come before the deprecated
+  `scan` reference. The CLI `--help` text (`long_about`, the `scan`/`query` summaries) was
+  updated to match.
+- **Code↔docs drift sweep.** Fixed the [capabilities](docs/capabilities.md) example
+  (`commands.stable` no longer lists `review`; `deprecated` adds it; `schemas.query_json` added);
+  migrated the [agent-recipe](docs/agent-recipe.md) decision procedure to query-JSON v2 field
+  names; added a deprecation banner to [scan-json](docs/scan-json.md) pointing to query-JSON v2;
+  corrected [clone-types](docs/clone-types.md) (`near` is part of the default surface, not
+  opt-in); updated [languages](docs/languages.md) for the #390 boundary/gap Raw split; and
+  refreshed the stale `nose query` dashboard examples against the shipped output.
 
 ## [0.9.1] - 2026-06-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nose-cli"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "nose-detect"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "nose-frontend",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "nose-eval"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "rustc-hash",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "nose-frontend"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "nose-il"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "lasso",
  "serde",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "nose-normalize"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "nose-il",
  "nose-semantics",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "nose-semantics"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "nose-il",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/corca-ai/nose"
@@ -25,12 +25,12 @@ rust-version = "1.85"
 [workspace.dependencies]
 # Internal crates carry an explicit `version` (not just `path`) so the tree has no
 # wildcard deps and the crates stay publishable; `path` wins for local builds.
-nose-il = { path = "crates/nose-il", version = "0.9.1" }
-nose-semantics = { path = "crates/nose-semantics", version = "0.9.1" }
-nose-frontend = { path = "crates/nose-frontend", version = "0.9.1" }
-nose-normalize = { path = "crates/nose-normalize", version = "0.9.1" }
-nose-detect = { path = "crates/nose-detect", version = "0.9.1" }
-nose-eval = { path = "crates/nose-eval", version = "0.9.1" }
+nose-il = { path = "crates/nose-il", version = "0.10.0" }
+nose-semantics = { path = "crates/nose-semantics", version = "0.10.0" }
+nose-frontend = { path = "crates/nose-frontend", version = "0.10.0" }
+nose-normalize = { path = "crates/nose-normalize", version = "0.10.0" }
+nose-detect = { path = "crates/nose-detect", version = "0.10.0" }
+nose-eval = { path = "crates/nose-eval", version = "0.10.0" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -31,36 +31,39 @@ scanned 23 files · python 14 · typescript 9
   by confidence: exact 1 · subdag 0 · copy-paste 1 · similar 2
 
 cleanest to extract (production first):
-  src/loaders/users.py:1  2 copies · 8/10 shared, 2p · ~8 removable · similar   nose query src id=b221962180
+  src/loaders/users.py:1  load_users  2 copies · 8/10 shared, 2p · ~8 removable · similar   nose query src id=b221962180
   …
-grammar:  nose query <path> [field=value | field>N | field~substr …] [group=FIELD | id=FAM] [sort=KEY] [top=N] [full] [all]
+grammar:  nose query <path> [field=value | field>N | field~substr …] [group=FIELD | id=FAM | at=FILE:LINE] [sort=KEY] [top=N] [full] [all]
 ```
 
 Then drill: `nose query src witness=exact` (only behavior-proven families), `nose query src
 group=dir` (by directory), `nose query src id=b221962180 full` (open one family with its
 all-copies extraction skeleton).
 
-For a **one-shot ranked report** — to read top-down, paste into a PR, or gate CI — use
-`nose scan`:
+`nose query` is the **one command** for every workflow over that dataset — explore, report,
+gate a PR, or feed a machine:
 
 ```sh
-nose scan src                              # the ranked report, cleanest-to-fold first
-nose scan src --show diff                  # also show exactly what differs inside each family
-nose scan src --format markdown            # a report to paste into a PR or issue
-nose review --base origin/main             # PR check: a change applied to one clone copy but not its siblings
-nose scan src --mode syntax --fail-on any  # jscpd-style copy-paste gate for CI
-nose scan src --format json                # the versioned machine-readable contract for batch tooling and CI
+nose query src                               # the landing dashboard, cleanest-to-fold first
+nose query src id=<fam> full                 # open one family: every copy + extraction skeleton
+nose query src base=origin/main              # PR check: a change applied to one copy but not its siblings
+nose query src --mode syntax --fail-on any   # jscpd-style copy-paste gate for CI
+nose query src --format markdown             # a ranked report to paste into a PR or issue
+nose query src --format json                 # the versioned machine-readable contract (query-JSON v2)
 ```
 
-`query` and `scan` read the **same** dataset: `query` is the interactive/agent surface,
-`scan` is the one-shot report plus the frozen JSON contract and the `--fail-on` CI gate. By
-default both run all three channels — `syntax` (copy-paste runs), `semantic` (exact
-same-logic Type-4 clones), and `near` (fuzzy near-duplicates) — and respect `.gitignore`.
-Pass `--mode` to run exactly the channels you list.
+By default it runs all three channels — `syntax` (copy-paste runs), `semantic` (exact
+same-logic Type-4 clones), and `near` (fuzzy near-duplicates) — and respects `.gitignore`;
+pass `--mode` to run exactly the channels you list.
+
+> `nose scan` (the one-shot ranked report + scan-JSON v1) and `nose review --base <ref>` (the
+> PR check) still work but are **deprecated** in favour of `nose query` and `nose query
+> base=<ref>`, which read the same dataset and now carry the CI gate and a versioned JSON
+> contract. See [usage](docs/usage.md).
 
 ## Documentation
 
-- [Getting started](docs/getting-started.md) — first scan and how to read the report.
+- [Getting started](docs/getting-started.md) — your first `nose query` and how to read the report.
 - [Documentation home](docs/home.md) — entry point for using, integrating, and contributing.
 - [Usage](docs/usage.md) — command and flag reference.
 - [Configuration](docs/configuration.md) — `nose.toml`, excludes, modes, thresholds, ignores.
@@ -77,7 +80,7 @@ wiki so claims have one source of truth:
 - [Benchmark](docs/benchmark.md)
 - [Architecture](docs/architecture.md)
 - [Semantic kernel](docs/semantic-kernel.md)
-- [Scan JSON schema](docs/scan-json.md)
+- [Query JSON contract](docs/query-json.md)
 
 ## License
 

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -23,12 +23,14 @@ use std::path::PathBuf;
     about = "Find duplicated code worth refactoring — exact, semantic (Type-4), and near-duplicate clone families",
     long_about = "nose lowers each language into one normalized IL, groups duplicated code into\n\
                   clone families, and ranks them by how cleanly each folds into one shared helper.\n\
-                  • `nose scan <paths>`                — find refactoring candidates (copy-paste + exact semantic + near-duplicates)\n\
-                  • `nose scan <paths> --show diff`    — also show exactly what differs inside each family\n\
-                  • `nose review --base origin/main`   — flag a change applied to one clone copy but not its siblings\n\
-                  • `nose stats <paths>`               — IL lowering coverage per language\n\
-                  • `nose il <file>`                   — inspect the IL (why two snippets do/don't converge)\n\
-                  • `nose capabilities`                — machine-readable integration contract"
+                  • `nose query <paths>`                  — explore the duplication interactively (the everyday command)\n\
+                  • `nose query <paths> id=<fam> full`    — open one family: every copy + its extraction skeleton\n\
+                  • `nose query <paths> base=origin/main` — flag a change applied to one clone copy but not its siblings\n\
+                  • `nose query <paths> --fail-on any`    — gate CI (exit non-zero on duplication); add `--format json` for the contract\n\
+                  • `nose stats <paths>`                  — IL lowering coverage per language\n\
+                  • `nose il <file>`                      — inspect the IL (why two snippets do/don't converge)\n\
+                  • `nose capabilities`                   — machine-readable integration contract\n\
+                  `nose scan` and `nose review` still work but are deprecated in favour of `nose query`."
 )]
 struct Cli {
     #[command(subcommand)]
@@ -97,13 +99,15 @@ enum Cmd {
         #[arg(long)]
         dump: Option<PathBuf>,
     },
-    /// Find duplicated code and rank refactoring candidates (the everyday command).
+    /// Rank refactoring candidates as a one-shot report. DEPRECATED — use `nose query`.
     ///
     /// Scans files/directories (respecting .gitignore), groups duplicated code into
     /// clone families, and ranks them by extractability — how cleanly each family
     /// folds into one shared helper. Default channels: `syntax,semantic,near`
     /// (copy-paste runs + exact semantic Type-4 + fuzzy near-duplicates). Passing
     /// --mode replaces that default with exactly the channels listed.
+    /// `nose query` reads the same dataset and carries the gate, baselines, and a
+    /// structured `--format json` contract; `scan` still works but will be removed later.
     Scan {
         /// Paths to source files or directories (recursively scanned).
         #[arg(required = true)]
@@ -194,10 +198,11 @@ enum Cmd {
         #[arg(long, value_enum, default_value_t = ScopeFilter::All)]
         scope: ScopeFilter,
     },
-    /// Explore the duplication dataset (#359) — a stateless, self-describing query
-    /// surface for an agent loop. `nose query <path>` prints a landing dashboard; add
-    /// terms to slice, facet, or open one family. Every result suggests runnable next
-    /// commands. Opt-in: it does not change `nose scan`.
+    /// Explore the duplication dataset — the everyday command (#359). A stateless,
+    /// self-describing query surface: `nose query <path>` prints a landing dashboard; add
+    /// terms to slice, facet, or open one family, and every result suggests runnable next
+    /// commands. Carries the analysis flags, the `--fail-on` CI gate, and a versioned
+    /// `--format json` contract — it subsumes the deprecated `scan`/`review`.
     Query {
         /// Path to a file or directory (recursively scanned).
         #[arg(required = true)]

--- a/docs/agent-recipe.md
+++ b/docs/agent-recipe.md
@@ -35,47 +35,54 @@ For non-interactive consumption — a CI gate, a one-shot triage of the whole tr
 the versioned contract to other tooling — read the JSON directly:
 
 ```sh
-nose scan <path> --format json --top 30        # the ranked triage surface (versioned contract)
-nose review --base origin/main --format json   # PR-time divergence findings
+nose query <path> --format json                    # the ranked triage surface (query-JSON v2 contract)
+nose query <path> base=origin/main --format json   # PR-time divergence (the base view)
 ```
 
-Parse `families[]` ([scan JSON](scan-json.md)). Do not scrape human output. The per-family
-decision procedure below applies to both a `nose query` row and a `scan` JSON family — they
-carry the same evidence fields.
+The deprecated equivalents are `nose scan <path> --format json` and `nose review --base
+origin/main --format json`. Parse the family objects — `top_candidates[]` in the dashboard
+view, `families[]` in a list view (a filter/`sort=`/`top=` term), `items[]` in the `base` view
+([query JSON](query-json.md)). Do not scrape human output. The per-family decision procedure
+below applies to both a `nose query` row and a JSON family — they carry the same evidence fields.
 
 ## Per-family decision procedure
 
 Read the fields in this order — each step either decides or narrows:
 
-1. **Surface filter.** Act on `recommended_surface == "default"` only;
-   `review`/`hidden`/`shallow`/`generated`/`declaration` are diagnostic surfaces. If you
-   widen past the default, `actionability_reason` names *why* a family was demoted — `trivial`
-   (too small to extract), `shallow-extraction` (the helper would be mostly
-   parameters), `declaration-run` (only import/include/use/re-export spans), or
-   `generated-source` — each a decidable classification, not a worthiness verdict.
-   A default-surface family has no `actionability_reason`.
-2. **Generated/vendored.** Drop the family if every location has
-   `looks_generated: true` or the paths are vendored (`vendor/`, `.min.`,
-   `*.pb.go`, lockfiles). A *partly* generated family is a real leak — keep it.
-3. **Why did it merge — `witness.kind`.**
-   - `exact-value-graph`: a behavioral proof (identical value graphs, literal
-     values included). Treat the members as computing the same thing; the only
+1. **Surface filter.** Act on `surface == "default"` only;
+   `review`/`hidden`/`shallow`/`generated`/`declaration` are diagnostic surfaces. The
+   non-default `surface` value *is* the demotion reason — a decidable classification, not a
+   worthiness verdict: `shallow` (the extracted helper would be mostly parameters), `declaration`
+   (only import/include/use/re-export spans), `generated` (every location in generated-header
+   source), and `review`/`hidden` (review-hazard or proof-only diagnostics, too small to extract).
+   A default-surface family carries `surface == "default"`.
+2. **Generated/vendored.** The `generated` surface already flags families whose every location
+   sits in generated-header source; also drop families whose paths are vendored (`vendor/`,
+   `.min.`, `*.pb.go`, lockfiles). A *partly* generated family keeps a ranked surface — it is a
+   real leak, so keep it.
+3. **Why did it merge — `witness`.**
+   - `exact`: a behavioral proof (identical value graphs, literal values included; `value_nodes`
+     is *how much* was proven). Treat the members as computing the same thing; the only
      question left is whether merging them couples unrelated concerns.
-   - `copy-paste-run`: token-identical run — classic copy-paste; identifiers and
-     literals may still vary per copy.
-   - `structural-similarity`: fuzzy. Read `mean_value_jaccard` vs
-     `mean_shape_jaccard`: high value + low shape = behaviorally convergent
-     (interesting); high shape + low value = surface likeness (skeptical).
-4. **What differs — `varying_spots` + `params` + `shared_lines`.** An all-literal
-   spot list over near-identical lines is a data table (`extract-data-table` or
-   not-worthy locale/i18n parallel data — check whether the literals are *content*
-   or *parameters*). Many spots (`params` high) relative to `shared_lines` means a
-   costly, ugly extraction. `extraction_shape` names the decidable shape of the fix
-   for a clean candidate (`call-existing-helper` is the strongest — an existing
+   - `subdag`: a common heavy anchor (shared sub-DAG core) is behavior-proven — each member's
+     `shared_subdag: [start, end]` shows where that computation lives.
+   - `copy-paste`: token-identical run — classic copy-paste; identifiers and literals may still
+     vary per copy.
+   - `similar`: the fuzzy near channel. Grade it with `spotclass` (next step) before trusting it.
+4. **What differs — `params` + `shared` + `spotclass`.** `params` counts the varying spots the
+   extracted helper would parameterize; with `full`, `skeleton` renders each as a
+   `⟨param N: class⟩` placeholder (`class` = literal/name/call/expr/block). An all-literal
+   placeholder list over near-identical lines is a data table (`extract-data-table` or not-worthy
+   locale/i18n parallel data — check whether the literals are *content* or *parameters*). Many
+   `params` relative to `shared` (the lines invariant across **all** copies) means a costly, ugly
+   extraction. For a near (`similar`) family, `spotclass` says whether those spots are `leaf-only`
+   (clean value-leaves to parameterize — interesting) or `structural` (a shape/arity/referent
+   divergence — genuine logic difference, be skeptical). `extraction_shape` names the decidable
+   shape of the fix for a clean candidate (`call-existing-helper` is the strongest — an existing
    helper is reinvented inline, so the action is to *call* it, not extract anew).
-5. **Where it lives — `scope` + `in_test_module`.** Test-scaffolding duplication is
-   still worthy (a test helper is the refactor) — but weigh it below production
-   logic when budgeting attention.
+5. **Where it lives — `scope`.** `scope` is `prod` / `test` / `mixed` (a Rust inline `mod tests`
+   counts as test scope even in a production file). Test-scaffolding duplication is still worthy
+   (a test helper is the refactor) — but weigh it below production logic when budgeting attention.
 6. **The core question** (the same rubric the v5 labels use,
    [bench/labels/RUBRIC.md](../bench/labels/RUBRIC.md)): *would extracting one
    shared abstraction reduce duplication without coupling unrelated concerns or
@@ -99,19 +106,22 @@ Read the fields in this order — each step either decides or narrows:
 
 ## Acting on a verdict
 
-- **Worthy** → propose the refactor. `varying_spots` are the helper's parameters;
-  `--show proposal` renders an extraction skeleton; `shared_lines` is the helper
-  body size. Reference locations by `file:start_line`.
+- **Worthy** → propose the refactor. The `params` are the helper's parameters;
+  `nose query <path> id=<fam> full` (or `full` on a list) renders the all-copies extraction
+  `skeleton`; `shared` is the helper body size. Reference locations by `file:start` (each
+  `locations[]` entry is `{file, start, end, name, lang}`).
 - **Not worthy, recurring** → write a [structured ignore](structured-ignores.md)
   entry (`family_id`, `reason`, `owner`, optional `expires`) so the family stops
   resurfacing.
-- **Unsure** → leave it; never auto-refactor on `structural-similarity` alone.
+- **Unsure** → leave it; never auto-refactor on a `similar` witness alone.
 
-## PR-time: review findings
+## PR-time: divergent-edit findings
 
-`nose review --format json` findings carry the #245 gate fields: `fire_eligible`
-(the conservative policy verdict), `witness_kind`, `scope`, and per-changed-site
-`touches_shared`. For a harm pass over the top findings, judge each as
+`nose query <path> base=<ref> --format json` (the `base` view — `nose review --format json` is
+the deprecated alias) emits one `items[]` finding per divergence, each carrying the #245 gate
+fields: `fire_eligible` (the conservative shared-logic policy verdict the gate fires on),
+`witness_kind`, `scope`, and per-changed-site `touches_shared`. For a harm pass over the top
+findings, judge each as
 should-propagate / intentional-divergence / not-a-clone using the changed member's
 diff and the un-updated sibling's body — the §BG-gold method; experiments §BR/§BV
 measured the base rates (most fires are not propagation hazards; the gate tier is
@@ -124,5 +134,6 @@ following this page over a deterministic top-K sample of v5-labeled families
 reproduced the human-audited worthy/not-worthy verdicts — see
 [experiments §BX](experiments.md) for the run and its agreement numbers.
 
-*See also: [usage › nose query](usage.md#nose-query) · [scan JSON](scan-json.md) ·
-[review](review.md) · [structured-ignores](structured-ignores.md) · [design](design.md).*
+*See also: [usage › nose query](usage.md#nose-query) · [query JSON](query-json.md) ·
+[scan JSON](scan-json.md) · [review](review.md) · [structured-ignores](structured-ignores.md) ·
+[design](design.md).*

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -31,10 +31,10 @@ python3 bench/labels/eval_by_language.py --rank extractability  # P@10 + worthy-
 
 `eval_by_language.py` still prints its historical `value` baseline and
 anti-unification re-rank columns. The current default `extractability` order is the native
-`nose scan --format json` family order; the snapshot below uses that same label matching
+`nose query --format json` family order; the snapshot below uses that same label matching
 with the native order kept.
 
-**Current reproducible snapshot (v0.9.0):** with the default `extractability` order — after
+**Reproducible snapshot (v0.9.0 baseline):** with the default `extractability` order — after
 the all-copies `shared_lines` (#366, §CL) and the member-span heterogeneity penalty (#365,
 §CM) — an audit run over the checked-out `bench/repos` corpus measured overall precision@10 at
 about **61% dev [56–66] / 59% held-out [54–64]**. Worthy-recall in that run was roughly
@@ -72,15 +72,17 @@ are counted in the summary without failing the run.
 The detector is parallel at every stage and designed for deterministic output; tests cover
 repeat runs and thread-count variation on the local platform. The archived §T run measured
 about **19,500 files/sec** warm on its pinned corpus/hardware, with frontend parse+lower
-dominating and scaling about 11.6x on 18 cores. `NOSE_TIME=1 nose scan <path> --top 0`
-prints the per-stage breakdown for your machine. The default mode already runs
+dominating and scaling about 11.6x on 18 cores. `NOSE_TIME=1 nose query <path>`
+prints the per-stage breakdown for your machine (the timing covers the whole scan
+regardless of how many families are displayed). The default mode already runs
 the full `syntax,semantic,near` surface. See
 experiments §T for the throughput work.
 
 ## The research commands
 
-The everyday surfaces are `nose query` (interactive exploration) and `nose scan` (one-shot
-report + CI gate) — both over the same dataset ([usage](usage.md)). The default mix is
+The everyday surface is `nose query` (interactive exploration, carrying the
+`--fail-on`/`--baseline` CI gate); `nose scan` is the deprecated one-shot alias over the
+same dataset ([usage](usage.md)). The default mix is
 `syntax,semantic,near` (experiments §BM priced the flip); benchmark runs that need the
 pre-flip exact-only surface pin `--mode syntax,semantic` explicitly. The benchmark also
 uses a hidden research surface:

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -2,8 +2,9 @@
 
 `nose capabilities` emits the stable machine-readable contract for the installed
 binary. Use it from installers, editor integrations, CI wrappers, and doctor
-commands before invoking `nose scan`. For the human command guide see
-[usage](usage.md); for scan result JSON see [scan-json](scan-json.md).
+commands before invoking `nose query` (or the deprecated `nose scan`). For the
+human command guide see [usage](usage.md); for the result JSON see
+[query-json](query-json.md) (the forward contract) and [scan-json](scan-json.md).
 
 ## Why this is not help text
 
@@ -42,12 +43,13 @@ nose capabilities
     "doctor_json": false
   },
   "commands": {
-    "stable": ["capabilities", "il", "query", "review", "semantic-pack", "stats"],
-    "deprecated": ["scan"]
+    "stable": ["capabilities", "il", "query", "semantic-pack", "stats"],
+    "deprecated": ["review", "scan"]
   },
   "schemas": {
     "capabilities": [1],
     "scan_json": [1],
+    "query_json": [2],
     "semantic_packs": ["nose.semantic-pack.v0"],
     "semantic_pack_conformance": [1]
   },
@@ -134,9 +136,10 @@ release so it can't drift.
 | `interfaces.version_json` | boolean | Whether `nose --version --json` is supported. Version 1 reports `false`. |
 | `interfaces.doctor_json` | boolean | Whether `nose doctor --json` is supported. Version 1 reports `false`. |
 | `commands.stable` | array | Stable user-facing commands that integrations may invoke (incl. `query`, the interactive exploration surface — see [usage › nose query](usage.md#nose-query), with its versioned [query-JSON](query-json.md) contract). Hidden research commands are intentionally omitted. |
-| `commands.deprecated` | array | Commands that still work but are being retired; integrations should migrate. `scan` → `nose query` (same dataset + gate + a structured `--format json` contract). |
+| `commands.deprecated` | array | Commands that still work but are being retired; integrations should migrate. `scan` → `nose query` (same dataset + gate + a structured `--format json` contract); `review` → `nose query <paths> base=<ref>` (same divergent-edit detection + gate). |
 | `schemas.capabilities` | array | Supported capabilities schema versions. |
-| `schemas.scan_json` | array | Supported `nose scan --format json` schema versions. |
+| `schemas.scan_json` | array | Supported `nose scan --format json` schema versions (deprecated; see `query_json`). |
+| `schemas.query_json` | array | Supported `nose query --format json` schema versions — the forward machine contract ([query-json](query-json.md)). |
 | `schemas.semantic_packs` | array | Supported semantic-pack manifest API versions, currently `nose.semantic-pack.v0`. |
 | `schemas.semantic_pack_conformance` | array | Supported `nose semantic-pack check --format json` schema versions. |
 | `scan.modes` | array | Supported `--mode` values. |

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -14,9 +14,9 @@ The four types:
   syntactic variants (semantic clones).
 
 This page states what nose does for each — including where it stops. The scan modes are
-detector channels, not perfect taxonomy buckets: the default combines `syntax` and
-`semantic`, and `near` is the opt-in fuzzy Type-3 surface. The engine is described in
-[architecture](architecture.md).
+detector channels, not perfect taxonomy buckets: the default combines `syntax`,
+`semantic`, and `near` (the fuzzy Type-3 channel is part of the default). The engine is
+described in [architecture](architecture.md).
 
 ## Type-1 — fully
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ format, `--show` views, baselines, cache location, and CI failure mode.
 
 All keys are optional; an absent key means "no opinion — use the CLI value or
 the built-in default". Keys are kebab-case and live under the `[scan]` table.
+`nose query` reads the same `[scan]` config keys as `nose scan`.
 
 | key | type | default | same as flag |
 |---|---|---|---|
@@ -72,7 +73,7 @@ they must name the same threshold because both modes share one fuzzy acceptance
 cutoff.
 
 ```sh
-nose scan src --mode syntax,semantic,near:0.70
+nose query src --mode syntax,semantic,near:0.70
 ```
 
 Config file paths are resolved from the config file's directory, so committed

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -4,6 +4,12 @@ nose is built to run in CI as a duplication gate. The pieces below turn the
 report from [usage](usage.md) into a pass/fail check that flags only *new* duplication
 and runs fast on every push.
 
+The gate command is now [`nose query`](usage.md#nose-query): it carries the same
+`--fail-on`/`--baseline`/`--ignore-file`/`--cache-dir` workflow flags and the same
+`--format sarif` output as the old `nose scan`. `nose scan` takes the same flags and
+still works, but it is **deprecated (0.10.0)** in favour of `nose query`; the examples
+below lead with the `query` spelling and note the `scan` equivalent where it differs.
+
 ## The `--fail-on any` gate
 
 `--fail-on any` makes nose exit non-zero if **any** family survives the filters.
@@ -15,13 +21,13 @@ closest jscpd replacement.
 For a jscpd-style copy-paste gate:
 
 ```sh
-nose scan src --mode syntax --fail-on any
+nose query src --mode syntax --fail-on any
 ```
 
 For a broader exact gate, pin both exact channels and keep only substantial findings:
 
 ```sh
-nose scan src --mode syntax,semantic --min-value 300 --min-members 3 --fail-on any
+nose query src --mode syntax,semantic --min-value 300 --min-members 3 --fail-on any
 ```
 
 To include Type-3 near-duplicates in a review ratchet, add `near` and tune the fuzzy
@@ -29,13 +35,13 @@ threshold. This is usually better as a report or ratchet with `--min-value` than
 bare "any finding fails" gate:
 
 ```sh
-nose scan src --mode syntax,semantic,near:0.70 --min-value 300 --min-members 3 --fail-on any
+nose query src --mode syntax,semantic,near:0.70 --min-value 300 --min-members 3 --fail-on any
 ```
 
 For an exact semantic-only gate, use `--mode semantic`. It does not use a
 similarity threshold.
 
-With committed settings in `nose.toml`, the CI command can be just `nose scan src --fail-on any`.
+With committed settings in `nose.toml`, the CI command can be just `nose query src --fail-on any`.
 If a wrapper needs to support multiple installed nose versions, have it query
 `nose capabilities` first instead of scraping `--help`; the JSON contract is
 documented in [capabilities](capabilities.md).
@@ -106,13 +112,13 @@ the gate can flag only duplication introduced *after* adoption.
 
 ```sh
 # 1. Accept today's state (writes the baseline file and exits):
-nose scan src --baseline .nose-baseline.json --write-baseline
+nose query src --baseline .nose-baseline.json --write-baseline
 
 # 2. From now on, show only NEW or CHANGED families:
-nose scan src --baseline .nose-baseline.json
+nose query src --baseline .nose-baseline.json
 
 # 3. Make CI fail only when NEW or CHANGED families exist:
-nose scan src --baseline .nose-baseline.json --fail-on new
+nose query src --baseline .nose-baseline.json --fail-on new
 ```
 
 `--baseline` by itself keeps the historical behavior and reports only families not
@@ -152,7 +158,7 @@ next to the code, or point to another file with `--ignore-file` / `ignore-file`
 in [configuration](configuration.md):
 
 ```sh
-nose scan src --ignore-file nose.ignore.json --fail-on any
+nose query src --ignore-file nose.ignore.json --fail-on any
 ```
 
 Ignored families are removed from the active report, so they do not fail `--fail-on any`
@@ -171,20 +177,28 @@ for the file format and selector semantics.
 findings as inline PR annotations:
 
 ```sh
-nose scan src --format sarif --top 0 > nose.sarif
-# then upload nose.sarif via github/codeql-action/upload-sarif
+nose query src --format sarif > nose.sarif    # then upload via github/codeql-action/upload-sarif
 ```
 
-**Pass `--top 0` for a complete upload.** `--top` (default 30) truncates *every*
+`nose query --format sarif` emits the same SARIF over the same dataset, but it caps
+output with the `top=` DSL term (default 30) and has **no all-escape**, so for a complete
+upload prefer `nose scan`'s `--top 0`:
+
+```sh
+nose scan src --format sarif --top 0 > nose.sarif   # deprecated, but the guaranteed-complete upload
+```
+
+**Pass `--top 0` (scan) for a complete upload.** `--top` (default 30) truncates *every*
 output format, SARIF included — without `--top 0` a repo with more than 30 families
 uploads only the first 30. The SARIF run records the full count in
 `runs[].properties` (`total_families` / `shown_families`) and, when families were
 hidden, adds a `note` notification under `runs[].invocations[]`, so a truncated upload
 is at least detectable; `--top 0` avoids the cap entirely.
 
-`--format json` is the general machine-readable form for any other tooling. Its
-versioned contract is documented in [scan-json](scan-json.md); it is truncated by
-`--top` in the same way.
+`--format json` is the general machine-readable form for any other tooling. The forward
+versioned contract is [query-json](query-json.md) (`nose query --format json`, schema v2);
+the deprecated equivalent is documented in [scan-json](scan-json.md) (schema v1). Both are
+truncated by their respective top limit in the same way.
 
 ## Fast re-runs: `--cache-dir`
 
@@ -194,7 +208,7 @@ extraction — which makes repeated invocations (CI, pre-commit, local iteration
 much faster. Point it at a directory your CI caches between runs.
 
 ```sh
-nose scan src --cache-dir .nose-cache --fail-on any
+nose query src --cache-dir .nose-cache --fail-on any
 ```
 
 ## Nightly pinned-corpus verify

--- a/docs/design.md
+++ b/docs/design.md
@@ -133,9 +133,9 @@ is held to proof discipline (§1). Actionability splits by **decidability, not c
 ### 2c. The bare default is the product
 
 A no-flags invocation is the first-user experience: `nose query <path>` (the interactive
-landing dashboard) for an exploring agent or human, `nose scan <path>` (the one-shot report)
-for a batch read or CI. Both render the **same default surface**, and its head is nose's one
-chance to demonstrate value. Two consequences:
+landing dashboard) for an exploring agent or human, or the deprecated `nose scan <path>`
+(the one-shot report) for a batch read or CI. Both render the **same default surface**, and
+its head is nose's one chance to demonstrate value. Two consequences:
 
 - The default surface must be **dominated by actionable findings**. A finding class leaves
   the default surface only when its non-actionability is *decidable* (§2b) or *measured*
@@ -155,9 +155,11 @@ chance to demonstrate value. Two consequences:
 
 - **Institutionalize adversarial per-rule batteries.** zero-false-merge is the premise both
   consumers depend on; this is what makes the guarantee scale as rules are added.
-- **scan-json evidence richness.** The real lever for consumer 1 — make equivalence
-  *explainable and actionable* in machine-readable form.
-- **`review`-as-gate.** The natural high-precision bottom-line for consumer 2; harden it past
+- **query-JSON v2 evidence richness.** The real lever for consumer 1 — make equivalence
+  *explainable and actionable* in machine-readable form (the shipped `nose query --format
+  json` contract; scan-JSON v1 deprecated).
+- **`query base=<ref>`-as-gate.** The natural high-precision bottom-line for consumer 2
+  (the shipped divergent-edit view, formerly `nose review`); harden it past
   v1 and define a conservative fire policy. *Measured 2026-06-11
   ([experiments §BR](experiments.md)): on replayed merged PRs the default arm fires on 33%
   of changes at ~4% top-1 strict precision — real catches exist but the fire policy work

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 nose finds duplicated code — literal copy-paste, renamed copies, and the same
 logic rewritten in a different style (and, occasionally, a different language) — and ranks each
 group by how cleanly you could fold it into one shared helper. Point it at a
-directory, read the list, refactor from the top.
+directory, read what it found, refactor from the top.
 
 This page takes you from install to a report you can act on in a few minutes. When
 you want the exact flag for something, the [usage](usage.md) reference has all of
@@ -25,11 +25,13 @@ Silicon + Intel) and Linux (x86_64 + arm64) are attached to every
 [release](https://github.com/corca-ai/nose/releases). To build from source
 instead, see [usage → Install](usage.md#install).
 
-## Explore interactively: `nose query`
+## Your first run: `nose query`
 
-The quickest way in is `nose query <path>`. It prints a **landing dashboard** of what nose
-found, and every result suggests the next command to run — so you (or an agent) navigate by
-following links instead of memorizing flags:
+`nose query <path>` is the one command you need. Point it at any file or directory
+and it prints a **landing dashboard** of what it found — and every result suggests the
+next command to run, so you (or an agent) navigate by following links instead of
+memorizing flags. It recurses, respects `.gitignore` files inside the scanned tree, and
+nothing is written to disk.
 
 ```
 $ nose query examples
@@ -37,150 +39,170 @@ nose — finds duplicated & refactorable code across languages.
 scanned 3 files · go 1 · python 1 · typescript 1
 
 1 duplicated-code families on the default surface.
-  by confidence: exact 0 · subdag 1 · copy-paste 0 · similar 0
+  by confidence: exact 1 · subdag 0 · copy-paste 0 · similar 0
+                 (exact/subdag = behavior-proven, value-graph-verified · copy-paste = token-identical · similar = fuzzy)
 
 cleanest to extract (production first):
-  examples/sum.go:3  6 copies · same logic in 3 languages · ~30 removable · subdag   nose query examples id=b658f483dc
-  …
-grammar:  nose query <path> [field=value | field>N | field~substr …] [group=FIELD | id=FAM] [sort=KEY] [top=N] [full] [all]
+  examples/sum.go:3  SumFor  6 copies · 0/7 shared, 0p · ~0 removable · exact   nose query examples id=a47c37baa1
+  nose query examples sort=extractability       # all 1 (default surface), cleanest first
+
+highest confidence — exact 1 (proven-identical) + shared-core 0:
+  examples/sum.go:3  SumFor  6 copies · 0/7 shared, 0p · ~0 removable · exact   nose query examples id=a47c37baa1
+
+most-duplicated directories:
+  nose query examples group=dir                 # full breakdown
+
+~30 duplicated lines on the default surface.
+
+grammar:  nose query <path> [field=value | field>N | field~substr | field!=value | field!~substr …] [group=FIELD | id=FAM | at=FILE:LINE]
+          fields: scope witness same_symbol lang path members files value params shared dir
+          · sort=extractability(default)|value|members  · top=N  · `full` expands the skeleton  · `all` widens past the default surface
 ```
 
-From there you **slice** (`nose query examples witness=exact`, `scope=prod`, `params<2`),
-**facet** (`group=dir`), or **open one family** (`nose query examples id=b658f483dc full`
-shows its copies and the all-copies extraction skeleton). Each result is a pure function of
-(repo state, command), and an unknown field or value is a hard error — so a typo can never
-read as "no duplication." It explores the *same* dataset `nose scan` computes; nothing is
-written and `nose scan` / CI are unaffected.
+That's the whole loop in one screen: a summary, the cleanest candidates, and a runnable
+command on every line. From here you **open** a family, **slice** the list, or **facet** it.
 
-## Your first scan
+## How to read the report
 
-For a **one-shot ranked report** — to read top-down, paste into a PR, or gate CI —
-use `nose scan`.
+**The first line — `scanned 3 files · go 1 · python 1 · typescript 1`** — is what nose
+actually analyzed. If `.gitignore` or `--exclude` pruned vendored deps or build output, this
+count is far smaller than the files on disk; glance at it to confirm nose looked where you
+expected. (The *ignored* count is deliberately not shown — counting it would mean walking into
+the very trees `.gitignore` exists to skip.)
 
-Run `nose scan` on any file or directory. It recurses, respects `.gitignore` files inside
-the scanned tree, and prints the duplication it found, most worth-refactoring first:
+**The confidence line** breaks the families down by *why* their copies merged — the evidence,
+strongest first:
 
-```sh
-nose scan path/to/project
+- `exact` / `subdag` — a **value-graph proof**: the copies provably compute the same thing
+  (`exact` = the whole unit; `subdag` = a shared heavy sub-computation). A shared *decision*.
+- `copy-paste` — a token-identical run; classic copy-paste (identifiers/literals may vary).
+- `similar` — fuzzy structural likeness. A shared *shape*, not a proven shared decision.
+
+**Each candidate row is one _family_** — one refactoring decision (extract a helper, base
+class, or data table). Read it left to right:
+
+```
+examples/sum.go:3  SumFor  6 copies · 0/7 shared, 0p · ~0 removable · exact   nose query examples id=a47c37baa1
+└─ first copy ──┘  └sym─┘  └ sites ┘  └─ payoff economics ──┘  witness   └─ the runnable drill command ─┘
 ```
 
-```
-$ nose scan examples --min-size 8
-scanned 3 files · go 1 · python 1 · typescript 1
-1 clone family, ranked by extractability (cleanest to fold into one helper)  ·  ~30 duplicated lines  (showing 1)
+- `6 copies` — how many places this code appears.
+- `0/7 shared, 0p` — the **honest** overlap across *all* the copies: 0 of the 7 representative
+  lines are invariant, with 0 varying spots (`p`) to parameterize. A family that looks identical
+  but really shares few lines is obvious at a glance. (This family is **cross-language** — copies
+  in Go, Python, and TypeScript share no *source* lines, so `shared` is 0 even though the logic is
+  proven identical; that's why the headline capability shows up as `exact` with `~0 removable`.)
+- `~0 removable` — roughly how much code a clean extraction would delete (`(copies − 1) × shared`).
+- `exact` — the evidence tag from the confidence line above.
+- The trailing `nose query … id=…` is the command to **open** this family.
 
-#1  id b658f483dcc2b097 · 6 copies · same logic in 3 languages (go, python, typescript) · ~30 lines removable
-    → local duplication — extract a helper (cross-language)
+**Scope tags.** A family may be tagged `prod`, `test`, or `mixed` (the same logic in a test
+*and* in production). These are context for *where* to refactor, not a penalty — duplication in
+tests is still a smell. Slice with `scope=prod` or `scope=test`.
+
+## Open one family
+
+Add `id=<id>` (any unambiguous prefix) to open a family — its copies, the all-copies extraction
+skeleton, and a diff. Add `full` to render the skeleton inline:
+
+```
+$ nose query examples id=a47c37baa1 full
+a47c37baa1 — exact · prod · 6 copies · 0/7 shared, 0p · ~0 removable
+  → local duplication — extract a helper (cross-language)
+  copies:
     examples/sum.go:3-9  SumFor
     examples/sum.go:11-17  SumRange
     examples/sum.py:1-7  sum_while
     examples/sum.ts:1-7  sumFor
     examples/sum.ts:9-15  sumOf
     examples/sum.py:10-14  sum_for
+     proposal  extract a shared helper · 0 shared lines · 1 parameter(s) vary (across all 6 copies)
+       │ ⟨param 1: block⟩
+     diff  examples/sum.go:3-9  vs  examples/sum.go:11-17
+       …
 ```
 
-That's the whole loop: scan, look at `#1`, decide whether to extract it, move on.
+The `→` line is a **hint** grounded in facts (a shared symbol name, how many directories it
+spans), never a guess about what the code means. Every site is listed with its exact
+`file:line-range` — you can't act on a clone you can't see. Each varying spot in the skeleton is
+a `⟨param N: class⟩` placeholder (the coarse value-class — `literal`/`name`/`call`/`expr`/`block`
+— a hint for the helper's signature).
 
-## How to read the report
+## Slice, facet, and follow links
 
-**The first line — for example, `scanned 3 files · go 1 · python 1 · typescript 1`** — is what
-nose actually analyzed. If `.gitignore` or `--exclude` pruned vendored deps or
-build output, this count will be far smaller than the files on disk. Glance at it
-to confirm nose looked where you expected. (The *ignored* count is deliberately
-not shown — counting it would mean walking into the very trees `.gitignore` exists
-to skip.)
-
-**The summary line** tells you how many groups were found, how they're ranked, and
-the total duplicated volume. By default nose shows the top 30 (`--top N` to change,
-`--top 0` for all).
-
-**Each numbered entry is one _family_** — one refactoring decision (extract a
-shared helper, base class, or data table). Read it left to right:
-
-- `3 copies` — how many places this code appears.
-- `same logic in 2 languages …` — what's shared. For copies in one language this
-  instead reads `N of M lines identical` (or `… shared, K spots differ`) — the
-  *honest* overlap counted across **all** the copies (not just two), so a family that
-  looks identical but really shares few lines is obvious. Cross-language copies have no
-  shared *source* lines, so they report the language list instead.
-- `~134 lines removable` — roughly how much code you'd delete by consolidating.
-- The **`→` line is a hint**, grounded in facts (a shared symbol name, how many
-  directories it spans), never a guess about what the code means.
-- Then **every site is listed** with its exact `file:line-range` — you can't act on
-  a clone you can't see.
-
-**Scope tags.** A family may end with `· in test code` (all copies in test code) or
-`· same code in tests and prod` (the same logic in a test *and* in production). These are context
-for *where* to refactor, not a penalty — duplication in tests is still a smell.
-(`--scope prod` or `--scope test` keeps one side only.)
-
-**Evidence tags.** Each entry names *why* its members merged: `exact behavior
-match` is a value-graph proof (the copies compute the same thing), `shared core
-computation` is a common heavy sub-computation, `copy-paste` is a
-token-identical run, and `near-duplicate` is fuzzy structural similarity. A
-shared *decision* reads differently from a shared *shape*.
-
-**Folded slices.** A `↳ N overlapping slice families fold into this entry` note
-means nearby families are overlapping slices of the same duplicated region —
-read the numbered entry as one refactoring opportunity, not several.
-
-### See more per family
-
-The `--show` option adds views so you can see the code, not just where it lives
-(repeatable / comma-list):
-
-```sh
-nose scan src --show diff       # show each family as a unified diff of its two copies
-nose scan src --show proposal   # show the extracted helper skeleton, varying spots as parameters
-```
-
-## Common recipes
+Every dashboard ends in runnable next-commands; the grammar is also printed each run. The moves:
 
 | You want… | Command |
 |---|---|
-| Explore interactively (or drive from an agent loop) | `nose query src` → follow the next-commands |
-| Only the behavior-proven families, interactively | `nose query src witness=exact` |
-| A report to paste into a PR or issue | `nose scan src --format markdown > REFACTOR.md` |
-| Only the biggest, cleanest wins | `nose scan src --min-value 300 --min-members 3` |
-| A copy-paste gate for CI (jscpd-style) | `nose scan src --mode syntax --fail-on any` |
-| High-confidence "same logic" clones only | `nose scan src --mode semantic` |
-| Fuzzy near-duplicates for review | `nose scan src --mode near:0.70` |
-| Machine-readable output | `nose scan src --format json` |
-| Faster repeated runs | `nose scan src --cache-dir .nose-cache` |
+| Only the behavior-proven families | `nose query src witness=exact` |
+| Production scope only | `nose query src scope=prod` |
+| Families in one area | `nose query src path~loaders` |
+| The duplication **hotspot** map (by directory) | `nose query src group=dir` |
+| Open one family with its skeleton | `nose query src id=<id> full` |
+| A ranked report to paste into a PR/issue | `nose query src --format markdown` |
+| The versioned machine contract | `nose query src --format json` |
+| Faster repeated runs | `nose query src --cache-dir .nose-cache` |
 
-`nose scan` runs `syntax` + `semantic` + `near` by default (literal copy-paste,
-exact same-logic clones, and fuzzy near-duplicates). Passing `--mode` replaces
-that default with exactly the channels you list — see
-[clone-types](clone-types.md) for what each one finds.
+Each result is a **pure function of (repo state, command)**, and an unknown field or value is a
+hard error — so a typo can never read as "no duplication." A typical loop is just
+`nose query .` → `nose query . witness=exact` → `nose query . id=<id> full`.
 
-## The second command: `nose review`
+By default nose runs all three channels — `syntax` (copy-paste runs), `semantic` (exact
+same-logic Type-4 clones), and `near` (fuzzy near-duplicates). Pass `--mode` to run exactly the
+channels you list — see [clone-types](clone-types.md) for what each finds.
 
-Once a codebase has clones, the risky moment is editing one of them: a fix
-applied to one copy and missed in its siblings ships a half-fixed bug.
-`nose review` compares the working tree to a git ref and flags exactly that
-situation in your diff:
+## Catch a missed sibling edit: `nose query base=<ref>`
+
+Once a codebase has clones, the risky moment is editing one of them: a fix applied to one copy
+and missed in its siblings ships a half-fixed bug. `nose query <path> base=<git-ref>` compares
+the working tree to a git ref and flags exactly that — a clone family changed in one copy but
+not the others:
 
 ```sh
-nose review                      # review uncommitted local changes (vs HEAD)
-nose review --base origin/main   # review a PR branch, e.g. in CI
+nose query .                            # explore the duplication first
+nose query . base=HEAD                  # review uncommitted local changes
+nose query . base=origin/main           # review a PR branch (e.g. in CI)
+nose query . base=origin/main --fail-on any   # the CI gate (fires only on the proven case)
 ```
 
-See [review](review.md) for how findings are ranked, the conservative `--fail`
-gate policy, and CI wiring.
+See [review](review.md) for how these findings are ranked and the gate policy.
+
+## Gate CI
+
+`--fail-on any` makes nose exit non-zero when families survive the filters; `--baseline` plus
+`--fail-on new` ignores accepted debt and fails only on *new* duplication. Pin `--mode` in a
+gate so its surface stays stable across upgrades:
+
+```sh
+nose query src --mode syntax --fail-on any          # jscpd-style copy-paste gate
+nose query src --baseline .nose-baseline.json --write-baseline   # accept today's state
+nose query src --baseline .nose-baseline.json --fail-on new      # then fail only on new/changed
+```
+
+The full gate, baselines, SARIF, and fast re-runs are in
+[continuous-integration](continuous-integration.md).
+
+> **`nose scan` and `nose review` are deprecated.** `nose scan` (the one-shot ranked report +
+> scan-JSON v1 contract) and `nose review --base <ref>` (the PR check) still work but are
+> superseded by `nose query` and `nose query base=<ref>`, which read the same dataset and now
+> carry the gate and a versioned JSON contract. An interactive run of either prints a one-line
+> nudge; both will be removed in a later release.
 
 ## Where to go next
 
 - **[usage › nose query](usage.md#nose-query)** — the full query grammar: filters,
-  facets, drill-into-one-family, and the agent loop.
-- **[usage](usage.md)** — every command and flag, the ranking keys, and the scan
+  facets, drill-into-one-family, the CI gate, and the agent loop.
+- **[usage](usage.md)** — every command and flag, the ranking keys, and the detection
   modes in full.
-- **[review](review.md)** — the git-aware companion command: catch a clone
-  changed in one copy but not its siblings.
+- **[review](review.md)** — the divergent-edit check (`nose query base=<ref>`): catch a
+  clone changed in one copy but not its siblings.
 - **[configuration](configuration.md)** — commit a `nose.toml` so CI and teammates
   don't retype long flag lists.
-- **[continuous-integration](continuous-integration.md)** — turn a scan into a
+- **[continuous-integration](continuous-integration.md)** — turn a query into a
   pass/fail gate that flags only *new* duplication, with baselines and SARIF.
 - **[clone-types](clone-types.md)** — what `syntax` / `semantic` / `near` cover
   across the Type-1–4 taxonomy, and the honest limits.
 - **[languages](languages.md)** — the supported languages and the embedded
   `<script>` extraction for Vue/Svelte/HTML.
+</content>
+</invoke>

--- a/docs/hazard-release-checklist.md
+++ b/docs/hazard-release-checklist.md
@@ -28,8 +28,9 @@ miss.
 | **Performance / refactor with identical output** | No | No | Nothing (confirm output is byte-identical first) |
 
 **How to tell if detection output changed**, if unsure: scan a fixed fixture corpus with
-the old and new binary and diff the JSON `families` (`nose scan <fixtures> --mode
-semantic,near --format json --top 0`), comparing **sort-independently** and looking only at
+the old and new binary and diff the JSON `families` (`nose query <fixtures> --mode
+semantic,near --format json top=10000`, a cap above the fixture family count since `query`
+has no uncapped escape), comparing **sort-independently** and looking only at
 the calibrated inputs — family identity, member sets, fingerprints, and the feature values in
 the row above (`mean_sem`, `shared_weight`, `params`, `mean_lines`, `modules`, `scope`). A
 change there → refresh. **Ignore** pure-display fields and ordering: a reorder of the

--- a/docs/home.md
+++ b/docs/home.md
@@ -12,33 +12,33 @@ where relevant. The pages are grouped by what you're here to do.
 
 ## Start here
 
-- [getting-started](getting-started.md) — install, run your first scan, and learn
+- [getting-started](getting-started.md) — install, run your first `nose query`, and learn
   to read the report in a few minutes. **The friendly on-ramp; read this first.**
 
 ## Fast paths
 
 - **Trying nose locally:** install from [getting-started](getting-started.md), then run
   `nose query <path>` to explore interactively (follow the suggested next-commands), or
-  `nose scan <path>` for a one-shot ranked report.
+  `nose query <path> --format markdown` for a one-shot ranked report.
 - **Driving nose from an agent:** run `nose query <path>` and follow the runnable `next:`
   links — see [usage › nose query](usage.md#nose-query) and the [agent-recipe](agent-recipe.md).
-- **Adding a repo gate:** start with [continuous integration](continuous-integration.md),
-  then commit shared defaults from [configuration](configuration.md).
+- **Adding a repo gate:** `nose query <path> --fail-on any`; see
+  [continuous integration](continuous-integration.md), then commit shared defaults from
+  [configuration](configuration.md).
 - **Building an integration:** use [capabilities](capabilities.md) before invoking a binary
-  and parse [scan JSON](scan-json.md), not human output.
+  and parse [query JSON](query-json.md), not human output.
 
 ## Using nose
 
 You want to *run* nose on a codebase and act on what it finds.
 
-- [usage](usage.md) — the complete command and flag reference (`query`, `scan`, `review`, `stats`, `il`, `capabilities`, `semantic-pack`), the ranking keys, and the scan modes.
-- [usage › nose query](usage.md#nose-query) — `nose query`: the stateless, self-describing **exploration surface** over the same dataset `scan` computes — a landing dashboard, sliceable filters/facets, drill-into-one-family, and a runnable next-command on every result. The interactive/agent entry point.
-- [review](review.md) — `nose review`: flag clones changed inconsistently in a diff (a copy fixed, its siblings missed) — a PR/CI check on top of git.
+- [usage](usage.md) — the complete command and flag reference: `query` (the everyday command), `stats`, `il`, `capabilities`, `semantic-pack` — plus the deprecated `scan`/`review` — the ranking keys, and the detection modes.
+- [usage › nose query](usage.md#nose-query) — `nose query`: the stateless, self-describing **everyday command** — a landing dashboard, sliceable filters/facets, drill-into-one-family with a runnable next-command on every result, the `--fail-on` CI gate, and a versioned JSON contract. The interactive/agent entry point.
+- [review](review.md) — the **divergent-edit** check: flag clones changed inconsistently in a diff (a copy fixed, its siblings missed). Now reached as `nose query <paths> base=<ref>`; `nose review` is the deprecated alias.
 - [configuration](configuration.md) — the `nose.toml` file: excludes, modes, ranking, thresholds, and structured-ignore defaults.
 - [continuous-integration](continuous-integration.md) — the `--fail-on any` gate, baseline-driven incremental adoption, SARIF, and fast re-runs.
 - [structured-ignores](structured-ignores.md) — suppress reviewed findings with reason, owner, expiry, and machine-readable ignored-family output.
 - [reinvented-helpers](reinvented-helpers.md) — the containment channel: code that reimplements an existing pure helper inline instead of calling it.
-- [reinvented-helper-audit-2026-06-13](reinvented-helper-audit-2026-06-13.md) — the hand-labeled field audit that promoted the reinvented-helper channel to the default surface.
 - [clone-types](clone-types.md) — what nose covers across the standard Type-1/2/3/4 taxonomy, with its honest limits.
 - [languages](languages.md) — the supported languages and the embedded `<script>` extraction for Vue/Svelte/HTML.
 
@@ -48,9 +48,9 @@ You're building tooling — an installer, CI wrapper, or editor integration — 
 of nose's machine-readable output.
 
 - [capabilities](capabilities.md) — the `nose capabilities` JSON contract: what an installed binary supports, so a wrapper never has to scrape `--help`.
-- [agent-recipe](agent-recipe.md) — the validated protocol for an LLM agent: explore interactively with `nose query` (follow the emitted next-commands), then read the `nose scan --format json` contract for the batch/gate path.
-- [scan-json](scan-json.md) — the versioned `nose scan --format json` contract for downstream tooling and CI (the batch surface; `nose query` is its interactive companion).
-- [query-json](query-json.md) — the versioned `nose query --format json` contract (schema v2): the structured, view-shaped machine form of the exploration surface.
+- [agent-recipe](agent-recipe.md) — the validated protocol for an LLM agent: explore interactively with `nose query` (follow the emitted next-commands), then read the `nose query --format json` contract for the batch/gate path.
+- [query-json](query-json.md) — the versioned `nose query --format json` contract (schema v2): the structured, view-shaped machine form of the exploration surface. **The forward machine contract.**
+- [scan-json](scan-json.md) — the versioned `nose scan --format json` v1 contract — **deprecated** in favour of query-JSON v2, documented for back-compat.
 
 ## Contributing
 
@@ -102,6 +102,7 @@ fundamentals; the rest is grouped by area.
 
 - [field-evaluation](field-evaluation.md) — qualitative results from running nose on real third-party projects.
 - [dogfooding](dogfooding.md) — nose run on its own source, and what its findings taught us.
+- [reinvented-helper-audit-2026-06-13](reinvented-helper-audit-2026-06-13.md) — the hand-labeled field audit that promoted the reinvented-helper channel to the default surface.
 - [scanjson-agent-audit-2026-06-10](scanjson-agent-audit-2026-06-10.md) — can an LLM agent decide and act from scan JSON alone? The measured gap list for consumer 1's evidence surface.
 - [scanjson-agent-audit-2026-06-13](scanjson-agent-audit-2026-06-13.md) — the re-validation after the gap fixes (incl. the graded witness): all five gaps closed, 8/8 decidable from JSON alone.
 - [fragment-quality-audit-2026-06-10](fragment-quality-audit-2026-06-10.md) — labeled Java/Python hidden/review exact-fragment sample and the resulting surface policy.

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -44,15 +44,20 @@ shows up as one cross-container family (confirmed on real projects in
 
 Lowering quality is measured by the **Raw-node ratio** — the fraction of CST
 nodes that fall through to an opaque `Raw` IL node instead of a real one. Lower
-is better; on the current pinned `bench/repos` corpus the overall ratio is about
-0.57%, with language-specific gaps visible in `nose stats`. Check it per language with:
+is better. `nose stats` distinguishes two kinds of Raw: by-design
+**protocol-boundary** Raw (await, try/`?`, defer, go, channel operations, select,
+yield — fail-closed boundaries, not coverage gaps) from genuine **lowering-gap**
+Raw. It reports `boundary_raw` and tags each unhandled construct `boundary` or
+`gap`. On the current pinned `bench/repos` corpus the overall ratio is in the low
+single-digit percent; run `nose stats` for the current figure, with
+language-specific gaps visible per construct. Check it per language with:
 
 ```sh
 nose stats <paths…>
 ```
 
-A high Raw ratio for a construct means that construct isn't lowering to a
-meaningful IL shape, so clones involving it won't converge. Closing those gaps
+A high *gap* ratio for a construct (not a by-design boundary) means that construct
+isn't lowering to a meaningful IL shape, so clones involving it won't converge. Closing those gaps
 (e.g. the Go composite-literal/`slice_expression`/`type_assertion` work that took
 Go from 0.40% to 0.03%, or Java local record/annotation declarations being erased
 as type metadata instead of surfacing as opaque statements, or Rust `async { ... }`

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -17,7 +17,7 @@ Every response is an object with:
 |---|---|
 | `schema_version` | `2` |
 | `tool` | `"nose"` |
-| `view` | which surface produced it: `dashboard` \| `list` \| `group` \| `family` |
+| `view` | which surface produced it: `dashboard` \| `list` \| `group` \| `family` \| `reinvented` \| `base` |
 | `path` | the scanned path, as given |
 
 plus the view-specific body below. Like the human surface, a result is a pure function of

--- a/docs/reinvented-helpers.md
+++ b/docs/reinvented-helpers.md
@@ -49,15 +49,21 @@ Two exclusions keep the surface honest:
 
 ## Surface
 
+- **`nose query <path> reinvented`** (primary): the forward exploration view — the
+  reinvented-helper findings as query-JSON's `reinvented` view (`items[]`, each
+  `{helper, site, value, approximate}`); the action is "call it". It lists every finding,
+  test-container ones included. `nose scan --show reinvented` is the deprecated equivalent.
+  See [query-json](query-json.md).
 - **Human report**: the default report LISTS the non-test findings (top by weight) —
   promoted from a one-line count after a [field audit](reinvented-helper-audit-2026-06-13.md)
   measured them at 94% genuine value-duplications / 71% directly actionable (design §2c).
   Findings whose CONTAINER is a test file (`container_in_test`) are a decidable
   judgment-deep class (§2b) — a test asserting the helper's value as a literal would be
-  circular to "fix" — so they are excluded from the default and shown only by
-  `--show reinvented`, which lists every finding.
-- **Scan JSON**: an additive `reinvented_helpers` array (omitted when empty) — see
-  [scan-json](scan-json.md#reinvented-helpers).
+  circular to "fix" — so they are excluded from the default and shown only by the `reinvented`
+  view (or the deprecated `nose scan --show reinvented`), which lists every finding.
+- **Machine JSON**: query-JSON's `reinvented` view (`items[]`) is the forward contract; the
+  deprecated equivalent is scan-JSON's additive `reinvented_helpers` array (omitted when empty)
+  — see [scan-json](scan-json.md#reinvented-helpers).
 - The container being a test file or vendored code is *judgment-deep* non-action
   ([design §2b](design.md)): the consumer decides; nose carries the locations.
 

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -1,14 +1,21 @@
 # Scan JSON schema
 
+> **Deprecated (0.10.0).** scan-JSON v1 is the legacy machine contract.
+> [query-JSON v2](query-json.md) (`nose query --format json`) is the forward,
+> view-shaped contract over the same family dataset — it mirrors the exploration
+> surface so a caller drives the same dashboard → slice → open-family loop. scan-JSON
+> v1 stays documented and emitted for back-compat; it will be removed in a later
+> release.
+
 `nose scan --format json` emits a versioned machine-readable report for CI,
 dashboards, editor integrations, and baselines that need clone families as data.
 For the command context see [usage](usage.md); for CI-oriented formats see
 [continuous-integration](continuous-integration.md). Tools can discover supported
 scan JSON schema versions with [capabilities](capabilities.md). An LLM agent
 consuming this schema should follow the validated triage protocol in
-[agent-recipe](agent-recipe.md). This is the one-shot batch contract; for *interactive*
-exploration of the same dataset, [`nose query`](usage.md#nose-query) is its companion
-surface (also `--format json`).
+[agent-recipe](agent-recipe.md). This is the deprecated one-shot batch contract; the
+forward, view-shaped machine contract over the same dataset is
+[query-JSON v2](query-json.md) (`nose query --format json`).
 
 ## Version 1
 

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -7,7 +7,7 @@ Back to [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md),
 Status: nose provides a local semantic-pack v0 conformance harness for manifest
 structure and declared fixture assets. The harness is a provider/user workflow,
 not nose approval of third-party semantic correctness. External packs remain
-`metadata-only` when loaded by `nose scan`.
+`metadata-only` when loaded by `nose query` (or the deprecated `nose scan`).
 
 ## Goal
 
@@ -128,7 +128,8 @@ Users who opt into external packs own the enablement decision. They should revie
 - whether exact-capable contracts are appropriate for their codebase;
 - the pack's own test or proof evidence outside nose.
 
-`nose scan --semantic-pack` and `[scan].semantic-packs` report loaded external
-packs under `semantic_packs` with `metadata-only` influence today. Future producer
+`nose query --semantic-pack` (or the deprecated `nose scan --semantic-pack`) and
+`[scan].semantic-packs` report loaded external packs under `semantic_packs` with
+`metadata-only` influence today. Future producer
 execution must keep the same provenance and fail-closed behavior before external
 packs can affect `near` or exact results.

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -12,11 +12,11 @@ fingerprints, or approve clone pairs.
 
 ## Local entry points
 
-Use `--semantic-pack <file-or-dir>` on `nose scan` to opt into local pack
-metadata for one run:
+Use `--semantic-pack <file-or-dir>` on `nose query` (the primary surface) or the
+deprecated `nose scan` to opt into local pack metadata for one run:
 
 ```sh
-nose scan src --format json --semantic-pack semantic-packs/python-math-prod.json
+nose query src --format json --semantic-pack semantic-packs/python-math-prod.json
 ```
 
 Commit stable project opt-ins in `nose.toml`:

--- a/docs/structured-ignores.md
+++ b/docs/structured-ignores.md
@@ -24,11 +24,13 @@ anything going through CI — prefer the structured file, because it stays audit
 
 ## Quick start
 
-Run a scan and copy the family ID from the human, markdown, or JSON report:
+Run nose and copy the family ID from the human, markdown, or JSON report:
 
 ```sh
-nose scan src --format json --top 0
+nose query src --format json all
 ```
+
+(`nose scan src --format json --top 0` is the deprecated equivalent.)
 
 Create `nose.ignore.json` in the directory where you invoke nose, or pass an explicit
 path with `--ignore-file`:
@@ -47,10 +49,10 @@ path with `--ignore-file`:
 }
 ```
 
-Then run `nose scan` from that directory. nose automatically reads
-`nose.ignore.json` when it exists. Use `--ignore-file <file>` or
-`ignore-file = "path/to/file.json"` in [configuration](configuration.md) when the
-file lives elsewhere.
+Then run `nose query` from that directory. nose automatically reads
+`nose.ignore.json` when it exists (`nose scan`, the deprecated equivalent, reads it the same
+way). Use `--ignore-file <file>` or `ignore-file = "path/to/file.json"` in
+[configuration](configuration.md) when the file lives elsewhere.
 
 Ignored families are removed from the active report and do not trip `--fail-on any` or
 `--fail-on new`. JSON output still carries them under `ignored_families` with the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,7 +1,7 @@
 # Usage
 
 The complete command and flag reference for `nose`. New here? Start with
-[getting-started](getting-started.md) — it walks through a first scan and how to
+[getting-started](getting-started.md) — it walks through a first run and how to
 read the report. For settings you'd commit to a repo see
 [configuration](configuration.md); for CI use see
 [continuous integration](continuous-integration.md).
@@ -26,202 +26,36 @@ from-source `./target/release/nose`.
 
 | You want to... | Use |
 |---|---|
-| Find refactoring candidates in a tree | `nose scan <paths...>` |
-| Explore the duplication interactively (agent loop) | `nose query <path> [terms...]` |
-| Catch a missed sibling edit in a diff or PR | `nose query <path> base=<ref>` (was `nose review --base`, now deprecated) |
+| Explore duplication and act on it (**the everyday command**) | `nose query <path> [terms…]` |
+| Open one family with its extraction skeleton | `nose query <path> id=<fam> full` |
+| Catch a missed sibling edit in a diff or PR | `nose query <path> base=<ref>` |
+| Gate CI on duplication | `nose query <path> --fail-on any` |
+| Read the result as machine-readable JSON | `nose query <path> --format json` ([query-json](query-json.md)) |
 | Ask what an installed binary supports | `nose capabilities` |
 | Check a local semantic-pack manifest | `nose semantic-pack check <file-or-dir>` |
 | Inspect lowering coverage for a language | `nose stats <paths...>` |
 | Debug why two snippets do or do not converge | `nose il <file> --normalized` |
+| One-shot ranked report (**deprecated**) | `nose scan <paths...>` — prefer `nose query --format markdown` |
 
-## `nose scan`
-
-> **Deprecated** (since 0.10.0) in favour of [`nose query`](#nose-query), which reads the
-> same dataset and now carries the analysis flags, the `--fail-on`/`--baseline` gate, and a
-> structured versioned [`--format json`](query-json.md) contract. `scan` still works (an
-> interactive run prints a one-line nudge); it will be removed in a later release.
-
-`nose scan <paths…>` scans one or more files/directories (recursively, respecting
-`.gitignore` files inside each scanned tree), groups duplicated code into **families**, and
-ranks them by **extractability** — how cleanly each family folds into one shared helper — so the
-duplication you can actually act on surfaces first. With no `--mode`, it runs
-`syntax,semantic,near`: CPD-style syntax runs, exact semantic Type-4 clones, and
-fuzzy Type-3 near-duplicates.
-
-```sh
-nose scan path/to/project
-```
-
-How to read the resulting report — the `scanned …` scope line, the per-family
-breakdown, scope tags, and the `→` hint — is covered in
-[getting-started → How to read the report](getting-started.md#how-to-read-the-report).
-The default human, Markdown, SARIF, and `--fail-on` surfaces show only
-action-oriented findings. Tiny proof-only fragments, review-only fragments,
-families wholly inside files with generated-code headers, declaration runs
-(spans that are only import/include/use/re-export lines — duplication the
-language mandates per file, with nothing to extract), and `shallow-extraction`
-families (unproven matches whose helper would be mostly parameters — `params` ≥ a
-third of the shared lines) are omitted with a short count line; `--format json
---top 0` keeps the post-ranking diagnostic families that survive rank-time pruning.
-
-Within the human report, **production findings lead and test-scope duplication is
-ranked beneath**, behind a `── N test-scope families …` separator (or a `+N more`
-footer when `--top` cuts them). Test duplication is still a real smell — nothing is
-dropped: the families stay ranked, in `--format json`, and one `--scope test` away.
-`--scope prod` hides them entirely; `--scope test` focuses on them.
-
-A named path that doesn't exist is an error (exit non-zero) — a typo'd path in a
-CI gate must fail loudly. A path that exists but contains no supported source
-files warns on stderr and reports an empty scan. The same rule applies to
-`nose review` and `nose stats`.
-
-Families whose members are overlapping slices of the same source regions are
-one refactoring *opportunity*: the best-ranked family keeps its numbered entry
-and the others fold into a `↳ N overlapping slice families…` note under it
-(`--format json` keeps every family, with `overlap_primary_id` marking the
-slices). Each entry also names its equivalence evidence — `exact behavior
-match` (value-graph proof), `shared core computation`, `copy-paste`, or
-`near-duplicate` — so a *shared decision* reads differently from a *shared
-shape*.
-
-### Flags
-
-Grouped by what they do. Config-backed scan defaults are listed in
-[configuration](configuration.md); workflow and output flags stay CLI-only.
-
-**Filter & shape the report**
-
-| flag | effect |
-|---|---|
-| `--sort KEY` | ranking: `extractability` (default), `value`, `sites`, or `hazard` (experimental; see [Ranking](#ranking)) |
-| `--top N` | show only the top N families (default 30; `--top 0` = all) |
-| `--min-members N` | only families with at least N duplicated sites (default 2) |
-| `--min-value V` | hide families below this finite non-negative refactoring value (noise floor on large repos) |
-| `--min-size N` | ignore units or syntax copy-paste runs smaller than this size, in IL tokens (default 24) |
-| `--scope prod\|test\|all` | keep one side of the test boundary: `prod` drops all-test families (test↔prod leaks stay), `test` keeps only them (default `all`). Applies to every output format and `--fail-on` |
-| `--mode MODE` | one or more of `syntax`, `semantic`, `near[:T]`; comma-list or repeatable; when present, replaces the default. Experimental `abstraction[:T]` is accepted but not a stable capabilities mode. |
-| `--exclude <glob>` | skip paths matching a gitignore-syntax glob (repeatable) |
-| `--ignore-file <file>` | suppress reviewed families using a structured ignore file with reason/owner/expiry metadata |
-| `--semantic-pack <file-or-dir>` | explicitly load local semantic-pack v0 manifest metadata for provenance reporting; external packs are metadata-only today |
-
-### Ranking
-
-`--sort` chooses what "most worth your attention first" means. `--min-value` is a
-noise floor on raw value and applies under every sort.
-
-| key | ranks by | use when |
-|---|---|---|
-| `extractability` *(default)* | invariant (shared) lines × copies × spread, weighted by tightness (shared/total) and penalized by parameter count and by member-span heterogeneity (copies of unlike length aren't one shape) | you want the duplication that folds *cleanly* into one helper — not the biggest block that merely looks similar |
-| `value` | raw duplicated volume: removable lines × similarity × spread | you want the most *code* deleted, accepting that divergent copies cost more to merge |
-| `sites` | number of copies | hunting the most-repeated patterns |
-| `hazard` *(experimental)* | divergent-edit *propensity*: line span × spread × invisibility × scope | you want a view of which clones tend to get edited inconsistently — **not yet a validated *harm* ranker** (see [hazard-ranking](hazard-ranking.md)) |
-
-Extractability is the default because raw volume over-rewards a large block whose
-copies share little: a 384-line family that shares only 22 lines across 14 varying
-spots is mostly scaffolding (6% invariant), not an extraction — it ranks far below a
-tight `15/15`-shared, zero-parameter pair. The honest `N/M shared · Pp` cell in the
-report is the same signal the ranking uses. Same-language families with **no** shared
-invariant lines (a language idiom, or two unrelated type literals with the same shape)
-have nothing to extract and sink to the bottom, even at `sim 1.00`. Extractability also
-demotes families whose copies **vary widely in length**: 25 same-shaped-but-different
-`Serializer` methods are not one helper waiting to happen, however many copies there
-are — a measured proxy for signature heterogeneity (experiments §CM).
-
-`--sort hazard` is an **experimental** severity-style ranking calibrated on mined
-divergent-edit history. It predicts *which clones get edited inconsistently* (divergence
-propensity) but, per a gold-label audit, **does not yet rank actual *harm* better than
-chance** — see [hazard-ranking](hazard-ranking.md) for the full, honest evaluation.
-
-**Review what was found**
-
-| flag | effect |
-|---|---|
-| `--show diff` | show each family inline as a unified diff between its two representative copies — both versions and exactly what differs |
-| `--show proposal` | show an extraction skeleton per family — the structure shared across **all** the family's copies, with the differing parts marked as parameters (so the helper is safe to apply to every copy, not just a representative pair) |
-| `--show hotspots` | after the report, rank directories by total duplicated lines (architecture view) |
-| `--show reinvented` | list **every** [reinvented-helper](reinvented-helpers.md) containment finding (code that reimplements an existing pure helper inline), including the test-container ones the default report excludes — the bare default already lists the non-test findings |
-| `--format human\|json\|markdown\|sarif` | output format (default `human`) |
-
-`--format json` emits a versioned object with `schema_version`, `tool_version`,
-scan scope, ranking metadata, and a `families` array. The stable contract and
-compatibility rule are documented in [scan-json](scan-json.md).
-
-**Workflow** (`--baseline`, `--write-baseline`, `--fail-on any|new`, `--ignore-file`, `--cache-dir`, `--config`, `--semantic-pack`) is covered in
-[continuous-integration](continuous-integration.md), [configuration](configuration.md), and
-[semantic-pack-loading](semantic-pack-loading.md).
-Structured suppressions are covered in [structured-ignores](structured-ignores.md).
-
-### Scan modes
-
-`nose scan` has three stable orthogonal channels. Omitting `--mode` runs all
-three: `syntax,semantic,near`. When `--mode` is present, nose runs exactly the
-channels you list; it does not add them to the default. See
-[clone-types](clone-types.md) for what each finds against the standard Type-1–4
-taxonomy.
-
-| mode | clone type | detector channel | use when |
-|---|---|---|---|
-| `syntax` | Type-1 / exact token-run floor | same-language jscpd-style contiguous copy-paste runs | replacing jscpd / blocking copy-paste clones in CI |
-| `semantic` | Type-4 | exact value-fingerprint matches | high-confidence semantic clones with no fuzzy threshold |
-| `near` | Type-3 | shape candidates + fuzzy structural/value scoring | finding near-duplicates for review |
-
-Examples:
-
-```sh
-nose scan src                                  # syntax + semantic + near (the default)
-nose scan src --mode syntax --fail-on any             # jscpd-style gate
-nose scan src --mode semantic                  # exact Type-4 only
-nose scan src --mode near:0.70                 # Type-3 only
-nose scan src --mode syntax,semantic           # exact channels only, no fuzzy near
-nose scan src --mode syntax --mode semantic    # same as --mode syntax,semantic
-```
-
-The `near` channel takes its acceptance threshold inline — `--mode near:0.8` (default
-`0.70`). `syntax` and `semantic` are exact channels and take no threshold.
-
-There is also a hidden experimental `abstraction[:T]` mode. It reuses the `near`
-candidate stream, defaults to threshold `0.50`, and then keeps only same-language
-families whose normalized IL differs by exactly one supported literal leaf. Its
-claim is weaker than `semantic`: it reports a refactoring-template witness with a
-typed hole and caveats such as `numeric-domain-sensitive`; it does not say the two
-copies are behavior-equivalent. Use `--format json --top 0` to consume the
-`abstraction_witness` field documented in [scan-json](scan-json.md#abstraction-witnesses).
-The witness is built from normalized IL, not line-level `--show proposal` text; its
-template is machine-oriented today and carries typed hole metadata for tooling. A
-reported abstraction family must share one literal-leaf hole position across all
-members; mixed families with different changed positions are left unwitnessed.
-When `near:T` and `abstraction:T` are combined in one scan, they share one fuzzy
-acceptance threshold; giving different inline values is rejected instead of silently
-choosing the last one.
-
-The `syntax` channel is the CPD floor: it finds same-language duplicated token runs even
-when they start or end in the middle of a function. The normalized unit channels
-(`semantic` and `near`) are where renamed identifiers, literal-varied Type-2 cases,
-cross-language convergence, and Type-3 edits are handled.
-
-`semantic` is still unit-bounded rather than an arbitrary-fragment equivalence search.
-Besides whole functions/classes/blocks, it admits only exact-safe sub-function fragments
-whose inputs, exits, and ordered effects are self-contained: direct return/throw values,
-bounded conditional guards, selected for-each append/index effects, and fixed-`this` Java
-field writes. General statement windows, dynamic receiver writes, mixed unproven effects,
-and arbitrary field/property mutation stay closed. The exact fragment contract and JSON
-metadata are documented in [fragment-contracts](fragment-contracts.md) and
-[scan-json](scan-json.md#fragment-metadata).
+`nose query` is the everyday command; the **Ranking** and **Scan modes** sections below
+document the shared ranking keys and detection channels both surfaces use.
 
 ## `nose query`
 
 `nose query <path> [terms…]` is the **exploration surface** (#359): a stateless,
-self-describing query over the same family dataset `scan` computes, designed for an LLM
-agent loop. With no terms it prints a **landing dashboard** — what nose is, the family
+self-describing query over the family dataset nose builds, designed for both a human and an
+LLM agent loop. With no terms it prints a **landing dashboard** — what nose is, the family
 count by confidence, the cleanest production candidates (each with its own runnable drill
 link), the highest-confidence families, the most-duplicated directories, and a one-line
 omission footer. Add terms to slice, facet, or open one family; every result ends in
-runnable `nose query …` next-commands, so an agent navigates by following links rather
-than re-reading a schema or hand-writing `jq`.
+runnable `nose query …` next-commands, so you navigate by following links rather than
+re-reading a schema or hand-writing `jq`.
 
-It is **opt-in and additive** — `nose scan`, `--fail-on`, and the scan-JSON contract are
-unchanged. With `--format json` every view emits the structured, versioned
-[query-JSON v2 contract](query-json.md).
+`nose query` is the **everyday command** — the primary surface over the family dataset. It
+carries the analysis flags, the `--fail-on` CI gate, and a structured contract: with
+`--format json` every view emits the versioned [query-JSON v2 contract](query-json.md), and
+`--format markdown`/`sarif` produce a ranked report. The deprecated `nose scan`/`nose review`
+read the same dataset.
 
 ```text
 nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE | reinvented | base=REF] [since=FILE] [sort=KEY] [top=N] [full] [all]
@@ -258,17 +92,201 @@ filters or groups by `spotclass`. The common query path pays nothing; a `spotcla
 
 A typical loop: `nose query .` → `nose query . witness=exact` → `nose query . id=<id> full`.
 
-`nose query` accepts the same **analysis flags** as `scan` — `--mode`, `--min-size`,
-`--min-value`, `--min-members`, `--exclude`, `--cache-dir`, `--ignore-file`,
-`--semantic-pack`, `--config` — so the dataset it explores is configured identically (the
-scope/sort/top knobs are the DSL's `scope=`/`sort=`/`top=` instead). It also takes the same
+`nose query` accepts the same **analysis flags** as the detection pipeline — `--mode`
+(see [Scan modes](#scan-modes)), `--min-size`, `--min-value`, `--min-members`, `--exclude`,
+`--cache-dir`, `--ignore-file`, `--semantic-pack`, `--config` — so the dataset it explores is
+configured by flag while scope/sort/top are the DSL's `scope=`/`sort=`/`top=`. It also takes the
 **CI gate** — `--fail-on any` / `--fail-on new` with `--baseline`/`--write-baseline` — and
-drops structured-ignored families, so `nose query <path> --fail-on any` is a drop-in gate.
+drops structured-ignored families, so `nose query <path> --fail-on any` is a drop-in gate (see
+[continuous-integration](continuous-integration.md)).
+
+How to read the resulting dashboard — the `scanned …` scope line, the confidence breakdown,
+the per-family economics, scope tags, and the `→` hint — is covered in
+[getting-started → How to read the report](getting-started.md#how-to-read-the-report).
+
+## Ranking
+
+`--sort` (scan) and `sort=` (query) choose what "most worth your attention first" means.
+`--min-value` is a noise floor on raw value and applies under every sort. `nose query`'s
+`sort=` accepts `extractability`, `value`, and `members`; `nose scan --sort` additionally
+offers `sites` and the experimental `hazard`.
+
+| key | ranks by | use when |
+|---|---|---|
+| `extractability` *(default)* | invariant (shared) lines × copies × spread, weighted by tightness (shared/total) and penalized by parameter count and by member-span heterogeneity (copies of unlike length aren't one shape) | you want the duplication that folds *cleanly* into one helper — not the biggest block that merely looks similar |
+| `value` | raw duplicated volume: removable lines × similarity × spread | you want the most *code* deleted, accepting that divergent copies cost more to merge |
+| `sites` / `members` | number of copies | hunting the most-repeated patterns |
+| `hazard` *(experimental, scan only)* | divergent-edit *propensity*: line span × spread × invisibility × scope | you want a view of which clones tend to get edited inconsistently — **not yet a validated *harm* ranker** (see [hazard-ranking](hazard-ranking.md)) |
+
+Extractability is the default because raw volume over-rewards a large block whose
+copies share little: a 384-line family that shares only 22 lines across 14 varying
+spots is mostly scaffolding (6% invariant), not an extraction — it ranks far below a
+tight `15/15`-shared, zero-parameter pair. The honest `N/M shared · Pp` cell in the
+report is the same signal the ranking uses. Same-language families with **no** shared
+invariant lines (a language idiom, or two unrelated type literals with the same shape)
+have nothing to extract and sink to the bottom, even at `sim 1.00`. Extractability also
+demotes families whose copies **vary widely in length**: 25 same-shaped-but-different
+`Serializer` methods are not one helper waiting to happen, however many copies there
+are — a measured proxy for signature heterogeneity (experiments §CM).
+
+`--sort hazard` is an **experimental** severity-style ranking calibrated on mined
+divergent-edit history. It predicts *which clones get edited inconsistently* (divergence
+propensity) but, per a gold-label audit, **does not yet rank actual *harm* better than
+chance** — see [hazard-ranking](hazard-ranking.md) for the full, honest evaluation.
+
+## Scan modes
+
+nose's detection has three stable orthogonal channels, selected with `--mode` on
+`nose query` (or the deprecated `nose scan`). Omitting `--mode` runs all three:
+`syntax,semantic,near`. When `--mode` is present, nose runs exactly the channels you list;
+it does not add them to the default. See [clone-types](clone-types.md) for what each finds
+against the standard Type-1–4 taxonomy.
+
+| mode | clone type | detector channel | use when |
+|---|---|---|---|
+| `syntax` | Type-1 / exact token-run floor | same-language jscpd-style contiguous copy-paste runs | replacing jscpd / blocking copy-paste clones in CI |
+| `semantic` | Type-4 | exact value-fingerprint matches | high-confidence semantic clones with no fuzzy threshold |
+| `near` | Type-3 | shape candidates + fuzzy structural/value scoring | finding near-duplicates for review |
+
+Examples:
+
+```sh
+nose query src                                  # syntax + semantic + near (the default)
+nose query src --mode syntax --fail-on any      # jscpd-style gate
+nose query src --mode semantic                  # exact Type-4 only
+nose query src --mode near:0.70                 # Type-3 only
+nose query src --mode syntax,semantic           # exact channels only, no fuzzy near
+nose query src --mode syntax --mode semantic    # same as --mode syntax,semantic
+```
+
+The `near` channel takes its acceptance threshold inline — `--mode near:0.8` (default
+`0.70`). `syntax` and `semantic` are exact channels and take no threshold.
+
+There is also a hidden experimental `abstraction[:T]` mode. It reuses the `near`
+candidate stream, defaults to threshold `0.50`, and then keeps only same-language
+families whose normalized IL differs by exactly one supported literal leaf. Its
+claim is weaker than `semantic`: it reports a refactoring-template witness with a
+typed hole and caveats such as `numeric-domain-sensitive`; it does not say the two
+copies are behavior-equivalent. Use `--format json --top 0` to consume the
+`abstraction_witness` field documented in [scan-json](scan-json.md#abstraction-witnesses).
+The witness is built from normalized IL, not line-level `--show proposal` text; its
+template is machine-oriented today and carries typed hole metadata for tooling. A
+reported abstraction family must share one literal-leaf hole position across all
+members; mixed families with different changed positions are left unwitnessed.
+When `near:T` and `abstraction:T` are combined in one scan, they share one fuzzy
+acceptance threshold; giving different inline values is rejected instead of silently
+choosing the last one.
+
+The `syntax` channel is the CPD floor: it finds same-language duplicated token runs even
+when they start or end in the middle of a function. The normalized unit channels
+(`semantic` and `near`) are where renamed identifiers, literal-varied Type-2 cases,
+cross-language convergence, and Type-3 edits are handled.
+
+`semantic` is still unit-bounded rather than an arbitrary-fragment equivalence search.
+Besides whole functions/classes/blocks, it admits only exact-safe sub-function fragments
+whose inputs, exits, and ordered effects are self-contained: direct return/throw values,
+bounded conditional guards, selected for-each append/index effects, and fixed-`this` Java
+field writes. General statement windows, dynamic receiver writes, mixed unproven effects,
+and arbitrary field/property mutation stay closed. The exact fragment contract and JSON
+metadata are documented in [fragment-contracts](fragment-contracts.md) and
+[scan-json](scan-json.md#fragment-metadata).
+
+## `nose scan`
+
+> **Deprecated** (since 0.10.0) in favour of [`nose query`](#nose-query), which reads the
+> same dataset and now carries the analysis flags, the `--fail-on`/`--baseline` gate, and a
+> structured versioned [`--format json`](query-json.md) contract. `scan` still works (an
+> interactive run prints a one-line nudge); it will be removed in a later release. The
+> [Ranking](#ranking) keys and [Scan modes](#scan-modes) above apply to both surfaces.
+
+`nose scan <paths…>` scans one or more files/directories (recursively, respecting
+`.gitignore` files inside each scanned tree), groups duplicated code into **families**, and
+ranks them by **extractability** — how cleanly each family folds into one shared helper — so the
+duplication you can actually act on surfaces first. With no `--mode`, it runs
+`syntax,semantic,near`: CPD-style syntax runs, exact semantic Type-4 clones, and
+fuzzy Type-3 near-duplicates.
+
+```sh
+nose scan path/to/project
+```
+
+How to read the resulting report — the `scanned …` scope line, the per-family
+breakdown, scope tags, and the `→` hint — is covered in
+[getting-started → How to read the report](getting-started.md#how-to-read-the-report).
+The default human, Markdown, SARIF, and `--fail-on` surfaces show only
+action-oriented findings. Tiny proof-only fragments, review-only fragments,
+families wholly inside files with generated-code headers, declaration runs
+(spans that are only import/include/use/re-export lines — duplication the
+language mandates per file, with nothing to extract), and `shallow-extraction`
+families (unproven matches whose helper would be mostly parameters — `params` ≥ a
+third of the shared lines) are omitted with a short count line; `--format json
+--top 0` keeps the post-ranking diagnostic families that survive rank-time pruning.
+
+Within the human report, **production findings lead and test-scope duplication is
+ranked beneath**, behind a `── N test-scope families …` separator (or a `+N more`
+footer when `--top` cuts them). Test duplication is still a real smell — nothing is
+dropped: the families stay ranked, in `--format json`, and one `--scope test` away.
+`--scope prod` hides them entirely; `--scope test` focuses on them.
+
+A named path that doesn't exist is an error (exit non-zero) — a typo'd path in a
+CI gate must fail loudly. A path that exists but contains no supported source
+files warns on stderr and reports an empty scan. The same rule applies to
+`nose query` and `nose stats`.
+
+Families whose members are overlapping slices of the same source regions are
+one refactoring *opportunity*: the best-ranked family keeps its numbered entry
+and the others fold into a `↳ N overlapping slice families…` note under it
+(`--format json` keeps every family, with `overlap_primary_id` marking the
+slices). Each entry also names its equivalence evidence — `exact behavior
+match` (value-graph proof), `shared core computation`, `copy-paste`, or
+`near-duplicate` — so a *shared decision* reads differently from a *shared
+shape*.
+
+### Flags
+
+Grouped by what they do. Config-backed defaults are listed in
+[configuration](configuration.md); workflow and output flags stay CLI-only. The ranking and
+mode flags are documented under [Ranking](#ranking) and [Scan modes](#scan-modes) above.
+
+**Filter & shape the report**
+
+| flag | effect |
+|---|---|
+| `--sort KEY` | ranking: `extractability` (default), `value`, `sites`, or `hazard` (experimental; see [Ranking](#ranking)) |
+| `--top N` | show only the top N families (default 30; `--top 0` = all) |
+| `--min-members N` | only families with at least N duplicated sites (default 2) |
+| `--min-value V` | hide families below this finite non-negative refactoring value (noise floor on large repos) |
+| `--min-size N` | ignore units or syntax copy-paste runs smaller than this size, in IL tokens (default 24) |
+| `--scope prod\|test\|all` | keep one side of the test boundary: `prod` drops all-test families (test↔prod leaks stay), `test` keeps only them (default `all`). Applies to every output format and `--fail-on` |
+| `--mode MODE` | one or more of `syntax`, `semantic`, `near[:T]`; comma-list or repeatable; when present, replaces the default. Experimental `abstraction[:T]` is accepted but not a stable capabilities mode. |
+| `--exclude <glob>` | skip paths matching a gitignore-syntax glob (repeatable) |
+| `--ignore-file <file>` | suppress reviewed families using a structured ignore file with reason/owner/expiry metadata |
+| `--semantic-pack <file-or-dir>` | explicitly load local semantic-pack v0 manifest metadata for provenance reporting; external packs are metadata-only today |
+
+**Review what was found**
+
+| flag | effect |
+|---|---|
+| `--show diff` | show each family inline as a unified diff between its two representative copies — both versions and exactly what differs |
+| `--show proposal` | show an extraction skeleton per family — the structure shared across **all** the family's copies, with the differing parts marked as parameters (so the helper is safe to apply to every copy, not just a representative pair) |
+| `--show hotspots` | after the report, rank directories by total duplicated lines (architecture view) |
+| `--show reinvented` | list **every** [reinvented-helper](reinvented-helpers.md) containment finding (code that reimplements an existing pure helper inline), including the test-container ones the default report excludes — the bare default already lists the non-test findings |
+| `--format human\|json\|markdown\|sarif` | output format (default `human`) |
+
+`--format json` emits a versioned object with `schema_version`, `tool_version`,
+scan scope, ranking metadata, and a `families` array. The stable contract and
+compatibility rule are documented in [scan-json](scan-json.md) (v1, deprecated; the
+forward contract is [query-json](query-json.md) v2).
+
+**Workflow** (`--baseline`, `--write-baseline`, `--fail-on any|new`, `--ignore-file`, `--cache-dir`, `--config`, `--semantic-pack`) is covered in
+[continuous-integration](continuous-integration.md), [configuration](configuration.md), and
+[semantic-pack-loading](semantic-pack-loading.md).
+Structured suppressions are covered in [structured-ignores](structured-ignores.md).
 
 ## Integrating with nose
 
 Use `nose capabilities` when another tool needs to decide what this installed
-binary supports before it invokes a scan:
+binary supports before it invokes a query:
 
 ```sh
 nose capabilities
@@ -279,7 +297,8 @@ commands, supported scan modes and output formats such as SARIF, JSON schema
 versions, config keys, and scan capability flags such as baselines, caching,
 and structured ignores. Do not scrape `nose --help`; help text is for humans
 and may change to improve readability. The stable contract is documented in
-[capabilities](capabilities.md).
+[capabilities](capabilities.md); the structured result JSON is in
+[query-json](query-json.md).
 
 ## Other commands
 
@@ -288,9 +307,9 @@ and may change to improve readability. The stable contract is documented in
   inconsistently in a diff (a copy edited, its siblings missed); defaults to `HEAD`, use
   `base=origin/main` for a PR branch. Full guide in [review](review.md).
 - `nose stats <paths…> [--top N] [--json]` — per-language IL lowering coverage (the
-  Raw-node ratio), with the top unhandled surface kinds (`--top`, default 30; `--json`
-  for machine output). Use it to spot a language/construct that isn't lowering well; see
-  [languages](languages.md).
+  Raw-node ratio, split into by-design protocol boundaries vs genuine lowering gaps), with
+  the top unhandled surface kinds (`--top`, default 30; `--json` for machine output). Use it
+  to spot a language/construct that isn't lowering well; see [languages](languages.md).
 - `nose semantic-pack check <file-or-dir> [--format human|json]` — validate local
   semantic-pack v0 manifest structure and declared fixture assets. It is a
   pack-author/user workflow, not external pack certification; see
@@ -304,5 +323,6 @@ and may change to improve readability. The stable contract is documented in
 integration surface; do not build automation around it without checking the current binary.
 
 Hidden `detect`, `verify`, `features`, `eval`, and `ceiling` commands exist for
-strict/research workflows. They are hidden from `--help` because `scan` is the command for
+strict/research workflows. They are hidden from `--help` because `query` is the command for
 everyday use; the [benchmark](benchmark.md) page documents them.
+</content>


### PR DESCRIPTION
Cuts **v0.10.0** — the release where `nose query` becomes the primary surface and `nose scan`/`nose review` are deprecated (the query features themselves shipped across #376–#395). This PR is the docs-and-release cut on top of that.

## Release mechanics
- Bump workspace version `0.9.1 → 0.10.0` (`Cargo.toml` + `Cargo.lock`).
- Convert the CHANGELOG `[Unreleased]` block into `## [0.10.0] - 2026-06-15`; open a fresh `[Unreleased]`; add a Documentation entry for this pass.

## Docs lead with `nose query` (structure, order, content)
- **README, home, getting-started, usage** rewritten/reordered so `nose query` is the one everyday command — explore, one-shot report (`--format markdown`), PR check (`base=<ref>`), CI gate (`--fail-on`), and the versioned **query-JSON v2** contract. `nose scan`/`nose review` are framed as deprecated aliases (kept for back-compat).
- `usage.md` reordered: the primary `nose query` section and the shared **Ranking** / **Scan modes** sections now come before the deprecated `nose scan` reference. Externally-linked anchors (`#nose-query`, `#ranking`, `#scan-modes`, `#install`, `#how-to-read-the-report`) preserved.

## Code↔docs drift sweep (verified against the built binary)
- CLI `--help` (`long_about` + the `scan`/`query` summaries) now lead with `query`; `nose scan --help` is marked DEPRECATED.
- `capabilities.md` example corrected: `commands.stable` drops `review`, `deprecated` adds it, `schemas.query_json` added — matches the binary + the capabilities test.
- `agent-recipe` decision procedure migrated to query-JSON v2 field names (`surface`/`witness`/`shared`/`params`/`spotclass`/`scope`/`skeleton`/`locations[]`).
- `scan-json` v1 carries a deprecation banner → `query-json` v2; `query-json` `view` enum lists all six views.
- `clone-types` factual fix (`near` is part of the default surface, not opt-in); `languages`/`stats` framing updated for the #390 boundary-vs-gap Raw split.
- Stale `nose query` dashboard examples refreshed against the shipped output (witness `subdag`→`exact`, symbol name in rows, current grammar).

## Gates (local)
`./scripts/check-ci-local.sh --fast` green (fmt, clippy `-D warnings`, nose-cli tests, docs-wiki lint). Also verified: `cargo build --release`, `RUSTDOCFLAGS=-D warnings cargo doc`, `awiki lint --root docs` (50 docs, 0 orphans), and the rebuilt binary's `--help`/`--version`/`capabilities`.

## Known follow-up (not in this PR)
`nose query top=0` yields an *empty* result (vs `nose scan --top 0` = all), and query has no uncapped "all rows" escape — a small UX inconsistency the lead-with-query work surfaced. Left as a follow-up (needs a code change + test); docs avoid the footgun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)