### PR TITLE
feat(css): canonicalize at-rule preludes (media/supports/container queries)

### DIFF
--- a/crates/nose-cli/tests/css_html_quality.rs
+++ b/crates/nose-cli/tests/css_html_quality.rs
@@ -96,6 +96,16 @@ const POSITIVES: &[(&str, Fp, &[&str])] = &[
         ".cta { padding: 12px; gap: 8px; align-items: center; display: flex }",
         "button.primary { gap: 8px; display: flex; padding: 12px; align-items: center }",
     ]),
+    ("css/media-query-canon", css_fp, &[
+        "@media screen and (max-width: 600px) { .a { color: red; padding: 1px } }",
+        "@media screen and (max-width:600px) { .b { color: red; padding: 1px } }",
+        "@media (max-width: 600px) and screen { .c { color: red; padding: 1px } }",
+        "@media ( max-width : 600px ) and screen { .d { color: red; padding: 1px } }",
+    ]),
+    ("css/media-query-value-canon", css_fp, &[
+        "@media (min-width: 0px) { .a { color: red; padding: 1px } }",
+        "@media (min-width: 0) { .b { color: red; padding: 1px } }",
+    ]),
     ("html/dom-normalize", html_fp, &[
         r#"<div class="card x"><img src="a.png" alt="p"><button type="button" disabled>Go</button></div>"#,
         "<div class=\"x card\">\n <img alt=\"p\"  src=\"a.png\">\n <button disabled=\"\" type=\"button\">Go</button>\n</div>",
@@ -159,6 +169,20 @@ const NEGATIVES: &[(&str, Fp, &str, &str)] = &[
         css_fp,
         ".a { color: hsl(0, 100%, 50%); padding: 1px }",
         ".b { color: hsl(120, 100%, 50%); padding: 1px }",
+    ),
+    (
+        // @media (X) and @supports (X) share a condition string but mean different
+        // things — must not merge (the at-rule type prefix keeps them apart).
+        "css/media-vs-supports",
+        css_fp,
+        "@media (min-width: 600px) { .a { color: red; padding: 1px } }",
+        "@supports (min-width: 600px) { .b { color: red; padding: 1px } }",
+    ),
+    (
+        "css/media-distinct-condition",
+        css_fp,
+        "@media (max-width: 600px) { .a { color: red; padding: 1px } }",
+        "@media (max-width: 900px) { .b { color: red; padding: 1px } }",
     ),
     (
         "html/distinct-text",

--- a/crates/nose-frontend/src/css.rs
+++ b/crates/nose-frontend/src/css.rs
@@ -194,6 +194,18 @@ fn lower_at_rule(lo: &mut Lowering, node: TsNode, out: &mut Vec<NodeId>, registe
     // keyword — `@container foo (max-width: 768px)` and `@container foo (min-width:
     // 769px)` are different CONDITIONS and must not merge. Capturing only the first
     // child (`@container`) was a false merge surfaced on the bulma corpus.
+    // Prefix the at-rule TYPE so the prelude always starts with `@<type>`: (1) it
+    // distinguishes a `@media (X)` context from a `@supports (X)` / `@container (X)` one
+    // — `media_statement`/`supports_statement` drop their keyword in the grammar, so
+    // without this their identical condition text would false-merge; and (2) it lets the
+    // fingerprint tell an at-rule prelude (canonicalizable as a query) from a CSS-nesting
+    // parent selector (case-sensitive, must stay raw — a selector never starts with `@`).
+    let at_type = match node.kind() {
+        "media_statement" => "@media ",
+        "supports_statement" => "@supports ",
+        "keyframes_statement" => "@keyframes ",
+        _ => "", // generic `at_rule` already carries its own `@keyword`
+    };
     let mut prelude_parts: Vec<String> = Vec::new();
     for c in Lowering::named_children(node) {
         match c.kind() {
@@ -204,7 +216,8 @@ fn lower_at_rule(lo: &mut Lowering, node: TsNode, out: &mut Vec<NodeId>, registe
     if inner.is_empty() {
         return;
     }
-    let prelude = (!prelude_parts.is_empty()).then(|| lo.sym(&prelude_parts.join(" ")));
+    let prelude_text = format!("{at_type}{}", prelude_parts.join(" "));
+    let prelude = (!prelude_text.trim().is_empty()).then(|| lo.sym(prelude_text.trim()));
     let mut children = Vec::new();
     if let Some(sym) = prelude {
         children.push(lo.add(NodeKind::CssSelector, Payload::Name(sym), span, &[]));

--- a/crates/nose-normalize/src/css.rs
+++ b/crates/nose-normalize/src/css.rs
@@ -135,9 +135,13 @@ fn collect_rule(
             }
             NodeKind::CssSelector if has_nested => {
                 // At-rule prelude / nesting context — keep it so a `@media`-scoped rule
-                // does not merge with an unconditional one.
+                // does not merge with an unconditional one. An at-rule prelude (`@…`) is
+                // canonicalized as a query (whitespace/value/and-order) so equivalent
+                // media/supports/container conditions converge; a nesting parent selector
+                // (non-`@`) is left raw (case-sensitive). See `css_value`.
                 if let Payload::Name(s) = il.node(c).payload {
-                    let ch = tagged(TAG_CTX, stable_symbol_hash(interner.resolve(s)));
+                    let canon = crate::css_value::canonicalize_at_rule_prelude(interner.resolve(s));
+                    let ch = tagged(TAG_CTX, stable_symbol_hash(&canon));
                     value.push(ch);
                     returns.push(ch);
                 }

--- a/crates/nose-normalize/src/css_value.rs
+++ b/crates/nose-normalize/src/css_value.rs
@@ -80,6 +80,76 @@ fn normalize_color_function_spelling(tok: &str) -> Option<String> {
     Some(format!("{name}{})", parts.join(" ")))
 }
 
+// ----- at-rule preludes (media / supports / container queries) -----
+
+/// Canonicalize an at-rule prelude so equivalent queries converge: whitespace around
+/// `( ) : ,` removed, `and`-joined terms and `,`-joined query-list entries sorted (both
+/// commutative), and each `(feature: value)`'s value canonicalized. Case is PRESERVED
+/// (keyframe/container names are case-sensitive). A non-`@` string (a CSS-nesting parent
+/// selector) is returned UNCHANGED — selectors are case-sensitive and order-significant.
+pub(crate) fn canonicalize_at_rule_prelude(s: &str) -> String {
+    if !s.starts_with('@') {
+        return s.to_string();
+    }
+    let (at, rest) = match s.split_once(' ') {
+        Some((a, r)) => (a.to_ascii_lowercase(), r.trim()),
+        None => (s.to_ascii_lowercase(), ""),
+    };
+    // Only the query-bearing at-rules get condition canonicalization; for others (e.g.
+    // `@keyframes name`, `@font-face`, `@page`) the rest is a case-sensitive name — keep it.
+    if !matches!(at.as_str(), "@media" | "@supports" | "@container") {
+        return if rest.is_empty() {
+            at
+        } else {
+            format!("{at} {rest}")
+        };
+    }
+    let cond = canonicalize_query(rest);
+    if cond.is_empty() {
+        at
+    } else {
+        format!("{at} {cond}")
+    }
+}
+
+fn canonicalize_query(s: &str) -> String {
+    let mut t = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    for (a, b) in [
+        ("( ", "("),
+        (" )", ")"),
+        (" :", ":"),
+        (": ", ":"),
+        (" ,", ","),
+        (", ", ","),
+    ] {
+        t = t.replace(a, b);
+    }
+    // `,` = a media-query LIST (a set → order-independent).
+    let mut queries: Vec<String> = t.split(',').map(canon_and_terms).collect();
+    queries.sort();
+    queries.join(",")
+}
+
+/// Sort the `and`-joined terms of one query (logical AND is commutative) and
+/// canonicalize each term's parenthesized value.
+fn canon_and_terms(q: &str) -> String {
+    let mut terms: Vec<String> = q.split(" and ").map(canon_term).collect();
+    terms.sort();
+    terms.join(" and ")
+}
+
+/// Canonicalize one query term: a `(feature:value)` has its value normalized; a bare
+/// media type / container name is kept verbatim.
+fn canon_term(t: &str) -> String {
+    if let Some(inner) = t.strip_prefix('(').and_then(|x| x.strip_suffix(')')) {
+        if let Some((feat, val)) = inner.split_once(':') {
+            return format!("({}:{})", feat, normalize_token(val));
+        }
+        return format!("({inner})");
+    }
+    t.to_string()
+}
+
 // ----- colors -----
 
 /// A color token → canonical `#rrggbb` / `#rrggbbaa` (lowercase). `None` if `tok` is

--- a/formal/obligations/normalize/css/computed_style/meta.toml
+++ b/formal/obligations/normalize/css/computed_style/meta.toml
@@ -5,4 +5,4 @@ summary = "The declarative (CSS/HTML) fingerprint asserts equal fingerprint ⟹ 
 
 [rust]
 files = ["crates/nose-normalize/src/css_value.rs"]
-symbols = ["canonicalize_value"]
+symbols = ["canonicalize_value", "canonicalize_at_rule_prelude", "canonicalize_query"]

--- a/scripts/check-formal-obligations.py
+++ b/scripts/check-formal-obligations.py
@@ -134,7 +134,7 @@ REQUIRED_OBLIGATIONS = (
     RequiredObligation(
         "normalize.css.computed_style",
         ("crates/nose-normalize/src/css_value.rs",),
-        ("canonicalize_value",),
+        ("canonicalize_value", "canonicalize_at_rule_prelude", "canonicalize_query"),
     ),
 )
 


### PR DESCRIPTION
Equivalent at-rule conditions now converge, and a **latent false merge** is closed.

## What
- **Frontend** prepends the at-rule TYPE (`@media`/`@supports`/`@keyframes`) to the prelude. `media_statement`/`supports_statement` drop their keyword in the grammar, so without this `@media (X)` and `@supports (X)` shared a condition string and could **false-merge**; the prefix also lets the fingerprint tell an at-rule prelude (canonicalizable) from a case-sensitive CSS-nesting parent selector (left raw).
- **`css_value::canonicalize_at_rule_prelude`** normalizes the query: whitespace around `( ) : ,` removed, `and`-joined terms and `,`-joined query-list entries sorted (both commutative), each `(feature: value)` value canonicalized. Case is preserved (keyframe/container names are case-sensitive).

So `@media screen and (max-width: 600px)` ≡ `@media (max-width:600px) and screen`, `(min-width: 0px)` ≡ `(min-width: 0)`, while `@media (X)` ≢ `@supports (X)` and distinct conditions stay distinct.

## Measured
- Declarative benchmark: **recall 13/13, soundness 14/14** (added media-canon positives + media-vs-supports / distinct-condition hard negatives).
- `verify` gate: **0 false merges** on the frontend corpus; determinism byte-identical; 1083 tests pass; clippy clean.

## Context
This is the one improvement that cleared the benefit bar in a rigorous audit of nose's CSS-semantic modeling (selectors, cascade, shorthands, values, at-rules). The other candidates (box/complex-shorthand↔longhand expansion, calc folding, keyword-case, var() resolution) measured ~0 marginal benefit — the common forms already converge as identical tokens and the divergent forms are rare — or carried soundness risk (font-name case, var() scope); selector-fragmentation / dead-rule ideas are CSS *linting*, a different product. Those were dropped with their measurements rather than shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)