### PR TITLE
analysis: extract match-arm pattern bindings so bound-name copies converge (#390 follow-up)

### DIFF
--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -5606,15 +5606,49 @@ fn rust_constructor_pattern_variant_test_stays_distinct() {
     let i = Interner::new();
     // #390: a binding constructor pattern's variant test lowers to the constructor PATH (the
     // discriminant), not the whole pattern as an opaque Raw node. The discriminant must still
-    // discriminate — matching `Some(_)` vs `Ok(_)` are different variants and stay distinct.
-    // (Full whole-family convergence for copies differing only in the *bound name* additionally
-    // needs binding extraction — a separate lever; here the body bindings still differ.)
+    // discriminate — matching `Some(_)` vs `Ok(_)` are different variants and stay distinct, even
+    // now that binding extraction makes the *bodies* converge (see
+    // `rust_constructor_pattern_binding_extraction_converges`): the arm conditions still differ.
     let some = "pub fn f(x: Option<i32>) -> i32 { match x { Some(a) => a + 1, None => 0 } }\n";
     let ok = "pub fn f(x: Result<i32, i32>) -> i32 { match x { Ok(a) => a + 1, Err(_) => 0 } }\n";
     assert_ne!(
         value_fp(&i, some, Lang::Rust),
         value_fp(&i, ok, Lang::Rust),
         "Some(_) and Ok(_) are different variants — must stay distinct"
+    );
+}
+
+#[test]
+fn rust_constructor_pattern_binding_extraction_converges() {
+    // #390 follow-up: a match arm projects its payload binding (`Some(v)` → `v = x.0`) ahead of
+    // the body so the body's uses of it alpha-canonicalize. Two copies that differ ONLY in the
+    // bound name now converge — closing the split the #390 lowering left open.
+    let i = Interner::new();
+    let some_a =
+        "pub fn f(x: Option<i32>) -> i32 { match x { Some(a) => a * 2 + 1, None => 0 } }\n";
+    let some_b =
+        "pub fn g(x: Option<i32>) -> i32 { match x { Some(b) => b * 2 + 1, None => 0 } }\n";
+    assert_eq!(
+        value_fp(&i, some_a, Lang::Rust),
+        value_fp(&i, some_b, Lang::Rust),
+        "`Some(a) => a*2+1` and `Some(b) => b*2+1` differ only in the bound name — must converge"
+    );
+    // The body still gates: a different arm computation must NOT merge (no false merge).
+    let some_c =
+        "pub fn h(x: Option<i32>) -> i32 { match x { Some(c) => c * 3 + 1, None => 0 } }\n";
+    assert_ne!(
+        value_fp(&i, some_a, Lang::Rust),
+        value_fp(&i, some_c, Lang::Rust),
+        "different arithmetic in the arm body must stay distinct"
+    );
+    // Cross-variant stays distinct even though both bodies are now `v = x.0; …` (the arm
+    // *condition* — `x == Some` vs `x == Ok` — keeps them apart).
+    let ok_a =
+        "pub fn k(x: Result<i32, i32>) -> i32 { match x { Ok(a) => a * 2 + 1, Err(_) => 0 } }\n";
+    assert_ne!(
+        value_fp(&i, some_a, Lang::Rust),
+        value_fp(&i, ok_a, Lang::Rust),
+        "Some and Ok are different variants — must stay distinct after binding extraction"
     );
 }
 

--- a/crates/nose-frontend/src/rust.rs
+++ b/crates/nose-frontend/src/rust.rs
@@ -1034,7 +1034,12 @@ fn lower_match(lo: &mut Lowering, node: TsNode) -> NodeId {
     for arm in arms {
         let body_node = arm.child_by_field_name("value");
         let body_node_id = body_node.map(|v| v.id());
-        let body = body_node
+        let pattern = arm.child_by_field_name("pattern").or_else(|| {
+            Lowering::named_children(arm)
+                .into_iter()
+                .find(|child| Some(child.id()) != body_node_id && !is_match_guard(*child))
+        });
+        let mut body = body_node
             .map(|v| {
                 if v.kind() == "block" {
                     lower_block(lo, v)
@@ -1043,11 +1048,15 @@ fn lower_match(lo: &mut Lowering, node: TsNode) -> NodeId {
                 }
             })
             .unwrap_or_else(|| lo.empty_block(span));
-        let pattern = arm.child_by_field_name("pattern").or_else(|| {
-            Lowering::named_children(arm)
-                .into_iter()
-                .find(|child| Some(child.id()) != body_node_id && !is_match_guard(*child))
-        });
+        // Bind the pattern's payload locals (`Some(v)` → `v = scrutinee.0`) ahead of the arm
+        // body so its uses of them alpha-canonicalize — converging two copies that differ only
+        // in the binding name (`Some(a) => f(a)` with `Some(b) => f(b)`), the #390 follow-up.
+        if let Some(mut binds) =
+            pattern.and_then(|pattern| rust_bind_arm_pattern(lo, pattern, scrutinee, span))
+        {
+            binds.push(body);
+            body = lo.add(NodeKind::Block, Payload::None, span, &binds);
+        }
         let pattern_cond =
             pattern.and_then(|pattern| lower_match_pattern_condition(lo, scrutinee, pattern, span));
         let guard_cond = arm
@@ -1142,6 +1151,53 @@ fn lower_match_pattern_condition(
         span,
         &[scrutinee, pat],
     ))
+}
+
+/// Bind a constructor pattern's payload locals as assignment targets so the arm body's uses of
+/// them alpha-canonicalize (`alpha.rs` renames a `Var` only when it is *bound* in scope) —
+/// converging copies that differ only in the binding name. Returns the binding assignments to
+/// prepend to the arm body, or `None` to leave the body unchanged.
+///
+/// Deliberately conservative — it must never emit a *wrong* projection (an unsound binding could
+/// seed a false merge):
+/// - `struct_pattern` (`Point { x, y }`): reuse the field-named projection (position-independent).
+/// - `tuple_struct_pattern` with exactly ONE payload element that is a simple binding (`Some(v)`,
+///   `Ok(v)`, `Err(e)`): bind it to field `0`, an unambiguous position. Multi-element tuple
+///   structs (where a `_` wildcard could shift positions) and nested/complex payloads are left
+///   unbound — no convergence, but no soundness risk.
+fn rust_bind_arm_pattern(
+    lo: &mut Lowering,
+    pattern: TsNode,
+    scrutinee: NodeId,
+    span: Span,
+) -> Option<Vec<NodeId>> {
+    match pattern.kind() {
+        // A match arm's pattern is wrapped in `match_pattern` (with an optional `if` guard);
+        // unwrap to the inner pattern, like `lower_match_pattern_condition`. The guard adds no
+        // bindings we project, so binding from the inner pattern alone is correct.
+        "match_pattern" => {
+            let inner = pattern
+                .child_by_field_name("pattern")
+                .or_else(|| Lowering::named_children(pattern).into_iter().next())?;
+            rust_bind_arm_pattern(lo, inner, scrutinee, span)
+        }
+        "struct_pattern" => lower_static_projection_pattern(lo, pattern, scrutinee, span),
+        "tuple_struct_pattern" => {
+            let path_id = constructor_path_node(pattern).map(|p| p.id());
+            let payload: Vec<TsNode> = Lowering::named_children(pattern)
+                .into_iter()
+                .filter(|child| Some(child.id()) != path_id)
+                .collect();
+            let [only] = payload[..] else {
+                return None;
+            };
+            let name = rust_binding_name(lo, only)?;
+            Some(vec![rust_projection_assign(
+                lo, scrutinee, "0", &name, span,
+            )])
+        }
+        _ => None,
+    }
 }
 
 /// The constructor path of a tuple-struct / struct pattern (`Some`, `Ok`, `mod::Point`) — the


### PR DESCRIPTION
A bounded recall lever following up #390 (the Rust constructor-pattern variant-test lowering).

## The gap
#390 made a binding constructor pattern's variant *test* lower to the discriminant path (Raw-free), but the arm body's payload binding — the `v` in `Some(v)` — was never registered as a binder. So `alpha.rs` (which alpha-renames a `Var` only when it is *bound* in scope) left it as a free `Var`, splitting two copies that differ **only in the bound name**:

```rust
match x { Some(a) => a * 2 + 1, None => 0 }   //  ─┐ identical logic,
match x { Some(b) => b * 2 + 1, None => 0 }   //  ─┘ but did NOT converge
```

This is the "falsified-test gap" the #390 test explicitly documented.

## The fix
Lower a match arm's payload binding to a projection assignment prepended to the body (`Some(v)` → `v = scrutinee.0`, mirroring how `x.0` lowers). That makes `v` an assignment target → alpha-canonicalized → the copies converge.

`rust_bind_arm_pattern` is deliberately conservative (an unsound projection could seed a false merge):
- **struct patterns** (`Point { x, y }`): reuse the existing field-named projection (position-independent).
- **tuple-struct patterns** with exactly ONE payload binding (`Some(v)`/`Ok(v)`/`Err(e)`): bind to field `0` — an unambiguous position.
- multi-element / nested / wildcard-mixed payloads are left **unbound** — no convergence, but no soundness risk (a `_` could otherwise shift positions).

## Verification
- `Some(a)`/`Some(b)` converge — new test `rust_constructor_pattern_binding_extraction_converges` + byte-identical normalized IL.
- **No false merge**: a different arm body (`c * 3 + 1`) and cross-variant (`Some` vs `Ok`) stay distinct.
- `nose verify --max-violations 0` clean (0 false merges) on examples + bench samples.
- Full `equivalence` + `detection` suite green; dogfooding **dup-gate** 20/28 (OK); fmt/clippy clean.

Part of the analysis-quality arc (lever B); the `Value::Map` reads prevalence probe (#391) is the remaining open recall lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)