### PR TITLE
deps: bump tree-sitter-javascript 0.23 → 0.25 (0.25.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-javascript"
-version = "0.23.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/nose-frontend/Cargo.toml
+++ b/crates/nose-frontend/Cargo.toml
@@ -16,7 +16,7 @@ serde = { workspace = true }
 
 tree-sitter = "0.24"
 tree-sitter-python = "0.25"
-tree-sitter-javascript = "0.23"
+tree-sitter-javascript = "0.25"
 tree-sitter-typescript = "0.23"
 tree-sitter-go = "0.23"
 tree-sitter-rust = "0.23"


### PR DESCRIPTION
Rebased onto current main (dependabot #238 was stale). Two-minor grammar jump (0.23.1 -> 0.25.0); full nose-cli suite green locally (22 JS equivalence cases + embedded Vue/Svelte/HTML script extraction). Closes #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)