### PR TITLE
deps: bump tree-sitter-c 0.23 → 0.24 (0.24.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-c"
-version = "0.23.4"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd2b1bf1585dc2ef6d69e87d01db8adb059006649dd5f96f31aa789ee6e9c71"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/nose-frontend/Cargo.toml
+++ b/crates/nose-frontend/Cargo.toml
@@ -21,7 +21,7 @@ tree-sitter-typescript = "0.23"
 tree-sitter-go = "0.23"
 tree-sitter-rust = "0.23"
 tree-sitter-java = "0.23"
-tree-sitter-c = "0.23"
+tree-sitter-c = "0.24"
 tree-sitter-ruby = "0.23"
 
 [lints]


### PR DESCRIPTION
Rebased onto current main (dependabot #240 was stale). Grammar bump (0.23.4 -> 0.24.2); full nose-cli suite green locally (equivalence/detection cover C). Closes #240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)