### PR TITLE
fix(markdown): rustdoc -D warnings — escape [0,1] in doc comments (fixes red main)

### DIFF
--- a/crates/nose-markdown/src/detect.rs
+++ b/crates/nose-markdown/src/detect.rs
@@ -32,7 +32,7 @@ pub struct WitnessRef {
 pub struct Family {
     /// Relation tier: `exact | near-high | near-med | near-low | partial`.
     pub tier: &'static str,
-    /// Mean pairwise relation score in [0,1].
+    /// Mean pairwise relation score in 0..=1.
     pub score: f64,
     pub members: Vec<Member>,
     pub files: usize,

--- a/crates/nose-markdown/src/verify.rs
+++ b/crates/nose-markdown/src/verify.rs
@@ -75,7 +75,7 @@ impl CorpusModel {
     }
 
     /// Commonness of the content shared by `a` and `b`: mean document-frequency fraction of the
-    /// shared grams, in [0,1]. High ⇒ the overlap is ubiquitous boilerplate (license/CoC/badges);
+    /// shared grams, in 0..=1. High ⇒ the overlap is ubiquitous boilerplate (license/CoC/badges);
     /// low ⇒ distinctive shared content. Orthogonal evidence, NOT a suppression decision.
     pub fn commonness(&self, a: &Fingerprint, b: &Fingerprint) -> f64 {
         if self.n == 0 {


### PR DESCRIPTION
Main went red after #444: `cargo doc --no-deps --workspace` with `RUSTDOCFLAGS=-D warnings` read `[0,1]` in two doc comments as a broken intra-doc link. Replaced with `0..=1`. Verified locally with the exact CI flags (fmt/clippy/test/doc all clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)