### PR TITLE
feat(detect): converge async↔sync twins in the near channel (dual-view await)

### DIFF
--- a/bench/labels/async_sync_hardneg.v1.json
+++ b/bench/labels/async_sync_hardneg.v1.json
@@ -1,0 +1,49 @@
+{
+ "hard_negatives": [
+  {
+   "repo": "async_sync",
+   "left": {
+    "repo": "async_sync",
+    "file": "hn1_a.py",
+    "start_line": 1,
+    "end_line": 12
+   },
+   "right": {
+    "repo": "async_sync",
+    "file": "hn1_b.py",
+    "start_line": 1,
+    "end_line": 8
+   }
+  },
+  {
+   "repo": "async_sync",
+   "left": {
+    "repo": "async_sync",
+    "file": "hn2_a.ts",
+    "start_line": 1,
+    "end_line": 13
+   },
+   "right": {
+    "repo": "async_sync",
+    "file": "hn2_b.ts",
+    "start_line": 1,
+    "end_line": 10
+   }
+  },
+  {
+   "repo": "async_sync",
+   "left": {
+    "repo": "async_sync",
+    "file": "hn3_a.py",
+    "start_line": 1,
+    "end_line": 12
+   },
+   "right": {
+    "repo": "async_sync",
+    "file": "hn3_b.py",
+    "start_line": 1,
+    "end_line": 9
+   }
+  }
+ ]
+}

--- a/bench/labels/async_sync_twins.v1.json
+++ b/bench/labels/async_sync_twins.v1.json
@@ -1,0 +1,106 @@
+{
+ "duplicates": [
+  {
+   "repo": "async_sync",
+   "kind": "production_async_sync",
+   "clone_type": "type4_semantic",
+   "left": {
+    "repo": "async_sync",
+    "file": "t1_handle_async.py",
+    "start_line": 1,
+    "end_line": 12
+   },
+   "right": {
+    "repo": "async_sync",
+    "file": "t1_handle_sync.py",
+    "start_line": 1,
+    "end_line": 12
+   }
+  },
+  {
+   "repo": "async_sync",
+   "kind": "production_async_sync",
+   "clone_type": "type4_semantic",
+   "left": {
+    "repo": "async_sync",
+    "file": "t2_loadall_async.ts",
+    "start_line": 1,
+    "end_line": 13
+   },
+   "right": {
+    "repo": "async_sync",
+    "file": "t2_loadall_sync.ts",
+    "start_line": 1,
+    "end_line": 13
+   }
+  },
+  {
+   "repo": "async_sync",
+   "kind": "production_async_sync",
+   "clone_type": "type4_semantic",
+   "left": {
+    "repo": "async_sync",
+    "file": "t3_aggregate_async.py",
+    "start_line": 1,
+    "end_line": 10
+   },
+   "right": {
+    "repo": "async_sync",
+    "file": "t3_aggregate_sync.py",
+    "start_line": 1,
+    "end_line": 10
+   }
+  },
+  {
+   "repo": "async_sync",
+   "kind": "production_async_sync",
+   "clone_type": "type4_semantic",
+   "left": {
+    "repo": "async_sync",
+    "file": "t4_collect_async.ts",
+    "start_line": 1,
+    "end_line": 13
+   },
+   "right": {
+    "repo": "async_sync",
+    "file": "t4_collect_sync.ts",
+    "start_line": 1,
+    "end_line": 13
+   }
+  },
+  {
+   "repo": "async_sync",
+   "kind": "production_async_sync",
+   "clone_type": "type4_semantic",
+   "left": {
+    "repo": "async_sync",
+    "file": "t5_pipeline_async.py",
+    "start_line": 1,
+    "end_line": 12
+   },
+   "right": {
+    "repo": "async_sync",
+    "file": "t5_pipeline_sync.py",
+    "start_line": 1,
+    "end_line": 12
+   }
+  },
+  {
+   "repo": "async_sync",
+   "kind": "production_async_sync",
+   "clone_type": "type4_semantic",
+   "left": {
+    "repo": "async_sync",
+    "file": "t6_retry_async.ts",
+    "start_line": 1,
+    "end_line": 14
+   },
+   "right": {
+    "repo": "async_sync",
+    "file": "t6_retry_sync.ts",
+    "start_line": 1,
+    "end_line": 14
+   }
+  }
+ ]
+}

--- a/bench/type4/coverage_matrix.v1.json
+++ b/bench/type4/coverage_matrix.v1.json
@@ -5,7 +5,7 @@
       "go": "n/a",
       "java": "n/a",
       "javascript": "none",
-      "python": "none",
+      "python": "covered",
       "ruby": "n/a",
       "rust": "none",
       "typescript": "none"
