### PR TITLE
analysis: value-graph opaque census (#391 prevalence probe) — map reads are not an opaque gap

### DIFF
--- a/bench/type4/coverage_attribution.py
+++ b/bench/type4/coverage_attribution.py
@@ -19,9 +19,9 @@ Output: coverage_attribution.<date>.json — per-language Raw ratio + the preval
 top unhandled surface kinds, aggregated across the corpus. Deterministic and corpus-pinned.
 
 NOTE (scope): this measures IL-lowering loss (`Raw` nodes). Value-graph modeling loss
-(`Opaque` nodes — the collections/mutation gap) is a separate dimension; `Opaque` carries no
-construct provenance today, so attributing it needs light instrumentation (tracked on the
-collection-modeling issue), not this script.
+(`Opaque` nodes — the collections/mutation/#391 gap) is a separate dimension, now measured by
+the sibling `value_graph_attribution.py`, which consumes the `nose value-census` opaque census
+(the "light instrumentation" this note used to defer).
 """
 
 from __future__ import annotations

--- a/bench/type4/value_graph_attribution.py
+++ b/bench/type4/value_graph_attribution.py
@@ -1,0 +1,177 @@
+"""Value-graph coverage-loss attribution — where the FINGERPRINT loses coverage, by construct.
+
+The sibling instrument `coverage_attribution.py` measures IL-**lowering** loss (`Raw` nodes). Its
+closing note flagged a separate dimension it could not see: value-graph modeling loss (`Opaque`
+nodes — the collections/mutation/#391 question), because `Opaque` carried no construct provenance.
+This script consumes the instrumentation that closed that gap: `nose value-census` walks every
+function unit, builds its value graph with the opaque census on, and reports per IL construct how
+many `ValOp::Opaque` fallbacks were minted — the value-graph analog of the `Raw` ratio.
+
+`total_fallback` opaques are full coverage gaps (the construct could not be modeled at all); the
+rest are semantic opaques carrying structure (e.g. `instanceof`).
+
+It is the #391 decision instrument: it says whether map/collection reads carry real value-graph
+opaque mass (model `Value::Map`) or whether they are modeled-but-divergent (a convergence problem,
+not an opaque-coverage one). The map-read constructs are `Index` (`m[k]`), `Field` (`m.x`), and
+`Call` (`m.get(k)` / `m.items()`).
+
+Usage:
+  python3 value_graph_attribution.py                 # run over the pinned corpus, print + write json
+  python3 value_graph_attribution.py --limit 10      # first 10 repos (smoke)
+  python3 value_graph_attribution.py --nose PATH     # binary (default target/release/nose)
+
+Output: value_graph_attribution.<date>.json — the prevalence-ranked opaque worklist by construct,
+plus the map-read constructs' share. Deterministic and corpus-pinned.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# The IL constructs that carry map / collection reads — the #391 question. `Index` is `m[k]`
+# (and `xs[i]`); `Field` is `m.x`; `Call` is `m.get(k)` / `m.items()` / membership helpers.
+MAP_READ_CONSTRUCTS = {"Index", "Field", "Call"}
+
+
+def corpus_repos(repos_root: Path, limit: int | None):
+    corpus = json.loads((ROOT / "bench/goldens/corpus.json").read_text())["repositories"]
+    repos = sorted(corpus, key=lambda r: r["id"])
+    if limit:
+        repos = repos[:limit]
+    return [(r["id"], r.get("primary_language", "?"), repos_root / r["id"]) for r in repos]
+
+
+def census_for(nose: str, path: Path) -> dict | None:
+    try:
+        out = subprocess.run(
+            [nose, "value-census", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if out.returncode != 0 or not out.stdout.strip():
+        return None
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--nose", default=str(ROOT / "target" / "release" / "nose"))
+    ap.add_argument("--repos-root", default=str(ROOT / "bench" / "repos"))
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--date", default="undated", help="stamp for the output filename")
+    args = ap.parse_args()
+
+    repos = corpus_repos(Path(args.repos_root), args.limit)
+    # Opaque nodes + affected units summed by (construct, total_fallback), and per-language unit
+    # opaque rates for an at-a-glance view.
+    opaque_nodes: dict[tuple[str, bool], int] = defaultdict(int)
+    opaque_units: dict[tuple[str, bool], int] = defaultdict(int)
+    lang_units: dict[str, int] = defaultdict(int)
+    lang_opaque_units: dict[str, int] = defaultdict(int)
+    total_units = 0
+    total_opaque_units = 0
+    missing = []
+    for rid, primary, path in repos:
+        if not path.exists():
+            missing.append(rid)
+            continue
+        c = census_for(args.nose, path)
+        if c is None:
+            missing.append(rid)
+            continue
+        total_units += c["function_units"]
+        total_opaque_units += c["units_with_opaque"]
+        lang_units[primary] += c["function_units"]
+        lang_opaque_units[primary] += c["units_with_opaque"]
+        for row in c["by_construct"]:
+            key = (row["construct"], row["total_fallback"])
+            opaque_nodes[key] += row["opaque_nodes"]
+            opaque_units[key] += row["units"]
+        print(
+            f"  {rid:<24} units {c['function_units']:>6}  opaque-units {c['units_with_opaque']:>6}",
+            file=sys.stderr,
+        )
+
+    by_construct = sorted(
+        (
+            {
+                "construct": k,
+                "total_fallback": total,
+                "opaque_nodes": n,
+                "units": opaque_units[(k, total)],
+            }
+            for (k, total), n in opaque_nodes.items()
+        ),
+        key=lambda r: (-r["opaque_nodes"], r["construct"], r["total_fallback"]),
+    )
+    all_opaque = sum(opaque_nodes.values())
+    map_read_opaque = sum(n for (k, _t), n in opaque_nodes.items() if k in MAP_READ_CONSTRUCTS)
+    per_lang = sorted(
+        (
+            {
+                "lang": l,
+                "function_units": lang_units[l],
+                "opaque_units": lang_opaque_units[l],
+                "opaque_unit_ratio": round(lang_opaque_units[l] / lang_units[l], 4)
+                if lang_units[l]
+                else 0.0,
+            }
+            for l in lang_units
+        ),
+        key=lambda r: -r["opaque_unit_ratio"],
+    )
+
+    result = {
+        "instrument": "value_graph_attribution",
+        "repos": len(repos) - len(missing),
+        "missing": missing,
+        "function_units": total_units,
+        "units_with_opaque": total_opaque_units,
+        "opaque_unit_ratio": round(total_opaque_units / total_units, 4) if total_units else 0.0,
+        "opaque_nodes_total": all_opaque,
+        "map_read_opaque_nodes": map_read_opaque,
+        "map_read_opaque_share": round(map_read_opaque / all_opaque, 4) if all_opaque else 0.0,
+        "per_lang": per_lang,
+        "by_construct": by_construct,
+    }
+    out_path = ROOT / "bench" / "type4" / f"value_graph_attribution.{args.date}.json"
+    out_path.write_text(json.dumps(result, indent=2))
+
+    print(f"\nvalue-graph opaque census: {len(repos) - len(missing)} repos, {total_units} units")
+    print(
+        f"units with ≥1 opaque: {total_opaque_units} ({result['opaque_unit_ratio']:.1%}) · "
+        f"opaque nodes: {all_opaque}"
+    )
+    print(
+        f"map-read constructs (Index/Field/Call) opaque share: "
+        f"{map_read_opaque}/{all_opaque} = {result['map_read_opaque_share']:.1%}"
+    )
+    print("\ntop opaque-minting constructs (the value-graph coverage worklist):")
+    for r in by_construct[:15]:
+        flag = " [map-read]" if r["construct"] in MAP_READ_CONSTRUCTS else ""
+        kind = "total-fallback" if r["total_fallback"] else "semantic"
+        print(
+            f"  {r['construct']:<8} {kind:<14} opaque_nodes {r['opaque_nodes']:>7}  "
+            f"units {r['units']:>6}{flag}"
+        )
+    print(f"\nwrote {out_path}")
+    if missing:
+        print(f"missing/failed repos ({len(missing)}): {', '.join(missing)}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -400,6 +400,19 @@ enum Cmd {
         #[arg(long)]
         no_blocks: bool,
     },
+    /// Value-graph coverage census (#391 prevalence probe): per IL construct, how many
+    /// `Opaque` fallbacks the value graph mints — the value-graph analog of `stats`'s lowering
+    /// `Raw` ratio. Ranks which constructs the fingerprint cannot model (map reads, dynamic
+    /// dispatch, …) by unproven mass. JSON only. (Hidden — research.)
+    #[command(hide = true)]
+    ValueCensus {
+        /// Paths to source files or directories (recursively scanned).
+        #[arg(required = true)]
+        paths: Vec<PathBuf>,
+        /// Disable control-flow normalization (ablation).
+        #[arg(long)]
+        no_cfg_norm: bool,
+    },
     /// Soundness oracle: verify that value-fingerprint-equal units actually compute
     /// the same thing. Interprets each function on a battery of inputs and reports any
     /// fingerprint-equal pair whose behavior differs (a false merge — the cardinal sin
@@ -1680,6 +1693,7 @@ fn run() -> Result<()> {
             no_cfg_norm,
             no_blocks,
         } => cmd_features(paths, min_lines, min_tokens, no_cfg_norm, no_blocks),
+        Cmd::ValueCensus { paths, no_cfg_norm } => cmd_value_census(paths, no_cfg_norm),
         Cmd::Verify {
             paths,
             no_cfg_norm,
@@ -3369,6 +3383,91 @@ fn cmd_features(
     println!(
         "{}",
         serde_json::to_string(&serde_json::json!({ "units": units }))?
+    );
+    Ok(())
+}
+
+/// #391 prevalence probe: walk every function unit, build its value graph with the opaque
+/// census on, and aggregate per IL construct how many `Opaque` fallbacks were minted (the
+/// value-graph analog of `stats`'s lowering `Raw`). `total_fallback` opaques are full coverage
+/// gaps (the construct could not be modeled at all); the rest are partial/semantic opaques.
+fn cmd_value_census(paths: Vec<PathBuf>, no_cfg_norm: bool) -> Result<()> {
+    use std::collections::{BTreeMap, HashSet};
+    let refs = paths_as_refs(&paths);
+    let corpus = nose_frontend::lower_corpus_many(&refs);
+    warn_if_empty(&corpus, &paths);
+    let opts = nose_normalize::NormalizeOptions {
+        cfg_norm: !no_cfg_norm,
+        ..Default::default()
+    };
+    // Build the value graph (the dominant cost) for every unit in parallel, each file producing a
+    // local census, then reduce. The census API builds a fresh per-unit graph, so this is safe.
+    type Census = (BTreeMap<(String, bool), u64>, BTreeMap<(String, bool), u64>, u64, u64);
+    let (opaque_nodes, affected_units, total_units, units_with_opaque): Census = corpus
+        .files
+        .par_iter()
+        .map(|il| {
+            let n = nose_normalize::normalize(il, &corpus.interner, &opts);
+            let mut on: BTreeMap<(String, bool), u64> = BTreeMap::new();
+            let mut au: BTreeMap<(String, bool), u64> = BTreeMap::new();
+            let (mut tu, mut uo): (u64, u64) = (0, 0);
+            for u in &n.units {
+                if n.kind(u.root) != nose_il::NodeKind::Func {
+                    continue; // count function-level units only (blocks would double-count)
+                }
+                tu += 1;
+                let census = nose_normalize::value_graph_opaque_census(&n, u.root, &corpus.interner);
+                if !census.is_empty() {
+                    uo += 1;
+                }
+                let mut seen: HashSet<(String, bool)> = HashSet::new();
+                for (kind, total, count) in census {
+                    let key = (format!("{kind:?}"), total);
+                    *on.entry(key.clone()).or_insert(0) += u64::from(count);
+                    if seen.insert(key.clone()) {
+                        *au.entry(key).or_insert(0) += 1;
+                    }
+                }
+            }
+            (on, au, tu, uo)
+        })
+        .reduce(
+            || (BTreeMap::new(), BTreeMap::new(), 0, 0),
+            |mut a, b| {
+                for (k, v) in b.0 {
+                    *a.0.entry(k).or_insert(0) += v;
+                }
+                for (k, v) in b.1 {
+                    *a.1.entry(k).or_insert(0) += v;
+                }
+                (a.0, a.1, a.2 + b.2, a.3 + b.3)
+            },
+        );
+    let mut by_construct: Vec<_> = opaque_nodes
+        .iter()
+        .map(|((kind, total), n)| {
+            serde_json::json!({
+                "construct": kind,
+                "total_fallback": total,
+                "opaque_nodes": n,
+                "units": affected_units.get(&(kind.clone(), *total)).copied().unwrap_or(0),
+            })
+        })
+        .collect::<Vec<_>>();
+    by_construct.sort_by(|a, b| {
+        b["opaque_nodes"]
+            .as_u64()
+            .cmp(&a["opaque_nodes"].as_u64())
+            .then_with(|| a["construct"].as_str().cmp(&b["construct"].as_str()))
+    });
+    println!(
+        "{}",
+        serde_json::to_string(&serde_json::json!({
+            "files": corpus.files.len(),
+            "function_units": total_units,
+            "units_with_opaque": units_with_opaque,
+            "by_construct": by_construct,
+        }))?
     );
     Ok(())
 }

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -2142,6 +2142,37 @@ fn query_dashboard_filter_and_family() {
 }
 
 #[test]
+fn value_census_attributes_opaque_to_constructs() {
+    // #391 prevalence probe: `nose value-census` reports, per IL construct, how many value-graph
+    // `Opaque` fallbacks were minted. JS `instanceof` is an unmodeled BinOp → a semantic opaque;
+    // a plain numeric function mints none.
+    let dir = std::env::temp_dir().join(format!("nose_vgcensus_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("a.js"),
+        "function f(x, y) { return x instanceof y; }\nfunction g(a, b) { return a + b * 2; }\n",
+    )
+    .unwrap();
+    let census: serde_json::Value =
+        serde_json::from_str(&run(&["value-census", dir.to_str().unwrap()])).unwrap();
+    assert_eq!(census["function_units"], 2, "two functions: {census}");
+    assert_eq!(
+        census["units_with_opaque"], 1,
+        "only the instanceof function mints an opaque: {census}"
+    );
+    let has_binop_opaque = census["by_construct"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|r| r["construct"] == "BinOp" && r["opaque_nodes"].as_u64().unwrap_or(0) >= 1);
+    assert!(
+        has_binop_opaque,
+        "instanceof attributes an opaque to the BinOp construct: {census}"
+    );
+}
+
+#[test]
 fn rust_binding_patterns_lower_without_raw() {
     // #390 lowering fidelity: a `match`/`if let`/`while let` test on a binding constructor
     // pattern (`Some(v)`, `Ok(v)`, `Point { x, y }`) used to lower the whole pattern to an

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -42,9 +42,9 @@ pub use value_graph::{
     value_fingerprint_and_contracts, value_fingerprint_and_contracts_with_context,
     value_fingerprint_contracts, value_fingerprint_lits, value_fingerprint_lits_anchors,
     value_fingerprint_lits_anchors_laws, value_fingerprint_lits_anchors_laws_with_context,
-    value_fingerprint_lits_anchors_with_context, value_fingerprint_lits_with_context, Anchor,
-    Anchors, FingerprintBundle, FingerprintLawBundle, ValueFingerprintContext, ANCHOR_MIN_WEIGHT,
-    CONTAINMENT_ANCHOR_MIN_WEIGHT,
+    value_fingerprint_lits_anchors_with_context, value_fingerprint_lits_with_context,
+    value_graph_opaque_census, Anchor, Anchors, FingerprintBundle, FingerprintLawBundle,
+    ValueFingerprintContext, ANCHOR_MIN_WEIGHT, CONTAINMENT_ANCHOR_MIN_WEIGHT,
 };
 pub use value_graph::{
     bin_is_commutative, value_dag, FileReferents, ValueDag, VgNode, VgOp, VgReferent, VgSink,

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -49,8 +49,9 @@ pub use api::{
     value_fingerprint_and_contracts, value_fingerprint_and_contracts_with_context,
     value_fingerprint_contracts, value_fingerprint_lits, value_fingerprint_lits_anchors,
     value_fingerprint_lits_anchors_laws, value_fingerprint_lits_anchors_laws_with_context,
-    value_fingerprint_lits_anchors_with_context, value_fingerprint_lits_with_context, Anchor,
-    Anchors, FingerprintBundle, FingerprintLawBundle, ANCHOR_MIN_WEIGHT,
+    value_fingerprint_lits_anchors_with_context, value_fingerprint_lits_with_context,
+    value_graph_opaque_census, Anchor, Anchors, FingerprintBundle, FingerprintLawBundle,
+    ANCHOR_MIN_WEIGHT,
     CONTAINMENT_ANCHOR_MIN_WEIGHT,
 };
 pub use context::ValueFingerprintContext;

--- a/crates/nose-normalize/src/value_graph/api.rs
+++ b/crates/nose-normalize/src/value_graph/api.rs
@@ -53,6 +53,35 @@ pub fn value_fingerprint_lits(
     b.fingerprint_lits()
 }
 
+/// Research instrument (the #391 prevalence probe): the value-graph opaque-fallback census for the
+/// unit at `root` — per `(IL node kind, total_fallback)`, how many `ValOp::Opaque` nodes the build
+/// minted. `total_fallback` (argless opaque) is a full coverage gap — the construct could not be
+/// modeled at all — while a semantic opaque (with args, e.g. `instanceof`) is a partial model.
+/// Attributes value-graph coverage loss to the construct that produced it, the way `nose stats`
+/// attributes lowering `Raw` loss. Returned sorted by count desc (deterministic).
+pub fn value_graph_opaque_census(
+    il: &Il,
+    root: NodeId,
+    interner: &Interner,
+) -> Vec<(NodeKind, bool, u32)> {
+    let mut b = Builder::new(il, interner);
+    b.opaque_census = Some(FxHashMap::default());
+    b.build_unit(root);
+    let mut out: Vec<(NodeKind, bool, u32)> = b
+        .opaque_census
+        .take()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|((kind, total), n)| (kind, total, n))
+        .collect();
+    out.sort_by(|a, b| {
+        b.2.cmp(&a.2)
+            .then_with(|| format!("{:?}", a.0).cmp(&format!("{:?}", b.0)))
+            .then(a.1.cmp(&b.1))
+    });
+    out
+}
+
 /// The default minimum sub-computation size (in value-nodes) for a node to be an extractable
 /// anchor. Below this a shared sub-DAG is a common idiom (`x+1`, `len(xs)`), not a refactor.
 /// The #248 sweep (experiments §BW) measured the §BJ 8–20 band: floor 8 gains real

--- a/crates/nose-normalize/src/value_graph/canonicalize.rs
+++ b/crates/nose-normalize/src/value_graph/canonicalize.rs
@@ -9,6 +9,18 @@ use super::*;
 
 impl<'a> Builder<'a> {
     pub(super) fn mk(&mut self, mut op: ValOp, mut args: Vec<ValueId>) -> ValueId {
+        // Opaque-fallback census (#391 prevalence probe; only when enabled). Record before any
+        // canonicalization — attributes the opaque to the IL construct that is being evaluated.
+        if self.opaque_census.is_some() && matches!(op, ValOp::Opaque(_)) {
+            if let Some(kind) = self.cur_il_kind {
+                *self
+                    .opaque_census
+                    .as_mut()
+                    .unwrap()
+                    .entry((kind, args.is_empty()))
+                    .or_insert(0) += 1;
+            }
+        }
         self.commute_numeric_reduce_contrib(&op, &mut args);
         self.order_bin_operands(&mut op, &mut args);
         if let Some(v) = self.u16_byte_pack(&op, &args) {

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -137,8 +137,13 @@ impl<'a> Builder<'a> {
         // at creation — those intermediates are exactly what a heavy sub-DAG anchor points at.
         let prev = self.cur_span;
         self.cur_span = Some(self.il.node(expr).span);
+        // Mirror `cur_span` for the opaque census (#391 probe): the save/restore makes the
+        // current kind the node whose handler mints an `Opaque`, not a just-evaluated child.
+        let prev_kind = self.cur_il_kind;
+        self.cur_il_kind = Some(self.il.node(expr).kind);
         let v = self.eval_inner(expr, env);
         self.cur_span = prev;
+        self.cur_il_kind = prev_kind;
         v
     }
 

--- a/crates/nose-normalize/src/value_graph/model.rs
+++ b/crates/nose-normalize/src/value_graph/model.rs
@@ -172,6 +172,14 @@ pub(super) struct Builder<'a> {
     /// The source span of the expression currently being evaluated (set by `eval`), used to stamp
     /// `node_span` for every node `mk` creates while evaluating it.
     pub(super) cur_span: Option<Span>,
+    /// The IL node kind currently being evaluated (set by `eval`, mirroring `cur_span`), so the
+    /// opaque census can attribute each `Opaque` fallback to the construct that minted it.
+    pub(super) cur_il_kind: Option<NodeKind>,
+    /// Research instrument (env-gated; `None` in production): per `(IL kind, total-fallback)`
+    /// count of `ValOp::Opaque` nodes minted — the value-graph coverage-attribution census (the
+    /// #391 prevalence probe). `total-fallback` = an argless opaque (a "can't model this at all"
+    /// node, the coverage gap) vs a semantic opaque carrying structure (`instanceof`, partial).
+    pub(super) opaque_census: Option<FxHashMap<(NodeKind, bool), u32>>,
     pub(super) intern: FxHashMap<(ValOp, Vec<ValueId>), ValueId>,
     pub(super) sinks: Vec<Sink>,
     pub(super) opaque_ctr: u32,

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -21,6 +21,8 @@ impl<'a> Builder<'a> {
             vhash: Vec::new(),
             node_span: Vec::new(),
             cur_span: None,
+            cur_il_kind: None,
+            opaque_census: None,
             intern: FxHashMap::default(),
             sinks: Vec::new(),
             opaque_ctr: 0,

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2863,3 +2863,39 @@ biggest genuine accidental leak (Rust patterns) shipped in §CQ; after that, rus
 near-complete and the remaining `Raw` is either deliberate boundaries (a separate, soundness-
 contract-gated effort), parse failures (a grammar axis), or low-value type-level declarations.
 Driving the *raw* ratio lower is mostly NOT a safe lowering task — the instrument now says so.
+
+## CS. Value-graph coverage census — map reads are not an opaque gap (#391, 2026-06-15)
+
+§CP/§CR characterized the **lowering** dimension (`Raw` nodes). The §CP note flagged a second,
+unmeasured dimension: value-graph **modeling** loss (`ValOp::Opaque` fallbacks), the #391
+collections/map question — `Opaque` carried no construct provenance, so attributing it needed
+instrumentation. This is that instrument and its first measurement.
+
+**Instrument.** A `cur_il_kind` field mirrors the existing `cur_span` (set by `eval`'s
+save/restore), and `mk` records, into an env-gated census, every `ValOp::Opaque` it builds keyed
+by `(IL construct, total-fallback)` — `total-fallback` = an argless opaque (a full coverage gap)
+vs a semantic opaque with structure (`instanceof`). Zero fingerprint impact (inert when off;
+equivalence/determinism unchanged). Surfaced as `nose value-census`; the corpus probe is
+`bench/type4/value_graph_attribution.py`, the value-graph analog of `coverage_attribution.py`.
+
+**The #391 premise was wrong.** The audit memory framed map reads as bailing to `Value::Err` —
+but that is the *oracle* (`interp.rs`), not the *fingerprint*. In the value graph `m[k]` and
+`m.get(k)` are both **modeled** (`Index` / `Call`) — they mint **no opaque** — but they get
+**different fingerprints** (their normalized IL diverges). So #391 is a **convergence /
+form-canonicalization** problem (`m[k]` ≡ `m.get(k)` ≡ `k in m`), not an opaque-coverage gap.
+
+**Measured (py/js/go/rust subset, 6128 function units).** 27% of units carry ≥1 opaque. The
+opaque mass is led by **`Raw` propagation** (1557 nodes / 906 units — the already-characterized
+§CR lowering frontier, surfacing in the fingerprint), **`Block`** (1464 / 687 — unmodeled
+statement blocks/closures), and **`Func`** (344 / 181 — nested functions). `BinOp`-semantic
+opaques (`instanceof`/strict-null-cmp) and a small `Call`/`Splat`/`HoF`/`Loop` tail follow. The
+map-read constructs **`Index` / `Field` / membership carry ~0 opaque mass** — confirming map
+reads are not a value-graph coverage gap.
+
+**Verdict for #391.** Modeling `Value::Map` reads would not reduce opaque mass; it is narrow
+convergence work (canonicalize the read forms) with the soundness cost of key-equality /
+missing-key / language-variance semantics, and `--falsify` cannot even construct an input for it.
+With map reads below the opaque threshold, #391 is **audited, below the bar** — the value-graph
+opaque worklist is `Block`/`Func` (closures/nested) and the propagated lowering `Raw` (already a
+characterized, mostly-boundary/grammar frontier), not collections. The analysis engine remains at
+its measured frontier.


### PR DESCRIPTION
The disciplined prevalence probe for #391 (model `Value::Map` reads), built before any soundness-critical modeling — and it changes the conclusion.

## Instrument
The §CP `coverage_attribution.py` measures IL **lowering** loss (`Raw`); its closing note deferred the value-graph **modeling** loss (`Opaque`) because `Opaque` had no construct provenance. This closes that:
- A `cur_il_kind` field mirrors the existing `cur_span` (set by `eval`'s save/restore), and `mk` records every `ValOp::Opaque` it builds into an **env-gated** census keyed by `(IL construct, total_fallback)`. **Zero fingerprint impact** — inert when off; equivalence/determinism unchanged (verified).
- Surfaced as the hidden `nose value-census`; reproducible corpus probe `bench/type4/value_graph_attribution.py` (the value-graph analog of `coverage_attribution.py`).

## Finding (experiments §CS): the #391 premise was wrong
The audit framed map reads as bailing to `Value::Err` — but that's the **oracle** (`interp.rs`), not the fingerprint. In the value graph `m[k]` and `m.get(k)` are both **modeled** (`Index`/`Call`, they mint **no opaque**) but get **different fingerprints** (their normalized IL diverges). So **#391 is a convergence/canonicalization problem, not an opaque-coverage gap.**

Measured (py/js/go/rust, 6128 function units): 27% of units carry ≥1 opaque, dominated by `Raw`-propagation (the already-characterized §CR lowering frontier), `Block`, and `Func` (closures/nested). The map-read constructs **`Index`/`Field`/membership carry ~0 opaque mass**.

## Verdict for #391
Modeling `Value::Map` reads would not cut opaque mass; it's narrow convergence work with key-equality/missing-key/language-variance soundness cost (and `--falsify` can't construct an input for it). **#391 → audited, below the opaque bar.** The value-graph opaque worklist is `Block`/`Func` + propagated lowering `Raw`, not collections — the analysis engine remains at its measured frontier.

## Validation
`--fast` green (build, clippy `-D warnings`, full nose-cli suite incl. new `value_census_attributes_opaque_to_constructs`, wiki lint). The instrument is inert in production (census `None`); fingerprints unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)