### PR TITLE
Revert incompatible tree-sitter grammar bumps (#399/#400/#401) — restore parsing on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-c"
-version = "0.24.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
+checksum = "afd2b1bf1585dc2ef6d69e87d01db8adb059006649dd5f96f31aa789ee6e9c71"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-javascript"
-version = "0.25.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -883,9 +883,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-python"
-version = "0.25.0"
+version = "0.23.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/nose-frontend/Cargo.toml
+++ b/crates/nose-frontend/Cargo.toml
@@ -15,13 +15,13 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 
 tree-sitter = "0.24"
-tree-sitter-python = "0.25"
-tree-sitter-javascript = "0.25"
+tree-sitter-python = "0.23"
+tree-sitter-javascript = "0.23"
 tree-sitter-typescript = "0.23"
 tree-sitter-go = "0.23"
 tree-sitter-rust = "0.23"
 tree-sitter-java = "0.23"
-tree-sitter-c = "0.24"
+tree-sitter-c = "0.23"
 tree-sitter-ruby = "0.23"
 
 [lints]


### PR DESCRIPTION
## Problem — main is red
The grammar bumps **#399** (tree-sitter-c 0.24.2), **#400** (tree-sitter-python 0.25.0), and **#401** (tree-sitter-javascript 0.25.0) compile to grammar **ABI 15**, but our pinned tree-sitter **core** is 0.24 (max ABI 14). A correctly-built binary therefore **cannot parse C/Python/JS** at runtime (`Incompatible language version 15. Expected minimum 13, maximum 14`). main's post-merge CI is failing on all three.

## Why it slipped through
Their PR checks — and my local `--fast` — passed only because cargo's incremental build **reused the stale pre-bump grammar objects**: `cargo update -p <cc-compiled crate>` doesn't force a recompile, so the binary under test still had the old ABI-14 grammars. A full `cargo clean` rebuild reproduces the failure; the same clean rebuild with 0.23 grammars parses everything correctly. **Lesson: native (`cc`) dependency bumps must be validated on a clean build, and against main's post-merge CI, not just PR checks.**

## Fix
Restore `tree-sitter-c = "0.23"` (0.23.4), `tree-sitter-python = "0.23"` (0.23.6), `tree-sitter-javascript = "0.23"` (0.23.1) — all ABI 14, compatible with core 0.24. Verified on a clean release build: C/Python/JS parse again; `--fast` green.

The `ignore` patch (#398) and the Actions bumps (#235/#236) are unaffected and stay.

## Follow-up
Taking these grammar updates needs a **tree-sitter core 0.24 → 0.25 upgrade** (core 0.25 supports ABI 14–15, so a coordinated bump of core + grammars can work). That's a deliberate epic with its own validation, not a drop-in dependabot bump — I'll file an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)