@@ -380,7 +380,7 @@
     },
     "python": {
       "applicable": 26,
-      "covered": 16
+      "covered": 17
     },
     "ruby": {
       "applicable": 24,

--- a/bench/type4/fixtures/async_sync/async_sync/hn1_a.py
+++ b/bench/type4/fixtures/async_sync/async_sync/hn1_a.py
@@ -1,0 +1,12 @@
+async def handle(records, threshold):
+    out = []
+    total = 0
+    for rec in records:
+        parsed = await parse(rec)
+        score = await evaluate(parsed)
+        if score > threshold:
+            total = total + score
+            out.append(parsed)
+        else:
+            await log_skip(rec)
+    return summarize(out, total)

--- a/bench/type4/fixtures/async_sync/async_sync/hn1_b.py
+++ b/bench/type4/fixtures/async_sync/async_sync/hn1_b.py
@@ -1,0 +1,8 @@
+def tally(ballots, base):
+    seen = {}
+    running = base
+    for b in ballots:
+        w = weight(b)
+        running = running - w * 2
+        seen[b] = running
+    return finalize(seen, running)

--- a/bench/type4/fixtures/async_sync/async_sync/hn2_a.ts
+++ b/bench/type4/fixtures/async_sync/async_sync/hn2_a.ts
@@ -1,0 +1,13 @@
+async function loadAll(ids, opts) {
+    const out = [];
+    let total = 0;
+    for (const id of ids) {
+        const item = await fetchItem(id);
+        const w = await weigh(item, opts);
+        if (w > opts.min) {
+            total += w;
+            out.push(item);
+        }
+    }
+    return finalize(out, total);
+}

--- a/bench/type4/fixtures/async_sync/async_sync/hn2_b.ts
+++ b/bench/type4/fixtures/async_sync/async_sync/hn2_b.ts
@@ -1,0 +1,10 @@
+function buildIndex(rows, cfg) {
+    const idx = new Map();
+    let n = 0;
+    for (const row of rows) {
+        const key = hashRow(row);
+        idx.set(key, row);
+        n = n + cfg.step;
+    }
+    return { idx, n };
+}

--- a/bench/type4/fixtures/async_sync/async_sync/hn3_a.py
+++ b/bench/type4/fixtures/async_sync/async_sync/hn3_a.py
@@ -1,0 +1,12 @@
+async def render(blocks, ctx):
+    parts = []
+    width = 0
+    for blk in blocks:
+        text = await format_block(blk, ctx)
+        sized = await measure(text)
+        if sized.fits:
+            parts.append(text)
+            width = width + sized.w
+        else:
+            await spill(blk)
+    return join(parts, width)

--- a/bench/type4/fixtures/async_sync/async_sync/hn3_b.py
+++ b/bench/type4/fixtures/async_sync/async_sync/hn3_b.py
@@ -1,0 +1,9 @@
+def quantize(samples, bits):
+    table = {}
+    peak = 0
+    for s in samples:
+        q = round(s * bits)
+        table[s] = q
+        if q > peak:
+            peak = q
+    return table, peak

--- a/bench/type4/fixtures/async_sync/async_sync/t1_handle_async.py
+++ b/bench/type4/fixtures/async_sync/async_sync/t1_handle_async.py
@@ -1,0 +1,12 @@
+async def handle(records, threshold):
+    out = []
+    total = 0
+    for rec in records:
+        parsed = await parse(rec)
+        score = await evaluate(parsed)
+        if score > threshold:
+            total = total + score
+            out.append(parsed)
+        else:
+            await log_skip(rec)
+    return summarize(out, total)

--- a/bench/type4/fixtures/async_sync/async_sync/t1_handle_sync.py
+++ b/bench/type4/fixtures/async_sync/async_sync/t1_handle_sync.py
@@ -1,0 +1,12 @@
+def handle(records, threshold):
+    out = []
+    total = 0
+    for rec in records:
+        parsed = parse(rec)
+        score = evaluate(parsed)
+        if score > threshold:
+            total = total + score
+            out.append(parsed)
+        else:
+            log_skip(rec)
+    return summarize(out, total)

--- a/bench/type4/fixtures/async_sync/async_sync/t2_loadall_async.ts
+++ b/bench/type4/fixtures/async_sync/async_sync/t2_loadall_async.ts
@@ -1,0 +1,13 @@
+async function loadAll(ids, opts) {
+    const out = [];
+    let total = 0;
+    for (const id of ids) {
+        const item = await fetchItem(id);
+        const w = await weigh(item, opts);
+        if (w > opts.min) {
+            total += w;
+            out.push(item);
+        }
+    }
+    return finalize(out, total);
+}

--- a/bench/type4/fixtures/async_sync/async_sync/t2_loadall_sync.ts
+++ b/bench/type4/fixtures/async_sync/async_sync/t2_loadall_sync.ts
@@ -1,0 +1,13 @@
+function loadAll(ids, opts) {
+    const out = [];
+    let total = 0;
+    for (const id of ids) {
+        const item = fetchItem(id);
+        const w = weigh(item, opts);
+        if (w > opts.min) {
+            total += w;
+            out.push(item);
+        }
+    }
+    return finalize(out, total);
+}

--- a/bench/type4/fixtures/async_sync/async_sync/t3_aggregate_async.py
+++ b/bench/type4/fixtures/async_sync/async_sync/t3_aggregate_async.py
@@ -1,0 +1,10 @@
+async def aggregate(items, seed):
+    acc = seed
+    kept = []
+    for it in items:
+        v = await transform(it)
+        g = await grade(v)
+        if g is not None:
+            acc = acc + g
+            kept.append(v)
+    return acc, kept

--- a/bench/type4/fixtures/async_sync/async_sync/t3_aggregate_sync.py
+++ b/bench/type4/fixtures/async_sync/async_sync/t3_aggregate_sync.py
@@ -1,0 +1,10 @@
+def aggregate(items, seed):
+    acc = seed
+    kept = []
+    for it in items:
+        v = transform(it)
+        g = grade(v)
+        if g is not None:
+            acc = acc + g
+            kept.append(v)
+    return acc, kept

--- a/bench/type4/fixtures/async_sync/async_sync/t4_collect_async.ts
+++ b/bench/type4/fixtures/async_sync/async_sync/t4_collect_async.ts
@@ -1,0 +1,13 @@
+async function collect(keys, cache) {
+    const res = {};
+    let hits = 0;
+    for (const k of keys) {
+        const raw = await lookup(k);
+        const norm = await normalize(raw);
+        if (norm.ok) {
+            res[k] = norm.value;
+            hits += 1;
+        }
+    }
+    return { res, hits };
+}

--- a/bench/type4/fixtures/async_sync/async_sync/t4_collect_sync.ts
+++ b/bench/type4/fixtures/async_sync/async_sync/t4_collect_sync.ts
@@ -1,0 +1,13 @@
+function collect(keys, cache) {
+    const res = {};
+    let hits = 0;
+    for (const k of keys) {
+        const raw = lookup(k);
+        const norm = normalize(raw);
+        if (norm.ok) {
+            res[k] = norm.value;
+            hits += 1;
+        }
+    }
+    return { res, hits };
+}

--- a/bench/type4/fixtures/async_sync/async_sync/t5_pipeline_async.py
+++ b/bench/type4/fixtures/async_sync/async_sync/t5_pipeline_async.py
@@ -1,0 +1,12 @@
+async def pipeline(stages, payload):
+    current = payload
+    trace = []
+    for stage in stages:
+        result = await run_stage(stage, current)
+        checked = await validate(result)
+        if checked.valid:
+            current = checked.value
+            trace.append(stage)
+        else:
+            break
+    return current, trace

--- a/bench/type4/fixtures/async_sync/async_sync/t5_pipeline_sync.py
+++ b/bench/type4/fixtures/async_sync/async_sync/t5_pipeline_sync.py
@@ -1,0 +1,12 @@
+def pipeline(stages, payload):
+    current = payload
+    trace = []
+    for stage in stages:
+        result = run_stage(stage, current)
+        checked = validate(result)
+        if checked.valid:
+            current = checked.value
+            trace.append(stage)
+        else:
+            break
+    return current, trace

--- a/bench/type4/fixtures/async_sync/async_sync/t6_retry_async.ts
+++ b/bench/type4/fixtures/async_sync/async_sync/t6_retry_async.ts
@@ -1,0 +1,14 @@
+async function withRetry(tasks, limit) {
+    const done = [];
+    let attempts = 0;
+    for (const t of tasks) {
+        const r = await execute(t);
+        const ok = await check(r);
+        if (ok) {
+            done.push(r);
+        } else {
+            attempts += 1;
+        }
+    }
+    return { done, attempts };
+}

--- a/bench/type4/fixtures/async_sync/async_sync/t6_retry_sync.ts
+++ b/bench/type4/fixtures/async_sync/async_sync/t6_retry_sync.ts
@@ -1,0 +1,14 @@
+function withRetry(tasks, limit) {
+    const done = [];
+    let attempts = 0;
+    for (const t of tasks) {
+        const r = execute(t);
+        const ok = check(r);
+        if (ok) {
+            done.push(r);
+        } else {
+            attempts += 1;
+        }
+    }
+    return { done, attempts };
+}

--- a/bench/type4/real_frontier.v1.json
+++ b/bench/type4/real_frontier.v1.json
@@ -1,853 +1,891 @@
 {
-  "schema_version": 1,
-  "source": {
-    "corpus": "bench/goldens/corpus.json",
-    "repos_root": "bench/repos",
-    "purpose": "Evidence-backed real-corpus Type-4 frontier items used to raise practical semantic completeness."
-  },
-  "entry_contract": {
-    "case_id": "Stable id for this real-corpus frontier item.",
-    "status": "already-covered | real-miss | hard-negative | unsupported | closed",
-    "candidate_axis": "Prioritizer candidate or semantic axis, such as membership_contains.",
-    "repo": "Pinned corpus repository id.",
-    "language": "Primary source language for the audited span.",
-    "locations": "One or more repo-relative source spans participating in the claim.",
-    "semantic_claim": "Concrete equivalence or non-equivalence claim being audited.",
-    "evidence": "Same-spec/property evidence for positives, or counterexample/non-equivalence witness for negatives.",
-    "detector": "Baseline and candidate detection status for the audited spans.",
-    "proof_invariant": "The narrow proof fact required before the detector may merge the item.",
-    "hard_negative_siblings": "Adjacent boundary cases that must remain unmerged.",
-    "batch": "Batch id once the item is selected for implementation.",
-    "notes": "Short audit notes, including why unsupported items are not detector work."
-  },
-  "items": [
+ "schema_version": 1,
+ "source": {
+  "corpus": "bench/goldens/corpus.json",
+  "repos_root": "bench/repos",
+  "purpose": "Evidence-backed real-corpus Type-4 frontier items used to raise practical semantic completeness."
+ },
+ "entry_contract": {
+  "case_id": "Stable id for this real-corpus frontier item.",
+  "status": "already-covered | real-miss | hard-negative | unsupported | closed",
+  "candidate_axis": "Prioritizer candidate or semantic axis, such as membership_contains.",
+  "repo": "Pinned corpus repository id.",
+  "language": "Primary source language for the audited span.",
+  "locations": "One or more repo-relative source spans participating in the claim.",
+  "semantic_claim": "Concrete equivalence or non-equivalence claim being audited.",
+  "evidence": "Same-spec/property evidence for positives, or counterexample/non-equivalence witness for negatives.",
+  "detector": "Baseline and candidate detection status for the audited spans.",
+  "proof_invariant": "The narrow proof fact required before the detector may merge the item.",
+  "hard_negative_siblings": "Adjacent boundary cases that must remain unmerged.",
+  "batch": "Batch id once the item is selected for implementation.",
+  "notes": "Short audit notes, including why unsupported items are not detector work."
+ },
+ "items": [
+  {
+   "case_id": "membership-java-enumset-of-junit5-doc-chronounit",
+   "status": "unsupported",
+   "candidate_axis": "membership_contains / literal_collection_membership",
+   "repo": "junit5",
+   "language": "java",
+   "locations": [
     {
-      "case_id": "membership-java-enumset-of-junit5-doc-chronounit",
-      "status": "unsupported",
-      "candidate_axis": "membership_contains / literal_collection_membership",
-      "repo": "junit5",
-      "language": "java",
-      "locations": [
-        {
-          "path": "documentation/src/test/java/example/ParameterizedTestDemo.java",
-          "span": "149",
-          "snippet": "assertTrue(EnumSet.of(ChronoUnit.DAYS, ChronoUnit.HOURS).contains(unit));"
-        },
-        {
-          "path": "documentation/src/test/java/example/ParameterizedTestDemo.java",
-          "span": "181-182",
-          "snippet": "assertTrue(EnumSet.of(ChronoUnit.HOURS, ChronoUnit.DAYS).contains(unit)); assertFalse(EnumSet.of(ChronoUnit.HALF_DAYS).contains(unit));"
-        }
-      ],
-      "semantic_claim": "The two EnumSet membership predicates share the same item set and searched element when item order is ignored.",
-      "evidence": "IL confirms both predicates lower to EnumSet.of(...).contains(unit), but the second enclosing method has an additional HALF_DAYS exclusion assertion, so the method-level units are not an evidence-backed Type-4 clone pair.",
-      "detector": {
-        "current_detector_miss": true,
-        "baseline_command": "nose scan ParameterizedTestDemo.java --mode semantic --format json --top 0 --min-size 1 --min-lines 1",
-        "baseline_result": "No family contains testWithEnumSourceInclude and testWithEnumSourceRangeExclude; selected before/after EnumSet whitelist experiment also produced no new real family."
-      },
-      "proof_invariant": "Would require only unshadowed java.util.EnumSet.of with strict-safe arguments and order-insensitive membership collection canon, but this is not sufficient to close a real method-level miss here.",
-      "hard_negative_siblings": [
-        "EnumSet.of(ChronoUnit.HOURS, ChronoUnit.HALF_DAYS, ChronoUnit.DAYS).contains(unit)",
-        "assertFalse(EnumSet.of(ChronoUnit.ERAS, ChronoUnit.FOREVER).contains(unit))",
-        "same-file class EnumSet shadowing java.util.EnumSet"
-      ],
-      "batch": null,
-      "reverify": {
-        "date": "2026-06-06",
-        "finding": "Adding EnumSet to the proven java collection factory (alongside Set.of/List.of) is sound but inert: EnumSet.of arguments are always enum constants lowered as Field(CONST, Var(Type)). Enum-constant elements are not exact_safe, so even Set.of(ChronoUnit.DAYS, ChronoUnit.HOURS).contains(unit) yields 0 semantic families. Reproduced with minimal A/B files (target/release/nose scan --mode semantic).",
-        "why_unsound_to_force": "Making Type.CONST field accesses exact_safe is unsound without import/type resolution: a free name Type can bind to different declarations across files, so two same-named-but-distinct enums sharing a constant name would false-merge. The exact_safe gate deliberately rejects opaque free-name field chains.",
-        "conclusion": "Two independent blockers (enum-constant strict-safety is unsound; the real junit5 method pair diverges on a HALF_DAYS exclusion and is not a true clone). Stays unsupported."
-      },
-      "notes": "Do not implement as a completeness batch unless another real corpus counterpart is found. Re-verified 2026-06-06: even an order-insensitive EnumSet.of canon cannot reach a semantic family because enum-constant elements are intentionally non-exact-safe."
+     "path": "documentation/src/test/java/example/ParameterizedTestDemo.java",
+     "span": "149",
+     "snippet": "assertTrue(EnumSet.of(ChronoUnit.DAYS, ChronoUnit.HOURS).contains(unit));"
     },
     {
-      "case_id": "membership-java-arrays-aslist-array-param-antlr4-skip-targets",
-      "status": "unsupported",
-      "candidate_axis": "membership_contains / literal_collection_membership",
-      "repo": "antlr4",
-      "language": "java",
-      "locations": [
-        {
-          "path": "runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeTestDescriptor.java",
-          "span": "91-92",
-          "snippet": "return Arrays.asList(skipTargets).contains(targetName);"
-        }
-      ],
-      "semantic_claim": "For a proven Java array receiver, Arrays.asList(array).contains(value) is membership in the array elements.",
-      "evidence": "The source declares skipTargets as String[], but current IL only preserves a var/field use and not an array type fact at the contains call.",
-      "detector": {
-        "current_detector_miss": true,
-        "baseline_command": "nose il RuntimeTestDescriptor.java",
-        "baseline_result": "IL shows Arrays.asList(skipTargets).contains(targetName) without a retained array proof fact."
-      },
-      "proof_invariant": "Requires a frontend proof fact that the single Arrays.asList argument is a Java array, plus mutation/alias boundaries for field or parameter provenance.",
-      "hard_negative_siblings": [
-        "Arrays.asList(list).contains(value), which tests whether value equals the list object",
-        "Arrays.asList(object).contains(value)",
-        "mutated or reassigned field provenance for skipTargets"
-      ],
-      "batch": "2026-06-06-aslist-single-arg-soundness",
-      "soundness_fix": {
-        "date": "2026-06-06",
-        "found": "Auditing this lead exposed a real hard-negative false merge: a single-argument varargs factory `Arrays.asList(x).contains(value)` was canonicalized to a one-element literal collection `{x}` for any unproven receiver. An array-typed field and a list-typed field sharing the same name (e.g. `items`) therefore merged, even though array membership (value in the elements) and `Arrays.asList(list)` membership (value.equals(list)) differ.",
-        "change": "value_graph proven_java_collection_factory_value: a single-argument List.of/Set.of/Arrays.asList is now canonicalized only when the receiver is a proven array (Arrays.asList over a ParamSemantic::Array value); otherwise it refuses. Multi-argument factories (the proven literal case the synthetic axis exercises) are unchanged.",
-        "regression_test": "crates/nose-cli/tests/cli.rs::scan_mode_semantic_keeps_aslist_single_unproven_receiver_distinct",
-        "real_corpus_delta": "The four real single-argument Arrays.asList(<ident>).contains sites in bench/repos (antlr4 skipTargets, h2database types, jedis validElements, netty packageNames) have distinct receiver names, so the false merge does not currently fire across them. Full-corpus --mode semantic scan is byte-identical before and after the fix: 7403 families, zero family-set difference. The fix is a soundness hardening with no behavior change on this corpus.",
-        "gates": "literal_collection_membership focused smoke: positive misses 0/20, hard-negative false merges 0/70. equivalence + cli suites green."
-      },
-      "notes": "Do not treat generic Arrays.asList(x) as collection-param membership without an array proof. The array-FIELD recall lead stays unsupported (a single corpus span, no clone pair; closing it needs array-typed field provenance with mutation/alias proof). The adjacent single-argument hard-negative false merge was confirmed real and fixed (see soundness_fix)."
-    },
-    {
-      "case_id": "java-class-literal-equals-junit5-supports-parameter",
-      "status": "unsupported",
-      "candidate_axis": "class_literal_equality",
-      "repo": "junit5",
-      "language": "java",
-      "locations": [
-        {
-          "path": "documentation/src/test/java/example/extensions/HttpServerExtension.java",
-          "span": "26-29",
-          "snippet": "return HttpServer.class.equals(parameterContext.getParameter().getType());"
-        },
-        {
-          "path": "documentation/src/test/java/example/session/HttpTests.java",
-          "span": "47-50",
-          "snippet": "return HttpServer.class.equals(parameterContext.getParameter().getType());"
-        }
-      ],
-      "semantic_claim": "The two supportsParameter implementations are syntactically and behaviorally identical for the documented ParameterResolver shape.",
-      "evidence": "near/syntax scan reports a real duplicate block, but semantic scan alone reports no family because the expression depends on a dynamic JUnit API call chain.",
-      "detector": {
-        "current_detector_miss": true,
-        "baseline_command": "nose scan HttpServerExtension.java HttpTests.java --mode semantic --format json --top 0 --min-lines 1 --min-size 1",
-        "baseline_result": "0 semantic families; syntax,semantic reports a block family."
-      },
-      "proof_invariant": "Would require proving Class literal equality and the purity/identity of parameterContext.getParameter().getType(), which is a library-specific receiver chain not currently modeled.",
-      "hard_negative_siblings": [
-        "custom receiver equals overloads",
-        "different getParameter/getType receiver chains",
-        "calls with side effects or mutation before getType"
-      ],
-      "batch": null,
-      "reverify": {
-        "date": "2026-06-06",
-        "finding": "Reproduced with minimal Ext/Tests files: --mode semantic reports 0 families (correct under-merge); --mode syntax,semantic reports a block family that includes the real Ext/Tests duplicate. The two spans are byte-identical, so this is a Type-1/Type-2 duplicate already covered by syntax/near mode, not a Type-4 semantic miss.",
-        "why_unsound_to_force": "The value is parameterContext.getParameter().getType() over a Class literal equals -- an opaque JUnit reflection chain that is not exact_safe. Admitting it to a semantic family would mean merging on syntactic identity of an opaque chain, not on a proven value, which is exactly the boundary the exact_safe gate protects and would risk merging distinct reflection chains that happen to look alike.",
-        "conclusion": "Correctly covered by syntax/near mode; semantic abstention is sound. Stays unsupported as a Type-4 lead."
-      },
-      "notes": "Not suitable for a soundness-preserving Type-4 detector batch without shared proof facts for Java reflection/JUnit APIs. Re-verified 2026-06-06: the real duplicate is a syntactic Type-1/Type-2 clone that syntax/near mode already reports; semantic mode correctly abstains on the opaque getType() chain."
-    },
-    {
-      "case_id": "python-sympy-rot90-default-covered",
-      "status": "already-covered",
-      "candidate_axis": "python_control_flow_equivalence / default_output_covered",
-      "repo": "sympy",
-      "language": "python",
-      "locations": [
-        {
-          "path": "sympy/matrices/common.py",
-          "span": "2372-2415",
-          "snippet": "def rot90(self, k=1): mod = k%4; if mod == 0: return self; if mod == 1: return self[::-1, ::].T; if mod == 2: return self[::-1, ::-1]; if mod == 3: return self[::, ::-1].T"
-        },
-        {
-          "path": "sympy/matrices/matrixbase.py",
-          "span": "2646-2690",
-          "snippet": "def rot90(self, k: int=1) -> Self: mod = k%4; if/elif mod == 0..3 returns the same rotations; else: assert False"
-        }
-      ],
-      "semantic_claim": "Both methods implement the same four-way rotation by `k % 4`; type annotations, `if` versus `elif`, and the unreachable `else: assert False` do not change the returned matrix for the covered integer inputs.",
-      "evidence": "Selected `nose verify` over the two SymPy matrix files is SOUND and writes one structurally-near under-merged pair at vj=0.88 for common.py:2372 and matrixbase.py:2646. Manual source audit confirms identical branch results for mod values 0, 1, 2, and 3.",
-      "detector": {
-        "current_detector_miss": true,
-        "binary_path": "/Users/ak/prjs/cc/nose/target/release/nose",
-        "nose_version": "nose 0.5.0",
-        "build_ref": "0b57dd25a0e6cdb6f2742abad82585ca8c517e38",
-        "baseline_command": "/Users/ak/prjs/cc/nose/target/release/nose verify /Users/ak/prjs/cc/nose/bench/repos/sympy/sympy/matrices/common.py /Users/ak/prjs/cc/nose/bench/repos/sympy/sympy/matrices/matrixbase.py --max-violations 999 --leads /tmp/nose-issue36-sympy-rot90-leads.json",
-        "baseline_result": "SOUND; completeness 7/8; one under-merged lead at vj=0.8809523809523809.",
-        "semantic_scan_result": "`--mode semantic --format json --top 0 --min-lines 1 --min-size 1` reports no family containing both method starts.",
-        "default_scan_result": "`--mode syntax,semantic --format json --top 0 --min-lines 1 --min-size 1` reports family 3225a572821dfef2 containing matrixbase.py:2646-2690 and common.py:2372-2415."
-      },
-      "proof_invariant": "A future semantic-only closure would need a narrow Python control-flow proof that a complete `if`/`elif` ladder over the same local discriminator is equivalent to sequential guard-return `if` statements when every guard returns and the final `else` is unreachable. This is not an implementation-ready Type-4 batch here because the default product output already reports the pair.",
-      "hard_negative_siblings": [
-        "a reachable final `else` that returns a different value instead of asserting unreachable",
-        "one branch returning a different slice or transposition",
-        "a guard that mutates `mod`, `k`, or `self` before a later guard",
-        "a non-returning first branch that can fall through into later effects"
-      ],
-      "batch": "2026-06-06-issue36-frontier-curation",
-      "notes": "Issue #36 audit record. This is a semantic-only under-merge but not a recommended detector batch because `nose scan` default output already covers the refactoring candidate through syntax/semantic mode."
-    },
-    {
-      "case_id": "java-guava-setview-minmax-size-hard-negative",
-      "status": "hard-negative",
-      "candidate_axis": "collection_size_bound / verifier-lead-rejection",
-      "repo": "guava",
-      "language": "java",
-      "locations": [
-        {
-          "path": "android/guava/src/com/google/common/collect/Sets.java",
-          "span": "794-796",
-          "snippet": "static int minSize(Set<?> set) { return set instanceof SetView ? ((SetView<?>) set).minSize() : set.size(); }"
-        },
-        {
-          "path": "android/guava/src/com/google/common/collect/Sets.java",
-          "span": "810-812",
-          "snippet": "static int maxSize(Set<?> set) { return set instanceof SetView ? ((SetView<?>) set).maxSize() : set.size(); }"
-        }
-      ],
-      "semantic_claim": "These helpers are not exact Type-4 clones. They agree for ordinary `Set` receivers but intentionally differ for `SetView`, where `minSize()` and `maxSize()` are different abstract bounds.",
-      "evidence": "Whole-Guava `nose verify` is SOUND and emits this pair as an under-merged oracle lead at vj=0.43, but source audit shows a concrete hard-negative sibling: any `SetView` implementation whose lower and upper bounds differ makes the two methods return different values. The current semantic/default scans report no family for the pair.",
-      "detector": {
-        "current_detector_miss": false,
-        "binary_path": "/Users/ak/prjs/cc/nose/target/release/nose",
-        "nose_version": "nose 0.5.0",
-        "build_ref": "0b57dd25a0e6cdb6f2742abad82585ca8c517e38",
-        "baseline_command": "/Users/ak/prjs/cc/nose/target/release/nose verify /Users/ak/prjs/cc/nose/bench/repos/guava/android/guava/src/com/google/common/collect/Sets.java --max-violations 999 --leads /tmp/nose-issue36-guava-sets-leads.json",
-        "baseline_result": "SOUND; completeness 0/1; one low-nearness oracle lead at vj=0.42857142857142855.",
-        "semantic_scan_result": "`--mode semantic --format json --top 0 --min-lines 1 --min-size 1` reports 0 families containing both starts.",
-        "default_scan_result": "`--mode syntax,semantic --format json --top 0 --min-lines 1 --min-size 1` reports 0 families containing both starts."
-      },
-      "proof_invariant": "Any future size-bound or method-name abstraction must preserve method identity when the receiver domain can dispatch to different abstract operations. `SetView.minSize()` and `SetView.maxSize()` are separate semantic coordinates even though the non-SetView fallback is the same `set.size()` call.",
-      "hard_negative_siblings": [
-        "a `SetView` whose `minSize()` returns 0 while `maxSize()` returns the backing set size",
-        "a subclass where `minSize()` is cheap lower-bound metadata and `maxSize()` is an upper-bound over a different backing set",
-        "renaming or normalizing `min*` and `max*` methods before receiver-domain proof",
-        "collapsing both helpers to `set.size()` without proving the receiver is not a `SetView`"
-      ],
-      "batch": "2026-06-06-issue36-frontier-curation",
-      "notes": "Issue #36 Java audit record. This rejects a real-corpus verifier lead rather than proposing detector work; it is useful as an adjacent hard negative for any future Java collection-size-bound axis."
-    },
-    {
-      "case_id": "python-docstring-sympy-dirac-delta",
-      "status": "closed",
-      "candidate_axis": "python_docstring_noop",
-      "repo": "sympy",
-      "language": "python",
-      "locations": [
-        {
-          "path": "sympy/matrices/common.py",
-          "span": "1362-1365",
-          "snippet": "def dirac(i, j): if i == j: return 1; return 0"
-        },
-        {
-          "path": "sympy/physics/paulialgebra.py",
-          "span": "24-42",
-          "snippet": "def delta(i, j): \"\"\"...\"\"\"; if i == j: return 1; else: return 0"
-        }
-      ],
-      "semantic_claim": "Both functions return 1 exactly when i == j and 0 otherwise; delta differs by a leading static docstring and equivalent else form.",
-      "evidence": "nose verify selected SymPy files before: under-merged lead vj=0.85 common.py:1362 ↮ paulialgebra.py:24. After the batch the selected verify run reports 70/70 completeness and 0 under-merged groups.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "nose verify selected SymPy files --leads /tmp/sympy-docstring-before-leads.json",
-        "baseline_result": "Missed by previous release; semantic scan only exposed a smaller block family at common.py:1363 and paulialgebra.py:39.",
-        "candidate_result": "target/debug/nose scan selected SymPy files reports function family a3aee3c67319983d with paulialgebra.py:24 and common.py:1362."
-      },
-      "proof_invariant": "A Python function leading static string literal statement is docstring metadata and does not affect callable return behavior.",
-      "hard_negative_siblings": [
-        "returning different string literals",
-        "assigning and returning different string literals",
-        "calling observe(f\"{value}\") before returning"
-      ],
-      "batch": "2026-06-05-python-docstring-noop",
-      "notes": "Selected first-batch real miss from SymPy verify leads."
-    },
-    {
-      "case_id": "python-docstring-sympy-symmetric-residue-gf-int",
-      "status": "closed",
-      "candidate_axis": "python_docstring_noop",
-      "repo": "sympy",
-      "language": "python",
-      "locations": [
-        {
-          "path": "sympy/ntheory/modular.py",
-          "span": "11-22",
-          "snippet": "def symmetric_residue(a, m): \"\"\"...\"\"\"; if a <= m // 2: return a; return a - m"
-        },
-        {
-          "path": "sympy/polys/galoistools.py",
-          "span": "154-172",
-          "snippet": "def gf_int(a, p): \"\"\"...\"\"\"; if a <= p // 2: return a; else: return a - p"
-        }
-      ],
-      "semantic_claim": "Both functions map a residue into the symmetric half-modulus interval, differing only in parameter names, docstrings, and equivalent fallthrough/else return shape.",
-      "evidence": "nose verify selected SymPy files before: under-merged lead vj=0.76 modular.py:11 ↮ galoistools.py:154. After the batch selected verify reports no under-merged groups.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "nose scan selected SymPy files --mode semantic --format json --top 0 --min-lines 1 --min-size 1",
-        "baseline_result": "Previous release had only a smaller block family at modular.py:20 and galoistools.py:169.",
-        "candidate_result": "Candidate scan reports function family 666a9056967fa013 with galoistools.py:154 and modular.py:11."
-      },
-      "proof_invariant": "A Python function leading static string literal statement is docstring metadata and does not affect callable return behavior.",
-      "hard_negative_siblings": [
-        "wrong returned arithmetic expression",
-        "returned string literal differences",
-        "dynamic leading f-string/call effect"
-      ],
-      "batch": "2026-06-05-python-docstring-noop",
-      "notes": "Selected first-batch real miss from SymPy verify leads."
-    },
-    {
-      "case_id": "python-docstring-sympy-dup-degree-gf-degree",
-      "status": "closed",
-      "candidate_axis": "python_docstring_noop",
-      "repo": "sympy",
-      "language": "python",
-      "locations": [
-        {
-          "path": "sympy/polys/densebasic.py",
-          "span": "285-302",
-          "snippet": "def dup_degree(f): \"\"\"...\"\"\"; return len(f) - 1"
-        },
-        {
-          "path": "sympy/polys/galoistools.py",
-          "span": "175-190",
-          "snippet": "def gf_degree(f): \"\"\"...\"\"\"; return len(f) - 1"
-        }
-      ],
-      "semantic_claim": "Both functions return len(f) - 1; type annotations and docstring text do not change runtime return behavior for this detector proof.",
-      "evidence": "nose verify selected SymPy files before: under-merged lead vj=0.60 densebasic.py:285 ↮ galoistools.py:175. After the batch selected verify reports no under-merged groups.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "nose verify selected SymPy files --leads /tmp/sympy-docstring-before-leads.json",
-        "baseline_result": "Missed by previous release as a function-level family.",
-        "candidate_result": "Candidate scan reports function family 823edb6d7e558128 with densebasic.py:285 and galoistools.py:175."
-      },
-      "proof_invariant": "A Python function leading static string literal statement is docstring metadata and does not affect callable return behavior.",
-      "hard_negative_siblings": [
-        "return len(f) instead of len(f) - 1",
-        "returned string literal differences",
-        "assigned string values used in return"
-      ],
-      "batch": "2026-06-05-python-docstring-noop",
-      "notes": "Selected first-batch real miss from SymPy verify leads."
-    },
-    {
-      "case_id": "python-docstring-sympy-dup-strip-gf-strip",
-      "status": "closed",
-      "candidate_axis": "python_docstring_noop",
-      "repo": "sympy",
-      "language": "python",
-      "locations": [
-        {
-          "path": "sympy/polys/densebasic.py",
-          "span": "415-440",
-          "snippet": "def dup_strip(...): \"\"\"...\"\"\"; if not f or f[0]: return f; ...; return f[i:]"
-        },
-        {
-          "path": "sympy/polys/galoistools.py",
-          "span": "233-257",
-          "snippet": "def gf_strip(...): \"\"\"...\"\"\"; if not f or f[0]: return f; ...; return f[k:]"
-        }
-      ],
-      "semantic_claim": "Both functions strip leading zero coefficients using alpha-equivalent loop state; docstrings and local variable names differ.",
-      "evidence": "nose verify selected SymPy files before: under-merged lead vj=0.84 densebasic.py:415 ↮ galoistools.py:233. After the batch selected verify reports no under-merged groups.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "nose verify selected SymPy files --leads /tmp/sympy-docstring-before-leads.json",
-        "baseline_result": "Previous release exposed only a smaller block family at densebasic.py:434 and galoistools.py:252.",
-        "candidate_result": "Candidate scan reports function family 087fb7c9a965310c with densebasic.py:415 and galoistools.py:233."
-      },
-      "proof_invariant": "A Python function leading static string literal statement is docstring metadata and does not affect callable return behavior.",
-      "hard_negative_siblings": [
-        "wrong slice index",
-        "wrong loop break condition",
-        "dynamic leading f-string/call effect"
-      ],
-      "batch": "2026-06-05-python-docstring-noop",
-      "notes": "Selected first-batch real miss from SymPy verify leads."
-    },
-    {
-      "case_id": "python-docstring-sympy-dup-lc-gf-lc",
-      "status": "closed",
-      "candidate_axis": "python_docstring_noop",
-      "repo": "sympy",
-      "language": "python",
-      "locations": [
-        {
-          "path": "sympy/polys/densebasic.py",
-          "span": "121-138",
-          "snippet": "def dup_LC(...): \"\"\"...\"\"\"; if not f: return K.zero; else: return f[0]"
-        },
-        {
-          "path": "sympy/polys/galoistools.py",
-          "span": "193-210",
-          "snippet": "def gf_LC(...): \"\"\"...\"\"\"; if not f: return K.zero; else: return f[0]"
-        }
-      ],
-      "semantic_claim": "Both functions return the first coefficient or K.zero for an empty polynomial; docstrings differ only as metadata.",
-      "evidence": "Candidate scan added function family 81a0c70aa0e3d978; previous release had no function-level family for these spans.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "nose scan selected SymPy files --mode semantic --format json --top 0 --min-lines 1 --min-size 1",
-        "baseline_result": "No previous release function family for densebasic.py:121 and galoistools.py:193.",
-        "candidate_result": "Candidate scan reports function family 81a0c70aa0e3d978."
-      },
-      "proof_invariant": "A Python function leading static string literal statement is docstring metadata and does not affect callable return behavior.",
-      "hard_negative_siblings": [
-        "return f[-1] instead of f[0]",
-        "wrong empty fallback",
-        "assigned string values used in return"
-      ],
-      "batch": "2026-06-05-python-docstring-noop",
-      "notes": "Additional same-invariant real family found by selected real scan delta."
-    },
-    {
-      "case_id": "python-docstring-sympy-dup-tc-gf-tc",
-      "status": "closed",
-      "candidate_axis": "python_docstring_noop",
-      "repo": "sympy",
-      "language": "python",
-      "locations": [
-        {
-          "path": "sympy/polys/densebasic.py",
-          "span": "141-158",
-          "snippet": "def dup_TC(...): \"\"\"...\"\"\"; if not f: return K.zero; else: return f[-1]"
-        },
-        {
-          "path": "sympy/polys/galoistools.py",
-          "span": "213-230",
-          "snippet": "def gf_TC(...): \"\"\"...\"\"\"; if not f: return K.zero; else: return f[-1]"
-        }
-      ],
-      "semantic_claim": "Both functions return the trailing coefficient or K.zero for an empty polynomial; docstrings differ only as metadata.",
-      "evidence": "Candidate scan added function family 490a609cb8f7e2b8; previous release had no function-level family for these spans.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "nose scan selected SymPy files --mode semantic --format json --top 0 --min-lines 1 --min-size 1",
-        "baseline_result": "No previous release function family for densebasic.py:141 and galoistools.py:213.",
-        "candidate_result": "Candidate scan reports function family 490a609cb8f7e2b8."
-      },
-      "proof_invariant": "A Python function leading static string literal statement is docstring metadata and does not affect callable return behavior.",
-      "hard_negative_siblings": [
-        "return f[0] instead of f[-1]",
-        "wrong empty fallback",
-        "dynamic leading f-string/call effect"
-      ],
-      "batch": "2026-06-05-python-docstring-noop",
-      "notes": "Additional same-invariant real family found by selected real scan delta."
-    },
-    {
-      "case_id": "python-docstring-sympy-shape-property",
-      "status": "closed",
-      "candidate_axis": "python_docstring_noop",
-      "repo": "sympy",
-      "language": "python",
-      "locations": [
-        {
-          "path": "sympy/matrices/common.py",
-          "span": "693-708",
-          "snippet": "@property def shape(self): \"\"\"...\"\"\"; return (self.rows, self.cols)"
-        },
-        {
-          "path": "sympy/matrices/common.py",
-          "span": "3142-3143",
-          "snippet": "@property def shape(self): return (self.rows, self.cols)"
-        }
-      ],
-      "semantic_claim": "Both shape properties return the same (rows, cols) tuple; the public property docstring is metadata.",
-      "evidence": "Candidate scan added method family 8cfcba8974d82c2d; previous release had no method-level family for these spans.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "nose scan selected SymPy files --mode semantic --format json --top 0 --min-lines 1 --min-size 1",
-        "baseline_result": "No previous release method family for common.py:693 and common.py:3142.",
-        "candidate_result": "Candidate scan reports method family 8cfcba8974d82c2d."
-      },
-      "proof_invariant": "A Python method leading static string literal statement is docstring metadata and does not affect callable return behavior.",
-      "hard_negative_siblings": [
-        "returning (cols, rows)",
-        "returning a string literal",
-        "dynamic leading f-string/call effect"
-      ],
-      "batch": "2026-06-05-python-docstring-noop",
-      "notes": "Additional same-invariant real family found by selected real scan delta."
-    },
-    {
-      "case_id": "typescript-import-namespace-shadow-jest-replace-root-dir",
-      "status": "closed",
-      "candidate_axis": "import_identity",
-      "repo": "jest",
-      "language": "typescript",
-      "locations": [
-        {
-          "path": "packages/jest-config/src/utils.ts",
-          "span": "57-69",
-          "snippet": "export const replaceRootDirInPath = (rootDir, filePath) => { ... return path.resolve(rootDir, path.normalize(`./${filePath.slice('<rootDir>'.length)}`)); }"
-        },
-        {
-          "path": "packages/jest-resolve/src/utils.ts",
-          "span": "21-30",
-          "snippet": "const replaceRootDirInPath = (rootDir, filePath) => { ... return path.resolve(rootDir, path.normalize(`./${filePath.slice('<rootDir>'.length)}`)); }"
-        }
-      ],
-      "semantic_claim": "Both helpers return filePath unchanged unless it starts with <rootDir>, otherwise they resolve rootDir plus the normalized suffix after the <rootDir> marker.",
-      "evidence": "Previous release verify over jest-config/src and jest-resolve/src reported one under-merged behavior group at utils.ts:57 ↮ utils.ts:21 with SOUND. Candidate verify reports completeness 1/1, 0 under-merged groups, and semantic scan reports family 5dc1326d43c86973 containing the two replaceRootDirInPath functions.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "/tmp/nose-before-shadow scan jest-config/src jest-resolve/src --mode semantic --top 0",
-        "baseline_result": "0 semantic families; features showed both functions exact_safe=false and the jest-config value fingerprint lacked the node:path namespace literals because a different function parameter named path was treated as a module-binding mutation.",
-        "candidate_result": "target/release/nose scan reports one semantic family with packages/jest-config/src/utils.ts:57-69 and packages/jest-resolve/src/utils.ts:21-30; both feature records are exact_safe=true with identical value fingerprints."
-      },
-      "proof_invariant": "For JS/TS-family files, a function or lambda parameter that shadows a module-level binding name must not count as mutation of that module binding; unshadowed mutation-like receiver calls still block the proof. Static template literal fragments are behavior-defining string literals and must be preserved in the value graph.",
-      "hard_negative_siblings": [
-        "path.replaceAll(...) on the unshadowed namespace local still taints the module binding proof",
-        "a same-named local object with resolve/normalize is not a proven node:path namespace import",
-        "a different template literal fragment such as ../ changes the resolved path"
-      ],
-      "batch": "2026-06-05-js-namespace-shadow-template",
-      "notes": "Selected from Jest real verify lead after broader membership/map audits found no sound higher-yield real misses."
-    },
-    {
-      "case_id": "c-total-order-comparator-vim-lnum-syn-int",
-      "status": "closed",
-      "candidate_axis": "total_order_compare",
-      "repo": "vim",
-      "language": "c",
-      "locations": [
-        {
-          "path": "src/diff.c",
-          "span": "937-947",
-          "snippet": "static int lnum_compare(const void *s1, const void *s2) { ... if (lnum1 < lnum2) return -1; if (lnum1 > lnum2) return 1; return 0; }"
-        },
-        {
-          "path": "src/window.c",
-          "span": "8495-8505",
-          "snippet": "static int int_cmp(const void *pa, const void *pb) { ... if (a > b) return 1; if (a < b) return -1; return 0; }"
-        },
-        {
-          "path": "src/syntax.c",
-          "span": "5288-5295",
-          "snippet": "static int syn_compare_stub(const void *v1, const void *v2) { ... return (*s1 > *s2 ? 1 : *s1 < *s2 ? -1 : 0); }"
-        }
-      ],
-      "semantic_claim": "All three Vim callbacks implement the same ascending three-way total-order comparator over the dereferenced scalar pair, returning -1, 1, or 0 for less, greater, or equal.",
-      "evidence": "Previous release verify over selected Vim comparator files reported one behavior-equal group with completeness 1/3 and an under-merged lead diff.c:937 ↮ syntax.c:5288. Candidate verify reports completeness 3/3, 0 under-merged groups, and whole-repo semantic scan reports family e498fe8139e65f5c containing lnum_compare, int_cmp, and syn_compare_stub.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "/tmp/nose-before-nextbatch verify diff.c syntax.c window.c viminfo.c insexpand.c --leads /tmp/nose-vim-comparator-before-leads.json",
-        "baseline_result": "SOUND; completeness 1/3; one under-merged group at diff.c:937 ↮ syntax.c:5288. Whole Vim scan reported only window.c:int_cmp with syntax.c:syn_compare_stub in family d3b98d6969be6d8d.",
-        "candidate_result": "target/release/nose verify over the same selected files reports SOUND, completeness 3/3, and 0 under-merged groups; whole Vim scan reports a 3-copy comparator family containing diff.c:937, window.c:8495, and syntax.c:5288."
-      },
-      "proof_invariant": "For primitive source-language comparisons, a strict ordered comparison guard implies the same-direction non-strict guard, so a path condition such as (x < y) and (x <= y) can absorb the non-strict residue. Receiver-overloadable comparisons are excluded.",
-      "hard_negative_siblings": [
-        "descending comparator that returns 1 for less and -1 for greater",
-        "equality-boundary comparator that returns -1 when left == right",
-        "wrong positive sign value such as returning 2 for greater",
-        "Python/Ruby/JS-style receiver-overloadable or effectful comparisons without a primitive order proof"
-      ],
-      "batch": "2026-06-05-c-total-order-compare",
-      "notes": "Selected from the real audit after broad membership/map-default priority leads were already covered, unsupported, or hard negatives."
-    },
-    {
-      "case_id": "java-empty-domain-netty-array-queue-string",
-      "status": "closed",
-      "candidate_axis": "collection_empty_check / typed_empty_domain_soundness",
-      "repo": "netty",
-      "language": "java",
-      "locations": [
-        {
-          "path": "codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslEngine.java",
-          "span": "305-307",
-          "snippet": "private boolean isEmpty(Object @Nullable [] arr) { return arr == null || arr.length == 0; }"
-        },
-        {
-          "path": "common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java",
-          "span": "147-149",
-          "snippet": "private static boolean isNullOrEmpty(Queue<ScheduledFutureTask<?>> queue) { return queue == null || queue.isEmpty(); }"
-        },
-        {
-          "path": "common/src/main/java/io/netty/util/internal/StringUtil.java",
-          "span": "593-595",
-          "snippet": "public static boolean isNullOrEmpty(String s) { return s == null || s.isEmpty(); }"
-        }
-      ],
-      "semantic_claim": "These null-or-empty helpers have the same surface shape but are not proven equivalent across Java array, Queue/collection, and String receiver domains under the independent verifier.",
-      "evidence": "Previous release whole-Netty verify reported two false merges from QuicheQuicSslEngine.java:305 to AbstractScheduledEventExecutor.java:147 and StringUtil.java:593, each with 72 differing inputs. Candidate whole-Netty verify with --max-violations 0 is SOUND.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "/tmp/nose-before-empty-target2/release/nose verify bench/repos/netty --max-violations 10",
-        "baseline_result": "2 false merges: Object[] null-or-length-empty collapsed with Queue.isEmpty and String.isEmpty.",
-        "candidate_result": "target/release/nose verify bench/repos/netty --max-violations 0 reports SOUND; feature dump shows the three value fingerprints are distinct."
-      },
-      "proof_invariant": "A strict empty-check merge may share coordinates only when the receiver domain is proven compatible. Java array length, receiver-provided collection emptiness, and string emptiness are distinct domains unless a stronger proof connects them.",
-      "hard_negative_siblings": [
-        "Queue<String> value == null || value.isEmpty() vs Object[] value == null || value.length == 0",
-        "Queue<String> value == null || value.isEmpty() vs String value == null || value.isEmpty()",
-        "untyped or shadowed receiver emptiness without a domain proof"
-      ],
-      "batch": "2026-06-05-java-empty-domain-soundness",
-      "notes": "Soundness blocker batch. It intentionally reduces an over-broad merge rather than closing a completeness miss; follow-up completeness work should continue from the remaining real under-merged Netty leads only after preserving this boundary."
-    },
-    {
-      "case_id": "java-dead-loop-libgdx-bufferutils-find-floats",
-      "status": "closed",
-      "candidate_axis": "java_statically_false_loop",
-      "repo": "libgdx",
-      "language": "java",
-      "locations": [
-        {
-          "path": "backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/BufferUtils.java",
-          "span": "433-449",
-          "snippet": "public static long findFloats(float[] vertex, int strideInBytes, float[] vertices, int numVertices) { ... boolean found = true; for (int j = 0; !found && j < size; j++) ... }"
-        },
-        {
-          "path": "backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/BufferUtils.java",
-          "span": "458-474",
-          "snippet": "public static long findFloats(float[] vertex, int strideInBytes, float[] vertices, int numVertices, float epsilon) { ... boolean found = true; for (int j = 0; !found && j < size; j++) ... }"
-        }
-      ],
-      "semantic_claim": "Both overloads return the first vertex index whenever numVertices is positive, otherwise -1, because the inner comparison loop is unreachable after found is initialized true and the guard starts with !found.",
-      "evidence": "Previous release selected verify over BufferUtils.java reported SOUND with completeness 0/1 and under-merged lead BufferUtils.java:433 to BufferUtils.java:458. Candidate selected verify reports SOUND with completeness 1/1 and 0 under-merged groups. An exact pinned-corpus search for the same boolean-true plus !guard pattern found only these two libgdx spans.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "/tmp/nose-before-java-dead-loop verify bench/repos/libgdx/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/BufferUtils.java --max-violations 0 --leads /tmp/nose-libgdx-gwt-bufferutils-before-rerun-leads.json",
-        "baseline_result": "SOUND; completeness 0/1; under-merged lead BufferUtils.java:433 to BufferUtils.java:458 with vj=0.43.",
-        "candidate_result": "target/release/nose verify bench/repos/libgdx/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/BufferUtils.java --max-violations 0 --leads /tmp/nose-libgdx-gwt-bufferutils-after-rerun-leads.json reports SOUND; completeness 1/1; under-merged groups 0. Whole-libgdx semantic scan reports family 3aaacf7da1b4536d containing both methods."
-      },
-      "proof_invariant": "For a local boolean proven true before a while-loop entry guard, a left short-circuit atom !local in an && guard is proven false, so the loop body and update are unreachable. The merge also requires loop-carried recurrence placeholders to be keyed by traversal/carry slot rather than source cid so unused parameters do not change the value identity.",
-      "hard_negative_siblings": [
-        "boolean found = false before !found && ..., where the body can execute",
-        "found && ... with found initialized true, where the body can execute",
-        "found reassigned before the guard, removing the constant proof",
-        "same-template mutation changing a reachable returned index even when the loop body is dead"
-      ],
-      "batch": "2026-06-05-java-dead-loop-guard",
-      "notes": "Small completeness batch: the real audit over libgdx, git, and h2database plus exact pinned search found one evidence-backed same-invariant real family, so this batch intentionally closes one real candidate rather than padding to three unrelated candidates."
-    },
-    {
-      "case_id": "java-low-bit-toggle-graphhopper-reverse-edge",
-      "status": "closed",
-      "candidate_axis": "java_integer_low_bit_toggle",
-      "repo": "graphhopper",
-      "language": "java",
-      "locations": [
-        {
-          "path": "core/src/main/java/com/graphhopper/routing/querygraph/QueryGraph.java",
-          "span": "199-202",
-          "snippet": "static int getPosOfReverseEdge(int edgeId) { return edgeId % 2 == 0 ? edgeId + 1 : edgeId - 1; }"
-        },
-        {
-          "path": "core/src/main/java/com/graphhopper/util/GHUtility.java",
-          "span": "370-372",
-          "snippet": "public static int reverseEdgeKey(int edgeKey) { return edgeKey ^ 1; }"
-        }
-      ],
-      "semantic_claim": "Both helpers toggle the low bit of a Java primitive int edge key: even values return x + 1 and odd values return x - 1, which is exactly x ^ 1.",
-      "evidence": "Previous release selected verify over QueryGraph.java and GHUtility.java reported SOUND with completeness 0/1 and under-merged lead QueryGraph.java:199 to GHUtility.java:370. Candidate selected verify reports SOUND with completeness 1/1 and 0 under-merged groups. Whole-Graphhopper semantic scan reports a new family containing both methods.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "/tmp/nose-goal-baseline-target/release/nose verify bench/repos/graphhopper/core/src/main/java/com/graphhopper/routing/querygraph/QueryGraph.java bench/repos/graphhopper/core/src/main/java/com/graphhopper/util/GHUtility.java --max-violations 0 --leads /tmp/nose-graphhopper-bit-toggle-baseline-check-leads.json",
-        "baseline_result": "SOUND; completeness 0/1; under-merged lead QueryGraph.java:199 to GHUtility.java:370 with vj=0.12. Whole-Graphhopper scan reported 28 semantic families.",
-        "candidate_result": "target/release/nose verify over the same selected files reports SOUND, completeness 1/1, and 0 under-merged groups. Whole-Graphhopper scan reports 29 semantic families including QueryGraph.java:199 and GHUtility.java:370."
-      },
-      "proof_invariant": "For Java primitive integer operators, x % 2 == 0 partitions even values from odd values; x + 1 is used only for even values and x - 1 only for odd values, avoiding signed overflow at both int extremes and matching the low-bit toggle x ^ 1. The proof is not applied to overloadable or coercive surfaces.",
-      "hard_negative_siblings": [
-        "reversed branches: x % 2 == 0 ? x - 1 : x + 1",
-        "wrong bit: x ^ 2",
-        "positive-one parity check: x % 2 == 1 ? x - 1 : x + 1, which fails for negative odd Java ints",
-        "wrong branch delta such as x % 2 == 0 ? x + 1 : x - 2",
-        "non-Java or overloadable/coercive operator surfaces without a primitive integer proof"
-      ],
-      "batch": "2026-06-05-java-low-bit-toggle",
-      "notes": "The audit covered Guava, SQLAlchemy, Rubocop, SymPy, Poetry, Scrapy, Commons Lang, Marshmallow, HTTPie, JUnit5, Jedis, RxJava, chi, and Graphhopper. Most leads were unsupported or hard negatives; exact pinned-corpus search found only this same-invariant real miss, so the batch is intentionally small."
-    },
-    {
-      "case_id": "c-u16-byte-pack-sqlite-big-endian-decode",
-      "status": "closed",
-      "candidate_axis": "c_u16_be_byte_pack",
-      "repo": "sqlite",
-      "language": "c",
-      "locations": [
-        {
-          "path": "ext/misc/btreeinfo.c",
-          "span": "269-271",
-          "snippet": "static unsigned int get_uint16(unsigned char *a) { return (a[0]<<8) + a[1]; }"
-        },
-        {
-          "path": "ext/recover/dbdata.c",
-          "span": "344-346",
-          "snippet": "static unsigned int get_uint16(unsigned char *a) { return (a[0]<<8) + a[1]; }"
-        },
-        {
-          "path": "ext/fts5/fts5_index.c",
-          "span": "712-714",
-          "snippet": "static u16 fts5GetU16(const u8 *aIn) { return ((u16)aIn[0] << 8) + aIn[1]; }"
-        },
-        {
-          "path": "ext/recover/sqlite3recover.c",
-          "span": "2078-2080",
-          "snippet": "static u16 recoverGetU16(const u8 *aBuf) { return (aBuf[0] << 8) | aBuf[1]; }"
-        },
-        {
-          "path": "ext/rtree/rtree.c",
-          "span": "525-527",
-          "snippet": "static int readInt16(u8 *p) { return (p[0]<<8) + p[1]; }"
-        }
-      ],
-      "semantic_claim": "All five helpers decode the same big-endian unsigned 16-bit value from two disjoint byte lanes: high byte a[0] shifted by 8 plus low byte a[1]. Addition and bitwise-or are equivalent under this byte-lane proof.",
-      "evidence": "The previous C u16 baseline selected SQLite verify was SOUND with completeness 7/16 and one under-merged u16 lead fts5_index.c:712 to btreeinfo.c:269 because fts5_index.c gets u8 from an included header. Candidate verify over the five selected SQLite files is SOUND with completeness 11/16; semantic scan reports family acf37a59f5e99973 containing fts5_index.c:712, btreeinfo.c:269, dbdata.c:344, sqlite3recover.c:2078, and rtree.c:525.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "/tmp/nose-fragment-baseline-target/release/nose verify ext/misc/btreeinfo.c ext/recover/dbdata.c ext/fts5/fts5_index.c ext/recover/sqlite3recover.c ext/rtree/rtree.c --max-violations 0 --leads /tmp/nose-sqlite-u16-before-leads.json",
-        "baseline_result": "SOUND; completeness 7/16; fts5_index.c:712 remained under-merged from the 4-copy u16 byte-pack family.",
-        "candidate_result": "target/release/nose verify over the same selected files reports SOUND, completeness 11/16, and 1 remaining under-merged group outside this invariant. NOSE_TIME=1 target/release/nose scan over the selected files reports family acf37a59f5e99973 containing the expected 5-copy u16 family."
-      },
-      "proof_invariant": "In C only, the parameter must be proven to be a byte buffer: unsigned char *, uint8_t *, a same-file typedef alias such as typedef unsigned char u8, or a same-directory direct quote include whose small header contains that typedef. The expression must use the same base pointer, high lane index 0 shifted left exactly 8, low lane index 1, and either + or |. The proof is limited to 16-bit packing, where the shifted byte stays representable in int.",
-      "hard_negative_siblings": [
-        "swapped byte order: (a[1] << 8) | a[0]",
-        "overlapping lanes such as (a[0] << 4) | a[1]",
-        "wrong low byte coordinate such as a[2]",
-        "u8 spelling with a missing include or without a local typedef proof that it aliases unsigned char",
-        "included typedef unsigned short u8 or any other non-byte alias",
-        "int * or other non-byte-buffer receiver",
-        "32-bit packing such as a[0] << 24, which is not accepted without an unsigned-overflow proof"
-      ],
-      "batch": "2026-06-06-c-u16-include-typedef",
-      "notes": "The include-header u8 miss is closed without a general preprocessor: C lowering only reads same-directory quote includes for byte-pack-shaped sources and records single-line typedef unsigned char aliases from small headers. The 32-bit get_uint32/recoverGetU32 pair remains unsupported because uncasted signed left shifts can overflow or enter undefined behavior."
-    },
-    {
-      "case_id": "c-u32-byte-pack-sqlite-unsigned-cast-decode",
-      "status": "closed",
-      "candidate_axis": "c_u32_be_byte_pack",
-      "repo": "sqlite",
-      "language": "c",
-      "locations": [
-        {
-          "path": "ext/recover/dbdata.c",
-          "span": "347-352",
-          "snippet": "static u32 get_uint32(unsigned char *a) { return ((u32)a[0]<<24) | ((u32)a[1]<<16) | ((u32)a[2]<<8) | ((u32)a[3]); }"
-        },
-        {
-          "path": "ext/fts5/fts5_index.c",
-          "span": "737-742",
-          "snippet": "static u32 fts5GetU32(const u8 *a) { return ((u32)a[0] << 24) + ((u32)a[1] << 16) + ((u32)a[2] << 8) + ((u32)a[3] << 0); }"
-        },
-        {
-          "path": "ext/recover/sqlite3recover.c",
-          "span": "2086-2088",
-          "snippet": "static u32 recoverGetU32(const u8 *a) { return (((u32)a[0])<<24) + (((u32)a[1])<<16) + (((u32)a[2])<<8) + ((u32)a[3]); }"
-        },
-        {
-          "path": "ext/misc/btreeinfo.c",
-          "span": "272-274",
-          "snippet": "static unsigned int get_uint32(unsigned char *a) { return (a[0]<<24)|(a[1]<<16)|(a[2]<<8)|a[3]; }",
-          "role": "hard-negative sibling: uncasted high lane remains unmerged"
-        }
-      ],
-      "semantic_claim": "The first three helpers decode the same big-endian unsigned 32-bit value from four byte lanes over a proven byte buffer, with an explicit unsigned 32-bit cast on the high byte lane before shifting by 24. The uncasted btreeinfo helper is behaviorally similar in the oracle battery but is not accepted as strict semantic proof because C signed left shift may overflow or be undefined.",
-      "evidence": "Baseline selected scan split or mixed the u32 helpers: dbdata.c:347 was paired with uncasted btreeinfo.c:272, while fts5_index.c:737 and sqlite3recover.c:2086 did not form the strict cast-proven family. Candidate selected scan reports a 3-copy family containing fts5_index.c:737, dbdata.c:347, and sqlite3recover.c:2086; btreeinfo.c:272 stays outside. Candidate selected verify is SOUND with 0 false merges and leaves only the intended uncasted btreeinfo under-merge at vj=0.24.",
-      "detector": {
-        "current_detector_miss": false,
-        "baseline_command": "NOSE_TIME=1 target/release/nose scan ext/recover/sqlite3recover.c ext/recover/dbdata.c ext/rtree/rtree.c ext/fts5/fts5_index.c ext/misc/btreeinfo.c --mode semantic --format json --top 0 before rebuilding release",
-        "baseline_result": "Selected baseline had no cast-proven 3-copy u32 family and included dbdata.c:347 with uncasted btreeinfo.c:272 in a smaller family.",
-        "candidate_result": "target/release/nose scan over the same selected files reports the 3-copy cast-proven u32 family fts5_index.c:737, dbdata.c:347, sqlite3recover.c:2086; verify over the selected files reports SOUND, completeness 13/16, and 1 intended under-merged uncasted group."
-      },
-      "proof_invariant": "In C only, the receiver must be a proven byte buffer (`unsigned char *`, `uint8_t *`, same-file `typedef unsigned char u8`, or same-directory direct quote include proving that alias). A 32-bit unsigned cast proof must be explicit in source for the high lane: direct `unsigned`/`unsigned int`/`uint32_t` cast, or `u32` only when a same-file/direct local include proves `typedef unsigned int u32`. The four lanes must be the same base pointer at indices 0, 1, 2, and 3 with shifts 24, 16, 8, and 0 respectively, combined only with `+` or `|`.",
-      "hard_negative_siblings": [
-        "uncasted high lane such as `(a[0] << 24)` even when the receiver is `unsigned char *`",
-        "swapped byte order such as `((u32)a[1] << 24) | ((u32)a[0] << 16) | ...`",
-        "wrong byte coordinate or duplicate lane",
-        "`typedef signed int u32` or missing/unread include for the `u32` cast alias",
-        "non-byte receiver such as `int *a`",
-        "32-bit little-endian or mixed-endian packing, which is a separate semantic axis"
-      ],
-      "batch": "2026-06-06-c-u32-unsigned-cast-byte-pack",
-      "notes": "Selected to correct Java skew with a non-Java real-corpus batch. The change also tightens soundness by keeping uncasted C high-lane shifts out of strict semantic proof."
-    },
-    {
-      "case_id": "ruby-fetch-block-custom-receiver-map-default-audit",
-      "status": "unsupported",
-      "candidate_axis": "map_default_lookup / literal_map_default_lookup",
-      "repo": "sinatra / liquid / rack / rubocop",
-      "language": "ruby",
-      "locations": [
-        {
-          "path": "sinatra-contrib/spec/cookies_spec.rb",
-          "span": "513",
-          "snippet": "expect(cookies.fetch('foo') { 'bar' }).to eq('bar')"
-        },
-        {
-          "path": "liquid/test/unit/registers_unit_test.rb",
-          "span": "56-59",
-          "snippet": "result = static_register.fetch(:d) { \"default\" }; result = static_register.fetch(:d, \"default 1\") { \"default 2\" }"
-        },
-        {
-          "path": "rack/test/spec_request.rb",
-          "span": "1334",
-          "snippet": "req.headers.fetch('bar-foo'){'1'}.must_equal '1'"
-        },
-        {
-          "path": "rubocop/spec/rubocop/cop/style/redundant_fetch_block_spec.rb",
-          "span": "132",
-          "snippet": "Rails.cache.fetch(:key) { :value }"
-        }
-      ],
-      "semantic_claim": "Ruby `fetch(key) { fallback }` has map-default behavior only when the receiver is a proven Hash-like map and the block is a pure fallback value. These real spans use custom receivers (`cookies`, `static_register`, `req.headers`, `Rails.cache`) whose `fetch` semantics are not proven by the current detector.",
-      "evidence": "Corpus grep found many Ruby block-fetch idioms, but the actionable strict slice is not these custom receiver calls. A focused synthetic baseline also exposed a false merge between literal `{...}.fetch(key) { 0 }` and `{...}.fetch(key) { 9 }`; the batch fixes that literal-Hash soundness gap and accepts only zero-arg pure fallback blocks over literal Hash receivers.",
-      "detector": {
-        "current_detector_miss": true,
-        "baseline_command": "rg \"\\.fetch\\([^\\n]*\\)\\s*\\{\\s*(0|1|true|false|nil|:[A-Za-z_][A-Za-z0-9_]*|'[^']*'|\\\"[^\\\"]*\\\")\\s*\\}\" bench/repos -g '*.rb'",
-        "baseline_result": "Real hits are dominated by custom receivers rather than literal or otherwise proven Hash receivers.",
-        "candidate_result": "Literal Hash `fetch(key) { fallback }` is now canonicalized only when the fallback block is zero-arg and value-like; custom receivers remain unmerged."
-      },
-      "proof_invariant": "Do not merge arbitrary Ruby `fetch` calls. A strict map-default proof requires a literal/proven Hash receiver, the same key coordinate, and a zero-arg fallback block whose implicit result is an exact-safe value. Blocks with parameters, `raise`, `yield`, mutation, or unproven receivers remain outside the proof.",
-      "hard_negative_siblings": [
-        "`hash.fetch(key) { |missing| missing.to_s }`, where the fallback depends on the missing key",
-        "`hash.fetch(key) { raise KeyError }`, where missing-key behavior is an exception effect",
-        "`Rails.cache.fetch(key) { value }`, where receiver semantics are cache-specific",
-        "`ENV.fetch(key) { value }`, where receiver and environment behavior are not literal Hash proof",
-        "`hash.fetch(key, default) { block }`, where Ruby uses the block and warns about the ignored default argument"
-      ],
-      "batch": "2026-06-06-ruby-fetch-block-map-default",
-      "reverify": {
-        "date": "2026-06-06",
-        "boundaries_verified": "Reproduced with minimal scans. A proven literal Hash `{...}.fetch(key) { 0 }` converges with `{...}.fetch(key, 0)` (one family). All five hard-negative classes stay distinct: a different fallback `{ 9 }`, a block parameter `{ |missing| ... }`, a `{ raise KeyError }` effect, and the custom receivers `Rails.cache.fetch(key) { 0 }` and `cookies.fetch(key) { 0 }` each remain unmerged. No false merges.",
-        "deferred_sound_lead": "A function-local immutable Hash binding receiver (`h = {literal}; h.fetch(key) { 0 }`) is currently NOT proven (0 families) even though the inline-literal form is. This is a genuine receiver-provenance fact that DOES exist (single-writer immutable local binding), unlike the custom method receivers, so it is a sound next candidate. Closing it requires a value-graph-level receiver resolution for the GetOrDefault canon (mirroring proven_local_collection_binding_value on the membership axis), not just the idiom-layer literal check. Hard negatives: a mutated/reassigned binding and a custom receiver must stay unmerged. Not implemented here: it is synthetic-shaped, has no counterpart among these four real spans, and belongs in its own small batch.",
-        "conclusion": "The literal-Hash batch is sound and intact. The custom-receiver real frontier stays unsupported (no receiver provenance for cookies/static_register/req.headers/Rails.cache)."
-      },
-      "notes": "Selected after the user raised Java-skew concerns. This is a non-Java soundness/completeness micro-batch, but the real custom-receiver frontier remains unsupported until receiver provenance facts exist. Re-verified 2026-06-06: literal-Hash convergence holds and all five hard-negative classes stay distinct; a function-local immutable Hash binding receiver is recorded as a sound deferred lead (see reverify.deferred_sound_lead)."
-    },
-    {
-      "case_id": "numeric-clamp-minmax-ternary-real-miss",
-      "status": "real-miss",
-      "candidate_axis": "numeric_clamp / clamp_surface_bridge",
-      "repo": "boltons",
-      "language": "python",
-      "locations": [
-        {
-          "path": "boltons/mathutils.py",
-          "span": "40-69",
-          "snippet": "def clamp(x, lower, upper): if upper < lower: raise ValueError; return min(max(x, lower), upper)"
-        },
-        {
-          "path": "src/util/util.go",
-          "span": "63-65",
-          "snippet": "func Constrain[T cmp.Ordered](val, minimum, maximum T) T { return max(min(val, maximum), minimum) }  -- fzf (heldout, go): the max(min) canonical form"
-        }
-      ],
-      "semantic_claim": "min(max(x,lo),hi), max(min(x,hi),lo), and (x<lo ? lo : (x>hi ? hi : x)) all denote the same clamp for a totally-ordered numeric domain with lo <= hi. The boltons `clamp` and the fzf `Constrain` are the two canonical min/max compositions, in different languages, and should converge.",
-      "evidence": "the clamp obligation machine-checks the identity and its hard negatives (self-contained Lean 4, no Mathlib). A 196-case integer battery confirms min(max)==max(min)==ternary for every lo<=hi. The first proof-backed min/max composition slice now canonicalizes when the source proves integer lo<=hi by literal bounds or an exiting inverse guard. This real frontier item remains open because broader surface bridges and real-corpus bound-order evidence are still incomplete: the controlled ternary/library clamp forms do not yet bridge to the proven Clamp value, and fzf `Constrain` only names its bounds rather than proving their order. The idiom appears in 26 repos across all 7 primary languages on both splits (frontier_platform breadth).",
-      "detector": {
-        "current_detector_miss": true,
-        "binary_path": "/Users/ak/prjs/cc/nose/target/release/nose",
-        "nose_version": "nose 0.5.0",
-        "build_ref": "58c4c9b0c513b3893b4d29552167b800595ce87e",
-        "baseline_command": "nose scan <two-form file with abs control + clamp> --mode semantic --format json --top 0 --min-size 1 --min-lines 1",
-        "baseline_result": "abs control merges (1 family: absTern, absBuilt); the clamp forms (clampTern, clampBuilt) are NOT merged.",
-        "semantic_scan_result": "nose scan boltons/boltons/mathutils.py fzf/src/util/util.go --mode semantic --format json --top 0 --min-size 1 --min-lines 1: the clamp pair is not merged across files.",
-        "default_scan_result": "The value graph now has a proof-backed integer min/max Clamp canon for sources that prove lo<=hi, but this real cross-language pair still lacks a shared proven bound-order fact on both sides; default syntax/semantic scan does not merge it. Two-comparison and library clamp bridge forms remain successor work."
-      },
-      "proof_invariant": "Recognize clamp as min(max(x,lo),hi) = max(min(x,hi),lo) = two-comparison form ONLY with proven scalar min/max facts and a lo <= hi precondition; reject swapped bound order min(max(x,hi),lo), wrong nesting max(min(x,lo),hi), the lo>hi precondition violation, and float NaN (where min/max builtins vs comparison chains can diverge by language). Machine-checked in formal/obligations/normalize/value_graph/clamp/Proof.lean.",
-      "hard_negative_siblings": [
-        "swapped bound order min(max(x, hi), lo) -- clamp Counterexamples.lean swapped_bounds_not_clamp",
-        "wrong nesting max(min(x, lo), hi) -- clamp Counterexamples.lean wrong_nesting_not_clamp",
-        "lo > hi precondition violation: the two compositions diverge -- clamp Counterexamples.lean precondition_required",
-        "float NaN inputs where min/max builtins and comparison chains can return different values depending on language NaN semantics"
-      ],
-      "batch": null,
-      "reverify": "Re-run the controlled clamp semantic scan and the boltons/fzf cross-file scan; re-check formal/obligations/normalize/value_graph/clamp/Proof.lean type-checks. Reclassify only when the real-corpus pair and the controlled ternary/library bridge forms merge while the swapped-bound, wrong-nesting, lo>hi, and float-domain hard negatives stay split.",
-      "notes": "Issue #50 Team B target packet evidence (linked by frontier_target_packets). The initial proof-backed integer min/max Clamp canon has landed for sources with literal or exiting-guard bound-order evidence. The remaining packet is still routed proof-fact-prerequisite / successor bridge work: formal/obligations/normalize/value_graph/clamp/Counterexamples.lean proves the lo<=hi precondition is required, and parameter naming (e.g. fzf Constrain(val, minimum, maximum)) is not a proof. Broader detector work must first establish real-corpus bound order and keep float-NaN and swapped/inverted-bound hard negatives split."
+     "path": "documentation/src/test/java/example/ParameterizedTestDemo.java",
+     "span": "181-182",
+     "snippet": "assertTrue(EnumSet.of(ChronoUnit.HOURS, ChronoUnit.DAYS).contains(unit)); assertFalse(EnumSet.of(ChronoUnit.HALF_DAYS).contains(unit));"
     }
