### PR TITLE
deps: take tree-sitter go 0.25 (with go.rs statement_list migration) + rust 0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,24 @@ break.
 - **tree-sitter core upgraded `0.24` → `0.25`, grammars `tree-sitter-c` → `0.24.2`,
   `tree-sitter-python`/`tree-sitter-javascript` → `0.25.0`** (#403, unblocks the reverted
   #399/#400/#401). The bumped grammars compile to grammar ABI 15; core 0.25 accepts ABI **14
-  and 15**, so the still-pinned 0.23 grammars (go/rust/java/ruby/typescript) keep loading
+  and 15**, so the still-pinned 0.23 grammars (java/ruby/typescript) keep loading
   alongside them. Internal-only — no Rust API changes were needed, and `nose query --format
   json` output is **byte-identical** across the bump on C/Python/JS corpora (the normalizer
   absorbs the CST-shape deltas), with the soundness gate (`verify --max-violations 0`) clean.
   Validated on a `cargo clean` release build (the stale-grammar-object trap that produced the
   #402 false-green; with core at 0.25 both ABI versions load, so it can no longer recur).
+- **`tree-sitter-rust` upgraded `0.23` → `0.24.2`** (ABI 15; follows #403). Behavior-neutral:
+  `nose query --format json` is **byte-identical** before/after on the Rust dogfood tree
+  (`crates/`) and a Rust corpus (alacritty), with the dup-gate and soundness gate clean.
+- **`tree-sitter-go` upgraded `0.23` → `0.25.0`** (ABI 15; follows #403), with the required
+  **`go.rs` migration**: go 0.25's one structural change is wrapping `block` / switch-case /
+  select-case statements in a new `statement_list` node, so the frontend now flattens that
+  wrapper (`stmt_children`) — without it every nested statement orphans to Raw, spiking the go
+  Raw ratio 0.7% → 29%. With the migration the Raw ratio is **restored to 0.7%** and `nose query`
+  output is **byte-identical** to go 0.23 on 12/16 go corpus repos; the remaining four differ by
+  ≤4 families from go 0.25's own parse-behaviour refinements (Raw ratio equal-or-lower, soundness
+  gate clean — not a lowering regression). (`type_alias` also gained a `type_parameters` field for
+  generic aliases; the frontend ignores type declarations, so it has no effect.)
 
 ## [0.10.0] - 2026-06-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-go"
-version = "0.23.4"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -905,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.23.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/nose-frontend/Cargo.toml
+++ b/crates/nose-frontend/Cargo.toml
@@ -15,15 +15,19 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 
 # Core 0.25 accepts grammar ABI 14 AND 15, so the ABI-15 grammars below (python/
-# javascript 0.25, c 0.24) load alongside the ABI-14 grammars still pinned at 0.23.
+# javascript 0.25, c 0.24, go 0.25, rust 0.24) load alongside the ABI-14 grammars
+# still pinned at 0.23 (java/ruby/typescript — no newer upstream line exists).
+# NOTE: go 0.25 wraps block / switch-case / select-case statements in a new
+# `statement_list` node; go.rs flattens that wrapper (see `stmt_children`) so the
+# lowering is byte-identical to go 0.23 — required, else the go Raw ratio explodes.
 # See #403. VALIDATE any bump on a `cargo clean` release build — incremental builds
 # reuse stale cc-compiled grammar objects and pass falsely (#399/#400/#401 → #402).
 tree-sitter = "0.25"
 tree-sitter-python = "0.25"
 tree-sitter-javascript = "0.25"
 tree-sitter-typescript = "0.23"
-tree-sitter-go = "0.23"
-tree-sitter-rust = "0.23"
+tree-sitter-go = "0.25"
+tree-sitter-rust = "0.24"
 tree-sitter-java = "0.23"
 tree-sitter-c = "0.24"
 tree-sitter-ruby = "0.23"

--- a/crates/nose-frontend/src/go.rs
+++ b/crates/nose-frontend/src/go.rs
@@ -34,8 +34,32 @@ fn lower_source(lo: &mut Lowering, node: TsNode) -> NodeId {
     crate::lower::collect_into(lo, node, NodeKind::Module, lower_stmt)
 }
 
+/// The statements of a `block` / switch-case / select-case. go 0.25 wraps them in
+/// a single `statement_list` node (go 0.23 listed them directly under the parent);
+/// flatten that wrapper — without an extra block level — so both grammar shapes
+/// lower identically. Non-`statement_list` children (e.g. a case's `value` field)
+/// pass through untouched for the caller to handle.
+fn stmt_children(node: TsNode) -> Vec<TsNode> {
+    let mut out = Vec::new();
+    for c in Lowering::named_children(node) {
+        if c.kind() == "statement_list" {
+            out.extend(Lowering::named_children(c));
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 fn lower_block(lo: &mut Lowering, node: TsNode) -> NodeId {
-    crate::lower::collect_into(lo, node, NodeKind::Block, lower_stmt)
+    let span = lo.span(node);
+    let mut stmts = Vec::new();
+    for c in stmt_children(node) {
+        if let Some(id) = lower_stmt(lo, c) {
+            stmts.push(id);
+        }
+    }
+    lo.add(NodeKind::Block, Payload::None, span, &stmts)
 }
 
 fn lower_stmt(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
@@ -156,7 +180,7 @@ fn lower_select_child(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
     match node.kind() {
         "communication_case" => {
-            let kids: Vec<NodeId> = Lowering::named_children(node)
+            let kids: Vec<NodeId> = stmt_children(node)
                 .into_iter()
                 .filter_map(|child| lower_stmt(lo, child))
                 .collect();
@@ -168,7 +192,7 @@ fn lower_select_child(lo: &mut Lowering, node: TsNode) -> NodeId {
             )
         }
         "default_case" => {
-            let kids: Vec<NodeId> = Lowering::named_children(node)
+            let kids: Vec<NodeId> = stmt_children(node)
                 .into_iter()
                 .filter_map(|child| lower_stmt(lo, child))
                 .collect();
@@ -771,7 +795,7 @@ fn lower_case_body(lo: &mut Lowering, case: TsNode) -> NodeId {
     // body. Skip the test so it doesn't land in the body block.
     let value_id = case.child_by_field_name("value").map(|v| v.id());
     let mut stmts = Vec::new();
-    for c in Lowering::named_children(case) {
+    for c in stmt_children(case) {
         if Some(c.id()) == value_id {
             continue;
         }
@@ -1082,6 +1106,36 @@ mod tests {
     fn switch_cases_compare_scrutinee_to_all_case_labels() {
         let src = "package main\nfunc f(x int) int { switch x { case 1, 2: return 3; default: return 4 } }\n";
         assert_eq!(switch_case_rhs_ints(src), vec![1, 2]);
+    }
+
+    #[test]
+    fn block_switch_select_bodies_survive_statement_list_wrapper() {
+        // go 0.25 wraps block / switch-case / select-case statements in a single
+        // `statement_list` node (go 0.23 listed them directly). `stmt_children` must
+        // flatten that wrapper, else every nested statement is orphaned to Raw — the
+        // go-0.25 Raw-ratio blowup (0.7% → 29%) this migration fixes. Each op below
+        // lives inside one of the three wrapper sites.
+        let block = ops("package main\nfunc f(a int, b int) int { c := a + b; return c }\n");
+        assert!(
+            block.contains(&Op::Add),
+            "block-body op orphaned, got {block:?}"
+        );
+
+        let sw = ops(
+            "package main\nfunc f(a int, b int, x int) int { switch x { case 1: return a - b; default: return a * b } }\n",
+        );
+        assert!(
+            sw.contains(&Op::Sub) && sw.contains(&Op::Mul),
+            "switch-case-body ops orphaned, got {sw:?}"
+        );
+
+        let sel = ops(
+            "package main\nfunc f(ch chan int, a int, b int) int { select { case <-ch: return a / b; default: return a + b } }\n",
+        );
+        assert!(
+            sel.contains(&Op::Div) && sel.contains(&Op::Add),
+            "select-case-body ops orphaned, got {sel:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #403 (core 0.25). Moves the two remaining grammars that have a newer upstream line onto ABI 15. **java/ruby/typescript stay at 0.23 — no newer upstream release exists.** Validated on a `cargo clean` release build (the stale-grammar-object trap that broke #402).

## `tree-sitter-rust` 0.23 → 0.24.2 — behavior-neutral
`nose query --format json` **byte-identical** before/after on the Rust dogfood tree (`crates/`) and a Rust corpus (alacritty); dup-gate + soundness gate clean.

## `tree-sitter-go` 0.23 → 0.25.0 — needs a frontend migration
A **bare** bump explodes the go Raw ratio **0.7% → 29%** (verified). Root cause, from a full `node-types.json` diff: go 0.25's *only* structural change is wrapping a `block` / switch-case / select-case's statements in a new **`statement_list`** node. `go.rs` iterated those children directly, so every nested statement orphaned to Raw.

> The one other schema delta — a `type_parameters` field on `type_alias` (generic aliases) — is moot: the frontend drops type declarations.

**Fix:** `stmt_children` flattens the `statement_list` wrapper (no extra block level) at the three statement-collection sites — `lower_block`, `lower_case_body`, `lower_select_child`.

### Validation (clean release build)
| check | result |
|---|---|
| go Raw ratio | **restored to 0.7%** (badger exactly matches the 0.23 baseline) |
| `nose query` byte-identical to go 0.23 | **12/16** go corpus repos |
| remaining 4 repos | differ by **≤4 families** from go 0.25's own parse-behaviour refinements — Raw ratio **equal-or-lower**, **soundness gate clean** on all four (not a lowering regression) |
| regression test | new test asserts block/switch/select bodies survive the wrapper |
| fmt / clippy -D warnings / `cargo test --release` | green (**1052 tests**) |

Why ship the 4 non-identical repos: their deltas come from go 0.25's genuinely-different (slightly *better* — Raw equal-or-lower) parsing, not from an incomplete migration (`statement_list` is the only structural change and it's fully handled). Soundness is preserved throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)