### PR TITLE
Release v0.12.0: scope-blind nose query output redesign + docs drift/IA sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to nose are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); pre-1.0, so minor versions may
 break.
 
+## [0.12.0] - 2026-06-18
+
+Reworks the `nose query` terminal output to match the project's reporting philosophy —
+**scope-blind, plain-language, colour-aware** — and sweeps the user-facing docs for drift and
+consistency. Detection behavior and the machine contract are unchanged: `--format json` still
+emits query-JSON v2 and spells the witness `subdag`.
+
+### Changed
+- **`nose query` human-output redesign (#431).** Families now rank purely by extractability,
+  **scope-blind** — test and production are treated alike. The old prod-first partition, the
+  "(production first)" label, and the pushed `scope=prod` recommendation are gone; `scope`
+  stays a neutral filter. The opaque `subdag` witness reads as **`shared-core`** throughout the
+  human output, and the confidence line regroups as *proven* (exact + shared-core) /
+  *copy-paste* / *similar* with a one-line legend. New **TTY-gated colour** (zero-dependency
+  `mod style`): witness tags colour-coded, paths dimmed, symbols bold — disabled under
+  `NO_COLOR`, when piped, and for the JSON/Markdown/SARIF formats, with column alignment
+  computed on visible width so ANSI never skews the columns. The terse `grammar:` block
+  becomes a runnable `explore` cheatsheet.
+- **CLI surface cleanup (#431).** The deprecated `scan`/`review` and the experimental
+  `behavioral-gate` are hidden from top-level `--help` (they still work, still warn on a TTY,
+  and stay listed under `capabilities.commands.deprecated`); flag docs are self-contained
+  instead of "(same as scan)"; count nouns are pluralized; empty/single-directory dashboards
+  no longer emit dead next-commands.
+
+### Documentation
+- **User-facing docs drift, consistency, and IA sweep (#431, #432).** Re-verified every
+  user-facing page against the live CLI (clap help, query DSL parser, query/scan JSON,
+  capabilities). Reconciled the witness vocabulary (`shared-core` human ↔ `subdag` JSON);
+  corrected scan-JSON-v1-only fields wrongly attributed to query-JSON v2 (`baseline_status`,
+  `ignore.expired`, `ignored_families`) and pointed query users at the `since=<baseline>` term;
+  clarified that the `top` config key bounds `nose scan` only; documented that `sort=sites`/
+  `hazard` work under `query` and that `behavioral-gate` is hidden; renamed usage "Scan modes"
+  → "Detection modes"; added a canonical "default surface" section; de-duplicated the CSS/HTML
+  detail against `languages.md`; gave Vue/Svelte their own extension table; and fixed broken
+  cross-links (`awiki lint` clean).
+
+### Notes
+- **Control-flow lowering converged on shared `lower.rs` helpers (#430).** The per-language
+  `if`/`for`/`while`/`stmt-as-block` lowering for C/Java/JS/TS collapsed onto three
+  closure-parameterized helpers; the emitted IL is byte-identical by construction (verified on
+  redis/guava/axios/bat/black), eliminating three of nose's own flagged self-clones. No
+  behavior change.
+
 ## [0.11.0] - 2026-06-17
 
 Adds a **declarative clone-detection track** — CSS and HTML/markup, by computed-style and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nose-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "nose-detect"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "nose-frontend",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "nose-eval"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "rustc-hash",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "nose-frontend"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "nose-il"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "lasso",
  "serde",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "nose-normalize"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "nose-il",
  "nose-semantics",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "nose-semantics"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "nose-il",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/corca-ai/nose"
@@ -25,12 +25,12 @@ rust-version = "1.85"
 [workspace.dependencies]
 # Internal crates carry an explicit `version` (not just `path`) so the tree has no
 # wildcard deps and the crates stay publishable; `path` wins for local builds.
-nose-il = { path = "crates/nose-il", version = "0.11.0" }
-nose-semantics = { path = "crates/nose-semantics", version = "0.11.0" }
-nose-frontend = { path = "crates/nose-frontend", version = "0.11.0" }
-nose-normalize = { path = "crates/nose-normalize", version = "0.11.0" }
-nose-detect = { path = "crates/nose-detect", version = "0.11.0" }
-nose-eval = { path = "crates/nose-eval", version = "0.11.0" }
+nose-il = { path = "crates/nose-il", version = "0.12.0" }
+nose-semantics = { path = "crates/nose-semantics", version = "0.12.0" }
+nose-frontend = { path = "crates/nose-frontend", version = "0.12.0" }
+nose-normalize = { path = "crates/nose-normalize", version = "0.12.0" }
+nose-detect = { path = "crates/nose-detect", version = "0.12.0" }
+nose-eval = { path = "crates/nose-eval", version = "0.12.0" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Cuts **v0.12.0** of the work staged since v0.11.0. Bumps the workspace version `0.11.0 → 0.12.0` (Cargo.toml + Cargo.lock) and adds the `[0.12.0] - 2026-06-18` CHANGELOG section. Tagging `v0.12.0` after merge triggers cargo-dist to build and publish the binaries/installers/Homebrew formula + the GitHub Release.

## What's in 0.12.0
- **`nose query` human-output redesign (#431)** — scope-blind ranking (test/production alike), the `subdag` witness reads as **`shared-core`** in human output, a regrouped *proven / copy-paste / similar* confidence line, **TTY-gated colour** with ANSI-safe column alignment, and a runnable `explore` cheatsheet. CLI surface cleanup: deprecated `scan`/`review` and experimental `behavioral-gate` hidden from top-level `--help` (still work, still in `capabilities.commands.deprecated`); pluralized count nouns; no dead next-commands on empty/single-dir dashboards.
- **User-facing docs drift, consistency & IA sweep (#431, #432)** — re-verified every page against the live CLI; reconciled `shared-core`↔`subdag`; corrected scan-JSON-v1-only fields wrongly attributed to query-JSON v2; renamed "Scan modes"→"Detection modes"; added a canonical "default surface" section; de-duplicated CSS/HTML detail; `awiki lint` clean.
- **Internal (#430)** — control-flow lowering converged onto shared `lower.rs` helpers; IL byte-identical (verified on redis/guava/axios/bat/black), three self-clones eliminated. No behavior change.

**Detection behavior and the machine contract are unchanged** — `--format json` still emits query-JSON v2 and spells the witness `subdag`.

## Release scope
- `Cargo.toml` — workspace version + 6 internal crate-dep versions → `0.12.0`.
- `Cargo.lock` — the 7 `nose-*` crate versions.
- `CHANGELOG.md` — new `[0.12.0]` section.

Verified locally: `nose --version` → `nose 0.12.0`; `cargo fmt --check`, `cargo build`, `cargo clippy --all-targets`, `cargo test -p nose-cli` all green.

> Note: this cycle's first commit on `main` (#431, 1c02c8b) had landed unformatted Rust, leaving `cargo fmt --check` (the gating CI job) red on `main`; #432 folded in the deterministic `cargo fmt` fix, so this release is cut from a green tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)