### PR TITLE
Expand Type-4 coverage evidence

### DIFF
--- a/bench/type4/README.md
+++ b/bench/type4/README.md
@@ -19,12 +19,15 @@ The factory is evidence-carrying by design:
 - generated source paths and metadata are written into a manifest.
 
 Swift is included as a first-party surface. Its checked-in coverage probes currently cover
-12/24 applicable matrix cells: collection emptiness, string prefix/suffix, collection
+15/24 applicable matrix cells: collection emptiness, string prefix/suffix, collection
 membership, option presence, for-in/indexed reduction, immutable binding, proven callee
 identity, extract-method inline, tail numeric recursion, scalar min/max, filter fusion, and
-map fusion, with adjacent hard negatives recorded in `coverage_evidence.v1.json`.
-The checked-in matrix now keeps every primary language at or above 50% covered applicable
-cells; pure hard-negative rows are counted only on soundness-family axes.
+map fusion, plus hard-negative guards for identity/value, loop extent, and typed
+concatenation soundness, with adjacent hard negatives recorded in
+`coverage_evidence.v1.json`.
+The checked-in matrix now keeps every primary language at or above 56% covered applicable
+cells; pure hard-negative rows are counted only on soundness-family axes. The focused probe
+harness permits `pos/`-less hard-negative fixtures only for those soundness-family axes.
 
 The generated manifest is a candidate benchmark artifact. A case becomes gold only after it
 passes the promotion rules in the docs.

--- a/bench/type4/capabilities.v1.json
+++ b/bench/type4/capabilities.v1.json
@@ -119,7 +119,7 @@
       "record_shape_guard": "unsupported",
       "string_prefix_suffix": "supported",
       "table_access": "unsupported",
