### PR TITLE
fix(swift): close implicit member lowering gap

### DIFF
--- a/crates/nose-frontend/src/swift.rs
+++ b/crates/nose-frontend/src/swift.rs
@@ -39,6 +39,7 @@ fn lower_items(lo: &mut Lowering, node: TsNode) -> NodeId {
 fn lower_item(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     match node.kind() {
         "function_declaration" => Some(lower_function(lo, node, false)),
+        "protocol_function_declaration" => Some(lower_function(lo, node, true)),
         "init_declaration" | "deinit_declaration" | "subscript_declaration" => {
             Some(lower_function(lo, node, true))
         }
@@ -47,7 +48,9 @@ fn lower_item(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
         | "enum_declaration"
         | "protocol_declaration" => Some(lower_type(lo, node)),
         "extension_declaration" => Some(lower_extension(lo, node)),
-        "property_declaration" => Some(lower_property(lo, node)),
+        "property_declaration"
+        | "protocol_property_declaration"
+        | "protocol_property_requirements" => Some(lower_property(lo, node)),
         "import_declaration" => Some(lower_import(lo, node)),
         "typealias_declaration"
         | "associatedtype_declaration"
@@ -225,12 +228,15 @@ fn lower_stmt(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
     match node.kind() {
         "statements" | "function_body" => Some(lower_block(lo, node)),
         "function_declaration" => Some(lower_function(lo, node, false)),
+        "protocol_function_declaration" => Some(lower_function(lo, node, true)),
         "class_declaration"
         | "struct_declaration"
         | "enum_declaration"
         | "protocol_declaration" => Some(lower_type(lo, node)),
         "extension_declaration" => Some(lower_extension(lo, node)),
-        "property_declaration" => Some(lower_property(lo, node)),
+        "property_declaration"
+        | "protocol_property_declaration"
+        | "protocol_property_requirements" => Some(lower_property(lo, node)),
         "assignment" => Some(lower_assignment(lo, node)),
         "control_transfer_statement" => lower_control_transfer(lo, node),
         "if_statement" | "guard_statement" => Some(lower_if(lo, node)),
@@ -913,9 +919,26 @@ fn lower_prefix(lo: &mut Lowering, node: TsNode) -> NodeId {
         lo.add(NodeKind::UnOp, Payload::Op(Op::Neg), span, &[operand])
     } else if op_text.starts_with('+') || op_text == "&" {
         operand
+    } else if op_text.starts_with('.') {
+        lower_implicit_member(lo, span, operand)
     } else {
         lo.raw("prefix_expression", span, &[operand])
     }
+}
+
+fn lower_implicit_member(lo: &mut Lowering, span: Span, member: NodeId) -> NodeId {
+    if lo.b.kind(member) == NodeKind::Var {
+        if let Payload::Name(field) = lo.b.payload(member) {
+            let base = lo.var("swift_implicit_member", span);
+            return lo.add(NodeKind::Field, Payload::Name(field), span, &[base]);
+        }
+    }
+    lo.add(
+        NodeKind::Seq,
+        Payload::Name(lo.sym("swift_implicit_member")),
+        span,
+        &[member],
+    )
 }
 
 fn lower_postfix(lo: &mut Lowering, node: TsNode) -> NodeId {
@@ -1363,6 +1386,21 @@ mod tests {
         il_with_interner(src).0
     }
 
+    fn raw_names(il: &Il, interner: &Interner) -> Vec<String> {
+        il.nodes
+            .iter()
+            .filter_map(|node| {
+                if node.kind != NodeKind::Raw {
+                    return None;
+                }
+                let Payload::Name(name) = node.payload else {
+                    return None;
+                };
+                Some(interner.resolve(name).to_string())
+            })
+            .collect()
+    }
+
     #[test]
     fn function_lowers_to_unit() {
         let il = il(r#"
@@ -1526,5 +1564,69 @@ func mapped(_ xs: [Int]) -> [Int] {
         assert!(!il.nodes.iter().any(|node| {
             node.kind == NodeKind::Seq && matches!(node.payload, Payload::Name(_))
         }));
+    }
+
+    #[test]
+    fn implicit_member_shorthand_lowers_without_raw_prefix() {
+        let (il, interner) = il_with_interner(
+            r#"
+func axis() -> Any {
+    return .vertical
+}
+
+func space() -> Any {
+    return .named("scroll")
+}
+"#,
+        );
+        assert!(
+            !raw_names(&il, &interner)
+                .iter()
+                .any(|name| name == "prefix_expression"),
+            "implicit member syntax should not stay as a generic Raw prefix"
+        );
+        let implicit = interner.intern("swift_implicit_member");
+        assert!(il.nodes.iter().enumerate().any(|(idx, node)| {
+            if node.kind != NodeKind::Field {
+                return false;
+            }
+            let children = il.children(NodeId(idx as u32));
+            matches!(
+                children,
+                [receiver]
+                    if il.kind(*receiver) == NodeKind::Var
+                        && il.node(*receiver).payload == Payload::Name(implicit)
+            )
+        }));
+    }
+
+    #[test]
+    fn protocol_requirements_lower_as_signature_units() {
+        let (il, interner) = il_with_interner(
+            r#"
+protocol Store {
+    var count: Int { get }
+    func fetch(_ key: String) async throws -> Int
+}
+"#,
+        );
+        let raw = raw_names(&il, &interner);
+        assert!(
+            !raw.iter().any(|name| matches!(
+                name.as_str(),
+                "protocol_function_declaration"
+                    | "protocol_property_declaration"
+                    | "protocol_property_requirements"
+            )),
+            "protocol requirements should lower as declaration/signature structure, got {raw:?}"
+        );
+        assert!(
+            il.units
+                .iter()
+                .any(|unit| unit.kind == UnitKind::Method
+                    && unit.name == Some(interner.intern("fetch"))),
+            "protocol function requirement should be a method-like unit"
+        );
+        assert!(il.nodes.iter().any(|node| node.kind == NodeKind::Param));
     }
 }

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -3053,3 +3053,44 @@ measure, not assume — here it is small.
 **Follow-up (not soundness):** real-corpus evidence for the js/ts/rust cells (js/ts libraries keep
 parallel sync/async versions far less often than Python ones, so no clean mined twin yet), and
 extending the mechanism to Rust `.await` and the other protocol boundaries.
+
+## CV. Swift lowering gap tranche from trace dogfood (#452, 2026-06-18)
+
+The `../trace` Swift app dogfood run made the Swift Raw tail concrete: baseline
+`nose stats ../trace` showed Swift at **18,083 Raw / 325,423 nodes = 5.557%**, with
+`prefix_expression` alone contributing **8,522** gap nodes. Inspecting the raw IL showed the
+dominant prefix shape was Swift's implicit member shorthand (`.vertical`, `.named(...)`,
+`.top`, etc.), especially in SwiftUI call sites. Treating that as an ordinary bare identifier
+would be unsound (`.vertical` is contextual enum/member syntax, not `vertical`), but keeping it
+as a generic `Raw("prefix_expression")` lost useful structure and made every shorthand look like
+the same lowering gap.
+
+**Fix shipped in this tranche.** Swift implicit member shorthand now lowers to a distinct
+sentinel receiver shape (`swift_implicit_member.member`), so it is not equal to a bare variable
+and does not claim a concrete enum type. Protocol function/property requirements also lower as
+signature/declaration structure instead of raw protocol declaration nodes, which directly
+addresses the protocol-heavy duplication seen in `../trace`.
+
+**Measured result.** Re-running the same dogfood command with the patched binary:
+
+```text
+swift 344 files · 330,442 nodes · 7,056 Raw · 2.135% raw · 2,062 boundary Raw
+```
+
+The total Swift Raw count drops **18,083 → 7,056** and `prefix_expression` /
+`protocol_function_declaration` leave the top gap list. The remaining largest Swift gaps are
+`value_binding_pattern` (1,963), `switch_pattern` (1,235), `enum_entry` (434),
+`key_path_expression` (213), and `ternary_expression` (127). `await` and `try` remain protocol
+boundaries, not lowering misses.
+
+**Query quality check.** `nose query ../trace lang=swift sort=extractability top=5` still leads
+with the previously hand-verified refactoring candidates (`sectionTitle`, `CurrentTimeLineView`,
+`EventsView`, the low-shared input/settings UI pattern, and `handleRecurringEventUpdate`), while
+the default Swift family count moves from 415 to 388 because the implicit-member structure changes
+some structural similarity grouping. This is acceptable for a lowering change; the top actionable
+signal did not disappear.
+
+**Next safe tranche.** `value_binding_pattern` and `switch_pattern` need pattern-aware lowering,
+not a blind Raw erase: `if let`, `case let`, wildcard, enum-associated-value, and binding
+patterns carry different control-flow and binding semantics. They should be closed with focused
+convergence fixtures before being generalized.


### PR DESCRIPTION
Closes #452.

## Summary
- lower Swift implicit member shorthand (`.foo` / `.named(...)`) with a `swift_implicit_member` sentinel receiver instead of generic `Raw(prefix_expression)`
- lower Swift protocol function and property requirements as signature/property units
- add focused frontend tests and record the trace dogfood measurement in docs

## Measurements
`../trace` with the release binary:
- Swift Raw nodes: 18,083 -> 7,056
- Swift Raw ratio: 5.557% -> 2.135%
- `prefix_expression` and protocol requirement declarations leave the top unhandled set
- Swift query families: 415 -> 388, while the top actionable candidates stay stable

Remaining prominent Swift gaps:
- `value_binding_pattern`: 1,963
- `switch_pattern`: 1,235
- `enum_entry`: 434
- `key_path_expression`: 213
- `ternary_expression`: 127

## Verification
- `cargo fmt --all`
- `cargo test -p nose-frontend swift::tests`
- `cargo test -p nose-cli swift_`
- `cargo build --release`
- `./target/release/nose stats ../trace --format json`
- `./target/release/nose query ../trace lang=swift sort=extractability top=5`
- `./scripts/check-ci-local.sh --fast`