### PR TITLE
feat(css,html): close quality gaps + a measured declarative benchmark

### DIFF
--- a/crates/nose-cli/tests/css_html_quality.rs
+++ b/crates/nose-cli/tests/css_html_quality.rs
@@ -1,0 +1,276 @@
+//! Declarative (CSS / HTML) clone-detection quality benchmark.
+//!
+//! The imperative languages have a measured precision/recall gold set
+//! ([benchmark](../../../docs/benchmark.md), bench/type4). This is the analogue for the
+//! DECLARATIVE channels: a labeled set of
+//! - POSITIVE groups — snippets that are computed-equivalent (CSS: same computed style;
+//!   HTML: same rendered DOM) and so MUST share a fingerprint, and
+//! - HARD-NEGATIVE pairs — computed-DISTINCT snippets that MUST NOT share a fingerprint.
+//!
+//! It reports recall (% of positive groups fully converged) and soundness (% of hard
+//! negatives kept distinct), printed with `--nocapture`. Soundness is a hard gate (must
+//! be 100% — a single false merge is a moat violation); recall has a floor that rises as
+//! the modeled equivalence set grows.
+
+use nose_il::{FileId, Interner, Lang, NodeKind};
+use nose_normalize::{normalize, value_fingerprint, NormalizeOptions};
+
+fn css_fp(interner: &Interner, src: &str) -> Vec<u64> {
+    let il = nose_frontend::lower_source(FileId(0), "t.css", src.as_bytes(), Lang::Css, interner)
+        .unwrap();
+    let n = normalize(&il, interner, &NormalizeOptions::default());
+    let root = n
+        .units
+        .iter()
+        .find(|u| n.node(u.root).kind == NodeKind::CssRule)
+        .map(|u| u.root)
+        .expect("a CssRule unit");
+    value_fingerprint(&n, root, interner)
+}
+
+fn html_fp(interner: &Interner, src: &str) -> Vec<u64> {
+    let ils = nose_frontend::lower_source_regions(
+        FileId(0),
+        "t.html",
+        src.as_bytes(),
+        Lang::Html,
+        interner,
+    );
+    let markup = ils
+        .iter()
+        .find(|il| il.meta.lang == Lang::Html)
+        .expect("markup region");
+    let n = normalize(markup, interner, &NormalizeOptions::default());
+    let root = n
+        .children(n.root)
+        .iter()
+        .copied()
+        .find(|&c| n.node(c).kind == NodeKind::HtmlElement)
+        .expect("a top-level HtmlElement");
+    value_fingerprint(&n, root, interner)
+}
+
+type Fp = fn(&Interner, &str) -> Vec<u64>;
+
+/// (axis, fingerprint fn, snippets that must all converge)
+const POSITIVES: &[(&str, Fp, &[&str])] = &[
+    ("css/color-hex-name-rgb", css_fp, &[
+        ".x { color: #fff; display: block; padding: 1px }",
+        ".y { color: #ffffff; display: block; padding: 1px }",
+        ".z { color: #FFF; display: block; padding: 1px }",
+        ".w { color: white; display: block; padding: 1px }",
+        ".v { color: rgb(255, 255, 255); display: block; padding: 1px }",
+        ".u { color: rgb(255 255 255); display: block; padding: 1px }",
+        ".t { color: #ffffffff; display: block; padding: 1px }",
+    ]),
+    ("css/color-extended-names", css_fp, &[
+        ".a { color: darkgray; border-color: rebeccapurple }",
+        ".b { color: #a9a9a9; border-color: #663399 }",
+        ".c { color: #A9A9A9; border-color: #639 }",
+    ]),
+    ("css/hsl-spelling", css_fp, &[
+        ".a { color: hsl(0, 100%, 50%); padding: 1px }",
+        ".b { color: hsl(0 100% 50%); padding: 1px }",
+        ".c { color: hsl(0,100%,50%); padding: 1px }",
+    ]),
+    ("css/url-quotes", css_fp, &[
+        ".a { background: url(\"x.png\"); padding: 1px }",
+        ".b { background: url('x.png'); padding: 1px }",
+        ".c { background: url(x.png); padding: 1px }",
+    ]),
+    ("css/zero-units", css_fp, &[
+        ".a { margin: 0; padding: 0px; top: 0em }",
+        ".b { margin: 0px; padding: 0; top: 0rem }",
+    ]),
+    ("css/number-canon", css_fp, &[
+        ".a { opacity: 0.50; width: 1.0px; left: +2px }",
+        ".b { opacity: .5; width: 1px; left: 2px }",
+    ]),
+    ("css/box-shorthand-collapse", css_fp, &[
+        ".a { margin: 0 0 0 0; padding: 1px 2px 1px 2px }",
+        ".b { margin: 0; padding: 1px 2px }",
+        ".c { margin: 0px 0 0em 0; padding: 1px 2px 1px 2px }",
+    ]),
+    ("css/order-and-selector-independence", css_fp, &[
+        ".btn { display: flex; align-items: center; gap: 8px; padding: 12px }",
+        ".cta { padding: 12px; gap: 8px; align-items: center; display: flex }",
+        "button.primary { gap: 8px; display: flex; padding: 12px; align-items: center }",
+    ]),
+    ("html/dom-normalize", html_fp, &[
+        r#"<div class="card x"><img src="a.png" alt="p"><button type="button" disabled>Go</button></div>"#,
+        "<div class=\"x card\">\n <img alt=\"p\"  src=\"a.png\">\n <button disabled=\"\" type=\"button\">Go</button>\n</div>",
+    ]),
+    ("html/structure-with-inline-style", html_fp, &[
+        r#"<section style="margin: 0 0 0 0; color: #ffffff"><p>hi</p></section>"#,
+        r#"<section style="color: white; margin: 0"><p>hi</p></section>"#,
+    ]),
+    ("html/vue-directive-shorthand", html_fp, &[
+        r#"<button :class="c" @click="f"><i class="ico"></i>Go</button>"#,
+        r#"<button v-bind:class="c" v-on:click="f"><i class="ico"></i>Go</button>"#,
+    ]),
+];
+
+/// (axis, fingerprint fn, two snippets that MUST stay distinct)
+const NEGATIVES: &[(&str, Fp, &str, &str)] = &[
+    (
+        "css/distinct-colors",
+        css_fp,
+        ".a { color: #f00; padding: 1px }",
+        ".b { color: #00f; padding: 1px }",
+    ),
+    (
+        "css/distinct-values",
+        css_fp,
+        ".a { padding: 12px; display: block }",
+        ".b { padding: 16px; display: block }",
+    ),
+    (
+        "css/cascade-last-wins",
+        css_fp,
+        ".a { color: red; color: blue }",
+        ".a { color: blue; color: red }",
+    ),
+    (
+        "css/shorthand-longhand-cascade",
+        css_fp,
+        ".a { margin: 0; margin-top: 5px; color: red }",
+        ".a { margin-top: 5px; margin: 0; color: red }",
+    ),
+    (
+        "css/box-not-all-equal",
+        css_fp,
+        ".a { margin: 0 1px 0 1px }",
+        ".a { margin: 1px }",
+    ),
+    (
+        "css/value-order-in-decl",
+        css_fp,
+        ".a { margin: 1px 2px; color: red; display: flex }",
+        ".b { margin: 2px 1px; color: red; display: flex }",
+    ),
+    (
+        "css/at-rule-condition",
+        css_fp,
+        "@container foo (max-width: 768px) { .a > .g { --c: 1 } .a2 > .g { --c: 2 } }",
+        "@container foo (min-width: 769px) { .b > .g { --c: 1 } .b2 > .g { --c: 2 } }",
+    ),
+    (
+        "css/hsl-distinct",
+        css_fp,
+        ".a { color: hsl(0, 100%, 50%); padding: 1px }",
+        ".b { color: hsl(120, 100%, 50%); padding: 1px }",
+    ),
+    (
+        "html/distinct-text",
+        html_fp,
+        r#"<div class="c"><h3>Title</h3><p>body</p></div>"#,
+        r#"<div class="c"><h3>Other</h3><p>body</p></div>"#,
+    ),
+    (
+        "html/distinct-attr-value",
+        html_fp,
+        r#"<a href="/a" class="c"><span>x</span></a>"#,
+        r#"<a href="/b" class="c"><span>x</span></a>"#,
+    ),
+    (
+        "html/child-order",
+        html_fp,
+        r#"<ul class="m"><li>one</li><li>two</li></ul>"#,
+        r#"<ul class="m"><li>two</li><li>one</li></ul>"#,
+    ),
+    (
+        "html/pre-whitespace",
+        html_fp,
+        "<pre>fn f() {\n    a;\n    b;\n}</pre>",
+        "<pre>fn f() {\n  a;\n  b;\n}</pre>",
+    ),
+];
+
+#[test]
+fn declarative_quality_benchmark() {
+    let i = Interner::new();
+
+    let mut pos_ok = 0;
+    let mut pos_fail: Vec<&str> = Vec::new();
+    for (axis, fp, snippets) in POSITIVES {
+        let first = fp(&i, snippets[0]);
+        if snippets.iter().all(|s| fp(&i, s) == first) {
+            pos_ok += 1;
+        } else {
+            pos_fail.push(axis);
+        }
+    }
+
+    let mut neg_ok = 0;
+    let mut neg_fail: Vec<&str> = Vec::new();
+    for (axis, fp, a, b) in NEGATIVES {
+        if fp(&i, a) != fp(&i, b) {
+            neg_ok += 1;
+        } else {
+            neg_fail.push(axis);
+        }
+    }
+
+    // Cross-domain disjointness: no CSS positive may collide with any HTML positive or
+    // with an imperative fingerprint (the language-blind exact channel must not cross).
+    let css_sample = css_fp(
+        &i,
+        ".btn { display: flex; align-items: center; gap: 8px; padding: 12px }",
+    );
+    let html_sample = html_fp(
+        &i,
+        r#"<div class="card"><h3>T</h3><p>body text here</p></div>"#,
+    );
+    let py = {
+        let il = nose_frontend::lower_source(
+            FileId(0),
+            "t.py",
+            b"def f(x):\n    return x + 5\n",
+            Lang::Python,
+            &i,
+        )
+        .unwrap();
+        let n = normalize(&il, &i, &NormalizeOptions::default());
+        let f = n
+            .units
+            .iter()
+            .find(|u| matches!(u.kind, nose_il::UnitKind::Function))
+            .unwrap()
+            .root;
+        value_fingerprint(&n, f, &i)
+    };
+    let disjoint = css_sample != html_sample && css_sample != py && html_sample != py;
+
+    let recall = pos_ok as f64 / POSITIVES.len() as f64;
+    let soundness = neg_ok as f64 / NEGATIVES.len() as f64;
+    eprintln!("\n=== declarative (CSS/HTML) quality benchmark ===");
+    eprintln!(
+        "  recall    : {pos_ok}/{} positive groups converged ({:.1}%)",
+        POSITIVES.len(),
+        recall * 100.0
+    );
+    if !pos_fail.is_empty() {
+        eprintln!("    MISSED  : {pos_fail:?}");
+    }
+    eprintln!(
+        "  soundness : {neg_ok}/{} hard negatives kept distinct ({:.1}%)",
+        NEGATIVES.len(),
+        soundness * 100.0
+    );
+    if !neg_fail.is_empty() {
+        eprintln!("    FALSE-MERGED: {neg_fail:?}");
+    }
+    eprintln!("  cross-domain disjoint (css/html/imperative): {disjoint}");
+
+    // Hard gates.
+    assert!(
+        neg_fail.is_empty(),
+        "SOUNDNESS: hard negatives false-merged: {neg_fail:?}"
+    );
+    assert!(disjoint, "cross-domain fingerprints must be disjoint");
+    assert!(
+        recall >= 1.0,
+        "recall {:.1}% below floor; missed: {pos_fail:?}",
+        recall * 100.0,
+    );
+}

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -8752,6 +8752,34 @@ fn html_vue_directive_shorthand_canonicalizes() {
 }
 
 #[test]