-      "total_order_compare": "unsupported",
+      "total_order_compare": "supported",
       "unsafe_boundary": "supported"
     },
     "javascript": {
@@ -206,6 +206,7 @@
       "map_default_lookup": "supported",
       "map_key_membership": "supported",
       "null_presence_predicate": "supported",
+      "numeric_clamp": "supported",
       "numeric_minmax_abs": "supported",
       "nullish_default": "supported",
       "own_property_guard": "unsupported",

--- a/bench/type4/coverage_evidence.v1.json
+++ b/bench/type4/coverage_evidence.v1.json
@@ -147,7 +147,62 @@
     {
       "axis": "extract_method_inline",
       "gen_axis": "probe:extract_method_inline",
+      "language": "javascript",
+      "status": "covered",
+      "pos_hit": 1,
+      "pos": 1,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "extract_method_inline",
+      "gen_axis": "probe:extract_method_inline",
+      "language": "python",
+      "status": "covered",
+      "pos_hit": 1,
+      "pos": 1,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "extract_method_inline",
+      "gen_axis": "probe:extract_method_inline",
+      "language": "rust",
+      "status": "covered",
+      "pos_hit": 1,
+      "pos": 1,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "extract_method_inline",
+      "gen_axis": "probe:extract_method_inline",
       "language": "swift",
+      "status": "covered",
+      "pos_hit": 1,
+      "pos": 1,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "extract_method_inline",
+      "gen_axis": "probe:extract_method_inline",
+      "language": "typescript",
+      "status": "covered",
+      "pos_hit": 1,
+      "pos": 1,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "filter_fusion",
+      "gen_axis": "probe:filter_fusion",
+      "language": "java",
       "status": "covered",
       "pos_hit": 1,
       "pos": 1,
@@ -272,6 +327,17 @@
       "status": "covered",
       "pos_hit": 1,
       "pos": 1,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "identity_value_soundness",
+      "gen_axis": "probe:identity_value_soundness",
+      "language": "swift",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
       "false_merges": 0,
       "neg": 1,
       "source": "probe"
@@ -574,6 +640,94 @@
       "source": "sweep"
     },
     {
+      "axis": "loop_extent_soundness",
+      "gen_axis": "probe:loop_extent_soundness",
+      "language": "c",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "loop_extent_soundness",
+      "gen_axis": "probe:loop_extent_soundness",
+      "language": "go",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "loop_extent_soundness",
+      "gen_axis": "probe:loop_extent_soundness",
+      "language": "javascript",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "loop_extent_soundness",
+      "gen_axis": "probe:loop_extent_soundness",
+      "language": "python",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "loop_extent_soundness",
+      "gen_axis": "probe:loop_extent_soundness",
+      "language": "ruby",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "loop_extent_soundness",
+      "gen_axis": "probe:loop_extent_soundness",
+      "language": "rust",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "loop_extent_soundness",
+      "gen_axis": "probe:loop_extent_soundness",
+      "language": "swift",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "loop_extent_soundness",
+      "gen_axis": "probe:loop_extent_soundness",
+      "language": "typescript",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
       "axis": "map_default_lookup",
       "gen_axis": "literal_map_default_lookup",
       "language": "python",
@@ -671,6 +825,17 @@
       "false_merges": 0,
       "neg": 1,
       "source": "sweep"
+    },
+    {
+      "axis": "map_fusion",
+      "gen_axis": "probe:map_fusion",
+      "language": "java",
+      "status": "covered",
+      "pos_hit": 1,
+      "pos": 1,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
     },
     {
       "axis": "map_fusion",
@@ -1034,6 +1199,17 @@
       "false_merges": 0,
       "neg": 4,
       "source": "sweep"
+    },
+    {
+      "axis": "numeric_clamp",
+      "gen_axis": "probe:numeric_clamp",
+      "language": "rust",
+      "status": "covered",
+      "pos_hit": 1,
+      "pos": 1,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
     },
     {
       "axis": "numeric_minmax_abs",
@@ -1664,6 +1840,17 @@
     },
     {
       "axis": "total_order_compare",
+      "gen_axis": "probe:total_order_compare",
+      "language": "java",
+      "status": "covered",
+      "pos_hit": 1,
+      "pos": 1,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "total_order_compare",
       "gen_axis": "total_order_compare",
       "language": "c",
       "status": "covered",
@@ -1672,6 +1859,94 @@
       "false_merges": 0,
       "neg": 5,
       "source": "sweep"
+    },
+    {
+      "axis": "typed_concat_soundness",
+      "gen_axis": "probe:typed_concat_soundness",
+      "language": "go",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "typed_concat_soundness",
+      "gen_axis": "probe:typed_concat_soundness",
+      "language": "java",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "typed_concat_soundness",
+      "gen_axis": "probe:typed_concat_soundness",
+      "language": "javascript",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "typed_concat_soundness",
+      "gen_axis": "probe:typed_concat_soundness",
+      "language": "python",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "typed_concat_soundness",
+      "gen_axis": "probe:typed_concat_soundness",
+      "language": "ruby",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "typed_concat_soundness",
+      "gen_axis": "probe:typed_concat_soundness",
+      "language": "rust",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "typed_concat_soundness",
+      "gen_axis": "probe:typed_concat_soundness",
+      "language": "swift",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
+    },
+    {
+      "axis": "typed_concat_soundness",
+      "gen_axis": "probe:typed_concat_soundness",
+      "language": "typescript",
+      "status": "no-positive",
+      "pos_hit": 0,
+      "pos": 0,
+      "false_merges": 0,
+      "neg": 1,
+      "source": "probe"
     }
   ],
   "oracle": [

--- a/bench/type4/coverage_matrix.v1.json
+++ b/bench/type4/coverage_matrix.v1.json
@@ -70,17 +70,17 @@
       "c": "covered",
       "go": "covered",
       "java": "none",
-      "javascript": "none",
-      "python": "none",
+      "javascript": "covered",
+      "python": "covered",
       "ruby": "none",
-      "rust": "none",
+      "rust": "covered",
       "swift": "covered",
-      "typescript": "none"
+      "typescript": "covered"
     },
     "filter_fusion": {
       "c": "none",
       "go": "none",
-      "java": "none",
+      "java": "covered",
       "javascript": "covered",
       "python": "covered",
       "ruby": "covered",
@@ -107,7 +107,7 @@
       "python": "hard-negative",
       "ruby": "hard-negative",
       "rust": "hard-negative",
-      "swift": "none",
+      "swift": "hard-negative",
       "typescript": "hard-negative"
     },
     "immutable_binding": {
@@ -155,15 +155,15 @@
       "typescript": "n/a"
     },
     "loop_extent_soundness": {
-      "c": "none",
-      "go": "none",
+      "c": "hard-negative",
+      "go": "hard-negative",
       "java": "hard-negative",
-      "javascript": "none",
-      "python": "none",
-      "ruby": "none",
-      "rust": "none",
-      "swift": "none",
-      "typescript": "none"
+      "javascript": "hard-negative",
+      "python": "hard-negative",
+      "ruby": "hard-negative",
+      "rust": "hard-negative",
+      "swift": "hard-negative",
+      "typescript": "hard-negative"
     },
     "map_default_lookup": {
       "c": "n/a",
@@ -179,7 +179,7 @@
     "map_fusion": {
       "c": "none",
       "go": "none",
-      "java": "none",
+      "java": "covered",
       "javascript": "covered",
       "python": "covered",
       "ruby": "covered",
@@ -216,7 +216,7 @@
       "javascript": "none",
       "python": "covered",
       "ruby": "none",
-      "rust": "none",
+      "rust": "covered",
       "swift": "none",
       "typescript": "none"
     },
@@ -355,7 +355,7 @@
     "total_order_compare": {
       "c": "covered",
       "go": "covered",
-      "java": "none",
+      "java": "covered",
       "javascript": "none",
       "python": "none",
       "ruby": "none",
@@ -365,14 +365,14 @@
     },
     "typed_concat_soundness": {
       "c": "none",
-      "go": "none",
-      "java": "none",
-      "javascript": "none",
-      "python": "none",
-      "ruby": "none",
-      "rust": "none",
-      "swift": "none",
-      "typescript": "none"
+      "go": "hard-negative",
+      "java": "hard-negative",
+      "javascript": "hard-negative",
+      "python": "hard-negative",
+      "ruby": "hard-negative",
+      "rust": "hard-negative",
+      "swift": "hard-negative",
+      "typescript": "hard-negative"
     },
     "value_domain_algebra": {
       "c": "out",
@@ -400,39 +400,39 @@
   "per_language": {
     "c": {
       "applicable": 23,
-      "covered": 12
+      "covered": 13
     },
     "go": {
       "applicable": 24,
-      "covered": 14
+      "covered": 16
     },
     "java": {
       "applicable": 27,
-      "covered": 15
+      "covered": 19
     },
     "javascript": {
       "applicable": 27,
-      "covered": 17
+      "covered": 20
     },
     "python": {
       "applicable": 26,
-      "covered": 18
+      "covered": 21
     },
     "ruby": {
       "applicable": 24,
-      "covered": 14
+      "covered": 16
     },
     "rust": {
       "applicable": 25,
-      "covered": 14
+      "covered": 18
     },
     "swift": {
       "applicable": 24,
-      "covered": 12
+      "covered": 15
     },
     "typescript": {
       "applicable": 27,
-      "covered": 17
+      "covered": 20
     }
   }
 }

--- a/bench/type4/coverage_probe.py
+++ b/bench/type4/coverage_probe.py
@@ -10,6 +10,9 @@ Layout:
   coverage_probes/<axis>/<lang>/pos/{a,b}.<ext>
   coverage_probes/<axis>/<lang>/neg-<tag>/{a,b}.<ext>
 
+Soundness-family axes may omit `pos/` and provide only `neg-*` siblings. Those cells are
+recorded as `no-positive`, which the matrix counts only as a soundness hard-negative.
+
   python3 coverage_probe.py [--nose target/debug/nose] [--axis reduce_minmax_anyall]
 """
 
@@ -21,6 +24,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import coverage_taxonomy as tax
 from eval_manifest import scan_families
 
 HERE = Path(__file__).resolve().parent
@@ -50,20 +54,27 @@ def converges(nose: str, pair_dir: Path) -> bool:
 def probe_cell(nose: str, axis_dir: Path, lang: str) -> dict | None:
     lang_dir = axis_dir / lang
     pos = lang_dir / "pos"
-    if not pos.is_dir():
-        return None
-    pos_ok = converges(nose, pos)
     neg_dirs = sorted(d for d in lang_dir.iterdir() if d.is_dir() and d.name.startswith("neg"))
+    has_pos = pos.is_dir()
+    if not has_pos:
+        axis = tax.axis_index().get(axis_dir.name)
+        if not neg_dirs or not axis or axis.get("family") != "soundness":
+            return None
+        pos_ok = False
+    else:
+        pos_ok = converges(nose, pos)
     merged = [d.name for d in neg_dirs if converges(nose, d)]
     if merged:
         status = "false-merge"
     elif pos_ok:
         status = "covered"
+    elif not has_pos:
+        status = "no-positive"
     else:
         status = "gap"
     return {
         "axis": axis_dir.name, "gen_axis": f"probe:{axis_dir.name}", "language": lang,
-        "status": status, "pos_hit": int(pos_ok), "pos": 1,
+        "status": status, "pos_hit": int(pos_ok), "pos": int(has_pos),
         "false_merges": len(merged), "neg": len(neg_dirs), "source": "probe",
     }
 
@@ -94,7 +105,8 @@ def main() -> int:
             flag = "  <-- SOUNDNESS BUG" if cell["status"] == "false-merge" else (
                 "  <-- GAP" if cell["status"] == "gap" else "")
             print(f"{cell['axis']:26s} {cell['language']:11s} {cell['status']:12s} "
-                  f"{cell['pos_hit']}/1  {cell['neg'] - cell['false_merges']}/{cell['neg']}{flag}")
+                  f"{cell['pos_hit']}/{cell['pos']}  "
+                  f"{cell['neg'] - cell['false_merges']}/{cell['neg']}{flag}")
 
     # merge into evidence (probe rows keyed distinct from sweep via gen_axis="probe:<axis>")
     prev = json.loads(EVIDENCE.read_text()) if EVIDENCE.exists() else {}
@@ -106,9 +118,12 @@ def main() -> int:
     EVIDENCE.write_text(json.dumps(
         {"schema_version": 1, "evidence": out, "oracle": prev.get("oracle", [])}, indent=2) + "\n")
     covered = sum(1 for r in rows if r["status"] == "covered")
+    hard_negatives = sum(1 for r in rows if r["status"] == "no-positive")
     bugs = [r for r in rows if r["status"] == "false-merge"]
     gaps = [r for r in rows if r["status"] == "gap"]
-    print(f"\nprobed {len(rows)} cells: {covered} covered, {len(gaps)} gaps, {len(bugs)} soundness bugs")
+    print(f"\nprobed {len(rows)} cells: {covered} covered, "
+          f"{hard_negatives} soundness hard-negatives, {len(gaps)} gaps, "
+          f"{len(bugs)} soundness bugs")
     if bugs:
         print("SOUNDNESS BUGS (hard negative converged — must fix):")
         for r in bugs:

--- a/bench/type4/coverage_probes/extract_method_inline/javascript/neg-body/a.js
+++ b/bench/type4/coverage_probes/extract_method_inline/javascript/neg-body/a.js
@@ -1,0 +1,4 @@
+function axisCase(x, y) {
+  const total = x + y;
+  return total * total + 1;
+}

--- a/bench/type4/coverage_probes/extract_method_inline/javascript/neg-body/b.js
+++ b/bench/type4/coverage_probes/extract_method_inline/javascript/neg-body/b.js
@@ -1,0 +1,8 @@
+function squarePlusOne(value) {
+  return value * value + 2;
+}
+
+function axisCase(x, y) {
+  const total = x + y;
+  return squarePlusOne(total);
+}

--- a/bench/type4/coverage_probes/extract_method_inline/javascript/pos/a.js
+++ b/bench/type4/coverage_probes/extract_method_inline/javascript/pos/a.js
@@ -1,0 +1,4 @@
+function axisCase(x, y) {
+  const total = x + y;
+  return total * total + 1;
+}

--- a/bench/type4/coverage_probes/extract_method_inline/javascript/pos/b.js
+++ b/bench/type4/coverage_probes/extract_method_inline/javascript/pos/b.js
@@ -1,0 +1,8 @@
+function squarePlusOne(value) {
+  return value * value + 1;
+}
+
+function axisCase(x, y) {
+  const total = x + y;
+  return squarePlusOne(total);
+}

--- a/bench/type4/coverage_probes/extract_method_inline/python/neg-body/a.py
+++ b/bench/type4/coverage_probes/extract_method_inline/python/neg-body/a.py
@@ -1,0 +1,3 @@
+def axis_case(x: int, y: int) -> int:
+    total = x + y
+    return total * total + 1

--- a/bench/type4/coverage_probes/extract_method_inline/python/neg-body/b.py
+++ b/bench/type4/coverage_probes/extract_method_inline/python/neg-body/b.py
@@ -1,0 +1,7 @@
+def square_plus_one(value: int) -> int:
+    return value * value + 2
+
+
+def axis_case(x: int, y: int) -> int:
+    total = x + y
+    return square_plus_one(total)

--- a/bench/type4/coverage_probes/extract_method_inline/python/pos/a.py
+++ b/bench/type4/coverage_probes/extract_method_inline/python/pos/a.py
@@ -1,0 +1,3 @@
+def axis_case(x: int, y: int) -> int:
+    total = x + y
+    return total * total + 1

--- a/bench/type4/coverage_probes/extract_method_inline/python/pos/b.py
+++ b/bench/type4/coverage_probes/extract_method_inline/python/pos/b.py
@@ -1,0 +1,7 @@
+def square_plus_one(value: int) -> int:
+    return value * value + 1
+
+
+def axis_case(x: int, y: int) -> int:
+    total = x + y
+    return square_plus_one(total)

--- a/bench/type4/coverage_probes/extract_method_inline/rust/neg-body/a.rs
+++ b/bench/type4/coverage_probes/extract_method_inline/rust/neg-body/a.rs
@@ -1,0 +1,4 @@
+pub fn axis_case(x: i64, y: i64) -> i64 {
+    let total = x + y;
+    total * total + 1
+}

--- a/bench/type4/coverage_probes/extract_method_inline/rust/neg-body/b.rs
+++ b/bench/type4/coverage_probes/extract_method_inline/rust/neg-body/b.rs
@@ -1,0 +1,8 @@
+fn square_plus_one(value: i64) -> i64 {
+    value * value + 2
+}
+
+pub fn axis_case(x: i64, y: i64) -> i64 {
+    let total = x + y;
+    square_plus_one(total)
+}

--- a/bench/type4/coverage_probes/extract_method_inline/rust/pos/a.rs
+++ b/bench/type4/coverage_probes/extract_method_inline/rust/pos/a.rs
@@ -1,0 +1,4 @@
+pub fn axis_case(x: i64, y: i64) -> i64 {
+    let total = x + y;
+    total * total + 1
+}

--- a/bench/type4/coverage_probes/extract_method_inline/rust/pos/b.rs
+++ b/bench/type4/coverage_probes/extract_method_inline/rust/pos/b.rs
@@ -1,0 +1,8 @@
+fn square_plus_one(value: i64) -> i64 {
+    value * value + 1
+}
+
+pub fn axis_case(x: i64, y: i64) -> i64 {
+    let total = x + y;
+    square_plus_one(total)
+}

--- a/bench/type4/coverage_probes/extract_method_inline/typescript/neg-body/a.ts
+++ b/bench/type4/coverage_probes/extract_method_inline/typescript/neg-body/a.ts
@@ -1,0 +1,4 @@
+function axisCase(x: number, y: number): number {
+  const total = x + y;
+  return total * total + 1;
+}

--- a/bench/type4/coverage_probes/extract_method_inline/typescript/neg-body/b.ts
+++ b/bench/type4/coverage_probes/extract_method_inline/typescript/neg-body/b.ts
@@ -1,0 +1,8 @@
+function squarePlusOne(value: number): number {
+  return value * value + 2;
+}
+
+function axisCase(x: number, y: number): number {
+  const total = x + y;
+  return squarePlusOne(total);
+}

--- a/bench/type4/coverage_probes/extract_method_inline/typescript/pos/a.ts
+++ b/bench/type4/coverage_probes/extract_method_inline/typescript/pos/a.ts
@@ -1,0 +1,4 @@
+function axisCase(x: number, y: number): number {
+  const total = x + y;
+  return total * total + 1;
+}

--- a/bench/type4/coverage_probes/extract_method_inline/typescript/pos/b.ts
+++ b/bench/type4/coverage_probes/extract_method_inline/typescript/pos/b.ts
@@ -1,0 +1,8 @@
+function squarePlusOne(value: number): number {
+  return value * value + 1;
+}
+
+function axisCase(x: number, y: number): number {
+  const total = x + y;
+  return squarePlusOne(total);
+}

--- a/bench/type4/coverage_probes/filter_fusion/java/neg-pred/A.java
+++ b/bench/type4/coverage_probes/filter_fusion/java/neg-pred/A.java
@@ -1,0 +1,7 @@
+import java.util.Arrays;
+
+public class A {
+    public static Object axisCase(int[] xs) {
+        return Arrays.stream(xs).filter(x -> x > 0).filter(x -> x < 10);
+    }
+}

--- a/bench/type4/coverage_probes/filter_fusion/java/neg-pred/B.java
+++ b/bench/type4/coverage_probes/filter_fusion/java/neg-pred/B.java
@@ -1,0 +1,7 @@
+import java.util.Arrays;
+
+public class B {
+    public static Object axisCase(int[] xs) {
+        return Arrays.stream(xs).filter(x -> x > 0 || x < 10);
+    }
+}

--- a/bench/type4/coverage_probes/filter_fusion/java/pos/A.java
+++ b/bench/type4/coverage_probes/filter_fusion/java/pos/A.java
@@ -1,0 +1,7 @@
+import java.util.Arrays;
+
+public class A {
+    public static Object axisCase(int[] xs) {
+        return Arrays.stream(xs).filter(x -> x > 0).filter(x -> x < 10);
+    }
+}

--- a/bench/type4/coverage_probes/filter_fusion/java/pos/B.java
+++ b/bench/type4/coverage_probes/filter_fusion/java/pos/B.java
@@ -1,0 +1,7 @@
+import java.util.Arrays;
+
+public class B {
+    public static Object axisCase(int[] xs) {
+        return Arrays.stream(xs).filter(x -> x > 0 && x < 10);
+    }
+}

--- a/bench/type4/coverage_probes/identity_value_soundness/swift/neg-param/a.swift
+++ b/bench/type4/coverage_probes/identity_value_soundness/swift/neg-param/a.swift
@@ -1,0 +1,3 @@
+func axisCase(_ x: Int, _ y: Int) -> Int {
+    return x
+}

--- a/bench/type4/coverage_probes/identity_value_soundness/swift/neg-param/b.swift
+++ b/bench/type4/coverage_probes/identity_value_soundness/swift/neg-param/b.swift
@@ -1,0 +1,3 @@
+func axisCase(_ x: Int, _ y: Int) -> Int {
+    return y
+}

--- a/bench/type4/coverage_probes/loop_extent_soundness/c/neg-start/a.c
+++ b/bench/type4/coverage_probes/loop_extent_soundness/c/neg-start/a.c
@@ -1,0 +1,7 @@
+int axis_case(int *xs, int n) {
+    int total = 0;
+    for (int i = 0; i < n; i++) {
+        total += xs[i];
+    }
+    return total;
+}

--- a/bench/type4/coverage_probes/loop_extent_soundness/c/neg-start/b.c
+++ b/bench/type4/coverage_probes/loop_extent_soundness/c/neg-start/b.c
@@ -1,0 +1,7 @@
+int axis_case(int *xs, int n) {
+    int total = 0;
+    for (int i = 1; i < n; i++) {
+        total += xs[i];
+    }
+    return total;
+}

--- a/bench/type4/coverage_probes/loop_extent_soundness/go/neg-start/a.go
+++ b/bench/type4/coverage_probes/loop_extent_soundness/go/neg-start/a.go
@@ -1,0 +1,9 @@
+package p
+
+func AxisCase(xs []int) int {
+	total := 0
+	for i := 0; i < len(xs); i++ {
+		total += xs[i]
+	}
+	return total
+}

--- a/bench/type4/coverage_probes/loop_extent_soundness/go/neg-start/b.go
+++ b/bench/type4/coverage_probes/loop_extent_soundness/go/neg-start/b.go
@@ -1,0 +1,9 @@
+package p
+
+func AxisCase(xs []int) int {
+	total := 0
+	for i := 1; i < len(xs); i++ {
+		total += xs[i]
+	}
+	return total
+}

--- a/bench/type4/coverage_probes/loop_extent_soundness/javascript/neg-start/a.js
+++ b/bench/type4/coverage_probes/loop_extent_soundness/javascript/neg-start/a.js
@@ -1,0 +1,7 @@
+function axisCase(xs) {
+  let total = 0;
+  for (let i = 0; i < xs.length; i++) {
+    total += xs[i];
+  }
+  return total;
+}

--- a/bench/type4/coverage_probes/loop_extent_soundness/javascript/neg-start/b.js
+++ b/bench/type4/coverage_probes/loop_extent_soundness/javascript/neg-start/b.js
@@ -1,0 +1,7 @@
+function axisCase(xs) {
+  let total = 0;
+  for (let i = 1; i < xs.length; i++) {
+    total += xs[i];
+  }
+  return total;
+}

--- a/bench/type4/coverage_probes/loop_extent_soundness/python/neg-start/a.py
+++ b/bench/type4/coverage_probes/loop_extent_soundness/python/neg-start/a.py
@@ -1,0 +1,5 @@
+def axis_case(xs):
+    total = 0
+    for i in range(0, len(xs)):
+        total += xs[i]
+    return total

--- a/bench/type4/coverage_probes/loop_extent_soundness/python/neg-start/b.py
+++ b/bench/type4/coverage_probes/loop_extent_soundness/python/neg-start/b.py
@@ -1,0 +1,5 @@
+def axis_case(xs):
+    total = 0
+    for i in range(1, len(xs)):
+        total += xs[i]
+    return total

--- a/bench/type4/coverage_probes/loop_extent_soundness/ruby/neg-start/a.rb
+++ b/bench/type4/coverage_probes/loop_extent_soundness/ruby/neg-start/a.rb
@@ -1,0 +1,9 @@
+def axis_case(xs)
+  total = 0
+  i = 0
+  while i < xs.length
+    total += xs[i]
+    i += 1
+  end
+  total
+end

--- a/bench/type4/coverage_probes/loop_extent_soundness/ruby/neg-start/b.rb
+++ b/bench/type4/coverage_probes/loop_extent_soundness/ruby/neg-start/b.rb
@@ -1,0 +1,9 @@
+def axis_case(xs)
+  total = 0
+  i = 1
+  while i < xs.length
+    total += xs[i]
+    i += 1
+  end
+  total
+end

--- a/bench/type4/coverage_probes/loop_extent_soundness/rust/neg-start/a.rs
+++ b/bench/type4/coverage_probes/loop_extent_soundness/rust/neg-start/a.rs
@@ -1,0 +1,7 @@
+pub fn axis_case(xs: &[i64]) -> i64 {
+    let mut total = 0;
+    for i in 0..xs.len() {
+        total += xs[i];
+    }
+    total
+}

--- a/bench/type4/coverage_probes/loop_extent_soundness/rust/neg-start/b.rs
+++ b/bench/type4/coverage_probes/loop_extent_soundness/rust/neg-start/b.rs
@@ -1,0 +1,7 @@
+pub fn axis_case(xs: &[i64]) -> i64 {
+    let mut total = 0;
+    for i in 1..xs.len() {
+        total += xs[i];
+    }
+    total
+}

--- a/bench/type4/coverage_probes/loop_extent_soundness/swift/neg-start/a.swift
+++ b/bench/type4/coverage_probes/loop_extent_soundness/swift/neg-start/a.swift
@@ -1,0 +1,9 @@
+func axisCase(_ xs: [Int]) -> Int {
+    var total = 0
+    var i = 0
+    while i < xs.count {
+        total += xs[i]
+        i += 1
+    }
+    return total
+}

--- a/bench/type4/coverage_probes/loop_extent_soundness/swift/neg-start/b.swift
+++ b/bench/type4/coverage_probes/loop_extent_soundness/swift/neg-start/b.swift
@@ -1,0 +1,9 @@
+func axisCase(_ xs: [Int]) -> Int {
+    var total = 0
+    var i = 1
+    while i < xs.count {
+        total += xs[i]
+        i += 1
+    }
+    return total
+}

--- a/bench/type4/coverage_probes/loop_extent_soundness/typescript/neg-start/a.ts
+++ b/bench/type4/coverage_probes/loop_extent_soundness/typescript/neg-start/a.ts
@@ -1,0 +1,7 @@
+function axisCase(xs: number[]): number {
+  let total = 0;
+  for (let i = 0; i < xs.length; i++) {
+    total += xs[i];
+  }
+  return total;
+}

--- a/bench/type4/coverage_probes/loop_extent_soundness/typescript/neg-start/b.ts
+++ b/bench/type4/coverage_probes/loop_extent_soundness/typescript/neg-start/b.ts
@@ -1,0 +1,7 @@
+function axisCase(xs: number[]): number {
+  let total = 0;
+  for (let i = 1; i < xs.length; i++) {
+    total += xs[i];
+  }
+  return total;
+}

--- a/bench/type4/coverage_probes/map_fusion/java/neg-order/A.java
+++ b/bench/type4/coverage_probes/map_fusion/java/neg-order/A.java
@@ -1,0 +1,7 @@
+import java.util.Arrays;
+
+public class A {
+    public static Object axisCase(int[] xs) {
+        return Arrays.stream(xs).map(x -> x + 1).map(x -> x * 2);
+    }
+}

--- a/bench/type4/coverage_probes/map_fusion/java/neg-order/B.java
+++ b/bench/type4/coverage_probes/map_fusion/java/neg-order/B.java
@@ -1,0 +1,7 @@
+import java.util.Arrays;
+
+public class B {
+    public static Object axisCase(int[] xs) {
+        return Arrays.stream(xs).map(x -> x + 1 * 2);
+    }
+}

--- a/bench/type4/coverage_probes/map_fusion/java/pos/A.java
+++ b/bench/type4/coverage_probes/map_fusion/java/pos/A.java
@@ -1,0 +1,7 @@
+import java.util.Arrays;
+
+public class A {
+    public static Object axisCase(int[] xs) {
+        return Arrays.stream(xs).map(x -> x + 1).map(x -> x * 2);
+    }
+}

--- a/bench/type4/coverage_probes/map_fusion/java/pos/B.java
+++ b/bench/type4/coverage_probes/map_fusion/java/pos/B.java
@@ -1,0 +1,7 @@
+import java.util.Arrays;
+
+public class B {
+    public static Object axisCase(int[] xs) {
+        return Arrays.stream(xs).map(x -> (x + 1) * 2);
+    }
+}

--- a/bench/type4/coverage_probes/numeric_clamp/rust/neg-bound/a.rs
+++ b/bench/type4/coverage_probes/numeric_clamp/rust/neg-bound/a.rs
@@ -1,0 +1,9 @@
+pub fn axis_case(x: i64) -> i64 {
+    if x < 0 {
+        0
+    } else if x > 10 {
+        10
+    } else {
+        x
+    }
+}

--- a/bench/type4/coverage_probes/numeric_clamp/rust/neg-bound/b.rs
+++ b/bench/type4/coverage_probes/numeric_clamp/rust/neg-bound/b.rs
@@ -1,0 +1,3 @@
+pub fn axis_case(x: i64) -> i64 {
+    x.clamp(0, 9)
+}

--- a/bench/type4/coverage_probes/numeric_clamp/rust/pos/a.rs
+++ b/bench/type4/coverage_probes/numeric_clamp/rust/pos/a.rs
@@ -1,0 +1,9 @@
+pub fn axis_case(x: i64) -> i64 {
+    if x < 0 {
+        0
+    } else if x > 10 {
+        10
+    } else {
+        x
+    }
+}

--- a/bench/type4/coverage_probes/numeric_clamp/rust/pos/b.rs
+++ b/bench/type4/coverage_probes/numeric_clamp/rust/pos/b.rs
@@ -1,0 +1,3 @@
+pub fn axis_case(x: i64) -> i64 {
+    x.clamp(0, 10)
+}

--- a/bench/type4/coverage_probes/total_order_compare/java/neg-operator/A.java
+++ b/bench/type4/coverage_probes/total_order_compare/java/neg-operator/A.java
@@ -1,0 +1,5 @@
+public class A {
+    public static boolean axisCase(int x, int y) {
+        return x < y || x <= y;
+    }
+}

--- a/bench/type4/coverage_probes/total_order_compare/java/neg-operator/B.java
+++ b/bench/type4/coverage_probes/total_order_compare/java/neg-operator/B.java
@@ -1,0 +1,5 @@
+public class B {
+    public static boolean axisCase(int x, int y) {
+        return x < y;
+    }
+}

--- a/bench/type4/coverage_probes/total_order_compare/java/pos/A.java
+++ b/bench/type4/coverage_probes/total_order_compare/java/pos/A.java
@@ -1,0 +1,5 @@
+public class A {
+    public static boolean axisCase(int x, int y) {
+        return x < y && x <= y;
+    }
+}

--- a/bench/type4/coverage_probes/total_order_compare/java/pos/B.java
+++ b/bench/type4/coverage_probes/total_order_compare/java/pos/B.java
@@ -1,0 +1,5 @@
+public class B {
+    public static boolean axisCase(int x, int y) {
+        return x < y;
+    }
+}

--- a/bench/type4/coverage_probes/typed_concat_soundness/go/neg-order/a.go
+++ b/bench/type4/coverage_probes/typed_concat_soundness/go/neg-order/a.go
@@ -1,0 +1,5 @@
+package p
+
+func AxisCase(a string, b string) string {
+	return a + b
+}

--- a/bench/type4/coverage_probes/typed_concat_soundness/go/neg-order/b.go
+++ b/bench/type4/coverage_probes/typed_concat_soundness/go/neg-order/b.go
@@ -1,0 +1,5 @@
+package p
+
+func AxisCase(a string, b string) string {
+	return b + a
+}

--- a/bench/type4/coverage_probes/typed_concat_soundness/java/neg-order/A.java
+++ b/bench/type4/coverage_probes/typed_concat_soundness/java/neg-order/A.java
@@ -1,0 +1,5 @@
+public class A {
+    public static String axisCase(String a, String b) {
+        return a + b;
+    }
+}

--- a/bench/type4/coverage_probes/typed_concat_soundness/java/neg-order/B.java
+++ b/bench/type4/coverage_probes/typed_concat_soundness/java/neg-order/B.java
@@ -1,0 +1,5 @@
+public class B {
+    public static String axisCase(String a, String b) {
+        return b + a;
+    }
+}

--- a/bench/type4/coverage_probes/typed_concat_soundness/javascript/neg-order/a.js
+++ b/bench/type4/coverage_probes/typed_concat_soundness/javascript/neg-order/a.js
@@ -1,0 +1,3 @@
+function axisCase(a, b) {
+  return a + b;
+}

--- a/bench/type4/coverage_probes/typed_concat_soundness/javascript/neg-order/b.js
+++ b/bench/type4/coverage_probes/typed_concat_soundness/javascript/neg-order/b.js
@@ -1,0 +1,3 @@
+function axisCase(a, b) {
+  return b + a;
+}

--- a/bench/type4/coverage_probes/typed_concat_soundness/python/neg-order/a.py
+++ b/bench/type4/coverage_probes/typed_concat_soundness/python/neg-order/a.py
@@ -1,0 +1,2 @@
+def axis_case(a: str, b: str) -> str:
+    return a + b

--- a/bench/type4/coverage_probes/typed_concat_soundness/python/neg-order/b.py
+++ b/bench/type4/coverage_probes/typed_concat_soundness/python/neg-order/b.py
@@ -1,0 +1,2 @@
+def axis_case(a: str, b: str) -> str:
+    return b + a

--- a/bench/type4/coverage_probes/typed_concat_soundness/ruby/neg-order/a.rb
+++ b/bench/type4/coverage_probes/typed_concat_soundness/ruby/neg-order/a.rb
@@ -1,0 +1,3 @@
+def axis_case(a, b)
+  a + b
+end

--- a/bench/type4/coverage_probes/typed_concat_soundness/ruby/neg-order/b.rb
+++ b/bench/type4/coverage_probes/typed_concat_soundness/ruby/neg-order/b.rb
@@ -1,0 +1,3 @@
+def axis_case(a, b)
+  b + a
+end

--- a/bench/type4/coverage_probes/typed_concat_soundness/rust/neg-order/a.rs
+++ b/bench/type4/coverage_probes/typed_concat_soundness/rust/neg-order/a.rs
@@ -1,0 +1,3 @@
+pub fn axis_case(a: String, b: String) -> String {
+    a + &b
+}

--- a/bench/type4/coverage_probes/typed_concat_soundness/rust/neg-order/b.rs
+++ b/bench/type4/coverage_probes/typed_concat_soundness/rust/neg-order/b.rs
@@ -1,0 +1,3 @@
+pub fn axis_case(a: String, b: String) -> String {
+    b + &a
+}

--- a/bench/type4/coverage_probes/typed_concat_soundness/swift/neg-order/a.swift
+++ b/bench/type4/coverage_probes/typed_concat_soundness/swift/neg-order/a.swift
@@ -1,0 +1,3 @@
+func axisCase(_ a: String, _ b: String) -> String {
+    return a + b
+}

--- a/bench/type4/coverage_probes/typed_concat_soundness/swift/neg-order/b.swift
+++ b/bench/type4/coverage_probes/typed_concat_soundness/swift/neg-order/b.swift
@@ -1,0 +1,3 @@
+func axisCase(_ a: String, _ b: String) -> String {
+    return b + a
+}

--- a/bench/type4/coverage_probes/typed_concat_soundness/typescript/neg-order/a.ts
+++ b/bench/type4/coverage_probes/typed_concat_soundness/typescript/neg-order/a.ts
@@ -1,0 +1,3 @@
+function axisCase(a: string, b: string): string {
+  return a + b;
+}

--- a/bench/type4/coverage_probes/typed_concat_soundness/typescript/neg-order/b.ts
+++ b/bench/type4/coverage_probes/typed_concat_soundness/typescript/neg-order/b.ts
@@ -1,0 +1,3 @@
+function axisCase(a: string, b: string): string {
+  return b + a;
+}

--- a/docs/type4-benchmark.md
+++ b/docs/type4-benchmark.md
@@ -88,15 +88,17 @@ unsafe boundaries), and the shared strict engine consumes them.
 `capabilities.v1.json` records which surfaces emit which facts, so unsupported cells stay
 visible.
 
-The checked-in matrix keeps every primary language at or above 50% applicable-cell
-coverage. Pure hard-negative sweep rows count only for soundness-family axes, where the
-cell claim is precisely that adjacent non-equivalent forms stay unmerged.
+The checked-in matrix keeps every primary language at or above 56% applicable-cell
+coverage. Pure hard-negative sweep/probe rows count only for soundness-family axes, where
+the cell claim is precisely that adjacent non-equivalent forms stay unmerged. The probe
+harness permits `pos/`-less hard-negative fixtures only for those soundness-family axes.
 
 Swift participates as a first-party surface in the capability matrix and generator. Its
-evidence-backed Type-4 matrix coverage is 12/24 applicable cells: collection emptiness,
+evidence-backed Type-4 matrix coverage is 15/24 applicable cells: collection emptiness,
 string affix, membership, option presence, for-in/indexed reduction, immutable binding,
 proven callee identity, extract-method inline, tail numeric recursion, scalar min/max,
-filter fusion, and map fusion. Swift flat-map/filter-map, map-default, clamp, import
+filter fusion, map fusion, and hard-negative guards for identity/value, loop extent, and
+typed concatenation soundness. Swift flat-map/filter-map, map-default, clamp, import
 identity, and scalar abs sign-ternary surfaces remain visible as unsupported or partial
 until their receiver, demand, or proof boundaries are modeled.
 


### PR DESCRIPTION
## Summary
- add evidence-backed recall probes for Java total-order comparison, Java filter/map fusion, Rust clamp, and extract-method inline for JS/TS/Python/Rust
- add soundness-only hard-negative probes for loop extent, typed concatenation order, and Swift identity/value boundaries
- restrict `pos/`-less probe support to taxonomy soundness-family axes and surface those rows as `no-positive`
- regenerate the Type-4 matrix and update benchmark docs

## Quantitative comparison
- python: 21/26 = 80.8% (+11.5pp)
- javascript: 20/27 = 74.1% (+11.1pp)
- typescript: 20/27 = 74.1% (+11.1pp)
- rust: 18/25 = 72.0% (+16.0pp)
- java: 19/27 = 70.4% (+14.8pp)
- go: 16/24 = 66.7% (+8.3pp)
- ruby: 16/24 = 66.7% (+8.3pp)
- swift: 15/24 = 62.5% (+12.5pp)
- c: 13/23 = 56.5% (+4.3pp)

Overall: 158/227 applicable cells = 69.6%.

## Discipline
- recall cells include `pos/` plus adjacent `neg-*` fixtures
- soundness-only cells omit `pos/` only on soundness-family axes and require `neg-*` fixtures with zero false merges
- non-target existing evidence rows were preserved; this PR adds 25 evidence rows

## Checks
- read-only verification of the 25 new probe cells
- `python3 bench/type4/coverage_matrix.py matrix`
- `git diff --check`
- `python3 -m py_compile bench/type4/coverage_probe.py bench/type4/coverage_matrix.py`
- `awiki lint --root docs`
- `./scripts/check-ci-local.sh --fast`
