### PR TITLE
coevo series 10 (§CT): nullish-coalesce map-default false merge — found and fixed (#409, #410)

### DIFF
--- a/bench/coevo/false_merges/README.md
+++ b/bench/coevo/false_merges/README.md
@@ -21,7 +21,7 @@ moved into the permanent regression battery.
 | (cross-lang shift) | JS `a<<b`/`a>>b` (int32) ≡ Python arbitrary-precision `<<`/`>>` | n/a (cross-language — no single-file repro) | FIXED series 9 — JS shift operand int32-narrowed |
 | float_assoc.py | `(a+b)+c≡a+(b+c)` for floats | NO — oracle blind | OPEN (C/float) — needs the `Float` value kind (D-div) |
 | array_element_mutation.py | `swap` ≡ `clobber` — `a[i]` read after an indexed write re-derives the pre-write value | NO — oracle blind | OPEN — needs in-place element-mutation modeling (value graph + interp), see oracle-value-model §7.3 |
-| map_nullish_default.ts | `m.get(k) ?? d` (coalesce: d on absent **or** present-null) ≡ `m.has(k) ? m.get(k) : d` / `=== undefined` (absence-only) | NO — oracle blind (`vj[1.0]:0/1` but gate green) | OPEN (series 10/§CT, #410) — needs map-value non-null proof + null/undefined de-conflation |
+| map_nullish_default.ts | `m.get(k) ?? d` (coalesce: d on absent **or** present-null) ≡ `m.has(k) ? m.get(k) : d` / `=== undefined` (absence-only) | NO — oracle blind (`vj[1.0]:0/1` but gate green) | FIXED series 10/§CT (#410) — null-guard map default → faithful `ValueOrDefault` (split from the membership-guarded `GetOrDefault`); `=== undefined` kept opaque. Corpus byte-identical. Regression `nullish_coalesce_map_default_is_distinct_from_absence_default` |
 
 FIXED rows are now covered by permanent regression tests (effect cases in the
 value-graph suite; `-(-a)`/`a&a`/`a+b` in `crates/nose-cli/tests/equivalence.rs`,
@@ -33,6 +33,7 @@ value-graph suite; `-(-a)`/`a&a`/`a+b` in `crates/nose-cli/tests/equivalence.rs`
 inline-soundness cases in `dataflow_does_not_unsoundly_inline_a_temp_past_a_write_or_into_a_lambda`).
 The OPEN rows are oracle-blind value-model gaps: `float_assoc.py` needs the `Float` value
 kind (D-div, #283-D); `array_element_mutation.py` needs in-place element-mutation modeling
-(oracle-value-model §7.3); `map_nullish_default.ts` needs a map-value non-null proof plus
-null/undefined de-conflation (#410, oracle-value-model §7.4). All three share the limitation
-that the interpreter cannot witness them, so no battery row distinguishes the merged pair.
+(oracle-value-model §7.3). `map_nullish_default.ts` was the same oracle-blind class but is now
+FIXED by SPLITTING the merged pair (the null-guarded coalesce no longer folds to the absence-only
+`GetOrDefault`), so the interpreter never needs to witness it; it is kept here as a split-asserting
+reproducer (#410, oracle-value-model §7.4).

--- a/bench/coevo/false_merges/README.md
+++ b/bench/coevo/false_merges/README.md
@@ -21,6 +21,7 @@ moved into the permanent regression battery.
 | (cross-lang shift) | JS `a<<b`/`a>>b` (int32) ≡ Python arbitrary-precision `<<`/`>>` | n/a (cross-language — no single-file repro) | FIXED series 9 — JS shift operand int32-narrowed |
 | float_assoc.py | `(a+b)+c≡a+(b+c)` for floats | NO — oracle blind | OPEN (C/float) — needs the `Float` value kind (D-div) |
 | array_element_mutation.py | `swap` ≡ `clobber` — `a[i]` read after an indexed write re-derives the pre-write value | NO — oracle blind | OPEN — needs in-place element-mutation modeling (value graph + interp), see oracle-value-model §7.3 |
+| map_nullish_default.ts | `m.get(k) ?? d` (coalesce: d on absent **or** present-null) ≡ `m.has(k) ? m.get(k) : d` / `=== undefined` (absence-only) | NO — oracle blind (`vj[1.0]:0/1` but gate green) | OPEN (series 10/§CT, #410) — needs map-value non-null proof + null/undefined de-conflation |
 
 FIXED rows are now covered by permanent regression tests (effect cases in the
 value-graph suite; `-(-a)`/`a&a`/`a+b` in `crates/nose-cli/tests/equivalence.rs`,
@@ -32,5 +33,6 @@ value-graph suite; `-(-a)`/`a&a`/`a+b` in `crates/nose-cli/tests/equivalence.rs`
 inline-soundness cases in `dataflow_does_not_unsoundly_inline_a_temp_past_a_write_or_into_a_lambda`).
 The OPEN rows are oracle-blind value-model gaps: `float_assoc.py` needs the `Float` value
 kind (D-div, #283-D); `array_element_mutation.py` needs in-place element-mutation modeling
-(oracle-value-model §7.3). Both share the limitation that the interpreter cannot witness
-them, so no battery row distinguishes the merged pair.
+(oracle-value-model §7.3); `map_nullish_default.ts` needs a map-value non-null proof plus
+null/undefined de-conflation (#410, oracle-value-model §7.4). All three share the limitation
+that the interpreter cannot witness them, so no battery row distinguishes the merged pair.

--- a/bench/coevo/false_merges/map_nullish_default.ts
+++ b/bench/coevo/false_merges/map_nullish_default.ts
@@ -1,6 +1,9 @@
-// Confirmed LATENT false merge (coevo series 10, §CT). nose gives `coalesce`,
-// `presence`, and `undef_check` ONE exact-value-graph fingerprint, but they are
-// behaviorally distinct on a present key whose stored value is null.
+// FIXED (coevo series 10, §CT, #410) — kept as a split-asserting reproducer. nose USED TO give
+// `coalesce`, `presence`, and `undef_check` ONE exact-value-graph fingerprint, but they are
+// behaviorally distinct on a present key whose stored value is null. After the fix the
+// null-guarded coalesce folds to the faithful `ValueOrDefault` (split from the membership-guarded
+// `GetOrDefault`) and `=== undefined` stays a distinct opaque, so all three get distinct
+// fingerprints — `nose query <this file> top=0` now reports NO multi-member family.
 //
 //   const m = new Map<string, number | null>([["x", null]]);
 //   coalesce(m, "x")    // 0     —  null ?? 0  →  0   (?? replaces present-null)

--- a/bench/coevo/false_merges/map_nullish_default.ts
+++ b/bench/coevo/false_merges/map_nullish_default.ts
@@ -1,0 +1,43 @@
+// Confirmed LATENT false merge (coevo series 10, §CT). nose gives `coalesce`,
+// `presence`, and `undef_check` ONE exact-value-graph fingerprint, but they are
+// behaviorally distinct on a present key whose stored value is null.
+//
+//   const m = new Map<string, number | null>([["x", null]]);
+//   coalesce(m, "x")    // 0     —  null ?? 0  →  0   (?? replaces present-null)
+//   presence(m, "x")    // null  —  m.has("x") is true → returns m.get("x") = null
+//   undef_check(m, "x") // null  —  null === undefined is false → returns null
+//
+// Root cause: `m.get(k) ?? d` (nullish-coalesce: d on absent OR present-null) is
+// folded to the same node as the absence-only `GetOrDefault` (d on absent only).
+// The fold is unsound whenever the map's value type admits null/undefined, and the
+// value model erases that type, so it cannot be gated on nullability. The `=== undefined`
+// form is additionally indistinguishable from `?? `/`== null` because the value model
+// conflates null and undefined into one constant (value_graph/eval.rs §7 comment).
+//
+// Oracle-blind: the interpreter shares the null/undefined conflation, so
+// `nose verify --max-violations 0` stays green (its calibration line even prints
+// `vj[1.0]: 0/1 = 0% behavior-equal`, but the gate does not trip). Same class as
+// float_assoc.py and array_element_mutation.py.
+//
+// Sound fix (deferred, see issue): fold `?? `/`== null`-guarded map defaults to the
+// faithful coalesce (ValueOrDefault), distinct from the membership-guarded GetOrDefault,
+// AND only re-converge them where the map's values are provably non-null (literal maps
+// with non-null literal values — already a separate fingerprint class, see
+// equivalence.rs::literal_map_default_lookup_converges_with_js_map_construction_boundaries).
+// This needs a "map values provably non-null" signal and de-conflation of null/undefined.
+
+function coalesce(lookup: Map<string, number | null>, key: string): number | null {
+    return lookup.get(key) ?? 0;
+}
+
+function presence(lookup: Map<string, number | null>, key: string): number | null {
+    if (lookup.has(key)) {
+        return lookup.get(key);
+    }
+    return 0;
+}
+
+function undef_check(lookup: Map<string, number | null>, key: string): number | null {
+    const g = lookup.get(key);
+    return g === undefined ? 0 : g;
+}

--- a/bench/coevo/packets.v1.json
+++ b/bench/coevo/packets.v1.json
@@ -756,6 +756,54 @@
    "summary": "GREEN with teeth. jedis (2508 families, 1063 near+graded): 2560 per-family witness comparisons across --top {0,5,30} + a 6-entry ignore file spanning near ranks 2..2507 — zero witness loss, all 6 ignored families keep graded at --top 5. Determinism 9/9 byte-identical (cmp) across RAYON_NUM_THREADS=1 vs default and repeats on jedis/commons-lang/flask.",
    "verdict": "green-confirmed",
    "defense": "n/a — the merge-time content-invariance and determinism claims hold."
+  },
+  {
+   "packet_id": "s10-vm-rust-pattern-variant",
+   "series": 10,
+   "campaign": "S1",
+   "persona": "soundness-skeptic",
+   "mode": "blind",
+   "surface": "value-model-rust-patterns",
+   "claim": "the #390/#404 Rust pattern lowering (constructor pattern → variant test; single-payload → field-0 projection; struct-field → named projection) never makes two behaviorally-distinct Rust functions share a clone family",
+   "summary": "Attacker reported variant-swap (route_first/route_second) and single-variant-token (select_foo/select_bar) near-family merges. On ISOLATED reproduction the merges did not occur (zero families) — the reported merges were contamination from extra harness files in the attacker's dir, and even as reported were near-channel (witness=similar) with verify clean. The exact equivalence channel and the projection rules held.",
+   "verdict": "green-confirmed",
+   "defense": "n/a — the new lowering rules produced no reproducible exact-channel false merge; field/payload projections were never wrong in probes."
+  },
+  {
+   "packet_id": "s10-vm-map-nullish-vs-presence",
+   "series": 10,
+   "campaign": "S2",
+   "persona": "language-specialist",
+   "mode": "blind",
+   "surface": "value-model-collections",
+   "claim": "nose models map/dict reads soundly — `m.get(k) ?? d` is not silently equated with the absence-only default",
+   "summary": "CONFIRMED latent false merge (witness=exact). `m.get(k) ?? d` (coalesce: d on absent OR present-null) folds to the same fingerprint as `m.has(k) ? m.get(k) : d` and `m.get(k) === undefined ? d : g` (absence-only). Diverge on a present key whose value is null: `Map<string,number|null>` with m['x']=null → ?? gives 0, presence gives null (verified with node). Oracle-blind: verify gate green though its calibration prints vj[1.0]:0/1 = 0% behavior-equal. Root = mk_value_or_map_default upgrading a null-guarded coalesce to GetOrDefault, plus the value model's null/undefined conflation collapsing `=== undefined` (absence) into `== null` (coalesce).",
+   "verdict": "deferred-issue",
+   "defense": "DEFERRED #410. The sound fix needs (a) a map-value non-null proof so the convergence survives only for provably-non-null maps — a blunt split breaks the provably-sound literal-map class (equivalence.rs::literal_map_default_lookup_converges_with_js_map_construction_boundaries) — and (b) de-conflation of null/undefined to re-home `=== undefined` with the absence class. Both are value-model-core + interp work beyond the campaign's surgical scope. Fixture: bench/coevo/false_merges/map_nullish_default.ts; oracle-value-model §7.4."
+  },
+  {
+   "packet_id": "s10-vm-map-nullish-vs-undefined",
+   "series": 10,
+   "campaign": "S2",
+   "persona": "language-specialist",
+   "mode": "blind",
+   "surface": "value-model-collections",
+   "claim": "`m.get(k) ?? d` ≡ `m.get(k) === undefined ? d : g` (the eval.rs §7 comment's stated equivalence)",
+   "summary": "The stated equivalence is itself unsound for nullable maps: `=== undefined` is the true absence check (keeps present-null) while `??` is coalesce (replaces present-null with d). The value model's null/undefined conflation makes the two indistinguishable, so they share a fingerprint. Sharpens the s10-map-nullish-vs-presence root cause.",
+   "verdict": "deferred-issue",
+   "defense": "DEFERRED #410 (same fix). Recorded as the second arm of the conflation gap."
+  },
+  {
+   "packet_id": "s10-grammar-bump-lowering",
+   "series": 10,
+   "campaign": "S3",
+   "persona": "grammar-lawyer",
+   "mode": "measurement",
+   "surface": "grammar-parsing",
+   "claim": "the today (#406/#407) tree-sitter bumps (c/python/javascript→0.25, go→0.25 statement_list, rust→0.24) preserve lowering fidelity and parse stability — assessor-run measurement, not a blind attacker (pricing IS the measurement, CI is rust-only)",
+   "summary": "Assessor measurement surface; not separately reported a violation this session. Covered indirectly: the value-model and collections attacks ran clean parses on c/python/javascript/ts fixtures post-bump. Per-language Raw-ratio + byte-identical query sweep recommended as the standing validation (nose-ci-gotchas).",
+   "verdict": "green-confirmed",
+   "defense": "n/a — no parse regression surfaced in the campaign's fixtures; full per-language sweep tracked as standing release validation."
   }
  ]
 }

--- a/bench/coevo/packets.v1.json
+++ b/bench/coevo/packets.v1.json
@@ -778,8 +778,8 @@
    "surface": "value-model-collections",
    "claim": "nose models map/dict reads soundly — `m.get(k) ?? d` is not silently equated with the absence-only default",
    "summary": "CONFIRMED latent false merge (witness=exact). `m.get(k) ?? d` (coalesce: d on absent OR present-null) folds to the same fingerprint as `m.has(k) ? m.get(k) : d` and `m.get(k) === undefined ? d : g` (absence-only). Diverge on a present key whose value is null: `Map<string,number|null>` with m['x']=null → ?? gives 0, presence gives null (verified with node). Oracle-blind: verify gate green though its calibration prints vj[1.0]:0/1 = 0% behavior-equal. Root = mk_value_or_map_default upgrading a null-guarded coalesce to GetOrDefault, plus the value model's null/undefined conflation collapsing `=== undefined` (absence) into `== null` (coalesce).",
-   "verdict": "deferred-issue",
-   "defense": "DEFERRED #410. The sound fix needs (a) a map-value non-null proof so the convergence survives only for provably-non-null maps — a blunt split breaks the provably-sound literal-map class (equivalence.rs::literal_map_default_lookup_converges_with_js_map_construction_boundaries) — and (b) de-conflation of null/undefined to re-home `=== undefined` with the absence class. Both are value-model-core + interp work beyond the campaign's surgical scope. Fixture: bench/coevo/false_merges/map_nullish_default.ts; oracle-value-model §7.4."
+   "verdict": "violation-fixed",
+   "defense": "FIXED #410 (same session). The deferral's recall worry was a measurement error: the coalesce and absence GetOrDefault feeders are separable WITHOUT a nullability proof — only the null-equality guard (??/==null) reached GetOrDefault via mk_value_or_map_default; the membership guards (has/in/getOrDefault/.get(k,d)) use a separate non-conflated path. Fix = two merge-removing splits (no new proof obligation): (1) null-guarded map default → faithful ValueOrDefault (mk_nullish_map_default), (2) drop the eval.rs `=== undefined`-over-map-get exception so the strict guard stays a distinct opaque. Corpus byte-identical (15 JS/TS repos / 5825 families + py/java/go/rust). Regression equivalence.rs::nullish_coalesce_map_default_is_distinct_from_absence_default; cross-language + CLI map-default tests now assert the sound partition."
   },
   {
    "packet_id": "s10-vm-map-nullish-vs-undefined",
@@ -790,8 +790,8 @@
    "surface": "value-model-collections",
    "claim": "`m.get(k) ?? d` ≡ `m.get(k) === undefined ? d : g` (the eval.rs §7 comment's stated equivalence)",
    "summary": "The stated equivalence is itself unsound for nullable maps: `=== undefined` is the true absence check (keeps present-null) while `??` is coalesce (replaces present-null with d). The value model's null/undefined conflation makes the two indistinguishable, so they share a fingerprint. Sharpens the s10-map-nullish-vs-presence root cause.",
-   "verdict": "deferred-issue",
-   "defense": "DEFERRED #410 (same fix). Recorded as the second arm of the conflation gap."
+   "verdict": "violation-fixed",
+   "defense": "FIXED #410 (same session). The deferral's recall worry was a measurement error: the coalesce and absence GetOrDefault feeders are separable WITHOUT a nullability proof — only the null-equality guard (??/==null) reached GetOrDefault via mk_value_or_map_default; the membership guards (has/in/getOrDefault/.get(k,d)) use a separate non-conflated path. Fix = two merge-removing splits (no new proof obligation): (1) null-guarded map default → faithful ValueOrDefault (mk_nullish_map_default), (2) drop the eval.rs `=== undefined`-over-map-get exception so the strict guard stays a distinct opaque. Corpus byte-identical (15 JS/TS repos / 5825 families + py/java/go/rust). Regression equivalence.rs::nullish_coalesce_map_default_is_distinct_from_absence_default; cross-language + CLI map-default tests now assert the sound partition."
   },
   {
    "packet_id": "s10-grammar-bump-lowering",

--- a/crates/nose-cli/tests/cli/semantic_idioms.rs
+++ b/crates/nose-cli/tests/cli/semantic_idioms.rs
@@ -1901,9 +1901,7 @@ fn scan_mode_semantic_proves_typed_typescript_map_default_lookup() {
     let semantic_families = scan_families(&semantic_json);
     let expected = [
         "map_default.go",
-        "ts_nullish.ts",
         "ts_has_get.ts",
-        "ts_temp_guard.ts",
         "ts_guard_return.ts",
         "java_guard_return.java",
         "py_dict.py",
@@ -1933,6 +1931,10 @@ fn scan_mode_semantic_proves_typed_typescript_map_default_lookup() {
         );
     }
     for unexpected in [
+        // `ts_nullish` (`?? `) is nullish COALESCE and `ts_temp_guard` (`=== undefined`) is conflated
+        // with `== null` — neither merges with the absence-only default family (#410, experiments §CT).
+        "ts_nullish.ts",
+        "ts_temp_guard.ts",
         "ts_wrong_key.ts",
         "ts_wrong_default.ts",
         "ts_wrong_map.ts",
@@ -2384,12 +2386,7 @@ fn scan_mode_semantic_proves_literal_map_default_lookup() {
         "map_default_java_entries.java",
         "map_default_java_local.java",
         "map_default_module.java",
-        "map_default_inline.js",
-        "map_default_local.js",
         "map_default_has_get.js",
-        "map_default_inline.ts",
-        "map_default_module.js",
-        "map_default_module.ts",
         "map_default_rust_hashmap.rs",
         "map_default_rust_btreemap.rs",
         "map_default_go_inline.go",
@@ -2417,6 +2414,37 @@ fn scan_mode_semantic_proves_literal_map_default_lookup() {
             "semantic mode should include {expected}: {semantic}"
         );
     }
+    // The nullish-coalesce `?? ` forms split into their OWN family — `m.get(k) ?? d` defaults on
+    // absent OR present-null, unsound to merge with the absence-only default (#410, experiments §CT).
+    let coalesce_expected = [
+        "map_default_inline.js",
+        "map_default_local.js",
+        "map_default_inline.ts",
+        "map_default_module.js",
+        "map_default_module.ts",
+    ];
+    let coalesce_family = semantic_families
+        .iter()
+        .find(|family| {
+            let family_text = family.to_string();
+            coalesce_expected
+                .iter()
+                .all(|expected| family_text.contains(expected))
+        })
+        .unwrap_or_else(|| {
+            panic!("semantic mode should report one nullish-coalesce family: {semantic}")
+        });
+    let coalesce_text = coalesce_family.to_string();
+    for expected in coalesce_expected {
+        assert!(
+            coalesce_text.contains(expected),
+            "semantic mode should include nullish-coalesce {expected}: {semantic}"
+        );
+    }
+    assert!(
+        !positive_text.contains("map_default_inline.js"),
+        "absence-default family must exclude the nullish-coalesce forms: {semantic}"
+    );
     let string_expected = [
         "map_default_string.py",
         "map_default_string.rb",

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -4990,10 +4990,15 @@ fn literal_map_default_lookup_converges_with_js_map_construction_boundaries() {
 
     let fp = value_fp(&i, py_literal, Lang::Python);
     assert_eq!(fp, value_fp(&i, ruby_literal, Lang::Ruby));
-    assert_eq!(fp, value_fp(&i, js_inline, Lang::JavaScript));
-    assert_eq!(fp, value_fp(&i, js_local, Lang::JavaScript));
-    assert_eq!(fp, value_fp(&i, js_has_get, Lang::JavaScript));
-    assert_eq!(fp, value_fp(&i, ts_inline, Lang::TypeScript));
+    assert_eq!(fp, value_fp(&i, js_has_get, Lang::JavaScript)); // membership absence — stays in family
+                                                                // `m.get(k) ?? d` is nullish COALESCE (default on absent OR present-null), NOT the absence-only
+                                                                // default; it must not merge with the family — unsound for a null-valued map, and the value
+                                                                // type's nullability is erased from the IL (#410, experiments §CT). The `?? ` forms converge
+                                                                // with each other as their own class.
+    let coalesce_fp = value_fp(&i, js_inline, Lang::JavaScript);
+    assert_eq!(coalesce_fp, value_fp(&i, js_local, Lang::JavaScript));
+    assert_eq!(coalesce_fp, value_fp(&i, ts_inline, Lang::TypeScript));
+    assert_ne!(fp, coalesce_fp);
     assert_ne!(fp, value_fp(&i, js_call, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, js_wrong_key, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, js_wrong_default, Lang::JavaScript));
@@ -5181,9 +5186,11 @@ fn literal_map_default_lookup_converges_with_module_map_bindings() {
     let java_shadowed = "class C { static final Map<String, Integer> LOOKUP = Map.of(\"red\", 1, \"blue\", 2); static int f(String key, String other) { return LOOKUP.getOrDefault(key, 0); } }\nclass Map { static java.util.Map<String, Integer> of(Object... values) { return java.util.Map.of(); } }\n";
 
     let fp = value_fp(&i, py_literal, Lang::Python);
-    assert_eq!(fp, value_fp(&i, js_module, Lang::JavaScript));
-    assert_eq!(fp, value_fp(&i, ts_module, Lang::TypeScript));
-    assert_eq!(fp, value_fp(&i, java_static, Lang::Java));
+    assert_eq!(fp, value_fp(&i, java_static, Lang::Java)); // getOrDefault absence — stays in family
+                                                           // `?? ` is nullish coalesce, distinct from the absence-default family (#410, experiments §CT):
+    let coalesce_fp = value_fp(&i, js_module, Lang::JavaScript);
+    assert_eq!(coalesce_fp, value_fp(&i, ts_module, Lang::TypeScript));
+    assert_ne!(fp, coalesce_fp);
     assert_ne!(fp, value_fp(&i, js_wrong_key, Lang::JavaScript));
     assert_ne!(fp, value_fp(&i, ts_wrong_default, Lang::TypeScript));
     assert_ne!(fp, value_fp(&i, java_wrong_map, Lang::Java));
@@ -5529,10 +5536,13 @@ fn map_default_lookup_converges_cross_language() {
     assert_eq!(fp, value_fp(&i, java_guard_return, Lang::Java));
     assert_eq!(fp, value_fp(&i, rust_explicit, Lang::Rust));
     assert_eq!(fp, value_fp(&i, rust_unwrap, Lang::Rust));
-    assert_eq!(fp, value_fp(&i, ts_nullish, Lang::TypeScript));
     assert_eq!(fp, value_fp(&i, ts_has_get, Lang::TypeScript));
-    assert_eq!(fp, value_fp(&i, ts_temp_guard, Lang::TypeScript));
     assert_eq!(fp, value_fp(&i, ts_guard_return, Lang::TypeScript));
+    // `lookup.get(key) ?? fallback` is nullish COALESCE; the strict `selected === undefined ? …`
+    // guard is conflated with `== null` by the null/undefined value model. Neither merges with the
+    // absence-default family — they diverge on a present null-valued key (#410, experiments §CT).
+    assert_ne!(fp, value_fp(&i, ts_nullish, Lang::TypeScript));
+    assert_ne!(fp, value_fp(&i, ts_temp_guard, Lang::TypeScript));
     assert_eq!(fp, value_fp(&i, py_dict, Lang::Python));
     assert_eq!(fp, value_fp(&i, py_guard_return, Lang::Python));
     assert_eq!(fp, value_fp(&i, py_mapping, Lang::Python));
@@ -5540,6 +5550,31 @@ fn map_default_lookup_converges_cross_language() {
     assert_eq!(fp, value_fp(&i, py_alias_mapping, Lang::Python));
     assert_eq!(fp, value_fp(&i, py_alias_mutable_mapping, Lang::Python));
     assert_eq!(fp, value_fp(&i, py_alias_dict, Lang::Python));
+}
+
+#[test]
+fn nullish_coalesce_map_default_is_distinct_from_absence_default() {
+    // #410 / experiments §CT: `m.get(k) ?? d` (nullish coalesce — default on absent OR present-null)
+    // must NOT share a fingerprint with the absence-only default `m.has(k) ? m.get(k) : d` /
+    // `dict.get(k, d)`. They diverge on a present key whose value is null:
+    //   const m = new Map<string, number | null>([["x", null]]);
+    //   m.get("x") ?? 0             // 0     (?? replaces present-null)
+    //   m.has("x") ? m.get("x") : 0 // null  (presence keeps the stored null)
+    // The value model erases the map's value-type nullability, so the merge can never be proven
+    // sound; it was the LATENT false merge recorded in bench/coevo/false_merges/map_nullish_default.ts.
+    let i = Interner::new();
+    let coalesce = "function f(m: Map<string, number | null>, k: string): number | null { return m.get(k) ?? 0; }\n";
+    let coalesce_eqnull = "function f(m: Map<string, number | null>, k: string): number | null { const g = m.get(k); return g == null ? 0 : g; }\n";
+    let presence_has = "function f(m: Map<string, number | null>, k: string): number | null { if (m.has(k)) { return m.get(k); } return 0; }\n";
+    let py_get_default = "def f(m, k):\n    return m.get(k, 0)\n";
+
+    let coalesce_fp = value_fp(&i, coalesce, Lang::TypeScript);
+    // the two nullish-coalesce spellings still converge as their own class
+    assert_eq!(coalesce_fp, value_fp(&i, coalesce_eqnull, Lang::TypeScript));
+    // …but coalesce is DISTINCT from the membership-guarded absence default (the fixed false merge)
+    assert_ne!(coalesce_fp, value_fp(&i, presence_has, Lang::TypeScript));
+    // …and distinct cross-language from Python's absence-only `dict.get(k, default)`
+    assert_ne!(coalesce_fp, value_fp(&i, py_get_default, Lang::Python));
 }
 
 #[test]

--- a/crates/nose-normalize/src/value_graph/collections.rs
+++ b/crates/nose-normalize/src/value_graph/collections.rs
@@ -773,7 +773,7 @@ impl<'a> Builder<'a> {
             }
             then_v
         };
-        Some(self.mk_value_or_map_default(value, default))
+        Some(self.mk_nullish_map_default(value, default))
     }
 
     pub(super) fn value_default_call(&self, value: ValueId) -> Option<(ValueId, ValueId)> {
@@ -807,13 +807,16 @@ impl<'a> Builder<'a> {
         )
     }
 
-    pub(super) fn mk_value_or_map_default(&mut self, value: ValueId, default: ValueId) -> ValueId {
-        if let Some((map, key)) = self.proven_map_get_value(value) {
-            return self.mk(
-                ValOp::Call(builtin_tag(Builtin::GetOrDefault)),
-                vec![map, key, default],
-            );
-        }
+    /// A NULL-guarded map default (`m.get(k) ?? d`, `m.get(k) == null ? d : …`) is the faithful
+    /// nullish coalesce — it replaces BOTH absent (`undefined`) AND a stored `null` with the
+    /// default. Model it as `ValueOrDefault`; do NOT upgrade it to `GetOrDefault(map, key, d)`,
+    /// the absence-only fold ("d iff the key is absent, else the stored value — null included").
+    /// The two diverge on a present key whose value is null, and the map's value-type nullability
+    /// is erased from the IL, so the upgrade cannot be proven sound — it false-merged the coalesce
+    /// form with the genuine presence-default `m.has(k) ? m.get(k) : d` (#410, experiments §CT).
+    /// The provable-absence forms (`m.has(k)`, `k in m`, Python `d.get(k, d)`) fold to
+    /// `GetOrDefault` through `map_presence_condition`, a separate path this never touches.
+    pub(super) fn mk_nullish_map_default(&mut self, value: ValueId, default: ValueId) -> ValueId {
         self.mk_value_default(value, default)
     }
 

--- a/crates/nose-normalize/src/value_graph/control.rs
+++ b/crates/nose-normalize/src/value_graph/control.rs
@@ -281,7 +281,7 @@ impl<'a> Builder<'a> {
             }
             (value_a, ret_a)
         };
-        Some(self.mk_value_or_map_default(value, default))
+        Some(self.mk_nullish_map_default(value, default))
     }
 
     pub(super) fn value_default_from_guarded_fallthrough(
@@ -302,7 +302,7 @@ impl<'a> Builder<'a> {
             }
             guarded_ret
         };
-        Some(self.mk_value_or_map_default(value, default))
+        Some(self.mk_nullish_map_default(value, default))
     }
 
     pub(super) fn guarded_return_parts(&self, value: ValueId) -> Option<(ValueId, ValueId)> {

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -62,24 +62,22 @@ impl<'a> Builder<'a> {
             if !strict {
                 return Some(self.mk(ValOp::Bin(op), vec![a, b]));
             }
-            // Exception: `=== undefined` against a value that provably cannot be
-            // null IS the faithful absence check — a typed `Map.get` result is
-            // `V | undefined`. Keep the model's Eq shape there so the map-default
-            // fold still proves `m.get(k) ?? d` ≡ the `=== undefined` guarded form.
-            let undefined_spelling = matches!(
-                (self.il.kind(null_kid), self.il.node(null_kid).payload),
-                (NodeKind::Var, Payload::Name(_))
-            );
-            let undefined_only_absence = self.proven_map_get_value(value_side).is_some();
-            if !(undefined_spelling && undefined_only_absence) {
-                let salt = combine(JS_STRICT_NULL_CMP_TAG, self.valued_subtree_hash(null_kid));
-                let eq = self.mk(ValOp::Opaque(salt), vec![value_side]);
-                return Some(if op == Op::Ne as u32 {
-                    self.mk(ValOp::Un(Op::Not as u32), vec![eq])
-                } else {
-                    eq
-                });
-            }
+            // Strict `=== null` / `=== undefined` is NOT the loose nullish check — keep it a
+            // distinct opaque keyed by the spelled operand. Earlier this carved out
+            // `=== undefined` over a map-get as a "faithful" absence `Eq` so it would fold to the
+            // map default like `m.get(k) ?? d`. But the value model conflates `null`/`undefined`
+            // into one constant, so that `Eq` was indistinguishable from `== null`/`?? ` and
+            // false-merged the COALESCE form (default on absent OR present-null) with the
+            // ABSENCE form (default on absent only) — they diverge on a present null-valued key
+            // (#410, experiments §CT). Keeping it opaque splits the two; `=== undefined` no longer
+            // claims equivalence with either `?? ` or the membership-guarded `GetOrDefault`.
+            let salt = combine(JS_STRICT_NULL_CMP_TAG, self.valued_subtree_hash(null_kid));
+            let eq = self.mk(ValOp::Opaque(salt), vec![value_side]);
+            return Some(if op == Op::Ne as u32 {
+                self.mk(ValOp::Un(Op::Not as u32), vec![eq])
+            } else {
+                eq
+            });
         }
         if loose {
             let tag = if op == Op::Ne as u32 {
@@ -757,7 +755,7 @@ impl<'a> Builder<'a> {
             if let [value, default] = kids {
                 let value = self.eval(*value, env);
                 let default = self.eval(*default, env);
-                return Some(self.mk_value_or_map_default(value, default));
+                return Some(self.mk_nullish_map_default(value, default));
             }
         }
         if let Payload::Builtin(b) = payload {

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2899,3 +2899,65 @@ With map reads below the opaque threshold, #391 is **audited, below the bar** �
 opaque worklist is `Block`/`Func` (closures/nested) and the propagated lowering `Raw` (already a
 characterized, mostly-boundary/grammar frontier), not collections. The analysis engine remains at
 its measured frontier.
+
+## CT. Adversarial co-evolution, series 10 — the nullish-coalesce map-default false merge (#409)
+
+One campaign (tracking #409), commit 9301beb, surfaces chosen by freshness: (S1) the
+1-day-old Rust pattern lowering (#390 constructor-pattern-as-variant-test, #404 match-arm
+payload binding — *merge-creating*, so soundness-class); (S2) the value-graph collection /
+map-read model (#391/#405 §CS); (S3) the same-day tree-sitter grammar bumps (#406/#407,
+c/python/javascript→0.25, go→0.25 `statement_list`, rust→0.24), priced as a measurement
+because CI is rust-only. Two blind persona-rotated attackers (soundness-skeptic on S1,
+language-specialist on S2); S3 run by the assessor.
+
+**S1 — Rust pattern lowering: green.** The attacker reported two near-family merges
+(variant-swap `route_first`/`route_second`; single-variant-token `select_foo`/`select_bar`).
+On *isolated* reproduction both produced **zero families** — the reported merges were
+contamination from extra harness files in the attacker's directory, and even as reported were
+near-channel (`witness=similar`) with `verify` clean. The exact equivalence channel and the
+field/payload projections held. The merge-creating #390/#404 rules came back clean.
+
+**S2 — the priced packet: `m.get(k) ?? d` false-merges with the absence-only default.** A
+real LATENT false merge (`witness=exact`). nose gives ONE fingerprint to the nullish-coalesce
+`m.get(k) ?? d` (default on absent **or** present-null) and the genuine **absence** forms
+`m.has(k) ? m.get(k) : d`, `m.get(k) === undefined ? d : g`, Python `d.get(k, d)`. They
+diverge on a present key whose value is null: `Map<string, number|null>` with `m["x"]=null`
+→ `??` gives `0`, presence gives `null` (verified with node). **Oracle-blind** — the
+interpreter shares the null/undefined conflation, so `nose verify --max-violations 0` stays
+green even as its own calibration prints `vj[1.0]: 0/1 = 0% behavior-equal`. The §AS scenario
+again: only a crafted attack finds it.
+
+Root cause has two coupled layers. `mk_value_or_map_default`
+(`value_graph/collections.rs`) **upgrades** a null-guarded coalesce to the absence-only
+`GetOrDefault`; and the value model **conflates `null` with `undefined`** (`eval.rs` §7
+comment), collapsing the true-absence `=== undefined` into the same `Eq(MapGet, null)` guard
+as `?? `/`== null`. The membership guards (`has`/`in`) fold to `GetOrDefault` through a
+separate, non-conflated path — they are the only forms the model can *prove* are absence.
+
+**Defense: deferred (#410), and deliberately not patched.** The fold is uniform across map
+kinds; soundness depends on the map's value-type **nullability**, which the IL erases. A blunt
+fix (route the null-guard fold to the faithful `ValueOrDefault`) was built and measured — it
+splits the attacker's parameter-map false merge, but it also **breaks the provably-sound
+literal-map convergence** (`equivalence.rs::literal_map_default_lookup_converges_with_js_map_
+construction_boundaries`: `new Map([["red",1]]).get(k) ?? 0` ≡ the `has` form IS sound, the
+values are non-null literals — already a distinct fingerprint class), and it cannot separate
+`??` from `=== undefined` (both null-guards, conflated). The sound fix needs a *map-value
+non-null proof* plus *null/undefined de-conflation* — value-model-core + interpreter work past
+this campaign's surgical scope. Recorded as `bench/coevo/false_merges/map_nullish_default.ts`,
+the third oracle-blind row beside `float_assoc.py` and `array_element_mutation.py`; see
+oracle-value-model §7.4. Same disposition as §250's #269/#270 deferrals: a priced packet whose
+sound defense exceeds scope closes as `deferred: #410` with fixture and measurement attached.
+
+**S3 — grammar bumps: no regression surfaced** in the campaign's c/python/javascript/ts
+fixtures (all parsed and lowered clean post-bump). The standing per-language validation
+(per-language Raw-ratio + byte-identical `query top=0`, run against a pre-bump baseline binary)
+remains the gate for the bumps, since the rust-only dogfood signal cannot see non-rust grammar
+regressions.
+
+**Lessons.** (1) A blind attacker's directory hygiene matters — S1's reported merges were a
+scratch-dir contamination artifact; always reproduce a submitted packet in isolation before
+pricing (the assessor's reproduction, not the attacker's report, is the verdict). (2) A
+soundness fix that would break a *provably-sound* sibling merge is not the largest sound
+generalization — it is the wrong axis; the value model must gain the missing proof
+(nullability) first. The campaign found nothing it could ship and that is the green-with-teeth
+result: one well-characterized latent false merge, scoped to #410.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2961,3 +2961,28 @@ soundness fix that would break a *provably-sound* sibling merge is not the large
 generalization — it is the wrong axis; the value model must gain the missing proof
 (nullability) first. The campaign found nothing it could ship and that is the green-with-teeth
 result: one well-characterized latent false merge, scoped to #410.
+
+**Resolution (#410, same session) — the deferral was lifted; the fix is corpus-inert.** The
+defer reasoning had a measurement gap: it assumed splitting the coalesce form from the absence
+form would cost real recall. It does not. The two GetOrDefault feeders are *separable without
+any nullability proof*: the **membership** guard (`has`/`in`, and Java/Go/Rust/Python's typed
+`getOrDefault`/comma-ok/`.get(k,d)`) folds to `GetOrDefault` through `map_presence_condition`,
+a path the null/undefined conflation never touches; only the **null-equality** guard
+(`?? `, `== null`) reached `GetOrDefault` via `mk_value_or_map_default`. The fix is two splits
+that can only *remove* merges (never create one, so no new proof obligation): (1) route the
+null-guarded map default to the faithful `ValueOrDefault` (`mk_nullish_map_default`) instead of
+`GetOrDefault`; (2) drop the eval.rs `=== undefined`-over-map-get exception so the strict guard
+stays a distinct opaque rather than the conflated null `Eq`. Result: `{?? , == null}` = coalesce,
+`{has, in, getOrDefault, .get(k,d), comma-ok, unwrap_or}` = absence, `=== undefined` = its own
+opaque — all false merges gone, the coalesce and absence classes each still converge internally.
+**Corpus impact: byte-identical** `query top=0 --format json` across 15 JS/TS repos (5825 families)
+AND the Python/Java/Go/Rust repos — the lost merges (`?? `≡absence, `=== undefined`≡`has`) fire
+only in the synthetic convergence tests, never on real code, so the "provably-sound literal
+merge" the deferral worried about has zero real-world prevalence. Regression:
+`equivalence.rs::nullish_coalesce_map_default_is_distinct_from_absence_default`; the cross-language
+and CLI map-default tests now assert the sound partition (coalesce family distinct from absence).
+**Lesson:** "soundness costs recall" is a hypothesis to *measure*, not assume — here the recall
+cost was a synthetic-test artifact and the sound fix shipped clean. Residual (still #410, now a
+pure recall enhancement): a map-value non-null proof would re-converge the coalesce forms with the
+absence family where it is provably sound (literal non-null maps), and null/undefined de-conflation
+would re-home `=== undefined` with the absence class — neither is a soundness obligation.

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -483,31 +483,37 @@ toward dynamic-language repos. Type-domain-aware input feeding remains the floor
 follow-up (§3); the rest of `verify_battery` stays hand-curated **on purpose** (the guard
 comment there points here).
 
-### 7.4 Nullish-coalesce map default ≡ absence default — OPEN (coevo series 10, #410)
+### 7.4 Nullish-coalesce map default ≡ absence default — FIXED (coevo series 10, #410)
 
 A LATENT, oracle-blind false merge found by adversarial co-evolution series 10 (experiments
-§CT). `m.get(k) ?? d` — replace the value with `d` when it is absent **or** present-null — gets
+§CT). `m.get(k) ?? d` — replace the value with `d` when it is absent **or** present-null — got
 the **same fingerprint** as the absence-only defaults `m.has(k) ? m.get(k) : d`,
 `m.get(k) === undefined ? d : g`, and Python `d.get(k, d)`. They diverge on a present key whose
 stored value is null: for `Map<string, number|null>` with `m["x"]=null`, `?? ` yields `0` while
 the presence forms yield `null`. Reproducer `bench/coevo/false_merges/map_nullish_default.ts`.
 
-Two coupled root causes. (1) `mk_value_or_map_default` (`value_graph/collections.rs`) upgrades a
-**null-guarded coalesce** to the absence-only `GetOrDefault`; the guards `has`/`in` reach
-`GetOrDefault` through a separate, non-conflated path and ARE provable absence, but the
-`?? `/`== null` null-equality guard is not. (2) The value model **conflates `null` and
-`undefined`** into one constant (eval.rs §7), so the true-absence `=== undefined` is
-indistinguishable from the coalesce `== null`.
+Root cause: `mk_value_or_map_default` (`value_graph/collections.rs`) upgraded a **null-equality
+guarded** default (`?? `, `== null`) to the absence-only `GetOrDefault`, while the **membership**
+guards (`has`/`in`, typed `getOrDefault`/comma-ok/`.get(k,d)`) reach `GetOrDefault` through a
+separate, non-conflated `map_presence_condition` path. The null-equality guard cannot be proven
+to be the absence check — the model **conflates `null`/`undefined`** (eval.rs §7), so the
+true-absence `=== undefined` is indistinguishable from the coalesce `== null`.
 
-Oracle-blind: the interpreter shares the conflation, so `verify` cannot witness the divergence
-(its calibration prints `vj[1.0]: 0/1 = 0% behavior-equal` but the gate stays green) — same
-limitation as §7.3 before #337 and as `float_assoc.py`. **Not surgically patchable**: the fold
-is uniform across map kinds and the IL erases value-type nullability, so de-merging blindly
-breaks the *provably-sound* literal-map convergence (`equivalence.rs::
-literal_map_default_lookup_converges_with_js_map_construction_boundaries` — non-null literal
-values). The sound fix needs a **map-value non-null proof** (re-converge only where provable)
-plus **null/undefined de-conflation** (re-home `=== undefined` with the absence class), carried
-through the interpreter so `verify` can witness it. Tracked at #410.
+**Fix (two splits, can only remove merges → no new proof obligation):** (1) the null-guarded map
+default folds to the faithful `ValueOrDefault` (`mk_nullish_map_default`), not `GetOrDefault`;
+(2) the eval.rs `=== undefined`-over-map-get exception is dropped, so the strict guard stays a
+distinct opaque rather than the conflated null `Eq`. Now `{?? , == null}` = coalesce,
+`{has, in, getOrDefault, .get(k,d), comma-ok, unwrap_or}` = absence, `=== undefined` = its own
+opaque; the false merge is gone and each class still converges internally. **Corpus byte-identical**
+(`query top=0 --format json`, 15 JS/TS repos / 5825 families + the Python/Java/Go/Rust repos) — the
+lost cross-idiom merges fire only in synthetic tests. The false merge is eliminated by splitting,
+so `verify` has nothing to witness (the oracle blindness is moot once the pair is no longer merged).
+Regression `equivalence.rs::nullish_coalesce_map_default_is_distinct_from_absence_default`.
+
+**Residual (pure recall enhancement, still #410, not a soundness obligation):** a *map-value
+non-null proof* would re-converge the coalesce forms with the absence family where provably sound
+(literal non-null maps); *null/undefined de-conflation* would re-home `=== undefined` with the
+absence class. Both are corpus-inert today, so deferred without urgency.
 
 ---
 

--- a/docs/oracle-value-model.md
+++ b/docs/oracle-value-model.md
@@ -483,6 +483,32 @@ toward dynamic-language repos. Type-domain-aware input feeding remains the floor
 follow-up (§3); the rest of `verify_battery` stays hand-curated **on purpose** (the guard
 comment there points here).
 
+### 7.4 Nullish-coalesce map default ≡ absence default — OPEN (coevo series 10, #410)
+
+A LATENT, oracle-blind false merge found by adversarial co-evolution series 10 (experiments
+§CT). `m.get(k) ?? d` — replace the value with `d` when it is absent **or** present-null — gets
+the **same fingerprint** as the absence-only defaults `m.has(k) ? m.get(k) : d`,
+`m.get(k) === undefined ? d : g`, and Python `d.get(k, d)`. They diverge on a present key whose
+stored value is null: for `Map<string, number|null>` with `m["x"]=null`, `?? ` yields `0` while
+the presence forms yield `null`. Reproducer `bench/coevo/false_merges/map_nullish_default.ts`.
+
+Two coupled root causes. (1) `mk_value_or_map_default` (`value_graph/collections.rs`) upgrades a
+**null-guarded coalesce** to the absence-only `GetOrDefault`; the guards `has`/`in` reach
+`GetOrDefault` through a separate, non-conflated path and ARE provable absence, but the
+`?? `/`== null` null-equality guard is not. (2) The value model **conflates `null` and
+`undefined`** into one constant (eval.rs §7), so the true-absence `=== undefined` is
+indistinguishable from the coalesce `== null`.
+
+Oracle-blind: the interpreter shares the conflation, so `verify` cannot witness the divergence
+(its calibration prints `vj[1.0]: 0/1 = 0% behavior-equal` but the gate stays green) — same
+limitation as §7.3 before #337 and as `float_assoc.py`. **Not surgically patchable**: the fold
+is uniform across map kinds and the IL erases value-type nullability, so de-merging blindly
+breaks the *provably-sound* literal-map convergence (`equivalence.rs::
+literal_map_default_lookup_converges_with_js_map_construction_boundaries` — non-null literal
+values). The sound fix needs a **map-value non-null proof** (re-converge only where provable)
+plus **null/undefined de-conflation** (re-home `=== undefined` with the absence class), carried
+through the interpreter so `verify` can witness it. Tracked at #410.
+
 ---
 
 *See also: [design & direction](design.md) · [formal soundness](formal-soundness.md) ·


### PR DESCRIPTION
Adversarial co-evolution **series 10** (§CT) — tracking #409, commit 9301beb. Two commits: the campaign record, then the fix it found.

## Finding (oracle-blind latent false merge)
JS `m.get(k) ?? d` (nullish coalesce: default on absent **or** present-null) shared an **exact** fingerprint with the absence-only defaults `m.has(k) ? m.get(k) : d`, `m.get(k) === undefined ? d : g`, and Python `d.get(k, d)`. They diverge on a present key whose stored value is null:

```ts
const m = new Map<string, number | null>([["x", null]]);
m.get("x") ?? 0             // 0
m.has("x") ? m.get("x") : 0 // null
```

Oracle-blind — `nose verify` stays green though its own calibration prints `vj[1.0]: 0/1 = 0% behavior-equal` (the interpreter shares the null/undefined conflation). The §AS scenario: only a crafted attack finds it.

## Fix (two merge-removing splits — can't create a false merge, no new proof obligation)
The two `GetOrDefault` feeders are separable **without** a nullability proof: the membership guards (`has`/`in`, typed `getOrDefault`/comma-ok/`.get(k,d)`) fold via `map_presence_condition` (the null/undefined conflation never touches it); only the null-equality guard (`?? `, `== null`) reached `GetOrDefault` via `mk_value_or_map_default`.

1. `mk_nullish_map_default`: a null-guarded map default → faithful `ValueOrDefault` (coalesce), not absence-only `GetOrDefault`.
2. eval.rs: drop the `=== undefined`-over-map-get exception → the strict guard stays a distinct opaque, not the conflated null `Eq`.

Now `{?? , == null}` = coalesce · `{has, in, getOrDefault, .get(k,d), comma-ok, unwrap_or}` = absence · `=== undefined` = its own opaque. False merge gone; each class still converges internally.

## Gates
- **Corpus byte-identical** `query top=0 --format json` across 15 JS/TS repos (5825 families) + the Python/Java/Go/Rust repos — the lost cross-idiom merges fire only in synthetic tests, never on real code (the deferral's "provably-sound literal merge" worry has zero real-world prevalence).
- All **1053 tests pass**; fmt + clippy clean; dup-gate 0 false merges.
- Regression `equivalence.rs::nullish_coalesce_map_default_is_distinct_from_absence_default`; cross-language + CLI map-default tests assert the sound partition.

## Why it shipped instead of deferring
The first commit recorded a deferral (sound fix looked like it needed value-nullability machinery). On measurement that was wrong — the fix is two splits with zero corpus impact. "Soundness costs recall" was a hypothesis to measure, not assume.

S1 (Rust pattern lowering #390/#404) came back **green** — the attacker's reported near-merges were scratch-dir contamination (zero families on isolated reproduction).

Closes #409 (campaign), #410 (fix). Residual in #410 is a pure recall enhancement (map-value non-null proof + null/undefined de-conflation), corpus-inert, no urgency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)