### PR TITLE
fix(query): `top=0` shows all families (subsume `scan --top 0`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ break.
 
 ## [Unreleased]
 
+### Fixed
+- **`nose query top=0` now shows *all* families** (matching `nose scan --top 0`), instead of
+  returning an empty result. The dataset build already used `top=0` for "every family"; the
+  display paths (`list`, `base`, `reinvented`, and the `--format markdown`/`sarif` report) now
+  agree, so `nose query <path> --format sarif top=0` is the complete-upload spelling and query
+  fully subsumes scan's truncation control. No `top=` term still defaults to 30.
+
 ## [0.10.0] - 2026-06-15
 
 Breaking: **`nose query` becomes the primary surface and `nose scan`/`nose review` are

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -4427,6 +4427,17 @@ fn run_query_base(args: &ScanArgs, base_ref: &str, q: &Query, path_arg: &str) ->
 /// Render the `base=` divergence view: query's v2 envelope around review's shared finding
 /// JSON, or a concise human report keyed on which copy changed and whether the edit touched
 /// shared logic (the propagation hazard).
+/// Resolve how many rows a query view shows. `top=N` shows N; `top=0` means *all*
+/// (matching `scan --top 0`, and the `top: Some(0)` the dataset build already uses for
+/// "every family"); an absent `top=` defaults to 30.
+fn query_row_limit(top: Option<usize>) -> usize {
+    match top {
+        Some(0) => usize::MAX,
+        Some(n) => n,
+        None => 30,
+    }
+}
+
 fn render_query_base(
     flagged: &[review::Divergence],
     changed_files: usize,
@@ -4435,7 +4446,7 @@ fn render_query_base(
     top: Option<usize>,
     json: bool,
 ) {
-    let limit = top.unwrap_or(30);
+    let limit = query_row_limit(top);
     let fire_eligible = flagged.iter().filter(|d| d.fire_eligible).count();
     if json {
         let items: Vec<_> = review::divergence_items_json(flagged)
@@ -4622,7 +4633,7 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
         ReportFormat::Markdown | ReportFormat::Sarif => {
             let selected =
                 query_selection(&dataset.families, &overrides, &opp, &q, &path_arg, since)?;
-            let top = q.top.unwrap_or(30);
+            let top = query_row_limit(q.top);
             let shown: Vec<&nose_detect::RefactorFamily> =
                 selected.iter().take(top).copied().collect();
             if matches!(format, ReportFormat::Sarif) {
@@ -4898,7 +4909,7 @@ fn render_query_reinvented(
     let shown: Vec<&nose_detect::ReinventedHelper> =
         reinvented.iter().filter(|r| !r.container_in_test).collect();
     let in_test = reinvented.len() - shown.len();
-    let limit = top.unwrap_or(30);
+    let limit = query_row_limit(top);
     if json {
         let items: Vec<_> = shown
             .iter()
@@ -4979,7 +4990,7 @@ fn render_query_list(
     json: bool,
     since: Option<&BaselineComparison>,
 ) {
-    let top = q.top.unwrap_or(30);
+    let top = query_row_limit(q.top);
     let shown = sel.len().min(top);
     if json {
         let fams: Vec<_> = sel

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1886,6 +1886,42 @@ fn proposal_aligns_across_all_copies() {
 }
 
 #[test]
+fn query_top_zero_shows_all_families() {
+    // Regression for the v0.10.0 query-subsumes-scan gap: `top=0` must mean *all* (matching
+    // `scan --top 0`, and the `top: Some(0)` the dataset build already uses for "every
+    // family"), not "zero rows". The display paths previously truncated it to an empty set.
+    let dir = make_mode_project("top_zero");
+    let p = dir.to_str().unwrap();
+    let count = |term: &str| -> usize {
+        let v: serde_json::Value = serde_json::from_str(&run(&[
+            "query",
+            p,
+            "all",
+            term,
+            "--min-size",
+            "1",
+            "--min-lines",
+            "1",
+            "--format",
+            "json",
+        ]))
+        .unwrap();
+        v["families"].as_array().unwrap().len()
+    };
+    let total = count("top=999");
+    assert!(
+        total >= 2,
+        "fixture should surface multiple families (got {total})"
+    );
+    assert_eq!(
+        count("top=0"),
+        total,
+        "query top=0 shows ALL families, like scan --top 0"
+    );
+    assert_eq!(count("top=1"), 1, "a finite top still truncates");
+}
+
+#[test]
 #[allow(clippy::too_many_lines, clippy::cognitive_complexity)] // one end-to-end walk of the query surface
 fn query_dashboard_filter_and_family() {
     // A sizeable 3-copy near family (one operator each) survives the default size floor.

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -177,23 +177,15 @@ for the file format and selector semantics.
 findings as inline PR annotations:
 
 ```sh
-nose query src --format sarif > nose.sarif    # then upload via github/codeql-action/upload-sarif
+nose query src --format sarif top=0 > nose.sarif   # then upload via github/codeql-action/upload-sarif
 ```
 
-`nose query --format sarif` emits the same SARIF over the same dataset, but it caps
-output with the `top=` DSL term (default 30) and has **no all-escape**, so for a complete
-upload prefer `nose scan`'s `--top 0`:
-
-```sh
-nose scan src --format sarif --top 0 > nose.sarif   # deprecated, but the guaranteed-complete upload
-```
-
-**Pass `--top 0` (scan) for a complete upload.** `--top` (default 30) truncates *every*
-output format, SARIF included — without `--top 0` a repo with more than 30 families
-uploads only the first 30. The SARIF run records the full count in
-`runs[].properties` (`total_families` / `shown_families`) and, when families were
-hidden, adds a `note` notification under `runs[].invocations[]`, so a truncated upload
-is at least detectable; `--top 0` avoids the cap entirely.
+**Pass `top=0` for a complete upload.** Every output format truncates to the row limit —
+`top=N` (default 30); `top=0` means *all* (matching the deprecated `nose scan --top 0`).
+Without it a repo with more than 30 families uploads only the first 30. The SARIF run records
+the full count in `runs[].properties` (`total_families` / `shown_families`) and, when families
+were hidden, adds a `note` notification under `runs[].invocations[]`, so a truncated upload is
+at least detectable; `top=0` avoids the cap entirely.
 
 `--format json` is the general machine-readable form for any other tooling. The forward
 versioned contract is [query-json](query-json.md) (`nose query --format json`, schema v2);

--- a/docs/hazard-release-checklist.md
+++ b/docs/hazard-release-checklist.md
@@ -29,8 +29,8 @@ miss.
 
 **How to tell if detection output changed**, if unsure: scan a fixed fixture corpus with
 the old and new binary and diff the JSON `families` (`nose query <fixtures> --mode
-semantic,near --format json top=10000`, a cap above the fixture family count since `query`
-has no uncapped escape), comparing **sort-independently** and looking only at
+semantic,near --format json top=0`, where `top=0` emits every family), comparing
+**sort-independently** and looking only at
 the calibrated inputs — family identity, member sets, fingerprints, and the feature values in
 the row above (`mean_sem`, `shared_weight`, `params`, `mean_lines`, `modules`, `scope`). A
 change there → refresh. **Ignore** pure-display fields and ordering: a reorder of the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -71,7 +71,7 @@ nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE | reinvented
 | `base=REF` | the **divergent-edit** view (the [`nose review`](review.md) pipeline, surfaced in query): detect families at the git ref, flag the ones a diff changed in one copy but not its siblings — a likely un-propagated fix. Each item carries `fire_eligible` (the §BV proven-shared-logic verdict); `base=REF --fail-on any` is the CI gate (fires only on the proven case) |
 | `since=FILE` | compare to a saved snapshot (written with `--baseline FILE --write-baseline`) and expose each family's **`status`** (`new`/`changed`/`unchanged`) as a queryable field — the temporal lens. Hides nothing (unlike `--baseline`); `since=B status=new --fail-on any` is the composable gate |
 | `sort=KEY` | `extractability` (default), `value`, or `members` |
-| `top=N` | show the first N rows (default 30) |
+| `top=N` | show the first N rows (default 30); `top=0` shows **all** (like the deprecated `scan --top 0`) |
 | `full` | on `id=` or a list, render the all-copies extraction skeletons inline (batched); each varying spot is `⟨param N: class⟩` — a coarse value-class hint (`literal`/`name`/`call`/`expr`/`block`) for the helper signature |
 | `all` | widen past the curated default surface to the full raw universe (demoted families labeled) |
 


### PR DESCRIPTION
Follow-up to v0.10.0 (#396): closes the one gap where `nose query` did **not** fully subsume `nose scan`.

## The bug
`nose query <path> top=0` returned an **empty** result, while `nose scan --top 0` means *all*. The query display paths resolved the row limit with `top.unwrap_or(30)` then `.take(top)`, so `top=0` truncated to zero rows — even though the dataset build already passes `top: Some(0)` to mean "every family". The consequence: no uncapped `--format json`/`sarif` dump and no complete SARIF upload from query, so the lead-with-query release had to point completeness-critical flows back at the deprecated `scan --top 0`.

## The fix
Add `query_row_limit(top)` — `Some(0)` → `usize::MAX`, `Some(n)` → `n`, `None` → `30` — and use it in all four query render paths (`list`, `base`, `reinvented`, and the `--format markdown`/`sarif` report selection). 

No `usize::MAX` leaks into the JSON contract: every summary field is a real count (`.len()` / `.min(limit)` / `saturating_sub` / totals), verified manually and by the test.

## Test
`query_top_zero_shows_all_families` (new): `top=0` returns the full family set (== a large finite `top`), and a finite `top=1` still truncates — so `top=0` is genuinely "all", not an ignored term. All 6 query CLI tests pass.

## Docs
`usage` grammar (`top=0` = all), CI SARIF complete-upload now `nose query ... --format sarif top=0`, hazard-release-checklist diff command simplified to `top=0`, and a CHANGELOG `[Unreleased]` → Fixed entry.

Local gate green: `./scripts/check-ci-local.sh --fast` (fmt, clippy `-D warnings`, full nose-cli suite, wiki lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)