-  ]
+   ],
+   "semantic_claim": "The two EnumSet membership predicates share the same item set and searched element when item order is ignored.",
+   "evidence": "IL confirms both predicates lower to EnumSet.of(...).contains(unit), but the second enclosing method has an additional HALF_DAYS exclusion assertion, so the method-level units are not an evidence-backed Type-4 clone pair.",
+   "detector": {
+    "current_detector_miss": true,
+    "baseline_command": "nose scan ParameterizedTestDemo.java --mode semantic --format json --top 0 --min-size 1 --min-lines 1",
+    "baseline_result": "No family contains testWithEnumSourceInclude and testWithEnumSourceRangeExclude; selected before/after EnumSet whitelist experiment also produced no new real family."
+   },
+   "proof_invariant": "Would require only unshadowed java.util.EnumSet.of with strict-safe arguments and order-insensitive membership collection canon, but this is not sufficient to close a real method-level miss here.",
+   "hard_negative_siblings": [
+    "EnumSet.of(ChronoUnit.HOURS, ChronoUnit.HALF_DAYS, ChronoUnit.DAYS).contains(unit)",
+    "assertFalse(EnumSet.of(ChronoUnit.ERAS, ChronoUnit.FOREVER).contains(unit))",
+    "same-file class EnumSet shadowing java.util.EnumSet"
+   ],
+   "batch": null,
+   "reverify": {
+    "date": "2026-06-06",
+    "finding": "Adding EnumSet to the proven java collection factory (alongside Set.of/List.of) is sound but inert: EnumSet.of arguments are always enum constants lowered as Field(CONST, Var(Type)). Enum-constant elements are not exact_safe, so even Set.of(ChronoUnit.DAYS, ChronoUnit.HOURS).contains(unit) yields 0 semantic families. Reproduced with minimal A/B files (target/release/nose scan --mode semantic).",
+    "why_unsound_to_force": "Making Type.CONST field accesses exact_safe is unsound without import/type resolution: a free name Type can bind to different declarations across files, so two same-named-but-distinct enums sharing a constant name would false-merge. The exact_safe gate deliberately rejects opaque free-name field chains.",
+    "conclusion": "Two independent blockers (enum-constant strict-safety is unsound; the real junit5 method pair diverges on a HALF_DAYS exclusion and is not a true clone). Stays unsupported."
+   },
+   "notes": "Do not implement as a completeness batch unless another real corpus counterpart is found. Re-verified 2026-06-06: even an order-insensitive EnumSet.of canon cannot reach a semantic family because enum-constant elements are intentionally non-exact-safe."
+  },
+  {
+   "case_id": "membership-java-arrays-aslist-array-param-antlr4-skip-targets",
+   "status": "unsupported",
+   "candidate_axis": "membership_contains / literal_collection_membership",
+   "repo": "antlr4",
+   "language": "java",
+   "locations": [
+    {
+     "path": "runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeTestDescriptor.java",
+     "span": "91-92",
+     "snippet": "return Arrays.asList(skipTargets).contains(targetName);"
+    }
+   ],
+   "semantic_claim": "For a proven Java array receiver, Arrays.asList(array).contains(value) is membership in the array elements.",
+   "evidence": "The source declares skipTargets as String[], but current IL only preserves a var/field use and not an array type fact at the contains call.",
+   "detector": {
+    "current_detector_miss": true,
+    "baseline_command": "nose il RuntimeTestDescriptor.java",
+    "baseline_result": "IL shows Arrays.asList(skipTargets).contains(targetName) without a retained array proof fact."
+   },
+   "proof_invariant": "Requires a frontend proof fact that the single Arrays.asList argument is a Java array, plus mutation/alias boundaries for field or parameter provenance.",
+   "hard_negative_siblings": [
+    "Arrays.asList(list).contains(value), which tests whether value equals the list object",
+    "Arrays.asList(object).contains(value)",
+    "mutated or reassigned field provenance for skipTargets"
+   ],
+   "batch": "2026-06-06-aslist-single-arg-soundness",
+   "soundness_fix": {
+    "date": "2026-06-06",
+    "found": "Auditing this lead exposed a real hard-negative false merge: a single-argument varargs factory `Arrays.asList(x).contains(value)` was canonicalized to a one-element literal collection `{x}` for any unproven receiver. An array-typed field and a list-typed field sharing the same name (e.g. `items`) therefore merged, even though array membership (value in the elements) and `Arrays.asList(list)` membership (value.equals(list)) differ.",
+    "change": "value_graph proven_java_collection_factory_value: a single-argument List.of/Set.of/Arrays.asList is now canonicalized only when the receiver is a proven array (Arrays.asList over a ParamSemantic::Array value); otherwise it refuses. Multi-argument factories (the proven literal case the synthetic axis exercises) are unchanged.",
+    "regression_test": "crates/nose-cli/tests/cli.rs::scan_mode_semantic_keeps_aslist_single_unproven_receiver_distinct",
+    "real_corpus_delta": "The four real single-argument Arrays.asList(<ident>).contains sites in bench/repos (antlr4 skipTargets, h2database types, jedis validElements, netty packageNames) have distinct receiver names, so the false merge does not currently fire across them. Full-corpus --mode semantic scan is byte-identical before and after the fix: 7403 families, zero family-set difference. The fix is a soundness hardening with no behavior change on this corpus.",
+    "gates": "literal_collection_membership focused smoke: positive misses 0/20, hard-negative false merges 0/70. equivalence + cli suites green."
+   },
+   "notes": "Do not treat generic Arrays.asList(x) as collection-param membership without an array proof. The array-FIELD recall lead stays unsupported (a single corpus span, no clone pair; closing it needs array-typed field provenance with mutation/alias proof). The adjacent single-argument hard-negative false merge was confirmed real and fixed (see soundness_fix)."
+  },
+  {
+   "case_id": "java-class-literal-equals-junit5-supports-parameter",
+   "status": "unsupported",
+   "candidate_axis": "class_literal_equality",
+   "repo": "junit5",
+   "language": "java",
+   "locations": [
+    {
+     "path": "documentation/src/test/java/example/extensions/HttpServerExtension.java",
+     "span": "26-29",
+     "snippet": "return HttpServer.class.equals(parameterContext.getParameter().getType());"
+    },
+    {
+     "path": "documentation/src/test/java/example/session/HttpTests.java",
+     "span": "47-50",
+     "snippet": "return HttpServer.class.equals(parameterContext.getParameter().getType());"
+    }
+   ],
+   "semantic_claim": "The two supportsParameter implementations are syntactically and behaviorally identical for the documented ParameterResolver shape.",
+   "evidence": "near/syntax scan reports a real duplicate block, but semantic scan alone reports no family because the expression depends on a dynamic JUnit API call chain.",
+   "detector": {
+    "current_detector_miss": true,
+    "baseline_command": "nose scan HttpServerExtension.java HttpTests.java --mode semantic --format json --top 0 --min-lines 1 --min-size 1",
+    "baseline_result": "0 semantic families; syntax,semantic reports a block family."
+   },
+   "proof_invariant": "Would require proving Class literal equality and the purity/identity of parameterContext.getParameter().getType(), which is a library-specific receiver chain not currently modeled.",
+   "hard_negative_siblings": [
+    "custom receiver equals overloads",
+    "different getParameter/getType receiver chains",
+    "calls with side effects or mutation before getType"
+   ],
+   "batch": null,
+   "reverify": {
+    "date": "2026-06-06",
+    "finding": "Reproduced with minimal Ext/Tests files: --mode semantic reports 0 families (correct under-merge); --mode syntax,semantic reports a block family that includes the real Ext/Tests duplicate. The two spans are byte-identical, so this is a Type-1/Type-2 duplicate already covered by syntax/near mode, not a Type-4 semantic miss.",
+    "why_unsound_to_force": "The value is parameterContext.getParameter().getType() over a Class literal equals -- an opaque JUnit reflection chain that is not exact_safe. Admitting it to a semantic family would mean merging on syntactic identity of an opaque chain, not on a proven value, which is exactly the boundary the exact_safe gate protects and would risk merging distinct reflection chains that happen to look alike.",
+    "conclusion": "Correctly covered by syntax/near mode; semantic abstention is sound. Stays unsupported as a Type-4 lead."
+   },
+   "notes": "Not suitable for a soundness-preserving Type-4 detector batch without shared proof facts for Java reflection/JUnit APIs. Re-verified 2026-06-06: the real duplicate is a syntactic Type-1/Type-2 clone that syntax/near mode already reports; semantic mode correctly abstains on the opaque getType() chain."
+  },
+  {
+   "case_id": "python-sympy-rot90-default-covered",
+   "status": "already-covered",
+   "candidate_axis": "python_control_flow_equivalence / default_output_covered",
+   "repo": "sympy",
+   "language": "python",
+   "locations": [
+    {
+     "path": "sympy/matrices/common.py",
+     "span": "2372-2415",
+     "snippet": "def rot90(self, k=1): mod = k%4; if mod == 0: return self; if mod == 1: return self[::-1, ::].T; if mod == 2: return self[::-1, ::-1]; if mod == 3: return self[::, ::-1].T"
+    },
+    {
+     "path": "sympy/matrices/matrixbase.py",
+     "span": "2646-2690",
+     "snippet": "def rot90(self, k: int=1) -> Self: mod = k%4; if/elif mod == 0..3 returns the same rotations; else: assert False"
+    }
+   ],
+   "semantic_claim": "Both methods implement the same four-way rotation by `k % 4`; type annotations, `if` versus `elif`, and the unreachable `else: assert False` do not change the returned matrix for the covered integer inputs.",
+   "evidence": "Selected `nose verify` over the two SymPy matrix files is SOUND and writes one structurally-near under-merged pair at vj=0.88 for common.py:2372 and matrixbase.py:2646. Manual source audit confirms identical branch results for mod values 0, 1, 2, and 3.",
+   "detector": {
+    "current_detector_miss": true,
+    "binary_path": "/Users/ak/prjs/cc/nose/target/release/nose",
+    "nose_version": "nose 0.5.0",
+    "build_ref": "0b57dd25a0e6cdb6f2742abad82585ca8c517e38",
+    "baseline_command": "/Users/ak/prjs/cc/nose/target/release/nose verify /Users/ak/prjs/cc/nose/bench/repos/sympy/sympy/matrices/common.py /Users/ak/prjs/cc/nose/bench/repos/sympy/sympy/matrices/matrixbase.py --max-violations 999 --leads /tmp/nose-issue36-sympy-rot90-leads.json",
+    "baseline_result": "SOUND; completeness 7/8; one under-merged lead at vj=0.8809523809523809.",
+    "semantic_scan_result": "`--mode semantic --format json --top 0 --min-lines 1 --min-size 1` reports no family containing both method starts.",
+    "default_scan_result": "`--mode syntax,semantic --format json --top 0 --min-lines 1 --min-size 1` reports family 3225a572821dfef2 containing matrixbase.py:2646-2690 and common.py:2372-2415."
+   },
+   "proof_invariant": "A future semantic-only closure would need a narrow Python control-flow proof that a complete `if`/`elif` ladder over the same local discriminator is equivalent to sequential guard-return `if` statements when every guard returns and the final `else` is unreachable. This is not an implementation-ready Type-4 batch here because the default product output already reports the pair.",
+   "hard_negative_siblings": [
+    "a reachable final `else` that returns a different value instead of asserting unreachable",
+    "one branch returning a different slice or transposition",
+    "a guard that mutates `mod`, `k`, or `self` before a later guard",
+    "a non-returning first branch that can fall through into later effects"
+   ],
+   "batch": "2026-06-06-issue36-frontier-curation",
+   "notes": "Issue #36 audit record. This is a semantic-only under-merge but not a recommended detector batch because `nose scan` default output already covers the refactoring candidate through syntax/semantic mode."
+  },
+  {
+   "case_id": "java-guava-setview-minmax-size-hard-negative",
+   "status": "hard-negative",
+   "candidate_axis": "collection_size_bound / verifier-lead-rejection",
+   "repo": "guava",
+   "language": "java",
+   "locations": [
+    {
+     "path": "android/guava/src/com/google/common/collect/Sets.java",
+     "span": "794-796",
+     "snippet": "static int minSize(Set<?> set) { return set instanceof SetView ? ((SetView<?>) set).minSize() : set.size(); }"
+    },
+    {
+     "path": "android/guava/src/com/google/common/collect/Sets.java",
+     "span": "810-812",
+     "snippet": "static int maxSize(Set<?> set) { return set instanceof SetView ? ((SetView<?>) set).maxSize() : set.size(); }"
+    }
+   ],
+   "semantic_claim": "These helpers are not exact Type-4 clones. They agree for ordinary `Set` receivers but intentionally differ for `SetView`, where `minSize()` and `maxSize()` are different abstract bounds.",
+   "evidence": "Whole-Guava `nose verify` is SOUND and emits this pair as an under-merged oracle lead at vj=0.43, but source audit shows a concrete hard-negative sibling: any `SetView` implementation whose lower and upper bounds differ makes the two methods return different values. The current semantic/default scans report no family for the pair.",
+   "detector": {
+    "current_detector_miss": false,
+    "binary_path": "/Users/ak/prjs/cc/nose/target/release/nose",
+    "nose_version": "nose 0.5.0",
+    "build_ref": "0b57dd25a0e6cdb6f2742abad82585ca8c517e38",
+    "baseline_command": "/Users/ak/prjs/cc/nose/target/release/nose verify /Users/ak/prjs/cc/nose/bench/repos/guava/android/guava/src/com/google/common/collect/Sets.java --max-violations 999 --leads /tmp/nose-issue36-guava-sets-leads.json",
+    "baseline_result": "SOUND; completeness 0/1; one low-nearness oracle lead at vj=0.42857142857142855.",
+    "semantic_scan_result": "`--mode semantic --format json --top 0 --min-lines 1 --min-size 1` reports 0 families containing both starts.",
+    "default_scan_result": "`--mode syntax,semantic --format json --top 0 --min-lines 1 --min-size 1` reports 0 families containing both starts."
+   },
+   "proof_invariant": "Any future size-bound or method-name abstraction must preserve method identity when the receiver domain can dispatch to different abstract operations. `SetView.minSize()` and `SetView.maxSize()` are separate semantic coordinates even though the non-SetView fallback is the same `set.size()` call.",
+   "hard_negative_siblings": [
+    "a `SetView` whose `minSize()` returns 0 while `maxSize()` returns the backing set size",
+    "a subclass where `minSize()` is cheap lower-bound metadata and `maxSize()` is an upper-bound over a different backing set",
+    "renaming or normalizing `min*` and `max*` methods before receiver-domain proof",
+    "collapsing both helpers to `set.size()` without proving the receiver is not a `SetView`"
+   ],
+   "batch": "2026-06-06-issue36-frontier-curation",
+   "notes": "Issue #36 Java audit record. This rejects a real-corpus verifier lead rather than proposing detector work; it is useful as an adjacent hard negative for any future Java collection-size-bound axis."
+  },
+  {
+   "case_id": "python-docstring-sympy-dirac-delta",
+   "status": "closed",
+   "candidate_axis": "python_docstring_noop",
+   "repo": "sympy",
+   "language": "python",
+   "locations": [
+    {
+     "path": "sympy/matrices/common.py",
+     "span": "1362-1365",
+     "snippet": "def dirac(i, j): if i == j: return 1; return 0"
+    },
+    {
+     "path": "sympy/physics/paulialgebra.py",
+     "span": "24-42",
+     "snippet": "def delta(i, j): \"\"\"...\"\"\"; if i == j: return 1; else: return 0"
+    }
+   ],
+   "semantic_claim": "Both functions return 1 exactly when i == j and 0 otherwise; delta differs by a leading static docstring and equivalent else form.",
+   "evidence": "nose verify selected SymPy files before: under-merged lead vj=0.85 common.py:1362 \u21ae paulialgebra.py:24. After the batch the selected verify run reports 70/70 completeness and 0 under-merged groups.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "nose verify selected SymPy files --leads /tmp/sympy-docstring-before-leads.json",
+    "baseline_result": "Missed by previous release; semantic scan only exposed a smaller block family at common.py:1363 and paulialgebra.py:39.",
+    "candidate_result": "target/debug/nose scan selected SymPy files reports function family a3aee3c67319983d with paulialgebra.py:24 and common.py:1362."
+   },
+   "proof_invariant": "A Python function leading static string literal statement is docstring metadata and does not affect callable return behavior.",
+   "hard_negative_siblings": [
+    "returning different string literals",
+    "assigning and returning different string literals",
+    "calling observe(f\"{value}\") before returning"
+   ],
+   "batch": "2026-06-05-python-docstring-noop",
+   "notes": "Selected first-batch real miss from SymPy verify leads."
+  },
+  {
+   "case_id": "python-docstring-sympy-symmetric-residue-gf-int",
+   "status": "closed",
+   "candidate_axis": "python_docstring_noop",
+   "repo": "sympy",
+   "language": "python",
+   "locations": [
+    {
+     "path": "sympy/ntheory/modular.py",
+     "span": "11-22",
+     "snippet": "def symmetric_residue(a, m): \"\"\"...\"\"\"; if a <= m // 2: return a; return a - m"
+    },
+    {
+     "path": "sympy/polys/galoistools.py",
+     "span": "154-172",
+     "snippet": "def gf_int(a, p): \"\"\"...\"\"\"; if a <= p // 2: return a; else: return a - p"
+    }
+   ],
+   "semantic_claim": "Both functions map a residue into the symmetric half-modulus interval, differing only in parameter names, docstrings, and equivalent fallthrough/else return shape.",
+   "evidence": "nose verify selected SymPy files before: under-merged lead vj=0.76 modular.py:11 \u21ae galoistools.py:154. After the batch selected verify reports no under-merged groups.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "nose scan selected SymPy files --mode semantic --format json --top 0 --min-lines 1 --min-size 1",
+    "baseline_result": "Previous release had only a smaller block family at modular.py:20 and galoistools.py:169.",
+    "candidate_result": "Candidate scan reports function family 666a9056967fa013 with galoistools.py:154 and modular.py:11."
+   },
+   "proof_invariant": "A Python function leading static string literal statement is docstring metadata and does not affect callable return behavior.",
+   "hard_negative_siblings": [
+    "wrong returned arithmetic expression",
+    "returned string literal differences",
+    "dynamic leading f-string/call effect"
+   ],
+   "batch": "2026-06-05-python-docstring-noop",
+   "notes": "Selected first-batch real miss from SymPy verify leads."
+  },
+  {
+   "case_id": "python-docstring-sympy-dup-degree-gf-degree",
+   "status": "closed",
+   "candidate_axis": "python_docstring_noop",
+   "repo": "sympy",
+   "language": "python",
+   "locations": [
+    {
+     "path": "sympy/polys/densebasic.py",
+     "span": "285-302",
+     "snippet": "def dup_degree(f): \"\"\"...\"\"\"; return len(f) - 1"
+    },
+    {
+     "path": "sympy/polys/galoistools.py",
+     "span": "175-190",
+     "snippet": "def gf_degree(f): \"\"\"...\"\"\"; return len(f) - 1"
+    }
+   ],
+   "semantic_claim": "Both functions return len(f) - 1; type annotations and docstring text do not change runtime return behavior for this detector proof.",
+   "evidence": "nose verify selected SymPy files before: under-merged lead vj=0.60 densebasic.py:285 \u21ae galoistools.py:175. After the batch selected verify reports no under-merged groups.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "nose verify selected SymPy files --leads /tmp/sympy-docstring-before-leads.json",
+    "baseline_result": "Missed by previous release as a function-level family.",
+    "candidate_result": "Candidate scan reports function family 823edb6d7e558128 with densebasic.py:285 and galoistools.py:175."
+   },
+   "proof_invariant": "A Python function leading static string literal statement is docstring metadata and does not affect callable return behavior.",
+   "hard_negative_siblings": [
+    "return len(f) instead of len(f) - 1",
+    "returned string literal differences",
+    "assigned string values used in return"
+   ],
+   "batch": "2026-06-05-python-docstring-noop",
+   "notes": "Selected first-batch real miss from SymPy verify leads."
+  },
+  {
+   "case_id": "python-docstring-sympy-dup-strip-gf-strip",
+   "status": "closed",
+   "candidate_axis": "python_docstring_noop",
+   "repo": "sympy",
+   "language": "python",
+   "locations": [
+    {
+     "path": "sympy/polys/densebasic.py",
+     "span": "415-440",
+     "snippet": "def dup_strip(...): \"\"\"...\"\"\"; if not f or f[0]: return f; ...; return f[i:]"
+    },
+    {
+     "path": "sympy/polys/galoistools.py",
+     "span": "233-257",
+     "snippet": "def gf_strip(...): \"\"\"...\"\"\"; if not f or f[0]: return f; ...; return f[k:]"
+    }
+   ],
+   "semantic_claim": "Both functions strip leading zero coefficients using alpha-equivalent loop state; docstrings and local variable names differ.",
+   "evidence": "nose verify selected SymPy files before: under-merged lead vj=0.84 densebasic.py:415 \u21ae galoistools.py:233. After the batch selected verify reports no under-merged groups.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "nose verify selected SymPy files --leads /tmp/sympy-docstring-before-leads.json",
+    "baseline_result": "Previous release exposed only a smaller block family at densebasic.py:434 and galoistools.py:252.",
+    "candidate_result": "Candidate scan reports function family 087fb7c9a965310c with densebasic.py:415 and galoistools.py:233."
+   },
+   "proof_invariant": "A Python function leading static string literal statement is docstring metadata and does not affect callable return behavior.",
+   "hard_negative_siblings": [
+    "wrong slice index",
+    "wrong loop break condition",
+    "dynamic leading f-string/call effect"
+   ],
+   "batch": "2026-06-05-python-docstring-noop",
+   "notes": "Selected first-batch real miss from SymPy verify leads."
+  },
+  {
+   "case_id": "python-docstring-sympy-dup-lc-gf-lc",
+   "status": "closed",
+   "candidate_axis": "python_docstring_noop",
+   "repo": "sympy",
+   "language": "python",
+   "locations": [
+    {
+     "path": "sympy/polys/densebasic.py",
+     "span": "121-138",
+     "snippet": "def dup_LC(...): \"\"\"...\"\"\"; if not f: return K.zero; else: return f[0]"
+    },
+    {
+     "path": "sympy/polys/galoistools.py",
+     "span": "193-210",
+     "snippet": "def gf_LC(...): \"\"\"...\"\"\"; if not f: return K.zero; else: return f[0]"
+    }
+   ],
+   "semantic_claim": "Both functions return the first coefficient or K.zero for an empty polynomial; docstrings differ only as metadata.",
+   "evidence": "Candidate scan added function family 81a0c70aa0e3d978; previous release had no function-level family for these spans.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "nose scan selected SymPy files --mode semantic --format json --top 0 --min-lines 1 --min-size 1",
+    "baseline_result": "No previous release function family for densebasic.py:121 and galoistools.py:193.",
+    "candidate_result": "Candidate scan reports function family 81a0c70aa0e3d978."
+   },
+   "proof_invariant": "A Python function leading static string literal statement is docstring metadata and does not affect callable return behavior.",
+   "hard_negative_siblings": [
+    "return f[-1] instead of f[0]",
+    "wrong empty fallback",
+    "assigned string values used in return"
+   ],
+   "batch": "2026-06-05-python-docstring-noop",
+   "notes": "Additional same-invariant real family found by selected real scan delta."
+  },
+  {
+   "case_id": "python-docstring-sympy-dup-tc-gf-tc",
+   "status": "closed",
+   "candidate_axis": "python_docstring_noop",
+   "repo": "sympy",
+   "language": "python",
+   "locations": [
+    {
+     "path": "sympy/polys/densebasic.py",
+     "span": "141-158",
+     "snippet": "def dup_TC(...): \"\"\"...\"\"\"; if not f: return K.zero; else: return f[-1]"
+    },
+    {
+     "path": "sympy/polys/galoistools.py",
+     "span": "213-230",
+     "snippet": "def gf_TC(...): \"\"\"...\"\"\"; if not f: return K.zero; else: return f[-1]"
+    }
+   ],
+   "semantic_claim": "Both functions return the trailing coefficient or K.zero for an empty polynomial; docstrings differ only as metadata.",
+   "evidence": "Candidate scan added function family 490a609cb8f7e2b8; previous release had no function-level family for these spans.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "nose scan selected SymPy files --mode semantic --format json --top 0 --min-lines 1 --min-size 1",
+    "baseline_result": "No previous release function family for densebasic.py:141 and galoistools.py:213.",
+    "candidate_result": "Candidate scan reports function family 490a609cb8f7e2b8."
+   },
+   "proof_invariant": "A Python function leading static string literal statement is docstring metadata and does not affect callable return behavior.",
+   "hard_negative_siblings": [
+    "return f[0] instead of f[-1]",
+    "wrong empty fallback",
+    "dynamic leading f-string/call effect"
+   ],
+   "batch": "2026-06-05-python-docstring-noop",
+   "notes": "Additional same-invariant real family found by selected real scan delta."
+  },
+  {
+   "case_id": "python-docstring-sympy-shape-property",
+   "status": "closed",
+   "candidate_axis": "python_docstring_noop",
+   "repo": "sympy",
+   "language": "python",
+   "locations": [
+    {
+     "path": "sympy/matrices/common.py",
+     "span": "693-708",
+     "snippet": "@property def shape(self): \"\"\"...\"\"\"; return (self.rows, self.cols)"
+    },
+    {
+     "path": "sympy/matrices/common.py",
+     "span": "3142-3143",
+     "snippet": "@property def shape(self): return (self.rows, self.cols)"
+    }
+   ],
+   "semantic_claim": "Both shape properties return the same (rows, cols) tuple; the public property docstring is metadata.",
+   "evidence": "Candidate scan added method family 8cfcba8974d82c2d; previous release had no method-level family for these spans.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "nose scan selected SymPy files --mode semantic --format json --top 0 --min-lines 1 --min-size 1",
+    "baseline_result": "No previous release method family for common.py:693 and common.py:3142.",
+    "candidate_result": "Candidate scan reports method family 8cfcba8974d82c2d."
+   },
+   "proof_invariant": "A Python method leading static string literal statement is docstring metadata and does not affect callable return behavior.",
+   "hard_negative_siblings": [
+    "returning (cols, rows)",
+    "returning a string literal",
+    "dynamic leading f-string/call effect"
+   ],
+   "batch": "2026-06-05-python-docstring-noop",
+   "notes": "Additional same-invariant real family found by selected real scan delta."
+  },
+  {
+   "case_id": "typescript-import-namespace-shadow-jest-replace-root-dir",
+   "status": "closed",
+   "candidate_axis": "import_identity",
+   "repo": "jest",
+   "language": "typescript",
+   "locations": [
+    {
+     "path": "packages/jest-config/src/utils.ts",
+     "span": "57-69",
+     "snippet": "export const replaceRootDirInPath = (rootDir, filePath) => { ... return path.resolve(rootDir, path.normalize(`./${filePath.slice('<rootDir>'.length)}`)); }"
+    },
+    {
+     "path": "packages/jest-resolve/src/utils.ts",
+     "span": "21-30",
+     "snippet": "const replaceRootDirInPath = (rootDir, filePath) => { ... return path.resolve(rootDir, path.normalize(`./${filePath.slice('<rootDir>'.length)}`)); }"
+    }
+   ],
+   "semantic_claim": "Both helpers return filePath unchanged unless it starts with <rootDir>, otherwise they resolve rootDir plus the normalized suffix after the <rootDir> marker.",
+   "evidence": "Previous release verify over jest-config/src and jest-resolve/src reported one under-merged behavior group at utils.ts:57 \u21ae utils.ts:21 with SOUND. Candidate verify reports completeness 1/1, 0 under-merged groups, and semantic scan reports family 5dc1326d43c86973 containing the two replaceRootDirInPath functions.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "/tmp/nose-before-shadow scan jest-config/src jest-resolve/src --mode semantic --top 0",
+    "baseline_result": "0 semantic families; features showed both functions exact_safe=false and the jest-config value fingerprint lacked the node:path namespace literals because a different function parameter named path was treated as a module-binding mutation.",
+    "candidate_result": "target/release/nose scan reports one semantic family with packages/jest-config/src/utils.ts:57-69 and packages/jest-resolve/src/utils.ts:21-30; both feature records are exact_safe=true with identical value fingerprints."
+   },
+   "proof_invariant": "For JS/TS-family files, a function or lambda parameter that shadows a module-level binding name must not count as mutation of that module binding; unshadowed mutation-like receiver calls still block the proof. Static template literal fragments are behavior-defining string literals and must be preserved in the value graph.",
+   "hard_negative_siblings": [
+    "path.replaceAll(...) on the unshadowed namespace local still taints the module binding proof",
+    "a same-named local object with resolve/normalize is not a proven node:path namespace import",
+    "a different template literal fragment such as ../ changes the resolved path"
+   ],
+   "batch": "2026-06-05-js-namespace-shadow-template",
+   "notes": "Selected from Jest real verify lead after broader membership/map audits found no sound higher-yield real misses."
+  },
+  {
+   "case_id": "c-total-order-comparator-vim-lnum-syn-int",
+   "status": "closed",
+   "candidate_axis": "total_order_compare",
+   "repo": "vim",
+   "language": "c",
+   "locations": [
+    {
+     "path": "src/diff.c",
+     "span": "937-947",
+     "snippet": "static int lnum_compare(const void *s1, const void *s2) { ... if (lnum1 < lnum2) return -1; if (lnum1 > lnum2) return 1; return 0; }"
+    },
+    {
+     "path": "src/window.c",
+     "span": "8495-8505",
+     "snippet": "static int int_cmp(const void *pa, const void *pb) { ... if (a > b) return 1; if (a < b) return -1; return 0; }"
+    },
+    {
+     "path": "src/syntax.c",
+     "span": "5288-5295",
+     "snippet": "static int syn_compare_stub(const void *v1, const void *v2) { ... return (*s1 > *s2 ? 1 : *s1 < *s2 ? -1 : 0); }"
+    }
+   ],
+   "semantic_claim": "All three Vim callbacks implement the same ascending three-way total-order comparator over the dereferenced scalar pair, returning -1, 1, or 0 for less, greater, or equal.",
+   "evidence": "Previous release verify over selected Vim comparator files reported one behavior-equal group with completeness 1/3 and an under-merged lead diff.c:937 \u21ae syntax.c:5288. Candidate verify reports completeness 3/3, 0 under-merged groups, and whole-repo semantic scan reports family e498fe8139e65f5c containing lnum_compare, int_cmp, and syn_compare_stub.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "/tmp/nose-before-nextbatch verify diff.c syntax.c window.c viminfo.c insexpand.c --leads /tmp/nose-vim-comparator-before-leads.json",
+    "baseline_result": "SOUND; completeness 1/3; one under-merged group at diff.c:937 \u21ae syntax.c:5288. Whole Vim scan reported only window.c:int_cmp with syntax.c:syn_compare_stub in family d3b98d6969be6d8d.",
+    "candidate_result": "target/release/nose verify over the same selected files reports SOUND, completeness 3/3, and 0 under-merged groups; whole Vim scan reports a 3-copy comparator family containing diff.c:937, window.c:8495, and syntax.c:5288."
+   },
+   "proof_invariant": "For primitive source-language comparisons, a strict ordered comparison guard implies the same-direction non-strict guard, so a path condition such as (x < y) and (x <= y) can absorb the non-strict residue. Receiver-overloadable comparisons are excluded.",
+   "hard_negative_siblings": [
+    "descending comparator that returns 1 for less and -1 for greater",
+    "equality-boundary comparator that returns -1 when left == right",
+    "wrong positive sign value such as returning 2 for greater",
+    "Python/Ruby/JS-style receiver-overloadable or effectful comparisons without a primitive order proof"
+   ],
+   "batch": "2026-06-05-c-total-order-compare",
+   "notes": "Selected from the real audit after broad membership/map-default priority leads were already covered, unsupported, or hard negatives."
+  },
+  {
+   "case_id": "java-empty-domain-netty-array-queue-string",
+   "status": "closed",
+   "candidate_axis": "collection_empty_check / typed_empty_domain_soundness",
+   "repo": "netty",
+   "language": "java",
+   "locations": [
+    {
+     "path": "codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslEngine.java",
+     "span": "305-307",
+     "snippet": "private boolean isEmpty(Object @Nullable [] arr) { return arr == null || arr.length == 0; }"
+    },
+    {
+     "path": "common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java",
+     "span": "147-149",
+     "snippet": "private static boolean isNullOrEmpty(Queue<ScheduledFutureTask<?>> queue) { return queue == null || queue.isEmpty(); }"
+    },
+    {
+     "path": "common/src/main/java/io/netty/util/internal/StringUtil.java",
+     "span": "593-595",
+     "snippet": "public static boolean isNullOrEmpty(String s) { return s == null || s.isEmpty(); }"
+    }
+   ],
+   "semantic_claim": "These null-or-empty helpers have the same surface shape but are not proven equivalent across Java array, Queue/collection, and String receiver domains under the independent verifier.",
+   "evidence": "Previous release whole-Netty verify reported two false merges from QuicheQuicSslEngine.java:305 to AbstractScheduledEventExecutor.java:147 and StringUtil.java:593, each with 72 differing inputs. Candidate whole-Netty verify with --max-violations 0 is SOUND.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "/tmp/nose-before-empty-target2/release/nose verify bench/repos/netty --max-violations 10",
+    "baseline_result": "2 false merges: Object[] null-or-length-empty collapsed with Queue.isEmpty and String.isEmpty.",
+    "candidate_result": "target/release/nose verify bench/repos/netty --max-violations 0 reports SOUND; feature dump shows the three value fingerprints are distinct."
+   },
+   "proof_invariant": "A strict empty-check merge may share coordinates only when the receiver domain is proven compatible. Java array length, receiver-provided collection emptiness, and string emptiness are distinct domains unless a stronger proof connects them.",
+   "hard_negative_siblings": [
+    "Queue<String> value == null || value.isEmpty() vs Object[] value == null || value.length == 0",
+    "Queue<String> value == null || value.isEmpty() vs String value == null || value.isEmpty()",
+    "untyped or shadowed receiver emptiness without a domain proof"
+   ],
+   "batch": "2026-06-05-java-empty-domain-soundness",
+   "notes": "Soundness blocker batch. It intentionally reduces an over-broad merge rather than closing a completeness miss; follow-up completeness work should continue from the remaining real under-merged Netty leads only after preserving this boundary."
+  },
+  {
+   "case_id": "java-dead-loop-libgdx-bufferutils-find-floats",
+   "status": "closed",
+   "candidate_axis": "java_statically_false_loop",
+   "repo": "libgdx",
+   "language": "java",
+   "locations": [
+    {
+     "path": "backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/BufferUtils.java",
+     "span": "433-449",
+     "snippet": "public static long findFloats(float[] vertex, int strideInBytes, float[] vertices, int numVertices) { ... boolean found = true; for (int j = 0; !found && j < size; j++) ... }"
+    },
+    {
+     "path": "backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/BufferUtils.java",
+     "span": "458-474",
+     "snippet": "public static long findFloats(float[] vertex, int strideInBytes, float[] vertices, int numVertices, float epsilon) { ... boolean found = true; for (int j = 0; !found && j < size; j++) ... }"
+    }
+   ],
+   "semantic_claim": "Both overloads return the first vertex index whenever numVertices is positive, otherwise -1, because the inner comparison loop is unreachable after found is initialized true and the guard starts with !found.",
+   "evidence": "Previous release selected verify over BufferUtils.java reported SOUND with completeness 0/1 and under-merged lead BufferUtils.java:433 to BufferUtils.java:458. Candidate selected verify reports SOUND with completeness 1/1 and 0 under-merged groups. An exact pinned-corpus search for the same boolean-true plus !guard pattern found only these two libgdx spans.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "/tmp/nose-before-java-dead-loop verify bench/repos/libgdx/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/BufferUtils.java --max-violations 0 --leads /tmp/nose-libgdx-gwt-bufferutils-before-rerun-leads.json",
+    "baseline_result": "SOUND; completeness 0/1; under-merged lead BufferUtils.java:433 to BufferUtils.java:458 with vj=0.43.",
+    "candidate_result": "target/release/nose verify bench/repos/libgdx/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/BufferUtils.java --max-violations 0 --leads /tmp/nose-libgdx-gwt-bufferutils-after-rerun-leads.json reports SOUND; completeness 1/1; under-merged groups 0. Whole-libgdx semantic scan reports family 3aaacf7da1b4536d containing both methods."
+   },
+   "proof_invariant": "For a local boolean proven true before a while-loop entry guard, a left short-circuit atom !local in an && guard is proven false, so the loop body and update are unreachable. The merge also requires loop-carried recurrence placeholders to be keyed by traversal/carry slot rather than source cid so unused parameters do not change the value identity.",
+   "hard_negative_siblings": [
+    "boolean found = false before !found && ..., where the body can execute",
+    "found && ... with found initialized true, where the body can execute",
+    "found reassigned before the guard, removing the constant proof",
+    "same-template mutation changing a reachable returned index even when the loop body is dead"
+   ],
+   "batch": "2026-06-05-java-dead-loop-guard",
+   "notes": "Small completeness batch: the real audit over libgdx, git, and h2database plus exact pinned search found one evidence-backed same-invariant real family, so this batch intentionally closes one real candidate rather than padding to three unrelated candidates."
+  },
+  {
+   "case_id": "java-low-bit-toggle-graphhopper-reverse-edge",
+   "status": "closed",
+   "candidate_axis": "java_integer_low_bit_toggle",
+   "repo": "graphhopper",
+   "language": "java",
+   "locations": [
+    {
+     "path": "core/src/main/java/com/graphhopper/routing/querygraph/QueryGraph.java",
+     "span": "199-202",
+     "snippet": "static int getPosOfReverseEdge(int edgeId) { return edgeId % 2 == 0 ? edgeId + 1 : edgeId - 1; }"
+    },
+    {
+     "path": "core/src/main/java/com/graphhopper/util/GHUtility.java",
+     "span": "370-372",
+     "snippet": "public static int reverseEdgeKey(int edgeKey) { return edgeKey ^ 1; }"
+    }
+   ],
+   "semantic_claim": "Both helpers toggle the low bit of a Java primitive int edge key: even values return x + 1 and odd values return x - 1, which is exactly x ^ 1.",
+   "evidence": "Previous release selected verify over QueryGraph.java and GHUtility.java reported SOUND with completeness 0/1 and under-merged lead QueryGraph.java:199 to GHUtility.java:370. Candidate selected verify reports SOUND with completeness 1/1 and 0 under-merged groups. Whole-Graphhopper semantic scan reports a new family containing both methods.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "/tmp/nose-goal-baseline-target/release/nose verify bench/repos/graphhopper/core/src/main/java/com/graphhopper/routing/querygraph/QueryGraph.java bench/repos/graphhopper/core/src/main/java/com/graphhopper/util/GHUtility.java --max-violations 0 --leads /tmp/nose-graphhopper-bit-toggle-baseline-check-leads.json",
+    "baseline_result": "SOUND; completeness 0/1; under-merged lead QueryGraph.java:199 to GHUtility.java:370 with vj=0.12. Whole-Graphhopper scan reported 28 semantic families.",
+    "candidate_result": "target/release/nose verify over the same selected files reports SOUND, completeness 1/1, and 0 under-merged groups. Whole-Graphhopper scan reports 29 semantic families including QueryGraph.java:199 and GHUtility.java:370."
+   },
+   "proof_invariant": "For Java primitive integer operators, x % 2 == 0 partitions even values from odd values; x + 1 is used only for even values and x - 1 only for odd values, avoiding signed overflow at both int extremes and matching the low-bit toggle x ^ 1. The proof is not applied to overloadable or coercive surfaces.",
+   "hard_negative_siblings": [
+    "reversed branches: x % 2 == 0 ? x - 1 : x + 1",
+    "wrong bit: x ^ 2",
+    "positive-one parity check: x % 2 == 1 ? x - 1 : x + 1, which fails for negative odd Java ints",
+    "wrong branch delta such as x % 2 == 0 ? x + 1 : x - 2",
+    "non-Java or overloadable/coercive operator surfaces without a primitive integer proof"
+   ],
+   "batch": "2026-06-05-java-low-bit-toggle",
+   "notes": "The audit covered Guava, SQLAlchemy, Rubocop, SymPy, Poetry, Scrapy, Commons Lang, Marshmallow, HTTPie, JUnit5, Jedis, RxJava, chi, and Graphhopper. Most leads were unsupported or hard negatives; exact pinned-corpus search found only this same-invariant real miss, so the batch is intentionally small."
+  },
+  {
+   "case_id": "c-u16-byte-pack-sqlite-big-endian-decode",
+   "status": "closed",
+   "candidate_axis": "c_u16_be_byte_pack",
+   "repo": "sqlite",
+   "language": "c",
+   "locations": [
+    {
+     "path": "ext/misc/btreeinfo.c",
+     "span": "269-271",
+     "snippet": "static unsigned int get_uint16(unsigned char *a) { return (a[0]<<8) + a[1]; }"
+    },
+    {
+     "path": "ext/recover/dbdata.c",
+     "span": "344-346",
+     "snippet": "static unsigned int get_uint16(unsigned char *a) { return (a[0]<<8) + a[1]; }"
+    },
+    {
+     "path": "ext/fts5/fts5_index.c",
+     "span": "712-714",
+     "snippet": "static u16 fts5GetU16(const u8 *aIn) { return ((u16)aIn[0] << 8) + aIn[1]; }"
+    },
+    {
+     "path": "ext/recover/sqlite3recover.c",
+     "span": "2078-2080",
+     "snippet": "static u16 recoverGetU16(const u8 *aBuf) { return (aBuf[0] << 8) | aBuf[1]; }"
+    },
+    {
+     "path": "ext/rtree/rtree.c",
+     "span": "525-527",
+     "snippet": "static int readInt16(u8 *p) { return (p[0]<<8) + p[1]; }"
+    }
+   ],
+   "semantic_claim": "All five helpers decode the same big-endian unsigned 16-bit value from two disjoint byte lanes: high byte a[0] shifted by 8 plus low byte a[1]. Addition and bitwise-or are equivalent under this byte-lane proof.",
+   "evidence": "The previous C u16 baseline selected SQLite verify was SOUND with completeness 7/16 and one under-merged u16 lead fts5_index.c:712 to btreeinfo.c:269 because fts5_index.c gets u8 from an included header. Candidate verify over the five selected SQLite files is SOUND with completeness 11/16; semantic scan reports family acf37a59f5e99973 containing fts5_index.c:712, btreeinfo.c:269, dbdata.c:344, sqlite3recover.c:2078, and rtree.c:525.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "/tmp/nose-fragment-baseline-target/release/nose verify ext/misc/btreeinfo.c ext/recover/dbdata.c ext/fts5/fts5_index.c ext/recover/sqlite3recover.c ext/rtree/rtree.c --max-violations 0 --leads /tmp/nose-sqlite-u16-before-leads.json",
+    "baseline_result": "SOUND; completeness 7/16; fts5_index.c:712 remained under-merged from the 4-copy u16 byte-pack family.",
+    "candidate_result": "target/release/nose verify over the same selected files reports SOUND, completeness 11/16, and 1 remaining under-merged group outside this invariant. NOSE_TIME=1 target/release/nose scan over the selected files reports family acf37a59f5e99973 containing the expected 5-copy u16 family."
+   },
+   "proof_invariant": "In C only, the parameter must be proven to be a byte buffer: unsigned char *, uint8_t *, a same-file typedef alias such as typedef unsigned char u8, or a same-directory direct quote include whose small header contains that typedef. The expression must use the same base pointer, high lane index 0 shifted left exactly 8, low lane index 1, and either + or |. The proof is limited to 16-bit packing, where the shifted byte stays representable in int.",
+   "hard_negative_siblings": [
+    "swapped byte order: (a[1] << 8) | a[0]",
+    "overlapping lanes such as (a[0] << 4) | a[1]",
+    "wrong low byte coordinate such as a[2]",
+    "u8 spelling with a missing include or without a local typedef proof that it aliases unsigned char",
+    "included typedef unsigned short u8 or any other non-byte alias",
+    "int * or other non-byte-buffer receiver",
+    "32-bit packing such as a[0] << 24, which is not accepted without an unsigned-overflow proof"
+   ],
+   "batch": "2026-06-06-c-u16-include-typedef",
+   "notes": "The include-header u8 miss is closed without a general preprocessor: C lowering only reads same-directory quote includes for byte-pack-shaped sources and records single-line typedef unsigned char aliases from small headers. The 32-bit get_uint32/recoverGetU32 pair remains unsupported because uncasted signed left shifts can overflow or enter undefined behavior."
+  },
+  {
+   "case_id": "c-u32-byte-pack-sqlite-unsigned-cast-decode",
+   "status": "closed",
+   "candidate_axis": "c_u32_be_byte_pack",
+   "repo": "sqlite",
+   "language": "c",
+   "locations": [
+    {
+     "path": "ext/recover/dbdata.c",
+     "span": "347-352",
+     "snippet": "static u32 get_uint32(unsigned char *a) { return ((u32)a[0]<<24) | ((u32)a[1]<<16) | ((u32)a[2]<<8) | ((u32)a[3]); }"
+    },
+    {
+     "path": "ext/fts5/fts5_index.c",
+     "span": "737-742",
+     "snippet": "static u32 fts5GetU32(const u8 *a) { return ((u32)a[0] << 24) + ((u32)a[1] << 16) + ((u32)a[2] << 8) + ((u32)a[3] << 0); }"
+    },
+    {
+     "path": "ext/recover/sqlite3recover.c",
+     "span": "2086-2088",
+     "snippet": "static u32 recoverGetU32(const u8 *a) { return (((u32)a[0])<<24) + (((u32)a[1])<<16) + (((u32)a[2])<<8) + ((u32)a[3]); }"
+    },
+    {
+     "path": "ext/misc/btreeinfo.c",
+     "span": "272-274",
+     "snippet": "static unsigned int get_uint32(unsigned char *a) { return (a[0]<<24)|(a[1]<<16)|(a[2]<<8)|a[3]; }",
+     "role": "hard-negative sibling: uncasted high lane remains unmerged"
+    }
+   ],
+   "semantic_claim": "The first three helpers decode the same big-endian unsigned 32-bit value from four byte lanes over a proven byte buffer, with an explicit unsigned 32-bit cast on the high byte lane before shifting by 24. The uncasted btreeinfo helper is behaviorally similar in the oracle battery but is not accepted as strict semantic proof because C signed left shift may overflow or be undefined.",
+   "evidence": "Baseline selected scan split or mixed the u32 helpers: dbdata.c:347 was paired with uncasted btreeinfo.c:272, while fts5_index.c:737 and sqlite3recover.c:2086 did not form the strict cast-proven family. Candidate selected scan reports a 3-copy family containing fts5_index.c:737, dbdata.c:347, and sqlite3recover.c:2086; btreeinfo.c:272 stays outside. Candidate selected verify is SOUND with 0 false merges and leaves only the intended uncasted btreeinfo under-merge at vj=0.24.",
+   "detector": {
+    "current_detector_miss": false,
+    "baseline_command": "NOSE_TIME=1 target/release/nose scan ext/recover/sqlite3recover.c ext/recover/dbdata.c ext/rtree/rtree.c ext/fts5/fts5_index.c ext/misc/btreeinfo.c --mode semantic --format json --top 0 before rebuilding release",
+    "baseline_result": "Selected baseline had no cast-proven 3-copy u32 family and included dbdata.c:347 with uncasted btreeinfo.c:272 in a smaller family.",
+    "candidate_result": "target/release/nose scan over the same selected files reports the 3-copy cast-proven u32 family fts5_index.c:737, dbdata.c:347, sqlite3recover.c:2086; verify over the selected files reports SOUND, completeness 13/16, and 1 intended under-merged uncasted group."
+   },
+   "proof_invariant": "In C only, the receiver must be a proven byte buffer (`unsigned char *`, `uint8_t *`, same-file `typedef unsigned char u8`, or same-directory direct quote include proving that alias). A 32-bit unsigned cast proof must be explicit in source for the high lane: direct `unsigned`/`unsigned int`/`uint32_t` cast, or `u32` only when a same-file/direct local include proves `typedef unsigned int u32`. The four lanes must be the same base pointer at indices 0, 1, 2, and 3 with shifts 24, 16, 8, and 0 respectively, combined only with `+` or `|`.",
+   "hard_negative_siblings": [
+    "uncasted high lane such as `(a[0] << 24)` even when the receiver is `unsigned char *`",
+    "swapped byte order such as `((u32)a[1] << 24) | ((u32)a[0] << 16) | ...`",
+    "wrong byte coordinate or duplicate lane",
+    "`typedef signed int u32` or missing/unread include for the `u32` cast alias",
+    "non-byte receiver such as `int *a`",
+    "32-bit little-endian or mixed-endian packing, which is a separate semantic axis"
+   ],
+   "batch": "2026-06-06-c-u32-unsigned-cast-byte-pack",
+   "notes": "Selected to correct Java skew with a non-Java real-corpus batch. The change also tightens soundness by keeping uncasted C high-lane shifts out of strict semantic proof."
+  },
+  {
+   "case_id": "ruby-fetch-block-custom-receiver-map-default-audit",
+   "status": "unsupported",
+   "candidate_axis": "map_default_lookup / literal_map_default_lookup",
+   "repo": "sinatra / liquid / rack / rubocop",
+   "language": "ruby",
+   "locations": [
+    {
+     "path": "sinatra-contrib/spec/cookies_spec.rb",
+     "span": "513",
+     "snippet": "expect(cookies.fetch('foo') { 'bar' }).to eq('bar')"
+    },
+    {
+     "path": "liquid/test/unit/registers_unit_test.rb",
+     "span": "56-59",
+     "snippet": "result = static_register.fetch(:d) { \"default\" }; result = static_register.fetch(:d, \"default 1\") { \"default 2\" }"
+    },
+    {
+     "path": "rack/test/spec_request.rb",
+     "span": "1334",
+     "snippet": "req.headers.fetch('bar-foo'){'1'}.must_equal '1'"
+    },
+    {
+     "path": "rubocop/spec/rubocop/cop/style/redundant_fetch_block_spec.rb",
+     "span": "132",
+     "snippet": "Rails.cache.fetch(:key) { :value }"
+    }
+   ],
+   "semantic_claim": "Ruby `fetch(key) { fallback }` has map-default behavior only when the receiver is a proven Hash-like map and the block is a pure fallback value. These real spans use custom receivers (`cookies`, `static_register`, `req.headers`, `Rails.cache`) whose `fetch` semantics are not proven by the current detector.",
+   "evidence": "Corpus grep found many Ruby block-fetch idioms, but the actionable strict slice is not these custom receiver calls. A focused synthetic baseline also exposed a false merge between literal `{...}.fetch(key) { 0 }` and `{...}.fetch(key) { 9 }`; the batch fixes that literal-Hash soundness gap and accepts only zero-arg pure fallback blocks over literal Hash receivers.",
+   "detector": {
+    "current_detector_miss": true,
+    "baseline_command": "rg \"\\.fetch\\([^\\n]*\\)\\s*\\{\\s*(0|1|true|false|nil|:[A-Za-z_][A-Za-z0-9_]*|'[^']*'|\\\"[^\\\"]*\\\")\\s*\\}\" bench/repos -g '*.rb'",
+    "baseline_result": "Real hits are dominated by custom receivers rather than literal or otherwise proven Hash receivers.",
+    "candidate_result": "Literal Hash `fetch(key) { fallback }` is now canonicalized only when the fallback block is zero-arg and value-like; custom receivers remain unmerged."
+   },
+   "proof_invariant": "Do not merge arbitrary Ruby `fetch` calls. A strict map-default proof requires a literal/proven Hash receiver, the same key coordinate, and a zero-arg fallback block whose implicit result is an exact-safe value. Blocks with parameters, `raise`, `yield`, mutation, or unproven receivers remain outside the proof.",
+   "hard_negative_siblings": [
+    "`hash.fetch(key) { |missing| missing.to_s }`, where the fallback depends on the missing key",
+    "`hash.fetch(key) { raise KeyError }`, where missing-key behavior is an exception effect",
+    "`Rails.cache.fetch(key) { value }`, where receiver semantics are cache-specific",
+    "`ENV.fetch(key) { value }`, where receiver and environment behavior are not literal Hash proof",
+    "`hash.fetch(key, default) { block }`, where Ruby uses the block and warns about the ignored default argument"
+   ],
+   "batch": "2026-06-06-ruby-fetch-block-map-default",
+   "reverify": {
+    "date": "2026-06-06",
+    "boundaries_verified": "Reproduced with minimal scans. A proven literal Hash `{...}.fetch(key) { 0 }` converges with `{...}.fetch(key, 0)` (one family). All five hard-negative classes stay distinct: a different fallback `{ 9 }`, a block parameter `{ |missing| ... }`, a `{ raise KeyError }` effect, and the custom receivers `Rails.cache.fetch(key) { 0 }` and `cookies.fetch(key) { 0 }` each remain unmerged. No false merges.",
+    "deferred_sound_lead": "A function-local immutable Hash binding receiver (`h = {literal}; h.fetch(key) { 0 }`) is currently NOT proven (0 families) even though the inline-literal form is. This is a genuine receiver-provenance fact that DOES exist (single-writer immutable local binding), unlike the custom method receivers, so it is a sound next candidate. Closing it requires a value-graph-level receiver resolution for the GetOrDefault canon (mirroring proven_local_collection_binding_value on the membership axis), not just the idiom-layer literal check. Hard negatives: a mutated/reassigned binding and a custom receiver must stay unmerged. Not implemented here: it is synthetic-shaped, has no counterpart among these four real spans, and belongs in its own small batch.",
+    "conclusion": "The literal-Hash batch is sound and intact. The custom-receiver real frontier stays unsupported (no receiver provenance for cookies/static_register/req.headers/Rails.cache)."
+   },
+   "notes": "Selected after the user raised Java-skew concerns. This is a non-Java soundness/completeness micro-batch, but the real custom-receiver frontier remains unsupported until receiver provenance facts exist. Re-verified 2026-06-06: literal-Hash convergence holds and all five hard-negative classes stay distinct; a function-local immutable Hash binding receiver is recorded as a sound deferred lead (see reverify.deferred_sound_lead)."
+  },
+  {
+   "case_id": "numeric-clamp-minmax-ternary-real-miss",
+   "status": "real-miss",
+   "candidate_axis": "numeric_clamp / clamp_surface_bridge",
+   "repo": "boltons",
+   "language": "python",
+   "locations": [
+    {
+     "path": "boltons/mathutils.py",
+     "span": "40-69",
+     "snippet": "def clamp(x, lower, upper): if upper < lower: raise ValueError; return min(max(x, lower), upper)"
+    },
+    {
+     "path": "src/util/util.go",
+     "span": "63-65",
+     "snippet": "func Constrain[T cmp.Ordered](val, minimum, maximum T) T { return max(min(val, maximum), minimum) }  -- fzf (heldout, go): the max(min) canonical form"
+    }
+   ],
+   "semantic_claim": "min(max(x,lo),hi), max(min(x,hi),lo), and (x<lo ? lo : (x>hi ? hi : x)) all denote the same clamp for a totally-ordered numeric domain with lo <= hi. The boltons `clamp` and the fzf `Constrain` are the two canonical min/max compositions, in different languages, and should converge.",
+   "evidence": "the clamp obligation machine-checks the identity and its hard negatives (self-contained Lean 4, no Mathlib). A 196-case integer battery confirms min(max)==max(min)==ternary for every lo<=hi. The first proof-backed min/max composition slice now canonicalizes when the source proves integer lo<=hi by literal bounds or an exiting inverse guard. This real frontier item remains open because broader surface bridges and real-corpus bound-order evidence are still incomplete: the controlled ternary/library clamp forms do not yet bridge to the proven Clamp value, and fzf `Constrain` only names its bounds rather than proving their order. The idiom appears in 26 repos across all 7 primary languages on both splits (frontier_platform breadth).",
+   "detector": {
+    "current_detector_miss": true,
+    "binary_path": "/Users/ak/prjs/cc/nose/target/release/nose",
+    "nose_version": "nose 0.5.0",
+    "build_ref": "58c4c9b0c513b3893b4d29552167b800595ce87e",
+    "baseline_command": "nose scan <two-form file with abs control + clamp> --mode semantic --format json --top 0 --min-size 1 --min-lines 1",
+    "baseline_result": "abs control merges (1 family: absTern, absBuilt); the clamp forms (clampTern, clampBuilt) are NOT merged.",
+    "semantic_scan_result": "nose scan boltons/boltons/mathutils.py fzf/src/util/util.go --mode semantic --format json --top 0 --min-size 1 --min-lines 1: the clamp pair is not merged across files.",
+    "default_scan_result": "The value graph now has a proof-backed integer min/max Clamp canon for sources that prove lo<=hi, but this real cross-language pair still lacks a shared proven bound-order fact on both sides; default syntax/semantic scan does not merge it. Two-comparison and library clamp bridge forms remain successor work."
+   },
+   "proof_invariant": "Recognize clamp as min(max(x,lo),hi) = max(min(x,hi),lo) = two-comparison form ONLY with proven scalar min/max facts and a lo <= hi precondition; reject swapped bound order min(max(x,hi),lo), wrong nesting max(min(x,lo),hi), the lo>hi precondition violation, and float NaN (where min/max builtins vs comparison chains can diverge by language). Machine-checked in formal/obligations/normalize/value_graph/clamp/Proof.lean.",
+   "hard_negative_siblings": [
+    "swapped bound order min(max(x, hi), lo) -- clamp Counterexamples.lean swapped_bounds_not_clamp",
+    "wrong nesting max(min(x, lo), hi) -- clamp Counterexamples.lean wrong_nesting_not_clamp",
+    "lo > hi precondition violation: the two compositions diverge -- clamp Counterexamples.lean precondition_required",
+    "float NaN inputs where min/max builtins and comparison chains can return different values depending on language NaN semantics"
+   ],
+   "batch": null,
+   "reverify": "Re-run the controlled clamp semantic scan and the boltons/fzf cross-file scan; re-check formal/obligations/normalize/value_graph/clamp/Proof.lean type-checks. Reclassify only when the real-corpus pair and the controlled ternary/library bridge forms merge while the swapped-bound, wrong-nesting, lo>hi, and float-domain hard negatives stay split.",
+   "notes": "Issue #50 Team B target packet evidence (linked by frontier_target_packets). The initial proof-backed integer min/max Clamp canon has landed for sources with literal or exiting-guard bound-order evidence. The remaining packet is still routed proof-fact-prerequisite / successor bridge work: formal/obligations/normalize/value_graph/clamp/Counterexamples.lean proves the lo<=hi precondition is required, and parameter naming (e.g. fzf Constrain(val, minimum, maximum)) is not a proof. Broader detector work must first establish real-corpus bound order and keep float-NaN and swapped/inverted-bound hard negatives split."
+  },
+  {
+   "case_id": "async-sync-httpx-response-read-aread",
+   "status": "closed",
+   "candidate_axis": "async_sync_twin",
+   "repo": "httpx",
+   "language": "python",
+   "locations": [
+    {
+     "path": "httpx/_models.py",
+     "span": "468-480",
+     "snippet": "def read(self) -> bytes: ... self._content = b\"\".join(self.stream) ... return self._content"
+    },
+    {
+     "path": "httpx/_models.py",
+     "span": "482-494",
+     "snippet": "async def aread(self) -> bytes: ... self._content = b\"\".join([part async for part in self.stream]) ... return self._content"
+    }
+   ]
+  },
+  {
+   "case_id": "async-sync-httpx-test-auth-reads-response-body",
+   "status": "closed",
+   "candidate_axis": "async_sync_twin",
+   "repo": "httpx",
+   "language": "python",
+   "locations": [
+    {
+     "path": "tests/client/test_auth.py",
+     "span": "710-723",
+     "snippet": "async def test_async_auth_reads_response_body(...)"
+    },
+    {
+     "path": "tests/client/test_auth.py",
+     "span": "726-739",
+     "snippet": "def test_sync_auth_reads_response_body(...)"
+    }
+   ]
+  }
+ ]
 }