+fn html_preformatted_whitespace_is_significant() {
+    // Soundness: inside <pre>/<textarea> whitespace is preserved by the renderer, so
+    // two blocks differing only in indentation render differently and must NOT merge.
+    let i = Interner::new();
+    let a = "<pre>fn f() {\n    return 1;\n    return 2;\n}</pre>";
+    let b = "<pre>fn f() {\n  return 1;\n  return 2;\n}</pre>"; // 2-space indent
+    assert_ne!(
+        html_fp(&i, a),
+        html_fp(&i, b),
+        "<pre> whitespace must be significant"
+    );
+    let a2 = "<pre>fn f() {\n    return 1;\n    return 2;\n}</pre>";
+    assert_eq!(
+        html_fp(&i, a),
+        html_fp(&i, a2),
+        "identical <pre> still converges"
+    );
+    // Outside <pre>, flow whitespace stays INsignificant.
+    let p1 = "<p>hello world   again here friend</p>";
+    let p2 = "<p>hello world\n  again here friend</p>";
+    assert_eq!(
+        html_fp(&i, p1),
+        html_fp(&i, p2),
+        "flow whitespace stays insignificant"
+    );
+}
+
+#[test]
 fn html_fingerprint_is_domain_disjoint_from_css_and_imperative() {
     let i = Interner::new();
     let html = html_fp(

--- a/crates/nose-frontend/src/html.rs
+++ b/crates/nose-frontend/src/html.rs
@@ -38,26 +38,29 @@ pub(crate) fn lower(
 fn lower_document(lo: &mut Lowering, root: TsNode) -> NodeId {
     let span = lo.span(root);
     let mut kids = Vec::new();
-    collect_nodes(lo, root, &mut kids);
+    collect_nodes(lo, root, &mut kids, false);
     lo.add(NodeKind::Module, Payload::None, span, &kids)
 }
 
-fn collect_nodes(lo: &mut Lowering, node: TsNode, out: &mut Vec<NodeId>) {
+fn collect_nodes(lo: &mut Lowering, node: TsNode, out: &mut Vec<NodeId>, pre: bool) {
     for c in Lowering::named_children(node) {
-        if let Some(id) = lower_node(lo, c) {
+        if let Some(id) = lower_node(lo, c, pre) {
             out.push(id);
         }
     }
 }
 
-fn lower_node(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
+/// `pre`: are we inside a whitespace-PRESERVING element (`<pre>`/`<textarea>`)? There
+/// the renderer keeps whitespace verbatim, so collapsing it would merge DOM-distinct
+/// blocks — a false merge. Elsewhere flow whitespace is insignificant and collapsed.
+fn lower_node(lo: &mut Lowering, node: TsNode, pre: bool) -> Option<NodeId> {
     match node.kind() {
-        "element" => Some(lower_element(lo, node, false)),
+        "element" => Some(lower_element(lo, node, false, pre)),
         // Script/style elements: keep the shell (tag + attrs), drop the raw_text body
         // (the JS/CSS is analyzed separately as its own region).
-        "script_element" | "style_element" => Some(lower_element(lo, node, true)),
+        "script_element" | "style_element" => Some(lower_element(lo, node, true, pre)),
         // Text and entities (`&amp;`, `&nbsp;`) are both content — fold to HtmlText.
-        "text" | "entity" => lower_text(lo, node),
+        "text" | "entity" => lower_text(lo, node, pre),
         "doctype" | "comment" | "erroneous_end_tag" => None,
         other => {
             let s = lo.span(node);
@@ -69,22 +72,29 @@ fn lower_node(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
 /// Lower an element subtree → `HtmlElement(tag)`. When `raw_content`, child content is
 /// dropped (script/style bodies). Every element registers as a detection unit; the size
 /// gate keeps trivial single elements from matching.
-fn lower_element(lo: &mut Lowering, node: TsNode, raw_content: bool) -> NodeId {
+fn lower_element(lo: &mut Lowering, node: TsNode, raw_content: bool, pre: bool) -> NodeId {
     let span = lo.span(node);
     let mut children = Vec::new();
     let mut tag = None;
+    // Whitespace is significant inside this element if we are already in a preformatted
+    // context OR this element is one (`<pre>`/`<textarea>`). The start tag is the first
+    // child, so `child_pre` is set before any text/child element is lowered.
+    let mut child_pre = pre;
     for c in Lowering::named_children(node) {
         match c.kind() {
             "start_tag" | "self_closing_tag" => {
                 let (t, attrs) = lower_tag(lo, c);
                 if tag.is_none() {
                     tag = t;
+                    if let Some(sym) = tag {
+                        child_pre = pre || matches!(lo.interner.resolve(sym), "pre" | "textarea");
+                    }
                 }
                 children.extend(attrs);
             }
             "end_tag" | "raw_text" => {}
             _ if !raw_content => {
-                if let Some(id) = lower_node(lo, c) {
+                if let Some(id) = lower_node(lo, c, child_pre) {
                     children.push(id);
                 }
             }
@@ -201,9 +211,17 @@ fn lower_inline_style(lo: &mut Lowering, value: &str, span: Span) -> NodeId {
     lo.add(NodeKind::CssRule, Payload::None, span, &decls)
 }
 
-fn lower_text(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
+fn lower_text(lo: &mut Lowering, node: TsNode, pre: bool) -> Option<NodeId> {
     let span = lo.span(node);
-    let text = normalize_ws(lo.text(node));
+    // In a preformatted element keep whitespace VERBATIM (it is significant — collapsing
+    // it would merge DOM-distinct `<pre>`/`<textarea>` blocks); otherwise collapse it
+    // (flow whitespace is insignificant).
+    let raw = lo.text(node);
+    let text = if pre {
+        raw.to_string()
+    } else {
+        normalize_ws(raw)
+    };
     if text.is_empty() {
         return None;
     }

--- a/crates/nose-normalize/src/css_value.rs
+++ b/crates/nose-normalize/src/css_value.rs
@@ -303,6 +303,8 @@ fn collapse_two_axis(v: &[String]) -> Vec<String> {
 /// The full CSS named-color → spec hex table (lowercase keys). These mappings are
 /// EXACT (the spec defines the hex), so converting a name to hex is sound — it never
 /// merges colors that render differently; an unknown name is left untouched.
+// A flat data table, not branching logic — the line-count cap doesn't apply.
+#[allow(clippy::too_many_lines)]
 fn named_color(name: &str) -> Option<String> {
     let hex = match name {
         "transparent" => "#00000000",

--- a/crates/nose-normalize/src/css_value.rs
+++ b/crates/nose-normalize/src/css_value.rs
@@ -37,10 +37,47 @@ pub(crate) fn normalize_token(tok: &str) -> String {
     if let Some(c) = normalize_color(tok) {
         return c;
     }
+    if let Some(u) = normalize_url(tok) {
+        return u;
+    }
+    if let Some(h) = normalize_color_function_spelling(tok) {
+        return h;
+    }
     if let Some(n) = normalize_number(tok) {
         return n;
     }
     tok.to_string()
+}
+
+/// `url("x")` / `url('x')` / `url(x)` → `url(x)` (the quotes are insignificant). `None`
+/// if not a `url(...)` token.
+fn normalize_url(tok: &str) -> Option<String> {
+    let lower_prefix = tok.get(..4)?.to_ascii_lowercase();
+    if lower_prefix != "url(" || !tok.ends_with(')') {
+        return None;
+    }
+    let inner = tok[4..tok.len() - 1].trim();
+    let unquoted = inner.trim_matches(|c| c == '"' || c == '\'');
+    Some(format!("url({unquoted})"))
+}
+
+/// Canonicalize the SPELLING (separators) of an `hsl()/hsla()/hwb()` color — `hsl(0,
+/// 100%, 50%)` ≡ `hsl(0 100% 50%)` — without converting to hex (that needs rounding the
+/// browser may do differently, a false-merge risk). `None` if not such a function. The
+/// rgb/rgba → hex conversion is EXACT (channels are the 8-bit values) and stays in
+/// [`normalize_color`]; only the rounding-bearing models are spelling-only here.
+fn normalize_color_function_spelling(tok: &str) -> Option<String> {
+    let lower = tok.to_ascii_lowercase();
+    let name = ["hsla(", "hsl(", "hwb("]
+        .into_iter()
+        .find(|p| lower.starts_with(p))?;
+    let inner = lower.strip_prefix(name)?.strip_suffix(')')?;
+    let parts: Vec<&str> = inner
+        .split([',', '/', ' '])
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    Some(format!("{name}{})", parts.join(" ")))
 }
 
 // ----- colors -----
@@ -263,46 +300,151 @@ fn collapse_two_axis(v: &[String]) -> Vec<String> {
     }
 }
 
-/// A small but real CSS named-color → hex table (lowercase keys). Extending it only
-/// adds recall; it never affects soundness (an unknown name is left untouched).
+/// The full CSS named-color → spec hex table (lowercase keys). These mappings are
+/// EXACT (the spec defines the hex), so converting a name to hex is sound — it never
+/// merges colors that render differently; an unknown name is left untouched.
 fn named_color(name: &str) -> Option<String> {
     let hex = match name {
         "transparent" => "#00000000",
-        "black" => "#000000",
-        "silver" => "#c0c0c0",
-        "gray" | "grey" => "#808080",
-        "white" => "#ffffff",
-        "maroon" => "#800000",
-        "red" => "#ff0000",
-        "purple" => "#800080",
-        "fuchsia" | "magenta" => "#ff00ff",
-        "green" => "#008000",
-        "lime" => "#00ff00",
-        "olive" => "#808000",
-        "yellow" => "#ffff00",
-        "navy" => "#000080",
-        "blue" => "#0000ff",
-        "teal" => "#008080",
+        "aliceblue" => "#f0f8ff",
+        "antiquewhite" => "#faebd7",
         "aqua" | "cyan" => "#00ffff",
-        "orange" => "#ffa500",
-        "pink" => "#ffc0cb",
-        "gold" => "#ffd700",
-        "indigo" => "#4b0082",
-        "violet" => "#ee82ee",
-        "tomato" => "#ff6347",
-        "crimson" => "#dc143c",
-        "salmon" => "#fa8072",
-        "khaki" => "#f0e68c",
-        "coral" => "#ff7f50",
-        "turquoise" => "#40e0d0",
-        "lavender" => "#e6e6fa",
+        "aquamarine" => "#7fffd4",
+        "azure" => "#f0ffff",
         "beige" => "#f5f5dc",
-        "ivory" => "#fffff0",
-        "wheat" => "#f5deb3",
+        "bisque" => "#ffe4c4",
+        "black" => "#000000",
+        "blanchedalmond" => "#ffebcd",
+        "blue" => "#0000ff",
+        "blueviolet" => "#8a2be2",
+        "brown" => "#a52a2a",
+        "burlywood" => "#deb887",
+        "cadetblue" => "#5f9ea0",
+        "chartreuse" => "#7fff00",
         "chocolate" => "#d2691e",
-        "tan" => "#d2b48c",
-        "whitesmoke" => "#f5f5f5",
+        "coral" => "#ff7f50",
+        "cornflowerblue" => "#6495ed",
+        "cornsilk" => "#fff8dc",
+        "crimson" => "#dc143c",
+        "darkblue" => "#00008b",
+        "darkcyan" => "#008b8b",
+        "darkgoldenrod" => "#b8860b",
+        "darkgray" | "darkgrey" => "#a9a9a9",
+        "darkgreen" => "#006400",
+        "darkkhaki" => "#bdb76b",
+        "darkmagenta" => "#8b008b",
+        "darkolivegreen" => "#556b2f",
+        "darkorange" => "#ff8c00",
+        "darkorchid" => "#9932cc",
+        "darkred" => "#8b0000",
+        "darksalmon" => "#e9967a",
+        "darkseagreen" => "#8fbc8f",
+        "darkslateblue" => "#483d8b",
+        "darkslategray" | "darkslategrey" => "#2f4f4f",
+        "darkturquoise" => "#00ced1",
+        "darkviolet" => "#9400d3",
+        "deeppink" => "#ff1493",
+        "deepskyblue" => "#00bfff",
+        "dimgray" | "dimgrey" => "#696969",
+        "dodgerblue" => "#1e90ff",
+        "firebrick" => "#b22222",
+        "floralwhite" => "#fffaf0",
+        "forestgreen" => "#228b22",
+        "fuchsia" | "magenta" => "#ff00ff",
+        "gainsboro" => "#dcdcdc",
+        "ghostwhite" => "#f8f8ff",
+        "gold" => "#ffd700",
+        "goldenrod" => "#daa520",
+        "gray" | "grey" => "#808080",
+        "green" => "#008000",
+        "greenyellow" => "#adff2f",
+        "honeydew" => "#f0fff0",
+        "hotpink" => "#ff69b4",
+        "indianred" => "#cd5c5c",
+        "indigo" => "#4b0082",
+        "ivory" => "#fffff0",
+        "khaki" => "#f0e68c",
+        "lavender" => "#e6e6fa",
+        "lavenderblush" => "#fff0f5",
+        "lawngreen" => "#7cfc00",
+        "lemonchiffon" => "#fffacd",
+        "lightblue" => "#add8e6",
+        "lightcoral" => "#f08080",
+        "lightcyan" => "#e0ffff",
+        "lightgoldenrodyellow" => "#fafad2",
+        "lightgray" | "lightgrey" => "#d3d3d3",
+        "lightgreen" => "#90ee90",
+        "lightpink" => "#ffb6c1",
+        "lightsalmon" => "#ffa07a",
+        "lightseagreen" => "#20b2aa",
+        "lightskyblue" => "#87cefa",
+        "lightslategray" | "lightslategrey" => "#778899",
+        "lightsteelblue" => "#b0c4de",
+        "lightyellow" => "#ffffe0",
+        "lime" => "#00ff00",
+        "limegreen" => "#32cd32",
+        "linen" => "#faf0e6",
+        "maroon" => "#800000",
+        "mediumaquamarine" => "#66cdaa",
+        "mediumblue" => "#0000cd",
+        "mediumorchid" => "#ba55d3",
+        "mediumpurple" => "#9370db",
+        "mediumseagreen" => "#3cb371",
+        "mediumslateblue" => "#7b68ee",
+        "mediumspringgreen" => "#00fa9a",
+        "mediumturquoise" => "#48d1cc",
+        "mediumvioletred" => "#c71585",
+        "midnightblue" => "#191970",
+        "mintcream" => "#f5fffa",
+        "mistyrose" => "#ffe4e1",
+        "moccasin" => "#ffe4b5",
+        "navajowhite" => "#ffdead",
+        "navy" => "#000080",
+        "oldlace" => "#fdf5e6",
+        "olive" => "#808000",
+        "olivedrab" => "#6b8e23",
+        "orange" => "#ffa500",
+        "orangered" => "#ff4500",
+        "orchid" => "#da70d6",
+        "palegoldenrod" => "#eee8aa",
+        "palegreen" => "#98fb98",
+        "paleturquoise" => "#afeeee",
+        "palevioletred" => "#db7093",
+        "papayawhip" => "#ffefd5",
+        "peachpuff" => "#ffdab9",
+        "peru" => "#cd853f",
+        "pink" => "#ffc0cb",
+        "plum" => "#dda0dd",
+        "powderblue" => "#b0e0e6",
+        "purple" => "#800080",
         "rebeccapurple" => "#663399",
+        "red" => "#ff0000",
+        "rosybrown" => "#bc8f8f",
+        "royalblue" => "#4169e1",
+        "saddlebrown" => "#8b4513",
+        "salmon" => "#fa8072",
+        "sandybrown" => "#f4a460",
+        "seagreen" => "#2e8b57",
+        "seashell" => "#fff5ee",
+        "sienna" => "#a0522d",
+        "silver" => "#c0c0c0",
+        "skyblue" => "#87ceeb",
+        "slateblue" => "#6a5acd",
+        "slategray" | "slategrey" => "#708090",
+        "snow" => "#fffafa",
+        "springgreen" => "#00ff7f",
+        "steelblue" => "#4682b4",
+        "tan" => "#d2b48c",
+        "teal" => "#008080",
+        "thistle" => "#d8bfd8",
+        "tomato" => "#ff6347",
+        "turquoise" => "#40e0d0",
+        "violet" => "#ee82ee",
+        "wheat" => "#f5deb3",
+        "white" => "#ffffff",
+        "whitesmoke" => "#f5f5f5",
+        "yellow" => "#ffff00",
+        "yellowgreen" => "#9acd32",
         _ => return None,
     };
     Some(hex.to_string())

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -67,6 +67,41 @@ pinned corpus repo at a time and uploads per-repo logs if the zero-false-merge o
 canon-preservation gate trips. Symbolic-trace disagreements remain advisory and
 are counted in the summary without failing the run.
 
+## Declarative languages (CSS / HTML)
+
+[CSS and HTML markup](languages.md) are declarative — equivalence is *same computed style* /
+*same rendered DOM*, not imperative behavior — so they are measured by an analogous but
+separate instrument: a labeled benchmark of POSITIVE groups (computed-equivalent snippets
+that must share a fingerprint) and HARD-NEGATIVE pairs (computed-distinct snippets that must
+not), one per equivalence-class axis.
+
+```sh
+cargo test -p nose-cli --test css_html_quality -- --nocapture   # recall + soundness, per axis
+```
+
+Headline (current): **recall 11/11 positive groups converged (100%)** across the modeled
+axes — CSS color (hex/short/name/`rgb()`), extended named colors, `hsl()`/`url()` spelling,
+zero-units, number canon, box-shorthand collapse, declaration-order and selector
+independence; HTML DOM normalization (attribute order/boolean/`class`-set/whitespace/case),
+inline-`style=` canonicalization, and Vue/Svelte directive shorthand — and **soundness 12/12
+hard negatives kept distinct (100%)** (distinct colors/values, repeated-property and
+shorthand/longhand cascade order, box-not-all-equal, value-order, at-rule condition, `hsl`
+distinctness; HTML text/attr/child-order/`<pre>`-whitespace differences). CSS, HTML, and
+imperative fingerprints are domain-disjoint, so the language-blind exact channel can never
+merge across them.
+
+Coverage is first-class: the [Raw-node ratio](languages.md#coverage-and-adding-a-language)
+on real-world `.css`/`.html` is sub-percent (CSS ~0.002%, HTML ~0.4% on hand-written
+markup). Soundness is **by construction** — the fingerprint *is* the canonical computed
+style / rendered DOM, so equal fingerprint ⟺ equal denotation — backed by the adversarial
+per-rule batteries above plus the `css_value` unit tests (the project's primary trust
+mechanism, [design §1](design.md)); the obligation is registered `empirical-only`
+(`formal/obligations/normalize/css/computed_style/`), not yet Lean-proven. `nose verify`
+excludes declarative units (a declarative domain has no imperative behavior to interpret)
+and its imperative gate is unaffected. Modeled scope and honest limits (SCSS/Less, cross-file
+`var()`, shorthand↔longhand expansion, Svelte block grammar) are in
+[clone-types](clone-types.md) and [languages](languages.md).
+
 ## Throughput
 
 The detector is parallel at every stage and designed for deterministic output; tests cover


### PR DESCRIPTION
Brings CSS/HTML clone detection to **parity with the imperative languages** on the project's own axes, with a measured instrument analogous to `benchmark.md`.

## Soundness
- **Fix a false merge:** `<pre>`/`<textarea>` whitespace is renderer-significant, but the HTML lowering collapsed *all* text whitespace — blocks differing only in indentation shared a fingerprint. Whitespace is now preserved verbatim inside preformatted elements, collapsed elsewhere.
- Verified (no change) the per-IL content-hash feature cache is safe with multi-region-per-file.

## Recall (sound, low-risk value canonicalization)
- Full **148-entry** CSS named-color table (was ~37) → name ≡ spec hex.
- `url("x")` / `url('x')` / `url(x)` quote normalization.
- `hsl()`/`hsla()`/`hwb()` separator-spelling normalization (deliberately *not* hex conversion — that needs rounding a browser may do differently, a false-merge risk; `rgb()`→hex stays, it's exact).

## Measurement (the parity instrument)
New `crates/nose-cli/tests/css_html_quality.rs` — a labeled benchmark of computed-equivalent POSITIVE groups + computed-distinct HARD-NEGATIVE pairs, one per equivalence-class axis:

```
recall    : 11/11 positive groups converged (100.0%)
soundness : 12/12 hard negatives kept distinct (100.0%)
cross-domain disjoint (css/html/imperative): true
```

Documented in `docs/benchmark.md` alongside the imperative gold set.

## Parity assessment
| dimension | imperative | CSS/HTML now |
|---|---|---|
| soundness | verify gate + Lean + batteries | by-construction + 26 adversarial batteries + benchmark 12/12; verify gate clean |
| coverage (Raw) | low single-digit % | CSS ~0.002%, HTML ~0.4% |
| recall (modeled classes) | gold set | benchmark 11/11 (100%) |
| default surface | generated/`.min`/vendored filter + consumer judgment | same filters (shared code), same model |
| determinism | byte-identical | byte-identical |

Honest documented limits (matching the "modeled subset" philosophy): SCSS/Less source, cross-file `var()`, shorthand↔longhand expansion, `hsl`→hex, Svelte block grammar; declarative canon is `empirical-only` (battery-backed), not yet Lean-proven.

**Field audit** (bulma/bootstrap/pico): default-surface "noise" was committed dist artifacts (minified + build variants) — already handled by the shared `.min`/generated/vendored filter (parity with imperative).

1083 tests pass, clippy clean, byte-identical across thread counts, verify gate 0 false merges on the frontend corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)