### PR TITLE
fix(query): bound report lines to EOF, unify stats on --format json, markdown drilldown skeleton (#419, #420, #421, #422)

### DIFF
--- a/bench/type4/coverage_attribution.py
+++ b/bench/type4/coverage_attribution.py
@@ -2,7 +2,7 @@
 
 §BS measured the behavior-keyed recall frontier NO-GO and concluded worthy-recall is bounded
 by **unit extraction / coverage**, not by missing matching machinery. This instrument makes
-that boundary actionable: it runs `nose stats --json` over the pinned corpus and ranks the
+that boundary actionable: it runs `nose stats --format json` over the pinned corpus and ranks the
 **IL-lowering loss** — the `Raw` nodes a construct lowers to, which are invisible to
 value-matching — by (language, surface-kind) prevalence. That ranked list is the worklist for
 lowering fidelity (the cheapest recall lever, zero soundness risk).
@@ -49,7 +49,7 @@ def stats_for(nose: str, path: Path) -> dict | None:
         # A high --top captures every unhandled surface kind per repo (for stats, --top 0
         # means "show none", not "all"); we re-rank by aggregated Raw mass below.
         out = subprocess.run(
-            [nose, "stats", str(path), "--json", "--top", "1000"],
+            [nose, "stats", str(path), "--format", "json", "--top", "1000"],
             capture_output=True,
             text=True,
             timeout=300,

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -351,9 +351,9 @@ enum Cmd {
         /// How many top unhandled surface kinds to list.
         #[arg(long, default_value_t = 30)]
         top: usize,
-        /// Emit JSON instead of a human-readable table.
-        #[arg(long)]
-        json: bool,
+        /// Output format (`human` or `json`) — same `--format` contract as `query`/`scan`/`il`.
+        #[arg(long, value_enum, default_value_t = StatsFormat::Human)]
+        format: StatsFormat,
     },
     /// Dump the IL for a source file — debug why two snippets do or don't converge.
     Il {
@@ -500,6 +500,15 @@ enum BatteryKind {
 #[derive(Clone, Copy, clap::ValueEnum)]
 enum Format {
     Sexpr,
+    Json,
+}
+
+#[derive(Clone, Copy, PartialEq, Default, clap::ValueEnum)]
+enum StatsFormat {
+    /// Human-readable coverage table.
+    #[default]
+    Human,
+    /// Machine-readable JSON.
     Json,
 }
 
@@ -777,8 +786,10 @@ enum SortKey {
     /// can actually fold into one helper, not the biggest block that merely *looks*
     /// similar (a *fixability* axis). The default.
     Extractability,
-    /// Raw duplicated volume: removable lines × similarity × spread. The most
-    /// *code* you'd delete, even if the copies diverge a lot (more manual work).
+    /// Raw duplicated volume: duplicated lines (mean span × copies) × similarity ×
+    /// spread. Ranks by how much *code* repeats, NOT by the `removable` field — a
+    /// structural (Type-4) family can have high volume yet `removable=0` when no
+    /// literal lines survive across all copies (nothing cleanly extractable).
     Value,
     /// Most copies first — the most-repeated patterns.
     Sites,
@@ -1685,7 +1696,7 @@ fn run() -> Result<()> {
             units,
             candidates,
         } => cmd_ceiling(gold, units, candidates),
-        Cmd::Stats { paths, top, json } => cmd_stats(paths, top, json),
+        Cmd::Stats { paths, top, format } => cmd_stats(paths, top, format == StatsFormat::Json),
         Cmd::Features {
             paths,
             min_lines,
@@ -4753,6 +4764,20 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
                     0,
                     None,
                 );
+                // `id=<fam>` is a single-family drilldown: render the extraction skeleton
+                // (and, on `full`, the representative diff) so markdown composes with
+                // `id=`/`full` the way the human/JSON views do (#422). Bulk reports stay a
+                // compact location list — the skeleton is paid only on drilldown.
+                if q.id.is_some() {
+                    for f in &shown {
+                        if f.locations.len() >= 2 {
+                            markdown_member_proposal(&f.locations);
+                            if q.id_full {
+                                markdown_member_diff(&f.locations[0], &f.locations[1]);
+                            }
+                        }
+                    }
+                }
             }
         }
         _ => {
@@ -7775,6 +7800,52 @@ fn line_diff(a: &[&str], b: &[&str]) -> Vec<(char, String)> {
     out.extend(a[i..].iter().map(|l| ('-', l.to_string())));
     out.extend(b[j..].iter().map(|l| ('+', l.to_string())));
     out
+}
+
+/// Markdown form of the all-copies extraction skeleton (#360), rendered on an `id=<fam>`
+/// drilldown so `--format markdown` honors the help's "every copy + extraction skeleton"
+/// promise the same way the human/JSON views do (#422). The bulk report stays a compact
+/// location list; the skeleton is paid only when the consumer drills into one family.
+fn markdown_member_proposal(locations: &[nose_detect::Loc]) {
+    let members: Vec<Vec<String>> = locations
+        .iter()
+        .filter_map(|l| read_lines(&l.file, l.start_line, l.end_line))
+        .collect();
+    if members.len() < 2 {
+        return;
+    }
+    let (skeleton, shared, params) = anti_unify_all(&members);
+    let copies = members.len();
+    println!(
+        "**proposal** — extract a shared helper · {shared} shared lines · {params} parameter(s) vary (across all {copies} copies)\n"
+    );
+    println!("```text");
+    for line in skeleton.iter().take(40) {
+        println!("{line}");
+    }
+    println!("```\n");
+}
+
+/// Markdown form of the representative two-copy diff, added on `id=<fam> full` (the `full`
+/// view, mirroring the human renderer's extra diff line).
+fn markdown_member_diff(a: &nose_detect::Loc, b: &nose_detect::Loc) {
+    let (Some(la), Some(lb)) = (
+        read_lines(&a.file, a.start_line, a.end_line),
+        read_lines(&b.file, b.start_line, b.end_line),
+    ) else {
+        return;
+    };
+    println!(
+        "**diff** — `{}:{}-{}` vs `{}:{}-{}`\n",
+        a.file, a.start_line, a.end_line, b.file, b.start_line, b.end_line
+    );
+    let ar: Vec<&str> = la.iter().map(String::as_str).collect();
+    let br: Vec<&str> = lb.iter().map(String::as_str).collect();
+    println!("```diff");
+    for (tag, line) in line_diff(&ar, &br) {
+        println!("{tag} {line}");
+    }
+    println!("```\n");
 }
 
 fn print_refactor_markdown(

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -2113,6 +2113,39 @@ fn query_dashboard_filter_and_family() {
         md.contains("duplicated lines"),
         "markdown report has the header: {md}"
     );
+    // #422: the bulk markdown report stays a compact location list (no per-family skeleton)…
+    assert!(
+        !md.contains("**proposal**"),
+        "bulk markdown stays compact — no extraction skeleton: {md}"
+    );
+    // …but `id=<fam>` drills into one family and renders the extraction skeleton, and `full`
+    // adds the representative diff — so markdown composes with `id=`/`full` like human/JSON.
+    let fid = {
+        let j: serde_json::Value =
+            serde_json::from_str(&run(&["query", p, "top=0", "--format", "json"])).unwrap();
+        j["families"][0]["id"].as_str().unwrap().to_string()
+    };
+    let drill = run(&["query", p, &format!("id={fid}"), "--format", "markdown"]);
+    assert!(
+        drill.contains("**proposal**") && drill.contains("⟨param"),
+        "id=<fam> markdown renders the extraction skeleton with parameter slots: {drill}"
+    );
+    assert!(
+        !drill.contains("**diff**"),
+        "id=<fam> without `full` omits the representative diff: {drill}"
+    );
+    let drill_full = run(&[
+        "query",
+        p,
+        &format!("id={fid}"),
+        "full",
+        "--format",
+        "markdown",
+    ]);
+    assert!(
+        drill_full.contains("**proposal**") && drill_full.contains("**diff**"),
+        "id=<fam> full markdown adds the representative diff: {drill_full}"
+    );
     let sarif: serde_json::Value =
         serde_json::from_str(&run(&["query", p, "--format", "sarif"])).unwrap();
     assert_eq!(
@@ -2191,7 +2224,8 @@ fn rust_binding_patterns_lower_without_raw() {
     let stats: serde_json::Value = serde_json::from_str(&run(&[
         "stats",
         dir.to_str().unwrap(),
-        "--json",
+        "--format",
+        "json",
         "--top",
         "50",
     ]))
@@ -2329,10 +2363,10 @@ fn query_since_status_classifies_against_a_snapshot() {
         !newfams.is_empty() && newfams.iter().all(|f| f["status"] == "new"),
         "status=new selects only new families, each tagged: {newj}"
     );
-    // The new family is Y (the post-snapshot `banner` copy-paste family in d/e/f), not the
-    // snapshotted `process` family (which is the `similar` witness in a/b/c).
+    // The new family is Y (the post-snapshot `banner` family in d/e/f — byte-identical copies,
+    // so the `exact` witness), not the snapshotted `process` family (the `similar` witness in a/b/c).
     assert!(
-        newfams.iter().all(|f| f["witness"] == "copy-paste"
+        newfams.iter().all(|f| f["witness"] == "exact"
             && f["locations"][0]["file"].as_str().unwrap().contains("/d/")),
         "the post-snapshot family (Y) is flagged new, not the snapshotted X: {newj}"
     );

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -121,12 +121,21 @@ impl<'a> Lowering<'a> {
 
     /// Build a [`Span`] from a CST node (1-based inclusive lines).
     pub(crate) fn span(&self, n: TsNode) -> Span {
+        let start_line = n.start_position().row as u32 + 1;
+        // A node whose text ends in a newline "ends" at column 0 of the NEXT
+        // row; counting that row would over-claim a line past the node's
+        // content (and, for file-spanning units, past EOF — see #419).
+        let end_pos = n.end_position();
+        let mut end_line = end_pos.row as u32 + 1;
+        if end_pos.column == 0 && end_line > start_line {
+            end_line -= 1;
+        }
         Span::new(
             self.b.file(),
             n.start_byte() as u32,
             n.end_byte() as u32,
-            n.start_position().row as u32 + 1,
-            n.end_position().row as u32 + 1,
+            start_line,
+            end_line,
         )
     }
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -2758,7 +2758,7 @@ global positional battery cannot avoid) manufacture phantom behavior differences
 *"worthy-recall is bounded by **unit extraction** and judgment, not by missing matching
 machinery,"* with the instrument limited to the ~29% of units that interpret. That makes the
 gating question not "what normalization is missing" but "what never gets modeled in the first
-place." `bench/type4/coverage_attribution.py` answers it: `nose stats --json` over the pinned
+place." `bench/type4/coverage_attribution.py` answers it: `nose stats --format json` over the pinned
 105-repo corpus, with the `Raw`-node loss (constructs that lower to an opaque node, invisible
 to value-matching) ranked by (language, surface-kind) prevalence
 (`coverage_attribution.2026-06-15.json`).
@@ -2825,7 +2825,7 @@ splits on the binding name's subtree hash. The recognized `Some(_)`-style single
   local), a separate lever; an early test asserting that convergence was *falsified* and the
   claim dropped. This PR is the coverage fix, not the alpha-convergence fix.
 
-Method: empirical leak isolation (probe each pattern position with `nose stats --json`) pinned
+Method: empirical leak isolation (probe each pattern position with `nose stats --format json`) pinned
 the leak to the binding cases (match-arm / if-let / while-let), not let-destructuring, before
 any edit. Re-run `coverage_attribution.py` to watch the ratio; next §CP levers: async `await`
 (cross-language), rust `try`/`?`, and tuple-struct binding extraction (the alpha-convergence

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -63,8 +63,8 @@ This is the same per-finding shape as `review --format json`.
 | `shared` | lines invariant across **all** copies (the all-copies anti-unification count) |
 | `rep_lines` | the representative copy's line count (`shared` of `rep_lines` are shared) |
 | `params` | varying spots the extracted helper would parameterize |
-| `removable` | `(members − 1) × shared` — lines a clean extraction would delete |
-| `value` | the raw duplicated-volume score |
+| `removable` | `(members − 1) × shared` — lines a clean extraction would delete (so `removable=0` when `shared=0`: the copies match structurally but no literal line survives all of them) |
+| `value` | the raw duplicated-volume score (mean span × copies × similarity × spread). Ranks by repeated *volume*, independent of `removable` — under `sort=value` a structural family can top the list with `removable=0` |
 | `extraction_shape` | the decidable fix shape (`extract-helper`, `call-existing-helper`, …) |
 | `same_symbol` | every copy is the same named symbol (the parallel-variant signal) |
 | `existing_helper` | (only for `call-existing-helper`) the member to call — `{name, file, start, end}`; the inline copies recompute it, so the fix is "call it", not a fresh extraction |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,7 +114,7 @@ offers `sites` and the experimental `hazard`.
 | key | ranks by | use when |
 |---|---|---|
 | `extractability` *(default)* | invariant (shared) lines × copies × spread, weighted by tightness (shared/total) and penalized by parameter count and by member-span heterogeneity (copies of unlike length aren't one shape) | you want the duplication that folds *cleanly* into one helper — not the biggest block that merely looks similar |
-| `value` | raw duplicated volume: removable lines × similarity × spread | you want the most *code* deleted, accepting that divergent copies cost more to merge |
+| `value` | raw duplicated volume: duplicated lines (mean span × copies) × similarity × spread — ranks by repeated *volume*, not the `removable` field (a structural Type-4 family can rank high here yet show `removable=0` when no literal lines survive all copies) | you want the most *code* deleted, accepting that divergent copies cost more to merge |
 | `sites` / `members` | number of copies | hunting the most-repeated patterns |
 | `hazard` *(experimental, scan only)* | divergent-edit *propensity*: line span × spread × invisibility × scope | you want a view of which clones tend to get edited inconsistently — **not yet a validated *harm* ranker** (see [hazard-ranking](hazard-ranking.md)) |
 
@@ -306,10 +306,11 @@ and may change to improve readability. The stable contract is documented in
   [`nose query <paths> base=<ref>`](#nose-query) (same detection + gate). Flags clones changed
   inconsistently in a diff (a copy edited, its siblings missed); defaults to `HEAD`, use
   `base=origin/main` for a PR branch. Full guide in [review](review.md).
-- `nose stats <paths…> [--top N] [--json]` — per-language IL lowering coverage (the
+- `nose stats <paths…> [--top N] [--format human|json]` — per-language IL lowering coverage (the
   Raw-node ratio, split into by-design protocol boundaries vs genuine lowering gaps), with
-  the top unhandled surface kinds (`--top`, default 30; `--json` for machine output). Use it
-  to spot a language/construct that isn't lowering well; see [languages](languages.md).
+  the top unhandled surface kinds (`--top`, default 30; `--format json` for machine output —
+  the same `--format` contract as `query`/`scan`/`il`).
+  Use it to spot a language/construct that isn't lowering well; see [languages](languages.md).
 - `nose semantic-pack check <file-or-dir> [--format human|json]` — validate local
   semantic-pack v0 manifest structure and declared fixture assets. It is a
   pack-author/user workflow, not external pack certification; see


### PR DESCRIPTION
Triage + fixes for the #419–#423 dogfooding batch. #423 is **deferred** (rationale in the issue); the other four land here.

## #419 — line ranges past EOF *(bug)*
`Frontend::span()` used tree-sitter `end_position().row + 1` verbatim. When a node ends in a trailing newline its `end_position()` is column 0 of the **next** row, so `end_line` came out as `content_lines + 1` — past EOF for file-spanning units (every repro had `start: 1`). The same column-0 correction was already documented/applied in `declaration_facts.rs`; it was just missing from the universal `span()` builder.

**Measured:** a sweep over `bench/repos` (zod, vue3-realworld, angularjs, alacritty, badger, black, boltons, axios, bat — Rust/Go/Python/JS/TS) now reports **0** out-of-bounds locations, down from 11 on zod alone. Family/location counts and the per-witness distribution are unchanged (fingerprints are structural, not line-based) — a reporting-correctness fix with no detection impact.

> The craken-agents case (`10-371` in a 160-line file) is +211, not the +1 fixed here, so it may be a separate/severer variant; couldn't reproduce without the repo.

## #420 — stats JSON contract *(contract)*
`capabilities` advertised `stats.output_formats: ["human","json"]`, implying the tool-wide `--format` convention, but `stats` only had a `--json` boolean — two different ways to ask for JSON across the tool. Converged on one: `nose stats --format json` (same as query/scan/il), and **removed** `--json` (not aliased — a hidden-but-working flag is its own honesty gap). Pre-1.0, niche diagnostic command; the single in-repo consumer (`bench/type4/coverage_attribution.py`) is migrated.

## #421 — value vs removable *(docs)*
`removable=0` with high `value` is not a contradiction — different axes, and `sort=value` is the raw-volume axis. The real defect was our own wording: the `value` key was described as "removable lines × …", but the formula uses *mean duplicated lines × copies × similarity × spread* and never touches the `removable` field. Corrected in help text, `docs/usage.md`, `docs/query-json.md`. Declined the proposed new JSON fields (`why_ranked`, etc.) — the info is already derivable from existing orthogonal fields.

## #422 — markdown drilldown skeleton *(consistency)*
`--format markdown` took the bulk-report path and ignored `id=`/`full`, so the drilldown only printed a location list — breaking the help's "every copy + extraction skeleton" promise for markdown. The skeleton engine (`family_skeleton()` / `anti_unify_all()`) already existed; this just wires it in. Now `id=<fam> --format markdown` renders the all-copies skeleton with `⟨param N⟩` slots, and `full` adds the representative diff, mirroring the human/JSON views. Bulk reports stay a compact location list. Not a duplicate of #360 (closed; delivered the engine + human/JSON views). New CLI test asserts skeleton-on-`id=`, diff-gated-behind-`full`, bulk-stays-compact.

## Verification
- Full workspace tests green; `nose-cli` + `nose-frontend` clippy clean.
- One over-fitted test (`query_since_status_classifies_against_a_snapshot`) had its witness assertion corrected from `copy-paste` to `exact` — which matches the test's own comment ("3 exact copies") and is the correct channel for byte-identical copies; the #419 span fix only flips it in that 7-line synthetic corner case (zod witness distribution is byte-identical before/after).

Closes #419, #420, #421, #422. (#423 stays open — deferred.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
