### PR TITLE
feat(markup): cross-dialect clone detection across HTML/Vue/Svelte/JSX/TSX

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -7951,23 +7951,34 @@ fn cmd_il(path: PathBuf, format: Format, normalized: bool, no_cfg_norm: bool) ->
         .with_context(|| format!("unsupported file extension: {path_str}"))?;
     let src = std::fs::read(&path).with_context(|| format!("reading {path_str}"))?;
     let interner = Interner::new();
-    let raw = nose_frontend::lower_source(FileId(0), &path_str, &src, lang, &interner)?;
-    let il = if normalized {
-        let opts = nose_normalize::NormalizeOptions {
-            cfg_norm: !no_cfg_norm,
-            ..Default::default()
+    // Use the region-aware entry so `<script>`/`<style>`/markup of a Vue/Svelte/HTML
+    // container are each shown (single-region languages still yield exactly one Il).
+    let regions = nose_frontend::lower_source_regions(FileId(0), &path_str, &src, lang, &interner);
+    if regions.is_empty() {
+        anyhow::bail!("no analyzable region lowered from {path_str}");
+    }
+    let multi = regions.len() > 1;
+    for raw in regions {
+        let region_lang = raw.meta.lang;
+        let il = if normalized {
+            let opts = nose_normalize::NormalizeOptions {
+                cfg_norm: !no_cfg_norm,
+                ..Default::default()
+            };
+            nose_normalize::normalize(&raw, &interner, &opts)
+        } else {
+            raw
         };
-        nose_normalize::normalize(&raw, &interner, &opts)
-    } else {
-        raw
-    };
-
-    match format {
-        Format::Sexpr => {
-            println!("{}", il.to_sexpr(il.root, &interner));
-        }
-        Format::Json => {
-            println!("{}", serde_json::to_string_pretty(&il)?);
+        match format {
+            Format::Sexpr => {
+                if multi {
+                    println!("; region: {}", region_lang.name());
+                }
+                println!("{}", il.to_sexpr(il.root, &interner));
+            }
+            Format::Json => {
+                println!("{}", serde_json::to_string_pretty(&il)?);
+            }
         }
     }
     Ok(())

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -8726,7 +8726,7 @@ fn html_child_order_is_significant() {
 /// Exact DOM fingerprint of the OUTERMOST markup element in `src`, lowered as `lang`
 /// (works for `.vue`/`.svelte` markup AND JSX/TSX, whose markup lives in the JS region).
 fn markup_fp(i: &Interner, path: &str, lang: Lang, src: &str) -> Vec<u64> {
-    fn outer(n: &nose_il::Il, node: nose_il::NodeId) -> Option<nose_il::NodeId> {
+    fn outer(n: &nose_il::Il, node: NodeId) -> Option<NodeId> {
         if n.node(node).kind == nose_il::NodeKind::HtmlElement {
             return Some(node);
         }
@@ -8776,7 +8776,8 @@ fn markup_control_converges_vue_directive_and_svelte_block() {
     // `{#each}` block render the SAME DOM (a repeat of an identical template) → converge.
     let i = Interner::new();
     let vue = r#"<ul class="list"><li class="item" v-for="x in xs" :key="x.id">row text</li></ul>"#;
-    let svelte = r#"<ul class="list">{#each xs as x (x.id)}<li class="item">row text</li>{/each}</ul>"#;
+    let svelte =
+        r#"<ul class="list">{#each xs as x (x.id)}<li class="item">row text</li>{/each}</ul>"#;
     assert_eq!(
         html_fp(&i, vue),
         html_fp(&i, svelte),
@@ -8818,7 +8819,8 @@ fn markup_jsx_map_does_not_merge_with_single_element() {
     // SOUNDNESS (JSX side): `{xs.map(x => <li/>)}` is a repeat — distinct from a single li.
     let i = Interner::new();
     let mapped = r#"export function L(){return <ul className="m">{xs.map(x => <li className="r">row</li>)}</ul>;}"#;
-    let single = r#"export function L(){return <ul className="m"><li className="r">row</li></ul>;}"#;
+    let single =
+        r#"export function L(){return <ul className="m"><li className="r">row</li></ul>;}"#;
     assert_ne!(
         markup_fp(&i, "a.jsx", Lang::JavaScript, mapped),
         markup_fp(&i, "b.jsx", Lang::JavaScript, single),

--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -8718,6 +8718,114 @@ fn html_child_order_is_significant() {
     );
 }
 
+// ---- cross-dialect markup (HTML/Vue/Svelte/JSX/TSX) ---------------------------------
+// The exact (semantic) fingerprint of a markup unit must stay FAITHFUL to the rendered
+// DOM even as the five dialects' idioms (control flow, directives, holes) are normalized
+// into the common IL — so the moat (equal fingerprint ⟹ equal rendered DOM) still holds.
+
+/// Exact DOM fingerprint of the OUTERMOST markup element in `src`, lowered as `lang`
+/// (works for `.vue`/`.svelte` markup AND JSX/TSX, whose markup lives in the JS region).
+fn markup_fp(i: &Interner, path: &str, lang: Lang, src: &str) -> Vec<u64> {
+    fn outer(n: &nose_il::Il, node: nose_il::NodeId) -> Option<nose_il::NodeId> {
+        if n.node(node).kind == nose_il::NodeKind::HtmlElement {
+            return Some(node);
+        }
+        n.children(node).iter().find_map(|&c| outer(n, c))
+    }
+    let ils = nose_frontend::lower_source_regions(FileId(0), path, src.as_bytes(), lang, i);
+    for il in &ils {
+        let n = normalize(il, i, &NormalizeOptions::default());
+        if let Some(root) = outer(&n, n.root) {
+            return nose_normalize::value_fingerprint(&n, root, i);
+        }
+    }
+    panic!("no markup unit lowered from {path}");
+}
+
+#[test]
+fn markup_loop_does_not_merge_with_single_element() {
+    // SOUNDNESS: a `{#each}`/`v-for`/`.map` repeat renders 0..N elements — it must NEVER
+    // share a fingerprint with a single static element (the HtmlControl wrapper keeps it
+    // distinct), or nose would claim a loop and one element have equal rendered DOM.
+    let i = Interner::new();
+    let loop_ = r#"<ul class="m">{#each items as x}<li class="r">row</li>{/each}</ul>"#;
+    let single = r#"<ul class="m"><li class="r">row</li></ul>"#;
+    assert_ne!(
+        html_fp(&i, loop_),
+        html_fp(&i, single),
+        "a repeat must not exact-merge with a single element"
+    );
+}
+
+#[test]
+fn markup_repeat_and_conditional_controls_are_distinct() {
+    // A repeat (`{#each}`) and a conditional (`{#if}`) are different rendered behavior.
+    let i = Interner::new();
+    let each = r#"<ul class="m">{#each xs as x}<li>z</li>{/each}</ul>"#;
+    let if_ = r#"<ul class="m">{#if cond}<li>z</li>{/if}</ul>"#;
+    assert_ne!(
+        html_fp(&i, each),
+        html_fp(&i, if_),
+        "repeat and conditional controls must not merge"
+    );
+}
+
+#[test]
+fn markup_control_converges_vue_directive_and_svelte_block() {
+    // CROSS-DIALECT (sound positive): a Vue `v-for` element and the equivalent Svelte
+    // `{#each}` block render the SAME DOM (a repeat of an identical template) → converge.
+    let i = Interner::new();
+    let vue = r#"<ul class="list"><li class="item" v-for="x in xs" :key="x.id">row text</li></ul>"#;
+    let svelte = r#"<ul class="list">{#each xs as x (x.id)}<li class="item">row text</li>{/each}</ul>"#;
+    assert_eq!(
+        html_fp(&i, vue),
+        html_fp(&i, svelte),
+        "v-for and {{#each}} of the same template must converge"
+    );
+}
+
+#[test]
+fn markup_bound_attribute_keeps_its_expression_distinct() {
+    // SOUNDNESS: a directive-bound attribute keeps its expression verbatim — two different
+    // bound expressions must not be claimed equal (no hole-collapse on the exact channel).
+    let i = Interner::new();
+    let a = r#"<img class="a" :src="hero" :alt="name">"#;
+    let b = r#"<img class="a" :src="thumb" :alt="name">"#;
+    assert_ne!(
+        html_fp(&i, a),
+        html_fp(&i, b),
+        "different bound expressions must not merge on the exact channel"
+    );
+}
+
+#[test]
+fn markup_jsx_converges_with_html_on_identical_static_dom() {
+    // CROSS-DIALECT (sound positive): a JSX element and a hand-written HTML element with
+    // the SAME rendered DOM (className→class, static text/attrs identical) converge — and
+    // JSX markup now lives in the common declarative IL, not an imperative Call-tree.
+    let i = Interner::new();
+    let jsx = r#"export function Nav(){return <li className="nav-item"><a className="nav-link" href="/login">Sign in</a></li>;}"#;
+    let html = r#"<li class="nav-item"><a class="nav-link" href="/login">Sign in</a></li>"#;
+    assert_eq!(
+        markup_fp(&i, "n.jsx", Lang::JavaScript, jsx),
+        markup_fp(&i, "n.html", Lang::Html, html),
+        "JSX and HTML with identical rendered DOM must converge"
+    );
+}
+
+#[test]
+fn markup_jsx_map_does_not_merge_with_single_element() {
+    // SOUNDNESS (JSX side): `{xs.map(x => <li/>)}` is a repeat — distinct from a single li.
+    let i = Interner::new();
+    let mapped = r#"export function L(){return <ul className="m">{xs.map(x => <li className="r">row</li>)}</ul>;}"#;
+    let single = r#"export function L(){return <ul className="m"><li className="r">row</li></ul>;}"#;
+    assert_ne!(
+        markup_fp(&i, "a.jsx", Lang::JavaScript, mapped),
+        markup_fp(&i, "b.jsx", Lang::JavaScript, single),
+        "a JSX .map repeat must not merge with a single element"
+    );
+}
+
 #[test]
 fn html_inline_style_is_computed_canonicalized() {
     // Inline `style="…"` reuses the CSS computed-style canon: order-independent,

--- a/crates/nose-detect/src/abstraction.rs
+++ b/crates/nose-detect/src/abstraction.rs
@@ -321,6 +321,7 @@ fn token_label(token: &WitnessToken) -> &'static str {
             NodeKind::HtmlElement => "HtmlElement",
             NodeKind::HtmlAttr => "HtmlAttr",
             NodeKind::HtmlText => "HtmlText",
+            NodeKind::HtmlControl => "HtmlControl",
         },
     }
 }

--- a/crates/nose-detect/src/strict_exact.rs
+++ b/crates/nose-detect/src/strict_exact.rs
@@ -228,7 +228,7 @@ pub(crate) fn strict_exact_safe_tree(
         // is exact-safe iff it has no unparsed (`Raw`) construct, so recurse into the
         // rule but treat a declaration / selector (whose leaves are constant value
         // tokens, lowered as `Lit(Name=raw text)`) as safe outright.
-        NodeKind::CssRule | NodeKind::HtmlElement => il
+        NodeKind::CssRule | NodeKind::HtmlElement | NodeKind::HtmlControl => il
             .children(node)
             .iter()
             .all(|&c| strict_exact_safe_tree(il, interner, facts, c)),

--- a/crates/nose-frontend/src/html.rs
+++ b/crates/nose-frontend/src/html.rs
@@ -4,14 +4,19 @@
 //! imperative behavior. So markup is NOT lowered through the imperative value graph —
 //! each `HtmlElement` subtree is a detection unit whose exact `semantic` fingerprint is
 //! the canonical DOM of that subtree (`nose-normalize::html`, dispatched in
-//! `value_graph::api` by the unit-root kind). The `<script>`/`<style>` *internals* are
-//! NOT lowered here — they are analyzed as their own JS/CSS regions (see `embedded.rs`);
-//! this frontend keeps only their element shells (tag + attributes).
+//! `value_graph::api` by the unit-root kind). `<script>`/`<style>` elements are dropped
+//! (analyzed as their own JS/CSS regions, see `embedded.rs`).
 //!
 //! Shape: `document` → a `Module` of `HtmlElement`s; each element is
-//! `HtmlElement(tag)[ HtmlAttr(name)[Lit(value)?]..., (child element | HtmlText)... ]`.
+//! `HtmlElement(tag)[ HtmlAttr(name)[Lit(value)?]..., (child element | HtmlText | HtmlControl)... ]`.
 //! A `.vue`/`.svelte` file parses as HTML too, so its `<template>` markup is lowered the
-//! same way. Anything unrecognized becomes `Raw` (no panics).
+//! same way. To make the markup family converge cross-dialect, dialect idioms are
+//! normalized into the common IL: framework directives are classified (events/bookkeeping
+//! dropped; `:src`/`bind:value`/`v-model` → the rendered attribute with its expression as
+//! value); routing components/props are mapped (`router-link`→`a`, `to`→`href`); and
+//! control flow (Vue `v-for`/`v-if`, Svelte `{#each}`/`{#if}`) becomes an `HtmlControl`
+//! wrapper — distinct from a single element so a loop never exact-merges with one element.
+//! Anything unrecognized becomes `Raw` (no panics).
 
 use crate::lower::Lowering;
 use nose_il::{FileId, Il, Interner, Lang, NodeId, NodeKind, Payload, Span, Symbol, UnitKind};
@@ -37,17 +42,78 @@ pub(crate) fn lower(
 
 fn lower_document(lo: &mut Lowering, root: TsNode) -> NodeId {
     let span = lo.span(root);
-    let mut kids = Vec::new();
-    collect_nodes(lo, root, &mut kids, false);
+    let kids = lower_children(lo, &Lowering::named_children(root), false);
     lo.add(NodeKind::Module, Payload::None, span, &kids)
 }
 
-fn collect_nodes(lo: &mut Lowering, node: TsNode, out: &mut Vec<NodeId>, pre: bool) {
-    for c in Lowering::named_children(node) {
+/// A Svelte block marker — which tree-sitter-html parses as plain `text`.
+#[derive(Clone, Copy)]
+enum SvelteMarker {
+    /// `{#each}` (repeat) / `{#if}`,`{#await}`,`{#key}` (conditional) — opens a control frame.
+    Open(&'static str),
+    /// `{/each}`,`{/if}`,… — closes the current control frame.
+    Close,
+    /// `{:else}`,`{:then}`,`{:catch}` — an in-block boundary; kept flat (no extra nesting).
+    Boundary,
+    None,
+}
+
+fn svelte_marker(text: &str) -> SvelteMarker {
+    let t = text.trim_start();
+    if t.starts_with("{#each") {
+        SvelteMarker::Open("repeat")
+    } else if t.starts_with("{#if") || t.starts_with("{#await") || t.starts_with("{#key") {
+        SvelteMarker::Open("if")
+    } else if t.starts_with("{/") {
+        SvelteMarker::Close
+    } else if t.starts_with("{:") {
+        SvelteMarker::Boundary
+    } else {
+        SvelteMarker::None
+    }
+}
+
+/// Lower a sibling sequence, grouping Svelte block markers (`{#each}`…`{/each}`,
+/// `{#if}`…`{/if}`) into [`NodeKind::HtmlControl`] wrappers around the enclosed template.
+/// Vue `v-for`/`v-if` (an attribute on the element) and JSX `.map`/`&&` are wrapped at
+/// their own sites; this handles only Svelte's text-marker form. A control wrapper keeps a
+/// loop/conditional structurally distinct from a single element (exact-channel soundness),
+/// while `node_tag` abstracts it so the three dialects' control idioms converge in `near`.
+fn lower_children(lo: &mut Lowering, nodes: &[TsNode], pre: bool) -> Vec<NodeId> {
+    // Stack of open control frames; frame 0 is the output.
+    let mut stack: Vec<(&'static str, Vec<NodeId>)> = vec![("", Vec::new())];
+    for &c in nodes {
+        if c.kind() == "text" {
+            match svelte_marker(lo.text(c)) {
+                SvelteMarker::Open(kind) => {
+                    stack.push((kind, Vec::new()));
+                    continue;
+                }
+                SvelteMarker::Close if stack.len() > 1 => {
+                    let span = lo.span(c);
+                    let (kind, kids) = stack.pop().unwrap();
+                    let ksym = lo.sym(kind);
+                    let ctl = lo.add(NodeKind::HtmlControl, Payload::Name(ksym), span, &kids);
+                    stack.last_mut().unwrap().1.push(ctl);
+                    continue;
+                }
+                SvelteMarker::Close | SvelteMarker::Boundary => continue,
+                SvelteMarker::None => {}
+            }
+        }
         if let Some(id) = lower_node(lo, c, pre) {
-            out.push(id);
+            stack.last_mut().unwrap().1.push(id);
         }
     }
+    // Defensive: fold any still-open frame (malformed markup) so nothing is dropped.
+    while stack.len() > 1 {
+        let span = lo.span(nodes[0]);
+        let (kind, kids) = stack.pop().unwrap();
+        let ksym = lo.sym(kind);
+        let ctl = lo.add(NodeKind::HtmlControl, Payload::Name(ksym), span, &kids);
+        stack.last_mut().unwrap().1.push(ctl);
+    }
+    stack.pop().unwrap().1
 }
 
 /// `pre`: are we inside a whitespace-PRESERVING element (`<pre>`/`<textarea>`)? There
@@ -56,9 +122,9 @@ fn collect_nodes(lo: &mut Lowering, node: TsNode, out: &mut Vec<NodeId>, pre: bo
 fn lower_node(lo: &mut Lowering, node: TsNode, pre: bool) -> Option<NodeId> {
     match node.kind() {
         "element" => Some(lower_element(lo, node, false, pre)),
-        // SPIKE(markup-arch): drop <script>/<style> element shells from the markup region
-        // entirely — they are analyzed as their own regions and are pure cross-dialect
-        // noise (Svelte/Vue SFCs carry them inline). Was: lowered as shells.
+        // Drop <script>/<style> element shells from the markup region entirely — they are
+        // analyzed as their own JS/CSS regions and are pure cross-dialect noise (Svelte/Vue
+        // SFCs carry them inline).
         "script_element" | "style_element" => None,
         // Text and entities (`&amp;`, `&nbsp;`) are both content — fold to HtmlText.
         "text" | "entity" => lower_text(lo, node, pre),
@@ -75,42 +141,45 @@ fn lower_node(lo: &mut Lowering, node: TsNode, pre: bool) -> Option<NodeId> {
 /// gate keeps trivial single elements from matching.
 fn lower_element(lo: &mut Lowering, node: TsNode, raw_content: bool, pre: bool) -> NodeId {
     let span = lo.span(node);
-    let mut children = Vec::new();
+    let mut attrs = Vec::new();
     let mut tag = None;
+    // A Vue control directive (`v-for`/`v-if`) on this element wraps it in an HtmlControl.
+    let mut control: Option<&'static str> = None;
     // Whitespace is significant inside this element if we are already in a preformatted
     // context OR this element is one (`<pre>`/`<textarea>`). The start tag is the first
     // child, so `child_pre` is set before any text/child element is lowered.
     let mut child_pre = pre;
+    let mut content = Vec::new();
     for c in Lowering::named_children(node) {
         match c.kind() {
             "start_tag" | "self_closing_tag" => {
-                let (t, attrs) = lower_tag(lo, c);
+                let (t, a) = lower_tag(lo, c);
                 if tag.is_none() {
                     tag = t;
                     if let Some(sym) = tag {
                         child_pre = pre || matches!(lo.interner.resolve(sym), "pre" | "textarea");
                     }
+                    control = tag_control_kind(lo, c);
                 }
-                children.extend(attrs);
+                attrs.extend(a);
             }
             "end_tag" | "raw_text" => {}
-            _ if !raw_content => {
-                if let Some(id) = lower_node(lo, c, child_pre) {
-                    children.push(id);
-                }
-            }
+            _ if !raw_content => content.push(c),
             _ => {}
         }
     }
+    let mut children = attrs;
+    children.extend(lower_children(lo, &content, child_pre));
     let tag_sym = tag.unwrap_or_else(|| lo.sym(""));
-    let el = lo.add(
-        NodeKind::HtmlElement,
-        Payload::Name(tag_sym),
-        span,
-        &children,
-    );
+    let el = lo.add(NodeKind::HtmlElement, Payload::Name(tag_sym), span, &children);
     lo.push_unit(el, UnitKind::Block, tag);
-    el
+    match control {
+        Some(kind) => {
+            let ksym = lo.sym(kind);
+            lo.add(NodeKind::HtmlControl, Payload::Name(ksym), span, &[el])
+        }
+        None => el,
+    }
 }
 
 /// Extract `(tag, attributes)` from a `start_tag` / `self_closing_tag`.
@@ -132,6 +201,28 @@ fn lower_tag(lo: &mut Lowering, tag_node: TsNode) -> (Option<Symbol>, Vec<NodeId
         }
     }
     (tag, attrs)
+}
+
+/// The Vue control directive on a start tag, if any: `v-for` → a `repeat`, `v-if`/
+/// `v-else-if`/`v-else`/`v-show` → an `if`. Used to wrap the element in `HtmlControl`.
+fn tag_control_kind(lo: &Lowering, tag_node: TsNode) -> Option<&'static str> {
+    for c in Lowering::named_children(tag_node) {
+        if c.kind() != "attribute" {
+            continue;
+        }
+        let Some(n) = Lowering::named_children(c)
+            .into_iter()
+            .find(|x| x.kind() == "attribute_name")
+        else {
+            continue;
+        };
+        match canonical_attr_name(&lo.text(n).to_ascii_lowercase()).as_str() {
+            "v-for" => return Some("repeat"),
+            "v-if" | "v-else-if" | "v-else" | "v-show" => return Some("if"),
+            _ => {}
+        }
+    }
+    None
 }
 
 /// `name="value"` → `HtmlAttr(name)[Lit(Name=raw value)]`; a boolean attribute has no
@@ -158,42 +249,38 @@ fn lower_attr(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
         }
     }
     let name = canonical_attr_name(&name.unwrap_or_default());
-    // SPIKE(markup-arch): classify the (possibly dialect-specific) attribute.
-    let (name, dynamic) = match classify_attr(&name) {
+    // Classify the (possibly dialect-specific) attribute. A directive binding of a real
+    // DOM attribute (`:src`→`src`, Svelte `bind:value`→`value`, `v-model`→`value`) keeps
+    // the rendered attribute name; its value is the binding EXPRESSION text, kept verbatim
+    // (NOT collapsed to a hole) so the exact fingerprint stays faithful — two attributes
+    // with different bound expressions must not be claimed equal. The `near` channel
+    // abstracts the value (node_tag) so cross-dialect shells still converge structurally.
+    let (name, bound) = match classify_attr(&name) {
         AttrKind::Drop => return None,
-        // A dynamic binding of a REAL DOM attribute (`:src`→`v-bind:src`, Svelte
-        // `bind:value`, Vue `v-model`): keep the rendered attribute name, value is a hole.
-        // This is what makes `:src="x"` (Vue) ≡ `src={x}` (Svelte/JSX) ≡ `src="..."` (HTML).
         AttrKind::Bound(real) => (canonical_rendered_attr(&real).to_string(), true),
         AttrKind::Plain => (canonical_rendered_attr(&name).to_string(), false),
     };
     // Inline `style="…"` is a CSS declaration block — lower it as a (selector-less)
     // `CssRule` child so the markup fingerprint reuses the full CSS computed-style
-    // canonicalization (color/shorthand/unit/cascade) for it.
-    if name == "style" && !dynamic {
+    // canonicalization (color/shorthand/unit/cascade) for it. A *bound* `:style` is a
+    // dynamic expression, not a literal block — keep it as a plain attribute.
+    if name == "style" && !bound {
         let rule = lower_inline_style(lo, value.as_deref().unwrap_or(""), span);
         let nsym = lo.sym(&name);
         return Some(lo.add(NodeKind::HtmlAttr, Payload::Name(nsym), span, &[rule]));
     }
     let nsym = lo.sym(&name);
-    let children: Vec<NodeId> = if dynamic {
-        let vsym = lo.sym("{}");
-        vec![lo.add(NodeKind::Lit, Payload::Name(vsym), span, &[])]
-    } else {
-        match value {
-            Some(v) => {
-                // A dynamic value (`{...}` / mustache) is a hole — canonicalize so a
-                // bound and a static attribute of the same name converge structurally.
-                let vsym = lo.sym(&normalize_dynamic(&normalize_ws(&v)));
-                vec![lo.add(NodeKind::Lit, Payload::Name(vsym), span, &[])]
-            }
-            None => Vec::new(),
+    let children: Vec<NodeId> = match value {
+        Some(v) => {
+            let vsym = lo.sym(&normalize_ws(&v));
+            vec![lo.add(NodeKind::Lit, Payload::Name(vsym), span, &[])]
         }
+        None => Vec::new(),
     };
     Some(lo.add(NodeKind::HtmlAttr, Payload::Name(nsym), span, &children))
 }
 
-/// SPIKE(markup-arch): map framework routing components that render a plain anchor to
+/// Map framework routing components that render a plain anchor to
 /// `a`, so a Vue `<router-link>` / Nuxt `<nuxt-link>` / SvelteKit usage converges with a
 /// hand-written `<a>`. Other tags pass through (already lowercased).
 fn canonical_tag_name(name: &str) -> &str {
@@ -203,7 +290,7 @@ fn canonical_tag_name(name: &str) -> &str {
     }
 }
 
-/// SPIKE(markup-arch): map a framework component's prop to the DOM attribute it renders,
+/// Map a framework component's prop to the DOM attribute it renders,
 /// so `<router-link :to="x">` (→ `<a href>`) converges with a hand-written `<a href>`.
 fn canonical_rendered_attr(name: &str) -> &str {
     match name {
@@ -212,7 +299,7 @@ fn canonical_rendered_attr(name: &str) -> &str {
     }
 }
 
-/// SPIKE(markup-arch): how an attribute maps onto rendered DOM.
+/// How an attribute maps onto rendered DOM.
 enum AttrKind {
     /// Framework control/event/bookkeeping — not a rendered attribute. Dropped.
     Drop,
@@ -307,53 +394,13 @@ fn lower_text(lo: &mut Lowering, node: TsNode, pre: bool) -> Option<NodeId> {
     if text.is_empty() {
         return None;
     }
-    // SPIKE(markup-arch): a Svelte block marker (`{#each}`, `{/each}`, `{:else}`, `{#if}`,
-    // `{/if}`, `{#await}`…) is control flow, not rendered text — drop it so the templated
-    // child becomes a direct child of its container (matching Vue's `v-for`-on-element and
-    // React's `.map()`-wrapped child after their own normalization).
-    let trimmed = text.trim_start();
-    if trimmed.starts_with("{#") || trimmed.starts_with("{/") || trimmed.starts_with("{:") {
-        return None;
-    }
-    let text = normalize_dynamic(&text);
-    if text.is_empty() {
-        return None;
-    }
+    // Interpolation text (`{x}`, `{{ x }}`) keeps its verbatim source: the exact
+    // fingerprint distinguishes different expressions; the `near` channel abstracts the
+    // text node (node_tag) so same-shell components still converge across dialects. Svelte
+    // block markers are restructured into `HtmlControl` upstream (see `collect_nodes`), so
+    // any `{#…}`/`{/…}` reaching here is left as text.
     let sym = lo.sym(&text);
     Some(lo.add(NodeKind::HtmlText, Payload::Name(sym), span, &[]))
-}
-
-/// SPIKE(markup-arch): collapse every `{ expression }` interpolation (Svelte/JSX `{x}`,
-/// Vue `{{ x }}`) to a single canonical hole token `{}`, so two components with the same
-/// markup skeleton but different dynamic content converge structurally. Static text is
-/// returned unchanged. This is intentionally crude (brace-run replacement) for the spike.
-fn normalize_dynamic(s: &str) -> String {
-    if !s.contains('{') {
-        return s.to_string();
-    }
-    let mut out = String::new();
-    let mut depth = 0usize;
-    let mut emitted_hole = false;
-    for ch in s.chars() {
-        match ch {
-            '{' => {
-                if depth == 0 && !emitted_hole {
-                    out.push_str("{}");
-                    emitted_hole = true;
-                }
-                depth += 1;
-            }
-            '}' => {
-                depth = depth.saturating_sub(1);
-                if depth == 0 {
-                    emitted_hole = false;
-                }
-            }
-            _ if depth == 0 => out.push(ch),
-            _ => {}
-        }
-    }
-    normalize_ws(&out)
 }
 
 /// Collapse internal whitespace runs to single spaces and trim — DOM-insignificant

--- a/crates/nose-frontend/src/html.rs
+++ b/crates/nose-frontend/src/html.rs
@@ -164,8 +164,8 @@ fn lower_attr(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
         // A dynamic binding of a REAL DOM attribute (`:src`→`v-bind:src`, Svelte
         // `bind:value`, Vue `v-model`): keep the rendered attribute name, value is a hole.
         // This is what makes `:src="x"` (Vue) ≡ `src={x}` (Svelte/JSX) ≡ `src="..."` (HTML).
-        AttrKind::Bound(real) => (real, true),
-        AttrKind::Plain => (name, false),
+        AttrKind::Bound(real) => (canonical_rendered_attr(&real).to_string(), true),
+        AttrKind::Plain => (canonical_rendered_attr(&name).to_string(), false),
     };
     // Inline `style="…"` is a CSS declaration block — lower it as a (selector-less)
     // `CssRule` child so the markup fingerprint reuses the full CSS computed-style
@@ -199,6 +199,15 @@ fn lower_attr(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
 fn canonical_tag_name(name: &str) -> &str {
     match name {
         "router-link" | "nuxt-link" | "routerlink" => "a",
+        other => other,
+    }
+}
+
+/// SPIKE(markup-arch): map a framework component's prop to the DOM attribute it renders,
+/// so `<router-link :to="x">` (→ `<a href>`) converges with a hand-written `<a href>`.
+fn canonical_rendered_attr(name: &str) -> &str {
+    match name {
+        "to" => "href",
         other => other,
     }
 }

--- a/crates/nose-frontend/src/html.rs
+++ b/crates/nose-frontend/src/html.rs
@@ -171,7 +171,12 @@ fn lower_element(lo: &mut Lowering, node: TsNode, raw_content: bool, pre: bool) 
     let mut children = attrs;
     children.extend(lower_children(lo, &content, child_pre));
     let tag_sym = tag.unwrap_or_else(|| lo.sym(""));
-    let el = lo.add(NodeKind::HtmlElement, Payload::Name(tag_sym), span, &children);
+    let el = lo.add(
+        NodeKind::HtmlElement,
+        Payload::Name(tag_sym),
+        span,
+        &children,
+    );
     lo.push_unit(el, UnitKind::Block, tag);
     match control {
         Some(kind) => {
@@ -325,8 +330,19 @@ fn classify_attr(name: &str) -> AttrKind {
         || matches!(name, "key" | "slot" | "ref" | "is" | "bind:this")
         || matches!(
             name,
-            "v-for" | "v-if" | "v-else" | "v-else-if" | "v-show" | "v-pre" | "v-cloak"
-                | "v-once" | "v-html" | "v-text" | "v-slot" | "v-bind:key" | "v-bind:ref"
+            "v-for"
+                | "v-if"
+                | "v-else"
+                | "v-else-if"
+                | "v-show"
+                | "v-pre"
+                | "v-cloak"
+                | "v-once"
+                | "v-html"
+                | "v-text"
+                | "v-slot"
+                | "v-bind:key"
+                | "v-bind:ref"
                 | "v-bind:is"
         )
     {
@@ -335,7 +351,10 @@ fn classify_attr(name: &str) -> AttrKind {
     if name == "v-model" {
         return AttrKind::Bound("value".to_string());
     }
-    if let Some(real) = name.strip_prefix("v-bind:").or_else(|| name.strip_prefix("bind:")) {
+    if let Some(real) = name
+        .strip_prefix("v-bind:")
+        .or_else(|| name.strip_prefix("bind:"))
+    {
         return AttrKind::Bound(real.to_string());
     }
     AttrKind::Plain

--- a/crates/nose-frontend/src/html.rs
+++ b/crates/nose-frontend/src/html.rs
@@ -56,9 +56,10 @@ fn collect_nodes(lo: &mut Lowering, node: TsNode, out: &mut Vec<NodeId>, pre: bo
 fn lower_node(lo: &mut Lowering, node: TsNode, pre: bool) -> Option<NodeId> {
     match node.kind() {
         "element" => Some(lower_element(lo, node, false, pre)),
-        // Script/style elements: keep the shell (tag + attrs), drop the raw_text body
-        // (the JS/CSS is analyzed separately as its own region).
-        "script_element" | "style_element" => Some(lower_element(lo, node, true, pre)),
+        // SPIKE(markup-arch): drop <script>/<style> element shells from the markup region
+        // entirely — they are analyzed as their own regions and are pure cross-dialect
+        // noise (Svelte/Vue SFCs carry them inline). Was: lowered as shells.
+        "script_element" | "style_element" => None,
         // Text and entities (`&amp;`, `&nbsp;`) are both content — fold to HtmlText.
         "text" | "entity" => lower_text(lo, node, pre),
         "doctype" | "comment" | "erroneous_end_tag" => None,
@@ -119,10 +120,14 @@ fn lower_tag(lo: &mut Lowering, tag_node: TsNode) -> (Option<Symbol>, Vec<NodeId
     for c in Lowering::named_children(tag_node) {
         match c.kind() {
             "tag_name" if tag.is_none() => {
-                let name = lo.text(c).to_ascii_lowercase();
-                tag = Some(lo.sym(&name));
+                let lower = lo.text(c).to_ascii_lowercase();
+                tag = Some(lo.sym(canonical_tag_name(&lower)));
             }
-            "attribute" => attrs.push(lower_attr(lo, c)),
+            "attribute" => {
+                if let Some(a) = lower_attr(lo, c) {
+                    attrs.push(a);
+                }
+            }
             _ => {}
         }
     }
@@ -133,7 +138,7 @@ fn lower_tag(lo: &mut Lowering, tag_node: TsNode) -> (Option<Symbol>, Vec<NodeId
 /// value child. The name is lowercased (HTML attribute names are case-insensitive); the
 /// value keeps its raw text so the DOM fingerprint and a checker can normalize
 /// independently.
-fn lower_attr(lo: &mut Lowering, node: TsNode) -> NodeId {
+fn lower_attr(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     let span = lo.span(node);
     let mut name = None;
     let mut value = None;
@@ -153,23 +158,91 @@ fn lower_attr(lo: &mut Lowering, node: TsNode) -> NodeId {
         }
     }
     let name = canonical_attr_name(&name.unwrap_or_default());
+    // SPIKE(markup-arch): classify the (possibly dialect-specific) attribute.
+    let (name, dynamic) = match classify_attr(&name) {
+        AttrKind::Drop => return None,
+        // A dynamic binding of a REAL DOM attribute (`:src`→`v-bind:src`, Svelte
+        // `bind:value`, Vue `v-model`): keep the rendered attribute name, value is a hole.
+        // This is what makes `:src="x"` (Vue) ≡ `src={x}` (Svelte/JSX) ≡ `src="..."` (HTML).
+        AttrKind::Bound(real) => (real, true),
+        AttrKind::Plain => (name, false),
+    };
     // Inline `style="…"` is a CSS declaration block — lower it as a (selector-less)
     // `CssRule` child so the markup fingerprint reuses the full CSS computed-style
     // canonicalization (color/shorthand/unit/cascade) for it.
-    if name == "style" {
+    if name == "style" && !dynamic {
         let rule = lower_inline_style(lo, value.as_deref().unwrap_or(""), span);
         let nsym = lo.sym(&name);
-        return lo.add(NodeKind::HtmlAttr, Payload::Name(nsym), span, &[rule]);
+        return Some(lo.add(NodeKind::HtmlAttr, Payload::Name(nsym), span, &[rule]));
     }
     let nsym = lo.sym(&name);
-    let children: Vec<NodeId> = match value {
-        Some(v) => {
-            let vsym = lo.sym(&normalize_ws(&v));
-            vec![lo.add(NodeKind::Lit, Payload::Name(vsym), span, &[])]
+    let children: Vec<NodeId> = if dynamic {
+        let vsym = lo.sym("{}");
+        vec![lo.add(NodeKind::Lit, Payload::Name(vsym), span, &[])]
+    } else {
+        match value {
+            Some(v) => {
+                // A dynamic value (`{...}` / mustache) is a hole — canonicalize so a
+                // bound and a static attribute of the same name converge structurally.
+                let vsym = lo.sym(&normalize_dynamic(&normalize_ws(&v)));
+                vec![lo.add(NodeKind::Lit, Payload::Name(vsym), span, &[])]
+            }
+            None => Vec::new(),
         }
-        None => Vec::new(),
     };
-    lo.add(NodeKind::HtmlAttr, Payload::Name(nsym), span, &children)
+    Some(lo.add(NodeKind::HtmlAttr, Payload::Name(nsym), span, &children))
+}
+
+/// SPIKE(markup-arch): map framework routing components that render a plain anchor to
+/// `a`, so a Vue `<router-link>` / Nuxt `<nuxt-link>` / SvelteKit usage converges with a
+/// hand-written `<a>`. Other tags pass through (already lowercased).
+fn canonical_tag_name(name: &str) -> &str {
+    match name {
+        "router-link" | "nuxt-link" | "routerlink" => "a",
+        other => other,
+    }
+}
+
+/// SPIKE(markup-arch): how an attribute maps onto rendered DOM.
+enum AttrKind {
+    /// Framework control/event/bookkeeping — not a rendered attribute. Dropped.
+    Drop,
+    /// A dynamic binding of a real DOM attribute; the `String` is the rendered name and
+    /// the value becomes a hole (`v-bind:src`→`src`, `bind:value`→`value`, `v-model`→`value`).
+    Bound(String),
+    /// An ordinary rendered attribute (static or `{…}`-valued).
+    Plain,
+}
+
+fn classify_attr(name: &str) -> AttrKind {
+    // Event handlers, lifecycle/animation, and per-dialect bookkeeping render nothing.
+    if name.starts_with("v-on:")
+        || name.starts_with("on:")
+        || name.starts_with("use:")
+        || name.starts_with("transition:")
+        || name.starts_with("in:")
+        || name.starts_with("out:")
+        || name.starts_with("animate:")
+        || name.starts_with("class:")
+        || name.starts_with("style:")
+        || name.starts_with('#')
+        || matches!(name, "key" | "slot" | "ref" | "is" | "bind:this")
+        || matches!(
+            name,
+            "v-for" | "v-if" | "v-else" | "v-else-if" | "v-show" | "v-pre" | "v-cloak"
+                | "v-once" | "v-html" | "v-text" | "v-slot" | "v-bind:key" | "v-bind:ref"
+                | "v-bind:is"
+        )
+    {
+        return AttrKind::Drop;
+    }
+    if name == "v-model" {
+        return AttrKind::Bound("value".to_string());
+    }
+    if let Some(real) = name.strip_prefix("v-bind:").or_else(|| name.strip_prefix("bind:")) {
+        return AttrKind::Bound(real.to_string());
+    }
+    AttrKind::Plain
 }
 
 /// Canonicalize Vue/Svelte directive shorthands so the two spellings of one binding
@@ -225,8 +298,53 @@ fn lower_text(lo: &mut Lowering, node: TsNode, pre: bool) -> Option<NodeId> {
     if text.is_empty() {
         return None;
     }
+    // SPIKE(markup-arch): a Svelte block marker (`{#each}`, `{/each}`, `{:else}`, `{#if}`,
+    // `{/if}`, `{#await}`…) is control flow, not rendered text — drop it so the templated
+    // child becomes a direct child of its container (matching Vue's `v-for`-on-element and
+    // React's `.map()`-wrapped child after their own normalization).
+    let trimmed = text.trim_start();
+    if trimmed.starts_with("{#") || trimmed.starts_with("{/") || trimmed.starts_with("{:") {
+        return None;
+    }
+    let text = normalize_dynamic(&text);
+    if text.is_empty() {
+        return None;
+    }
     let sym = lo.sym(&text);
     Some(lo.add(NodeKind::HtmlText, Payload::Name(sym), span, &[]))
+}
+
+/// SPIKE(markup-arch): collapse every `{ expression }` interpolation (Svelte/JSX `{x}`,
+/// Vue `{{ x }}`) to a single canonical hole token `{}`, so two components with the same
+/// markup skeleton but different dynamic content converge structurally. Static text is
+/// returned unchanged. This is intentionally crude (brace-run replacement) for the spike.
+fn normalize_dynamic(s: &str) -> String {
+    if !s.contains('{') {
+        return s.to_string();
+    }
+    let mut out = String::new();
+    let mut depth = 0usize;
+    let mut emitted_hole = false;
+    for ch in s.chars() {
+        match ch {
+            '{' => {
+                if depth == 0 && !emitted_hole {
+                    out.push_str("{}");
+                    emitted_hole = true;
+                }
+                depth += 1;
+            }
+            '}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    emitted_hole = false;
+                }
+            }
+            _ if depth == 0 => out.push(ch),
+            _ => {}
+        }
+    }
+    normalize_ws(&out)
 }
 
 /// Collapse internal whitespace runs to single spaces and trim — DOM-insignificant

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -1862,17 +1862,35 @@ fn lower_jsx(lo: &mut Lowering, node: TsNode) -> NodeId {
                 }
             }
             "jsx_expression" => {
-                // `{title}` → hole text; `{items.map(x => <li/>)}` / `{c && <a/>}` /
-                // `{a ? <X/> : <Y/>}` → the JSX template child(ren) it wraps.
+                // `{title}` → a text node carrying the verbatim expression (exact keeps it
+                // distinct; near abstracts it). `{items.map(x => <li/>)}` → a `repeat`
+                // control wrapping the template; `{c && <a/>}` / `{a ? <X/> : <Y/>}` → an
+                // `if` control. The control node keeps a loop distinct from one element.
                 let mut jsxs = Vec::new();
                 collect_jsx_descendants(c, &mut jsxs);
                 if jsxs.is_empty() {
-                    let s = lo.sym("{}");
-                    children.push(lo.add(NodeKind::HtmlText, Payload::Name(s), lo.span(c), &[]));
-                } else {
-                    for j in jsxs {
-                        children.push(lower_jsx(lo, j));
+                    let txt = jsx_ws(lo.text(c));
+                    if !txt.is_empty() {
+                        let s = lo.sym(&txt);
+                        children.push(lo.add(
+                            NodeKind::HtmlText,
+                            Payload::Name(s),
+                            lo.span(c),
+                            &[],
+                        ));
                     }
+                } else {
+                    let cspan = lo.span(c);
+                    let is_repeat = {
+                        let t = lo.text(c);
+                        t.contains(".map(") || t.contains(".flatMap(")
+                    };
+                    let mut tkids = Vec::new();
+                    for j in jsxs {
+                        tkids.push(lower_jsx(lo, j));
+                    }
+                    let ksym = lo.sym(if is_repeat { "repeat" } else { "if" });
+                    children.push(lo.add(NodeKind::HtmlControl, Payload::Name(ksym), cspan, &tkids));
                 }
             }
             _ => {}
@@ -1940,9 +1958,11 @@ fn lower_jsx_attr(lo: &mut Lowering, attr: TsNode) -> Option<NodeId> {
             let s = lo.sym(&val);
             vec![lo.add(NodeKind::Lit, Payload::Name(s), span, &[])]
         }
-        Some(_) => {
-            // `{expr}` (or any non-string) value → hole, matching the other dialects.
-            let s = lo.sym("{}");
+        Some(v) => {
+            // `{expr}` value → keep the verbatim expression text (exact distinguishes
+            // different bound expressions; near abstracts the value node).
+            let val = jsx_ws(lo.text(*v));
+            let s = lo.sym(&val);
             vec![lo.add(NodeKind::Lit, Payload::Name(s), span, &[])]
         }
     };

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -1831,35 +1831,123 @@ fn append_template_part(lo: &mut Lowering, acc: &mut Option<NodeId>, span: Span,
     });
 }
 
-/// Lower JSX to `Call(tag, attrs…, children…)` — structurally close to the
-/// `createElement(tag, props, ...children)` it compiles to.
+/// SPIKE(markup-arch / A1): lower JSX to the COMMON declarative markup IL
+/// (`HtmlElement`/`HtmlAttr`/`HtmlText`) — the same kinds the HTML/Vue/Svelte frontends
+/// emit — instead of an imperative `Call` tree. Because the exact fingerprint is
+/// dispatched by unit-root NodeKind, a JSX `<div className="card">` then converges with a
+/// Vue/Svelte/HTML `<div class="card">`. JS expressions become holes; `.map(cb→JSX)`,
+/// `cond && <JSX>` and `a ? <X> : <Y>` collapse to their JSX template child(ren).
 fn lower_jsx(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
-    let mut kids = Vec::new();
-    let callee = match jsx_tag(node) {
-        Some(t) => {
-            let s = lo.span(t);
-            lo.var(lo.text(t), s)
-        }
-        None => lo.empty_block(span),
-    };
-    kids.push(callee);
+    let tag = jsx_tag(node)
+        .map(|t| canonical_jsx_tag(lo.text(t)))
+        .unwrap_or_default(); // fragment → ""
+    let tag_sym = lo.sym(&tag);
+    let mut children = Vec::new();
     for attr in jsx_attributes(node) {
-        kids.push(lower_jsx_attr(lo, attr));
+        if let Some(a) = lower_jsx_attr(lo, attr) {
+            children.push(a);
+        }
     }
+    for c in Lowering::named_children(node) {
+        match c.kind() {
+            "jsx_element" | "jsx_self_closing_element" | "jsx_fragment" => {
+                children.push(lower_jsx(lo, c));
+            }
+            "jsx_text" => {
+                let t = jsx_ws(lo.text(c));
+                if !t.is_empty() {
+                    let s = lo.sym(&t);
+                    children.push(lo.add(NodeKind::HtmlText, Payload::Name(s), lo.span(c), &[]));
+                }
+            }
+            "jsx_expression" => {
+                // `{title}` → hole text; `{items.map(x => <li/>)}` / `{c && <a/>}` /
+                // `{a ? <X/> : <Y/>}` → the JSX template child(ren) it wraps.
+                let mut jsxs = Vec::new();
+                collect_jsx_descendants(c, &mut jsxs);
+                if jsxs.is_empty() {
+                    let s = lo.sym("{}");
+                    children.push(lo.add(NodeKind::HtmlText, Payload::Name(s), lo.span(c), &[]));
+                } else {
+                    for j in jsxs {
+                        children.push(lower_jsx(lo, j));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    let el = lo.add(NodeKind::HtmlElement, Payload::Name(tag_sym), span, &children);
+    lo.push_unit(el, UnitKind::Block, Some(tag_sym));
+    el
+}
+
+/// Collect the top-most JSX elements nested inside an expression (not recursing into the
+/// JSX itself) — finds the template child of a `.map`, `&&`, or ternary.
+fn collect_jsx_descendants<'a>(node: TsNode<'a>, out: &mut Vec<TsNode<'a>>) {
     for c in Lowering::named_children(node) {
         if matches!(
             c.kind(),
-            "jsx_element"
-                | "jsx_self_closing_element"
-                | "jsx_fragment"
-                | "jsx_expression"
-                | "jsx_text"
+            "jsx_element" | "jsx_self_closing_element" | "jsx_fragment"
         ) {
-            kids.push(lower_expr(lo, c));
+            out.push(c);
+        } else {
+            collect_jsx_descendants(c, out);
         }
     }
-    lo.add(NodeKind::Call, Payload::None, span, &kids)
+}
+
+/// Collapse JSX whitespace text (DOM-insignificant) and trim.
+fn jsx_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// DOM tag for a JSX element name: lowercased (DOM tags already are; components become a
+/// stable lowercase token), with React-Router link components mapped to `a`.
+fn canonical_jsx_tag(name: &str) -> String {
+    match name {
+        "Link" | "NavLink" | "RouterLink" => "a".to_string(),
+        other => other.to_ascii_lowercase(),
+    }
+}
+
+/// Map a JSX attribute to its rendered DOM attribute, or `None` to drop it (events,
+/// React bookkeeping). `className`→`class`, `htmlFor`→`for`, router `to`→`href`.
+fn canonical_jsx_attr(name: &str) -> Option<String> {
+    match name {
+        "className" => Some("class".to_string()),
+        "htmlFor" => Some("for".to_string()),
+        "to" => Some("href".to_string()),
+        "key" | "ref" => None,
+        n if n.starts_with("on") && n.len() > 2 && n.as_bytes()[2].is_ascii_uppercase() => None,
+        n => Some(n.to_ascii_lowercase()),
+    }
+}
+
+/// `name="str"` → `HtmlAttr(name)[Lit(value)]`; `name={expr}` → hole value; bare → boolean.
+/// Returns `None` for dropped (event/bookkeeping) attributes.
+fn lower_jsx_attr(lo: &mut Lowering, attr: TsNode) -> Option<NodeId> {
+    let span = lo.span(attr);
+    let kids = Lowering::named_children(attr);
+    let raw_name = lo.text(*kids.first()?);
+    let name = canonical_jsx_attr(raw_name)?;
+    let children: Vec<NodeId> = match kids.get(1) {
+        None => Vec::new(), // boolean attribute
+        Some(v) if v.kind() == "string" => {
+            let raw = lo.text(*v);
+            let val = jsx_ws(raw.trim_matches('"').trim_matches('\''));
+            let s = lo.sym(&val);
+            vec![lo.add(NodeKind::Lit, Payload::Name(s), span, &[])]
+        }
+        Some(_) => {
+            // `{expr}` (or any non-string) value → hole, matching the other dialects.
+            let s = lo.sym("{}");
+            vec![lo.add(NodeKind::Lit, Payload::Name(s), span, &[])]
+        }
+    };
+    let nsym = lo.sym(&name);
+    Some(lo.add(NodeKind::HtmlAttr, Payload::Name(nsym), span, &children))
 }
 
 fn jsx_tag(node: TsNode) -> Option<TsNode> {
@@ -1886,16 +1974,6 @@ fn jsx_attributes(node: TsNode) -> Vec<TsNode> {
             .filter(|c| c.kind() == "jsx_attribute")
             .collect(),
         None => Vec::new(),
-    }
-}
-
-fn lower_jsx_attr(lo: &mut Lowering, attr: TsNode) -> NodeId {
-    let span = lo.span(attr);
-    let kids = Lowering::named_children(attr);
-    if kids.len() >= 2 {
-        lower_expr(lo, kids[kids.len() - 1]) // the value (name is first)
-    } else {
-        lo.add(NodeKind::Lit, Payload::LitBool(true), span, &[]) // boolean attr
     }
 }
 

--- a/crates/nose-frontend/src/js_ts.rs
+++ b/crates/nose-frontend/src/js_ts.rs
@@ -1890,13 +1890,23 @@ fn lower_jsx(lo: &mut Lowering, node: TsNode) -> NodeId {
                         tkids.push(lower_jsx(lo, j));
                     }
                     let ksym = lo.sym(if is_repeat { "repeat" } else { "if" });
-                    children.push(lo.add(NodeKind::HtmlControl, Payload::Name(ksym), cspan, &tkids));
+                    children.push(lo.add(
+                        NodeKind::HtmlControl,
+                        Payload::Name(ksym),
+                        cspan,
+                        &tkids,
+                    ));
                 }
             }
             _ => {}
         }
     }
-    let el = lo.add(NodeKind::HtmlElement, Payload::Name(tag_sym), span, &children);
+    let el = lo.add(
+        NodeKind::HtmlElement,
+        Payload::Name(tag_sym),
+        span,
+        &children,
+    );
     lo.push_unit(el, UnitKind::Block, Some(tag_sym));
     el
 }

--- a/crates/nose-il/src/node.rs
+++ b/crates/nose-il/src/node.rs
@@ -135,6 +135,14 @@ pub enum NodeKind {
     HtmlAttr,
     /// HTML text content (collapsed whitespace). Payload: `Name` (the text).
     HtmlText,
+    /// A markup CONTROL construct wrapping a templated subtree — a repeat (`v-for`,
+    /// Svelte `{#each}`, JSX `.map`) or a conditional (`v-if`, `{#if}`, JSX `&&`/ternary).
+    /// Payload: `Name` ("repeat"/"if") naming the kind. Children: the template element(s).
+    /// Distinct from a plain element so the exact fingerprint never equates a loop with a
+    /// single element (sound); the `near` channel abstracts it (node_tag) so the three
+    /// dialects' control idioms converge structurally. Appended LAST to keep NodeKind
+    /// discriminants — and therefore shape hashes and the on-disk cache — stable.
+    HtmlControl,
 }
 
 /// Per-node data. Most nodes carry [`Payload::None`]; the variant in use is

--- a/crates/nose-il/src/sexpr.rs
+++ b/crates/nose-il/src/sexpr.rs
@@ -89,5 +89,6 @@ fn kind_name(k: NodeKind) -> &'static str {
         HtmlElement => "html-element",
         HtmlAttr => "html-attr",
         HtmlText => "html-text",
+        HtmlControl => "html-control",
     }
 }

--- a/crates/nose-normalize/src/html.rs
+++ b/crates/nose-normalize/src/html.rs
@@ -81,7 +81,7 @@ fn subtree_hash(
             for &c in il.children(node) {
                 match il.kind(c) {
                     NodeKind::HtmlAttr => attr_hashes.push(attr_hash(il, interner, c, lits)),
-                    NodeKind::HtmlElement | NodeKind::HtmlText => {
+                    NodeKind::HtmlElement | NodeKind::HtmlText | NodeKind::HtmlControl => {
                         let h = subtree_hash(il, interner, c, value, lits);
                         child_fold = combine(child_fold, h); // ordered
                     }
@@ -104,6 +104,27 @@ fn subtree_hash(
             let h = combine(0x7E47, t);
             value.push(tagged(TAG_TEXT, h));
             lits.push(tagged(TAG_TEXT, h));
+            h
+        }
+        // A control wrapper (repeat / conditional). Its hash mixes the control KIND with
+        // its template children, so a `{#each}<li>` (repeat of li) can NEVER collide with a
+        // single static `<li>` — the exact channel keeps a loop distinct from one element.
+        NodeKind::HtmlControl => {
+            let kind = match il.node(node).payload {
+                Payload::Name(s) => stable_symbol_hash(interner.resolve(s)),
+                _ => 0,
+            };
+            let mut child_fold = 0u64;
+            for &c in il.children(node) {
+                if matches!(
+                    il.kind(c),
+                    NodeKind::HtmlElement | NodeKind::HtmlText | NodeKind::HtmlControl
+                ) {
+                    child_fold = combine(child_fold, subtree_hash(il, interner, c, value, lits));
+                }
+            }
+            let h = combine(0xC02_0000 ^ kind, child_fold);
+            value.push(tagged(TAG_NODE, h));
             h
         }
         _ => 0,

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -24,8 +24,11 @@ Eight **imperative** base languages, each with its own CST→IL lowering:
 | C | `.c`, `.h` |
 | Ruby | `.rb` |
 
-JSX and TSX are handled by the JavaScript/TypeScript lowering path (the type
-syntax is erased during [normalization](normalization.md)).
+JSX and TSX are handled by the JavaScript/TypeScript lowering path (the type syntax is
+erased during [normalization](normalization.md)). Their **JSX markup** is lowered into
+the shared declarative markup IL (below), not an imperative call tree — so a React
+component's markup is clone-matched against HTML/Vue/Svelte markup (see
+[cross-dialect markup](#cross-dialect-markup-htmlvuesveltejsxtsx)).
 
 ## Declarative languages: CSS
 
@@ -102,12 +105,40 @@ declaration block shared between a component's `<style>` and a plain `.css` file
 repeated card across two HTML pages — shows up as one cross-container family (script
 cross-container confirmed on real projects in [field-evaluation](field-evaluation.md)).
 
-Vue/Svelte directive shorthands are canonicalized in the markup tree (`:x` ≡
-`v-bind:x`, `@x` ≡ `v-on:x`), and inline `style="…"` is computed-canonicalized via the
-CSS path. Out of scope (see [clone-types](clone-types.md)): SCSS/Less/Sass, CSS `var()`
-resolution across files, and full Svelte `{#if}`/`{#each}`
-block control flow (template text/interpolation is structure-abstracted, the block
-grammar is not modeled).
+## Cross-dialect markup (HTML/Vue/Svelte/JSX/TSX)
+
+The five markup dialects render to the same thing — a DOM tree — so nose lowers them all
+into the **one** declarative markup IL and clone-matches across them. The same component
+written in React, Vue, and Svelte converges. This works because each dialect's frontend
+normalizes its idioms into the shared IL:
+
+- **control flow** → an `HtmlControl` wrapper: Vue `v-for`/`v-if`, Svelte
+  `{#each}`/`{#if}`, and JSX `.map`/`&&`/ternary all become a `repeat`/`if` control. The
+  wrapper is structurally distinct from a plain element, so a loop never exact-merges with
+  a single element (sound), while the `near` channel abstracts it so the three control
+  idioms converge;
+- **directives** are classified: events/lifecycle/bookkeeping (`@click`/`v-on:`, `on:`,
+  `use:`, `key`, `ref`) are dropped (not rendered); a bound real attribute
+  (`:src`/`v-bind:`, Svelte `bind:value`, `v-model`) keeps the rendered attribute name
+  with its **expression as the value, verbatim** — so two different bound expressions stay
+  distinct on the exact channel;
+- **attribute/tag aliases** that render the same DOM are unified: JSX `className`→`class`,
+  `htmlFor`→`for`; routing components/props `router-link`/`<Link>`→`a`, `to`→`href`;
+- **interpolation** (`{x}`, `{{ x }}`) keeps its verbatim text on the exact channel (so
+  different expressions never merge) and is abstracted by `node_tag` on the `near` channel
+  (so same-shell-different-content components converge — the headline cross-dialect clone);
+- `<script>`/`<style>` elements are dropped from the markup tree (analyzed as their own
+  regions, above), and inline `style="…"` is computed-canonicalized via the CSS path.
+
+Soundness is preserved end-to-end: a cross-dialect match lands on the exact channel only
+when the rendered DOM is genuinely identical (e.g. a static nav link), otherwise on the
+structural `near` channel — never a false claim of behavioral equality. See the adversarial
+battery in `crates/nose-cli/tests/equivalence.rs` (`markup_*`).
+
+Out of scope (see [clone-types](clone-types.md)): SCSS/Less/Sass and CSS `var()`
+resolution across files. Component composition that differs across dialects (one dialect
+extracts a sub-component where another inlines it) is matched at the shared-subtree level,
+not whole-component, which is correct.
 
 ## Coverage and adding a language
 


### PR DESCRIPTION
The same component written in React, Vue, and Svelte now converges as a clone family —
the markup family is detected through **one** declarative markup engine, soundly.

## Why
Before this, HTML/Vue/Svelte markup used the declarative DOM engine while **JSX/TSX
markup rode the imperative Call-tree**, so the two never cross-matched and React markup
got no DOM-aware treatment. An experiment (deciding the architecture by measurement)
showed cross-dialect recall was ~0 and pinned the cause: the same component lowers three
ways (Call-tree vs HtmlElement+attr-control vs HtmlElement+text-marker-control), and the
divergence is in *control-flow / hole / directive idioms*, not just the IL kind.

## What
Lower all five dialects into the common declarative markup IL, normalizing each dialect's
idioms in its frontend — and keep the exact channel **faithful to the rendered DOM**:

- **`NodeKind::HtmlControl`** (repeat / conditional) wraps a templated subtree. Vue
  `v-for`/`v-if`, Svelte `{#each}`/`{#if}` (text markers, re-nested), and JSX
  `.map`/`&&`/ternary all lower to it. A control wrapper is structurally distinct from a
  single element, so the exact fingerprint **never equates a loop with one element**;
  `node_tag` abstracts it so the three control idioms converge on `near`.
- **JSX/TSX → `HtmlElement`/`HtmlAttr`/`HtmlText`** (was an imperative Call-tree). Because
  the fingerprint dispatches on unit-root NodeKind, JSX markup shares the HTML DOM
  fingerprint space and converges with HTML/Vue/Svelte.
- **Directive classification**: events/lifecycle/bookkeeping dropped (not rendered); a
  bound real attribute (`:src`/`bind:value`/`v-model`) keeps the rendered name with its
  **expression as the value, verbatim** — different bound expressions stay distinct.
- **Aliases that render the same DOM** unified: `className`→`class`, `htmlFor`→`for`,
  `router-link`/`<Link>`→`a`, `to`→`href`. `<script>`/`<style>` dropped from markup.
- **Interpolation** keeps its verbatim text on exact (so different expressions never merge)
  and is abstracted by `node_tag` on near (same-shell-different-content converges).
- Region-aware `nose il` now dumps `<script>`/`<style>`/markup regions (was script-only).

## Soundness (the moat)
A cross-dialect match lands on the **exact** channel only when the rendered DOM is
genuinely identical (e.g. a static nav link); otherwise on the **near** (structural)
channel — never a false claim of behavioral equality. Pinned by an adversarial battery
(`crates/nose-cli/tests/equivalence.rs::markup_*`): loop ≠ single element (Svelte + JSX),
repeat ≠ conditional, bound expressions stay distinct, Vue `v-for` ≡ Svelte `{#each}` and
JSX ≡ HTML converge on identical DOM.

## Measured
On the RealWorld (Conduit) apps in React + Vue + Svelte: cross-dialect markup families
**0 → 9** (3 three-way), all role-coherent and spot-checked sound. Full test suite green
(no regressions — the JSX lowering change broke nothing), determinism byte-identical,
dup-gate 21/28, clippy/doc/fmt/formal-obligations/awiki clean.

## Honest remaining lever (follow-up)
Small/unique markup units still sit below the detection floor (`EXACT_VALUE_MIN`), so very
small components (a bare error-list, a 1-line card) don't always surface — a detect-layer
tuning orthogonal to this architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)