### PR TITLE
deps: bump tree-sitter-python 0.23 → 0.25 (0.25.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,9 +883,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-python"
-version = "0.23.6"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/nose-frontend/Cargo.toml
+++ b/crates/nose-frontend/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 
 tree-sitter = "0.24"
-tree-sitter-python = "0.23"
+tree-sitter-python = "0.25"
 tree-sitter-javascript = "0.23"
 tree-sitter-typescript = "0.23"
 tree-sitter-go = "0.23"


### PR DESCRIPTION
Rebased onto current main (dependabot #239 was stale). Two-minor grammar jump (0.23.6 -> 0.25.0); full nose-cli suite green locally (38 Python equivalence cases + detection cover it). Closes #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)