### PR TITLE
docs: consistency pass — design.md framing, navigation, code alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # nose
 
-**nose** finds duplicated code worth refactoring — literal copy-paste, renamed
-copies, and the same logic written in a different style or language — across
-Python, JavaScript, TypeScript, Go, Rust, Java, C, Ruby, plus declarative **CSS**
-(matched by computed-style equivalence) and **HTML markup** (rendered-DOM
-equivalence) — including the `<script>`/`<style>`/markup regions inside Vue,
-Svelte, and HTML. One self-contained Rust binary; no runtime, services, or network.
+**nose** finds duplicated code — literal copy-paste, renamed copies, and the same
+logic written in a different style or language — across Python, JavaScript,
+TypeScript, Go, Rust, Java, C, Ruby, plus declarative **CSS** (computed-style
+equivalence) and **HTML markup** (rendered-DOM equivalence), including the
+`<script>`/`<style>`/markup regions inside Vue, Svelte, and HTML. It **proves** its
+semantic matches are real — equal fingerprint ⟹ equal behavior, never a false
+equivalence — and ranks candidates by refactoring value for the coding agent or CI
+gate that consumes them. One self-contained Rust binary; no runtime, services, or
+network.
 
 ## Install
 

--- a/docs/demand-effect-semantics.md
+++ b/docs/demand-effect-semantics.md
@@ -1,9 +1,5 @@
 # Demand and effect semantics
 
-Back to [semantic-kernel](semantic-kernel.md). The implemented code shape is
-summarized in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); remaining
-work is tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md).
-
 Demand/effect contracts describe how an already-admitted semantic operation
 evaluates its children, invokes callbacks, and exposes effects. They do not
 admit a source API by name. API admission still requires source, symbol, import,
@@ -123,3 +119,10 @@ work includes:
   exact-size/materialization, and callback-effect contracts;
 - report-level provenance for which demand/effect contract influenced an exact
   result.
+
+## See also
+
+- [semantic-kernel](semantic-kernel.md)
+- The implemented code shape is summarized in
+  [semantic-kernel-snapshot](semantic-kernel-snapshot.md); remaining work is
+  tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md).

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -1,11 +1,5 @@
 # Semantic evidence records
 
-Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
-recorded in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and
-remaining work are tracked in
-[semantic-kernel-roadmap](semantic-kernel-roadmap.md). Source-origin facts are
-covered in [source-facts](source-facts.md).
-
 Evidence records are the internal substrate that lets current first-party
 frontends, and future language/library packs, emit proof facts without giving
 those producers authority to approve exact clones. They are facts, not verdicts.
@@ -684,3 +678,11 @@ materialization, channels, async, call-by-need, and callback effects, full
 scope-resolution and namespace-member evidence, broader guard evidence, general
 cross-module dependency manifests, report-level provenance, and external
 manifest loading are still open work.
+
+## See also
+
+Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
+recorded in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and
+remaining work are tracked in
+[semantic-kernel-roadmap](semantic-kernel-roadmap.md). Source-origin facts are
+covered in [source-facts](source-facts.md).

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -308,7 +308,7 @@ not replicate** on larger labelsets (next sections).
 
 A multi-section arc (per-language eval, bootstrap CIs, labelsets v2–v4 up to 4,615 families)
 that **dissolved its own narrative before anything shipped**. A per-language A/B first showed
-the §Y gain was +22pp on TypeScript and −5pp on Rust; bootstrap CIs (§AB) then showed *both*
+the §Y gain was +22pp on TypeScript and −5pp on Rust; bootstrap CIs (§Z–AD) then showed *both*
 were within noise and the re-rank gain never replicated heldout (62% → 62%). Two durable
 results: **do not ship the uniform re-rank** (recall-side levers are the real ones), and
 **per-language precision power is bounded by #repos × 10, not #labels** (P@10 samples only the
@@ -332,7 +332,7 @@ whole-file clones).
 
 ## AG. Lowering closure — every language to non-ERROR Raw ≤ 0.5%
 
