### PR TITLE
deps: upgrade tree-sitter core 0.24 → 0.25 to accept ABI-15 grammars (c/python/javascript)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ break.
   agree, so `nose query <path> --format sarif top=0` is the complete-upload spelling and query
   fully subsumes scan's truncation control. No `top=` term still defaults to 30.
 
+### Changed
+- **tree-sitter core upgraded `0.24` → `0.25`, grammars `tree-sitter-c` → `0.24.2`,
+  `tree-sitter-python`/`tree-sitter-javascript` → `0.25.0`** (#403, unblocks the reverted
+  #399/#400/#401). The bumped grammars compile to grammar ABI 15; core 0.25 accepts ABI **14
+  and 15**, so the still-pinned 0.23 grammars (go/rust/java/ruby/typescript) keep loading
+  alongside them. Internal-only — no Rust API changes were needed, and `nose query --format
+  json` output is **byte-identical** across the bump on C/Python/JS corpora (the normalizer
+  absorbs the CST-shape deltas), with the soundness gate (`verify --max-violations 0`) clean.
+  Validated on a `cargo clean` release build (the stale-grammar-object trap that produced the
+  #402 false-green; with core at 0.25 both ABI versions load, so it can no longer recur).
+
 ## [0.10.0] - 2026-06-15
 
 Breaking: **`nose query` becomes the primary surface and `nose scan`/`nose review` are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -824,22 +825,23 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.7"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
 dependencies = [
  "cc",
  "regex",
  "regex-syntax",
+ "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-c"
-version = "0.23.4"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd2b1bf1585dc2ef6d69e87d01db8adb059006649dd5f96f31aa789ee6e9c71"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -867,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-javascript"
-version = "0.23.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -883,9 +885,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-python"
-version = "0.23.6"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -3402,7 +3402,12 @@ fn cmd_value_census(paths: Vec<PathBuf>, no_cfg_norm: bool) -> Result<()> {
     };
     // Build the value graph (the dominant cost) for every unit in parallel, each file producing a
     // local census, then reduce. The census API builds a fresh per-unit graph, so this is safe.
-    type Census = (BTreeMap<(String, bool), u64>, BTreeMap<(String, bool), u64>, u64, u64);
+    type Census = (
+        BTreeMap<(String, bool), u64>,
+        BTreeMap<(String, bool), u64>,
+        u64,
+        u64,
+    );
     let (opaque_nodes, affected_units, total_units, units_with_opaque): Census = corpus
         .files
         .par_iter()
@@ -3416,7 +3421,8 @@ fn cmd_value_census(paths: Vec<PathBuf>, no_cfg_norm: bool) -> Result<()> {
                     continue; // count function-level units only (blocks would double-count)
                 }
                 tu += 1;
-                let census = nose_normalize::value_graph_opaque_census(&n, u.root, &corpus.interner);
+                let census =
+                    nose_normalize::value_graph_opaque_census(&n, u.root, &corpus.interner);
                 if !census.is_empty() {
                     uo += 1;
                 }

--- a/crates/nose-frontend/Cargo.toml
+++ b/crates/nose-frontend/Cargo.toml
@@ -14,14 +14,18 @@ ignore = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 
-tree-sitter = "0.24"
-tree-sitter-python = "0.23"
-tree-sitter-javascript = "0.23"
+# Core 0.25 accepts grammar ABI 14 AND 15, so the ABI-15 grammars below (python/
+# javascript 0.25, c 0.24) load alongside the ABI-14 grammars still pinned at 0.23.
+# See #403. VALIDATE any bump on a `cargo clean` release build — incremental builds
+# reuse stale cc-compiled grammar objects and pass falsely (#399/#400/#401 → #402).
+tree-sitter = "0.25"
+tree-sitter-python = "0.25"
+tree-sitter-javascript = "0.25"
 tree-sitter-typescript = "0.23"
 tree-sitter-go = "0.23"
 tree-sitter-rust = "0.23"
 tree-sitter-java = "0.23"
-tree-sitter-c = "0.23"
+tree-sitter-c = "0.24"
 tree-sitter-ruby = "0.23"
 
 [lints]

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -51,8 +51,7 @@ pub use api::{
     value_fingerprint_lits_anchors_laws, value_fingerprint_lits_anchors_laws_with_context,
     value_fingerprint_lits_anchors_with_context, value_fingerprint_lits_with_context,
     value_graph_opaque_census, Anchor, Anchors, FingerprintBundle, FingerprintLawBundle,
-    ANCHOR_MIN_WEIGHT,
-    CONTAINMENT_ANCHOR_MIN_WEIGHT,
+    ANCHOR_MIN_WEIGHT, CONTAINMENT_ANCHOR_MIN_WEIGHT,
 };
 pub use context::ValueFingerprintContext;
 pub use value_dag::{

--- a/crates/nose-normalize/src/value_graph/canonicalize.rs
+++ b/crates/nose-normalize/src/value_graph/canonicalize.rs
@@ -11,14 +11,9 @@ impl<'a> Builder<'a> {
     pub(super) fn mk(&mut self, mut op: ValOp, mut args: Vec<ValueId>) -> ValueId {
         // Opaque-fallback census (#391 prevalence probe; only when enabled). Record before any
         // canonicalization — attributes the opaque to the IL construct that is being evaluated.
-        if self.opaque_census.is_some() && matches!(op, ValOp::Opaque(_)) {
-            if let Some(kind) = self.cur_il_kind {
-                *self
-                    .opaque_census
-                    .as_mut()
-                    .unwrap()
-                    .entry((kind, args.is_empty()))
-                    .or_insert(0) += 1;
+        if matches!(op, ValOp::Opaque(_)) {
+            if let (Some(census), Some(kind)) = (self.opaque_census.as_mut(), self.cur_il_kind) {
+                *census.entry((kind, args.is_empty())).or_insert(0) += 1;
             }
         }
         self.commute_numeric_reduce_contrib(&op, &mut args);


### PR DESCRIPTION
Closes #403. Takes the grammar bumps reverted in #402 (tree-sitter-c 0.24.2, -python 0.25.0, -javascript 0.25.0) **properly**, by upgrading tree-sitter **core** 0.24 → 0.25 first.

## Why this is the right way
The bumped grammars compile to grammar **ABI 15**. Core 0.24 (max ABI 14) rejects them at load time — that's why the bare dependabot bumps (#399/#400/#401) made `main` go red on a clean build even though their PR checks were green (incremental builds reused stale ABI-14 grammar objects → false-green; see #402).

Core 0.25 accepts ABI **14 *and* 15**, so the still-pinned 0.23 grammars (go/rust/java/ruby/typescript, ABI 14) keep loading alongside the new ABI-15 ones. **No version is rejected**, which also means the #402 stale-object trap can no longer break `main`: a stale-vs-fresh object mix is harmless when both ABIs load.

No Rust API changes were needed across 0.24 → 0.25 (frontend already uses `LANGUAGE.into()` + `set_language(&lang)`).

## Validation (on a `cargo clean` release build)
| check | result |
|---|---|
| clean build compiles | ✅ no code changes needed |
| all 8 languages parse | ✅ C/Python/JS = freshly-compiled **ABI 15** (the exact path that false-passed in #402) |
| behavior-neutral | ✅ `nose query --format json` **byte-identical** 0.23-vs-0.25 on redis (C, 475 fams), black (Py, 122), axios (JS, 132) — normalizer absorbs CST-shape deltas |
| deterministic | ✅ byte-identical across runs |
| soundness gate | ✅ `verify --max-violations 0` exits 0 on all three |
| fmt / clippy -D warnings / machete / `cargo test --release` | ✅ green (1051 tests) |

## Follow-up (optional, now unblocked)
Bump go/rust/java/ruby/typescript to their 0.25 lines for ABI consistency — same validation recipe.

Incidental: tidies the #405 census `mk()` opaque-count branch (`.as_mut().unwrap()` → `if let` tuple-match) + rustfmt reflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)