### PR TITLE
feat(markdown): P3 containment-witness gate — drop scattered-vocab small-in-large FPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ break.
   spec repo went 206 incoherent families → 140 families + 14 templates; nose's own docs' jargon
   over-merge is now a template, surfacing the real drift finding at #0. Golden metrics unchanged
   (PR-AUC 0.995). Addresses #443.
+- **`nose markdown` containment-witness gate (P3, from the second field eval).** A genuine
+  small-in-large (size-disparate) containment match must now have a real *contiguous* shared-line
+  block, not just scattered char-gram overlap — a small generic stub doc no longer gets pulled
+  into a large unrelated doc by common-morpheme coincidence. Surgical: one field project's
+  spurious mixed-granularity families dropped (8 → 5, all remaining coherent) with zero change to
+  any other project, genuine small-in-large and reworded same-size near-dups preserved, golden
+  metrics unchanged (PR-AUC 0.995).
 
 ## [0.12.0] - 2026-06-18
 

--- a/crates/nose-markdown/src/detect.rs
+++ b/crates/nose-markdown/src/detect.rs
@@ -61,6 +61,9 @@ pub struct Options {
     /// floor that drops thin overlaps without requiring identical lines (so reworded near-dups,
     /// which have no identical line but share many grams, are preserved).
     pub min_shared_grams: usize,
+    /// A containment-rescued (small-in-large) pair must have a contiguous span witness of at least
+    /// this many lines — proof of a real shared block, not scattered-vocabulary coincidence.
+    pub min_containment_witness: u32,
 }
 
 impl Default for Options {
@@ -70,6 +73,7 @@ impl Default for Options {
             threshold: 0.5,
             cluster_threshold: 0.7,
             min_shared_grams: 24,
+            min_containment_witness: 2,
         }
     }
 }
@@ -132,12 +136,27 @@ pub fn detect(docs: &[(String, String)], opts: &Options) -> Vec<Family> {
     for (i, j) in cands {
         let cos = model.tfidf_cosine(&fps[i], &fps[j]);
         let cont = fingerprint::containment(&fps[i].shingles, &fps[j].shingles);
-        // TF-IDF is the primary relation score; containment rescues small-in-large.
+        // TF-IDF is the primary relation score; containment rescues small-in-large (unchanged).
         let rel = if cont >= 0.8 && cont > cos { cont } else { cos };
         let shared = fingerprint::shared_grams(&fps[i].shingles, &fps[j].shingles);
-        if rel >= opts.threshold && shared >= opts.min_shared_grams {
-            accepted.push((i, j, rel));
+        if rel < opts.threshold || shared < opts.min_shared_grams {
+            continue;
         }
+        // Genuine SMALL-IN-LARGE (a real size disparity) only: a small unit's grams are
+        // "contained" in a large one even by mere common-morpheme coincidence between unrelated
+        // docs. Require a real CONTIGUOUS shared block (line witness) before trusting it — so a
+        // tiny stub doc is not pulled into a big unrelated doc. Same-size high-overlap pairs are
+        // left to the score above (cosine/containment), so reworded near-dups are unaffected.
+        let (la, lb) = (fps[i].shingles.len(), fps[j].shingles.len());
+        let small_in_large = la.min(lb) * 2 < la.max(lb) && cont >= 0.8 && cont > cos;
+        if small_in_large {
+            let has_block = witness::witness(&units[i], &units[j])
+                .is_some_and(|w| w.matched_lines >= opts.min_containment_witness);
+            if !has_block {
+                continue;
+            }
+        }
+        accepted.push((i, j, rel));
     }
     if accepted.is_empty() {
         return Vec::new();
@@ -361,5 +380,25 @@ mod tests {
             fams.is_empty(),
             "thin shared phrase must not form a family: {fams:?}"
         );
+    }
+
+    #[test]
+    fn genuine_small_in_large_still_detected() {
+        // A real multi-line block pasted into a larger doc must still be found (P3 must not
+        // break true small-in-large — only scattered-vocabulary containment is dropped).
+        let block = "The configuration loader reads the settings file at startup.\n\
+                     It validates every required field before continuing.\n\
+                     Then the server begins accepting incoming network connections.";
+        let small = format!("# Note\n\n{block}");
+        let large = format!(
+            "# Host\n\nAn unrelated introduction about entirely different matters here.\n\n\
+             {block}\n\nAn unrelated conclusion about other separate topics here too."
+        );
+        let fams = detect(
+            &[doc("small.md", &small), doc("large.md", &large)],
+            &Options::default(),
+        );
+        assert_eq!(fams.len(), 1, "pasted block should be found: {fams:?}");
+        assert!(fams[0].witness.is_some());
     }
 }


### PR DESCRIPTION
## P3 — containment-witness gate (drops scattered-vocab small-in-large false positives)

Final fix from the cross-project field evaluation. A small, generic doc's char-grams get "contained" in a large doc even by **common-morpheme coincidence** between unrelated docs, so tiny stub docs were pulled into big unrelated docs (craken-agents: a 4-line stub clustered with a 229-line doc, **no shared block**).

**Fix (additive, surgical):** a containment-rescued pair that is genuinely **size-disparate** (small-in-large) must also have a **contiguous span witness** (≥ `min_containment_witness` lines) — proof of a real shared block, not scattered overlap. Same-size high-overlap pairs are scored exactly as before, so reworded same-size near-dups and templates are unaffected.

### Evaluation (no problems found)
- **Golden: unchanged** — PR-AUC 0.9952, ROC 0.9916, R@P95 0.964, candidate-recall 1.0 (score_pairs path untouched).
- **Target fixed:** craken-agents **8 → 5 families**; the 3 mixed-granularity containment over-merges are gone, all 5 remaining are coherent/genuine (exact SKILL.md sections + parallel eval-report blocks, each with a witness).
- **Zero collateral damage:** every other field project identical to before (moonlight 140+14, specdown 4, tts 2, security-audit 3, ocr 1, nose-self 3+1, clean repos 0). Genuine small-in-large preserved.

### Gates
`cargo test --workspace`, `clippy --workspace --all-targets`, `cargo doc -D warnings`, `cargo fmt --check` all green. 28 `nose-markdown` tests incl. `genuine_small_in_large_still_detected`.

Addresses #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