-Closed the lowering campaign (begun in §AA, the per-language Raw-gap work) to target: all 9
+Closed the lowering campaign (begun in §Z–AD, the per-language Raw-gap work) to target: all 9
 languages at 0.01–0.25% non-ERROR Raw, no construct > 0.3%. Two disciplines: route stray
 statement kinds back through the statement path, and erase type-level nodes to `empty_block`,
 not `Raw`. The remaining Raw is essentially all ERROR (tree-sitter parse failures — the
@@ -676,7 +676,7 @@ interpreter oracle as an in-loop *acceptance gate*, then chased the lead it surf
   `Math.min(a,b)` now an opaque call, not `Builtin::Min`). **Obsoleted and dropped:** map-read and
   nullish/option modeling (depended on the deleted builtins) and two-arg scalar `min`/`max` (now
   inert). **Survived / re-validated:** the §BB lattice canon (`convergence_probe5` 10/10) and the
-  §BE pointer-length contract (re-measured 800 → 252). The durable lesson: **a soundness-oracle
+  §BC–BF pointer-length contract (re-measured 800 → 252). The durable lesson: **a soundness-oracle
   improvement is durable only insofar as the IL shape it keys on is durable** — canons keyed on
   stable value-graph structure survived; builtin-keyed modeling did not.
 
@@ -970,7 +970,7 @@ constructs* keep units out of the interpreter. `nose verify --exclusion-census`
 (`crates/nose-cli/src/verify_census.rs`) records every counted function unit's oracle
 outcome, fingerprint, and raw construct tags — for excluded AND interpretable
 populations, deriving the discriminating constructs at analysis time instead of
