### PR TITLE
bench(labels): frontend gold set v1 — 448 panel-labeled CSS/HTML/cross-dialect families

### DIFF
--- a/bench/labels/README.md
+++ b/bench/labels/README.md
@@ -13,6 +13,34 @@ detection changes honest (it has rejected several plausible-but-wrong ideas; see
 - **9,461 families** — 4,940 worthy / 4,521 not-worthy.
 - **105 repos, 7 languages**, with a dev (5,445) / **held-out** (4,016) split — held-out
   is a generalization gate; tune only on dev.
+
+## The declarative set — `frontend_families.v1.json`
+
+The same product metric for the **declarative track** (CSS + HTML/Vue/Svelte/JSX/TSX
+markup, incl. cross-dialect). Same schema, same RUBRIC, same 3-persona panel + 2-1
+tiebreak methodology; built by the `frontend-goldset-panel` workflow over a nose
+low-threshold pool (generated-filtered per `is_generated_loc`, capped ≤60/repo for
+diversity) across 19 frontend repos + the RealWorld trio for cross-dialect.
+
+- **448 families** — 71 worthy / 377 not-worthy. dev 386 / **heldout** 62.
+- **Worthy-rate by corpus kind** (the headline precision profile):
+  | kind | families | worthy |
+  |---|---|---|
+  | app (hand-written markup) | 44 | **50%** |
+  | cross-dialect (React≡Vue≡Svelte) | 10 | **70%** |
+  | CSS framework (dist) | 394 | **10%** |
+- **What it measures.** On real app markup, precision is ~50% — on par with the imperative
+  languages. On shipped CSS frameworks it is ~10%: the surface there is **69% `generated`**
+  (CSS compiled from SCSS — `css/bulma.css` etc., which `is_generated_loc` does NOT catch
+  because they are not `.min`/`dist/`) plus `parallel-by-design` utility scales. The
+  cross-dialect arm (nose's novel capability) is 70% worthy — genuinely-shared components
+  (TagList, article-meta, error-list, banner) across frameworks; the 30% not-worthy are
+  small generic shells (`li.nav-item`, a `<button>`) coincidentally same-shaped across
+  unrelated components. This says nothing is broken in the markup engine — it quantifies
+  that **the CSS-framework default surface needs a compiled-CSS filter** (a measured lever)
+  and that real-code/cross-dialect precision is healthy.
+- Each family records its 3-persona `votes`. **v1 is dev-grade** (panel-labeled, not yet
+  human-arbitrated); the 45 medium-confidence (2-1 split) families are the audit queue.
 - Each family records its 3-persona `votes`, so agreement is auditable. The format is
   defined in [`schema.json`](schema.json).
 

--- a/bench/labels/frontend_families.v1.json
+++ b/bench/labels/frontend_families.v1.json
@@ -1,0 +1,27756 @@
+{
+ "schema_version": "0.1.0",
+ "families": [
+  {
+   "family_id": "ea57ccefb9432c38",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4265,
+     "end_line": 4274,
+     "name": ".image.is-square img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4281,
+     "end_line": 4290,
+     "name": ".image.is-1by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4294,
+     "end_line": 4303,
+     "name": ".image.is-5by4 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4307,
+     "end_line": 4316,
+     "name": ".image.is-4by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4320,
+     "end_line": 4329,
+     "name": ".image.is-3by2 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4333,
+     "end_line": 4342,
+     "name": ".image.is-5by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4346,
+     "end_line": 4355,
+     "name": ".image.is-16by9 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4359,
+     "end_line": 4368,
+     "name": ".image.is-2by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4372,
+     "end_line": 4381,
+     "name": ".image.is-3by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4385,
+     "end_line": 4394,
+     "name": ".image.is-4by5 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4398,
+     "end_line": 4407,
+     "name": ".image.is-3by4 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4411,
+     "end_line": 4420,
+     "name": ".image.is-2by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4424,
+     "end_line": 4433,
+     "name": ".image.is-3by5 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4437,
+     "end_line": 4446,
+     "name": ".image.is-9by16 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4450,
+     "end_line": 4459,
+     "name": ".image.is-1by2 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4463,
+     "end_line": 4472,
+     "name": ".image.is-1by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".image.is-square .has-ratio"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1462,
+     "end_line": 1471,
+     "name": ".image.is-square img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1478,
+     "end_line": 1487,
+     "name": ".image.is-1by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1491,
+     "end_line": 1500,
+     "name": ".image.is-5by4 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1504,
+     "end_line": 1513,
+     "name": ".image.is-4by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1517,
+     "end_line": 1526,
+     "name": ".image.is-3by2 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1530,
+     "end_line": 1539,
+     "name": ".image.is-5by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1543,
+     "end_line": 1552,
+     "name": ".image.is-16by9 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1556,
+     "end_line": 1565,
+     "name": ".image.is-2by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1569,
+     "end_line": 1578,
+     "name": ".image.is-3by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1582,
+     "end_line": 1591,
+     "name": ".image.is-4by5 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1595,
+     "end_line": 1604,
+     "name": ".image.is-3by4 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1608,
+     "end_line": 1617,
+     "name": ".image.is-2by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1621,
+     "end_line": 1630,
+     "name": ".image.is-3by5 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1634,
+     "end_line": 1643,
+     "name": ".image.is-9by16 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1647,
+     "end_line": 1656,
+     "name": ".image.is-1by2 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1660,
+     "end_line": 1669,
+     "name": ".image.is-1by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".image.is-square .has-ratio"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4265,
+     "end_line": 4274,
+     "name": ".bulma-image.bulma-is-square img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4281,
+     "end_line": 4290,
+     "name": ".bulma-image.bulma-is-1by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4294,
+     "end_line": 4303,
+     "name": ".bulma-image.bulma-is-5by4 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4307,
+     "end_line": 4316,
+     "name": ".bulma-image.bulma-is-4by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4320,
+     "end_line": 4329,
+     "name": ".bulma-image.bulma-is-3by2 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4333,
+     "end_line": 4342,
+     "name": ".bulma-image.bulma-is-5by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4346,
+     "end_line": 4355,
+     "name": ".bulma-image.bulma-is-16by9 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4359,
+     "end_line": 4368,
+     "name": ".bulma-image.bulma-is-2by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4372,
+     "end_line": 4381,
+     "name": ".bulma-image.bulma-is-3by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4385,
+     "end_line": 4394,
+     "name": ".bulma-image.bulma-is-4by5 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4398,
+     "end_line": 4407,
+     "name": ".bulma-image.bulma-is-3by4 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4411,
+     "end_line": 4420,
+     "name": ".bulma-image.bulma-is-2by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4424,
+     "end_line": 4433,
+     "name": ".bulma-image.bulma-is-3by5 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4437,
+     "end_line": 4446,
+     "name": ".bulma-image.bulma-is-9by16 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4450,
+     "end_line": 4459,
+     "name": ".bulma-image.bulma-is-1by2 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4463,
+     "end_line": 4472,
+     "name": ".bulma-image.bulma-is-1by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-image.bulma-is-square .bulma-has-ratio"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4265,
+     "end_line": 4274,
+     "name": ".image.is-square img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4281,
+     "end_line": 4290,
+     "name": ".image.is-1by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4294,
+     "end_line": 4303,
+     "name": ".image.is-5by4 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4307,
+     "end_line": 4316,
+     "name": ".image.is-4by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4320,
+     "end_line": 4329,
+     "name": ".image.is-3by2 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4333,
+     "end_line": 4342,
+     "name": ".image.is-5by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4346,
+     "end_line": 4355,
+     "name": ".image.is-16by9 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4359,
+     "end_line": 4368,
+     "name": ".image.is-2by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4372,
+     "end_line": 4381,
+     "name": ".image.is-3by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4385,
+     "end_line": 4394,
+     "name": ".image.is-4by5 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4398,
+     "end_line": 4407,
+     "name": ".image.is-3by4 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4411,
+     "end_line": 4420,
+     "name": ".image.is-2by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4424,
+     "end_line": 4433,
+     "name": ".image.is-3by5 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4437,
+     "end_line": 4446,
+     "name": ".image.is-9by16 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4450,
+     "end_line": 4459,
+     "name": ".image.is-1by2 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4463,
+     "end_line": 4472,
+     "name": ".image.is-1by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".image.is-square .has-ratio"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4265,
+     "end_line": 4274,
+     "name": ".bulma-image.bulma-is-square img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4281,
+     "end_line": 4290,
+     "name": ".bulma-image.bulma-is-1by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4294,
+     "end_line": 4303,
+     "name": ".bulma-image.bulma-is-5by4 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4307,
+     "end_line": 4316,
+     "name": ".bulma-image.bulma-is-4by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4320,
+     "end_line": 4329,
+     "name": ".bulma-image.bulma-is-3by2 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4333,
+     "end_line": 4342,
+     "name": ".bulma-image.bulma-is-5by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4346,
+     "end_line": 4355,
+     "name": ".bulma-image.bulma-is-16by9 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4359,
+     "end_line": 4368,
+     "name": ".bulma-image.bulma-is-2by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4372,
+     "end_line": 4381,
+     "name": ".bulma-image.bulma-is-3by1 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4385,
+     "end_line": 4394,
+     "name": ".bulma-image.bulma-is-4by5 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4398,
+     "end_line": 4407,
+     "name": ".bulma-image.bulma-is-3by4 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4411,
+     "end_line": 4420,
+     "name": ".bulma-image.bulma-is-2by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4424,
+     "end_line": 4433,
+     "name": ".bulma-image.bulma-is-3by5 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4437,
+     "end_line": 4446,
+     "name": ".bulma-image.bulma-is-9by16 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4450,
+     "end_line": 4459,
+     "name": ".bulma-image.bulma-is-1by2 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4463,
+     "end_line": 4472,
+     "name": ".bulma-image.bulma-is-1by3 img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-image.bulma-is-square .bulma-has-ratio"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".image.is-square .has-ratio"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "32dcbf1102890656",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 2877,
+     "end_line": 2881,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 3034,
+     "end_line": 3037,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 74,
+     "end_line": 78,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 231,
+     "end_line": 234,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 2877,
+     "end_line": 2881,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 3034,
+     "end_line": 3037,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 2877,
+     "end_line": 2881,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 3034,
+     "end_line": 3037,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 2877,
+     "end_line": 2881,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 3034,
+     "end_line": 3037,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 1243,
+     "end_line": 1247,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 1400,
+     "end_line": 1403,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "img"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ea96852da75c4f85",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 3833,
+     "end_line": 3836,
+     "name": ".button.is-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 3880,
+     "end_line": 3883,
+     "name": ".buttons.are-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".button.is-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1030,
+     "end_line": 1033,
+     "name": ".button.is-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1077,
+     "end_line": 1080,
+     "name": ".buttons.are-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".button.is-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 3833,
+     "end_line": 3836,
+     "name": ".bulma-button.bulma-is-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 3880,
+     "end_line": 3883,
+     "name": ".bulma-buttons.bulma-are-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-button.bulma-is-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 3833,
+     "end_line": 3836,
+     "name": ".button.is-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 3880,
+     "end_line": 3883,
+     "name": ".buttons.are-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".button.is-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 3833,
+     "end_line": 3836,
+     "name": ".bulma-button.bulma-is-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 3880,
+     "end_line": 3883,
+     "name": ".bulma-buttons.bulma-are-medium"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-button.bulma-is-medium"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 2923,
+     "end_line": 2926,
+     "name": ".button.is-medium"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 2970,
+     "end_line": 2973,
+     "name": ".buttons.are-medium"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".button.is-medium"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "65d97ee07277cadd",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4877,
+     "end_line": 4883,
+     "name": ".table td.is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4989,
+     "end_line": 4994,
+     "name": ".table tr.is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".table td.is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 2074,
+     "end_line": 2080,
+     "name": ".table td.is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 2186,
+     "end_line": 2191,
+     "name": ".table tr.is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".table td.is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4877,
+     "end_line": 4883,
+     "name": ".bulma-table td.bulma-is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4989,
+     "end_line": 4994,
+     "name": ".bulma-table tr.bulma-is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-table td.bulma-is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4877,
+     "end_line": 4883,
+     "name": ".table td.is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4989,
+     "end_line": 4994,
+     "name": ".table tr.is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".table td.is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4877,
+     "end_line": 4883,
+     "name": ".bulma-table td.bulma-is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4989,
+     "end_line": 4994,
+     "name": ".bulma-table tr.bulma-is-text"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-table td.bulma-is-text"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".table td.is-text"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "019d3c13b3e7281d",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 3950,
+     "end_line": 3968,
+     "name": ".content"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".content"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1147,
+     "end_line": 1165,
+     "name": ".content"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".content"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 3950,
+     "end_line": 3968,
+     "name": ".bulma-content"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-content"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 3950,
+     "end_line": 3968,
+     "name": ".content"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".content"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 3950,
+     "end_line": 3968,
+     "name": ".bulma-content"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-content"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 3090,
+     "end_line": 3108,
+     "name": ".content"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".content"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1151dad5781ee2ae",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 5927,
+     "end_line": 5934,
+     "name": ".file.is-white"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".file.is-white"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 3124,
+     "end_line": 3131,
+     "name": ".file.is-white"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".file.is-white"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 5927,
+     "end_line": 5934,
+     "name": ".bulma-file.bulma-is-white"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-file.bulma-is-white"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 5927,
+     "end_line": 5934,
+     "name": ".file.is-white"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".file.is-white"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 5927,
+     "end_line": 5934,
+     "name": ".bulma-file.bulma-is-white"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-file.bulma-is-white"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 651,
+     "end_line": 658,
+     "name": ".file.is-white"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".file.is-white"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "24d13c55bc00fabc",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 2977,
+     "end_line": 2983,
+     "name": "a:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 174,
+     "end_line": 180,
+     "name": "a:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 2977,
+     "end_line": 2983,
+     "name": "a:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 2977,
+     "end_line": 2983,
+     "name": "a:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 2977,
+     "end_line": 2983,
+     "name": "a:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 1343,
+     "end_line": 1349,
+     "name": "a:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "a:focus-visible"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "3fc167fc67a5502c",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 3999,
+     "end_line": 4002,
+     "name": ".content h2"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".content h2"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1196,
+     "end_line": 1199,
+     "name": ".content h2"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".content h2"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 3999,
+     "end_line": 4002,
+     "name": ".bulma-content h2"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-content h2"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 3999,
+     "end_line": 4002,
+     "name": ".content h2"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".content h2"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 3999,
+     "end_line": 4002,
+     "name": ".bulma-content h2"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-content h2"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 3139,
+     "end_line": 3142,
+     "name": ".content h2"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".content h2"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "5102039c182421d1",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 5975,
+     "end_line": 5982,
+     "name": ".file.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".file.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 3172,
+     "end_line": 3179,
+     "name": ".file.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".file.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 5975,
+     "end_line": 5982,
+     "name": ".bulma-file.bulma-is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-file.bulma-is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 5975,
+     "end_line": 5982,
+     "name": ".file.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".file.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 5975,
+     "end_line": 5982,
+     "name": ".bulma-file.bulma-is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-file.bulma-is-link"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 699,
+     "end_line": 706,
+     "name": ".file.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".file.is-link"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "5fbe66e4154e58db",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 3104,
+     "end_line": 3108,
+     "name": "@keyframes pulsate"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@keyframes pulsate"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 301,
+     "end_line": 305,
+     "name": "@keyframes pulsate"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@keyframes pulsate"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 3104,
+     "end_line": 3108,
+     "name": "@keyframes pulsate"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@keyframes pulsate"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 3104,
+     "end_line": 3108,
+     "name": "@keyframes pulsate"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@keyframes pulsate"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 3104,
+     "end_line": 3108,
+     "name": "@keyframes pulsate"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@keyframes pulsate"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 1470,
+     "end_line": 1474,
+     "name": "@keyframes pulsate"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "@keyframes pulsate"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "6cb90d3521e56146",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4580,
+     "end_line": 4583,
+     "name": ".notification.is-black.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".notification.is-black.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1777,
+     "end_line": 1780,
+     "name": ".notification.is-black.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".notification.is-black.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4580,
+     "end_line": 4583,
+     "name": ".bulma-notification.bulma-is-black.bulma-is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-notification.bulma-is-black.bulma-is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4580,
+     "end_line": 4583,
+     "name": ".notification.is-black.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".notification.is-black.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4580,
+     "end_line": 4583,
+     "name": ".bulma-notification.bulma-is-black.bulma-is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-notification.bulma-is-black.bulma-is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 3342,
+     "end_line": 3345,
+     "name": ".notification.is-black.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".notification.is-black.is-dark"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "7dbd89ea63f59d32",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4576,
+     "end_line": 4579,
+     "name": ".notification.is-black.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".notification.is-black.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1773,
+     "end_line": 1776,
+     "name": ".notification.is-black.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".notification.is-black.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4576,
+     "end_line": 4579,
+     "name": ".bulma-notification.bulma-is-black.bulma-is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-notification.bulma-is-black.bulma-is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4576,
+     "end_line": 4579,
+     "name": ".notification.is-black.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".notification.is-black.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4576,
+     "end_line": 4579,
+     "name": ".bulma-notification.bulma-is-black.bulma-is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-notification.bulma-is-black.bulma-is-light"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 3338,
+     "end_line": 3341,
+     "name": ".notification.is-black.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".notification.is-black.is-light"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "8dad6ba2f68c971b",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4688,
+     "end_line": 4691,
+     "name": ".notification.is-warning.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".notification.is-warning.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1885,
+     "end_line": 1888,
+     "name": ".notification.is-warning.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".notification.is-warning.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4688,
+     "end_line": 4691,
+     "name": ".bulma-notification.bulma-is-warning.bulma-is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-notification.bulma-is-warning.bulma-is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4688,
+     "end_line": 4691,
+     "name": ".notification.is-warning.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".notification.is-warning.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4688,
+     "end_line": 4691,
+     "name": ".bulma-notification.bulma-is-warning.bulma-is-light"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-notification.bulma-is-warning.bulma-is-light"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 3450,
+     "end_line": 3453,
+     "name": ".notification.is-warning.is-light"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".notification.is-warning.is-light"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "9e3926abb8e3fddf",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4678,
+     "end_line": 4681,
+     "name": ".notification.is-success.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".notification.is-success.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1875,
+     "end_line": 1878,
+     "name": ".notification.is-success.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".notification.is-success.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4678,
+     "end_line": 4681,
+     "name": ".bulma-notification.bulma-is-success.bulma-is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-notification.bulma-is-success.bulma-is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4678,
+     "end_line": 4681,
+     "name": ".notification.is-success.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".notification.is-success.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4678,
+     "end_line": 4681,
+     "name": ".bulma-notification.bulma-is-success.bulma-is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-notification.bulma-is-success.bulma-is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 3440,
+     "end_line": 3443,
+     "name": ".notification.is-success.is-dark"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".notification.is-success.is-dark"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ab334ae1f197913f",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 5726,
+     "end_line": 5729,
+     "name": ".select.is-rounded select"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".select.is-rounded select"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 2923,
+     "end_line": 2926,
+     "name": ".select.is-rounded select"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".select.is-rounded select"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 5726,
+     "end_line": 5729,
+     "name": ".bulma-select.bulma-is-rounded select"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-select.bulma-is-rounded select"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 5726,
+     "end_line": 5729,
+     "name": ".select.is-rounded select"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".select.is-rounded select"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 5726,
+     "end_line": 5729,
+     "name": ".bulma-select.bulma-is-rounded select"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-select.bulma-is-rounded select"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 461,
+     "end_line": 464,
+     "name": ".select.is-rounded select"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".select.is-rounded select"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "bfb986df2c3b8ac7",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4209,
+     "end_line": 4218,
+     "name": ".icon"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".icon"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1406,
+     "end_line": 1415,
+     "name": ".icon"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".icon"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4209,
+     "end_line": 4218,
+     "name": ".bulma-icon"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-icon"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4209,
+     "end_line": 4218,
+     "name": ".icon"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".icon"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4209,
+     "end_line": 4218,
+     "name": ".bulma-icon"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-icon"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 3049,
+     "end_line": 3058,
+     "name": ".icon"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".icon"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "cc86be4055391268",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 5209,
+     "end_line": 5214,
+     "name": ".tag.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".tag.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 2406,
+     "end_line": 2411,
+     "name": ".tag.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".tag.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 5209,
+     "end_line": 5214,
+     "name": ".bulma-tag.bulma-is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-tag.bulma-is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 5209,
+     "end_line": 5214,
+     "name": ".tag.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".tag.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 5209,
+     "end_line": 5214,
+     "name": ".bulma-tag.bulma-is-link"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-tag.bulma-is-link"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 3694,
+     "end_line": 3699,
+     "name": ".tag.is-link"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".tag.is-link"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "da4bd161a0d4e21d",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4116,
+     "end_line": 4120,
+     "name": ".content table tfoot td"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".content table tfoot td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1313,
+     "end_line": 1317,
+     "name": ".content table tfoot td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".content table tfoot td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4116,
+     "end_line": 4120,
+     "name": ".bulma-content table tfoot td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-content table tfoot td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4116,
+     "end_line": 4120,
+     "name": ".content table tfoot td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".content table tfoot td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4116,
+     "end_line": 4120,
+     "name": ".bulma-content table tfoot td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-content table tfoot td"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 3252,
+     "end_line": 3256,
+     "name": ".content table tfoot td"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".content table tfoot td"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "f1774d29bb078a56",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 5249,
+     "end_line": 5254,
+     "name": ".tag.is-danger"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".tag.is-danger"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 2446,
+     "end_line": 2451,
+     "name": ".tag.is-danger"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".tag.is-danger"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 5249,
+     "end_line": 5254,
+     "name": ".bulma-tag.bulma-is-danger"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-tag.bulma-is-danger"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 5249,
+     "end_line": 5254,
+     "name": ".tag.is-danger"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".tag.is-danger"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 5249,
+     "end_line": 5254,
+     "name": ".bulma-tag.bulma-is-danger"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-tag.bulma-is-danger"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 3734,
+     "end_line": 3739,
+     "name": ".tag.is-danger"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".tag.is-danger"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "05966499380456a6",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 9948,
+     "end_line": 9952,
+     "name": "@media screen and (min-width: 1024px) and (max-width: 1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 7145,
+     "end_line": 7149,
+     "name": "@media screen and (min-width: 1024px) and (max-width: 1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 9948,
+     "end_line": 9952,
+     "name": "@media screen and (min-width: 1024px) and (max-width: 1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 9948,
+     "end_line": 9952,
+     "name": "@media screen and (min-width: 1024px) and (max-width: 1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 9948,
+     "end_line": 9952,
+     "name": "@media screen and (min-width: 1024px) and (max-width: 1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "19406e484bc6bbb2",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4839,
+     "end_line": 4848,
+     "name": ".table td"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".table td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 2036,
+     "end_line": 2045,
+     "name": ".table td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".table td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4839,
+     "end_line": 4848,
+     "name": ".bulma-table td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-table td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4839,
+     "end_line": 4848,
+     "name": ".table td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".table td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4839,
+     "end_line": 4848,
+     "name": ".bulma-table td"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-table td"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".table td"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "2dacbf1a23dcfc6c",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 8440,
+     "end_line": 8443,
+     "name": ".tabs.is-toggle li:last-child a"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".tabs.is-toggle li:last-child a"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 5637,
+     "end_line": 5640,
+     "name": ".tabs.is-toggle li:last-child a"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".tabs.is-toggle li:last-child a"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 8440,
+     "end_line": 8443,
+     "name": ".bulma-tabs.bulma-is-toggle li:last-child a"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-tabs.bulma-is-toggle li:last-child a"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 8440,
+     "end_line": 8443,
+     "name": ".tabs.is-toggle li:last-child a"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".tabs.is-toggle li:last-child a"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 8440,
+     "end_line": 8443,
+     "name": ".bulma-tabs.bulma-is-toggle li:last-child a"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-tabs.bulma-is-toggle li:last-child a"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".tabs.is-toggle li:last-child a"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "407d8cd918e67d15",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 8584,
+     "end_line": 8587,
+     "name": ".columns.is-mobile > .column.is-4"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".columns.is-mobile>.column.is-4"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 5781,
+     "end_line": 5784,
+     "name": ".columns.is-mobile > .column.is-4"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".columns.is-mobile>.column.is-4"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 8584,
+     "end_line": 8587,
+     "name": ".bulma-columns.bulma-is-mobile > .bulma-column.bulma-is-4"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-columns.bulma-is-mobile>.bulma-column.bulma-is-4"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 8584,
+     "end_line": 8587,
+     "name": ".columns.is-mobile > .column.is-4"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".columns.is-mobile>.column.is-4"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 8584,
+     "end_line": 8587,
+     "name": ".bulma-columns.bulma-is-mobile > .bulma-column.bulma-is-4"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-columns.bulma-is-mobile>.bulma-column.bulma-is-4"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".columns.is-mobile>.column.is-4"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "51fb26a5edea938f",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 13365,
+     "end_line": 13372,
+     "name": ".hero.is-primary"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".hero.is-primary"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 10562,
+     "end_line": 10569,
+     "name": ".hero.is-primary"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".hero.is-primary"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 13365,
+     "end_line": 13372,
+     "name": ".bulma-hero.bulma-is-primary"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-hero.bulma-is-primary"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 13365,
+     "end_line": 13372,
+     "name": ".hero.is-primary"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".hero.is-primary"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 13365,
+     "end_line": 13372,
+     "name": ".bulma-hero.bulma-is-primary"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-hero.bulma-is-primary"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".hero.is-primary"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "5e0fbace7ff536f2",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 9713,
+     "end_line": 9717,
+     "name": "@media screen and (min-width: 1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 6910,
+     "end_line": 6914,
+     "name": "@media screen and (min-width: 1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 9713,
+     "end_line": 9717,
+     "name": "@media screen and (min-width: 1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 9713,
+     "end_line": 9717,
+     "name": "@media screen and (min-width: 1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 9713,
+     "end_line": 9717,
+     "name": "@media screen and (min-width: 1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "@media screen and (min-width:1216px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "6a24e065a942da9f",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 5324,
+     "end_line": 5342,
+     "name": ".title"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".subtitle"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 2521,
+     "end_line": 2539,
+     "name": ".title"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".subtitle"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 5324,
+     "end_line": 5342,
+     "name": ".bulma-title"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-subtitle"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 5324,
+     "end_line": 5342,
+     "name": ".title"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".subtitle"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 5324,
+     "end_line": 5342,
+     "name": ".bulma-title"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-subtitle"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".subtitle"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "7807858d83d59e06",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 9827,
+     "end_line": 9831,
+     "name": "@media screen and (max-width: 768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 7024,
+     "end_line": 7028,
+     "name": "@media screen and (max-width: 768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 9827,
+     "end_line": 9831,
+     "name": "@media screen and (max-width: 768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 9827,
+     "end_line": 9831,
+     "name": "@media screen and (max-width: 768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 9827,
+     "end_line": 9831,
+     "name": "@media screen and (max-width: 768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:768px)"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "@media screen and (max-width:768px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "857fdaf874a777d4",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 9708,
+     "end_line": 9712,
+     "name": "@media screen and (min-width: 1024px) and (max-width: 1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 6905,
+     "end_line": 6909,
+     "name": "@media screen and (min-width: 1024px) and (max-width: 1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 9708,
+     "end_line": 9712,
+     "name": "@media screen and (min-width: 1024px) and (max-width: 1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 9708,
+     "end_line": 9712,
+     "name": "@media screen and (min-width: 1024px) and (max-width: 1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 9708,
+     "end_line": 9712,
+     "name": "@media screen and (min-width: 1024px) and (max-width: 1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "a625399e6f499dc7",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 8605,
+     "end_line": 8608,
+     "name": ".columns.is-mobile > .column.is-7"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".columns.is-mobile>.column.is-7"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 5802,
+     "end_line": 5805,
+     "name": ".columns.is-mobile > .column.is-7"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".columns.is-mobile>.column.is-7"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 8605,
+     "end_line": 8608,
+     "name": ".bulma-columns.bulma-is-mobile > .bulma-column.bulma-is-7"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-columns.bulma-is-mobile>.bulma-column.bulma-is-7"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 8605,
+     "end_line": 8608,
+     "name": ".columns.is-mobile > .column.is-7"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".columns.is-mobile>.column.is-7"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 8605,
+     "end_line": 8608,
+     "name": ".bulma-columns.bulma-is-mobile > .bulma-column.bulma-is-7"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-columns.bulma-is-mobile>.bulma-column.bulma-is-7"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".columns.is-mobile>.column.is-7"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "b7f5e05920153fad",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 9890,
+     "end_line": 9894,
+     "name": "@media screen and (max-width: 1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 7087,
+     "end_line": 7091,
+     "name": "@media screen and (max-width: 1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 9890,
+     "end_line": 9894,
+     "name": "@media screen and (max-width: 1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 9890,
+     "end_line": 9894,
+     "name": "@media screen and (max-width: 1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 9890,
+     "end_line": 9894,
+     "name": "@media screen and (max-width: 1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "@media screen and (max-width:1023px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "c4b085c666b3fda8",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 8612,
+     "end_line": 8615,
+     "name": ".columns.is-mobile > .column.is-8"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".columns.is-mobile>.column.is-8"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 5809,
+     "end_line": 5812,
+     "name": ".columns.is-mobile > .column.is-8"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".columns.is-mobile>.column.is-8"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 8612,
+     "end_line": 8615,
+     "name": ".bulma-columns.bulma-is-mobile > .bulma-column.bulma-is-8"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-columns.bulma-is-mobile>.bulma-column.bulma-is-8"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 8612,
+     "end_line": 8615,
+     "name": ".columns.is-mobile > .column.is-8"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".columns.is-mobile>.column.is-8"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 8612,
+     "end_line": 8615,
+     "name": ".bulma-columns.bulma-is-mobile > .bulma-column.bulma-is-8"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-columns.bulma-is-mobile>.bulma-column.bulma-is-8"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".columns.is-mobile>.column.is-8"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "d32dace44cf51d95",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 4473,
+     "end_line": 4476,
+     "name": ".image.is-16x16"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".image.is-16x16"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 1670,
+     "end_line": 1673,
+     "name": ".image.is-16x16"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".image.is-16x16"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 4473,
+     "end_line": 4476,
+     "name": ".bulma-image.bulma-is-16x16"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-image.bulma-is-16x16"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 4473,
+     "end_line": 4476,
+     "name": ".image.is-16x16"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".image.is-16x16"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 4473,
+     "end_line": 4476,
+     "name": ".bulma-image.bulma-is-16x16"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-image.bulma-is-16x16"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".image.is-16x16"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ebc43d8a6e6d5c01",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 8525,
+     "end_line": 8528,
+     "name": ".columns.is-mobile > .column.is-four-fifths"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".columns.is-mobile>.column.is-four-fifths"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 5722,
+     "end_line": 5725,
+     "name": ".columns.is-mobile > .column.is-four-fifths"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".columns.is-mobile>.column.is-four-fifths"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 8525,
+     "end_line": 8528,
+     "name": ".bulma-columns.bulma-is-mobile > .bulma-column.bulma-is-four-fifths"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-columns.bulma-is-mobile>.bulma-column.bulma-is-four-fifths"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 8525,
+     "end_line": 8528,
+     "name": ".columns.is-mobile > .column.is-four-fifths"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".columns.is-mobile>.column.is-four-fifths"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 8525,
+     "end_line": 8528,
+     "name": ".bulma-columns.bulma-is-mobile > .bulma-column.bulma-is-four-fifths"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-columns.bulma-is-mobile>.bulma-column.bulma-is-four-fifths"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".columns.is-mobile>.column.is-four-fifths"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "fd9192ae933b81bd",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 6665,
+     "end_line": 6688,
+     "name": ".dropdown"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".dropdown"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 3862,
+     "end_line": 3885,
+     "name": ".dropdown"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".dropdown"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 6665,
+     "end_line": 6688,
+     "name": ".bulma-dropdown"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-dropdown"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 6665,
+     "end_line": 6688,
+     "name": ".dropdown"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".dropdown"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 6665,
+     "end_line": 6688,
+     "name": ".bulma-dropdown"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-dropdown"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".dropdown"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "0ab18f13990fd9d0",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/docs/cyp/components/breadcrumb.html",
+     "start_line": 13,
+     "end_line": 17,
+     "name": "nav"
+    },
+    {
+     "file": "bench/repos/bulma/docs/cyp/components/breadcrumb.html",
+     "start_line": 19,
+     "end_line": 23,
+     "name": "nav"
+    },
+    {
+     "file": "bench/repos/bulma/docs/cyp/components/breadcrumb.html",
+     "start_line": 25,
+     "end_line": 29,
+     "name": "nav"
+    },
+    {
+     "file": "bench/repos/bulma/docs/cyp/components/breadcrumb.html",
+     "start_line": 32,
+     "end_line": 36,
+     "name": "nav"
+    },
+    {
+     "file": "bench/repos/bulma/docs/cyp/components/breadcrumb.html",
+     "start_line": 39,
+     "end_line": 43,
+     "name": "nav"
+    },
+    {
+     "file": "bench/repos/bulma/docs/cyp/components/breadcrumb.html",
+     "start_line": 45,
+     "end_line": 49,
+     "name": "nav"
+    },
+    {
+     "file": "bench/repos/bulma/docs/cyp/components/breadcrumb.html",
+     "start_line": 51,
+     "end_line": 55,
+     "name": "nav"
+    },
+    {
+     "file": "bench/repos/bulma/docs/cyp/components/breadcrumb.html",
+     "start_line": 57,
+     "end_line": 61,
+     "name": "nav"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "0f6e051d4ce15e45",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 21114,
+     "end_line": 21119,
+     "name": "@media screen and (min-width: 1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 18311,
+     "end_line": 18316,
+     "name": "@media screen and (min-width: 1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 21114,
+     "end_line": 21119,
+     "name": "@media screen and (min-width: 1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1216px)"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "@media screen and (min-width:1216px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "2ea4aea17d792922",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 18944,
+     "end_line": 18950,
+     "name": "a.has-text-warning:hover"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a.has-text-warning:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 16141,
+     "end_line": 16147,
+     "name": "a.has-text-warning:hover"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a.has-text-warning:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 18944,
+     "end_line": 18950,
+     "name": "a.bulma-has-text-warning:hover"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a.bulma-has-text-warning:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "a.has-text-warning:focus-visible"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "46dba45ec6b6d189",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 21214,
+     "end_line": 21219,
+     "name": "@media screen and (max-width: 1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 18411,
+     "end_line": 18416,
+     "name": "@media screen and (max-width: 1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 21214,
+     "end_line": 21219,
+     "name": "@media screen and (max-width: 1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:1023px)"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "@media screen and (max-width:1023px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "59a74465b55e33f9",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 19833,
+     "end_line": 19836,
+     "name": ".is-float-right"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".is-float-right"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 17030,
+     "end_line": 17033,
+     "name": ".is-float-right"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".is-float-right"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 19833,
+     "end_line": 19836,
+     "name": ".bulma-is-float-right"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bulma-is-float-right"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".is-float-right"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "6fd54971ab034a7e",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 19456,
+     "end_line": 19462,
+     "name": "a.has-background-danger:hover"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a.has-background-danger:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 16653,
+     "end_line": 16659,
+     "name": "a.has-background-danger:hover"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a.has-background-danger:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 19456,
+     "end_line": 19462,
+     "name": "a.bulma-has-background-danger:hover"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a.bulma-has-background-danger:focus-visible"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "a.has-background-danger:focus-visible"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "81761ec8493714c4",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 20934,
+     "end_line": 20938,
+     "name": "@media screen and (min-width: 1024px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 18131,
+     "end_line": 18135,
+     "name": "@media screen and (min-width: 1024px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 20934,
+     "end_line": 20938,
+     "name": "@media screen and (min-width: 1024px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px)"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "@media screen and (min-width:1024px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "9b31750d74b68c24",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 18465,
+     "end_line": 18469,
+     "name": "a.has-background-success:active"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a.has-background-success:active"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 15662,
+     "end_line": 15666,
+     "name": "a.has-background-success:active"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a.has-background-success:active"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 18465,
+     "end_line": 18469,
+     "name": "a.bulma-has-background-success:active"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "a.bulma-has-background-success:active"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "a.has-background-success:active"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "bde38dcc20ca9f2d",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 20859,
+     "end_line": 20863,
+     "name": "@media screen and (min-width: 1216px) and (max-width: 1407px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1216px) and (max-width:1407px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 18056,
+     "end_line": 18060,
+     "name": "@media screen and (min-width: 1216px) and (max-width: 1407px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1216px) and (max-width:1407px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 20859,
+     "end_line": 20863,
+     "name": "@media screen and (min-width: 1216px) and (max-width: 1407px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1216px) and (max-width:1407px)"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "@media screen and (min-width:1216px) and (max-width:1407px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "d364684debb3874b",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 20869,
+     "end_line": 20873,
+     "name": "@media screen and (max-width: 768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 18066,
+     "end_line": 18070,
+     "name": "@media screen and (max-width: 768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 20869,
+     "end_line": 20873,
+     "name": "@media screen and (max-width: 768px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:768px)"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "@media screen and (max-width:768px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "f34100554f582f7b",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 21527,
+     "end_line": 21532,
+     "name": "@media screen and (min-width: 1024px) and (max-width: 1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/bulma.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 18724,
+     "end_line": 18729,
+     "name": "@media screen and (min-width: 1024px) and (max-width: 1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 21527,
+     "end_line": 21532,
+     "name": "@media screen and (min-width: 1024px) and (max-width: 1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/website.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "@media screen and (min-width:1024px) and (max-width:1215px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "67796666b349c3f5",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/docs/_includes/library/layout/hero.html",
+     "start_line": 44,
+     "end_line": 102,
+     "name": "section"
+    },
+    {
+     "file": "bench/repos/bulma/docs/_includes/library/layout/hero.html",
+     "start_line": 104,
+     "end_line": 171,
+     "name": "section"
+    },
+    {
+     "file": "bench/repos/bulma/docs/_includes/library/layout/hero.html",
+     "start_line": 173,
+     "end_line": 231,
+     "name": "section"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/layout/hero.html",
+     "start_line": 213,
+     "end_line": 271,
+     "name": "section"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/layout/hero.html",
+     "start_line": 274,
+     "end_line": 341,
+     "name": "section"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/layout/hero.html",
+     "start_line": 344,
+     "end_line": 402,
+     "name": "section"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "1264fa5a6e3a1b99",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 6887,
+     "end_line": 6891,
+     "name": ".message"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 4084,
+     "end_line": 4088,
+     "name": ".message"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 6887,
+     "end_line": 6891,
+     "name": ".bulma-message"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 6887,
+     "end_line": 6891,
+     "name": ".message"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 6887,
+     "end_line": 6891,
+     "name": ".bulma-message"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "9b94c3a476adf58b",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/docs/documentation/columns/responsiveness.html",
+     "start_line": 120,
+     "end_line": 122,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/elements/button.html",
+     "start_line": 794,
+     "end_line": 802,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/form/general.html",
+     "start_line": 930,
+     "end_line": 935,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/form/input.html",
+     "start_line": 403,
+     "end_line": 411,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/form/select.html",
+     "start_line": 337,
+     "end_line": 345,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "e40ef53e549eb177",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 13774,
+     "end_line": 13780,
+     "name": ".media .media"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 10971,
+     "end_line": 10977,
+     "name": ".media .media"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers-prefixed.css",
+     "start_line": 13774,
+     "end_line": 13780,
+     "name": ".bulma-media .bulma-media"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 13774,
+     "end_line": 13780,
+     "name": ".media .media"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 13774,
+     "end_line": 13780,
+     "name": ".bulma-media .bulma-media"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "32ddfcf8cffdaf4c",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/docs/documentation/grid/smart-grid.html",
+     "start_line": 75,
+     "end_line": 82,
+     "name": "thead"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/helpers/palette-helpers.html",
+     "start_line": 66,
+     "end_line": 73,
+     "name": "thead"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/start/alternative-versions.html",
+     "start_line": 75,
+     "end_line": 82,
+     "name": "thead"
+    },
+    {
+     "file": "bench/repos/bulma/docs/made-with-bulma.html",
+     "start_line": 74,
+     "end_line": 81,
+     "name": "thead"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "d3e804c2d0c22bea",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 6289,
+     "end_line": 6299,
+     "name": ".field.has-addons .control .button:not([disabled]):focus:hover"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 3486,
+     "end_line": 3496,
+     "name": ".field.has-addons .control .button:not([disabled]):focus:hover"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-helpers.css",
+     "start_line": 6289,
+     "end_line": 6299,
+     "name": ".field.has-addons .control .button:not([disabled]):focus:hover"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/css/custom.css",
+     "start_line": 1005,
+     "end_line": 1015,
+     "name": ".field.has-addons .control .button:not([disabled]):focus:hover"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "2eebbdd2e19668f1",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/docs/_includes/docs/side-sponsr.html",
+     "start_line": 4,
+     "end_line": 13,
+     "name": "a"
+    },
+    {
+     "file": "bench/repos/bulma/docs/backers.html",
+     "start_line": 18,
+     "end_line": 24,
+     "name": "a"
+    },
+    {
+     "file": "bench/repos/bulma/docs/backers.html",
+     "start_line": 27,
+     "end_line": 33,
+     "name": "a"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   }
+  },
+  {
+   "family_id": "75a430424c175b4b",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/css/bulma.css",
+     "start_line": 21261,
+     "end_line": 21266,
+     "name": "@media screen and (min-width: 769px) print"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-no-dark-mode.css",
+     "start_line": 18458,
+     "end_line": 18463,
+     "name": "@media screen and (min-width: 769px) print"
+    },
+    {
+     "file": "bench/repos/bulma/css/versions/bulma-prefixed.css",
+     "start_line": 21261,
+     "end_line": 21266,
+     "name": "@media screen and (min-width: 769px) print"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "b4f4b76bf9c7352e",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/docs/documentation/form/general.html",
+     "start_line": 481,
+     "end_line": 492,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/form/general.html",
+     "start_line": 496,
+     "end_line": 507,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/form/general.html",
+     "start_line": 511,
+     "end_line": 522,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "f024af8721014989",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/docs/_includes/docs/modals/example-js-modal.html",
+     "start_line": 1,
+     "end_line": 12,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bulma/docs/_includes/library/components/modal.html",
+     "start_line": 26,
+     "end_line": 37,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/components/modal.html",
+     "start_line": 66,
+     "end_line": 77,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "22ce5e42cb026498",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/docs/documentation/columns/gap.html",
+     "start_line": 116,
+     "end_line": 144,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/columns/options.html",
+     "start_line": 130,
+     "end_line": 158,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "parameterize"
+    }
+   },
+   "note": "Two standalone bulma doc demo grids differing only by is-gapless; they teach different features on different doc pages and the literal copy-paste example is the design \u2014 merging couples unrelated docs."
+  },
+  {
+   "family_id": "52c954f8a36430c0",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/docs/_react/bulma-customizer/src/App.module.css",
+     "start_line": 32,
+     "end_line": 36,
+     "name": ".open"
+    },
+    {
+     "file": "bench/repos/bulma/docs/assets/javascript/bulma-customizer/index.css",
+     "start_line": 1,
+     "end_line": 1,
+     "name": "._open_1oamh_32"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "829a5d30e5e10738",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/docs/_react/bulma-customizer/src/App.jsx",
+     "start_line": 559,
+     "end_line": 565,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/bulma/docs/_react/bulma-customizer/src/components/Export.jsx",
+     "start_line": 89,
+     "end_line": 94,
+     "name": "button"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "a5e75ecf70d68994",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/docs/documentation/elements/box.html",
+     "start_line": 48,
+     "end_line": 57,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/layout/media-object.html",
+     "start_line": 23,
+     "end_line": 31,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   },
+   "note": "Matched region is only a .content div wrapping a lorem <p> (body text actually differs); a bare demo content wrapper, too small to abstract."
+  },
+  {
+   "family_id": "cefe1de1117bc68f",
+   "repo": "bulma",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bulma/docs/_includes/library/elements/icon.html",
+     "start_line": 12,
+     "end_line": 32,
+     "name": "span"
+    },
+    {
+     "file": "bench/repos/bulma/docs/documentation/elements/icon.html",
+     "start_line": 35,
+     "end_line": 55,
+     "name": "span"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "7e7c54b037924043",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.amber.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.amber.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.blue.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.blue.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.amber.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.amber.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.blue.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.blue.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.amber.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.amber.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.blue.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.blue.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.cyan.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.cyan.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.fuchsia.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.fuchsia.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.green.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.green.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.grey.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.grey.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.indigo.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.indigo.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.jade.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.jade.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.lime.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.lime.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.orange.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.orange.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.pink.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.pink.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.pumpkin.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.pumpkin.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.purple.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.purple.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.red.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.red.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.sand.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.sand.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.slate.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.slate.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.violet.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.violet.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.yellow.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.yellow.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.zinc.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.zinc.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.cyan.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.cyan.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.fuchsia.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.fuchsia.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.green.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.green.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.grey.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.grey.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.indigo.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.indigo.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.jade.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.jade.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.lime.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.lime.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.orange.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.orange.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.pink.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.pink.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.pumpkin.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.pumpkin.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.purple.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.purple.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.red.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.red.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.sand.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.sand.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.slate.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.slate.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.violet.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.violet.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.yellow.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.yellow.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.zinc.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.zinc.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.amber.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.amber.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.blue.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.blue.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.cyan.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.cyan.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.fuchsia.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.fuchsia.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.green.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.green.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.grey.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.grey.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.indigo.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.indigo.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.jade.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.jade.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.lime.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.lime.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.orange.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.orange.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pink.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pink.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pumpkin.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pumpkin.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.purple.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.purple.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.red.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.red.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.sand.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.sand.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.slate.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.slate.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.violet.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.violet.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.yellow.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.yellow.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.zinc.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.zinc.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.cyan.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.cyan.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.amber.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.amber.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.blue.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.blue.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.amber.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.amber.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.blue.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.blue.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.cyan.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.cyan.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.fuchsia.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.fuchsia.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.green.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.green.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.grey.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.grey.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.indigo.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.indigo.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.jade.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.jade.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.lime.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.lime.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.orange.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.orange.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.pink.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.pink.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.pumpkin.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.pumpkin.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.purple.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.purple.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.red.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.red.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.sand.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.sand.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.slate.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.slate.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.violet.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.violet.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.yellow.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.yellow.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.zinc.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.zinc.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.cyan.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.cyan.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.fuchsia.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.fuchsia.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.green.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.green.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.grey.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.grey.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.indigo.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.indigo.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.jade.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.jade.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.lime.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.lime.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.orange.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.orange.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.pink.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.pink.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.pumpkin.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.pumpkin.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.purple.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.purple.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.red.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.red.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.sand.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.sand.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.slate.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.slate.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.violet.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.violet.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.yellow.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.yellow.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.zinc.css",
+     "start_line": 9,
+     "end_line": 46,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.zinc.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fuchsia.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fuchsia.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.green.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.green.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.grey.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.grey.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.indigo.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.indigo.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.jade.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.jade.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.lime.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.lime.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.orange.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.orange.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.pink.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.pink.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.pumpkin.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.pumpkin.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.purple.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.purple.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.red.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.red.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.sand.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.sand.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.slate.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.slate.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.violet.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.violet.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.yellow.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.yellow.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.zinc.css",
+     "start_line": 9,
+     "end_line": 48,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.zinc.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ":host"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "646da3b0120110f2",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.amber.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.blue.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.amber.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.blue.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.amber.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.blue.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.cyan.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.fuchsia.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.green.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.grey.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.indigo.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.jade.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.lime.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.orange.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.pink.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.pumpkin.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.purple.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.red.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.sand.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.slate.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.violet.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.yellow.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.zinc.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.cyan.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.fuchsia.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.green.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.grey.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.indigo.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.jade.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.lime.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.orange.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.pink.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.pumpkin.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.purple.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.red.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.sand.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.slate.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.violet.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.yellow.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.zinc.css",
+     "start_line": 757,
+     "end_line": 760,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.amber.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.blue.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.cyan.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.fuchsia.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.green.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.grey.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.indigo.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.jade.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.lime.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.orange.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pink.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pumpkin.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.purple.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.red.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.sand.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.slate.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.violet.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.yellow.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.zinc.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.cyan.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.amber.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.blue.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.amber.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.blue.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.cyan.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.fuchsia.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.green.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.grey.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.indigo.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.jade.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.lime.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.orange.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.pink.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.pumpkin.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.purple.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.red.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.sand.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.slate.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.violet.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.yellow.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.zinc.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ".pico :where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.cyan.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.fuchsia.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.green.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.grey.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.indigo.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.jade.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.lime.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.orange.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.pink.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.pumpkin.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.purple.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.red.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.sand.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.slate.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.violet.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.yellow.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.zinc.css",
+     "start_line": 720,
+     "end_line": 723,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fuchsia.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.green.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.grey.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.indigo.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.jade.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.lime.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.orange.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.pink.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.pumpkin.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.purple.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.red.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.sand.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.slate.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.violet.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.yellow.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.zinc.css",
+     "start_line": 857,
+     "end_line": 860,
+     "name": ":where(dl, ol, ul) :where(dl, ol, ul)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "5b9abc16117ea92c",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.amber.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.blue.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.amber.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.blue.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.cyan.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.fuchsia.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.green.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.grey.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.indigo.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.jade.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.lime.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.orange.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.pink.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.pumpkin.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.purple.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.red.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.sand.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.slate.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.violet.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.yellow.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.zinc.css",
+     "start_line": 1527,
+     "end_line": 1535,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.cyan.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.amber.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.blue.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.cyan.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.fuchsia.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.green.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.grey.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.indigo.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.jade.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.lime.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.orange.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.pink.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.pumpkin.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.purple.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.red.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.sand.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.slate.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.violet.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.yellow.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.zinc.css",
+     "start_line": 1490,
+     "end_line": 1498,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fuchsia.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.green.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.grey.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.indigo.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.jade.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.lime.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.orange.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.pink.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.pumpkin.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.purple.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.red.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.sand.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.slate.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.violet.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.yellow.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.zinc.css",
+     "start_line": 1699,
+     "end_line": 1707,
+     "name": "[type=checkbox][aria-invalid=false]:checked"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ba8e4b182de5f398",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.amber.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.blue.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.amber.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.blue.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.cyan.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.fuchsia.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.green.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.grey.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.indigo.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.jade.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.lime.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.orange.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.pink.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.pumpkin.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.purple.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.red.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.sand.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.slate.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.violet.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.yellow.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.zinc.css",
+     "start_line": 1300,
+     "end_line": 1309,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.cyan.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.amber.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.blue.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.cyan.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.fuchsia.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.green.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.grey.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.indigo.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.jade.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.lime.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.orange.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.pink.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.pumpkin.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.purple.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.red.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.sand.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.slate.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.violet.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.yellow.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.zinc.css",
+     "start_line": 1263,
+     "end_line": 1272,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fuchsia.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.green.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.grey.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.indigo.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.jade.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.lime.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.orange.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.pink.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.pumpkin.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.purple.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.red.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.sand.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.slate.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.violet.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.yellow.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.zinc.css",
+     "start_line": 1472,
+     "end_line": 1481,
+     "name": ":where(input, select, textarea):not([type=checkbox], [type=radio], [type=date], [type=datetime-local], [type=month], [type=time], [type=week], [type=range])[aria-invalid=false]:not(select)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "47c612b5b1b46f00",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.amber.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.blue.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.cyan.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.fuchsia.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.green.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.grey.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.indigo.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.jade.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.lime.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.orange.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.pink.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.pumpkin.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.purple.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.red.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.sand.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.slate.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.violet.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.yellow.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.zinc.css",
+     "start_line": 1246,
+     "end_line": 1254,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.amber.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.blue.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.cyan.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.fuchsia.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.green.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.grey.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.indigo.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.jade.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.lime.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.orange.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pink.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pumpkin.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.purple.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.red.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.sand.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.slate.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.violet.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.yellow.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.zinc.css",
+     "start_line": 1418,
+     "end_line": 1426,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.amber.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.blue.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.cyan.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.fuchsia.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.green.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.grey.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.indigo.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.jade.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.lime.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.orange.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.pink.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.pumpkin.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.purple.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.red.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.sand.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.slate.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.violet.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.yellow.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.zinc.css",
+     "start_line": 1209,
+     "end_line": 1217,
+     "name": ".pico input:not([type=submit], [type=button], [type=reset], [type=checkbox], [type=radio], [readonly]):is(:active, :focus)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "923595114bd4fcef",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.amber.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.blue.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.cyan.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.fuchsia.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.green.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.grey.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.indigo.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.jade.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.lime.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.orange.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.pink.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.pumpkin.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.purple.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.red.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.sand.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.slate.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.violet.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.yellow.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.zinc.css",
+     "start_line": 2183,
+     "end_line": 2188,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.amber.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.blue.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.cyan.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.fuchsia.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.green.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.grey.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.indigo.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.jade.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.lime.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.orange.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pink.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pumpkin.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.purple.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.red.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.sand.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.slate.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.violet.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.yellow.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.zinc.css",
+     "start_line": 2560,
+     "end_line": 2565,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.amber.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.blue.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.cyan.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.fuchsia.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.green.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.grey.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.indigo.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.jade.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.lime.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.orange.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.pink.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.pumpkin.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.purple.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.red.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.sand.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.slate.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.violet.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.yellow.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.zinc.css",
+     "start_line": 2146,
+     "end_line": 2151,
+     "name": ".pico aside nav"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "f1d5af91549b9a23",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.amber.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.blue.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.cyan.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.fuchsia.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.green.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.grey.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.indigo.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.jade.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.lime.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.orange.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.pink.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.pumpkin.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.purple.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.red.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.sand.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.slate.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.violet.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.yellow.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.classless.conditional.zinc.css",
+     "start_line": 2000,
+     "end_line": 2007,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.amber.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.blue.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.cyan.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.fuchsia.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.green.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.grey.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.indigo.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.jade.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.lime.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.orange.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pink.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pumpkin.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.purple.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.red.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.sand.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.slate.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.violet.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.yellow.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.zinc.css",
+     "start_line": 2332,
+     "end_line": 2339,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.amber.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.blue.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.cyan.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.fuchsia.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.green.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.grey.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.indigo.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.jade.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.lime.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.orange.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.pink.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.pumpkin.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.purple.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.red.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.sand.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.slate.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.violet.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.yellow.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.fluid.classless.conditional.zinc.css",
+     "start_line": 1963,
+     "end_line": 1970,
+     "name": ".pico button[aria-busy=true]"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "fadd3be30510a704",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.conditional.amber.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.blue.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.cyan.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.fuchsia.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.green.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.grey.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.indigo.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.jade.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.lime.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.orange.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pink.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.pumpkin.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.purple.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.red.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.sand.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.slate.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.violet.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.yellow.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.conditional.zinc.css",
+     "start_line": 611,
+     "end_line": 617,
+     "name": "[data-theme=dark] .pico [aria-busy=true]:not(input, select, textarea).contrast:is(button, [type=submit], [type=button], [type=reset], [role=button]):not(.outline)::before"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "0382efda9849f42a",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2562,
+     "end_line": 2565,
+     "name": ".pico-background-indigo-450"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-indigo-450"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "07ac85cd4ec95726",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2472,
+     "end_line": 2475,
+     "name": ".pico-background-violet-350"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-violet-350"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "0b282399b86a2492",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3372,
+     "end_line": 3375,
+     "name": ".pico-background-amber-350"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-amber-350"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "0f6f915af0256923",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3627,
+     "end_line": 3630,
+     "name": ".pico-background-sand-800"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-sand-800"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "144f43bf699bdadc",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3812,
+     "end_line": 3815,
+     "name": ".pico-background-zinc-950"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-zinc-950"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1b14c137bcdb710e",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3462,
+     "end_line": 3465,
+     "name": ".pico-background-pumpkin-450"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-pumpkin-450"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1de76c890ea0ab02",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3662,
+     "end_line": 3665,
+     "name": ".pico-background-sand-450"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-sand-450"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "228b36553ba33db1",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2017,
+     "end_line": 2020,
+     "name": ".pico-background-red-900"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-red-900"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "25fc4986b6ab5f98",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2462,
+     "end_line": 2465,
+     "name": ".pico-background-violet-450"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-violet-450"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "2d65550c0c521686",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2782,
+     "end_line": 2785,
+     "name": ".pico-background-azure-250"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-azure-250"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "33fb45b7fc695d00",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3397,
+     "end_line": 3400,
+     "name": ".pico-background-amber-100"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-amber-100"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "38c0637cc75548a8",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3612,
+     "end_line": 3615,
+     "name": ".pico-background-sand-950"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-sand-950"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "408bd4ad8af85a47",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2767,
+     "end_line": 2770,
+     "name": ".pico-background-azure-400"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-azure-400"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "42b46ab829a92557",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2947,
+     "end_line": 2950,
+     "name": ".pico-background-jade-600"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-jade-600"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "49fc074e0ac60562",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3932,
+     "end_line": 3935,
+     "name": ".pico-background-slate-750"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-slate-750"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "4ca5fadbac8da23a",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2297,
+     "end_line": 2300,
+     "name": ".pico-background-fuchsia-100"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-fuchsia-100"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "50e1648fa69e6e63",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3057,
+     "end_line": 3060,
+     "name": ".pico-background-green-500"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-green-500"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "54380d5f7bcd25fb",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2557,
+     "end_line": 2560,
+     "name": ".pico-background-indigo-500"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-indigo-500"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "56df75094b74f6d3",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3287,
+     "end_line": 3290,
+     "name": ".pico-background-yellow-200"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-yellow-200"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "5ced585bc2004261",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3527,
+     "end_line": 3530,
+     "name": ".pico-background-orange-800"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-orange-800"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "63140f61d96b07b3",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3827,
+     "end_line": 3830,
+     "name": ".pico-background-zinc-800"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-zinc-800"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "674cbb29b457cfdb",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3617,
+     "end_line": 3620,
+     "name": ".pico-background-sand-900"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-sand-900"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "6aebddbbe87ba810",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2752,
+     "end_line": 2755,
+     "name": ".pico-background-azure-550"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-azure-550"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "6ff172bd9fddace2",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3572,
+     "end_line": 3575,
+     "name": ".pico-background-orange-350"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-orange-350"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "7544d3a83e096806",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2982,
+     "end_line": 2985,
+     "name": ".pico-background-jade-250"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-jade-250"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "7cd2600e31137ea2",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2522,
+     "end_line": 2525,
+     "name": ".pico-background-indigo-850"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-indigo-850"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "82447e7796012861",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3967,
+     "end_line": 3970,
+     "name": ".pico-background-slate-400"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-slate-400"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "8927c66cbd9e1192",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2322,
+     "end_line": 2325,
+     "name": ".pico-background-purple-850"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-purple-850"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "8f88e35bb34a7731",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2607,
+     "end_line": 2610,
+     "name": ".pico-background-indigo"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-indigo"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "946851df456455d9",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2407,
+     "end_line": 2410,
+     "name": ".pico-background-purple"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-purple"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "974d7e40d5acee96",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3862,
+     "end_line": 3865,
+     "name": ".pico-background-zinc-450"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-zinc-450"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "9ac83e92f6e30cc8",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3697,
+     "end_line": 3700,
+     "name": ".pico-background-sand-100"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-sand-100"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "a13e9c8ef5642afc",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2402,
+     "end_line": 2405,
+     "name": ".pico-background-purple-50"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-purple-50"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "a599bdd754682f57",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2367,
+     "end_line": 2370,
+     "name": ".pico-background-purple-400"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-purple-400"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "a90ca7b3de68002d",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 4007,
+     "end_line": 4010,
+     "name": ".pico-background-slate"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-slate"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ad0a27d1075ce13a",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3682,
+     "end_line": 3685,
+     "name": ".pico-background-sand-250"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-sand-250"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "b882e49e8b31818d",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3117,
+     "end_line": 3120,
+     "name": ".pico-background-lime-900"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-lime-900"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "be13c99445da5b36",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3802,
+     "end_line": 3805,
+     "name": ".pico-background-grey-50"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-grey-50"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "c5b335809f91ad1a",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3732,
+     "end_line": 3735,
+     "name": ".pico-background-grey-750"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-grey-750"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "c7435c62b9baf0f6",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3712,
+     "end_line": 3715,
+     "name": ".pico-background-grey-950"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-grey-950"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ca326b2737f3521e",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3392,
+     "end_line": 3395,
+     "name": ".pico-background-amber-150"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-amber-150"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ce64571fdab66ea6",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2812,
+     "end_line": 2815,
+     "name": ".pico-background-cyan-950"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-cyan-950"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "d133616683ff7dc7",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2317,
+     "end_line": 2320,
+     "name": ".pico-background-purple-900"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-purple-900"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "d54ba35517f0908f",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2177,
+     "end_line": 2180,
+     "name": ".pico-background-pink-300"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-pink-300"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "d992a8f3a06dac83",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3857,
+     "end_line": 3860,
+     "name": ".pico-background-zinc-500"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-zinc-500"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "dea0f430e00efcad",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3917,
+     "end_line": 3920,
+     "name": ".pico-background-slate-900"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-slate-900"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e27ae828daa42658",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3322,
+     "end_line": 3325,
+     "name": ".pico-background-amber-850"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-amber-850"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e7bc7ff8564bcc16",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2072,
+     "end_line": 2075,
+     "name": ".pico-background-red-350"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-red-350"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "eb8b9fc32fd419a0",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 3897,
+     "end_line": 3900,
+     "name": ".pico-background-zinc-100"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-zinc-100"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "f356f1d964d615a2",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2292,
+     "end_line": 2295,
+     "name": ".pico-background-fuchsia-150"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-fuchsia-150"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "f6991811f3b833ba",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2612,
+     "end_line": 2615,
+     "name": ".pico-background-blue-950"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-blue-950"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "fa9b3cebc015dd0b",
+   "repo": "pico",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/pico/css/pico.colors.css",
+     "start_line": 2127,
+     "end_line": 2130,
+     "name": ".pico-background-pink-800"
+    },
+    {
+     "file": "bench/repos/pico/css/pico.colors.min.css",
+     "start_line": 4,
+     "end_line": 4,
+     "name": ".pico-background-pink-800"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "742fc83cc9fcf2e6",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/dist/css/bootstrap.css",
+     "start_line": 2442,
+     "end_line": 2446,
+     "name": ".form-check-input:disabled"
+    },
+    {
+     "file": "bench/repos/bootstrap/dist/css/bootstrap.min.css",
+     "start_line": 5,
+     "end_line": 5,
+     "name": ".form-check-input:disabled"
+    },
+    {
+     "file": "bench/repos/bootstrap/dist/css/bootstrap.rtl.css",
+     "start_line": 2440,
+     "end_line": 2444,
+     "name": ".form-check-input:disabled"
+    },
+    {
+     "file": "bench/repos/bootstrap/dist/css/bootstrap.rtl.min.css",
+     "start_line": 5,
+     "end_line": 5,
+     "name": ".form-check-input:disabled"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/list-groups/list-groups.css",
+     "start_line": 33,
+     "end_line": 38,
+     "name": ".list-group-item-check[disabled] + .list-group-item"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/list-groups/list-groups.css",
+     "start_line": 58,
+     "end_line": 63,
+     "name": ".list-group-radio .form-check-input[disabled] + .list-group-item"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "8904d80b44137b10",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/collapse.html",
+     "start_line": 29,
+     "end_line": 42,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/collapse.html",
+     "start_line": 43,
+     "end_line": 56,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/collapse.html",
+     "start_line": 57,
+     "end_line": 70,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/modal.html",
+     "start_line": 75,
+     "end_line": 88,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/modal.html",
+     "start_line": 89,
+     "end_line": 102,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   },
+   "note": "Same Bootstrap accordion card item copy-pasted 5x across two visual-test files, differing only by heading index/aria-id; a coherent reusable component (only the XSS item is a quirk)."
+  },
+  {
+   "family_id": "af15e707679ebc63",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.css",
+     "start_line": 32,
+     "end_line": 36,
+     "name": ".bd-aside a:hover"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.css",
+     "start_line": 49,
+     "end_line": 53,
+     "name": ".bd-aside .btn:hover"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.rtl.css",
+     "start_line": 32,
+     "end_line": 36,
+     "name": ".bd-aside a:hover"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.rtl.css",
+     "start_line": 49,
+     "end_line": 53,
+     "name": ".bd-aside .btn:hover"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "87eef6f3b5a6cda3",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/dropdown.html",
+     "start_line": 106,
+     "end_line": 116,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/dropdown.html",
+     "start_line": 128,
+     "end_line": 138,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/dropdown.html",
+     "start_line": 150,
+     "end_line": 160,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "eba1894cfc5b3d5c",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/modal.html",
+     "start_line": 118,
+     "end_line": 121,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/modal.html",
+     "start_line": 142,
+     "end_line": 145,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/modal.html",
+     "start_line": 160,
+     "end_line": 163,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "0018600eb600bc89",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/dropdown.html",
+     "start_line": 70,
+     "end_line": 80,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/dropdown.html",
+     "start_line": 176,
+     "end_line": 186,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "0a7a4453f9968d48",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.css",
+     "start_line": 40,
+     "end_line": 43,
+     "name": ".marketing .col-lg-4 p"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.rtl.css",
+     "start_line": 39,
+     "end_line": 42,
+     "name": ".marketing .col-lg-4 p"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "0f4b9eba9b9ff7fb",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.css",
+     "start_line": 9,
+     "end_line": 17,
+     "name": ".bd-heading a::before"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.rtl.css",
+     "start_line": 9,
+     "end_line": 17,
+     "name": ".bd-heading a::before"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1189801f48cc2ad5",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/dashboard/dashboard.css",
+     "start_line": 11,
+     "end_line": 20,
+     "name": "@media (min-width: 768px)"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/dashboard/dashboard.rtl.css",
+     "start_line": 11,
+     "end_line": 20,
+     "name": "@media (min-width: 768px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1c7f5f1f09aaff8d",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.css",
+     "start_line": 81,
+     "end_line": 91,
+     "name": "[id=\"modal\"] .bd-example .btn"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.rtl.css",
+     "start_line": 78,
+     "end_line": 88,
+     "name": "[id=\"modal\"] .bd-example .btn"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1e7e35e9f6e3c641",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/dashboard/dashboard.css",
+     "start_line": 1,
+     "end_line": 5,
+     "name": ".bi"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/dashboard/dashboard.rtl.css",
+     "start_line": 1,
+     "end_line": 5,
+     "name": ".bi"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "2cb840434e8eb810",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.css",
+     "start_line": 94,
+     "end_line": 163,
+     "name": "@media (min-width: 1200px)"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.rtl.css",
+     "start_line": 91,
+     "end_line": 156,
+     "name": "@media (min-width: 1200px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "6016725d0242bf55",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.css",
+     "start_line": 38,
+     "end_line": 41,
+     "name": ".bd-aside .active"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.rtl.css",
+     "start_line": 38,
+     "end_line": 41,
+     "name": ".bd-aside .active"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "620adcb6022ecf87",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.css",
+     "start_line": 35,
+     "end_line": 38,
+     "name": ".marketing .col-lg-4"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.rtl.css",
+     "start_line": 35,
+     "end_line": 38,
+     "name": ".marketing .col-lg-4"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "71bdd2dd2fca8fdc",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.css",
+     "start_line": 50,
+     "end_line": 52,
+     "name": ".featurette-divider"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.rtl.css",
+     "start_line": 48,
+     "end_line": 50,
+     "name": ".featurette-divider"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "7d5303c0321375db",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/alert.html",
+     "start_line": 18,
+     "end_line": 27,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/alert.html",
+     "start_line": 29,
+     "end_line": 38,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "83e95104b58b4047",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/dashboard/dashboard.css",
+     "start_line": 22,
+     "end_line": 25,
+     "name": ".sidebar .nav-link"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/dashboard/dashboard.rtl.css",
+     "start_line": 22,
+     "end_line": 25,
+     "name": ".sidebar .nav-link"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "8a2f0e2e5f299041",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/blog/blog.css",
+     "start_line": 16,
+     "end_line": 18,
+     "name": ".flex-auto"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/blog/blog.rtl.css",
+     "start_line": 16,
+     "end_line": 18,
+     "name": ".flex-auto"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "8da2d7dab5d84b95",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.css",
+     "start_line": 25,
+     "end_line": 30,
+     "name": ".bd-aside a"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.rtl.css",
+     "start_line": 25,
+     "end_line": 30,
+     "name": ".bd-aside a"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "a81f958f547622ff",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/dropdown.html",
+     "start_line": 21,
+     "end_line": 23,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/bootstrap/js/tests/visual/modal.html",
+     "start_line": 24,
+     "end_line": 26,
+     "name": "li"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "b77da4f69e8d31af",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.css",
+     "start_line": 20,
+     "end_line": 23,
+     "name": ".carousel-caption"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.rtl.css",
+     "start_line": 20,
+     "end_line": 23,
+     "name": ".carousel-caption"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "c06471cdb63f66c7",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/blog/blog.css",
+     "start_line": 36,
+     "end_line": 39,
+     "name": ".blog-post-meta"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/blog/blog.rtl.css",
+     "start_line": 36,
+     "end_line": 39,
+     "name": ".blog-post-meta"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "c2b9956927b01a01",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/blog/blog.css",
+     "start_line": 21,
+     "end_line": 23,
+     "name": "@media (min-width: 768px)"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/blog/blog.rtl.css",
+     "start_line": 21,
+     "end_line": 23,
+     "name": "@media (min-width: 768px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "c81a725eb13880c1",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/dashboard/dashboard.css",
+     "start_line": 39,
+     "end_line": 44,
+     "name": ".navbar-brand"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/dashboard/dashboard.rtl.css",
+     "start_line": 39,
+     "end_line": 44,
+     "name": ".navbar-brand"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "cf818866480faef5",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.css",
+     "start_line": 43,
+     "end_line": 47,
+     "name": ".bd-aside .btn"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.rtl.css",
+     "start_line": 43,
+     "end_line": 47,
+     "name": ".bd-aside .btn"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e0ee8749f27eef05",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.css",
+     "start_line": 5,
+     "end_line": 9,
+     "name": "body"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.rtl.css",
+     "start_line": 5,
+     "end_line": 9,
+     "name": "body"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e68a08fece715a0d",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.css",
+     "start_line": 55,
+     "end_line": 57,
+     "name": ".bd-aside .btn:focus"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/cheatsheet/cheatsheet.rtl.css",
+     "start_line": 55,
+     "end_line": 57,
+     "name": ".bd-aside .btn:focus"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "eda9282640f776e9",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/dashboard/dashboard.css",
+     "start_line": 46,
+     "end_line": 48,
+     "name": ".navbar .form-control"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/dashboard/dashboard.rtl.css",
+     "start_line": 46,
+     "end_line": 48,
+     "name": ".navbar .form-control"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "eff75c68b15d8136",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.css",
+     "start_line": 78,
+     "end_line": 82,
+     "name": "@media (min-width: 62em)"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.rtl.css",
+     "start_line": 70,
+     "end_line": 74,
+     "name": "@media (min-width: 62em)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "f020216539a7153d",
+   "repo": "bootstrap",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.css",
+     "start_line": 65,
+     "end_line": 76,
+     "name": "@media (min-width: 40em)"
+    },
+    {
+     "file": "bench/repos/bootstrap/site/src/assets/examples/carousel/carousel.rtl.css",
+     "start_line": 57,
+     "end_line": 68,
+     "name": "@media (min-width: 40em)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "3c36c9418edd66a1",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 880,
+     "end_line": 880,
+     "name": ".link:link"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 881,
+     "end_line": 881,
+     "name": ".link:hover"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 882,
+     "end_line": 882,
+     "name": ".link:active"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".link"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_links.css",
+     "start_line": 13,
+     "end_line": 16,
+     "name": ".link:link"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_links.css",
+     "start_line": 17,
+     "end_line": 19,
+     "name": ".link:hover"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_links.css",
+     "start_line": 20,
+     "end_line": 22,
+     "name": ".link:active"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "c02e9f6f99d7111b",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1842,
+     "end_line": 1842,
+     "name": ".dim"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1851,
+     "end_line": 1851,
+     "name": ".glow:hover"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1867,
+     "end_line": 1867,
+     "name": ".hide-child:hover .child"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".hide-child:active .child"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_hovers.css",
+     "start_line": 21,
+     "end_line": 24,
+     "name": ".dim"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_hovers.css",
+     "start_line": 42,
+     "end_line": 46,
+     "name": ".glow:hover"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_hovers.css",
+     "start_line": 67,
+     "end_line": 72,
+     "name": ".hide-child:hover .child"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "b7b597f8565894b7",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1795,
+     "end_line": 1795,
+     "name": ".clip"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".clip"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_visibility.css",
+     "start_line": 18,
+     "end_line": 23,
+     "name": ".clip"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_visibility.css",
+     "start_line": 25,
+     "end_line": 32,
+     "name": "@media (--breakpoint-not-small)"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_visibility.css",
+     "start_line": 34,
+     "end_line": 41,
+     "name": "@media (--breakpoint-medium)"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_visibility.css",
+     "start_line": 43,
+     "end_line": 50,
+     "name": "@media (--breakpoint-large)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "895b8bb9773b4190",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 55,
+     "end_line": 55,
+     "name": "pre"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 75,
+     "end_line": 75,
+     "name": "code"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "pre"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_normalize.css",
+     "start_line": 56,
+     "end_line": 59,
+     "name": "pre"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_normalize.css",
+     "start_line": 97,
+     "end_line": 102,
+     "name": "code"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e180cba835b8abe6",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1762,
+     "end_line": 1762,
+     "name": ".indent"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1950,
+     "end_line": 1950,
+     "name": ".nested-copy-indent p+p"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".indent"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_nested.css",
+     "start_line": 31,
+     "end_line": 35,
+     "name": ".nested-copy-indent p+p"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_typography.css",
+     "start_line": 31,
+     "end_line": 35,
+     "name": ".indent"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "048541fc47d7810c",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 147,
+     "end_line": 147,
+     "name": "[type=\"checkbox\"]"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "[type=checkbox]"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_normalize.css",
+     "start_line": 262,
+     "end_line": 266,
+     "name": "[type=\"checkbox\"]"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "0ecabd938598b85d",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 166,
+     "end_line": 166,
+     "name": "::-webkit-file-upload-button"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "::-webkit-file-upload-button"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_normalize.css",
+     "start_line": 300,
+     "end_line": 303,
+     "name": "::-webkit-file-upload-button"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1266e6ceebd2e8ee",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 639,
+     "end_line": 639,
+     "name": ".flex-auto"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".flex-auto"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_flexbox.css",
+     "start_line": 17,
+     "end_line": 21,
+     "name": ".flex-auto"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "138beb6b010a9439",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 157,
+     "end_line": 157,
+     "name": "[type=\"search\"]"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "[type=search]"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_normalize.css",
+     "start_line": 282,
+     "end_line": 285,
+     "name": "[type=\"search\"]"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1603dcad789075c2",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 723,
+     "end_line": 723,
+     "name": "code"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".code"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_font-family.css",
+     "start_line": 37,
+     "end_line": 41,
+     "name": "code"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1d0c1662d226cb5b",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 521,
+     "end_line": 521,
+     "name": ".pre"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".pre"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_code.css",
+     "start_line": 7,
+     "end_line": 11,
+     "name": ".pre"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "2096c478b1cba561",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 437,
+     "end_line": 437,
+     "name": ".br--left"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".br--left"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_border-radius.css",
+     "start_line": 46,
+     "end_line": 49,
+     "name": ".br--left"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "2407ce3396d7b853",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 84,
+     "end_line": 84,
+     "name": "sub"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "sub"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_normalize.css",
+     "start_line": 117,
+     "end_line": 123,
+     "name": "sub"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "2a32912f5a4f69c8",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 227,
+     "end_line": 227,
+     "name": ".aspect-ratio--object"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".aspect-ratio--object"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_aspect-ratios.css",
+     "start_line": 42,
+     "end_line": 51,
+     "name": ".aspect-ratio--object"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "2a8584c56587201c",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1890,
+     "end_line": 1890,
+     "name": ".bg-animate"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".bg-animate"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_hovers.css",
+     "start_line": 155,
+     "end_line": 159,
+     "name": ".bg-animate"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "35f9ea7b75633a32",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1765,
+     "end_line": 1765,
+     "name": ".truncate"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".truncate"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_typography.css",
+     "start_line": 43,
+     "end_line": 47,
+     "name": ".truncate"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "3753e0adcb545f0e",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1635,
+     "end_line": 1635,
+     "name": ".collapse"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".collapse"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_tables.css",
+     "start_line": 8,
+     "end_line": 11,
+     "name": ".collapse"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "37685a9c5e2085e8",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 730,
+     "end_line": 730,
+     "name": ".georgia"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".georgia"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_font-family.css",
+     "start_line": 71,
+     "end_line": 74,
+     "name": ".georgia"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "3cce2df149cbb304",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 735,
+     "end_line": 735,
+     "name": ".baskerville"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".baskerville"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_font-family.css",
+     "start_line": 96,
+     "end_line": 99,
+     "name": ".baskerville"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "3d064c127d820956",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 791,
+     "end_line": 791,
+     "name": ".button-reset::-moz-focus-inner"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".button-reset::-moz-focus-inner"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_forms.css",
+     "start_line": 12,
+     "end_line": 16,
+     "name": ".button-reset::-moz-focus-inner"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "4af7ae17e0242ed4",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 50,
+     "end_line": 50,
+     "name": "hr"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "hr"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_normalize.css",
+     "start_line": 45,
+     "end_line": 49,
+     "name": "hr"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "5518c9ce06213b6b",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/src/_coordinates.css",
+     "start_line": 61,
+     "end_line": 88,
+     "name": "@media (--breakpoint-not-small)"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_coordinates.css",
+     "start_line": 90,
+     "end_line": 117,
+     "name": "@media (--breakpoint-medium)"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_coordinates.css",
+     "start_line": 119,
+     "end_line": 146,
+     "name": "@media (--breakpoint-large)"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "6334322d1b8c12c7",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1866,
+     "end_line": 1866,
+     "name": ".hide-child .child"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".hide-child .child"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_hovers.css",
+     "start_line": 63,
+     "end_line": 66,
+     "name": ".hide-child .child"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "633a99f67f33f1cf",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1886,
+     "end_line": 1886,
+     "name": ".shadow-hover::after"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".shadow-hover:after"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_hovers.css",
+     "start_line": 133,
+     "end_line": 145,
+     "name": ".shadow-hover::after"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "6aaccbe1ef692db9",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 568,
+     "end_line": 568,
+     "name": ".absolute--fill"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".absolute--fill"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_coordinates.css",
+     "start_line": 54,
+     "end_line": 59,
+     "name": ".absolute--fill"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "70686195003e3b91",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1949,
+     "end_line": 1949,
+     "name": ".nested-list-reset ul"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".nested-list-reset ol"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_nested.css",
+     "start_line": 24,
+     "end_line": 29,
+     "name": ".nested-list-reset ul"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "715b1425076de5a5",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 134,
+     "end_line": 134,
+     "name": "legend"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "legend"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_normalize.css",
+     "start_line": 232,
+     "end_line": 239,
+     "name": "legend"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "71bda8610d372f2d",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 117,
+     "end_line": 118,
+     "name": "button::-moz-focus-inner"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "[type=button]::-moz-focus-inner"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_normalize.css",
+     "start_line": 198,
+     "end_line": 204,
+     "name": "button::-moz-focus-inner"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "84c6d1d4abd3ef59",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 215,
+     "end_line": 215,
+     "name": ".aspect-ratio"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".aspect-ratio"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_aspect-ratios.css",
+     "start_line": 20,
+     "end_line": 23,
+     "name": ".aspect-ratio"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "8c79925e22c31510",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 122,
+     "end_line": 123,
+     "name": "button:-moz-focusring"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "[type=button]:-moz-focusring"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_normalize.css",
+     "start_line": 210,
+     "end_line": 215,
+     "name": "button:-moz-focusring"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "8fd86d0f82fdc244",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1952,
+     "end_line": 1952,
+     "name": ".nested-img img"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".nested-img img"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_nested.css",
+     "start_line": 41,
+     "end_line": 45,
+     "name": ".nested-img img"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "997e7d8d91fbeb2a",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 790,
+     "end_line": 790,
+     "name": ".input-reset"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".input-reset"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_forms.css",
+     "start_line": 7,
+     "end_line": 10,
+     "name": ".input-reset"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "9a738f01b0308cd9",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 729,
+     "end_line": 729,
+     "name": ".athelas"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".athelas"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_font-family.css",
+     "start_line": 65,
+     "end_line": 69,
+     "name": ".athelas"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "9fe4afeeae00396a",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 718,
+     "end_line": 718,
+     "name": ".serif"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".serif"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_font-family.css",
+     "start_line": 19,
+     "end_line": 23,
+     "name": ".serif"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "b568c40dddf2d108",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 731,
+     "end_line": 731,
+     "name": ".times"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".times"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_font-family.css",
+     "start_line": 76,
+     "end_line": 79,
+     "name": ".times"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "b7bcc3d51478a38e",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 99,
+     "end_line": 99,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_normalize.css",
+     "start_line": 152,
+     "end_line": 161,
+     "name": "button"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ba96e2ce8c8e9ed3",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/src/_background-position.css",
+     "start_line": 47,
+     "end_line": 72,
+     "name": "@media (--breakpoint-not-small)"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_background-position.css",
+     "start_line": 74,
+     "end_line": 99,
+     "name": "@media (--breakpoint-medium)"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_background-position.css",
+     "start_line": 101,
+     "end_line": 126,
+     "name": "@media (--breakpoint-large)"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "bd788b139fb0107c",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 734,
+     "end_line": 734,
+     "name": ".garamond"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".garamond"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_font-family.css",
+     "start_line": 91,
+     "end_line": 94,
+     "name": ".garamond"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "bf88a24c3eaffad4",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 624,
+     "end_line": 624,
+     "name": ".dt--fixed"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".dt--fixed"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_display.css",
+     "start_line": 43,
+     "end_line": 46,
+     "name": ".dt--fixed"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "d42237790ede3a45",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 32,
+     "end_line": 32,
+     "name": "html"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "html"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_normalize.css",
+     "start_line": 11,
+     "end_line": 14,
+     "name": "html"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "d52555fa618682c7",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 434,
+     "end_line": 434,
+     "name": ".br--bottom"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ".br--bottom"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_border-radius.css",
+     "start_line": 34,
+     "end_line": 37,
+     "name": ".br--bottom"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "dbc1ea4f2f359849",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 43,
+     "end_line": 43,
+     "name": "h1"
+    },
+    {
+     "file": "bench/repos/tachyons/css/tachyons.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "h1"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_normalize.css",
+     "start_line": 32,
+     "end_line": 35,
+     "name": "h1"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ebdb1b17dee25ec2",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/src/_aspect-ratios.css",
+     "start_line": 53,
+     "end_line": 79,
+     "name": "@media (--breakpoint-not-small)"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_aspect-ratios.css",
+     "start_line": 81,
+     "end_line": 107,
+     "name": "@media (--breakpoint-medium)"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_aspect-ratios.css",
+     "start_line": 109,
+     "end_line": 135,
+     "name": "@media (--breakpoint-large)"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "1424f6ad5019d7b1",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 879,
+     "end_line": 879,
+     "name": ".link"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_links.css",
+     "start_line": 8,
+     "end_line": 11,
+     "name": ".link"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1736863866c70c7e",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 193,
+     "end_line": 197,
+     "name": "html"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_box-sizing.css",
+     "start_line": 7,
+     "end_line": 47,
+     "name": "html"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1cff50d39488947f",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 1843,
+     "end_line": 1843,
+     "name": ".dim:hover"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_hovers.css",
+     "start_line": 25,
+     "end_line": 29,
+     "name": ".dim:hover"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "2c7085c6567698df",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 726,
+     "end_line": 726,
+     "name": ".helvetica"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_font-family.css",
+     "start_line": 52,
+     "end_line": 55,
+     "name": ".helvetica"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "32deb0c804d0a667",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 275,
+     "end_line": 275,
+     "name": ".bg-right"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_background-position.css",
+     "start_line": 32,
+     "end_line": 35,
+     "name": ".bg-right"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "3edd07d2ce59951e",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 276,
+     "end_line": 276,
+     "name": ".bg-bottom"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_background-position.css",
+     "start_line": 37,
+     "end_line": 40,
+     "name": ".bg-bottom"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "50475cc517c4d7a2",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 727,
+     "end_line": 727,
+     "name": ".avenir"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_font-family.css",
+     "start_line": 57,
+     "end_line": 60,
+     "name": ".avenir"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "5233f8c915b1f76a",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 274,
+     "end_line": 274,
+     "name": ".bg-top"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_background-position.css",
+     "start_line": 27,
+     "end_line": 30,
+     "name": ".bg-top"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "5ee574345caca1ed",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 717,
+     "end_line": 717,
+     "name": ".sans-serif"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_font-family.css",
+     "start_line": 9,
+     "end_line": 17,
+     "name": ".sans-serif"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "77b075d348f85471",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 435,
+     "end_line": 435,
+     "name": ".br--top"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_border-radius.css",
+     "start_line": 38,
+     "end_line": 41,
+     "name": ".br--top"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "7a735130068da985",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 277,
+     "end_line": 277,
+     "name": ".bg-left"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_background-position.css",
+     "start_line": 42,
+     "end_line": 45,
+     "name": ".bg-left"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "9e38d94b8fb63a60",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 883,
+     "end_line": 883,
+     "name": ".link:focus"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_links.css",
+     "start_line": 23,
+     "end_line": 26,
+     "name": ".link:focus"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "b2d8c487b6b85b3e",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 724,
+     "end_line": 724,
+     "name": ".courier"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_font-family.css",
+     "start_line": 43,
+     "end_line": 47,
+     "name": ".courier"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "cd760fa55d2ff7ad",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 732,
+     "end_line": 732,
+     "name": ".bodoni"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_font-family.css",
+     "start_line": 81,
+     "end_line": 84,
+     "name": ".bodoni"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "d639de470ebd9e5e",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 436,
+     "end_line": 436,
+     "name": ".br--right"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_border-radius.css",
+     "start_line": 42,
+     "end_line": 45,
+     "name": ".br--right"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "d649482b7d0da4d9",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 733,
+     "end_line": 733,
+     "name": ".calisto"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_font-family.css",
+     "start_line": 86,
+     "end_line": 89,
+     "name": ".calisto"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "dae2e2e6d29ae521",
+   "repo": "tachyons",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/tachyons/css/tachyons.css",
+     "start_line": 273,
+     "end_line": 273,
+     "name": ".bg-center"
+    },
+    {
+     "file": "bench/repos/tachyons/src/_background-position.css",
+     "start_line": 22,
+     "end_line": 25,
+     "name": ".bg-center"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "5fb4e63f4d3be6ad",
+   "repo": "water.css",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/water.css/src/parts/_range.css",
+     "start_line": 58,
+     "end_line": 63,
+     "name": "input[type='range']::-ms-fill-lower"
+    },
+    {
+     "file": "bench/repos/water.css/src/parts/_range.css",
+     "start_line": 65,
+     "end_line": 70,
+     "name": "input[type='range']::-ms-fill-upper"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-data-table",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   },
+   "note": "::-ms-fill-lower and ::-ms-fill-upper have byte-identical 4-declaration bodies and are both -ms-prefixed, so they safely combine into one comma-grouped rule in this source partial \u2014 not trivial (4 real decls incl. border + box-shadow)."
+  },
+  {
+   "family_id": "867a6b7bc2511d81",
+   "repo": "water.css",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/water.css/src/parts/_range.css",
+     "start_line": 11,
+     "end_line": 17,
+     "name": "input[type='range']::-webkit-slider-runnable-track"
+    },
+    {
+     "file": "bench/repos/water.css/src/parts/_range.css",
+     "start_line": 33,
+     "end_line": 39,
+     "name": "input[type='range']::-moz-range-track"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "fbcff83d406bea69",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3000,
+     "end_line": 3005,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3019,
+     "end_line": 3024,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3038,
+     "end_line": 3043,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3057,
+     "end_line": 3062,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3076,
+     "end_line": 3081,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3095,
+     "end_line": 3100,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3114,
+     "end_line": 3119,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3133,
+     "end_line": 3138,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3152,
+     "end_line": 3157,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3171,
+     "end_line": 3176,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3190,
+     "end_line": 3195,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3207,
+     "end_line": 3212,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3224,
+     "end_line": 3229,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3241,
+     "end_line": 3246,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3258,
+     "end_line": 3263,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3275,
+     "end_line": 3280,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3292,
+     "end_line": 3297,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3387,
+     "end_line": 3392,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3397,
+     "end_line": 3402,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3407,
+     "end_line": 3412,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3417,
+     "end_line": 3422,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3427,
+     "end_line": 3432,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3437,
+     "end_line": 3442,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3447,
+     "end_line": 3452,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3457,
+     "end_line": 3462,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3467,
+     "end_line": 3472,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3477,
+     "end_line": 3482,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3487,
+     "end_line": 3492,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3497,
+     "end_line": 3502,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3507,
+     "end_line": 3512,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3517,
+     "end_line": 3522,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3527,
+     "end_line": 3532,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3537,
+     "end_line": 3542,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3547,
+     "end_line": 3552,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3557,
+     "end_line": 3562,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3567,
+     "end_line": 3572,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3577,
+     "end_line": 3582,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3587,
+     "end_line": 3592,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3597,
+     "end_line": 3602,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3607,
+     "end_line": 3612,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3623,
+     "end_line": 3628,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3647,
+     "end_line": 3652,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 3669,
+     "end_line": 3674,
+     "name": "button"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "68d8e19bcb553278",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2662,
+     "end_line": 2669,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2670,
+     "end_line": 2677,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2678,
+     "end_line": 2685,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2686,
+     "end_line": 2693,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2694,
+     "end_line": 2701,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2702,
+     "end_line": 2709,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2710,
+     "end_line": 2717,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2718,
+     "end_line": 2725,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2726,
+     "end_line": 2733,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2734,
+     "end_line": 2741,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2742,
+     "end_line": 2749,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2750,
+     "end_line": 2757,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2758,
+     "end_line": 2765,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2766,
+     "end_line": 2773,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2774,
+     "end_line": 2781,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "parameterize",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "parameterize"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "parameterize"
+    }
+   }
+  },
+  {
+   "family_id": "a5f470c25836fe97",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 405,
+     "end_line": 411,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 412,
+     "end_line": 418,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 419,
+     "end_line": 425,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 426,
+     "end_line": 431,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 465,
+     "end_line": 470,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 471,
+     "end_line": 476,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 488,
+     "end_line": 493,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 494,
+     "end_line": 499,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "f60b0002c140a26a",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2145,
+     "end_line": 2151,
+     "name": "header"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 2225,
+     "end_line": 2230,
+     "name": "header"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 4632,
+     "end_line": 4635,
+     "name": "header"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 4649,
+     "end_line": 4652,
+     "name": "header"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 4694,
+     "end_line": 4697,
+     "name": "header"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "0bc37104afb6e8c0",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 1315,
+     "end_line": 1322,
+     "name": "blockquote"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 1911,
+     "end_line": 1917,
+     "name": "blockquote"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 4319,
+     "end_line": 4325,
+     "name": "blockquote"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 4505,
+     "end_line": 4510,
+     "name": "blockquote"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "6384acc3e6350acd",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.css",
+     "start_line": 4,
+     "end_line": 69,
+     "name": ":where(.btn,button,input:is([type=\"button\"],[type=\"submit\"],[type=\"reset\"]))"
+    },
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.dark.css",
+     "start_line": 4,
+     "end_line": 54,
+     "name": ":where(.btn,button,input:is([type=\"button\"],[type=\"submit\"],[type=\"reset\"]))"
+    },
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.light.css",
+     "start_line": 4,
+     "end_line": 56,
+     "name": ":where(.btn,button,input:is([type=\"button\"],[type=\"submit\"],[type=\"reset\"]))"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "9c868ddd4e7d7aec",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.css",
+     "start_line": 134,
+     "end_line": 143,
+     "name": ":where(input[type=\"file\"])"
+    },
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.dark.css",
+     "start_line": 107,
+     "end_line": 116,
+     "name": ":where(input[type=\"file\"])"
+    },
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.light.css",
+     "start_line": 109,
+     "end_line": 118,
+     "name": ":where(input[type=\"file\"])"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-base"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   },
+   "note": "Identical theme-independent :where(input[type=file]) rule across base/dark/light button stylesheet variants; the rule is shared only because it uses CSS vars, and the duplication is inherent to shipping standalone per-theme deliverables."
+  },
+  {
+   "family_id": "a5c711c57fc30f95",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.css",
+     "start_line": 145,
+     "end_line": 149,
+     "name": ":where(input[type=\"file\"])::-webkit-file-upload-button"
+    },
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.dark.css",
+     "start_line": 118,
+     "end_line": 122,
+     "name": ":where(input[type=\"file\"])::-webkit-file-upload-button"
+    },
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.light.css",
+     "start_line": 120,
+     "end_line": 124,
+     "name": ":where(input[type=\"file\"])::-webkit-file-upload-button"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "cc0006910d475a02",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 119,
+     "end_line": 124,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 125,
+     "end_line": 130,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 131,
+     "end_line": 136,
+     "name": "li"
+    }
+   ],
+   "worthy": true,
+   "reason": "parameterize",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "parameterize"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "parameterize"
+    }
+   }
+  },
+  {
+   "family_id": "f2d9dc924012a3eb",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.css",
+     "start_line": 71,
+     "end_line": 102,
+     "name": ":where(.btn,button,input:is([type=\"button\"],[type=\"submit\"],[type=\"reset\"]))"
+    },
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.dark.css",
+     "start_line": 56,
+     "end_line": 84,
+     "name": ":where(.btn,button,input:is([type=\"button\"],[type=\"submit\"],[type=\"reset\"]))"
+    },
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.light.css",
+     "start_line": 58,
+     "end_line": 86,
+     "name": ":where(.btn,button,input:is([type=\"button\"],[type=\"submit\"],[type=\"reset\"]))"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "3bcbb143205bdfec",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 101,
+     "end_line": 107,
+     "name": "a"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.html",
+     "start_line": 4755,
+     "end_line": 4761,
+     "name": "a"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "559486045b0c0e75",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/docsite/index.css",
+     "start_line": 442,
+     "end_line": 445,
+     "name": ".just-for-gap"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.css",
+     "start_line": 1690,
+     "end_line": 1693,
+     "name": ".duration-demo-container"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "7d96b9d1c9930cee",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/docsite/index.css",
+     "start_line": 90,
+     "end_line": 93,
+     "name": "header"
+    },
+    {
+     "file": "bench/repos/open-props/docsite/index.css",
+     "start_line": 447,
+     "end_line": 450,
+     "name": ".just-for-sm-gap"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "f57a3bf47980c3cb",
+   "repo": "open-props",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.dark.css",
+     "start_line": 92,
+     "end_line": 99,
+     "name": ":where([type=\"reset\"])"
+    },
+    {
+     "file": "bench/repos/open-props/src/extra/buttons.light.css",
+     "start_line": 94,
+     "end_line": 101,
+     "name": ":where([type=\"reset\"])"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "0cf05ee9dc71f607",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 177,
+     "end_line": 193,
+     "name": ".button"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 177,
+     "end_line": 193,
+     "name": ".button"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 176,
+     "end_line": 192,
+     "name": ".button"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 176,
+     "end_line": 192,
+     "name": ".button"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 176,
+     "end_line": 192,
+     "name": ".button"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 176,
+     "end_line": 192,
+     "name": ".button"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 177,
+     "end_line": 193,
+     "name": ".button"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 176,
+     "end_line": 192,
+     "name": ".button"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "11504c8ab6869c2e",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 221,
+     "end_line": 230,
+     "name": "textarea"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 221,
+     "end_line": 230,
+     "name": "textarea"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 220,
+     "end_line": 229,
+     "name": "textarea"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 220,
+     "end_line": 229,
+     "name": "textarea"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 220,
+     "end_line": 229,
+     "name": "textarea"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 220,
+     "end_line": 229,
+     "name": "textarea"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 221,
+     "end_line": 230,
+     "name": "textarea"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 220,
+     "end_line": 229,
+     "name": "textarea"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1c4ab4808cba501f",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 194,
+     "end_line": 202,
+     "name": ".button:hover"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 194,
+     "end_line": 202,
+     "name": ".button:hover"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 193,
+     "end_line": 201,
+     "name": ".button:hover"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 193,
+     "end_line": 201,
+     "name": ".button:hover"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 193,
+     "end_line": 201,
+     "name": ".button:hover"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 193,
+     "end_line": 201,
+     "name": ".button:hover"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 194,
+     "end_line": 202,
+     "name": ".button:hover"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 193,
+     "end_line": 201,
+     "name": ".button:hover"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "2a239e71031e8b4b",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 69,
+     "end_line": 72,
+     "name": "p"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 69,
+     "end_line": 72,
+     "name": "p"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 68,
+     "end_line": 71,
+     "name": "p"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 68,
+     "end_line": 71,
+     "name": "p"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 68,
+     "end_line": 71,
+     "name": "p"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 68,
+     "end_line": 71,
+     "name": "p"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 69,
+     "end_line": 72,
+     "name": "p"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 68,
+     "end_line": 71,
+     "name": "p"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "36a51987cd1f87b1",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 23,
+     "end_line": 27,
+     "name": "@media (max-width: 684px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 23,
+     "end_line": 27,
+     "name": "@media (max-width: 684px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 22,
+     "end_line": 26,
+     "name": "@media (max-width: 684px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 22,
+     "end_line": 26,
+     "name": "@media (max-width: 684px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 22,
+     "end_line": 26,
+     "name": "@media (max-width: 684px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 22,
+     "end_line": 26,
+     "name": "@media (max-width: 684px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 23,
+     "end_line": 27,
+     "name": "@media (max-width: 684px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 22,
+     "end_line": 26,
+     "name": "@media (max-width: 684px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "507ef66e03111717",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 212,
+     "end_line": 219,
+     "name": ".button:focus-visible"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 212,
+     "end_line": 219,
+     "name": ".button:focus-visible"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 211,
+     "end_line": 218,
+     "name": ".button:focus-visible"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 211,
+     "end_line": 218,
+     "name": ".button:focus-visible"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 211,
+     "end_line": 218,
+     "name": ".button:focus-visible"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 211,
+     "end_line": 218,
+     "name": ".button:focus-visible"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 212,
+     "end_line": 219,
+     "name": ".button:focus-visible"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 211,
+     "end_line": 218,
+     "name": ".button:focus-visible"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "5d1209d56d3e8c11",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 128,
+     "end_line": 136,
+     "name": "pre"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 128,
+     "end_line": 136,
+     "name": "pre"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 127,
+     "end_line": 135,
+     "name": "pre"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 127,
+     "end_line": 135,
+     "name": "pre"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 127,
+     "end_line": 135,
+     "name": "pre"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 127,
+     "end_line": 135,
+     "name": "pre"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 128,
+     "end_line": 136,
+     "name": "pre"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 127,
+     "end_line": 135,
+     "name": "pre"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "73fd4aef36bc89c7",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 28,
+     "end_line": 32,
+     "name": "@media (max-width: 382px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 28,
+     "end_line": 32,
+     "name": "@media (max-width: 382px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "@media (max-width: 382px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "@media (max-width: 382px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "@media (max-width: 382px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "@media (max-width: 382px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 28,
+     "end_line": 32,
+     "name": "@media (max-width: 382px)"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "@media (max-width: 382px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "7e0aa04865ec6622",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 240,
+     "end_line": 244,
+     "name": "label"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 240,
+     "end_line": 244,
+     "name": "label"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 239,
+     "end_line": 243,
+     "name": "label"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 239,
+     "end_line": 243,
+     "name": "label"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 239,
+     "end_line": 243,
+     "name": "label"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 239,
+     "end_line": 243,
+     "name": "label"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 240,
+     "end_line": 244,
+     "name": "label"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 239,
+     "end_line": 243,
+     "name": "label"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "858b941a3c4ba99d",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 138,
+     "end_line": 143,
+     "name": "code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 138,
+     "end_line": 143,
+     "name": "code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 137,
+     "end_line": 142,
+     "name": "code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 137,
+     "end_line": 142,
+     "name": "code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 137,
+     "end_line": 142,
+     "name": "code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 137,
+     "end_line": 142,
+     "name": "code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 138,
+     "end_line": 143,
+     "name": "code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 137,
+     "end_line": 142,
+     "name": "code"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "99b9ce3bd53d1cbb",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 33,
+     "end_line": 43,
+     "name": "h1"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 33,
+     "end_line": 43,
+     "name": "h1"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 32,
+     "end_line": 42,
+     "name": "h1"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 32,
+     "end_line": 42,
+     "name": "h1"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 32,
+     "end_line": 42,
+     "name": "h1"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 32,
+     "end_line": 42,
+     "name": "h1"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 33,
+     "end_line": 43,
+     "name": "h1"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 32,
+     "end_line": 42,
+     "name": "h1"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ae72329e94ebda47",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 153,
+     "end_line": 158,
+     "name": "table"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 153,
+     "end_line": 158,
+     "name": "table"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 152,
+     "end_line": 157,
+     "name": "table"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 152,
+     "end_line": 157,
+     "name": "table"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 152,
+     "end_line": 157,
+     "name": "table"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 152,
+     "end_line": 157,
+     "name": "table"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 153,
+     "end_line": 158,
+     "name": "table"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 152,
+     "end_line": 157,
+     "name": "table"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "c139b0099de76d4b",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 13,
+     "end_line": 21,
+     "name": "body"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 13,
+     "end_line": 21,
+     "name": "body"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 12,
+     "end_line": 20,
+     "name": "body"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 12,
+     "end_line": 20,
+     "name": "body"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 12,
+     "end_line": 20,
+     "name": "body"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 12,
+     "end_line": 20,
+     "name": "body"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 13,
+     "end_line": 21,
+     "name": "body"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 12,
+     "end_line": 20,
+     "name": "body"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "cb8b06316956c679",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 104,
+     "end_line": 114,
+     "name": "blockquote"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 104,
+     "end_line": 114,
+     "name": "blockquote"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 103,
+     "end_line": 113,
+     "name": "blockquote"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 103,
+     "end_line": 113,
+     "name": "blockquote"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 103,
+     "end_line": 113,
+     "name": "blockquote"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 103,
+     "end_line": 113,
+     "name": "blockquote"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 104,
+     "end_line": 114,
+     "name": "blockquote"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 103,
+     "end_line": 113,
+     "name": "blockquote"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "cfca1a08d8156f4a",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 120,
+     "end_line": 125,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 120,
+     "end_line": 125,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 119,
+     "end_line": 124,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 119,
+     "end_line": 124,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 119,
+     "end_line": 124,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 119,
+     "end_line": 124,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 120,
+     "end_line": 125,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 119,
+     "end_line": 124,
+     "name": "img"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e3ea92a8416c5ca5",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 94,
+     "end_line": 98,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 94,
+     "end_line": 98,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 93,
+     "end_line": 97,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 93,
+     "end_line": 97,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 93,
+     "end_line": 97,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 93,
+     "end_line": 97,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 94,
+     "end_line": 98,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 93,
+     "end_line": 97,
+     "name": "ul"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "fe6d67d8600b13c2",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 145,
+     "end_line": 150,
+     "name": "pre > code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 145,
+     "end_line": 150,
+     "name": "pre > code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 144,
+     "end_line": 149,
+     "name": "pre > code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 144,
+     "end_line": 149,
+     "name": "pre > code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 144,
+     "end_line": 149,
+     "name": "pre > code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 144,
+     "end_line": 149,
+     "name": "pre > code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 145,
+     "end_line": 150,
+     "name": "pre > code"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 144,
+     "end_line": 149,
+     "name": "pre > code"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "fe8aa872dd5efe91",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 204,
+     "end_line": 211,
+     "name": ".button[disabled]"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 204,
+     "end_line": 211,
+     "name": ".button[disabled]"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 203,
+     "end_line": 210,
+     "name": ".button[disabled]"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 203,
+     "end_line": 210,
+     "name": ".button[disabled]"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 203,
+     "end_line": 210,
+     "name": ".button[disabled]"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-radical.css",
+     "start_line": 203,
+     "end_line": 210,
+     "name": ".button[disabled]"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 204,
+     "end_line": 211,
+     "name": ".button[disabled]"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 203,
+     "end_line": 210,
+     "name": ".button[disabled]"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "0e0a1bf02d4f8369",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/sakura-dark-solarized.css",
+     "start_line": 8,
+     "end_line": 11,
+     "name": "html"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-dark.css",
+     "start_line": 8,
+     "end_line": 11,
+     "name": "html"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-earthly.css",
+     "start_line": 7,
+     "end_line": 10,
+     "name": "html"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-ink.css",
+     "start_line": 7,
+     "end_line": 10,
+     "name": "html"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-pink.css",
+     "start_line": 7,
+     "end_line": 10,
+     "name": "html"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura-vader.css",
+     "start_line": 8,
+     "end_line": 11,
+     "name": "html"
+    },
+    {
+     "file": "bench/repos/sakura/css/sakura.css",
+     "start_line": 7,
+     "end_line": 10,
+     "name": "html"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1432448fe9f39f73",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 127,
+     "end_line": 149,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 122,
+     "end_line": 144,
+     "name": "article"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "14c9873c5440aab8",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 680,
+     "end_line": 697,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 675,
+     "end_line": 689,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "166cd1e39ffeb6ac",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 550,
+     "end_line": 577,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 545,
+     "end_line": 572,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "174bf489677414db",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 430,
+     "end_line": 442,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 425,
+     "end_line": 437,
+     "name": "article"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "1c672c39eec6e4d9",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 702,
+     "end_line": 707,
+     "name": "footer"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 694,
+     "end_line": 699,
+     "name": "footer"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   },
+   "note": "Site footer (author credit + GitHub link) duplicated identically across index.html and test.html; canonical shared chrome partial \u2014 the cross-view-chrome calibration is explicitly worthy."
+  },
+  {
+   "family_id": "238b3842ff9191c9",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 536,
+     "end_line": 548,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 531,
+     "end_line": 543,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "23c37b8bda0f8d21",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 45,
+     "end_line": 86,
+     "name": "nav"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 40,
+     "end_line": 81,
+     "name": "nav"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "2462f77c86bb5299",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 188,
+     "end_line": 248,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 183,
+     "end_line": 243,
+     "name": "article"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "2f8136da0ad6de44",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 342,
+     "end_line": 379,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 337,
+     "end_line": 374,
+     "name": "article"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "3589b131b69df1f9",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 10,
+     "end_line": 17,
+     "name": "#toggle"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 11,
+     "end_line": 18,
+     "name": "#toggle"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "37a68f712d4ec87f",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 412,
+     "end_line": 420,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 407,
+     "end_line": 415,
+     "name": "article"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   },
+   "note": "Thin demo-article wrapper around a single <meter>; one entry in a parallel element-showcase series, too small/narrow to be its own shared abstraction (the real abstraction spans the differing articles, not this identical pair)."
+  },
+  {
+   "family_id": "3c17856625c1156d",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 249,
+     "end_line": 277,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 244,
+     "end_line": 272,
+     "name": "article"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "415c7ee74eeb4acb",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 389,
+     "end_line": 402,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 384,
+     "end_line": 397,
+     "name": "article"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   },
+   "note": "Same demo-article wrapper around a <video>; a single showcase entry with no principled distinction from the other (trivial) article demos \u2014 overriding the panel toward rubric consistency."
+  },
+  {
+   "family_id": "4539ecee6f769858",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 632,
+     "end_line": 678,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 627,
+     "end_line": 673,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "486dd14308559070",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 619,
+     "end_line": 630,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 614,
+     "end_line": 625,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   },
+   "note": "A single forms-demo <fieldset> (textarea) duplicated index<->test; one specific entry in a form-element showcase, too narrow to abstract on its own."
+  },
+  {
+   "family_id": "4e78015ccb7b19ac",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 150,
+     "end_line": 176,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 145,
+     "end_line": 171,
+     "name": "article"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "5de27eb2666d84dd",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 177,
+     "end_line": 187,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 172,
+     "end_line": 182,
+     "name": "article"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   },
+   "note": "Demo-article wrapper around a bare <hr>; minimal payload, a showcase-series entry too small to extract."
+  },
+  {
+   "family_id": "662b62bfecdcfdfa",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 458,
+     "end_line": 534,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 453,
+     "end_line": 529,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "7619a16aab36f909",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 278,
+     "end_line": 335,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 273,
+     "end_line": 330,
+     "name": "article"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "76bfb7b5d14ccef6",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 93,
+     "end_line": 108,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 88,
+     "end_line": 103,
+     "name": "article"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "8a1d9842a05cd7b4",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 403,
+     "end_line": 411,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 398,
+     "end_line": 406,
+     "name": "article"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   },
+   "note": "Demo-article wrapper around a single <canvas>; scaffolding-only showcase entry, too small/narrow to abstract."
+  },
+  {
+   "family_id": "956c1719d1f12de2",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 421,
+     "end_line": 429,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 416,
+     "end_line": 424,
+     "name": "article"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   },
+   "note": "Demo-article wrapper around a single <progress>; a lone element-showcase entry, too small to extract on its own."
+  },
+  {
+   "family_id": "cdf6d5b238cef1c9",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 579,
+     "end_line": 617,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 574,
+     "end_line": 612,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "d82545d305b1900f",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/sakura/css/normalize.css",
+     "start_line": 92,
+     "end_line": 95,
+     "name": "pre"
+    },
+    {
+     "file": "bench/repos/sakura/css/normalize.css",
+     "start_line": 154,
+     "end_line": 159,
+     "name": "code"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e9db711ccdec5d4b",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 443,
+     "end_line": 451,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 438,
+     "end_line": 446,
+     "name": "article"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   },
+   "note": "Demo-article wrapper around a single <iframe>; scaffolding-only showcase entry, too narrow to abstract."
+  },
+  {
+   "family_id": "ebaf5fd855e6ca0a",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 37,
+     "end_line": 43,
+     "name": "header"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 32,
+     "end_line": 38,
+     "name": "header"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   },
+   "note": "Page banner header (h1 + descriptive prose) duplicated identically across index.html and test.html; canonical shared chrome partial, like cross-view nav."
+  },
+  {
+   "family_id": "f837edfcf4615e0a",
+   "repo": "sakura",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/sakura/index.html",
+     "start_line": 380,
+     "end_line": 388,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/sakura/test.html",
+     "start_line": 375,
+     "end_line": 383,
+     "name": "article"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "4b79d0e2650911bf",
+   "repo": "mvp.css",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/mvp.css/index.html",
+     "start_line": 256,
+     "end_line": 283,
+     "name": "pre"
+    },
+    {
+     "file": "bench/repos/mvp.css/index.html",
+     "start_line": 332,
+     "end_line": 344,
+     "name": "pre"
+    },
+    {
+     "file": "bench/repos/mvp.css/mvp.html",
+     "start_line": 118,
+     "end_line": 122,
+     "name": "pre"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "5973d73ec3e1154f",
+   "repo": "mvp.css",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/mvp.css/index.html",
+     "start_line": 82,
+     "end_line": 89,
+     "name": "thead"
+    },
+    {
+     "file": "bench/repos/mvp.css/mvp.html",
+     "start_line": 68,
+     "end_line": 75,
+     "name": "thead"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "2435262fa412013c",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/components.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/accordions.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/avatars.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/badges.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/bars.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/breadcrumbs.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/cards.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/chips.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/empty.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/menu.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/modals.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/nav.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/pagination.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/panels.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/popovers.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/steps.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/tabs.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/tiles.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/toasts.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/tooltips.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/buttons.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/code.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/icons.html",
+     "start_line": 204,
+     "end_line": 214,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/labels.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/media.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/tables.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/typography.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/autocomplete.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/calendars.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/carousels.html",
+     "start_line": 204,
+     "end_line": 214,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/comparison.html",
+     "start_line": 204,
+     "end_line": 214,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 204,
+     "end_line": 214,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/meters.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/off-canvas.html",
+     "start_line": 204,
+     "end_line": 214,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/parallax.html",
+     "start_line": 204,
+     "end_line": 214,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/progress.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/sliders.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/timelines.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/viewer-360.html",
+     "start_line": 204,
+     "end_line": 214,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/getting-started.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/getting-started/browsers.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/getting-started/custom.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/getting-started/installation.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/getting-started/whatsnew.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/index.html",
+     "start_line": 60,
+     "end_line": 72,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/grid.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/hero.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/navbar.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/responsive.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/rtl.html",
+     "start_line": 269,
+     "end_line": 293,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/colors.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/cursors.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/display.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/divider.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/loading.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/position.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/shapes.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/text.html",
+     "start_line": 203,
+     "end_line": 213,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ce4047744f9591f8",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/components.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/accordions.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/avatars.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/badges.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/bars.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/breadcrumbs.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/cards.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/chips.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/empty.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/menu.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/modals.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/nav.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/pagination.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/panels.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/popovers.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/steps.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/tabs.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/tiles.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/toasts.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/tooltips.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/buttons.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/code.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/icons.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/labels.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/media.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/tables.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/typography.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/autocomplete.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/calendars.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/carousels.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/comparison.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/meters.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/off-canvas.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/parallax.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/progress.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/sliders.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/timelines.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/viewer-360.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/getting-started.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/getting-started/browsers.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/getting-started/custom.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/getting-started/installation.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/getting-started/whatsnew.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/grid.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/hero.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/navbar.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/responsive.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/colors.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/cursors.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/display.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/divider.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/loading.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/position.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/shapes.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/text.html",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "a5f5d1e41825d985",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 233,
+     "end_line": 238,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 241,
+     "end_line": 246,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 249,
+     "end_line": 254,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 257,
+     "end_line": 262,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 265,
+     "end_line": 270,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 273,
+     "end_line": 278,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 281,
+     "end_line": 286,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 289,
+     "end_line": 294,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 297,
+     "end_line": 302,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 305,
+     "end_line": 310,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 313,
+     "end_line": 318,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/filters.html",
+     "start_line": 321,
+     "end_line": 326,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/getting-started.html",
+     "start_line": 255,
+     "end_line": 260,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-data-table",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    }
+   },
+   "note": "13 identical Spectre filter cards differing only by data-tag/title/category in a hand-authored demo page (not a build artifact); textbook one card template + data table."
+  },
+  {
+   "family_id": "8d6403b4a644c3d2",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/layout/grid.html",
+     "start_line": 289,
+     "end_line": 296,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/grid.html",
+     "start_line": 304,
+     "end_line": 311,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/grid.html",
+     "start_line": 323,
+     "end_line": 330,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/grid.html",
+     "start_line": 354,
+     "end_line": 361,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/grid.html",
+     "start_line": 362,
+     "end_line": 369,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/grid.html",
+     "start_line": 370,
+     "end_line": 377,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/grid.html",
+     "start_line": 378,
+     "end_line": 385,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/grid.html",
+     "start_line": 386,
+     "end_line": 393,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/grid.html",
+     "start_line": 411,
+     "end_line": 418,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/grid.html",
+     "start_line": 419,
+     "end_line": 426,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/utilities/shapes.html",
+     "start_line": 215,
+     "end_line": 222,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "bc0ffca6da89da74",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/components/cards.html",
+     "start_line": 235,
+     "end_line": 241,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/buttons.html",
+     "start_line": 215,
+     "end_line": 221,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/buttons.html",
+     "start_line": 287,
+     "end_line": 293,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/buttons.html",
+     "start_line": 307,
+     "end_line": 313,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/buttons.html",
+     "start_line": 320,
+     "end_line": 326,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/buttons.html",
+     "start_line": 327,
+     "end_line": 333,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/buttons.html",
+     "start_line": 334,
+     "end_line": 340,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/buttons.html",
+     "start_line": 341,
+     "end_line": 347,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "aab3461d51dea49c",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 252,
+     "end_line": 259,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 260,
+     "end_line": 267,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 505,
+     "end_line": 512,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 519,
+     "end_line": 526,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 783,
+     "end_line": 788,
+     "name": "select"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 792,
+     "end_line": 797,
+     "name": "select"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 890,
+     "end_line": 897,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   },
+   "note": "spectre docs/elements/forms.html is built from docs/src/elements/forms.pug (gulp docs_pug); the repeated select+option demos are build output (and intentional per-modifier variant demos), not the maintainer's to dedupe in HTML."
+  },
+  {
+   "family_id": "359a3bd9f8deb257",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/components/accordions.html",
+     "start_line": 220,
+     "end_line": 225,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/accordions.html",
+     "start_line": 230,
+     "end_line": 235,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/accordions.html",
+     "start_line": 240,
+     "end_line": 245,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/accordions.html",
+     "start_line": 252,
+     "end_line": 257,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/accordions.html",
+     "start_line": 262,
+     "end_line": 267,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/accordions.html",
+     "start_line": 272,
+     "end_line": 277,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   },
+   "note": "accordions.html is pug-generated build output; the 6 accordion-body menu demos differ only in link labels and are emitted from accordions.pug, not hand-edited."
+  },
+  {
+   "family_id": "3859475c3f336d7d",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/components/menu.html",
+     "start_line": 320,
+     "end_line": 324,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/menu.html",
+     "start_line": 330,
+     "end_line": 334,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/menu.html",
+     "start_line": 347,
+     "end_line": 351,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/panels.html",
+     "start_line": 224,
+     "end_line": 228,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/tabs.html",
+     "start_line": 225,
+     "end_line": 229,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/spectre/docs/rtl.html",
+     "start_line": 98,
+     "end_line": 108,
+     "name": "ul"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "a634b38b56a5d17e",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/components/modals.html",
+     "start_line": 284,
+     "end_line": 292,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 283,
+     "end_line": 293,
+     "name": "form"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 373,
+     "end_line": 380,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 434,
+     "end_line": 446,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 808,
+     "end_line": 815,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   },
+   "note": "modals.html and forms.html are both pug-generated; the gender-radio form-group demos are build output showcasing different form layouts, not actionable in the HTML."
+  },
+  {
+   "family_id": "4488da5e10107deb",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/experimentals/calendars.html",
+     "start_line": 224,
+     "end_line": 232,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/calendars.html",
+     "start_line": 433,
+     "end_line": 441,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/responsive.html",
+     "start_line": 217,
+     "end_line": 225,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/responsive.html",
+     "start_line": 228,
+     "end_line": 236,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   }
+  },
+  {
+   "family_id": "f1e3584147e58d2d",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/components/popovers.html",
+     "start_line": 216,
+     "end_line": 231,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/popovers.html",
+     "start_line": 232,
+     "end_line": 247,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/popovers.html",
+     "start_line": 248,
+     "end_line": 263,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/popovers.html",
+     "start_line": 264,
+     "end_line": 279,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "parameterize"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   },
+   "note": "popovers.html is pug-generated; the 4 identical cards are intentional top/right/bottom/left directional variant demos (parallel-by-design) emitted as build output."
+  },
+  {
+   "family_id": "5d8cebe8bfae31c4",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 677,
+     "end_line": 686,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 693,
+     "end_line": 702,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 725,
+     "end_line": 734,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "726b9380b3444a15",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/index.html",
+     "start_line": 39,
+     "end_line": 44,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/index.html",
+     "start_line": 45,
+     "end_line": 50,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/index.html",
+     "start_line": 51,
+     "end_line": 56,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-data-table",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    }
+   }
+  },
+  {
+   "family_id": "7bb583e6e25356b7",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/layout/hero.html",
+     "start_line": 215,
+     "end_line": 224,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/hero.html",
+     "start_line": 233,
+     "end_line": 242,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/hero.html",
+     "start_line": 243,
+     "end_line": 252,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "fd36e77902c34266",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/elements/typography.html",
+     "start_line": 357,
+     "end_line": 361,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/typography.html",
+     "start_line": 370,
+     "end_line": 374,
+     "name": "ol"
+    },
+    {
+     "file": "bench/repos/spectre/docs/getting-started/whatsnew.html",
+     "start_line": 439,
+     "end_line": 443,
+     "name": "ul"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "03b99afd43d8f78a",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/layout/responsive.html",
+     "start_line": 270,
+     "end_line": 377,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/layout/responsive.html",
+     "start_line": 386,
+     "end_line": 493,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    }
+   },
+   "note": "responsive.html is built from responsive.pug; the hide-*/show-* visibility demo tables are non-actionable build output (also parallel breakpoint demos). Overriding the 2-1 worthy lean: both worthy voters missed it is generated."
+  },
+  {
+   "family_id": "4ab64a5294c0f55d",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/experimentals/viewer-360.html",
+     "start_line": 216,
+     "end_line": 223,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/viewer-360.html",
+     "start_line": 225,
+     "end_line": 232,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "parameterize"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   },
+   "note": "viewer-360.html is pug-generated; the two 360-viewer demos differ only in image URL and are build output / parallel demos, not hand-maintained."
+  },
+  {
+   "family_id": "68aa43254c1ca370",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/components/breadcrumbs.html",
+     "start_line": 222,
+     "end_line": 228,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/breadcrumbs.html",
+     "start_line": 229,
+     "end_line": 235,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "parameterize"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   },
+   "note": "breadcrumbs.html is pug-generated build output; the two breadcrumb demos differ only in the last item and are not edited in HTML."
+  },
+  {
+   "family_id": "6b6693a75dacae42",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/elements/tables.html",
+     "start_line": 215,
+     "end_line": 249,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/tables.html",
+     "start_line": 271,
+     "end_line": 305,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "77ea9339f623f0ad",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 709,
+     "end_line": 716,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 717,
+     "end_line": 724,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "8cd975f21499919b",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/components/modals.html",
+     "start_line": 215,
+     "end_line": 242,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/modals.html",
+     "start_line": 306,
+     "end_line": 333,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "9515938d91571c01",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 310,
+     "end_line": 323,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/elements/forms.html",
+     "start_line": 333,
+     "end_line": 346,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "da3c831cba1533ea",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/index.html",
+     "start_line": 28,
+     "end_line": 29,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/rtl.html",
+     "start_line": 25,
+     "end_line": 30,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "f0fe411fcf602ccc",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/components/panels.html",
+     "start_line": 240,
+     "end_line": 248,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/components/panels.html",
+     "start_line": 249,
+     "end_line": 257,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-data-table",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    }
+   }
+  },
+  {
+   "family_id": "f8db1342276702e6",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/experimentals/autocomplete.html",
+     "start_line": 216,
+     "end_line": 229,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/autocomplete.html",
+     "start_line": 269,
+     "end_line": 284,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "ff2c5f07d63eae5d",
+   "repo": "spectre",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/spectre/docs/experimentals/calendars.html",
+     "start_line": 218,
+     "end_line": 222,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/spectre/docs/experimentals/calendars.html",
+     "start_line": 427,
+     "end_line": 431,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   },
+   "note": "calendars.html is pug-generated; the two identical calendar-nav headers are build output emitted from calendars.pug."
+  },
+  {
+   "family_id": "258ff13470c3201b",
+   "repo": "nes.css",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/nes.css/docs/index.html",
+     "start_line": 115,
+     "end_line": 136,
+     "name": "section"
+    },
+    {
+     "file": "bench/repos/nes.css/docs/index.html",
+     "start_line": 137,
+     "end_line": 158,
+     "name": "section"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "50bade806e6cd4b6",
+   "repo": "nes.css",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/nes.css/docs/index.html",
+     "start_line": 173,
+     "end_line": 177,
+     "name": "article"
+    },
+    {
+     "file": "bench/repos/nes.css/docs/index.html",
+     "start_line": 178,
+     "end_line": 182,
+     "name": "article"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-data-table",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "parameterize"
+    }
+   }
+  },
+  {
+   "family_id": "dfcac251055a3c26",
+   "repo": "milligram",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/milligram/example.html",
+     "start_line": 138,
+     "end_line": 146,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/milligram/example.html",
+     "start_line": 147,
+     "end_line": 155,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/milligram/example.html",
+     "start_line": 156,
+     "end_line": 164,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/milligram/example.html",
+     "start_line": 165,
+     "end_line": 173,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/milligram/example.html",
+     "start_line": 174,
+     "end_line": 182,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/milligram/example.html",
+     "start_line": 183,
+     "end_line": 191,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/milligram/example.html",
+     "start_line": 192,
+     "end_line": 200,
+     "name": "li"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-data-table",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "parameterize"
+    }
+   }
+  },
+  {
+   "family_id": "61f51d14975bf99a",
+   "repo": "milligram",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/milligram/example.html",
+     "start_line": 232,
+     "end_line": 236,
+     "name": "a"
+    },
+    {
+     "file": "bench/repos/milligram/example.html",
+     "start_line": 265,
+     "end_line": 269,
+     "name": "a"
+    },
+    {
+     "file": "bench/repos/milligram/example.html",
+     "start_line": 278,
+     "end_line": 282,
+     "name": "a"
+    },
+    {
+     "file": "bench/repos/milligram/test/index.html",
+     "start_line": 869,
+     "end_line": 873,
+     "name": "a"
+    },
+    {
+     "file": "bench/repos/milligram/test/index.html",
+     "start_line": 914,
+     "end_line": 918,
+     "name": "a"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "parameterize"
+    }
+   },
+   "note": "bare <a href title>text</a> anchors across milligram example.html and test/index.html; each differs in destination and has no real structure \u2014 too small to extract (majority not:trivial confirmed)."
+  },
+  {
+   "family_id": "3fd47e3e518906d1",
+   "repo": "milligram",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/milligram/test/index.html",
+     "start_line": 147,
+     "end_line": 177,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/milligram/test/index.html",
+     "start_line": 180,
+     "end_line": 210,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/milligram/test/index.html",
+     "start_line": 211,
+     "end_line": 241,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "parameterize"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   },
+   "note": "milligram test page: the 3 columns render the same 6-button style grid for input type submit/reset/button \u2014 an intentional visual-test matrix; merging into one parameterized block would defeat the per-type test coverage."
+  },
+  {
+   "family_id": "7fadcb333b3c80a3",
+   "repo": "milligram",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/milligram/example.html",
+     "start_line": 3,
+     "end_line": 23,
+     "name": "head"
+    },
+    {
+     "file": "bench/repos/milligram/test/index.html",
+     "start_line": 3,
+     "end_line": 24,
+     "name": "head"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "99102204ce9343a7",
+   "repo": "milligram",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/milligram/example.html",
+     "start_line": 286,
+     "end_line": 304,
+     "name": "footer"
+    },
+    {
+     "file": "bench/repos/milligram/test/index.html",
+     "start_line": 923,
+     "end_line": 941,
+     "name": "footer"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "ddec5e7357f745ce",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/chota/docs/_includes/grid.html",
+     "start_line": 20,
+     "end_line": 30,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/docs/_includes/grid.html",
+     "start_line": 88,
+     "end_line": 98,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/docs/_includes/grid.html",
+     "start_line": 126,
+     "end_line": 136,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/docs/_includes/grid.html",
+     "start_line": 137,
+     "end_line": 147,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/docs/_includes/grid.html",
+     "start_line": 149,
+     "end_line": 159,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/docs/_includes/grid.html",
+     "start_line": 160,
+     "end_line": 170,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/docs/_includes/grid.html",
+     "start_line": 240,
+     "end_line": 250,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/docs/_includes/grid.html",
+     "start_line": 252,
+     "end_line": 262,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 187,
+     "end_line": 197,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 264,
+     "end_line": 274,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 275,
+     "end_line": 285,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 294,
+     "end_line": 304,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 305,
+     "end_line": 315,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 316,
+     "end_line": 326,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 349,
+     "end_line": 359,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 360,
+     "end_line": 370,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 371,
+     "end_line": 381,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "b9a70de220fc52f4",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/chota/test/index.html",
+     "start_line": 198,
+     "end_line": 204,
+     "name": "tr"
+    },
+    {
+     "file": "bench/repos/chota/test/index.html",
+     "start_line": 205,
+     "end_line": 211,
+     "name": "tr"
+    },
+    {
+     "file": "bench/repos/chota/test/index.html",
+     "start_line": 242,
+     "end_line": 248,
+     "name": "tr"
+    },
+    {
+     "file": "bench/repos/chota/test/index.html",
+     "start_line": 249,
+     "end_line": 255,
+     "name": "tr"
+    },
+    {
+     "file": "bench/repos/chota/test/index.html",
+     "start_line": 256,
+     "end_line": 262,
+     "name": "tr"
+    },
+    {
+     "file": "bench/repos/chota/test/index.html",
+     "start_line": 263,
+     "end_line": 269,
+     "name": "tr"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "26a579b03f8ac866",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/chota/docs/_includes/grid.html",
+     "start_line": 191,
+     "end_line": 198,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 286,
+     "end_line": 293,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 327,
+     "end_line": 334,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 335,
+     "end_line": 342,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "081389c1d6a87a79",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 865,
+     "end_line": 867,
+     "name": ".text-light"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".text-light"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 54,
+     "end_line": 56,
+     "name": ".text-light"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1748f2d6917443eb",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 874,
+     "end_line": 876,
+     "name": ".text-error"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".text-error"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 66,
+     "end_line": 68,
+     "name": ".text-error"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1caf87dcf0c23373",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 805,
+     "end_line": 808,
+     "name": ".tag.is-small"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".tag.is-small"
+    },
+    {
+     "file": "bench/repos/chota/src/_tag.css",
+     "start_line": 11,
+     "end_line": 14,
+     "name": ".tag.is-small"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "1f8a0ff374f04860",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 614,
+     "end_line": 617,
+     "name": ".button.outline.dark"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".button.outline.dark"
+    },
+    {
+     "file": "bench/repos/chota/src/_form.css",
+     "start_line": 179,
+     "end_line": 182,
+     "name": ".button.outline.dark"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "2843bdf56a9b6d96",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/chota/docs/_includes/tag.html",
+     "start_line": 4,
+     "end_line": 4,
+     "name": "p"
+    },
+    {
+     "file": "bench/repos/chota/docs/_includes/tag.html",
+     "start_line": 6,
+     "end_line": 12,
+     "name": "p"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 170,
+     "end_line": 179,
+     "name": "section"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "313de74261199a37",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 871,
+     "end_line": 873,
+     "name": ".text-grey"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".text-grey"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 62,
+     "end_line": 64,
+     "name": ".text-grey"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "3dd55f43ef71389a",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 829,
+     "end_line": 831,
+     "name": ".bg-light"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bg-light"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 6,
+     "end_line": 8,
+     "name": ".bg-light"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "45bb36a7ec31e0ae",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 112,
+     "end_line": 116,
+     "name": "td"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "td"
+    },
+    {
+     "file": "bench/repos/chota/src/_base.css",
+     "start_line": 124,
+     "end_line": 128,
+     "name": "td"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "489561482fab29d0",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 464,
+     "end_line": 477,
+     "name": "input:not([type=\"checkbox\"], [type=\"radio\"], [type=\"submit\"], [type=\"color\"], [type=\"button\"], [type=\"reset\"])"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "input:not([type=checkbox],[type=radio],[type=submit],[type=color],[type=button],[type=reset])"
+    },
+    {
+     "file": "bench/repos/chota/src/_form.css",
+     "start_line": 11,
+     "end_line": 23,
+     "name": "input:not([type=\"checkbox\"], [type=\"radio\"], [type=\"submit\"], [type=\"color\"], [type=\"button\"], [type=\"reset\"])"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "54cbee72d438607d",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 850,
+     "end_line": 852,
+     "name": ".bd-dark"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bd-dark"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 34,
+     "end_line": 36,
+     "name": ".bd-dark"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "56080ee344cf3d0a",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 884,
+     "end_line": 886,
+     "name": ".pull-right"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".pull-right"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 79,
+     "end_line": 81,
+     "name": ".pull-right"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "5fd867a41b498dcf",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 986,
+     "end_line": 990,
+     "name": ".clearfix"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".clearfix"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 177,
+     "end_line": 181,
+     "name": ".clearfix"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "6225b040407321dd",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 738,
+     "end_line": 742,
+     "name": ".nav .brand"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".nav .brand"
+    },
+    {
+     "file": "bench/repos/chota/src/_nav.css",
+     "start_line": 63,
+     "end_line": 67,
+     "name": ".nav .brand"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "63d42db5de9e3a61",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 456,
+     "end_line": 458,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/chota/src/_form.css",
+     "start_line": 1,
+     "end_line": 3,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "67de7454b9727126",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 459,
+     "end_line": 463,
+     "name": "legend"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "legend"
+    },
+    {
+     "file": "bench/repos/chota/src/_form.css",
+     "start_line": 5,
+     "end_line": 9,
+     "name": "legend"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "69ae9a4151d7641c",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 859,
+     "end_line": 861,
+     "name": ".bd-success"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bd-success"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 46,
+     "end_line": 48,
+     "name": ".bd-success"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "6e19d663fbb31034",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 48,
+     "end_line": 56,
+     "name": "h1"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "h1"
+    },
+    {
+     "file": "bench/repos/chota/src/_base.css",
+     "start_line": 44,
+     "end_line": 52,
+     "name": "h1"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "72095a4e6148817d",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 835,
+     "end_line": 837,
+     "name": ".bg-grey"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bg-grey"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 14,
+     "end_line": 16,
+     "name": ".bg-grey"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "777c41d6c828ca6f",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 551,
+     "end_line": 554,
+     "name": ".grouped.gapless > *:first-child"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".grouped.gapless>:first-child"
+    },
+    {
+     "file": "bench/repos/chota/src/_form.css",
+     "start_line": 101,
+     "end_line": 104,
+     "name": ".grouped.gapless > *:first-child"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "78ddaca6783e2125",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 847,
+     "end_line": 849,
+     "name": ".bd-light"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bd-light"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 30,
+     "end_line": 32,
+     "name": ".bd-light"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "7d13ed016d613f2b",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 856,
+     "end_line": 858,
+     "name": ".bd-error"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bd-error"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 42,
+     "end_line": 44,
+     "name": ".bd-error"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "840792083cd8f34f",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 977,
+     "end_line": 979,
+     "name": ".is-marginless"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".is-marginless"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 165,
+     "end_line": 167,
+     "name": ".is-marginless"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "85ca9a05114f9b30",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 999,
+     "end_line": 1003,
+     "name": "@media screen and (min-width: 600px) and (max-width: 899px)"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:600px) and (max-width:899px)"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 193,
+     "end_line": 197,
+     "name": "@media screen and (min-width: 600px) and (max-width: 899px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "860666ace1eb0c06",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 117,
+     "end_line": 119,
+     "name": "thead"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "thead"
+    },
+    {
+     "file": "bench/repos/chota/src/_base.css",
+     "start_line": 130,
+     "end_line": 132,
+     "name": "thead"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "8bf5ce1231c30d63",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 1004,
+     "end_line": 1008,
+     "name": "@media screen and (min-width: 900px) and (max-width: 1199px)"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (min-width:900px) and (max-width:1199px)"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 199,
+     "end_line": 203,
+     "name": "@media screen and (min-width: 900px) and (max-width: 1199px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "8dbd7e8510b88dd2",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 547,
+     "end_line": 550,
+     "name": ".grouped.gapless > *"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".grouped.gapless>*"
+    },
+    {
+     "file": "bench/repos/chota/src/_form.css",
+     "start_line": 96,
+     "end_line": 99,
+     "name": ".grouped.gapless > *"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "9913b4fea23c4481",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 493,
+     "end_line": 513,
+     "name": ".button"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".button"
+    },
+    {
+     "file": "bench/repos/chota/src/_form.css",
+     "start_line": 40,
+     "end_line": 58,
+     "name": ".button"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "9f5bda9edb0b9b90",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 759,
+     "end_line": 762,
+     "name": ".card header > *"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".card header>*"
+    },
+    {
+     "file": "bench/repos/chota/src/_card.css",
+     "start_line": 12,
+     "end_line": 15,
+     "name": ".card header > *"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "a7576b30db42a88f",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 826,
+     "end_line": 828,
+     "name": ".bg-primary"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bg-primary"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 2,
+     "end_line": 4,
+     "name": ".bg-primary"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "a80fe8c1fd07230d",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 862,
+     "end_line": 864,
+     "name": ".text-primary"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".text-primary"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 50,
+     "end_line": 52,
+     "name": ".text-primary"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ad8308844ef167cf",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 915,
+     "end_line": 917,
+     "name": ".is-full-width"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".is-full-width"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 120,
+     "end_line": 122,
+     "name": ".is-full-width"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "b0d66b8b5f87414d",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 130,
+     "end_line": 138,
+     "name": "code"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "code"
+    },
+    {
+     "file": "bench/repos/chota/src/_base.css",
+     "start_line": 146,
+     "end_line": 154,
+     "name": "code"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "bb59fa30567a52d7",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 1014,
+     "end_line": 1018,
+     "name": "@media print"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media print"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 211,
+     "end_line": 215,
+     "name": "@media print"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "c4b924bb4f99da23",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 88,
+     "end_line": 92,
+     "name": "blockquote"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "blockquote"
+    },
+    {
+     "file": "bench/repos/chota/src/_base.css",
+     "start_line": 95,
+     "end_line": 99,
+     "name": "blockquote"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "c7af1cef0809a669",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 781,
+     "end_line": 786,
+     "name": ".tabs > a[aria-current=\"page\"]"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".tabs>a.active"
+    },
+    {
+     "file": "bench/repos/chota/src/_tab.css",
+     "start_line": 18,
+     "end_line": 23,
+     "name": ".tabs > a[aria-current=\"page\"]"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "cc9afac6b233f116",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 120,
+     "end_line": 122,
+     "name": "tfoot"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "tfoot"
+    },
+    {
+     "file": "bench/repos/chota/src/_base.css",
+     "start_line": 134,
+     "end_line": 136,
+     "name": "tfoot"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "d16637e1308b0abf",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 841,
+     "end_line": 843,
+     "name": ".bg-success"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".bg-success"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 22,
+     "end_line": 24,
+     "name": ".bg-success"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "d5758f3977834c1e",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 38,
+     "end_line": 47,
+     "name": "body"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "body"
+    },
+    {
+     "file": "bench/repos/chota/src/_base.css",
+     "start_line": 33,
+     "end_line": 42,
+     "name": "body"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "d7ca12b5f2893fc1",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 868,
+     "end_line": 870,
+     "name": ".text-dark"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".text-dark"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 58,
+     "end_line": 60,
+     "name": ".text-dark"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e0d7c6d62c524dc8",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 918,
+     "end_line": 920,
+     "name": ".is-full-height"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".is-full-height"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 124,
+     "end_line": 126,
+     "name": ".is-full-height"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e1a77bf801bfde91",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 514,
+     "end_line": 524,
+     "name": ".button.primary"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".button.dark"
+    },
+    {
+     "file": "bench/repos/chota/src/_form.css",
+     "start_line": 60,
+     "end_line": 70,
+     "name": ".button.primary"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ef3d9d9638a0bdfc",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 994,
+     "end_line": 998,
+     "name": "@media screen and (max-width: 599px)"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "@media screen and (max-width:599px)"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 187,
+     "end_line": 191,
+     "name": "@media screen and (max-width: 599px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "f6d24fa2c95ca643",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 602,
+     "end_line": 605,
+     "name": ".button.outline"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".button.outline"
+    },
+    {
+     "file": "bench/repos/chota/src/_form.css",
+     "start_line": 164,
+     "end_line": 167,
+     "name": ".button.outline"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "f888893febc2e18b",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 974,
+     "end_line": 976,
+     "name": ".is-paddingless"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".is-paddingless"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 161,
+     "end_line": 163,
+     "name": ".is-paddingless"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "fa490ba23ee1beb5",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 911,
+     "end_line": 914,
+     "name": ".is-full-screen"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".is-full-screen"
+    },
+    {
+     "file": "bench/repos/chota/src/_util.css",
+     "start_line": 115,
+     "end_line": 118,
+     "name": ".is-full-screen"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "fef411c41bed75f2",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 618,
+     "end_line": 622,
+     "name": ".button.clear"
+    },
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": ".button.clear"
+    },
+    {
+     "file": "bench/repos/chota/src/_form.css",
+     "start_line": 184,
+     "end_line": 188,
+     "name": ".button.clear"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "0dbacf700ef5604f",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/chota/docs/_includes/grid.html",
+     "start_line": 50,
+     "end_line": 87,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 198,
+     "end_line": 235,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "4fe105e2dcb1d178",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/src/_grid.css",
+     "start_line": 103,
+     "end_line": 163,
+     "name": "@media screen and (min-width: 900px)"
+    },
+    {
+     "file": "bench/repos/chota/src/_grid.css",
+     "start_line": 165,
+     "end_line": 225,
+     "name": "@media screen and (min-width: 1200px)"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "55ab7b33c642ca2a",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "mixed",
+   "members": [
+    {
+     "file": "bench/repos/chota/docs/_includes/card.html",
+     "start_line": 20,
+     "end_line": 33,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 137,
+     "end_line": 152,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "5f9479e8f0ec7273",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 25,
+     "end_line": 27,
+     "name": "h1"
+    },
+    {
+     "file": "bench/repos/chota/test/index.html",
+     "start_line": 22,
+     "end_line": 24,
+     "name": "h1"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   },
+   "note": "identical dark-mode toggle widget (h1>a onclick=switchMode, behavior-bearing) copied verbatim across chota test/components.html and test/index.html; rubric calibration treats identical structure copied across views as worthy -> shared header partial. Borderline-small but functional."
+  },
+  {
+   "family_id": "660367173c1f849f",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 195,
+     "end_line": 199,
+     "name": ".col"
+    },
+    {
+     "file": "bench/repos/chota/src/_grid.css",
+     "start_line": 24,
+     "end_line": 28,
+     "name": ".col"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "8691ad0b06705e10",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 525,
+     "end_line": 531,
+     "name": ".button:hover"
+    },
+    {
+     "file": "bench/repos/chota/src/_form.css",
+     "start_line": 72,
+     "end_line": 78,
+     "name": ".button:hover"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "9c5d3b276cb0dd13",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 123,
+     "end_line": 129,
+     "name": "code"
+    },
+    {
+     "file": "bench/repos/chota/src/_base.css",
+     "start_line": 138,
+     "end_line": 144,
+     "name": "code"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "9d8f02b537e81d52",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 102,
+     "end_line": 108,
+     "name": "table"
+    },
+    {
+     "file": "bench/repos/chota/src/_base.css",
+     "start_line": 112,
+     "end_line": 118,
+     "name": "table"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "aeaf413a2e9afbd7",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "test",
+   "members": [
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 56,
+     "end_line": 60,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/chota/test/components.html",
+     "start_line": 107,
+     "end_line": 111,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "b19002192b3fa243",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.css",
+     "start_line": 733,
+     "end_line": 737,
+     "name": ".nav [aria-current=\"page\"]:not(.button)"
+    },
+    {
+     "file": "bench/repos/chota/src/_nav.css",
+     "start_line": 57,
+     "end_line": 61,
+     "name": ".nav [aria-current=\"page\"]:not(.button)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "dfa8dd1a1257776b",
+   "repo": "chota",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/chota/dist/chota.min.css",
+     "start_line": 3,
+     "end_line": 3,
+     "name": "html"
+    },
+    {
+     "file": "bench/repos/chota/src/_base.css",
+     "start_line": 20,
+     "end_line": 25,
+     "name": "html"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "0016b4313d353382",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 299,
+     "end_line": 302,
+     "name": "table"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "table"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "26f89ba01921778c",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 42,
+     "end_line": 45,
+     "name": "*"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "*"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "3f344a346fafe355",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 229,
+     "end_line": 232,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "428afa8be748d488",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 184,
+     "end_line": 190,
+     "name": "button:disabled"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "button:disabled"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "4c15cf12bdfe2ab7",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 102,
+     "end_line": 104,
+     "name": "main section + section"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "main section+section"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "52e633a8869b6dbd",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 7,
+     "end_line": 14,
+     "name": ":root"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": ":root"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "6158a5728dd15f29",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 375,
+     "end_line": 379,
+     "name": "pre > code"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "pre>code"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "6ac0274440945517",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 162,
+     "end_line": 177,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "button"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "79d9e58ea9789296",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 278,
+     "end_line": 280,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "83e65635241b2a3c",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 112,
+     "end_line": 120,
+     "name": "body > header"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "body>footer"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "992551e582bd11d7",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 287,
+     "end_line": 292,
+     "name": "input::placeholder"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "input::placeholder"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "9f2e2ec387c869e7",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 352,
+     "end_line": 358,
+     "name": "blockquote"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "blockquote"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "a1083db8a159fa4e",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 387,
+     "end_line": 399,
+     "name": "progress"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "progress"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "c056b66ac357588d",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 250,
+     "end_line": 272,
+     "name": "input[type=\"email\"]"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "input[type=email]"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "d1a49564bf3c6456",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 333,
+     "end_line": 336,
+     "name": "th"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "th"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e279d8e5edc309d4",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 429,
+     "end_line": 431,
+     "name": "hr"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "hr"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e4e966e0218c8a3e",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 32,
+     "end_line": 35,
+     "name": "html"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "html"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e5d4a43309f8c82e",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 127,
+     "end_line": 131,
+     "name": "body > header"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "body>header"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e72cd42a88d3d6ff",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 342,
+     "end_line": 344,
+     "name": "td"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "td"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "e8417a14c1f70666",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 93,
+     "end_line": 96,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "img"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "ebdf9ed48b911640",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 220,
+     "end_line": 223,
+     "name": "nav ul li"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "nav ul li"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "eeab69d9f4fded1e",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 20,
+     "end_line": 25,
+     "name": "@media (prefers-color-scheme: dark)"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "@media (prefers-color-scheme:dark)"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "f2ee96e49598641f",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 203,
+     "end_line": 205,
+     "name": "nav"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "nav"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "f87bae1da49e4872",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 81,
+     "end_line": 86,
+     "name": "figcaption"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "figcaption"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "f90b083888eca1fa",
+   "repo": "concrete.css",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/concrete.css/concrete.css",
+     "start_line": 211,
+     "end_line": 214,
+     "name": "nav ul"
+    },
+    {
+     "file": "bench/repos/concrete.css/concrete.min.css",
+     "start_line": 2,
+     "end_line": 2,
+     "name": "nav ul"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "001a5fc0d816a4af",
+   "repo": "html5-boilerplate",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/html5-boilerplate/dist/index.html",
+     "start_line": 2,
+     "end_line": 33,
+     "name": "html"
+    },
+    {
+     "file": "bench/repos/html5-boilerplate/src/index.html",
+     "start_line": 2,
+     "end_line": 33,
+     "name": "html"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "a9045229c90fd5f7",
+   "repo": "html5-boilerplate",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/html5-boilerplate/dist/404.html",
+     "start_line": 2,
+     "end_line": 61,
+     "name": "html"
+    },
+    {
+     "file": "bench/repos/html5-boilerplate/src/404.html",
+     "start_line": 2,
+     "end_line": 61,
+     "name": "html"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "eb1a28734bb1ba03",
+   "repo": "vue-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue-realworld/src/views/Login.vue",
+     "start_line": 18,
+     "end_line": 26,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Login.vue",
+     "start_line": 27,
+     "end_line": 35,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Register.vue",
+     "start_line": 18,
+     "end_line": 26,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Register.vue",
+     "start_line": 27,
+     "end_line": 35,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Register.vue",
+     "start_line": 36,
+     "end_line": 44,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Settings.vue",
+     "start_line": 10,
+     "end_line": 18,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Settings.vue",
+     "start_line": 19,
+     "end_line": 27,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Settings.vue",
+     "start_line": 37,
+     "end_line": 45,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Settings.vue",
+     "start_line": 46,
+     "end_line": 54,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "5ebe1523f2620d49",
+   "repo": "vue-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue-realworld/src/components/TheHeader.vue",
+     "start_line": 11,
+     "end_line": 19,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/components/TheHeader.vue",
+     "start_line": 40,
+     "end_line": 48,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Profile.vue",
+     "start_line": 51,
+     "end_line": 59,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Profile.vue",
+     "start_line": 60,
+     "end_line": 68,
+     "name": "li"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "parameterize"
+    }
+   }
+  },
+  {
+   "family_id": "71216963898465e0",
+   "repo": "vue-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue-realworld/src/components/ArticleMeta.vue",
+     "start_line": 8,
+     "end_line": 14,
+     "name": "a"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Home.vue",
+     "start_line": 15,
+     "end_line": 21,
+     "name": "a"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Home.vue",
+     "start_line": 24,
+     "end_line": 30,
+     "name": "a"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   }
+  },
+  {
+   "family_id": "24bae392ff284e15",
+   "repo": "vue-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue-realworld/src/views/ArticleEdit.vue",
+     "start_line": 9,
+     "end_line": 17,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/ArticleEdit.vue",
+     "start_line": 18,
+     "end_line": 26,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "parameterize"
+    }
+   }
+  },
+  {
+   "family_id": "7235d9904b595b8e",
+   "repo": "vue-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue-realworld/src/components/VPagination.vue",
+     "start_line": 10,
+     "end_line": 16,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Settings.vue",
+     "start_line": 55,
+     "end_line": 60,
+     "name": "button"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   }
+  },
+  {
+   "family_id": "abc9c774e23b7287",
+   "repo": "vue-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue-realworld/src/views/Login.vue",
+     "start_line": 12,
+     "end_line": 16,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Register.vue",
+     "start_line": 12,
+     "end_line": 16,
+     "name": "ul"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "f9c9679186142afc",
+   "repo": "vue-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue-realworld/src/components/TheHeader.vue",
+     "start_line": 20,
+     "end_line": 28,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/components/TheHeader.vue",
+     "start_line": 29,
+     "end_line": 37,
+     "name": "li"
+    }
+   ],
+   "worthy": true,
+   "reason": "parameterize",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "parameterize"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "parameterize"
+    }
+   }
+  },
+  {
+   "family_id": "2ddc587234b34a5a",
+   "repo": "svelte-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/+page.svelte",
+     "start_line": 33,
+     "end_line": 37,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/+page.svelte",
+     "start_line": 40,
+     "end_line": 42,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/+page.svelte",
+     "start_line": 44,
+     "end_line": 46,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/Nav.svelte",
+     "start_line": 26,
+     "end_line": 30,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/Nav.svelte",
+     "start_line": 32,
+     "end_line": 36,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/Nav.svelte",
+     "start_line": 38,
+     "end_line": 42,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/profile/@[user]/+layout.svelte",
+     "start_line": 71,
+     "end_line": 79,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/profile/@[user]/+layout.svelte",
+     "start_line": 81,
+     "end_line": 89,
+     "name": "li"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "parameterize"
+    }
+   }
+  },
+  {
+   "family_id": "a2b2e27b7e04f935",
+   "repo": "svelte-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/svelte-realworld/src/lib/ArticleList/ArticlePreview.svelte",
+     "start_line": 43,
+     "end_line": 46,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/article/[slug]/ArticleMeta.svelte",
+     "start_line": 26,
+     "end_line": 28,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/profile/@[user]/+layout.svelte",
+     "start_line": 48,
+     "end_line": 56,
+     "name": "button"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   }
+  },
+  {
+   "family_id": "036335f173a47891",
+   "repo": "svelte-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/svelte-realworld/src/lib/ArticleList/ArticlePreview.svelte",
+     "start_line": 55,
+     "end_line": 59,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/article/[slug]/+page.svelte",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "ul"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "5a77238442c58141",
+   "repo": "svelte-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/svelte-realworld/src/lib/ArticleList/ArticlePreview.svelte",
+     "start_line": 13,
+     "end_line": 16,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/article/[slug]/ArticleMeta.svelte",
+     "start_line": 12,
+     "end_line": 17,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "bfe0385aaeea313f",
+   "repo": "svelte-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/editor/Editor.svelte",
+     "start_line": 19,
+     "end_line": 26,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/editor/Editor.svelte",
+     "start_line": 28,
+     "end_line": 35,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "parameterize"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "d4606b273e037760",
+   "repo": "svelte-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/svelte-realworld/src/app.html",
+     "start_line": 9,
+     "end_line": 13,
+     "name": "link"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/app.html",
+     "start_line": 14,
+     "end_line": 18,
+     "name": "link"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "0eb8d2b72845a31c",
+   "repo": "react-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Editor.js",
+     "start_line": 106,
+     "end_line": 113,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Editor.js",
+     "start_line": 115,
+     "end_line": 122,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Login.js",
+     "start_line": 61,
+     "end_line": 68,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Login.js",
+     "start_line": 70,
+     "end_line": 77,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Register.js",
+     "start_line": 68,
+     "end_line": 75,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Register.js",
+     "start_line": 77,
+     "end_line": 84,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Register.js",
+     "start_line": 86,
+     "end_line": 93,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Settings.js",
+     "start_line": 68,
+     "end_line": 75,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Settings.js",
+     "start_line": 77,
+     "end_line": 84,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Settings.js",
+     "start_line": 96,
+     "end_line": 103,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Settings.js",
+     "start_line": 105,
+     "end_line": 112,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "a277d3c089d8063a",
+   "repo": "react-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Header.js",
+     "start_line": 9,
+     "end_line": 13,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Header.js",
+     "start_line": 15,
+     "end_line": 19,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Header.js",
+     "start_line": 21,
+     "end_line": 25,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Header.js",
+     "start_line": 38,
+     "end_line": 42,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Home/MainView.js",
+     "start_line": 15,
+     "end_line": 21,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Home/MainView.js",
+     "start_line": 33,
+     "end_line": 40,
+     "name": "li"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   },
+   "note": "family lumps router <Link> nav items (Header.js) with onClick feed-tab toggles (MainView.js); only the Bootstrap li.nav-item/.nav-link class shape is shared. A single component would couple routing-nav with tab-state and leak the active-conditional/onClick quirks."
+  },
+  {
+   "family_id": "b7eed0c22b9fce16",
+   "repo": "react-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Editor.js",
+     "start_line": 159,
+     "end_line": 165,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Login.js",
+     "start_line": 79,
+     "end_line": 84,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Register.js",
+     "start_line": 95,
+     "end_line": 100,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Settings.js",
+     "start_line": 114,
+     "end_line": 119,
+     "name": "button"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "parameterize"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "6b7dda60e4c0d8e3",
+   "repo": "react-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Article/ArticleMeta.js",
+     "start_line": 13,
+     "end_line": 20,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/ArticlePreview.js",
+     "start_line": 43,
+     "end_line": 50,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "ae9c4876d965962d",
+   "repo": "react-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Editor.js",
+     "start_line": 124,
+     "end_line": 132,
+     "name": "fieldset"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Settings.js",
+     "start_line": 86,
+     "end_line": 94,
+     "name": "fieldset"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "parameterize"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "c7fb7e994985eb0e",
+   "repo": "react-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Article/index.js",
+     "start_line": 62,
+     "end_line": 74,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/ArticlePreview.js",
+     "start_line": 63,
+     "end_line": 73,
+     "name": "ul"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "b4729bcb4a4100cb",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/EditArticle.vue",
+     "start_line": 8,
+     "end_line": 15,
+     "name": "input"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/EditArticle.vue",
+     "start_line": 17,
+     "end_line": 24,
+     "name": "input"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/EditArticle.vue",
+     "start_line": 35,
+     "end_line": 44,
+     "name": "input"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Settings.vue",
+     "start_line": 19,
+     "end_line": 26,
+     "name": "input"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Settings.vue",
+     "start_line": 28,
+     "end_line": 35,
+     "name": "input"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Settings.vue",
+     "start_line": 46,
+     "end_line": 53,
+     "name": "input"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Settings.vue",
+     "start_line": 55,
+     "end_line": 62,
+     "name": "input"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "06123017d5aba7ab",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 558,
+     "end_line": 562,
+     "name": ".btn-secondary"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 647,
+     "end_line": 651,
+     "name": ".btn-outline-secondary:hover"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 653,
+     "end_line": 658,
+     "name": ".btn-outline-secondary:focus"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 660,
+     "end_line": 665,
+     "name": ".btn-outline-secondary:active"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "0785c7e9ede0aa14",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 505,
+     "end_line": 509,
+     "name": ".btn-primary"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 607,
+     "end_line": 611,
+     "name": ".btn-outline-primary:hover"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 613,
+     "end_line": 618,
+     "name": ".btn-outline-primary:focus"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 620,
+     "end_line": 625,
+     "name": ".btn-outline-primary:active"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "generated"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "generated"
+    }
+   }
+  },
+  {
+   "family_id": "b64aa0583eefa987",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/EditArticle.vue",
+     "start_line": 62,
+     "end_line": 68,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Login.vue",
+     "start_line": 50,
+     "end_line": 56,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Register.vue",
+     "start_line": 58,
+     "end_line": 64,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Settings.vue",
+     "start_line": 63,
+     "end_line": 69,
+     "name": "button"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "parameterize"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "6d056e67f9071591",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/src/components/ArticleDetailComment.vue",
+     "start_line": 15,
+     "end_line": 20,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/components/ArticleDetailCommentsForm.vue",
+     "start_line": 24,
+     "end_line": 29,
+     "name": "img"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Profile.vue",
+     "start_line": 14,
+     "end_line": 20,
+     "name": "img"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "7e4a9c88c734bd1b",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/src/components/ArticleDetailComment.vue",
+     "start_line": 24,
+     "end_line": 30,
+     "name": "applink"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/components/ArticleDetailMeta.vue",
+     "start_line": 11,
+     "end_line": 17,
+     "name": "applink"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/components/ArticlesListArticlePreview.vue",
+     "start_line": 11,
+     "end_line": 17,
+     "name": "applink"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "935057594487ad31",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/src/components/AppFooter.vue",
+     "start_line": 4,
+     "end_line": 9,
+     "name": "applink"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/components/AppNavigation.vue",
+     "start_line": 4,
+     "end_line": 9,
+     "name": "applink"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/NotFound.vue",
+     "start_line": 7,
+     "end_line": 12,
+     "name": "applink"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   }
+  },
+  {
+   "family_id": "94a73fb8c1b7a340",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/src/components/ArticleDetailCommentsForm.vue",
+     "start_line": 15,
+     "end_line": 21,
+     "name": "textarea"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/EditArticle.vue",
+     "start_line": 26,
+     "end_line": 32,
+     "name": "textarea"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Settings.vue",
+     "start_line": 37,
+     "end_line": 43,
+     "name": "textarea"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "95880af0bd4b9968",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Login.vue",
+     "start_line": 14,
+     "end_line": 21,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Register.vue",
+     "start_line": 14,
+     "end_line": 21,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Settings.vue",
+     "start_line": 10,
+     "end_line": 14,
+     "name": "ul"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "c5e9b5c61498dfdc",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/src/components/ArticlesList.vue",
+     "start_line": 8,
+     "end_line": 13,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/components/ArticlesList.vue",
+     "start_line": 15,
+     "end_line": 20,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Profile.vue",
+     "start_line": 7,
+     "end_line": 12,
+     "name": "div"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   }
+  },
+  {
+   "family_id": "ddf6888b984fffb2",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 687,
+     "end_line": 691,
+     "name": ".btn-outline-danger:hover"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 693,
+     "end_line": 698,
+     "name": ".btn-outline-danger:focus"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 700,
+     "end_line": 705,
+     "name": ".btn-outline-danger:active"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "22e53f55d788bcae",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/src/components/ArticleDetail.vue",
+     "start_line": 6,
+     "end_line": 10,
+     "name": "articledetailmeta"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/components/ArticleDetail.vue",
+     "start_line": 41,
+     "end_line": 45,
+     "name": "articledetailmeta"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "28b7de617f279785",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 543,
+     "end_line": 549,
+     "name": ".btn-primary.disabled:focus"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 551,
+     "end_line": 555,
+     "name": ".btn-primary.disabled:hover"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "379440141531714c",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 126,
+     "end_line": 130,
+     "name": "a:focus"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 467,
+     "end_line": 476,
+     "name": ".btn:focus"
+    }
+   ],
+   "worthy": false,
+   "reason": "generated",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    }
+   },
+   "note": "public/main.css is vendored/minimal Conduit (Bootstrap-derived) CSS ('only classes used in this codebase'); the duplicated a:focus/.btn:focus outline is Bootstrap's tab-focus() mixin flattened into a delivered asset \u2014 third-party, not app-owned to dedupe."
+  },
+  {
+   "family_id": "4f954e8f1afbefff",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 433,
+     "end_line": 437,
+     "name": ".form-control-lg"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 720,
+     "end_line": 724,
+     "name": ".btn-lg"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   }
+  },
+  {
+   "family_id": "88fcf72a8a57de4f",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 511,
+     "end_line": 515,
+     "name": ".btn-primary:hover"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 517,
+     "end_line": 522,
+     "name": ".btn-primary:focus"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "9a2362f3482c57d8",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 564,
+     "end_line": 568,
+     "name": ".btn-secondary:hover"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 570,
+     "end_line": 575,
+     "name": ".btn-secondary:focus"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    }
+   }
+  },
+  {
+   "family_id": "a586376c33aefb0c",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Article.vue",
+     "start_line": 5,
+     "end_line": 9,
+     "name": "template"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/Article.vue",
+     "start_line": 18,
+     "end_line": 22,
+     "name": "template"
+    }
+   ],
+   "worthy": false,
+   "reason": "trivial",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "trivial"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "bffe1a9a3aa584a2",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/src/components/ArticleDetailMeta.vue",
+     "start_line": 3,
+     "end_line": 8,
+     "name": "applink"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/components/ArticlesListArticlePreview.vue",
+     "start_line": 4,
+     "end_line": 9,
+     "name": "applink"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "c8cd5b2ab7a54b73",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/src/components/ArticleDetailComment.vue",
+     "start_line": 35,
+     "end_line": 43,
+     "name": "i"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/src/pages/EditArticle.vue",
+     "start_line": 50,
+     "end_line": 57,
+     "name": "i"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "parameterize"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   },
+   "note": "both <i> icons share a deliberate accessible-clickable-icon idiom (role=button, tabindex=0, @click + @keypress.enter mirror) across two Vue files, differing only in icon class/aria-label/handler -> extract one accessible IconButton component; the a11y boilerplate is reusable, not coincidental."
+  },
+  {
+   "family_id": "d7e3c2655a63dd10",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 585,
+     "end_line": 591,
+     "name": ".btn-secondary.disabled:focus"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 593,
+     "end_line": 597,
+     "name": ".btn-secondary.disabled:hover"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "f49bb01eada7d5bd",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 132,
+     "end_line": 135,
+     "name": "a:not([href])"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 137,
+     "end_line": 141,
+     "name": "a:not([href]):focus"
+    }
+   ],
+   "worthy": false,
+   "reason": "parallel-by-design",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "parallel-by-design"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "ffb39afea97907bf",
+   "repo": "vue3-realworld",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 925,
+     "end_line": 929,
+     "name": ".card-block::after"
+    },
+    {
+     "file": "bench/repos/vue3-realworld/public/main.css",
+     "start_line": 941,
+     "end_line": 945,
+     "name": ".card-footer::after"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-data-table",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-data-table"
+    }
+   }
+  },
+  {
+   "family_id": "0e5c8dcb15695253",
+   "repo": "react-mobx-realworld",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-mobx-realworld/src/pages/Home/MainView.js",
+     "start_line": 10,
+     "end_line": 23,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-mobx-realworld/src/pages/Home/MainView.js",
+     "start_line": 31,
+     "end_line": 44,
+     "name": "li"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "299bdf1462df75e3",
+   "repo": "react-mobx-realworld",
+   "split": "heldout",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-mobx-realworld/src/pages/Article/Comment.js",
+     "start_line": 22,
+     "end_line": 27,
+     "name": "a"
+    },
+    {
+     "file": "bench/repos/react-mobx-realworld/src/pages/Home/Tags.js",
+     "start_line": 12,
+     "end_line": 21,
+     "name": "a"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   }
+  },
+  {
+   "family_id": "6ce536d7c60543d3",
+   "repo": "realworld-xdialect",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Header.js",
+     "start_line": 9,
+     "end_line": 13,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Header.js",
+     "start_line": 15,
+     "end_line": 19,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Header.js",
+     "start_line": 21,
+     "end_line": 25,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Header.js",
+     "start_line": 38,
+     "end_line": 42,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Home/MainView.js",
+     "start_line": 15,
+     "end_line": 21,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Home/MainView.js",
+     "start_line": 33,
+     "end_line": 40,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/+page.svelte",
+     "start_line": 33,
+     "end_line": 37,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/+page.svelte",
+     "start_line": 40,
+     "end_line": 42,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/+page.svelte",
+     "start_line": 44,
+     "end_line": 46,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/Nav.svelte",
+     "start_line": 26,
+     "end_line": 30,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/Nav.svelte",
+     "start_line": 32,
+     "end_line": 36,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/Nav.svelte",
+     "start_line": 38,
+     "end_line": 42,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/profile/@[user]/+layout.svelte",
+     "start_line": 71,
+     "end_line": 79,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/profile/@[user]/+layout.svelte",
+     "start_line": 81,
+     "end_line": 89,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Home.vue",
+     "start_line": 14,
+     "end_line": 22,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Home.vue",
+     "start_line": 23,
+     "end_line": 31,
+     "name": "li"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   }
+  },
+  {
+   "family_id": "a3a8608bc0bd66ea",
+   "repo": "realworld-xdialect",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Article/index.js",
+     "start_line": 62,
+     "end_line": 74,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/ArticlePreview.js",
+     "start_line": 63,
+     "end_line": 73,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/lib/ArticleList/ArticlePreview.svelte",
+     "start_line": 55,
+     "end_line": 59,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/article/[slug]/+page.svelte",
+     "start_line": 27,
+     "end_line": 31,
+     "name": "ul"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "590e62be8ff03f7a",
+   "repo": "realworld-xdialect",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Article/CommentContainer.js",
+     "start_line": 24,
+     "end_line": 29,
+     "name": "p"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/article/[slug]/CommentContainer.svelte",
+     "start_line": 14,
+     "end_line": 19,
+     "name": "p"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Article.vue",
+     "start_line": 35,
+     "end_line": 48,
+     "name": "p"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "medium",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "trivial"
+    }
+   }
+  },
+  {
+   "family_id": "27422f3dbc4f61e9",
+   "repo": "realworld-xdialect",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Article/ArticleMeta.js",
+     "start_line": 13,
+     "end_line": 20,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/ArticlePreview.js",
+     "start_line": 43,
+     "end_line": 50,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/lib/ArticleList/ArticlePreview.svelte",
+     "start_line": 13,
+     "end_line": 16,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/article/[slug]/ArticleMeta.svelte",
+     "start_line": 12,
+     "end_line": 17,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "16aa158306c10182",
+   "repo": "realworld-xdialect",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/ListPagination.js",
+     "start_line": 41,
+     "end_line": 48,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Profile.js",
+     "start_line": 92,
+     "end_line": 98,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/Profile.js",
+     "start_line": 100,
+     "end_line": 106,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/ProfileFavorites.js",
+     "start_line": 33,
+     "end_line": 39,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/react-realworld/src/components/ProfileFavorites.js",
+     "start_line": 41,
+     "end_line": 47,
+     "name": "li"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/Pagination.svelte",
+     "start_line": 17,
+     "end_line": 17,
+     "name": "li"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   }
+  },
+  {
+   "family_id": "33b243b11c1aebae",
+   "repo": "realworld-xdialect",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Home/Tags.js",
+     "start_line": 8,
+     "end_line": 27,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/+page.svelte",
+     "start_line": 67,
+     "end_line": 71,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "65f4377a32620772",
+   "repo": "realworld-xdialect",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Editor.js",
+     "start_line": 143,
+     "end_line": 156,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/ArticleEdit.vue",
+     "start_line": 45,
+     "end_line": 54,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "7617170f015fa521",
+   "repo": "realworld-xdialect",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Home/Banner.js",
+     "start_line": 8,
+     "end_line": 15,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/svelte-realworld/src/routes/+page.svelte",
+     "start_line": 20,
+     "end_line": 25,
+     "name": "div"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Home.vue",
+     "start_line": 3,
+     "end_line": 8,
+     "name": "div"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  },
+  {
+   "family_id": "2ff1edd2f684df43",
+   "repo": "realworld-xdialect",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/react-realworld/src/components/Settings.js",
+     "start_line": 157,
+     "end_line": 161,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Profile.vue",
+     "start_line": 26,
+     "end_line": 32,
+     "name": "button"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Profile.vue",
+     "start_line": 33,
+     "end_line": 39,
+     "name": "button"
+    }
+   ],
+   "worthy": false,
+   "reason": "coincidental-shape",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "dedupe": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    },
+    "skeptic": {
+     "worthy": false,
+     "reason": "coincidental-shape"
+    }
+   }
+  },
+  {
+   "family_id": "6c8aee2bb5ce176f",
+   "repo": "realworld-xdialect",
+   "split": "dev",
+   "channel": "structural",
+   "scope": "prod",
+   "members": [
+    {
+     "file": "bench/repos/svelte-realworld/src/lib/ListErrors.svelte",
+     "start_line": 6,
+     "end_line": 10,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Login.vue",
+     "start_line": 12,
+     "end_line": 16,
+     "name": "ul"
+    },
+    {
+     "file": "bench/repos/vue-realworld/src/views/Register.vue",
+     "start_line": 12,
+     "end_line": 16,
+     "name": "ul"
+    }
+   ],
+   "worthy": true,
+   "reason": "extract-helper",
+   "confidence": "high",
+   "labeler": "panel",
+   "votes": {
+    "pragmatic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "dedupe": {
+     "worthy": true,
+     "reason": "extract-helper"
+    },
+    "skeptic": {
+     "worthy": true,
+     "reason": "extract-helper"
+    }
+   }
+  }
+ ]
+}


