### PR TITLE
docs: drift/consistency/IA sweep + rustfmt unblock for main CI

### DIFF
--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -5124,7 +5124,9 @@ fn render_query_dashboard(
         if n_exact > 0 {
             println!(
                 "  nose query {path} witness=exact             {}",
-                style::dim(&format!("# the {n_exact} proven byte-for-behavior identical"))
+                style::dim(&format!(
+                    "# the {n_exact} proven byte-for-behavior identical"
+                ))
             );
         }
         if n_subdag > 0 {
@@ -5189,14 +5191,42 @@ fn render_query_dashboard(
         style::bold("explore — terms combine with AND; swap <path> for yours and run any line:")
     );
     for (verb, cmd, note) in [
-        ("filter", "nose query <path> witness=exact", "keep only the proven-identical families"),
-        ("", "nose query <path> members>3 path~api", "compare with > < , ~ (contains), != (negate)"),
-        ("group", "nose query <path> group=dir", "totals by directory (or: witness, lang, scope, same_symbol)"),
-        ("open", "nose query <path> id=<id> full", "one family: every copy + the extraction skeleton"),
-        ("sort", "nose query <path> sort=value", "by duplicated volume (or: extractability [default], members)"),
-        ("more", "nose query <path> all", "include families held back below the default surface"),
+        (
+            "filter",
+            "nose query <path> witness=exact",
+            "keep only the proven-identical families",
+        ),
+        (
+            "",
+            "nose query <path> members>3 path~api",
+            "compare with > < , ~ (contains), != (negate)",
+        ),
+        (
+            "group",
+            "nose query <path> group=dir",
+            "totals by directory (or: witness, lang, scope, same_symbol)",
+        ),
+        (
+            "open",
+            "nose query <path> id=<id> full",
+            "one family: every copy + the extraction skeleton",
+        ),
+        (
+            "sort",
+            "nose query <path> sort=value",
+            "by duplicated volume (or: extractability [default], members)",
+        ),
+        (
+            "more",
+            "nose query <path> all",
+            "include families held back below the default surface",
+        ),
     ] {
-        println!("  {}  {cmd:<37}  {}", style::bold(&format!("{verb:<6}")), style::dim(note));
+        println!(
+            "  {}  {cmd:<37}  {}",
+            style::bold(&format!("{verb:<6}")),
+            style::dim(note)
+        );
     }
     println!(
         "\n  {}",

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -1968,7 +1968,10 @@ fn query_dashboard_filter_and_family() {
     // A filter narrows to a ranked list; a facet groups it. (The count noun is
     // pluralized — "1 family" / "N families" — so match the stem.)
     assert!(run(&["query", p, "members>1"]).contains("famil"));
-    assert!(run(&["query", p, "group=dir"]).contains("famil") && run(&["query", p, "group=dir"]).contains("by dir"));
+    assert!(
+        run(&["query", p, "group=dir"]).contains("famil")
+            && run(&["query", p, "group=dir"]).contains("by dir")
+    );
 
     // An unknown term is a hard error (a typo must not silently widen the result).
     assert!(run_fail(&["query", p, "wat"]).contains("unrecognized term"));

--- a/docs/agent-recipe.md
+++ b/docs/agent-recipe.md
@@ -50,7 +50,7 @@ below applies to both a `nose query` row and a JSON family — they carry the sa
 Read the fields in this order — each step either decides or narrows:
 
 1. **Surface filter.** Act on `surface == "default"` only;
-   `review`/`hidden`/`shallow`/`generated`/`declaration` are diagnostic surfaces. The
+   `review`/`hidden`/`shallow`/`generated`/`declaration`/`debug` are diagnostic surfaces. The
    non-default `surface` value *is* the demotion reason — a decidable classification, not a
    worthiness verdict: `shallow` (the extracted helper would be mostly parameters), `declaration`
    (only import/include/use/re-export spans), `generated` (every location in generated-header

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -173,37 +173,31 @@ contract (deprecated, but still the reference for these fragment fields).
 
 The taxonomy above is for imperative code, where Type-4 means *same computation*. For
 declarative languages it is re-based on the right denotation: **CSS** equivalence is
-*same computed style*, **HTML markup** equivalence is *same rendered DOM* (see
-[languages](languages.md), [normalization](normalization.md)). These ride the same
-channels but a declarative-specific fingerprint, dispatched by unit-root kind rather than
-the value graph.
+*same computed style*, **HTML markup** equivalence is *same rendered DOM*. These ride the
+same channels but a declarative-specific fingerprint, dispatched by unit-root kind rather
+than the value graph. The fingerprints, value canonicalization, cascade rules, and the
+out-of-scope list live in [languages](languages.md); the taxonomy mapping is:
 
 - **Type-1/2/3** behave as elsewhere: identical/whitespace-varied blocks converge; the
   `near` channel scores *structural* similarity with leaf values (text, CSS values)
   abstracted, so "the same repeated component shell or rule shape with different content"
   surfaces as a near family — the highest-value declarative clone.
-- **Type-4 analog (the exact `semantic` channel)** is *computed-equivalence*, not
-  textual identity:
-  - **CSS** — selector- and declaration-order-independent, with value canonicalization
-    (`#fff` ≡ `#ffffff` ≡ `white`, `0px` ≡ `0`, `margin: 0 0 0 0` ≡ `margin: 0`); so a
-    duplicated declaration block under different selectors is one exact family.
-  - **HTML** — attribute-order/boolean-form/`class`-set/whitespace/case normalized, with
-    tag/structure, child order, text, and attribute values kept distinct; inline
-    `style="…"` is computed-canonicalized via the CSS path.
-- **Soundness** is by construction (the fingerprint *is* the canonical computed
-  style / rendered DOM, so equal fingerprint ⟺ equal denotation) plus adversarial
-  per-rule batteries; CSS, HTML, and imperative fingerprints are domain-disjoint, so the
-  language-blind exact channel can never merge across them. Cascade is preserved
-  (repeated-property last-wins; a shorthand mixed with its longhand is order-sensitive;
-  an at-rule's full condition is context).
+- **Type-4 analog (the exact `semantic` channel)** is *computed-equivalence*, not textual
+  identity: a CSS declaration block duplicated under different selectors is one exact
+  family even when values are spelled differently, and two markup blocks that render the
+  same DOM are one exact family. The canonicalization and cascade rules that keep this
+  sound — and where it deliberately refuses to merge — are in
+  [languages › declarative CSS](languages.md#declarative-languages-css) and
+  [HTML markup](languages.md#declarative-languages-html-markup).
 
-What declarative detection does **not** do: SCSS/Less/Sass (`<style lang="scss">` is
-skipped); CSS custom-property (`var()`) resolution across files; full Svelte
-`{#if}`/`{#each}` block grammar (template *text/interpolation* is structure-abstracted,
-but block control flow is not modeled). Lowering coverage is first-class — the Raw-node
-ratio on real `.css`/`.html` is sub-percent (generated/templated pages aside).
+**Soundness** is by construction (the fingerprint *is* the canonical computed style /
+rendered DOM, so equal fingerprint ⟺ equal denotation) plus adversarial per-rule
+batteries; CSS, HTML, and imperative fingerprints are domain-disjoint, so the
+language-blind exact channel can never merge across them. What declarative detection does
+**not** do (SCSS/Less, cross-file `var()` resolution, full Svelte block grammar) is in
+[languages › cross-dialect markup](languages.md#cross-dialect-markup-htmlvuesveltejsxtsx).
 
-## Scan modes, and cross-language
+## Detection modes, and cross-language
 
 Each type maps to a detection channel by evidence surface: **Type-1 and token-level
 copy floors → `syntax`**, identifier/type-normalized **Type-2 → `semantic` or `near`**,
@@ -211,7 +205,7 @@ literal-varied Type-2 and **Type-3 → `near`** (fuzzy; the threshold rides on t
 `near:0.70` by default), and exact **Type-4 → `semantic`**. The experimental
 `abstraction[:T]` mode is a weak family-wide witness layer over a narrow `near` subset;
 it does not feed `semantic` or `verify`. The default is `syntax,semantic,near`; see
-[usage → Scan modes](usage.md#scan-modes) for the full table and how to compose channels.
+[usage → Detection modes](usage.md#detection-modes) for the full table and how to compose channels.
 
 The taxonomy is usually stated within a single language; because every language lowers to
 one shared IL, nose applies Type-1–4 **across languages** as well — though in practice

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ sort        = "extractability"
 min-value   = 200
 min-members = 3
 min-size    = 30
-top         = 50
+top         = 50            # bounds `nose scan` only; `nose query` uses the `top=` term
 ignore-file = "nose.ignore.json"
 semantic-packs = ["semantic-packs/python-math-prod.json"]
 ```
@@ -34,7 +34,9 @@ CI failure mode.
 
 All keys are optional; an absent key means "no opinion — use the CLI value or
 the built-in default". Keys are kebab-case and live under the `[scan]` table.
-`nose query` reads the same `[scan]` config keys as `nose scan`.
+`nose query` reads the same `[scan]` config keys as `nose scan`, with one exception:
+`top` has no effect under `nose query` (its row limit is the `top=` query term, default
+30); it only bounds the deprecated `nose scan`'s report.
 
 The **CLI override** column gives the per-run flag (or, where they differ, the `nose query`
 term — `nose query` spells `sort`/`top` as the DSL terms `sort=`/`top=`, not `--sort`/`--top`).
@@ -48,7 +50,7 @@ term — `nose query` spells `sort`/`top` as the DSL terms `sort=`/`top=`, not `
 | `min-members` | int | `2` | `--min-members` |
 | `min-size` | int (IL tokens) | `24` | `--min-size` |
 | `min-lines` | int (advanced) | `5` | `--min-lines` |
-| `top` | int | `30` | `top=` (query term); `--top` (deprecated scan) |
+| `top` | int | `30` | `top=` (query term); `--top` (deprecated scan). **Config key bounds `scan` only** — `nose query`'s limit is the `top=` term |
 | `ignore-file` | string path | auto-read `nose.ignore.json` when present | `--ignore-file` |
 | `semantic-packs` | list of file or directory paths | `[]` | `--semantic-pack` |
 

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -12,7 +12,9 @@ below use the `query` spelling throughout.
 
 ## The `--fail-on any` gate
 
-`--fail-on any` makes nose exit non-zero if **any** family survives the filters.
+`--fail-on any` makes nose exit non-zero if any family is reported on the **default
+surface** (after filters) — families held back below that surface, visible only under
+`all`, never trip the gate. See [the default surface](usage.md#the-default-surface).
 **A gate should pin `--mode` explicitly** rather than ride the default: the default mix
 serves the report/agent surface and now includes fuzzy `near` candidates, and a pinned
 mode keeps the gate's surface stable across nose upgrades. `--mode syntax` is the
@@ -72,7 +74,7 @@ nose query src --baseline .nose-baseline.json --fail-on new
 accepted by the baseline (the default whenever `--baseline` is present). Use
 `--fail-on new` when you want a CI ratchet that ignores accepted debt but exits
 non-zero for new or changed clone families. Plain `--fail-on any` still means "fail if
-anything is reported after the active filters."
+anything is reported on the default surface after the active filters."
 
 Commit `.nose-baseline.json`. Families are keyed by their sorted reported member
 locations: displayed path, language, span, unit kind, symbol name, and fragment
@@ -94,8 +96,13 @@ When `--baseline` is present, the file must exist and parse as a valid baseline.
 Missing or malformed baselines are hard errors; otherwise a CI ratchet could
 silently compare against an empty accepted state.
 
-With `--format json`, the top-level `baseline` object carries those counts and each
-reported family gets `baseline_status: "new"` or `"changed"`.
+To read this temporal status from JSON under `nose query`, use the `since=<baseline>`
+query term: it leaves every family in place and exposes each one's `status`
+(`new`/`changed`/`unchanged`) as a queryable field — so `nose query src
+since=.nose-baseline.json status=new --format json` is the machine-readable "what's new"
+view. (The deprecated `nose scan --format json` instead carries a top-level `baseline`
+object with the counts and a per-family `baseline_status`; query-JSON v2 has neither — see
+[query-json](query-json.md).)
 
 ## Structured ignores — audited suppressions
 
@@ -113,10 +120,11 @@ or `--fail-on new`. The ignore file keeps each suppression's reason, note, owner
 selectors as the audit record. (The deprecated `nose scan --format json` also echoes the
 suppressed families back under an `ignored_families` array.)
 
-Malformed ignore files fail the run. Expired entries are reported as warnings and
-listed in `ignore.expired`, but are not applied. That makes stale waivers visible
-instead of silently hiding duplication. See [structured-ignores](structured-ignores.md)
-for the file format and selector semantics.
+Malformed ignore files fail the run. Expired entries are reported as warnings on stderr
+and are not applied (the deprecated `nose scan --format json` also lists them under
+`ignore.expired`). That makes stale waivers visible instead of silently hiding
+duplication. See [structured-ignores](structured-ignores.md) for the file format and
+selector semantics.
 
 ## SARIF for code scanning
 

--- a/docs/hazard-release-checklist.md
+++ b/docs/hazard-release-checklist.md
@@ -9,7 +9,7 @@
 features (`mean_lines`, `modules`, `mean_sem`, `params`, …) are produced by nose*. A
 change to detection can silently invalidate those weights. The **labels** (G0/G1/G2) come
 from git history and are version-independent — see
-[hazard-benchmark › Versioning and refresh](hazard-benchmark.md#versioning-and-refresh)
+[hazard-benchmark › Versioning and refresh](hazard-benchmark.md#versioning-and-refresh-coupling-to-nose)
 for the full coupling model. This checklist makes the re-calibration step impossible to
 miss.
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -11,7 +11,8 @@ semantic matching fail-closed unless the required facts and contracts are presen
 
 ## Supported languages
 
-Eight **imperative** base languages, each with its own CST→IL lowering:
+Eight **imperative** base languages, each with its own CST→IL lowering (JavaScript and
+TypeScript share one path):
 
 | language | extensions |
 |---|---|
@@ -90,6 +91,11 @@ and from imperative code. Real-world markup lowers at a first-class Raw-node rat
 the rare residue is malformed/generated pages, left as honest `Raw`).
 
 ## Embedded `<script>` / `<style>` in HTML / Vue / Svelte
+
+| language | extensions |
+|---|---|
+| Vue component | `.vue` |
+| Svelte component | `.svelte` |
 
 `.html`/`.htm`, `.vue`, and `.svelte` files mix logic, style, and markup. nose lowers
 each file into **several regions**, analyzed independently and all sharing the file's

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -26,7 +26,10 @@ plus the view-specific body below. Like the human surface, a result is a pure fu
 ## Views
 
 **`dashboard`** (no terms) — `summary` (`scanned_files`, `families`, `by_confidence`
-`{exact,subdag,copy_paste,similar}`, `reinvented` = non-test reinvented-helper findings),
+`{exact,subdag,copy_paste,similar}`, `reinvented` = non-test reinvented-helper findings).
+Note the copy-paste bucket key is `copy_paste` (underscore), while the per-family `witness`
+enum value spells it `copy-paste` (hyphen) — so don't index `by_confidence[family.witness]`
+for that one channel.
 `top_candidates[]` (the top 5 families ranked by extractability — scope-blind, so test and
 production are ranked alike; each a *family object*), and `next[]` (runnable follow-up
 commands).
@@ -46,10 +49,11 @@ value, approximate}` — code that reimplements an existing helper; the action i
 
 **`base`** (`base=<git-ref>`) — the divergent-edit view (the [`nose review`](review.md)
 pipeline). `base` (the ref), `summary` (`changed_files`, `divergences`, `fire_eligible`), and
-`items[]` of `{family_id, similarity, scope, witness_kind, fire_eligible, graded, changed[],
-not_updated[]}` — each `changed`/`not_updated` site carries `{file, name, start_line, end_line,
-…, touches_shared}`. `fire_eligible` is the conservative proven-shared-logic verdict the gate
-fires on. This is the same per-finding shape as the deprecated `nose review --format json`.
+`items[]` of `{family_id, similarity, complexity, scope, witness_kind, fire_eligible, graded,
+changed[], not_updated[]}` — each `changed`/`not_updated` site carries `{file, name,
+start_line, end_line, …, touches_shared}`. `fire_eligible` is the conservative
+proven-shared-logic verdict the gate fires on. This is the same per-finding shape as the
+deprecated `nose review --format json`.
 
 ## The family object
 
@@ -58,7 +62,7 @@ fires on. This is the same per-finding shape as the deprecated `nose review --fo
 | `id` | family id (the `id=` handle; any unique prefix opens it) |
 | `scope` | `prod` \| `test` \| `mixed` (context, never a worthiness penalty) |
 | `witness` | why the copies merged: `exact` \| `subdag` (behavior-proven) \| `copy-paste` \| `similar` |
-| `surface` | `default` \| `review` \| `hidden` \| `shallow` \| `generated` \| `declaration` (curation tier) |
+| `surface` | `default` \| `review` \| `hidden` \| `shallow` \| `generated` \| `declaration` \| `debug` (curation tier; `debug` is a reserved diagnostic tier normal runs don't emit) |
 | `members` | number of copies |
 | `files` / `dirs` | distinct files / directories the copies span |
 | `shared` | lines invariant across **all** copies (the all-copies anti-unification count) |
@@ -73,8 +77,8 @@ fires on. This is the same per-finding shape as the deprecated `nose review --fo
 | `value_nodes` | (exact families) the size of the shared value multiset proven identical — *how much* is proven, not just that it is |
 | `status` | (only with `since=`) `new` \| `changed` \| `unchanged` against the snapshot — the temporal lens |
 | `folds` | count of overlapping slice families folded under this one |
-| `subsumes` | (in the `family` view) the `id=` handles of the slice families this one subsumes — open any to inspect |
-| `subsumed_by` | (in the `family` view) the `id=` handle of the fuller overlapping family this one is a slice of |
+| `subsumes` | (present when this family has folded slices, in any view) the `id=` handles of the slice families this one subsumes — open any to inspect |
+| `subsumed_by` | (present when this family is a slice, in any view) the `id=` handle of the fuller overlapping family this one is a slice of |
 | `locations[]` | every copy: `{file, start, end, name, lang}`; the `existing_helper` member also carries `role: "existing-helper"`; a sub-dag clone's member carries `shared_subdag: [start, end]` — where the proven shared computation lives at that site |
 | `skeleton` | (only with `full`) the all-copies extraction-skeleton lines, each varying spot a `⟨param N: class⟩` placeholder (`class` = `literal`/`name`/`call`/`expr`/`block` — a coarse value-class hint for the helper signature) |
 

--- a/docs/review.md
+++ b/docs/review.md
@@ -1,6 +1,6 @@
 # Review — catch un-propagated changes
 
-> **Deprecated (0.10.0).** `nose review --base <ref>` is now `nose query <paths> base=<ref>`
+> **Deprecated since 0.10.0** (still works in 0.11.0). `nose review --base <ref>` is now `nose query <paths> base=<ref>`
 > — the same detection and the same `fire_eligible` gate, under the unified
 > [query](usage.md#nose-query) surface (`base=REF --fail-on any` is the gate). `review` still
 > works and `capabilities` lists it under `commands.deprecated`; it is slated for removal in a
@@ -15,9 +15,9 @@ siblings for you and asks: *should this change have gone there too?*
 Where plain [`nose query`](usage.md#nose-query) is stateless (point it at any source, no
 history), the `base=` view needs a **git repository** — it compares the working tree to a ref.
 It shares query's detection channels, size gates, excludes, config loading, structured
-ignores, and `top=`; report-shaping terms such as `sort=`, `min-value`, `min-members`, and
-baselines (`--baseline` / `--fail-on new`) do not carry over. For the standard clone taxonomy
-see [clone types](clone-types.md).
+ignores, and `top=`; report-shaping controls — the `sort=` term and the `--min-value` /
+`--min-members` flags — and baselines (`--baseline` / `--fail-on new`) do not carry over. For
+the standard clone taxonomy see [clone types](clone-types.md).
 
 ## Quick start
 

--- a/docs/scan-json.md
+++ b/docs/scan-json.md
@@ -77,6 +77,28 @@ The top-level value is always an object:
         "positive_fixtures": 36,
         "hard_negatives": 2
       }
+    },
+    {
+      "id": "nose.value_graph.laws",
+      "hash": "f65998031968ccc9",
+      "kind": "LawPack",
+      "version": "<version>",
+      "display_name": "nose value-graph law pack",
+      "trust": "default-first-party",
+      "enabled_by_default": true,
+      "source": "compiled-first-party",
+      "influence": "evidence-and-contracts",
+      "provider": "Corca, Inc.",
+      "repository": "https://github.com/corca-ai/nose",
+      "license": "MIT",
+      "supported_languages": [],
+      "counts": {
+        "evidence_producers": 0,
+        "contracts": 0,
+        "value_laws": 2,
+        "positive_fixtures": 2,
+        "hard_negatives": 4
+      }
     }
   ],
   "ranking": {
@@ -116,7 +138,9 @@ A checked-in example lives at
 [crates/nose-cli/tests/fixtures/scan-json-v1.json](../crates/nose-cli/tests/fixtures/scan-json-v1.json)
 and is read by the CLI test suite. `tool_version` is shown above as the `<version>`
 placeholder: it always reports the installed binary's own version, so the example does not
-pin a release.
+pin a release. The `semantic_packs` array always lists the compiled first-party packs shown
+above; the `ignore` object appears **only** when an ignore file is read (via `--ignore-file`
+or an auto-detected `nose.ignore.json`), so a plain run omits it.
 
 > **`--top` truncates machine output too.** `families` contains only the top `--top`
 > families (default 30) from the active ranked set, so it is *not* the full set by

--- a/docs/structured-ignores.md
+++ b/docs/structured-ignores.md
@@ -139,8 +139,9 @@ dates, or entries with no selector. Silent ignore mistakes would make the report
 untrustworthy.
 
 Expired entries are different: they are valid historical decisions whose date has
-passed. nose prints a warning, does not apply the entry, and includes the expired
-entry in the JSON `ignore.expired` list.
+passed. nose prints a warning on stderr and does not apply the entry (the deprecated
+`nose scan --format json` additionally lists it under `ignore.expired`; query-JSON v2
+carries no `ignore` object).
 
 ## Which suppression to use
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,7 +41,7 @@ from-source `./target/release/nose`.
 | Debug why two snippets do or do not converge | `nose il <file> --normalized` |
 | One-shot ranked report (**deprecated**) | `nose scan <paths...>` — prefer `nose query --format markdown` |
 
-`nose query` is the everyday command; the **Ranking** and **Scan modes** sections below
+`nose query` is the everyday command; the **Ranking** and **Detection modes** sections below
 document the shared ranking keys and detection channels both surfaces use.
 
 ## `nose query`
@@ -74,7 +74,7 @@ nose query <path> [FILTER … | group=FIELD | id=FAM | at=FILE:LINE | reinvented
 | `reinvented` | the **reinvented-helper** view: code that reimplements an existing helper inline (the action is "call it"). Complements `shape=call-existing-helper` (those are the cases the family clusterer caught; these are the ones it did not) |
 | `base=REF` | the **divergent-edit** view (the [`nose review`](review.md) pipeline, surfaced in query): detect families at the git ref, flag the ones a diff changed in one copy but not its siblings — a likely un-propagated fix. Each item carries `fire_eligible` (the conservative proven-shared-logic verdict); `base=REF --fail-on any` is the CI gate (fires only on the proven case) |
 | `since=FILE` | compare to a saved snapshot (written with `--baseline FILE --write-baseline`) and expose each family's **`status`** (`new`/`changed`/`unchanged`) as a queryable field — the temporal lens. Hides nothing (unlike `--baseline`); `since=B status=new --fail-on any` is the composable gate |
-| `sort=KEY` | `extractability` (default), `value`, or `members` |
+| `sort=KEY` | `extractability` (default), `value`, `members` (also `sites` and the experimental `hazard` — see [Ranking](#ranking)) |
 | `top=N` | show the first N rows (default 30); `top=0` shows **all** (like the deprecated `scan --top 0`) |
 | `full` | on `id=` or a list, render the all-copies extraction skeletons inline (batched); each varying spot is `⟨param N: class⟩` — a coarse value-class hint (`literal`/`name`/`call`/`expr`/`block`) for the helper signature |
 | `all` | widen past the curated default surface to the full raw universe (demoted families labeled) |
@@ -83,7 +83,8 @@ Fields: `scope` (prod\|test\|mixed), `witness` (exact\|shared-core\|copy-paste\|
 `shared-core` is spelled `subdag` in `--format json`; both are accepted as filter values),
 `same_symbol` (true\|false — every copy is the same named symbol, the parallel-variant
 signature), `spotclass` (leaf-only\|structural — for near families, whether the varying spots
-are clean value-leaves to parameterize or genuine logic divergence), `status`
+are clean value-leaves to parameterize or genuine logic divergence; non-near families group
+as `unwitnessed` under `group=spotclass`, which is not itself a filterable value), `status`
 (new\|changed\|unchanged — vs the `since=` snapshot), `lang`, `path`, `dir`,
 `members`, `files`, `value`, `params`, `shared`. Every row shows the payoff economics —
 `M/REP shared, Pp · ~N removable` — so a candidate can be triaged without opening it. Each
@@ -98,7 +99,7 @@ filters or groups by `spotclass`. The common query path pays nothing; a `spotcla
 A typical loop: `nose query .` → `nose query . witness=exact` → `nose query . id=<id> full`.
 
 `nose query` accepts the same **analysis flags** as the detection pipeline — `--mode`
-(see [Scan modes](#scan-modes)), `--min-size`, `--min-value`, `--min-members`, `--exclude`,
+(see [Detection modes](#detection-modes)), `--min-size`, `--min-value`, `--min-members`, `--exclude`,
 `--cache-dir`, `--ignore-file`, `--semantic-pack`, `--config` — so the dataset it explores is
 configured by flag while scope/sort/top are the DSL's `scope=`/`sort=`/`top=`. It also takes the
 **CI gate** — `--fail-on any` / `--fail-on new` with `--baseline`/`--write-baseline` — and
@@ -109,19 +110,32 @@ How to read the resulting dashboard — the `scanned …` scope line, the confid
 the per-family economics, scope tags, and the `→` hint — is covered in
 [getting-started → How to read the report](getting-started.md#how-to-read-the-report).
 
+### The default surface
+
+The dashboard, the other formats, and the `--fail-on` gate show a curated **default
+surface** of action-oriented families, and hold the rest back behind a one-line omission
+footer (`omitted N families …`). Held back are tiny proof-only fragments, review-only
+fragments, families wholly inside files with generated-code headers, **declaration runs**
+(spans that are only import/include/use/re-export lines — duplication the language mandates
+per file, with nothing to extract), and **shallow-extraction** families (a helper that would
+be mostly parameters — `params` ≥ a third of the shared lines). Add `all` to widen the view
+to the full raw universe, each demoted family labeled with why it was held back. This curated
+surface is what `--fail-on` gates on — a family in the `all` view alone never fails a run.
+
 ## Ranking
 
 `--sort` (scan) and `sort=` (query) choose what "most worth your attention first" means.
-`--min-value` is a noise floor on raw value and applies under every sort. `nose query`'s
-`sort=` accepts `extractability`, `value`, and `members`; `nose scan --sort` additionally
-offers `sites` and the experimental `hazard`.
+`--min-value` is a noise floor on raw value and applies under every sort. Both surfaces
+accept the same keys — `extractability`, `value`, `sites`, and the experimental `hazard`;
+`nose query` additionally accepts `members` as an alias for `sites`. (The query dashboard's
+`sort` cheatsheet advertises only the everyday three — `extractability`, `value`, `members`.)
 
 | key | ranks by | use when |
 |---|---|---|
 | `extractability` *(default)* | invariant (shared) lines × copies × spread, weighted by tightness (shared/total) and penalized by parameter count and by member-span heterogeneity (copies of unlike length aren't one shape) | you want the duplication that folds *cleanly* into one helper — not the biggest block that merely looks similar |
 | `value` | raw duplicated volume: duplicated lines (mean span × copies) × similarity × spread — ranks by repeated *volume*, not the `removable` field (a structural Type-4 family can rank high here yet show `removable=0` when no literal lines survive all copies) | you want the most *code* deleted, accepting that divergent copies cost more to merge |
 | `sites` / `members` | number of copies | hunting the most-repeated patterns |
-| `hazard` *(experimental, scan only)* | divergent-edit *propensity*: line span × spread × invisibility × scope | you want a view of which clones tend to get edited inconsistently — **not yet a validated *harm* ranker** (see [hazard-ranking](hazard-ranking.md)) |
+| `hazard` *(experimental)* | divergent-edit *propensity*: line span × spread × invisibility × scope | you want a view of which clones tend to get edited inconsistently — **not yet a validated *harm* ranker** (see [hazard-ranking](hazard-ranking.md)) |
 
 Extractability is the default because raw volume over-rewards a large block whose
 copies share little: a 384-line family that shares only 22 lines across 14 varying
@@ -139,7 +153,7 @@ divergent-edit history. It predicts *which clones get edited inconsistently* (di
 propensity) but, per a gold-label audit, **does not yet rank actual *harm* better than
 chance** — see [hazard-ranking](hazard-ranking.md) for the full, honest evaluation.
 
-## Scan modes
+## Detection modes
 
 nose's detection has three stable orthogonal channels, selected with `--mode` on
 `nose query` (or the deprecated `nose scan`). Omitting `--mode` runs all three:
@@ -172,7 +186,8 @@ candidate stream, defaults to threshold `0.50`, and then keeps only same-languag
 families whose normalized IL differs by exactly one supported literal leaf. Its
 claim is weaker than `semantic`: it reports a refactoring-template witness with a
 typed hole and caveats such as `numeric-domain-sensitive`; it does not say the two
-copies are behavior-equivalent. Use `--format json --top 0` to consume the
+copies are behavior-equivalent. Emit all families as JSON (`nose query … top=0 --format json`,
+or the deprecated `nose scan … --top 0 --format json`) to consume the
 `abstraction_witness` field documented in [scan-json](scan-json.md#abstraction-witnesses).
 The witness is built from normalized IL, not line-level `--show proposal` text; its
 template is machine-oriented today and carries typed hole metadata for tooling. A
@@ -202,7 +217,7 @@ metadata are documented in [fragment-contracts](fragment-contracts.md) and
 > same dataset and now carries the analysis flags, the `--fail-on`/`--baseline` gate, and a
 > structured versioned [`--format json`](query-json.md) contract. `scan` still works (an
 > interactive run prints a one-line nudge); it will be removed in a later release. The
-> [Ranking](#ranking) keys and [Scan modes](#scan-modes) above apply to both surfaces.
+> [Ranking](#ranking) keys and [Detection modes](#detection-modes) above apply to both surfaces.
 
 `nose scan <paths…>` scans one or more files/directories (recursively, respecting
 `.gitignore` files inside each scanned tree), groups duplicated code into **families**, and
@@ -218,20 +233,18 @@ nose scan path/to/project
 How to read the resulting report — the `scanned …` scope line, the per-family
 breakdown, scope tags, and the `→` hint — is covered in
 [getting-started → How to read the report](getting-started.md#how-to-read-the-report).
-The default human, Markdown, SARIF, and `--fail-on` surfaces show only
-action-oriented findings. Tiny proof-only fragments, review-only fragments,
-families wholly inside files with generated-code headers, declaration runs
-(spans that are only import/include/use/re-export lines — duplication the
-language mandates per file, with nothing to extract), and `shallow-extraction`
-families (unproven matches whose helper would be mostly parameters — `params` ≥ a
-third of the shared lines) are omitted with a short count line; `--format json
---top 0` keeps the post-ranking diagnostic families that survive rank-time pruning.
+Like `nose query`, `scan` shows only the curated [default surface](#the-default-surface)
+of action-oriented findings and omits the held-back categories with a short count line;
+`--format json --top 0` keeps the post-ranking diagnostic families that survive rank-time
+pruning.
 
 Within the human report, **production findings lead and test-scope duplication is
 ranked beneath**, behind a `── N test-scope families …` separator (or a `+N more`
 footer when `--top` cuts them). Test duplication is still a real smell — nothing is
 dropped: the families stay ranked, in `--format json`, and one `--scope test` away.
-`--scope prod` hides them entirely; `--scope test` focuses on them.
+`--scope prod` hides them entirely; `--scope test` focuses on them. (This prod-first
+ordering is specific to the deprecated `scan` view; `nose query` is **scope-blind** —
+it ranks test and production purely by extractability and slices with `scope=`.)
 
 A named path that doesn't exist is an error (exit non-zero) — a typo'd path in a
 CI gate must fail loudly. A path that exists but contains no supported source
@@ -245,13 +258,14 @@ and the others fold into a `↳ N overlapping slice families…` note under it
 slices). Each entry also names its equivalence evidence — `exact behavior
 match` (value-graph proof), `shared core computation`, `copy-paste`, or
 `near-duplicate` — so a *shared decision* reads differently from a *shared
-shape*.
+shape*. These are the deprecated `scan` view's spellings of the same evidence
+classes `nose query` tags `exact` / `shared-core` / `copy-paste` / `similar`.
 
 ### Flags
 
 Grouped by what they do. Config-backed defaults are listed in
 [configuration](configuration.md); workflow and output flags stay CLI-only. The ranking and
-mode flags are documented under [Ranking](#ranking) and [Scan modes](#scan-modes) above.
+mode flags are documented under [Ranking](#ranking) and [Detection modes](#detection-modes) above.
 
 **Filter & shape the report**
 
@@ -325,9 +339,8 @@ and may change to improve readability. The stable contract is documented in
   [normalization](normalization.md) passes). A debugging tool for understanding why two
   snippets do or don't converge; see [architecture](architecture.md).
 
-`nose behavioral-gate` is a visible experimental Type-4 benchmark command, not a stable
-integration surface; do not build automation around it without checking the current binary.
-
-Hidden `detect`, `verify`, `features`, `eval`, and `ceiling` commands exist for
-strict/research workflows. They are hidden from `--help` because `query` is the command for
-everyday use; the [benchmark](benchmark.md) page documents them.
+Hidden `behavioral-gate`, `detect`, `verify`, `features`, `eval`, and `ceiling` commands
+exist for strict/research workflows — an experimental Type-4 benchmark harness and oracle
+tooling, not stable integration surfaces; do not build automation around them without
+checking the current binary. They are hidden from `--help` because `query` is the command
+for everyday use; the [benchmark](benchmark.md) page documents them.


### PR DESCRIPTION
Audited every user-facing doc against the **v0.11.0 binary** (full `--help`, `query`/`scan` JSON, `capabilities`), fixed the drift, then swept for cross-doc consistency and reading structure from a user's perspective. **Also folds in a one-commit `cargo fmt` unblock** — #431 (1c02c8b) landed unformatted Rust, so `cargo fmt --check` (the `build · test · lint · dup-gate` job) has been failing on `main` since; this makes both this branch and main green again.

## CI unblock (last commit)
- `style: apply rustfmt to nose-cli` — deterministic `cargo fmt` output for `main.rs` + `tests/cli/commands.rs`, whitespace-only, no behavior change. Fixes the rustfmt regression #431 left on `main`.

## Code-docs drift (each verified against the binary)
- **usage** — `sort=sites`/`sort=hazard` are accepted by `nose query` too (were wrongly labeled "scan only"); `query` additionally accepts `members` as a `sites` alias. `behavioral-gate` is a hidden command, not "visible".
- **configuration** — the `top` config key bounds `nose scan` only; `nose query`'s row limit is the `top=` term (`run_query_cmd` hardcodes `top=0`), so config `top` is silently ignored by query.
- **continuous-integration + structured-ignores** — `baseline`/`baseline_status` and `ignore.expired` are **scan-JSON v1 only**; query-JSON v2 has neither. Point query users at the `since=<baseline>` term (exposes per-family `status`). Expired-ignore warnings go to **stderr**.
- **query-json** — `base` items carry `complexity`; the `surface` enum includes the reserved `debug` tier; `subsumes`/`subsumed_by` appear whenever a family overlaps (any view, not just `family`); noted `by_confidence.copy_paste` (underscore) vs the `copy-paste` witness value (hyphen).
- **scan-json** — example was missing the third compiled pack (`nose.value_graph.laws`); now matches live output and the checked-in fixture. Marked the `ignore` block conditional.
- **agent-recipe** — added `debug` to the diagnostic-surface list.
- **`--fail-on` wording** — the gate fires on the **default surface**, not every filtered family.

## Consistency & terminology
- Map deprecated `scan` spellings (`near-duplicate`) to `query` witness names (`exact`/`shared-core`/`copy-paste`/`similar`); clarify `members`↔`sites` are one ranking key.
- Note `nose query` is scope-blind while the deprecated `scan` view ranks prod-first.
- **review** — "Deprecated since 0.10.0 (still works in 0.11.0)"; relabel `--min-value`/`--min-members` as flags (only `sort=` is a term).

## Structure / user-perspective
- Rename usage **"Scan modes" → "Detection modes"** and update every `#scan-modes` anchor (usage ×3, clone-types).
- Add a canonical **"The default surface"** section under `nose query`; scan section back-references it (DRY).
- Note the `unwitnessed` group bucket isn't a filterable `spotclass` value.
- **languages** — give Vue/Svelte their own extension table; note JS/TS share one lowering path.
- **clone-types** — collapse CSS/HTML detail that duplicated `languages.md` into a pointer (SRP).
- Fix a pre-existing broken anchor in `hazard-release-checklist`.

## Verification
- All internal links/anchors checked programmatically — clean.
- `awiki lint --root docs` → `ok connected_graph orphan_rate=0.0000 content_coverage=1.0000`.
- `cargo fmt --check`, `cargo build`, `cargo clippy --all-targets`, `cargo test -p nose-cli` (314+ tests) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)