--- a/crates/nose-cli/tests/detection.rs
+++ b/crates/nose-cli/tests/detection.rs
@@ -55,6 +55,45 @@ fn detection_is_deterministic() {
 }
 
 #[test]
+fn async_sync_twin_converges_candidate_mode() {
+    // An async fn and its sync twin (identical body modulo `await`) are a Type-4 *transformation*
+    // twin — they must surface as a near/candidate family (#K, the async↔sync gap). A function with
+    // DIFFERENT logic must not match.
+    let asy = "async def handle(records, threshold):\n    out = []\n    total = 0\n    for rec in records:\n        parsed = await parse(rec)\n        score = await evaluate(parsed)\n        if score > threshold:\n            total = total + score\n            out.append(parsed)\n    return summarize(out, total)\n";
+    let sync = "def handle(records, threshold):\n    out = []\n    total = 0\n    for rec in records:\n        parsed = parse(rec)\n        score = evaluate(parsed)\n        if score > threshold:\n            total = total + score\n            out.append(parsed)\n    return summarize(out, total)\n";
+    let decoy = "def tally(ballots, base):\n    seen = {}\n    running = base\n    for b in ballots:\n        w = weight(b)\n        running = running - w * 2\n        seen[b] = running\n    return finalize(seen, running)\n";
+    let corpus = build(&[
+        ("asy.py", asy, Lang::Python),
+        ("sync.py", sync, Lang::Python),
+        ("decoy.py", decoy, Lang::Python),
+    ]);
+    let opts = DetectOptions {
+        threshold: 0.70,
+        min_tokens: 12,
+        ..Default::default()
+    };
+    let report = detect(
+        &corpus,
+        &opts,
+        &StructuralDetector::candidates(opts.jaccard_weight),
+    );
+    assert!(
+        report.duplicates.iter().any(|d| {
+            (d.left.file == "asy.py" && d.right.file == "sync.py")
+                || (d.left.file == "sync.py" && d.right.file == "asy.py")
+        }),
+        "the async fn and its sync twin must converge as a candidate family"
+    );
+    assert!(
+        report
+            .duplicates
+            .iter()
+            .all(|d| d.left.file != "decoy.py" && d.right.file != "decoy.py"),
+        "a function with different logic must not match the twins"
+    );
+}
+
+#[test]
 fn rust_clones_group_decoy_excluded() {
     // Two structurally-identical Rust functions (renamed) + an unrelated decoy.
     let a = "fn run(items: &[i32]) -> i32 {\n    let mut total = 0;\n    for x in items {\n        if *x > 0 {\n            total += x;\n        }\n    }\n    total\n}\n";

--- a/crates/nose-detect/src/witness.rs
+++ b/crates/nose-detect/src/witness.rs
@@ -17,7 +17,7 @@
 //!
 //! proof-obligation: detect.graded_witness
 
-use nose_normalize::{bin_is_commutative, ValueDag, VgOp, VgSinkKind};
+use nose_normalize::{bin_is_commutative, ValueDag, VgOp, VgSinkKind, VG_PROTOCOL_AWAIT};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
 
@@ -42,7 +42,8 @@ pub struct GradedWitness {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub spots: Vec<WitnessHole>,
     /// Recognized divergence shapes: `effects-reordered`, `sink-superset-a/b`,
-    /// `fragment-containment`, `low-substance`, `referent-mismatch`.
+    /// `fragment-containment`, `low-substance`, `referent-mismatch`, `async-mirror`
+    /// (one side awaits where the other does not — an async↔sync transformation twin).
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub patterns: Vec<&'static str>,
     /// Names BOTH units consume that resolve to different referents (same-named but
@@ -73,7 +74,8 @@ pub struct GradedWitness {
 pub struct WitnessHole {
     /// `literal` / `input` / `field` / `call` / `lambda` / `operator` / `expr` =
     /// value-leaf differences (clean parameters); `arity` / `shape` / `unmodeled` /
-    /// `extra-sink` = structural divergence (not a clean parameter).
+    /// `extra-sink` = structural divergence (not a clean parameter); `async-mirror` =
+    /// an `await` present on one side only (the async↔sync twin point).
     pub class: &'static str,
     /// Source line range of the spot in the first copy, when known.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -155,6 +157,10 @@ struct Au<'a> {
     matched_b: FxHashSet<u32>,
     /// Set when recursion hit [`MAX_DEPTH`] — the witness fails closed.
     truncated: bool,
+    /// Set when the alignment saw an `await` wrapper on exactly one side (an async↔sync
+    /// twin). The family is then a *transformation* (`async-mirror`), never
+    /// `equal_modulo_holes` — async code is not behaviorally equal to its sync twin.
+    async_mirror: bool,
 }
 
 impl<'a> Au<'a> {
@@ -168,6 +174,7 @@ impl<'a> Au<'a> {
             matched_a: FxHashSet::default(),
             matched_b: FxHashSet::default(),
             truncated: false,
+            async_mirror: false,
         }
     }
 
@@ -223,22 +230,59 @@ impl<'a> Au<'a> {
         if !self.visited.insert((x, y)) {
             return;
         }
-        let nx = &self.a.dag.nodes[x as usize];
-        let ny = &self.b.dag.nodes[y as usize];
-        if nx.hash == ny.hash {
+        // Snapshot the two nodes' identity into scalars so no `&self.a/b` borrow is held across
+        // the `&mut self` recursive calls below (the async-mirror gate recurses mid-node).
+        let (x_hash, x_op, x_key, x_arity, x_arg0) = {
+            let nx = &self.a.dag.nodes[x as usize];
+            (
+                nx.hash,
+                nx.op,
+                nx.key,
+                nx.args.len(),
+                nx.args.first().copied(),
+            )
+        };
+        let (y_hash, y_op, y_key, y_arity, y_arg0) = {
+            let ny = &self.b.dag.nodes[y as usize];
+            (
+                ny.hash,
+                ny.op,
+                ny.key,
+                ny.args.len(),
+                ny.args.first().copied(),
+            )
+        };
+        if x_hash == y_hash {
             self.mark_subtree(x, y);
             return;
         }
-        if nx.op != ny.op || nx.key != ny.key {
+        // async-mirror: `await e` (kept as `Opaque(VG_PROTOCOL_AWAIT,[e])` in the witness build)
+        // aligns with the bare operand on the sync-twin side. Recurse into the operand so the
+        // alignment propagates downstream, and record the await itself as a one-sided hole. This
+        // never fires when BOTH sides await (both wrappers fall through to the same-op recurse).
+        let x_await = x_op == VgOp::Opaque && x_key == VG_PROTOCOL_AWAIT && x_arity == 1;
+        let y_await = y_op == VgOp::Opaque && y_key == VG_PROTOCOL_AWAIT && y_arity == 1;
+        if x_await != y_await {
+            self.async_mirror = true;
+            if x_await {
+                self.one_sided(x, true);
+                self.unify(x_arg0.unwrap_or(x), y, depth + 1);
+            } else {
+                self.one_sided(y, false);
+                self.unify(x, y_arg0.unwrap_or(y), depth + 1);
+            }
+            return;
+        }
+        if x_op != y_op || x_key != y_key {
             self.hole(x, y);
             return;
         }
         // Same op and key.
-        if nx.op == VgOp::Bin && bin_is_commutative(nx.key) {
+        if x_op == VgOp::Bin && bin_is_commutative(x_key) {
             self.unify_commutative(x, y, depth);
             return;
         }
-        if nx.args.len() != ny.args.len() {
+        if x_arity != y_arity {
             self.hole(x, y);
             return;
         }
@@ -410,6 +454,14 @@ fn pair_sinks(a: &Dag<'_>, b: &Dag<'_>, kind: VgSinkKind) -> SinkPairing {
 
 fn classify(a: &Dag<'_>, b: &Dag<'_>, x: u32, y: u32) -> &'static str {
     if x == NONE || y == NONE {
+        let present = if x == NONE {
+            &b.dag.nodes[y as usize]
+        } else {
+            &a.dag.nodes[x as usize]
+        };
+        if present.op == VgOp::Opaque && present.key == VG_PROTOCOL_AWAIT {
+            return "async-mirror";
+        }
         return "arity";
     }
     let (ta, tb) = (a.dag.nodes[x as usize].op, b.dag.nodes[y as usize].op);
@@ -487,6 +539,8 @@ struct Alignment {
     holes: Vec<(u32, u32)>,
     extra: Vec<(u32, bool)>,
     reordered: bool,
+    /// One side awaited where the other did not (an async↔sync twin).
+    async_mirror: bool,
 }
 
 /// Pair every sink kind and anti-unify the matched roots. `None` if the alignment hit
@@ -517,6 +571,7 @@ fn align(da: &Dag<'_>, db: &Dag<'_>) -> Option<Alignment> {
         holes: std::mem::take(&mut au.holes),
         extra,
         reordered,
+        async_mirror: au.async_mirror,
     })
 }
 
@@ -616,15 +671,23 @@ pub fn graded_witness(
     let low_substance = k > 0 && na.min(nb) < 10;
     let mut patterns = derive_patterns(&al, na, nb, low_substance);
 
+    if al.async_mirror {
+        patterns.push("async-mirror");
+    }
+
     let (referent_mismatches, caveat_names) = compare_referents(a, b);
     if !referent_mismatches.is_empty() {
         patterns.push("referent-mismatch");
     }
 
+    // `async-mirror` is a *transformation* twin (async ↔ sync), never a behavioral equivalence —
+    // a coroutine is not its resolved value. So it can never be `equal_modulo_holes`, regardless
+    // of how cleanly the rest aligns.
     let equal_modulo_holes = al.extra.is_empty()
         && !al.reordered
         && all_leafy
         && !low_substance
+        && !al.async_mirror
         && referent_mismatches.is_empty();
 
     Some(GradedWitness {
@@ -641,7 +704,7 @@ pub fn graded_witness(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nose_normalize::{ValueDag, VgNode, VgReferent, VgSink};
+    use nose_normalize::{ValueDag, VgNode, VgReferent, VgSink, VG_PROTOCOL_AWAIT};
 
     fn node(op: VgOp, key: u64, args: &[u32], hash: u64) -> VgNode {
         VgNode {
@@ -703,6 +766,71 @@ mod tests {
         assert_eq!(w.holes, 1);
         assert_eq!(w.spots.len(), 1);
         assert_eq!(w.spots[0].class, "literal");
+        assert!(w.equal_modulo_holes);
+    }
+
+    /// An async↔sync twin pair: side A wraps the inner `Call` in `await`
+    /// (`Opaque(VG_PROTOCOL_AWAIT,[call])`), side B uses the bare call; both return a `len`-deep
+    /// `Un` chain over that value, so they sit above the low-substance floor and differ ONLY at
+    /// the await point.
+    fn async_sync_twin(len: u32) -> (ValueDag, ValueDag) {
+        let mk = |nodes: Vec<VgNode>, top: u32| ValueDag {
+            sinks: vec![VgSink {
+                kind: VgSinkKind::Return,
+                value: top,
+                effect_ord: None,
+            }],
+            referents: vec![],
+            nodes,
+        };
+        // sync (B): Const -> Call -> Un chain over the Call.
+        let mut sync = vec![
+            node(VgOp::Const, 5, &[], 100),
+            node(VgOp::Call, 42, &[0], 200),
+        ];
+        for i in 0..len {
+            let arg = sync.len() as u32 - 1;
+            sync.push(node(VgOp::Un, 7, &[arg], 300 + u64::from(i)));
+        }
+        let sync_top = sync.len() as u32 - 1;
+        // async (A): Const -> Call -> await(Call) -> Un chain over the await. Same Call hash as
+        // B's (so the operand matches after the gate); the Un chain uses distinct hashes so the
+        // witness recurses down to the await point instead of fast-matching.
+        let mut asy = vec![
+            node(VgOp::Const, 5, &[], 100),
+            node(VgOp::Call, 42, &[0], 200),
+            node(VgOp::Opaque, VG_PROTOCOL_AWAIT, &[1], 250),
+        ];
+        for i in 0..len {
+            let arg = asy.len() as u32 - 1;
+            asy.push(node(VgOp::Un, 7, &[arg], 400 + u64::from(i)));
+        }
+        let asy_top = asy.len() as u32 - 1;
+        (mk(asy, asy_top), mk(sync, sync_top))
+    }
+
+    #[test]
+    fn async_await_aligns_with_sync_twin_as_async_mirror() {
+        let (a, b) = async_sync_twin(12);
+        let w = graded_witness(&a, &b, false, false).unwrap();
+        assert!(
+            w.patterns.contains(&"async-mirror"),
+            "expected async-mirror, got {:?}",
+            w.patterns
+        );
+        assert!(
+            !w.equal_modulo_holes,
+            "async↔sync is a transformation twin, never a behavioral equivalence"
+        );
+        assert!(w.spots.iter().any(|s| s.class == "async-mirror"));
+    }
+
+    #[test]
+    fn both_sides_await_is_not_async_mirror() {
+        // Two identical async copies (both await) align cleanly — no one-sided await, no mirror.
+        let (a, _) = async_sync_twin(12);
+        let w = graded_witness(&a, &a, false, false).unwrap();
+        assert!(!w.patterns.contains(&"async-mirror"));
         assert!(w.equal_modulo_holes);
     }
 

--- a/crates/nose-normalize/src/lib.rs
+++ b/crates/nose-normalize/src/lib.rs
@@ -48,7 +48,7 @@ pub use value_graph::{
 };
 pub use value_graph::{
     bin_is_commutative, value_dag, FileReferents, ValueDag, VgNode, VgOp, VgReferent, VgSink,
-    VgSinkKind,
+    VgSinkKind, VG_PROTOCOL_AWAIT,
 };
 
 use nose_il::{FileMeta, Il, IlBuilder, Interner, NodeId, NodeKind, Payload, Symbol, Unit};

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -56,7 +56,7 @@ pub use api::{
 pub use context::ValueFingerprintContext;
 pub use value_dag::{
     bin_is_commutative, value_dag, FileReferents, ValueDag, VgNode, VgOp, VgReferent, VgSink,
-    VgSinkKind,
+    VgSinkKind, VG_PROTOCOL_AWAIT,
 };
 
 use crate::combine;

--- a/crates/nose-normalize/src/value_graph/eval.rs
+++ b/crates/nose-normalize/src/value_graph/eval.rs
@@ -145,6 +145,12 @@ impl<'a> Builder<'a> {
         v
     }
 
+    /// Whether a `Raw` node is the `await` protocol boundary (the one `Raw` we model as a
+    /// value-preserving wrapper, see the `NodeKind::Raw` arm in `eval_inner`).
+    fn is_await_raw(&self, payload: &Payload) -> bool {
+        matches!(payload, Payload::Name(s) if self.interner.resolve(*s) == "await")
+    }
+
     pub(super) fn eval_inner(&mut self, expr: NodeId, env: &FxHashMap<u32, ValueId>) -> ValueId {
         let node = *self.il.node(expr);
         match node.kind {
@@ -190,7 +196,32 @@ impl<'a> Builder<'a> {
                     .unwrap_or_else(|| self.mk(ValOp::Opaque(0), vec![]));
                 self.mk(ValOp::KwArg(name_hash), vec![value])
             }
-            // Any unlowered / unhandled construct — notably `Raw`, which wraps a
+            // `await e` is the ONE `Raw` we key as a wrapper that KEEPS its operand as a
+            // child — `Opaque(VG_PROTOCOL_AWAIT, [eval(e)])` — so the near/graded witness can
+            // align an async fn with its sync twin through the wrapper (the `async-mirror`
+            // pattern). The wrapper still makes `await e` ≠ `e` and ≠ `await f`, so the EXACT
+            // channel never merges a Future with its resolved value — and async units are
+            // non-`exact_safe` anyway (a `Raw` in the IL ⇒ `strict_exact` returns false), the
+            // load-bearing guard. Every OTHER `Raw` stays on the childless arm below.
+            NodeKind::Raw if self.is_await_raw(&node.payload) => {
+                let operand = self
+                    .il
+                    .children(expr)
+                    .first()
+                    .map(|&v| self.eval(v, env))
+                    .unwrap_or_else(|| self.mk(ValOp::Opaque(VG_PROTOCOL_AWAIT), vec![]));
+                if self.await_transparent {
+                    // Fingerprint build: `await e` ≡ `e`'s value, so the operand identity flows
+                    // downstream and an async fn's fingerprint matches its sync twin (vj↑).
+                    operand
+                } else {
+                    // Witness build: keep the wrapper so `value_dag`'s graded anti-unification can
+                    // see the await and label the difference `async-mirror` (a transformation, not
+                    // a behavioral equivalence).
+                    self.mk(ValOp::Opaque(VG_PROTOCOL_AWAIT), vec![operand])
+                }
+            }
+            // Any other unlowered / unhandled construct — notably `Raw`, which wraps a
             // macro, C compound literal, `#ifdef`, parse-ERROR, etc. Key it by its full
             // subtree hash (surface kind + lowered children), exactly like `Lambda`, so
             // behaviorally-different unlowered constructs produce DIFFERENT fingerprints.

--- a/crates/nose-normalize/src/value_graph/model.rs
+++ b/crates/nose-normalize/src/value_graph/model.rs
@@ -175,6 +175,13 @@ pub(super) struct Builder<'a> {
     /// The IL node kind currently being evaluated (set by `eval`, mirroring `cur_span`), so the
     /// opaque census can attribute each `Opaque` fallback to the construct that minted it.
     pub(super) cur_il_kind: Option<NodeKind>,
+    /// Dual-view flag for the `await` protocol boundary. `true` (the default, used by the
+    /// FINGERPRINT build) evaluates `await e` to `e`'s value directly so an async fn's fingerprint
+    /// matches its sync twin's (near-channel `vj` convergence — the #1 Type-4 gap, §K). `false`
+    /// (set only by `value_dag`, the WITNESS build) keeps the `Opaque(VG_PROTOCOL_AWAIT,[e])`
+    /// wrapper so the graded witness can label the difference `async-mirror`. Both are exact-safe:
+    /// `await`→`Raw` in the IL ⇒ the unit is non-`exact_safe`, excluded from exact families.
+    pub(super) await_transparent: bool,
     /// Research instrument (env-gated; `None` in production): per `(IL kind, total-fallback)`
     /// count of `ValOp::Opaque` nodes minted — the value-graph coverage-attribution census (the
     /// #391 prevalence probe). `total-fallback` = an argless opaque (a "can't model this at all"

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -22,6 +22,7 @@ impl<'a> Builder<'a> {
             node_span: Vec::new(),
             cur_span: None,
             cur_il_kind: None,
+            await_transparent: true,
             opaque_census: None,
             intern: FxHashMap::default(),
             sinks: Vec::new(),

--- a/crates/nose-normalize/src/value_graph/value_dag.rs
+++ b/crates/nose-normalize/src/value_graph/value_dag.rs
@@ -25,6 +25,17 @@ use nose_il::{CallTargetEvidenceKind, EvidenceKind, ImportEvidenceKind};
 /// near-identical bodies (which would falsely differ).
 const SELF_REFERENT: u64 = 0x5e1f_5e1f_5e1f_5e1f;
 
+/// Reserved `Opaque` key for the `await` protocol boundary. An `await e` lowers to an
+/// `Opaque(VG_PROTOCOL_AWAIT, [eval(e)])` wrapper that PRESERVES the awaited operand as a
+/// child (unlike the childless `Opaque(subtree_hash)` every other `Raw` gets) — so the
+/// near/graded witness can see *through* the wrapper to align an async fn with its sync
+/// twin, while the wrapper itself keeps `await e` ≠ `e` so the EXACT channel never merges
+/// a Future with its resolved value (async units are non-`exact_safe` regardless, the
+/// load-bearing guard). The `args.len() == 1` shape is the witness's safety gate against
+/// the (2⁻⁶⁴) chance a real `Raw`'s `subtree_hash` equals this key — a colliding `Raw` is
+/// childless. See `crates/nose-detect/src/witness.rs` (the `async-mirror` pattern).
+pub const VG_PROTOCOL_AWAIT: u64 = 0xA5A5_0A17_C0DE_0001;
+
 /// The operator family of a [`VgNode`]. Mirrors the private `ValOp`; the paired `key`
 /// disambiguates within a family (the operator code for `Bin`/`Un`, the builtin
 /// discriminant for `Call`, the field-name hash for `Field`, …).
@@ -519,6 +530,10 @@ pub fn value_dag(
         Some(ctx) => Builder::new_with_context(il, interner, ctx),
         None => Builder::new(il, interner),
     };
+    // The witness build keeps the `await` wrapper visible (vs the fingerprint build's transparency)
+    // so the graded anti-unification can align an async fn with its sync twin and label it
+    // `async-mirror` — see `crates/nose-detect/src/witness.rs`.
+    b.await_transparent = false;
     b.build_unit_with_context(root, context);
     let nodes = b
         .nodes

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -3029,6 +3029,13 @@ provably inert:** `verify --max-violations 0` clean (axios/rxjs/trpc/flask/guava
 the change only ADDs near families. Deterministic. Tests: witness `async-mirror`/`both-sides-await`
 units + an end-to-end detection test (twin converges, different-logic decoy excluded).
 
-**Follow-up (not soundness):** the formal eval substrate — gold `production_async_sync` pairs +
-hard-negatives mined from the corpus, the `nose eval` `near_exact_or_structural` recall number, and
-flipping the `coverage_matrix` cells none→covered — plus extending to Rust `.await`.
+**Recall (eval substrate).** A first `production_async_sync` gold set — 6 Python+JS/TS twin pairs
+(`bench/type4/fixtures/async_sync/`, gold `bench/labels/async_sync_twins.v1.json`) + 3
+async-vs-different-logic hard-negatives — measured with `nose eval`: the `near_exact_or_structural`
+twin recall goes **0/6 → 6/6** (baseline binary vs this change), **HN-FP 0/3**. (A 4th would-be
+negative — two async fns differing only `+`/`-` — was dropped: candidate mode surfaces
+same-shape-different-operator BY DESIGN, on the baseline too, so it is not an async-twin miss.)
+
+**Follow-up (not soundness):** mine REAL-corpus twin instances to flip the `coverage_matrix`
+`async_sync_twin` cells none→covered (the matrix tracks real-corpus coverage, not synthetic
+fixtures), and extend to Rust `.await` and the other protocol boundaries.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2986,3 +2986,49 @@ cost was a synthetic-test artifact and the sound fix shipped clean. Residual (st
 pure recall enhancement): a map-value non-null proof would re-converge the coalesce forms with the
 absence family where it is provably sound (literal non-null maps), and null/undefined de-conflation
 would re-home `=== undefined` with the absence class — neither is a soundness obligation.
+
+## CU. async↔sync twins — the dual-view await (the #1 Type-4 gap, §K)
+
+§K named **async ↔ sync twins** "the real Type-4 gap in production code": an `async def f` and
+its sync twin (identical body modulo `await`) are duplicated logic a maintainer would want
+surfaced, but nose detected **0 families** for them (`async_sync_twin: none` in
+`coverage_matrix.v1.json`). The convergence was deliberately gated: `await` lowers to a
+`Raw("await")` protocol boundary the value graph turns into a **childless** `Opaque(subtree_hash)`
+(eval.rs), so twins share no value-DAG structure. Erasing `await` was the *old* unsound path (it
+removed the IL `Raw` → the unit became `exact_safe` → an exact false merge of a Future with its
+resolved value).
+
+**The channel was wrong.** async↔sync twins are NOT behaviorally equal (a coroutine ≠ a value), so
+they belong in the **near/graded** channel (refactoring candidates — no equivalence claim), never
+the exact channel. Two empirical findings shaped the mechanism: (1) a wrapper that keeps the await
+visible **poisons downstream value identity** — `v = await f(x)` makes `v` the wrapper, so every
+later `v+1` diverges from the sync twin's, and family formation is pure `vj`/`sj` scoring (the
+witness only *labels*); so a wrapper alone never converges twins. (2) Full transparency (eval
+`await e → e`) DOES converge them and stays exact-safe (the IL `Raw` keeps the unit non-`exact_safe`
+— `strict_exact` returns false on `Raw` — so async units are excluded from exact families
+regardless of the fingerprint). "Soundness costs recall" was again a hypothesis to measure: it
+didn't, the exact channel is provably inert.
+
+**The fix is a DUAL VIEW** of the value graph, keyed by `Builder.await_transparent`:
+- **Fingerprint build** (default `true`): `await e` ≡ `e`'s value → an async fn's fingerprint
+  matches its sync twin → they converge on `vj` in candidate mode.
+- **ValueDag/witness build** (`false`, set in `value_dag()`): keeps an `Opaque(VG_PROTOCOL_AWAIT,[e])`
+  wrapper so the graded witness *sees* the await. `Au::unify` aligns the wrapper against the bare
+  operand on the sync side (recursing through it so the alignment propagates downstream), records a
+  one-sided **`async-mirror`** hole, and forces `equal_modulo_holes = false` — a transformation
+  twin is never an equivalence claim.
+
+So scoring sees *through* await (twins converge) while the witness *sees* await (honest
+`async-mirror` label + the precision gate). First increment: **Python + JS/TS** (both lower `await`
+through `await_boundary`); Rust `.await` and the other protocol boundaries (`yield`/`try`-`?`/
+channels — non-pass-through semantics) deferred.
+
+**Gates.** Full suite **1056 pass**; the dual-view broke no existing await test. **Exact-channel
+provably inert:** `verify --max-violations 0` clean (axios/rxjs/trpc/flask/guava), and the
+`exact-value-graph` families are **byte-identical** before/after on zod/prettier/flask/guava/gorm —
+the change only ADDs near families. Deterministic. Tests: witness `async-mirror`/`both-sides-await`
+units + an end-to-end detection test (twin converges, different-logic decoy excluded).
+
+**Follow-up (not soundness):** the formal eval substrate — gold `production_async_sync` pairs +
+hard-negatives mined from the corpus, the `nose eval` `near_exact_or_structural` recall number, and
+flipping the `coverage_matrix` cells none→covered — plus extending to Rust `.await`.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -3036,6 +3036,20 @@ twin recall goes **0/6 → 6/6** (baseline binary vs this change), **HN-FP 0/3**
 negative — two async fns differing only `+`/`-` — was dropped: candidate mode surfaces
 same-shape-different-operator BY DESIGN, on the baseline too, so it is not an async-twin miss.)
 
-**Follow-up (not soundness):** mine REAL-corpus twin instances to flip the `coverage_matrix`
-`async_sync_twin` cells none→covered (the matrix tracks real-corpus coverage, not synthetic
-fixtures), and extend to Rust `.await` and the other protocol boundaries.
+**Real-corpus lift — measured, and modest.** Mining = run nose (with this feature) on
+async/sync-mirror-rich repos and keep the families whose members span an `async def` and a plain
+`def`. httpx (`Client`/`AsyncClient`) surfaces **8** such twin families, including the production
+`Response.read` / `aread` (`_models.py:468`/`482`). But the **differential** (FIX vs the baseline
+binary) is small: httpx **+1** new twin (`test_*_auth_reads_response_body`), scrapy re-grouped,
+sqlalchemy +0 — because most real twins ALREADY converge via the sub-DAG/anchor path (their shared
+non-await body is a big enough common anchor; `read`/`aread` itself converges on the baseline too).
+So the synthetic 0→6/6 proves the *mechanism*; the marginal real-corpus recall is **+1-ish**, and
+the durable wins are the explicit candidate-mode convergence + the honest `async-mirror` witness
+label (which the anchor path does not give). The `coverage_matrix` `async_sync_twin` **python** cell
+is flipped none→covered (evidence: the hand-verified httpx `read`/`aread`, `real_frontier.v1.json`).
+Lesson, the twin of §CU's first: a new recall feature's *real-corpus lift* is also a hypothesis to
+measure, not assume — here it is small.
+
+**Follow-up (not soundness):** real-corpus evidence for the js/ts/rust cells (js/ts libraries keep
+parallel sync/async versions far less often than Python ones, so no clean mined twin yet), and
+extending the mechanism to Rust `.await` and the other protocol boundaries.

--- a/docs/graded-witness.md
+++ b/docs/graded-witness.md
@@ -48,6 +48,13 @@ Some divergences are better described than itemized as holes:
 - `fragment-containment` — the smaller copy is a sliver of the larger (a containment,
   not a clone claim);
 - `low-substance` — the units are too small for the claim to mean much.
+- `async-mirror` — one copy `await`s where the other does not: an async↔sync
+  *transformation* twin (§K / experiments §CU). The witness build keeps `await e` as an
+  `Opaque(VG_PROTOCOL_AWAIT,[e])` wrapper; the alignment recurses *through* it (matching the
+  operand against the bare sync value) and records the await as a one-sided hole. Always sets
+  `equal_modulo_holes = false` — a coroutine is not its resolved value, so this is a refactoring
+  lead, never a behavioral-equivalence claim. (The fingerprint build, by contrast, makes `await e`
+  transparent so the twin's `vj` converges — see the dual view in `value_graph/eval.rs`.)
 
 ## Soundness — the referent check
 


### PR DESCRIPTION
Closes the **#1 real-world Type-4 gap** (§K, experiments §CU): an `async def f` and its sync twin (identical body modulo `await`) were detected as **0 families** — `await` lowers to a `Raw("await")` protocol boundary the value graph turned into a *childless* opaque, so twins shared no value-DAG structure.

## The channel was wrong
async↔sync twins are **not** behaviorally equal (a coroutine ≠ a value), so they belong in the **near/graded** channel (refactoring candidates — no equivalence claim), never the exact channel. Naively erasing `await` was the *old* unsound path (it removed the IL `Raw` → the unit became `exact_safe` → an exact false merge).

## Mechanism — a dual view of the value graph (`Builder.await_transparent`)
- **Fingerprint build** (default `true`): `await e` ≡ `e`'s value → an async fn's fingerprint matches its sync twin → they converge on `vj` in candidate mode.
- **ValueDag/witness build** (`false`, set in `value_dag()`): keeps an `Opaque(VG_PROTOCOL_AWAIT,[e])` wrapper so the graded witness *sees* the await. `Au::unify` aligns the wrapper against the bare operand (recursing through it), records a one-sided **`async-mirror`** hole, and forces `equal_modulo_holes = false` — a transformation twin is never an equivalence claim.

So scoring sees *through* await (twins converge) while the witness *sees* await (honest `async-mirror` label + precision gate).

## Soundness — exact channel provably inert
`await`→IL `Raw`→`exact_safe = false` (`strict_exact.rs`) ⇒ async units are excluded from exact families regardless of the transparent fingerprint. Verified:
- `verify --max-violations 0` **clean** (axios/rxjs/trpc/flask/guava).
- `exact-value-graph` families **byte-identical** before/after (zod/prettier/flask/guava/gorm) — the change only ADDs near families.
- **Deterministic**; full suite **1056 pass**; fmt/clippy clean.

## Tests
Witness `async-mirror` + `both-sides-await` units; an end-to-end detection test (twin converges, different-logic decoy excluded).

## Scope / follow-ups (not soundness)
First increment is **Python + JS/TS** (both lower `await` through `await_boundary`). Deferred: the formal eval substrate (gold `production_async_sync` pairs + hard-negatives mined from the corpus, the `nose eval` recall number, flipping the `coverage_matrix` cells none→covered), and extending to Rust `.await` and the other protocol boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)