### PR TITLE
ci: bump actions/checkout v4 → v6 (Node 20 → 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: build · test · lint · dup-gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -49,7 +49,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
@@ -68,7 +68,7 @@ jobs:
     name: minimum supported rust version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Read the MSRV from Cargo.toml so this job never drifts from the declared value.
       - id: msrv
         run: echo "v=$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*\"(.*)\".*/\1/')" >> "$GITHUB_OUTPUT"
@@ -83,7 +83,7 @@ jobs:
     name: unused-deps · advisories · licenses
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       # Prebuilt binaries — no compile cost.
       - uses: taiki-e/install-action@v2
@@ -98,7 +98,7 @@ jobs:
     name: docs wiki connectivity (awiki)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version: stable
@@ -112,7 +112,7 @@ jobs:
     name: formal obligations · lean proofs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # The formal obligation registry maps proof-sensitive semantic surfaces to Lean
       # proof files and counterexamples. Shared Lean models are compiled under target/lean;
       # each proof must type-check with warnings promoted to errors. See formal/README.md.

--- a/.github/workflows/corpus-verify.yml
+++ b/.github/workflows/corpus-verify.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 


### PR DESCRIPTION
`actions/checkout@v4` runs on **Node.js 20**, which GitHub deprecated on its runners — every CI job carried a *"Node.js 20 actions are deprecated … will be forced to run with Node.js 24"* annotation, and the forced cutover starts **2026-06-16**.

Bumps the 7 remaining `@v4` pins to **`@v6`**, the version `release.yml` already standardizes on:
- `ci.yml` ×6
- `corpus-verify.yml` ×1

No-op otherwise — identical checkout step, Node-24 runtime. Clears the deprecation annotation across all jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)