### PR DESCRIPTION
The declarative-track analogue of `refactoring_families.v5.json` — the first **label-based
precision** ground truth for nose's CSS/HTML/Vue/Svelte/JSX/TSX clone detection (incl.
cross-dialect). Same schema, same `RUBRIC.md`, same 3-persona panel + 2-1 tiebreak method.

## How built
A workflow (`frontend-goldset-panel`, 92 agents) labeled a nose low-threshold candidate
pool: declarative families, generated-filtered via `is_generated_loc`, capped ≤60/repo for
diversity, across 19 frontend repos + the RealWorld (Conduit) trio (React/Vue/Svelte) for
cross-dialect. 3 personas (pragmatic/dedupe/skeptic) judged each family from its member
code; 2-1 splits went to a rubric-strict tiebreak.

## The set — 448 families, 71 worthy / 377 not (dev 386 / heldout 62)
Measured **precision profile** (worthy-rate by corpus kind):

| kind | families | worthy |
|---|---|---|
| app (hand-written markup) | 44 | **50%** |
| cross-dialect (React≡Vue≡Svelte) | 10 | **70%** |
| CSS framework (dist) | 394 | **10%** |

## What it tells us (measurement-first)
- **Real app / cross-dialect precision is healthy** (~50–70%, on par with the imperative
  languages) — nothing is broken in the markup engine.
- **CSS-framework surface is ~10% worthy**: 69% of it is `generated` — CSS *compiled from
  SCSS* (`css/bulma.css` etc.), which `is_generated_loc` does NOT catch because those paths
  are not `.min`/`dist/`. So the next measured lever is a **compiled-CSS filter**, not the
  engine.
- The 30% not-worthy cross-dialect families are small generic shells (`li.nav-item`, a
  `<button>`) coincidentally same-shaped across unrelated components — the precision tail.

Not a CI gate (a manual research instrument, like v5). **v1 is dev-grade** (panel, not yet
human-arbitrated); the 45 medium-confidence 2-1 splits are the audit queue. `votes` are
embedded for auditability. Member paths reference `bench/repos/*` (gitignored corpus), same
as v5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)