-hard-coding an "unsupported" list that would rot when lowerings change (the §BF
+hard-coding an "unsupported" list that would rot when lowerings change (the §BC–BF
 durability lesson). Run per repo (merge pairs counted within a repo, matching how scans
 run) and merged by `bench/labels/merge_exclusion_census.py`; artifact
 `bench/labels/oracle_exclusion_census_2026_06_10.json` (104 repos; `raylib` excluded —
@@ -995,7 +995,7 @@ mass).
 **Campaign order this fixes:** (1) uninterpreted-function handling for opaque calls
 and field reads — evaluate them as symbolic applications/projections recorded in the
 ordered effect trace, rather than bailing the whole unit; structure-keyed, so it
-survives lowering drift (§BF). (2) Statement coverage that rides on it (Throw/Try).
+survives lowering drift (§BC–BF). (2) Statement coverage that rides on it (Throw/Try).
 (3) Deprioritize unretained-literal units: their merges are already outside the exact
 channel.
 
@@ -1378,7 +1378,7 @@ value multiset, so "code that does X" fingerprinted like "code that doesn't":
    except {return x}` keeps its handler under an exception guard); element-free effects
    under a loop keyed by the loop's canonical element source (for-in over keys vs
    for-of over values no longer collide — prettier); and the oracle binds battery rows
-   under each parameter's DECLARED type domain, the §BE convention extended to types
+   under each parameter's DECLARED type domain, the §BC–BF convention extended to types
    (a typed `int` never receives a List, so rxjava's order-swapped typed field writes
    stop flagging on impossible type-states).
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -5,7 +5,8 @@ eight imperative languages — plus declarative **CSS** (computed-style equivale
 and **HTML markup** (rendered-DOM equivalence), and the `<script>`/`<style>` regions
 inside Vue, Svelte, and HTML — by
 lowering every language into one normalized intermediate language (IL) and
-ranking duplicated code by how much it's worth refactoring. The repository
+ranking the candidates by refactoring value — a deterministic triage signal, not a
+worth-it verdict (that judgment is the consumer's). The repository
 [README](../README.md) is the one-screen overview; this wiki is the full guide.
 
 Every wiki page lives in `docs/` and links to its neighbours with relative links, so the

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -102,6 +102,13 @@ declaration block shared between a component's `<style>` and a plain `.css` file
 repeated card across two HTML pages — shows up as one cross-container family (script
 cross-container confirmed on real projects in [field-evaluation](field-evaluation.md)).
 
+Vue/Svelte directive shorthands are canonicalized in the markup tree (`:x` ≡
+`v-bind:x`, `@x` ≡ `v-on:x`), and inline `style="…"` is computed-canonicalized via the
+CSS path. Out of scope (see [clone-types](clone-types.md)): SCSS/Less/Sass, CSS `var()`
+resolution across files, and full Svelte `{#if}`/`{#each}`
+block control flow (template text/interpolation is structure-abstracted, the block
+grammar is not modeled).
+
 ## Coverage and adding a language
 
 Lowering quality is measured by the **Raw-node ratio** — the fraction of CST

--- a/docs/semantic-kernel-audit-2026-06-09.md
+++ b/docs/semantic-kernel-audit-2026-06-09.md
@@ -1,11 +1,5 @@
 # Semantic kernel audit, 2026-06-09
 
-Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
-in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); remaining work is
-tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The later
-closeout for the #150-#157 foundation tranche is in
-[semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
-
 This audit closes issue #150. It assumes PR #147 is merged and asks whether any
 remaining first-party semantic consumer still opens exact semantics from raw
 shape, selector spelling, raw `Seq`/payload tags, or local
@@ -186,4 +180,12 @@ tranches:
   provenance.
 
 The #109 closeout is recorded in
+[semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
+
+## See also
+
+Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
+in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); remaining work is
+tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The later
+closeout for the #150-#157 foundation tranche is in
 [semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -1,14 +1,5 @@
 # Semantic kernel roadmap
 
-Back to [semantic-kernel](semantic-kernel.md). Current code shape is recorded in
-[semantic-kernel-snapshot](semantic-kernel-snapshot.md). The post-PR #147 audit
-of remaining raw/local semantic pockets is in
-[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md). The
-provider-facing v0 extension API is in
-[semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md). The
-closeout for the #109 semantic-kernel migration is in
-[semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
-
 This page tracks decisions, history, and remaining work for the semantic kernel
 and pack ecosystem.
 
@@ -970,3 +961,15 @@ considered successful because it:
 The next implementation slices should be judged by whether they remove another
 class of scattered semantic knowledge without widening exact acceptance beyond
 the available evidence.
+
+## See also
+
+- Back to [semantic-kernel](semantic-kernel.md).
+- Current code shape is recorded in
+  [semantic-kernel-snapshot](semantic-kernel-snapshot.md).
+- The post-PR #147 audit of remaining raw/local semantic pockets is in
+  [semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md).
+- The provider-facing v0 extension API is in
+  [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md).
+- The closeout for the #109 semantic-kernel migration is in
+  [semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -1,18 +1,5 @@
 # Semantic kernel snapshot
 
-Back to [semantic-kernel](semantic-kernel.md). This page records the current
-implementation shape; planned work and decision history live in
-[semantic-kernel-roadmap](semantic-kernel-roadmap.md). The internal evidence
-record substrate is described in [evidence-records](evidence-records.md). The
-post-PR #147 raw/local pocket audit is recorded in
-[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md). The
-v0 provider-facing extension API is defined in
-[semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md), and the
-local provider/user conformance workflow is in
-[semantic-pack-conformance](semantic-pack-conformance.md). The closeout for the
-#109 semantic-kernel migration is in
-[semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
-
 Snapshot date: 2026-06-09. The current implementation has an internal
 semantic-kernel facade, evidence-gated field state, sequence-surface contracts,
 proof-backed append fragment evidence, operator-law contracts, typed import
@@ -831,4 +818,19 @@ Remaining migration targets are tracked in
 classification snapshot is in
 [semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md), and
 the completed #109 foundation and follow-up tranche is in
+[semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
+
+## See also
+
+Back to [semantic-kernel](semantic-kernel.md). This page records the current
+implementation shape; planned work and decision history live in
+[semantic-kernel-roadmap](semantic-kernel-roadmap.md). The internal evidence
+record substrate is described in [evidence-records](evidence-records.md). The
+post-PR #147 raw/local pocket audit is recorded in
+[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md). The
+v0 provider-facing extension API is defined in
+[semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md), and the
+local provider/user conformance workflow is in
+[semantic-pack-conformance](semantic-pack-conformance.md). The closeout for the
+#109 semantic-kernel migration is in
 [semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).

--- a/docs/semantic-kernel-tranche-closeout-2026-06-09.md
+++ b/docs/semantic-kernel-tranche-closeout-2026-06-09.md
@@ -1,15 +1,11 @@
 # Semantic kernel #109 closeout, 2026-06-09
 
-Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
-in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); long-range phases
-and history are in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). This
-closeout updates the post-PR #147 audit recorded in
-[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md).
+This page closes the semantic-kernel foundation work tracked under GitHub issue
+#109.
 
 ## Scope
 
-This page closes the semantic-kernel foundation work tracked under GitHub issue
-#109. The first tranche covered the follow-up issues created from the post-PR
+The first tranche covered the follow-up issues created from the post-PR
 #147 audit:
 
 | issue | PR | outcome |
@@ -83,3 +79,11 @@ work should be opened as new, scoped issues when a concrete language surface,
 producer family, LawPack family, or ecosystem-pack runtime slice is selected.
 The active companion issue is #149, which is a quality-gate ratchet and
 large-file cleanup track rather than a semantic-kernel behavior migration.
+
+## See also
+
+Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
+in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); long-range phases
+and history are in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). This
+closeout updates the post-PR #147 audit recorded in
+[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md).

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -1,24 +1,10 @@
 # Semantic kernel and packs
 
-Back to [home](home.md). Current implementation status is in
-[semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and remaining
-work are tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The
-post-PR #147 raw/local pocket audit is recorded in
-[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md), and the
-#109 closeout is recorded in
-[semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
-The versioned provider-facing extension surface is defined in
-[semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md). Source
-origin evidence is detailed in [source-facts](source-facts.md); the shared
-internal evidence substrate is described in
-[evidence-records](evidence-records.md). The current demand/effect contract
-model is described in [demand-effect-semantics](demand-effect-semantics.md).
-
-## Context
-
 nose's long-term moat is not "more parsers". It is a precise, extensible model of
 what code means across many languages and libraries, strong enough to support exact
 semantic clone detection while still practical enough to run on real repositories.
+
+## Context
 
 The current engine already has the right instincts: fail-closed exact matching,
 language-specific lowering, a value graph, an interpreter oracle, hard negatives,
@@ -340,3 +326,19 @@ It should be:
 3. which semantic law applied;
 4. which domains, demand rules, and effect conditions were proven;
 5. which channel eligibility admitted the result.
+
+## See also
+
+Back to [home](home.md). Current implementation status is in
+[semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and remaining
+work are tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The
+post-PR #147 raw/local pocket audit is recorded in
+[semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md), and the
+#109 closeout is recorded in
+[semantic-kernel-tranche-closeout-2026-06-09](semantic-kernel-tranche-closeout-2026-06-09.md).
+The versioned provider-facing extension surface is defined in
+[semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md). Source
+origin evidence is detailed in [source-facts](source-facts.md); the shared
+internal evidence substrate is described in
+[evidence-records](evidence-records.md). The current demand/effect contract
+model is described in [demand-effect-semantics](demand-effect-semantics.md).

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -1,9 +1,5 @@
 # Semantic pack conformance
 
-Back to [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md),
-[semantic-pack-loading](semantic-pack-loading.md), and
-[semantic-kernel](semantic-kernel.md).
-
 Status: nose provides a local semantic-pack v0 conformance harness for manifest
 structure and declared fixture assets. The harness is a provider/user workflow,
 not nose approval of third-party semantic correctness. External packs remain
@@ -133,3 +129,9 @@ Users who opt into external packs own the enablement decision. They should revie
 `metadata-only` influence today. Future producer
 execution must keep the same provenance and fail-closed behavior before external
 packs can affect `near` or exact results.
+
+## See also
+
+- [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md)
+- [semantic-pack-loading](semantic-pack-loading.md)
+- [semantic-kernel](semantic-kernel.md)

--- a/docs/semantic-pack-extension-api-v0.md
+++ b/docs/semantic-pack-extension-api-v0.md
@@ -1,22 +1,5 @@
 # Semantic pack extension API v0
 
-Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
-in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and remaining
-work are tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The
-internal evidence substrate is described in
-[evidence-records](evidence-records.md), and source-origin evidence is described
-in [source-facts](source-facts.md).
-
-Schema artifacts:
-
-- [semantic-pack-v0 schema](schemas/semantic-pack-v0.schema.json)
-- [language-pack example](examples/semantic-packs/v0/language-pack.json)
-- [library-pack example](examples/semantic-packs/v0/library-pack.json)
-- [law-pack example](examples/semantic-packs/v0/law-pack.json)
-- [Python stdlib type-domain pack example](examples/semantic-packs/v0/python-typing-domain-pack.json)
-- [semantic-pack-conformance](semantic-pack-conformance.md)
-- [semantic-pack-loading](semantic-pack-loading.md)
-
 Status: design v0 plus local metadata loading and a local conformance harness.
 nose can load local manifests for explicit opt-in provenance reporting, and pack
 authors can run `nose semantic-pack check` against manifests and declared fixture
@@ -506,3 +489,22 @@ This issue is complete when:
 - the docs state that external pack correctness is provider/user responsibility;
 - the docs state that first-party built-in semantics use the same extension
   vocabulary even if they remain compiled in initially.
+
+## See also
+
+Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
+in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and remaining
+work are tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md). The
+internal evidence substrate is described in
+[evidence-records](evidence-records.md), and source-origin evidence is described
+in [source-facts](source-facts.md).
+
+Schema artifacts:
+
+- [semantic-pack-v0 schema](schemas/semantic-pack-v0.schema.json)
+- [language-pack example](examples/semantic-packs/v0/language-pack.json)
+- [library-pack example](examples/semantic-packs/v0/library-pack.json)
+- [law-pack example](examples/semantic-packs/v0/law-pack.json)
+- [Python stdlib type-domain pack example](examples/semantic-packs/v0/python-typing-domain-pack.json)
+- [semantic-pack-conformance](semantic-pack-conformance.md)
+- [semantic-pack-loading](semantic-pack-loading.md)

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -1,9 +1,5 @@
 # Semantic pack loading
 
-Back to [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md),
-[semantic-pack-conformance](semantic-pack-conformance.md), and
-[semantic-kernel](semantic-kernel.md).
-
 Status: nose can load local semantic-pack v0 manifests for provenance and trust
 reporting, and it can run a separate local conformance check for manifests and
 declared fixture assets. External packs are explicit opt-ins and are currently
@@ -84,3 +80,9 @@ The loader validates manifest shape and pack provenance only. It does not yet:
 Future loader work should keep this boundary: external pack claims can become
 usable only through dependency-backed evidence records and fail-closed kernel
 contracts, never through raw selectors or manifest presence alone.
+
+## See also
+
+- [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md)
+- [semantic-pack-conformance](semantic-pack-conformance.md)
+- [semantic-kernel](semantic-kernel.md)

--- a/docs/source-facts.md
+++ b/docs/source-facts.md
@@ -1,12 +1,5 @@
 # Source facts and semantic evidence
 
-Back to [semantic-kernel](semantic-kernel.md). Current implementation status is
-recorded in [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and
-remaining work are tracked in
-[semantic-kernel-roadmap](semantic-kernel-roadmap.md). The shared internal record
-shape for all semantic evidence is described in
-[evidence-records](evidence-records.md).
-
 Source facts are the bridge between source syntax and semantic contracts. They
 preserve source-origin distinctions that the shared IL intentionally abstracts
 away, such as `new Set(...)` versus `Set(...)`, a JavaScript regex literal versus
@@ -181,3 +174,12 @@ claims exact eligibility for a source/API surface must declare:
 Meeting this shape is not nose certification. First-party default packs are
 validated by the nose project. External packs are provider/user responsibility
 and must be explicitly enabled by the user.
+
+## See also
+
+- [semantic-kernel](semantic-kernel.md)
+- Current implementation status is recorded in
+  [semantic-kernel-snapshot](semantic-kernel-snapshot.md); history and remaining
+  work are tracked in [semantic-kernel-roadmap](semantic-kernel-roadmap.md).
+- The shared internal record shape for all semantic evidence is described in
+  [evidence-records](evidence-records.md).


### PR DESCRIPTION
A wiki-wide audit (8 parallel readers checking every doc against `docs/design.md` and the source) plus the resulting fixes. Docs-only.

## What & why
- **Framing vs design.md §2/§2b.** README and `home.md` no longer describe nose as finding/ranking code *"worth refactoring"* — design.md is explicit that the worth-it judgment is the **consumer's** (their LLM), not nose's. README now leads with the soundness moat (*equal fingerprint ⟹ equal behavior*) and frames ranking as a **refactoring-value triage signal**; `home.md` matches.
- **Navigation anti-pattern.** 11 docs opened with a `Back to X` breadcrumb instead of a real introduction. Each now opens with its substantive intro; the breadcrumb + any leading cross-reference links are relocated **verbatim** to a trailing `## See also` (every link preserved). `awiki lint` is clean — graph still fully connected, 0 orphans.
- **Dangling cross-refs.** Fixed 6 section references in `experiments.md` (`§AA`/`§AB` → `§Z–AD`, `§BE`/`§BF` → `§BC–BF`) after those sections were consolidated. Historical content otherwise untouched.
- **`languages.md`.** Noted Vue/Svelte directive-shorthand + inline-`style=` canonicalization and the out-of-scope set (SCSS/Less, cross-file `var()`, Svelte block grammar) introduced in #413.

## Notes
- The audit found **zero code-doc drift and zero style inconsistencies** — the wiki was already well-maintained; this pass is framing + navigation.
- No source changed (docs-only), so build/test/clippy are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)