### PR TITLE
feat(markdown): field-eval quality fixes — vendor excludes, anti-over-merge, template framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ break.
   self-calibration 1.0): PR-AUC 0.995, R@P95 0.96, candidate-recall 1.0. Built on the algorithm
   survey in `docs/markdown-dup-detection-algorithm-survey-2026-06-18.md`. See
   [docs/markdown-duplication.md](docs/markdown-duplication.md). (#436 #437 #438 #439 #440 #441)
+- **`nose markdown` precision/usefulness fixes from the cross-project field evaluation.**
+  (P0) default vendor-dir excludes (`node_modules`, `vendor`, `target`, …) + `nose.toml`
+  `exclude` globs, so a non-git project's `node_modules` no longer floods the report (one field
+  project went 145 noise families → 0); a **min-shared-grams** match-substance floor drops
+  thin overlaps. (P1) strip GFM table scaffolding (pipes/separator rows are format, not content);
+  **strong-edge clustering** (weak edges corroborate but don't chain mega-families);
+  confidence-weighted ranking. (P2) large multi-file clusters are reported as **templated
+  sections** ("skeleton repeated N× across M files"), not a clone family — so a templated-doc
+  blob no longer masquerades as one family or tops the list. Field deltas: a templated Korean
+  spec repo went 206 incoherent families → 140 families + 14 templates; nose's own docs' jargon
+  over-merge is now a template, surfacing the real drift finding at #0. Golden metrics unchanged
+  (PR-AUC 0.995). Addresses #443.
 
 ## [0.12.0] - 2026-06-18
 

--- a/crates/nose-cli/src/markdown.rs
+++ b/crates/nose-cli/src/markdown.rs
@@ -9,22 +9,65 @@ use anyhow::{Context, Result};
 use nose_markdown::{detect, Family, Options};
 use std::path::{Path, PathBuf};
 
-/// Discover `.md`/`.markdown` files under the given paths, respecting `.gitignore`.
+/// Vendor/build directories never worth scanning for prose duplication. Excluded even without a
+/// `.gitignore` — the field eval hit a non-git project whose `node_modules` flooded the report.
+const DEFAULT_EXCLUDE_DIRS: &[&str] = &[
+    "node_modules",
+    "vendor",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    "target",
+    "bower_components",
+    ".next",
+    ".nuxt",
+    "site-packages",
+    ".tox",
+    ".mypy_cache",
+    "__pycache__",
+    ".cache",
+    ".git",
+];
+
+/// Discover `.md`/`.markdown` files under the given paths, respecting `.gitignore`, default
+/// vendor-dir excludes, and `nose.toml` `exclude` globs.
 fn discover(paths: &[PathBuf]) -> Vec<PathBuf> {
-    let mut builder = ignore::WalkBuilder::new(&paths[0]);
-    for p in &paths[1..] {
-        builder.add(p);
-    }
+    use ignore::overrides::OverrideBuilder;
+    let cfg_excludes = crate::config::load_scan(None)
+        .map(|c| c.exclude)
+        .unwrap_or_default();
+
     let mut out = Vec::new();
-    for dent in builder.build().flatten() {
-        let p = dent.path();
-        if dent.file_type().is_some_and(|t| t.is_file())
-            && matches!(
+    for root in paths {
+        let mut builder = ignore::WalkBuilder::new(root);
+        builder.parents(false).require_git(false);
+        let mut ob = OverrideBuilder::new(root);
+        for d in DEFAULT_EXCLUDE_DIRS {
+            let _ = ob.add(&format!("!**/{d}/**"));
+            let _ = ob.add(&format!("!**/{d}"));
+        }
+        for g in &cfg_excludes {
+            let _ = ob.add(&format!("!{g}"));
+        }
+        if let Ok(ov) = ob.build() {
+            builder.overrides(ov);
+        }
+        for dent in builder.build().flatten() {
+            let p = dent.path();
+            let is_md = matches!(
                 p.extension().and_then(|e| e.to_str()),
                 Some("md") | Some("markdown")
-            )
-        {
-            out.push(p.to_path_buf());
+            );
+            // Safety net: never report files under a vendor dir even if the override missed it.
+            let vendored = p.components().any(|c| {
+                c.as_os_str()
+                    .to_str()
+                    .is_some_and(|s| DEFAULT_EXCLUDE_DIRS.contains(&s))
+            });
+            if dent.file_type().is_some_and(|t| t.is_file()) && is_md && !vendored {
+                out.push(p.to_path_buf());
+            }
         }
     }
     out.sort();
@@ -87,6 +130,7 @@ pub(crate) fn cmd_markdown(args: Args) -> Result<()> {
     let opts = Options {
         min_words: args.min_words,
         threshold: args.threshold,
+        ..Options::default()
     };
     let families = detect(&docs, &opts);
     if args.json {
@@ -99,53 +143,85 @@ pub(crate) fn cmd_markdown(args: Args) -> Result<()> {
 }
 
 fn print_human(scanned: usize, families: &[Family], top: usize) {
+    let (templates, dups): (Vec<&Family>, Vec<&Family>) = families.iter().partition(|f| f.template);
     println!(
-        "scanned {scanned} markdown files \u{2192} {} near-duplicate {} \
-         (near-dup score + span witness + commonness; not a judgment of intent)",
-        families.len(),
-        if families.len() == 1 {
+        "scanned {scanned} markdown files \u{2192} {} near-duplicate {}, {} templated {} \
+         (score + span witness + commonness; not a judgment of intent)",
+        dups.len(),
+        if dups.len() == 1 {
             "family"
         } else {
             "families"
-        }
-    );
-    for (n, f) in families.iter().take(top).enumerate() {
-        let common = if f.commonness > 0.25 {
-            "  [common / likely boilerplate]"
+        },
+        templates.len(),
+        if templates.len() == 1 {
+            "section"
         } else {
-            ""
-        };
+            "sections"
+        },
+    );
+    for (n, f) in dups.iter().take(top).enumerate() {
+        print_family(n, f);
+    }
+    if !templates.is_empty() {
         println!(
-            "\n#{n} [{}] score={:.2}  members={} files={} removable~{} commonness={:.2}{}",
-            f.tier,
-            f.score,
-            f.members.len(),
-            f.files,
-            f.removable,
-            f.commonness,
-            common
+            "\n\u{2014} templated sections (one section skeleton repeated across files; \
+             consider a single source / generator) \u{2014}"
         );
-        if let Some(h) = f.members.first().and_then(|m| m.heading.as_deref()) {
-            println!("   heading: {}", short(h, 70));
-        }
-        for m in f.members.iter().take(6) {
-            println!("   - {}:{}-{}", m.path, m.start_line, m.end_line);
-        }
-        if f.members.len() > 6 {
-            println!("   … and {} more", f.members.len() - 6);
-        }
-        if let Some(w) = &f.witness {
+        for f in templates.iter().take(top) {
+            let h = f
+                .members
+                .first()
+                .and_then(|m| m.heading.as_deref())
+                .unwrap_or("(section)");
             println!(
-                "   witness: {} shared lines (e.g. {}:{}-{} \u{2248} {}:{}-{})",
-                w.span.matched_lines,
-                file_only(&w.a_path),
-                w.span.a_start,
-                w.span.a_end,
-                file_only(&w.b_path),
-                w.span.b_start,
-                w.span.b_end,
+                "  \u{2022} \"{}\" repeated {}\u{00d7} across {} files (score {:.2}, removable~{})",
+                short(h, 60),
+                f.members.len(),
+                f.files,
+                f.score,
+                f.removable
             );
         }
+    }
+}
+
+fn print_family(n: usize, f: &Family) {
+    let common = if f.commonness > 0.25 {
+        "  [common / likely boilerplate]"
+    } else {
+        ""
+    };
+    println!(
+        "\n#{n} [{}] score={:.2}  members={} files={} removable~{} commonness={:.2}{}",
+        f.tier,
+        f.score,
+        f.members.len(),
+        f.files,
+        f.removable,
+        f.commonness,
+        common
+    );
+    if let Some(h) = f.members.first().and_then(|m| m.heading.as_deref()) {
+        println!("   heading: {}", short(h, 70));
+    }
+    for m in f.members.iter().take(6) {
+        println!("   - {}:{}-{}", m.path, m.start_line, m.end_line);
+    }
+    if f.members.len() > 6 {
+        println!("   \u{2026} and {} more", f.members.len() - 6);
+    }
+    if let Some(w) = &f.witness {
+        println!(
+            "   witness: {} shared lines (e.g. {}:{}-{} \u{2248} {}:{}-{})",
+            w.span.matched_lines,
+            file_only(&w.a_path),
+            w.span.a_start,
+            w.span.a_end,
+            file_only(&w.b_path),
+            w.span.b_start,
+            w.span.b_end,
+        );
     }
 }
 

--- a/crates/nose-markdown/src/detect.rs
+++ b/crates/nose-markdown/src/detect.rs
@@ -42,6 +42,9 @@ pub struct Family {
     pub commonness: f64,
     /// Whether all members are normalized-identical (a true exact-render claim).
     pub exact: bool,
+    /// A large, multi-file cluster: a repeated section *skeleton* (a template), not a per-instance
+    /// clone. Reported separately so a templated-doc blob does not masquerade as one clone family.
+    pub template: bool,
     /// Representative duplicated span (from the highest-scoring member pair), with its files.
     pub witness: Option<WitnessRef>,
 }
@@ -51,6 +54,13 @@ pub struct Options {
     pub min_words: usize,
     /// Relation acceptance threshold on the TF-IDF/containment score.
     pub threshold: f64,
+    /// Edges below this score do not *merge* clusters (they avoid weak transitive chaining into
+    /// mega-families); they still corroborate a family formed by stronger edges.
+    pub cluster_threshold: f64,
+    /// A pair must share at least this many char-gram shingles to be accepted — a match-substance
+    /// floor that drops thin overlaps without requiring identical lines (so reworded near-dups,
+    /// which have no identical line but share many grams, are preserved).
+    pub min_shared_grams: usize,
 }
 
 impl Default for Options {
@@ -58,9 +68,15 @@ impl Default for Options {
         Options {
             min_words: 8,
             threshold: 0.5,
+            cluster_threshold: 0.7,
+            min_shared_grams: 24,
         }
     }
 }
+
+/// A cluster this large and spread this wide is treated as a repeated template skeleton.
+const TEMPLATE_MIN_MEMBERS: usize = 8;
+const TEMPLATE_MIN_FILES: usize = 4;
 
 struct UnionFind {
     parent: Vec<usize>,
@@ -118,7 +134,8 @@ pub fn detect(docs: &[(String, String)], opts: &Options) -> Vec<Family> {
         let cont = fingerprint::containment(&fps[i].shingles, &fps[j].shingles);
         // TF-IDF is the primary relation score; containment rescues small-in-large.
         let rel = if cont >= 0.8 && cont > cos { cont } else { cos };
-        if rel >= opts.threshold {
+        let shared = fingerprint::shared_grams(&fps[i].shingles, &fps[j].shingles);
+        if rel >= opts.threshold && shared >= opts.min_shared_grams {
             accepted.push((i, j, rel));
         }
     }
@@ -126,16 +143,18 @@ pub fn detect(docs: &[(String, String)], opts: &Options) -> Vec<Family> {
         return Vec::new();
     }
 
-    // Cluster by transitive closure.
+    // Cluster on STRONG edges only (>= cluster_threshold): weak edges in
+    // [threshold, cluster_threshold) corroborate but never chain a mega-family together.
     let mut uf = UnionFind::new(units.len());
-    for &(i, j, _) in &accepted {
-        uf.union(i, j);
+    for &(i, j, s) in &accepted {
+        if s >= opts.cluster_threshold {
+            uf.union(i, j);
+        }
     }
     let mut groups: std::collections::BTreeMap<usize, Vec<usize>> =
         std::collections::BTreeMap::new();
     for idx in 0..units.len() {
         let r = uf.find(idx);
-        // only keep indices that participate in at least one accepted pair
         groups.entry(r).or_default().push(idx);
     }
 
@@ -144,11 +163,13 @@ pub fn detect(docs: &[(String, String)], opts: &Options) -> Vec<Family> {
         .filter_map(|members| build_family(members, &units, &fps, &model, &accepted))
         .collect();
 
-    // Rank: removable lines first, then score, then members; deterministic tie-break by path.
+    // Rank: real per-instance families before templated blobs; then confidence-weighted
+    // removable (so a low-cohesion blob can't top the list on raw size alone).
     families.sort_by(|a, b| {
-        b.removable
-            .cmp(&a.removable)
-            .then(b.score.partial_cmp(&a.score).unwrap())
+        let key = |f: &Family| (f.removable as f64) * f.score;
+        a.template
+            .cmp(&b.template)
+            .then(key(b).partial_cmp(&key(a)).unwrap())
             .then(b.members.len().cmp(&a.members.len()))
             .then(a.members[0].path.cmp(&b.members[0].path))
     });
@@ -232,6 +253,11 @@ fn build_family(
         "near-low"
     };
 
+    // A large cluster spread across many files is a repeated section skeleton (template), not a
+    // per-instance clone — reported separately so it doesn't masquerade as one clone family.
+    let template =
+        !exact && fam_members.len() >= TEMPLATE_MIN_MEMBERS && files >= TEMPLATE_MIN_FILES;
+
     Some(Family {
         tier,
         score,
@@ -240,6 +266,7 @@ fn build_family(
         removable,
         commonness,
         exact,
+        template,
         witness: wit,
     })
 }
@@ -297,6 +324,42 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&a).unwrap(),
             serde_json::to_string(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn large_multifile_cluster_is_flagged_template() {
+        // 8 near-identical (not byte-identical) sections across 8 files → a repeated skeleton.
+        let docs: Vec<(String, String)> = (0..8)
+            .map(|i| {
+                doc(
+                    &format!("f{i}.md"),
+                    &format!(
+                        "# Endpoint\n\nThe service validates the request payload and then writes the \
+                         record to the primary datastore before returning a confirmation number {i}."
+                    ),
+                )
+            })
+            .collect();
+        let fams = detect(&docs, &Options::default());
+        assert_eq!(fams.len(), 1);
+        assert!(
+            fams[0].template,
+            "8 members across 8 files should be a template"
+        );
+        assert!(!fams[0].exact);
+    }
+
+    #[test]
+    fn thin_overlap_is_not_a_family() {
+        // Two docs sharing only a short generic phrase (below the min-shared-grams floor).
+        let a =
+            "# A\n\nThis document explains the alpha subsystem and its asynchronous queue drains.";
+        let b = "# B\n\nThis document explains the beta module and its synchronous retular cache loads.";
+        let fams = detect(&[doc("a.md", a), doc("b.md", b)], &Options::default());
+        assert!(
+            fams.is_empty(),
+            "thin shared phrase must not form a family: {fams:?}"
         );
     }
 }

--- a/crates/nose-markdown/src/fingerprint.rs
+++ b/crates/nose-markdown/src/fingerprint.rs
@@ -159,6 +159,12 @@ pub fn containment(a: &[u64], b: &[u64]) -> f64 {
     intersection_len(a, b) as f64 / a.len().min(b.len()) as f64
 }
 
+/// Number of shared char-gram shingles between two sorted, de-duplicated sets — an absolute
+/// measure of how much content two units actually share (used as a match-substance floor).
+pub fn shared_grams(a: &[u64], b: &[u64]) -> usize {
+    intersection_len(a, b)
+}
+
 fn intersection_len(a: &[u64], b: &[u64]) -> usize {
     let (mut i, mut j, mut c) = (0, 0, 0);
     while i < a.len() && j < b.len() {

--- a/crates/nose-markdown/src/norm.rs
+++ b/crates/nose-markdown/src/norm.rs
@@ -24,6 +24,9 @@ static EMPH: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(\*\*|__|\*|_|~~)")
 static LIST_MARK: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?m)^\s*([-*+]|\d+\.)\s+").unwrap());
 static BLOCKQUOTE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?m)^\s*>\s?").unwrap());
+// GFM table separator row (`|---|:--:|`): pure scaffolding, no content.
+static TABLE_SEP: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^[ \t|:-]*-[ \t|:-]*$").unwrap());
 static WS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\s+").unwrap());
 
 /// True for characters from no-space scripts (CJK, Hangul, Thai) where there are no word
@@ -67,6 +70,11 @@ pub fn normalize_text(raw: &str, strip_md: bool) -> String {
         t = BLOCKQUOTE.replace_all(&t, "").into_owned();
         t = LIST_MARK.replace_all(&t, "").into_owned();
         t = EMPH.replace_all(&t, "").into_owned();
+        // Strip GFM table scaffolding: separator rows entirely, and cell-delimiter pipes
+        // to spaces. Table pipes/separators are format, not content — keeping them makes
+        // every table near-identical and drives over-merge across templated docs.
+        t = TABLE_SEP.replace_all(&t, " ").into_owned();
+        t = t.replace('|', " ");
     }
     let t = fold_width(&t).to_lowercase();
     WS.replace_all(t.trim(), " ").into_owned()
@@ -186,5 +194,17 @@ mod tests {
         let prose = normalize_text(s, true);
         assert!(prose.contains("intro") && prose.contains("outro"));
         assert!(!prose.contains("let x")); // code dropped from prose
+    }
+
+    #[test]
+    fn strips_table_scaffolding() {
+        let n = normalize_text("| Method | GET |\n|---|---|\n| Path | /x |", true);
+        assert!(!n.contains('|'), "pipes removed: {n}");
+        assert!(!n.contains("---"), "separator removed: {n}");
+        assert!(n.contains("method") && n.contains("get") && n.contains("path"));
+        // Two tables with identical scaffolding but different content do NOT collapse to equal.
+        let a = normalize_text("| k | v |\n|---|---|\n| Method | GET |", true);
+        let b = normalize_text("| k | v |\n|---|---|\n| Method | POST |", true);
+        assert_ne!(a, b);
     }
 }


### PR DESCRIPTION
## `nose markdown` quality fixes from the cross-project field evaluation

Ran `nose markdown` across ~24 projects under `~/prjs/cc` and fixed the precision/usefulness gaps it surfaced. Three tiers (P0/P1/P2). No new public surface beyond internal tuning + a `template` field.

### P0 — make it usable on real projects
- **Default vendor-dir excludes** (`node_modules`, `vendor`, `target`, `dist`, `.venv`, …) applied even without a `.gitignore`, plus `nose.toml` `exclude` globs. A non-git project's `node_modules` previously flooded the report (**corcatown: 145 families, 100% node_modules → 0**).
- **Min-shared-grams floor**: a pair must share enough char-grams to be accepted — drops thin overlaps *without* requiring identical lines, so reworded near-dups are preserved.

### P1 — fix the dominant over-merge
- **Strip GFM table scaffolding** (pipes / `|---|` separator rows are format, not content) so templated tables stop looking near-identical.
- **Strong-edge clustering**: edges below `cluster_threshold` corroborate a family but don't chain mega-families through weak transitive links.
- **Confidence-weighted ranking** so a low-cohesion blob can't top the list on raw size alone.

### P2 — honest framing
- Large multi-file clusters are reported as **templated sections** ("skeleton repeated N× across M files"), not a clone family — a templated-doc blob no longer masquerades as one family.

### Evaluation
- **Golden: no regression** — `nose markdown bench/markdown/corpus --eval bench/markdown/golden.v1.json` is byte-identical to baseline: PR-AUC **0.995**, ROC 0.992, R@P95 0.96, R@P99 0.93, candidate-recall 1.0.
- **Field before → after:**
  - corcatown: 185 files / **145 families → 0** (node_modules excluded).
  - moonlight (templated Korean specs): **206 incoherent families → 140 families + 14 templates**; the 128/137-member mega-blobs are gone.
  - nose's own docs: **4 families → 3 families + 1 template**; the jargon over-merge is now a template, and the real drift finding (NO-GO duplicated across two docs) is ranked **#0**.
  - clean repos (trace, …) still **0**; deterministic (byte-identical across runs).

### Gates
`cargo test --workspace`, `clippy --workspace --all-targets`, `cargo doc -D warnings`, `cargo fmt --check` all green. 27 `nose-markdown` unit tests (incl. table-scaffolding strip, template flag, thin-overlap drop).

Addresses #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
