### PR TITLE
deps: bump ignore 0.4.25 → 0.4.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,9 +360,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",


### PR DESCRIPTION
Rebased onto current main (the original dependabot #237 was stale behind the 0.10.0 Cargo.lock rewrite). Lock-only patch bump of the gitignore-walking crate; `--fast` gate green.

Closes #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)