### PR TITLE
fix(normalize): gate structural_fold to integer heads + close Lean coverage gaps

### DIFF
--- a/crates/nose-cli/tests/equivalence.rs
+++ b/crates/nose-cli/tests/equivalence.rs
@@ -569,6 +569,35 @@ fn rust_recursion_converges_with_iteration_via_return_unwrap() {
 }
 
 #[test]
+fn float_valued_head_structural_fold_stays_closed() {
+    // The recursion→accumulator-fold canon (`normalize.recursion.structural_fold`) is sound only
+    // over an associative monoid — and float `+` is NOT associative, so a float-VALUED head must
+    // not fold (right-fold recursion → left-fold loop would change the result). The coarse
+    // `ValueDomain::Number` does not separate int from float, so the recursion gate excludes a
+    // float head via `head_possibly_float`. Proven boundary: structural_fold/Counterexamples.lean.
+    let i = Interner::new();
+    // INT control: the head `n + 1` is integer-valued — the fold fires and converges with the loop.
+    let int_rec = "def g(n):\n    if n == 0:\n        return 0\n    return (n + 1) + g(n - 1)\n";
+    let int_loop =
+        "def g(n):\n    acc = 0\n    while n != 0:\n        acc = acc + (n + 1)\n        n = n - 1\n    return acc\n";
+    assert_eq!(
+        value_fp(&i, int_rec, Lang::Python),
+        value_fp(&i, int_loop, Lang::Python),
+        "an integer-valued head must still fold to its accumulator loop"
+    );
+    // FLOAT: the head `n + 1.0` is float-valued — the fold must NOT fire, so the recursion does NOT
+    // converge with the left-fold loop (they differ for floats under reassociation).
+    let flt_rec = "def g(n):\n    if n == 0:\n        return 0\n    return (n + 1.0) + g(n - 1)\n";
+    let flt_loop =
+        "def g(n):\n    acc = 0\n    while n != 0:\n        acc = acc + (n + 1.0)\n        n = n - 1\n    return acc\n";
+    assert_ne!(
+        value_fp(&i, flt_rec, Lang::Python),
+        value_fp(&i, flt_loop, Lang::Python),
+        "a float-valued head must NOT fold (float + is non-associative)"
+    );
+}
+
+#[test]
 fn ruby_shovel_builder_each_stays_closed_without_receiver_proof() {
     // Ruby `xs.each { ... }` stays an ordinary block call until a pack supplies receiver/protocol
     // proof for `xs`. The Ruby `<<` builder signal is still retained inside the opaque call body,

--- a/crates/nose-normalize/src/recursion/structural_fold.rs
+++ b/crates/nose-normalize/src/recursion/structural_fold.rs
@@ -3,8 +3,9 @@
 //! proof-obligation: normalize.recursion.structural_fold
 
 use super::Rebuilder;
-use nose_il::{NodeId, NodeKind, Op, Payload, Span};
-use nose_semantics::{semantics, ValueDomain, ValueLaw};
+use nose_il::{LitClass, NodeId, NodeKind, Op, Payload, Span};
+use nose_semantics::{domain_evidence_for_param, semantics, ValueDomain, ValueLaw};
+use rustc_hash::FxHashSet;
 
 pub(super) struct Plan {
     pub(super) param_cids: Vec<u32>,
@@ -60,6 +61,14 @@ pub(super) fn recognize(
     {
         return None;
     }
+    // `ValueDomain::Number` does not separate integer from float, but the fold's soundness
+    // (right-fold == left-fold) holds only over an associative monoid — and float `+`/`*` is NOT
+    // associative (`normalize.recursion.structural_fold` is proven over `Int` only; see
+    // Counterexamples.lean). A `Number` HEAD that could carry a float at runtime must therefore be
+    // rejected, exactly as the `algebra` IL pass holds float `+`/`*` chains via `possibly_float`.
+    if head_possibly_float(rb, fid, head) {
+        return None;
+    }
     let want_identity = match op {
         Op::Add => 0,
         Op::Mul => 1,
@@ -76,6 +85,42 @@ pub(super) fn recognize(
         args,
         identity,
     })
+}
+
+/// Whether the fold's `HEAD` could evaluate to a FLOAT, so `+`/`*` over it is non-associative and
+/// the right-fold→left-fold rewrite would not preserve meaning. A truly-untyped dynamic-language
+/// param cannot reach here — its `ValueDomain` is `Unknown`, which the `Number` head gate already
+/// rejects — so the only float sources are a float literal, a true-division (`Op::TrueDiv`, which
+/// is float-valued even over integer operands, unlike truncating `Op::Div`), or a statically
+/// float-typed parameter (`f64`/`double`/…). This mirrors `algebra`'s `possibly_float` hold.
+fn head_possibly_float(rb: &Rebuilder<'_>, fid: NodeId, head: NodeId) -> bool {
+    let float_param_cids: FxHashSet<u32> = rb
+        .old
+        .children(fid)
+        .iter()
+        .filter(|&&c| rb.old.kind(c) == NodeKind::Param)
+        .filter_map(|&c| match rb.old.node(c).payload {
+            Payload::Cid(cid) => domain_evidence_for_param(rb.old, c)
+                .is_some_and(|d| d.is_float())
+                .then_some(cid),
+            _ => None,
+        })
+        .collect();
+    let mut stack = vec![head];
+    while let Some(n) = stack.pop() {
+        match rb.old.node(n).payload {
+            Payload::LitFloat(_) | Payload::Lit(LitClass::Float) => return true,
+            Payload::Op(Op::TrueDiv) => return true,
+            Payload::Cid(cid)
+                if rb.old.kind(n) == NodeKind::Var && float_param_cids.contains(&cid) =>
+            {
+                return true
+            }
+            _ => {}
+        }
+        stack.extend(rb.old.children(n).iter().copied());
+    }
+    false
 }
 
 pub(super) fn build_body(

--- a/formal/README.md
+++ b/formal/README.md
@@ -52,10 +52,10 @@ obligation, or a marker in a file not named by that obligation's `rust.files`, f
   `x*f + y*f -> (x+y)*f`, gated to proven numeric leaves.
 - `normalize.value_graph.free_monoid` — ordered string/list builder concatenation:
   associative with identity, not commutative, and not a ring for distribution.
-- `normalize.value_graph.compare` — comparison direction, negated comparisons, and
-  total-order lattice canons.
-- `normalize.control_flow.guard_returns` — guard-return, dead-code-after-return, and
-  ternary-return control-flow canons.
+- `normalize.value_graph.compare` — comparison direction, negated comparisons,
+  equality-operand commutativity, and total-order lattice canons.
+- `normalize.control_flow.guard_returns` — guard-return, dead-code-after-return,
+  ternary-return, conjoined-guard merge, and continue-guard unwrap control-flow canons.
 - `normalize.value_graph.functor` — map/filter fusion and count-of-filter.
 - `normalize.value_graph.bool_reduce` — any/all Bool reductions.
 - `normalize.value_graph.min_max` — min/max select idioms and reductions.
@@ -63,8 +63,9 @@ obligation, or a marker in a file not named by that obligation's `rust.files`, f
 - `normalize.value_graph.field_writes` — final field-state semantics, last-write-wins,
   distinct-field commutativity, and same-field order counterexample.
 - `normalize.recursion.tail` — tail-recursive self-call elimination into a while loop.
-- `normalize.recursion.structural_fold` — numeric structural recursion as an accumulator
-  fold for `+` and `*`, with counterexamples for subtraction and wrong identities.
+- `normalize.recursion.structural_fold` — integer structural recursion as an accumulator
+  fold for `+` and `*`, with counterexamples for subtraction, wrong identities, and float
+  reassociation (a float-valued HEAD is non-associative and is excluded by the Rust gate).
 - `detect.fragment.effect_place` — append/index effects need no receiver proof; field
   writes require an exact-safe place and reject `Unknown`.
 - `detect.fragment.free_inputs` — wrapper parameters are reads minus fragment-local

--- a/formal/obligations/normalize/control_flow/guard_returns/Proof.lean
+++ b/formal/obligations/normalize/control_flow/guard_returns/Proof.lean
@@ -8,25 +8,34 @@ Proven here:
                             (value_graph.rs `process_block` guard-clause path narrowing)
   • dead_code_after_return — a statement after an unconditional return is unreachable
                             (value_graph.rs `process_block` dead-code break)
+  • conjoined_guard_merge — `if a { if b { X } }`  ≡  `if a && b { X }`  (no else)
+                            (cfg_norm.rs nested-guard merge)
+  • continue_guard_unwrap — as a loop body, `if c { continue }; S`  ≡  `if !c { S }`
+                            (cfg_norm.rs continue-guard unwrap)
 
 Self-contained; checked by the formal obligation CI gate.
 -/
 
 namespace NoseControl
 
-/-- A minimal statement: return a value, an if/else, a sequence, or a no-op. The branch
-    condition is modeled by its truth value (what the value graph's path captures). -/
+/-- A minimal statement: return a value, `continue` (skip the rest of this loop iteration), an
+    if/else, a sequence, or a no-op. The branch condition is modeled by its truth value (what the
+    value graph's path captures). -/
 inductive Stmt where
   | ret  : Int → Stmt
+  | cont : Stmt
   | ife  : Bool → Stmt → Stmt → Stmt
   | seq  : Stmt → Stmt → Stmt
   | skip : Stmt
 
-/-- Execution denotation: `some n` if the statement returns `n`, `none` if it falls
-    through. In a sequence, once the first part returns, the rest is dead. -/
+/-- Value denotation: `some n` if the statement returns `n`, `none` if it falls through. A
+    `continue` yields no value here (like a fall-through in the value channel); its loop-control
+    effect is modeled separately by `run`/`proceeds` below. In a sequence, once the first part
+    returns, the rest is dead. -/
 def exec : Stmt → Option Int
   | .ret n     => some n
   | .skip      => none
+  | .cont      => none
   | .ife c t e => if c then exec t else exec e
   | .seq a b   => match exec a with
                   | some n => some n
@@ -60,6 +69,47 @@ theorem guard_clause_cascade (c d : Bool) (a b e : Int) :
     with `guard_clause`, converges a nested ternary with an `elif` cascade. -/
 theorem ternary_return (c : Bool) (a b : Int) :
     exec (.ret (if c then a else b)) = exec (.ife c (.ret a) (.ret b)) := by
+  cases c <;> rfl
+
+/-- CONJOINED-GUARD MERGE: an `if` nested directly inside an `if` with NO else on either level —
+    `if a { if b { X } }` — denotes exactly the conjoined guard `if a && b { X }`. When `a` is
+    false the outer else (`skip`) falls through, matching `a && b = false`; when `a` is true the
+    inner `if b { X }` matches `b`-guarded `X`. So cfg_norm.rs collapsing the nested guard into a
+    single `&&` condition is sound (it preserves short-circuit `a ∧ b`). -/
+theorem conjoined_guard_merge (a b : Bool) (x : Stmt) :
+    exec (.ife a (.ife b x .skip) .skip) = exec (.ife (a && b) x .skip) := by
+  cases a <;> cases b <;> rfl
+
+/-- Loop-control outcome of a body, used for `continue_guard_unwrap`: a body either falls through,
+    issues a `continue`, or `return`s a value. -/
+inductive Flow where
+  | fall
+  | cont
+  | ret : Int → Flow
+
+/-- Control-flow denotation: the `Flow` outcome of running a statement as a loop body. In a
+    sequence, a `return` or `continue` in the first part skips the rest of THIS iteration. -/
+def run : Stmt → Flow
+  | .ret n     => .ret n
+  | .cont      => .cont
+  | .skip      => .fall
+  | .ife c t e => if c then run t else run e
+  | .seq a b   => match run a with
+                  | .fall  => run b
+                  | other  => other
+
+/-- What the enclosing loop observes: a `return` exits with a value; a `continue` and a
+    fall-through are INDISTINGUISHABLE — both advance to the next iteration. -/
+def proceeds : Flow → Option Int
+  | .ret n => some n
+  | _      => none
+
+/-- CONTINUE-GUARD UNWRAP: as a loop body, `if c { continue }; S` drives the loop identically to
+    `if !c { S }`. When `c` holds, the first form `continue`s and the second falls through — both
+    advance the loop (collapsed by `proceeds`) without running `S`; when `¬c`, both run `S`. So
+    cfg_norm.rs rewriting `if c { continue } S` to `if !c { S }` is sound. -/
+theorem continue_guard_unwrap (c : Bool) (s : Stmt) :
+    proceeds (run (.seq (.ife c .cont .skip) s)) = proceeds (run (.ife (!c) s .skip)) := by
   cases c <;> rfl
 
 end NoseControl

--- a/formal/obligations/normalize/control_flow/guard_returns/meta.toml
+++ b/formal/obligations/normalize/control_flow/guard_returns/meta.toml
@@ -1,7 +1,7 @@
 id = "normalize.control_flow.guard_returns"
 status = "proven"
 kind = "soundness"
-summary = "Guard-return, dead-code-after-return, and ternary-return control-flow canons preserve return semantics."
+summary = "Guard-return, dead-code-after-return, ternary-return, conjoined-guard merge, and continue-guard unwrap control-flow canons preserve return/loop semantics."
 
 [rust]
 files = [
@@ -18,4 +18,6 @@ theorems = [
   "NoseControl.guard_clause_cascade",
   "NoseControl.dead_code_after_return",
   "NoseControl.ternary_return",
+  "NoseControl.conjoined_guard_merge",
+  "NoseControl.continue_guard_unwrap",
 ]

--- a/formal/obligations/normalize/recursion/structural_fold/Counterexamples.lean
+++ b/formal/obligations/normalize/recursion/structural_fold/Counterexamples.lean
@@ -18,4 +18,26 @@ theorem wrong_mul_identity_changes_fold :
       (([2, 3] : List Int).foldr (fun head total => head * total) 1) := by
   decide
 
+/-
+FLOAT BOUNDARY. The rewrite (right-fold recursion → left-fold loop) is sound only over an
+ASSOCIATIVE monoid. IEEE float `+`/`*` is NOT associative — rounding makes the grouping
+observable — so a float-valued HEAD must be excluded by the Rust gate (`head_possibly_float` in
+`recursion/structural_fold.rs`), NOT admitted just because its coarse `ValueDomain` is `Number`
+(which does not separate integer from float). Lean's `Float` is opaque (no `decide`), so we witness
+the SAME failure mode with a faithful low-precision model: `radd` rounds the sum to the nearest ten
+(half up) but keeps an EXACT identity (`x ⊕ 0 = 0 ⊕ x = x`, mirroring `a +. 0.0 = a`). Even with the
+exact identity the monoid law assumes, the rounded sum is non-associative — `(100 ⊕ 4) ⊕ 4 = 100`
+loses both small terms, while `100 ⊕ (4 ⊕ 4) = 110` keeps them — so foldl and foldr disagree, which
+is exactly why the rewrite must stay integer-only.
+-/
+def round10 (x : Int) : Int := ((x + 5) / 10) * 10
+
+def radd (a b : Int) : Int :=
+  if a = 0 then b else if b = 0 then a else round10 (a + b)
+
+theorem float_like_rounding_breaks_fold :
+    (([100, 4, 4] : List Int).foldl (fun total head => radd total head) 0) ≠
+      (([100, 4, 4] : List Int).foldr (fun head total => radd head total) 0) := by
+  decide
+
 end NoseRecursionStructuralFoldCounterexamples

--- a/formal/obligations/normalize/recursion/structural_fold/meta.toml
+++ b/formal/obligations/normalize/recursion/structural_fold/meta.toml
@@ -1,11 +1,11 @@
 id = "normalize.recursion.structural_fold"
 status = "proven"
 kind = "soundness"
-summary = "Numeric structural recursion can be emitted as an accumulator fold for addition and multiplication monoids."
+summary = "Integer structural recursion can be emitted as an accumulator fold for addition and multiplication monoids; a float-valued HEAD is non-associative and is excluded by the Rust gate (head_possibly_float), not admitted via the coarse Number domain."
 
 [rust]
 files = ["crates/nose-normalize/src/recursion/structural_fold.rs"]
-symbols = ["recognize", "build_body"]
+symbols = ["recognize", "build_body", "head_possibly_float"]
 
 [lean]
 proof = "Proof.lean"
@@ -19,4 +19,5 @@ counterexamples = "Counterexamples.lean"
 counterexample_theorems = [
   "NoseRecursionStructuralFoldCounterexamples.subtraction_is_not_a_structural_fold_monoid",
   "NoseRecursionStructuralFoldCounterexamples.wrong_mul_identity_changes_fold",
+  "NoseRecursionStructuralFoldCounterexamples.float_like_rounding_breaks_fold",
 ]

--- a/formal/obligations/normalize/value_graph/compare/Proof.lean
+++ b/formal/obligations/normalize/value_graph/compare/Proof.lean
@@ -88,4 +88,20 @@ theorem lt_or_eq_eq_le (a b : Int) : (lt a b || eq a b) = le a b := by
   · rw [decide_eq_false (by omega : ¬ a < b), decide_eq_false (by omega : ¬ a = b),
         decide_eq_false h]; rfl
 
+/-- EQUALITY COMMUTATIVITY: `a == b ≡ b == a` — the `emit_commutative_cmp` operand reorder for
+    `Eq` (`algebra.rs`, gated by `ComparisonLaw::EqualityCommutativity`). The interpreter compares
+    by value, so swapping the operands preserves the Bool result. -/
+theorem eq_commutes (a b : Int) : eq a b = eq b a := by
+  unfold eq
+  by_cases h : a = b
+  · rw [decide_eq_true h, decide_eq_true (by omega : b = a)]
+  · rw [decide_eq_false h, decide_eq_false (by omega : ¬ b = a)]
+
+/-- EQUALITY COMMUTATIVITY (dual): `a != b ≡ b != a` — the `Ne` operand reorder. -/
+theorem ne_commutes (a b : Int) : ne a b = ne b a := by
+  unfold ne
+  by_cases h : a = b
+  · rw [decide_eq_false (by omega : ¬ a ≠ b), decide_eq_false (by omega : ¬ b ≠ a)]
+  · rw [decide_eq_true (by omega : a ≠ b), decide_eq_true (by omega : b ≠ a)]
+
 end NoseCompare

--- a/formal/obligations/normalize/value_graph/compare/meta.toml
+++ b/formal/obligations/normalize/value_graph/compare/meta.toml
@@ -1,7 +1,7 @@
 id = "normalize.value_graph.compare"
 status = "proven"
 kind = "soundness"
-summary = "Comparison direction, negated comparisons, and total-order lattice canons preserve Int comparison denotation."
+summary = "Comparison direction, negated comparisons, equality-operand commutativity, and total-order lattice canons preserve Int comparison denotation."
 
 [rust]
 files = [
@@ -9,7 +9,7 @@ files = [
   "crates/nose-normalize/src/value_graph/ops.rs",
   "crates/nose-normalize/src/algebra.rs",
 ]
-symbols = ["negate_cmp_code", "lattice_le_ne_to_lt", "lattice_lt_eq_to_le"]
+symbols = ["negate_cmp_code", "lattice_le_ne_to_lt", "lattice_lt_eq_to_le", "emit_commutative_cmp"]
 
 [lean]
 proof = "Proof.lean"
@@ -23,4 +23,6 @@ theorems = [
   "NoseCompare.not_eq_eq_ne",
   "NoseCompare.le_and_ne_eq_lt",
   "NoseCompare.lt_or_eq_eq_le",
+  "NoseCompare.eq_commutes",
+  "NoseCompare.ne_commutes",
 ]


### PR DESCRIPTION
## Summary

A Lean proof-obligation audit (all 24 obligations vs their Rust gates) found **one genuine Lean↔code discrepancy** and several **firing-but-unproven** rewrites. Every soundness claim was verified empirically (`unit_hash`/`value_fp` collision tests) before any gate change — most agent-flagged "drift" was false-positive and left untouched.

### Discrepancy fixed — `normalize.recursion.structural_fold`
The recursion→accumulator-fold canon (right-fold recursion → left-fold loop) is proven sound over **`Int` only**, but the gate admitted a float-**valued** head via the coarse `ValueDomain::Number` (which does not separate int from float). Float `+`/`*` is non-associative (observable; see `interp.rs`), so reassociation could change results.

- Added `head_possibly_float` (rejects float literal / `Op::TrueDiv` / float-typed param; untyped dynamic-language params already fail the `Number` gate), mirroring `algebra`'s existing `possibly_float` hold.
- **Measured: all 135 corpus repos + nose's own source byte-identical** (baseline↔patched `query` sweep) and the integer fold still fires → **0 recall change, soundness gain.**

### Added Lean theorems for confirmed-firing rewrites with no proof
| obligation | added |
|---|---|
| `compare` | `eq_commutes`, `ne_commutes` (EqualityCommutativity operand reorder) |
| `guard_returns` | `conjoined_guard_merge`, `continue_guard_unwrap` (cfg_norm canons; model extended with `continue`/`Flow`) |
| `structural_fold` | `float_like_rounding_breaks_fold` boundary counterexample (faithful rounding model w/ exact identity — Lean `Float` is opaque to `decide`) |

Plus a permanent regression test (`float_valued_head_structural_fold_stays_closed`) and `meta.toml`/`formal/README.md` sync.

### Investigated & left unchanged (non-reproducing / out of model)
min_max NaN, factor_distribute float/string (index-promotion), compare-lattice `le_ne→lt`, field_writes cross-branch — none reproduce as a false merge; the gating is consistent with the `Int` proofs via the oracle's Number→Int value model. Operator-overloading concerns are outside nose's semantic model.

## Verification
- `cargo fmt --check` · `clippy -D warnings` · `cargo test` ✅
- `scripts/check-formal-obligations.py` (24) · `scripts/check-lean-proofs.sh` (31 files) ✅
- dup-gate 21/28 ✅ · corpus 135/135 byte-identical ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)