### PR TITLE
Release v0.13.0: Swift frontend + Markdown near-dup as a `nose query` domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,64 @@ All notable changes to nose are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); pre-1.0, so minor versions may
 break.
 
-## [Unreleased]
+## [0.13.0] - 2026-06-18
+
+Adds a **Swift** language frontend and brings **Markdown near-duplicate prose** detection into
+`nose query` as a new domain (alongside code, CSS, and HTML), plus a Type-4 soundness fix and a
+higher cross-language Type-4 coverage floor. Detection of the existing languages and the
+`--format json` query-JSON v2 contract are unchanged.
 
 ### Added
+- **Swift language frontend (#442).** Swift joins the first-party languages (Python, JavaScript,
+  TypeScript, Go, Rust, Java, C, Ruby) with tree-sitter lowering and semantic coverage, so Swift
+  copy-paste, renamed, and Type-4 same-logic clones are detected and proven like the others.
+- **Markdown same-language near-duplicate prose as a `nose query` domain (epic #435).** `nose
+  query` now reports near-duplicate **prose** across Markdown documents alongside code clones. Per
+  *capabilities over features*, duplication has **one entry point**, so markdown is surfaced
+  through `nose query` exactly as the CSS/HTML declarative track is — a "markdown near-duplicates"
+  section in the human dashboard and a top-level `markdown` array under `--format json` — not as a
+  separate command. Prose is not code, so it uses a deliberately separate `nose-markdown` engine:
+  a character-n-gram pipeline (MinHash-LSH + winnowing + containment candidate generation →
+  IDF-weighted TF-IDF verify/rank → line-level Smith-Waterman span witness), not the value-graph
+  IL. Reports ranked families with a relation tier + score, an exact **span witness**, and
+  orthogonal evidence (**commonness**/DF, removable lines, files). Honesty contract:
+  "near-duplicate (score + witness + commonness)", never "same meaning" or "worth removing" —
+  boilerplate copies are true duplicates surfaced with high commonness, never suppressed.
+  Same-language only (cross-lingual/paraphrase need an LLM, out of scope). Deterministic
+  (byte-identical output). Measured against frozen, **LLM-built goldens** (`bench/markdown/`, no
+  human in the loop: 3 heterogeneous judges, Fleiss κ 0.70/0.71, anchor self-calibration 1.0):
+  PR-AUC 0.995 / R@P95 0.96 on the code-of-conduct corpus, and an honest multi-genre baseline of
+  PR-AUC **0.944** / R@P95 **0.74** across 5 doc genres, candidate-recall 1.0. Built on the
+  algorithm survey in `docs/markdown-dup-detection-algorithm-survey-2026-06-18.md`. See
+  [docs/markdown-duplication.md](docs/markdown-duplication.md).
+  (#435 #436 #437 #438 #439 #440 #441 #444)
+  - **Field-evaluation precision/usefulness fixes (#443, #447).** (P0) default vendor-dir excludes
+    (`node_modules`, `vendor`, `target`, …) + `nose.toml` `exclude` globs, so a non-git project's
+    `node_modules` no longer floods the report (one field project went 145 noise families → 0); a
+    **min-shared-grams** match-substance floor drops thin overlaps. (P1) strip GFM table
+    scaffolding (pipes/separator rows are format, not content); **strong-edge clustering** (weak
+    edges corroborate but don't chain mega-families); confidence-weighted ranking. (P2) large
+    multi-file clusters are reported as **templated sections** ("skeleton repeated N× across M
+    files"), not a clone family — so a templated-doc blob no longer masquerades as one family.
+  - **Containment-witness gate (P3, #449).** A size-disparate small-in-large containment match
+    must now have a real *contiguous* shared-line block, not just scattered char-gram overlap — a
+    small generic stub no longer gets pulled into a large unrelated doc by common-morpheme
+    coincidence. Surgical: one field project's spurious mixed-granularity families dropped 8 → 5
+    with genuine small-in-large and reworded same-size near-dups preserved.
+  - **Synthetic recall-vs-edit-ratio benchmark + recall gate (#443, #450).** The golden gates
+    precision; this adds the missing **recall** gate — a deterministic, self-contained benchmark
+    (`nose-markdown::synth`, committed base corpus) that injects controlled edits at known ratios
+    and asserts recall floors (1.00 / 0.95 / 0.85 / 0.65 at 0/0.1/0.2/0.35 edit ratio), so a
+    future change that silently sacrifices recall fails CI.
+  - **Multi-domain precision golden + regression gate (#443, #454).** The original precision
+    golden was single-genre boilerplate (Contributor Covenant CoC), which over-stated precision.
+    Added a frozen **multi-domain** golden — `bench/markdown/corpus-docs/` (165 files across 5
+    genres: CLI reference, function/API reference, guides, framework docs, READMEs) +
+    `golden.docs.v1.json`, built the same no-human way (Fleiss κ 0.71), wired into a precision
+    regression gate (`eval::docs_golden_precision_floor`). The golden-build scripts now take paths
+    so any corpus can be golden'd.
+
+### Changed
 - **Swift Type-4 exact coverage parity slice.** Swift now has evidence-backed exact-query
   coverage for five previously-open matrix cells: typed `flatMap` vs nested append builders,
   module import identity, `Dictionary[key, default:]` map-default lookup, literal `Int`
@@ -16,53 +71,21 @@ break.
   comparisons remain adjacent hard negatives. The checked-in Type-4 matrix moves Swift from
   15/24 to 20/24 applicable cells, and focused probes now run through
   `nose query ... witness=exact` rather than the deprecated scan path.
-- **Markdown same-language near-duplicate detection (`nose markdown`, epic #435).** A new,
-  deliberately separate `nose-markdown` engine finds near-duplicate **prose** across Markdown
-  documents — prose is not code, so it uses a character-n-gram pipeline (MinHash-LSH + winnowing
-  + containment candidate generation → IDF-weighted TF-IDF verify/rank → line-level
-  Smith-Waterman span witness), not the value-graph IL. Reports ranked families with a relation
-  tier + score, an exact **span witness**, and orthogonal evidence (**commonness**/DF, removable
-  lines, files). Honesty contract: "near-duplicate (score + witness + commonness)", never "same
-  meaning" or "worth removing" — boilerplate copies are true duplicates surfaced with high
-  commonness, never suppressed. Same-language only (cross-lingual/paraphrase need an LLM, out of
-  scope). Deterministic (byte-identical output). Measured against a frozen, **LLM-built golden**
-  (`bench/markdown/`, no human in the loop: 3 heterogeneous judges, Fleiss κ 0.70, anchor
-  self-calibration 1.0): PR-AUC 0.995, R@P95 0.96, candidate-recall 1.0. Built on the algorithm
-  survey in `docs/markdown-dup-detection-algorithm-survey-2026-06-18.md`. See
-  [docs/markdown-duplication.md](docs/markdown-duplication.md). (#436 #437 #438 #439 #440 #441)
-- **`nose markdown` precision/usefulness fixes from the cross-project field evaluation.**
-  (P0) default vendor-dir excludes (`node_modules`, `vendor`, `target`, …) + `nose.toml`
-  `exclude` globs, so a non-git project's `node_modules` no longer floods the report (one field
-  project went 145 noise families → 0); a **min-shared-grams** match-substance floor drops
-  thin overlaps. (P1) strip GFM table scaffolding (pipes/separator rows are format, not content);
-  **strong-edge clustering** (weak edges corroborate but don't chain mega-families);
-  confidence-weighted ranking. (P2) large multi-file clusters are reported as **templated
-  sections** ("skeleton repeated N× across M files"), not a clone family — so a templated-doc
-  blob no longer masquerades as one family or tops the list. Field deltas: a templated Korean
-  spec repo went 206 incoherent families → 140 families + 14 templates; nose's own docs' jargon
-  over-merge is now a template, surfacing the real drift finding at #0. Golden metrics unchanged
-  (PR-AUC 0.995). Addresses #443.
-- **`nose markdown` containment-witness gate (P3, from the second field eval).** A genuine
-  small-in-large (size-disparate) containment match must now have a real *contiguous* shared-line
-  block, not just scattered char-gram overlap — a small generic stub doc no longer gets pulled
-  into a large unrelated doc by common-morpheme coincidence. Surgical: one field project's
-  spurious mixed-granularity families dropped (8 → 5, all remaining coherent) with zero change to
-  any other project, genuine small-in-large and reworded same-size near-dups preserved, golden
-  metrics unchanged (PR-AUC 0.995).
-- **Synthetic recall-vs-edit-ratio benchmark (#443).** The golden gates precision; this adds the
-  missing **recall** gate — a deterministic, self-contained benchmark (`nose-markdown::synth`,
-  committed base corpus) that injects controlled edits at known ratios and asserts recall floors
-  (1.00 / 0.95 / 0.85 / 0.65 at 0/0.1/0.2/0.35 edit ratio), so a future change that silently
-  sacrifices recall fails CI. Closes the actionable remainder of #443.
-- **Multi-domain precision golden (#443).** The original precision golden was single-genre
-  boilerplate (Contributor Covenant CoC), which over-stated precision. Added a frozen, committed
-  **multi-domain** golden — `bench/markdown/corpus-docs/` (165 files across 5 genres: CLI
-  reference, function/API reference, guides, framework docs, READMEs) + `golden.docs.v1.json`,
-  built the same no-human way (3 heterogeneous judges, Fleiss κ 0.71, anchor self-calibration
-  1.0). It is the honest baseline: PR-AUC **0.944** / R@P95 **0.74** (vs 0.995 / 0.96 on CoC),
-  candidate-recall 1.0 — the templated-but-different pairs across real doc genres are genuinely
-  harder. Wired into a **precision regression gate** (`eval::docs_golden_precision_floor`). The
-  golden-build scripts now take paths so any corpus can be golden'd.
+- **Type-4 coverage floor raised to ≥50%.** The checked-in coverage matrix
+  (`bench/type4/coverage_matrix.v1.json`) now keeps every primary language at or above 56% of
+  covered applicable cells, backed by new evidence-carrying probes (extract-method-inline,
+  numeric tail recursion, …) for C, Go, and others.
+
+### Fixed
+- **`structural_fold` reassociation gated to integer heads (#434).** A Lean obligation audit (all
+  24) found the right-fold→left-fold loop rewrite — proven sound over `Int` only — could admit a
+  float-valued head via the coarse `ValueDomain::Number`, and float `+`/`*` is non-associative, so
+  results could change. Added `head_possibly_float` (rejects float literal / `Op::TrueDiv` /
+  float-typed param), measured **byte-identical on all 135 corpus repos** (0 recall cost,
+  soundness gain), plus added Lean theorems for previously-unproven firing rewrites
+  (`eq_commutes`/`ne_commutes`, guard merges, and a `structural_fold` float counterexample).
+- **Swift implicit-member lowering gap (#452, #455).** Swift implicit-member expressions now lower
+  correctly, closing a coverage gap.
 
 ## [0.12.0] - 2026-06-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nose-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "nose-detect"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "nose-frontend",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "nose-eval"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "rustc-hash",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "nose-frontend"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "nose-il"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "lasso",
  "serde",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "nose-markdown"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "regex",
  "serde",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "nose-normalize"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "nose-il",
  "nose-semantics",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "nose-semantics"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "nose-il",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/corca-ai/nose"
@@ -26,13 +26,13 @@ rust-version = "1.85"
 [workspace.dependencies]
 # Internal crates carry an explicit `version` (not just `path`) so the tree has no
 # wildcard deps and the crates stay publishable; `path` wins for local builds.
-nose-il = { path = "crates/nose-il", version = "0.12.0" }
-nose-semantics = { path = "crates/nose-semantics", version = "0.12.0" }
-nose-frontend = { path = "crates/nose-frontend", version = "0.12.0" }
-nose-normalize = { path = "crates/nose-normalize", version = "0.12.0" }
-nose-detect = { path = "crates/nose-detect", version = "0.12.0" }
-nose-eval = { path = "crates/nose-eval", version = "0.12.0" }
-nose-markdown = { path = "crates/nose-markdown", version = "0.12.0" }
+nose-il = { path = "crates/nose-il", version = "0.13.0" }
+nose-semantics = { path = "crates/nose-semantics", version = "0.13.0" }
+nose-frontend = { path = "crates/nose-frontend", version = "0.13.0" }
+nose-normalize = { path = "crates/nose-normalize", version = "0.13.0" }
+nose-detect = { path = "crates/nose-detect", version = "0.13.0" }
+nose-eval = { path = "crates/nose-eval", version = "0.13.0" }
+nose-markdown = { path = "crates/nose-markdown", version = "0.13.0" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ nose query src base=origin/main              # PR check: a change applied to one
 nose query src --mode syntax --fail-on any   # jscpd-style copy-paste gate for CI
 nose query src --format markdown             # a ranked report to paste into a PR or issue
 nose query src --format json                 # the versioned machine-readable contract (query-JSON v2)
+nose query docs                              # also reports same-language near-duplicate Markdown prose
 ```
 
 By default it runs all three channels — `syntax` (copy-paste runs), `semantic` (exact
@@ -86,6 +87,7 @@ Pre-1.0. Current capability, language, JSON, benchmark, and soundness details li
 wiki so claims have one source of truth:
 
 - [Languages](docs/languages.md)
+- [Markdown duplication](docs/markdown-duplication.md)
 - [Clone types](docs/clone-types.md)
 - [Benchmark](docs/benchmark.md)
 - [Architecture](docs/architecture.md)

--- a/bench/markdown/README.md
+++ b/bench/markdown/README.md
@@ -30,7 +30,7 @@ options that share a skeleton), not just one boilerplate family.
 
 ## How a golden is built (no human labeling)
 
-1. `nose markdown <corpus> --dump-pairs` → scored candidate pairs (with text).
+1. `cargo run -p nose-markdown --example mddup -- <corpus> --dump-pairs` → scored candidate pairs (with text).
 2. `sample_golden.py <pairs> <sample> <anchors>` → deterministic stratified sample across score
    bands + construction-identical anchors (normalized-identical pairs → certain positives).
 3. **3 heterogeneous LLM judges** (opus / sonnet / haiku — distinct models to decorrelate bias)
@@ -55,7 +55,7 @@ trust signal). The multi-domain set is genuinely harder to label (more `not`, mo
 
 ## Detector measurement
 
-`nose markdown <corpus> --eval <golden>`:
+`cargo run -p nose-markdown --example mddup -- <corpus> --eval <golden>`:
 
 | | golden.v1 (CoC) | golden.docs.v1 (multi-domain) |
 |---|---|---|

--- a/crates/nose-cli/src/main.rs
+++ b/crates/nose-cli/src/main.rs
@@ -405,32 +405,6 @@ enum Cmd {
         #[arg(long, value_enum, default_value_t = StatsFormat::Human)]
         format: StatsFormat,
     },
-    /// Find same-language near-duplicate prose across Markdown documents — sections copied or
-    /// near-copied across files. Reports a span witness + commonness evidence; it does NOT judge
-    /// whether a repetition is intentional or worth removing (that is the maintainer's call).
-    Markdown {
-        /// Markdown files or directories (recursively scanned; .gitignore respected).
-        #[arg(required = true)]
-        paths: Vec<PathBuf>,
-        /// Output format (`human` or `json`) — same `--format` contract as `query`/`stats`.
-        #[arg(long, value_enum, default_value_t = StatsFormat::Human)]
-        format: StatsFormat,
-        /// Minimum normalized prose words for a section to participate (trivial-fragment floor).
-        #[arg(long, default_value_t = 8)]
-        min_words: usize,
-        /// Relation acceptance threshold in 0..1 (IDF-cosine / containment).
-        #[arg(long, default_value_t = 0.5)]
-        threshold: f64,
-        /// Limit how many families to print (human format only).
-        #[arg(long, default_value_t = 50)]
-        top: usize,
-        /// Dump all scored candidate pairs (with text) as JSON — for building a golden set.
-        #[arg(long)]
-        dump_pairs: bool,
-        /// Evaluate against a labeled golden JSON (`{"pairs":[{a,b,label}]}`) and print metrics.
-        #[arg(long)]
-        eval: Option<PathBuf>,
-    },
     /// Dump the IL for a source file — debug why two snippets do or don't converge.
     Il {
         /// Path to a source file.
@@ -1774,23 +1748,6 @@ fn run() -> Result<()> {
             candidates,
         } => cmd_ceiling(gold, units, candidates),
         Cmd::Stats { paths, top, format } => cmd_stats(paths, top, format == StatsFormat::Json),
-        Cmd::Markdown {
-            paths,
-            format,
-            min_words,
-            threshold,
-            top,
-            dump_pairs,
-            eval,
-        } => markdown::cmd_markdown(markdown::Args {
-            paths,
-            json: format == StatsFormat::Json,
-            min_words,
-            threshold,
-            top,
-            dump_pairs,
-            eval,
-        }),
         Cmd::Features {
             paths,
             min_lines,
@@ -3939,7 +3896,7 @@ fn warn_no_files(paths: &[PathBuf]) {
         .join(", ");
     eprintln!(
         "warning: no supported source files found under: {joined}\n  \
-         (supported extensions: py/pyi, js/jsx/mjs/cjs, ts/tsx/mts/cts, go, rs, java, c/h, rb, swift, css, vue/svelte/html/htm)"
+         (supported extensions: py/pyi, js/jsx/mjs/cjs, ts/tsx/mts/cts, go, rs, java, c/h, rb, swift, css, vue/svelte/html/htm, md/markdown)"
     );
 }
 
@@ -4929,6 +4886,9 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
         .filter(|f| is_default_surface(f, &overrides))
         .collect();
     let opp = OpportunityGroups::from_ranked(&default_fams);
+    // Markdown is a query domain: a docs-only tree (no code, but real `.md` near-dups) is not
+    // "nothing found". The dashboard sets this so the empty-corpus warning below stays accurate.
+    let mut markdown_found = false;
     match format {
         // Report formats (for PRs / code-scanning, like scan's): non-interactive, so they
         // ignore dashboard/group navigation and just render the family set the query selects,
@@ -4981,6 +4941,11 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
                     .iter()
                     .filter(|r| !r.container_in_test)
                     .count();
+                // Markdown near-duplicate prose is a query domain (converged from the former
+                // `nose markdown` command): the dashboard reports `.md` near-dup families
+                // alongside code clones, via the separate `nose-markdown` engine.
+                let md = markdown::detect_under(&args.paths[0], &dataset.settings.exclude);
+                markdown_found = !md.is_empty();
                 render_query_dashboard(
                     &dataset.families,
                     &overrides,
@@ -4990,6 +4955,7 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
                     reinvented_prod,
                     json,
                     since,
+                    &md,
                 );
             } else if let Some(at) = &q.at {
                 // `at=file:line` → the family whose member span covers that location (stable
@@ -5034,6 +5000,13 @@ fn run_query_cmd(cmd: Cmd) -> Result<()> {
             }
         }
     }
+    // Warn when discovery found nothing to report, so a mistyped path or unsupported tree
+    // doesn't masquerade as "no duplication found" (and a CI `--fail-on` gate doesn't silently
+    // pass on a bad path). A docs-only tree with markdown near-dups is a real result, so the
+    // dashboard's `markdown_found` suppresses it there.
+    if dataset.scope.files == 0 && !markdown_found {
+        warn_no_files(&args.paths);
+    }
     // CI gate (same as scan): a non-empty default-report family set fails `--fail-on`.
     let reportable: Vec<&nose_detect::RefactorFamily> = dataset
         .families
@@ -5063,6 +5036,7 @@ fn render_query_dashboard(
     reinvented_prod: usize,
     json: bool,
     since: Option<&BaselineComparison>,
+    markdown: &[nose_markdown::Family],
 ) {
     // Default surface, slice-folds removed (shown under their primary) — matches scan.
     let def: Vec<&nose_detect::RefactorFamily> = families
@@ -5098,6 +5072,9 @@ fn render_query_dashboard(
                     "reinvented": reinvented_prod,
                 },
                 "top_candidates": top,
+                // Markdown near-duplicate families (separate prose engine). Additive key —
+                // existing query-JSON v2 consumers ignore it.
+                "markdown": markdown::families_json(markdown),
                 "next": [format!("nose query {path} sort=extractability"), format!("nose query {path} group=dir"),
                     format!("nose query {path} witness=exact"), format!("nose query {path} all")],
             })
@@ -5276,6 +5253,8 @@ fn render_query_dashboard(
         "\n  {}",
         style::dim("filter/group fields: scope · witness · lang · path · members · files · value · params · shared · dir · same_symbol")
     );
+    // Markdown near-duplicate prose, reported as a query domain (separate `nose-markdown` engine).
+    markdown::print_section(markdown, path);
 }
 
 /// The `reinvented` view: code that reimplements an existing helper's body (the `reinvented`
@@ -5806,6 +5785,11 @@ fn cmd_scan(args: ScanArgs) -> Result<()> {
         reinvented,
         opts,
     } = build_scan_dataset(&args, &refs)?;
+    // Warn when discovery found no code, so a mistyped path doesn't masquerade as "no
+    // duplication found". (`nose scan` is code-only; the markdown domain lives in `nose query`.)
+    if scope.files == 0 {
+        warn_no_files(&args.paths);
+    }
     // Baseline: write the current state, or hide already-accepted families so only
     // new/changed duplication is reported and gated.
     if args.write_baseline {
@@ -5946,7 +5930,6 @@ fn scan_report(
         // the non-cached path including imported-immutable-literal convergence
         // (#275), which the old per-file source-content cache skipped.
         let corpus = time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude));
-        warn_if_empty(&corpus, &args.paths);
         let scope = ScanScope::from_corpus(&corpus);
         let cache::CachedUnits {
             units,
@@ -5957,7 +5940,6 @@ fn scan_report(
         (report, scope)
     } else {
         let corpus = time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude));
-        warn_if_empty(&corpus, &args.paths);
         let scope = ScanScope::from_corpus(&corpus);
         (nose_detect::detect(&corpus, opts, detector), scope)
     }

--- a/crates/nose-cli/src/markdown.rs
+++ b/crates/nose-cli/src/markdown.rs
@@ -1,16 +1,17 @@
-//! `nose markdown` — same-language near-duplicate detection for Markdown documents.
+//! Markdown near-duplicate detection as a **`nose query` domain** (epic #435).
 //!
-//! Runs the `nose-markdown` pipeline (units → MinHash/winnowing candidates → TF-IDF/containment
-//! verify → local-alignment witness) and surfaces ranked near-duplicate families with a span
-//! witness + orthogonal evidence (commonness, removable, files). Honesty contract (epic #435):
-//! it reports near-duplication, never "same meaning" and never "worth removing".
+//! Converged from the former standalone `nose markdown` subcommand: per "capabilities over
+//! features", duplication has one entry point (`nose query`). `nose query` discovers `.md` and
+//! reports markdown near-duplicate families alongside code clones, using the separate
+//! `nose-markdown` engine (char-n-gram MinHash/winnowing/TF-IDF/alignment — prose is not code).
+//! Honesty contract: near-dup score + span witness + commonness evidence, never "same meaning"
+//! or "worth removing". Dev golden-build/eval tooling lives in `nose-markdown`'s `mddup` example.
 
-use anyhow::{Context, Result};
 use nose_markdown::{detect, Family, Options};
 use std::path::{Path, PathBuf};
 
-/// Vendor/build directories never worth scanning for prose duplication. Excluded even without a
-/// `.gitignore` — the field eval hit a non-git project whose `node_modules` flooded the report.
+/// Vendor/build directories never worth scanning for prose duplication — excluded even without a
+/// `.gitignore` (a non-git project's `node_modules` otherwise floods the report).
 const DEFAULT_EXCLUDE_DIRS: &[&str] = &[
     "node_modules",
     "vendor",
@@ -30,44 +31,38 @@ const DEFAULT_EXCLUDE_DIRS: &[&str] = &[
     ".git",
 ];
 
-/// Discover `.md`/`.markdown` files under the given paths, respecting `.gitignore`, default
-/// vendor-dir excludes, and `nose.toml` `exclude` globs.
-fn discover(paths: &[PathBuf]) -> Vec<PathBuf> {
+/// Discover `.md`/`.markdown` files under `root`, respecting `.gitignore`, default vendor-dir
+/// excludes, and the query's `exclude` globs (config + `--exclude`).
+fn discover(root: &Path, excludes: &[String]) -> Vec<PathBuf> {
     use ignore::overrides::OverrideBuilder;
-    let cfg_excludes = crate::config::load_scan(None)
-        .map(|c| c.exclude)
-        .unwrap_or_default();
-
+    let mut builder = ignore::WalkBuilder::new(root);
+    builder.parents(false).require_git(false);
+    let mut ob = OverrideBuilder::new(root);
+    for d in DEFAULT_EXCLUDE_DIRS {
+        let _ = ob.add(&format!("!**/{d}/**"));
+        let _ = ob.add(&format!("!**/{d}"));
+    }
+    for g in excludes {
+        let _ = ob.add(&format!("!{g}"));
+    }
+    if let Ok(ov) = ob.build() {
+        builder.overrides(ov);
+    }
     let mut out = Vec::new();
-    for root in paths {
-        let mut builder = ignore::WalkBuilder::new(root);
-        builder.parents(false).require_git(false);
-        let mut ob = OverrideBuilder::new(root);
-        for d in DEFAULT_EXCLUDE_DIRS {
-            let _ = ob.add(&format!("!**/{d}/**"));
-            let _ = ob.add(&format!("!**/{d}"));
-        }
-        for g in &cfg_excludes {
-            let _ = ob.add(&format!("!{g}"));
-        }
-        if let Ok(ov) = ob.build() {
-            builder.overrides(ov);
-        }
-        for dent in builder.build().flatten() {
-            let p = dent.path();
-            let is_md = matches!(
-                p.extension().and_then(|e| e.to_str()),
-                Some("md") | Some("markdown")
-            );
-            // Safety net: never report files under a vendor dir even if the override missed it.
-            let vendored = p.components().any(|c| {
-                c.as_os_str()
-                    .to_str()
-                    .is_some_and(|s| DEFAULT_EXCLUDE_DIRS.contains(&s))
-            });
-            if dent.file_type().is_some_and(|t| t.is_file()) && is_md && !vendored {
-                out.push(p.to_path_buf());
-            }
+    for dent in builder.build().flatten() {
+        let p = dent.path();
+        let is_md = matches!(
+            p.extension().and_then(|e| e.to_str()),
+            Some("md") | Some("markdown")
+        );
+        // Safety net: never report files under a vendor dir even if the override missed it.
+        let vendored = p.components().any(|c| {
+            c.as_os_str()
+                .to_str()
+                .is_some_and(|s| DEFAULT_EXCLUDE_DIRS.contains(&s))
+        });
+        if dent.file_type().is_some_and(|t| t.is_file()) && is_md && !vendored {
+            out.push(p.to_path_buf());
         }
     }
     out.sort();
@@ -75,8 +70,10 @@ fn discover(paths: &[PathBuf]) -> Vec<PathBuf> {
     out
 }
 
-fn read_docs(files: &[PathBuf]) -> Vec<(String, String)> {
-    files
+/// Detect markdown near-duplicate families under `root` for the `nose query` dashboard.
+pub(crate) fn detect_under(root: &Path, excludes: &[String]) -> Vec<Family> {
+    let files = discover(root, excludes);
+    let docs: Vec<(String, String)> = files
         .iter()
         .filter_map(|p| {
             std::fs::read(p).ok().map(|b| {
@@ -86,143 +83,79 @@ fn read_docs(files: &[PathBuf]) -> Vec<(String, String)> {
                 )
             })
         })
-        .collect()
+        .collect();
+    detect(&docs, &Options::default())
 }
 
-pub(crate) struct Args {
-    pub paths: Vec<PathBuf>,
-    pub json: bool,
-    pub min_words: usize,
-    pub threshold: f64,
-    pub top: usize,
-    pub dump_pairs: bool,
-    pub eval: Option<PathBuf>,
+/// The `markdown` array for the query-JSON dashboard (additive, backwards-compatible). `Family`
+/// already derives `Serialize`, so this is its faithful structured form.
+pub(crate) fn families_json(fams: &[Family]) -> serde_json::Value {
+    serde_json::to_value(fams).unwrap_or(serde_json::Value::Array(vec![]))
 }
 
-pub(crate) fn cmd_markdown(args: Args) -> Result<()> {
-    let files = discover(&args.paths);
-    let docs = read_docs(&files);
-
-    // Golden-building mode: emit all scored candidate pairs (with text) as JSON.
-    if args.dump_pairs {
-        let pairs = nose_markdown::dump_pairs(&docs, args.min_words);
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&serde_json::json!({
-                "scanned_files": docs.len(),
-                "pairs": pairs,
-            }))?
-        );
-        return Ok(());
+/// Human "Markdown near-duplicates" section appended to the `nose query` dashboard.
+pub(crate) fn print_section(fams: &[Family], path: &str) {
+    if fams.is_empty() {
+        return;
     }
-
-    // Measurement mode: score candidates and evaluate against a labeled golden.
-    if let Some(golden_path) = args.eval {
-        let golden: nose_markdown::Golden =
-            serde_json::from_str(&std::fs::read_to_string(&golden_path)?)
-                .with_context(|| format!("parsing golden {}", golden_path.display()))?;
-        let scored = nose_markdown::score_pairs(&docs, args.min_words);
-        let metrics = nose_markdown::evaluate(&scored, &golden);
-        println!("{}", serde_json::to_string_pretty(&metrics)?);
-        return Ok(());
-    }
-
-    let opts = Options {
-        min_words: args.min_words,
-        threshold: args.threshold,
-        ..Options::default()
-    };
-    let families = detect(&docs, &opts);
-    if args.json {
-        let out = serde_json::json!({ "scanned_files": docs.len(), "families": families });
-        println!("{}", serde_json::to_string_pretty(&out)?);
-    } else {
-        print_human(docs.len(), &families, args.top);
-    }
-    Ok(())
-}
-
-fn print_human(scanned: usize, families: &[Family], top: usize) {
-    let (templates, dups): (Vec<&Family>, Vec<&Family>) = families.iter().partition(|f| f.template);
+    let (templates, dups): (Vec<&Family>, Vec<&Family>) = fams.iter().partition(|f| f.template);
     println!(
-        "scanned {scanned} markdown files \u{2192} {} near-duplicate {}, {} templated {} \
-         (score + span witness + commonness; not a judgment of intent)",
-        dups.len(),
-        if dups.len() == 1 {
-            "family"
-        } else {
-            "families"
-        },
+        "\n{} ({}, {} templated)",
+        crate::style::bold("markdown near-duplicates"),
+        plural(dups.len(), "family", "families"),
         templates.len(),
-        if templates.len() == 1 {
-            "section"
-        } else {
-            "sections"
-        },
     );
-    for (n, f) in dups.iter().take(top).enumerate() {
-        print_family(n, f);
+    println!(
+        "  {}",
+        crate::style::dim(
+            "prose near-dup: score + span witness + commonness; not a worth-it verdict"
+        )
+    );
+    for f in dups.iter().take(5) {
+        let common = if f.commonness > 0.25 {
+            "  [common]"
+        } else {
+            ""
+        };
+        let head = f
+            .members
+            .first()
+            .and_then(|m| m.heading.as_deref())
+            .map(|h| short(h, 48))
+            .unwrap_or_default();
+        let loc = f
+            .members
+            .first()
+            .map(|m| format!("{}:{}-{}", file_only(&m.path), m.start_line, m.end_line))
+            .unwrap_or_default();
+        println!(
+            "  {loc:<40}  {} copies · {} · ~{} removable · {}{}",
+            f.members.len(),
+            crate::style::blue(f.tier),
+            f.removable,
+            short(&head, 40),
+            crate::style::dim(common),
+        );
     }
     if !templates.is_empty() {
         println!(
-            "\n\u{2014} templated sections (one section skeleton repeated across files; \
-             consider a single source / generator) \u{2014}"
+            "  {}",
+            crate::style::dim(&format!(
+                "+ {} templated section(s) (one skeleton repeated across files)",
+                templates.len()
+            ))
         );
-        for f in templates.iter().take(top) {
-            let h = f
-                .members
-                .first()
-                .and_then(|m| m.heading.as_deref())
-                .unwrap_or("(section)");
-            println!(
-                "  \u{2022} \"{}\" repeated {}\u{00d7} across {} files (score {:.2}, removable~{})",
-                short(h, 60),
-                f.members.len(),
-                f.files,
-                f.score,
-                f.removable
-            );
-        }
     }
+    println!(
+        "  {}",
+        crate::style::dim(&format!(
+            "see all: nose query {path} --format json  # markdown[] array"
+        ))
+    );
 }
 
-fn print_family(n: usize, f: &Family) {
-    let common = if f.commonness > 0.25 {
-        "  [common / likely boilerplate]"
-    } else {
-        ""
-    };
-    println!(
-        "\n#{n} [{}] score={:.2}  members={} files={} removable~{} commonness={:.2}{}",
-        f.tier,
-        f.score,
-        f.members.len(),
-        f.files,
-        f.removable,
-        f.commonness,
-        common
-    );
-    if let Some(h) = f.members.first().and_then(|m| m.heading.as_deref()) {
-        println!("   heading: {}", short(h, 70));
-    }
-    for m in f.members.iter().take(6) {
-        println!("   - {}:{}-{}", m.path, m.start_line, m.end_line);
-    }
-    if f.members.len() > 6 {
-        println!("   \u{2026} and {} more", f.members.len() - 6);
-    }
-    if let Some(w) = &f.witness {
-        println!(
-            "   witness: {} shared lines (e.g. {}:{}-{} \u{2248} {}:{}-{})",
-            w.span.matched_lines,
-            file_only(&w.a_path),
-            w.span.a_start,
-            w.span.a_end,
-            file_only(&w.b_path),
-            w.span.b_start,
-            w.span.b_end,
-        );
-    }
+fn plural(n: usize, one: &str, many: &str) -> String {
+    format!("{n} {}", if n == 1 { one } else { many })
 }
 
 fn short(s: &str, n: usize) -> String {

--- a/crates/nose-markdown/examples/mddup.rs
+++ b/crates/nose-markdown/examples/mddup.rs
@@ -1,6 +1,11 @@
-//! Smoke/eval runner: `cargo run --example mddup -- <paths...> [--json]`
-//! Recursively finds `.md`/`.markdown` files under the given paths, runs the pipeline, and
-//! prints ranked families (human summary, or `--json` for the machine contract).
+//! Dev runner / golden-build tooling for the markdown near-dup engine.
+//!
+//!   cargo run -p nose-markdown --example mddup -- <paths...>            # human summary
+//!   cargo run -p nose-markdown --example mddup -- <paths...> --json     # families as JSON
+//!   cargo run -p nose-markdown --example mddup -- <paths...> --dump-pairs   # candidate pairs (golden build)
+//!   cargo run -p nose-markdown --example mddup -- <paths...> --eval <golden.json>  # metrics
+//!
+//! (User-facing markdown detection lives in `nose query`; this is the dev/benchmark surface.)
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -24,11 +29,20 @@ fn collect_md(root: &Path, out: &mut Vec<PathBuf>) {
 }
 
 fn main() {
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    let json = args.iter().any(|a| a == "--json");
-    let roots: Vec<&String> = args.iter().filter(|a| !a.starts_with("--")).collect();
+    let raw: Vec<String> = std::env::args().skip(1).collect();
+    let json = raw.iter().any(|a| a == "--json");
+    let dump = raw.iter().any(|a| a == "--dump-pairs");
+    let eval_idx = raw.iter().position(|a| a == "--eval");
+    let eval_golden = eval_idx.and_then(|i| raw.get(i + 1).cloned());
+    // roots = positional args, excluding flags and the value after `--eval`.
+    let roots: Vec<&String> = raw
+        .iter()
+        .enumerate()
+        .filter(|(i, a)| !a.starts_with("--") && Some(*i) != eval_idx.map(|e| e + 1))
+        .map(|(_, a)| a)
+        .collect();
     if roots.is_empty() {
-        eprintln!("usage: mddup <paths...> [--json]");
+        eprintln!("usage: mddup <paths...> [--json | --dump-pairs | --eval <golden.json>]");
         std::process::exit(2);
     }
 
@@ -49,6 +63,23 @@ fn main() {
         }
     }
 
+    // Golden-build: dump all scored candidate pairs (with text).
+    if dump {
+        let pairs = nose_markdown::dump_pairs(&docs, 8);
+        let out = serde_json::json!({ "scanned_files": docs.len(), "pairs": pairs });
+        println!("{}", serde_json::to_string_pretty(&out).unwrap());
+        return;
+    }
+    // Measurement: evaluate the detector against a labeled golden.
+    if let Some(golden_path) = eval_golden {
+        let golden: nose_markdown::Golden =
+            serde_json::from_str(&fs::read_to_string(&golden_path).expect("read golden"))
+                .expect("parse golden");
+        let metrics = nose_markdown::evaluate(&nose_markdown::score_pairs(&docs, 8), &golden);
+        println!("{}", serde_json::to_string_pretty(&metrics).unwrap());
+        return;
+    }
+
     let fams = nose_markdown::detect(&docs, &nose_markdown::Options::default());
 
     if json {
@@ -57,7 +88,7 @@ fn main() {
     }
 
     eprintln!(
-        "scanned {} markdown files → {} near-duplicate families",
+        "scanned {} markdown files \u{2192} {} near-duplicate families",
         docs.len(),
         fams.len()
     );

--- a/docs/home.md
+++ b/docs/home.md
@@ -44,7 +44,7 @@ You want to *run* nose on a codebase and act on what it finds.
 - [reinvented-helpers](reinvented-helpers.md) — the containment channel: code that reimplements an existing pure helper inline instead of calling it.
 - [clone-types](clone-types.md) — what nose covers across the standard Type-1/2/3/4 taxonomy, with its honest limits.
 - [languages](languages.md) — the supported languages, declarative CSS and HTML markup, and the `<script>`/`<style>`/markup region extraction for Vue/Svelte/HTML.
-- [markdown-duplication](markdown-duplication.md) — `nose markdown`: same-language near-duplicate **prose** detection across Markdown documents (a separate char-n-gram engine; span witness + commonness evidence; no LLM, same-language only).
+- [markdown-duplication](markdown-duplication.md) — same-language near-duplicate **prose** detection across Markdown documents, surfaced as a `nose query` domain (a separate char-n-gram engine; span witness + commonness evidence; no LLM, same-language only).
 
 ## Integrating nose
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -9,9 +9,9 @@ first-party and external languages to enter through the same pack extension
 boundary described in [semantic-kernel](semantic-kernel.md), while keeping exact
 semantic matching fail-closed unless the required facts and contracts are present.
 
-> **Markdown prose** is handled by a separate engine, not this IL: `nose markdown`
-> finds same-language near-duplicate *prose* via a character-n-gram pipeline (prose is
-> not code). See [markdown-duplication](markdown-duplication.md).
+> **Markdown prose** is handled by a separate engine, not this IL: `nose query` reports
+> same-language near-duplicate *prose* via a character-n-gram pipeline (prose is not code),
+> as one of its domains. See [markdown-duplication](markdown-duplication.md).
 
 ## Supported languages
 

--- a/docs/markdown-duplication.md
+++ b/docs/markdown-duplication.md
@@ -1,10 +1,13 @@
 # Markdown duplication
 
-`nose markdown` finds **same-language near-duplicate prose** across Markdown documents —
-sections that are copied or near-copied across files (drifting copy-paste, repeated boilerplate,
-single-source-of-truth candidates). It is a deliberately **separate engine** from the code-clone
-pipeline: prose is not code, so it does not go through the value-graph IL. Instead it runs the
-character-n-gram pipeline validated by the
+`nose query` reports **same-language near-duplicate prose** across Markdown documents as one of its
+domains — sections that are copied or near-copied across files (drifting copy-paste, repeated
+boilerplate, single-source-of-truth candidates). Per [capabilities over features](design.md),
+duplication has **one entry point** (`nose query`); markdown is surfaced there exactly as the
+CSS/HTML declarative track is, not as a separate command.
+
+It is a deliberately **separate engine** from the code-clone pipeline: prose is not code, so it does
+not go through the value-graph IL. Instead it runs the character-n-gram pipeline validated by the
 [algorithm survey](markdown-dup-detection-algorithm-survey-2026-06-18.md).
 
 Scope (fixed): **same-language only.** Cross-lingual / translation duplication is out of scope (it
@@ -13,13 +16,13 @@ needs an LLM). Paraphrase / Type-4 semantic equivalence is also out of scope for
 ## Usage
 
 ```
-nose markdown <paths...>            # human report (ranked families)
-nose markdown <paths...> --format json
-nose markdown <paths...> --min-words 8 --threshold 0.5 --top 50
+nose query <paths...>                 # dashboard: a "markdown near-duplicates" section
+nose query <paths...> --format json   # a top-level "markdown" array of families
 ```
 
-Walks `.md`/`.markdown` under the paths (respecting `.gitignore`) and reports ranked
-near-duplicate **families**, each with:
+`nose query` discovers `.md`/`.markdown` under the paths (respecting `.gitignore` and the same
+`exclude` globs as code) and reports ranked near-duplicate **families** alongside the code clones,
+each with:
 
 - a **relation tier** (`exact` / `near-high` / `near-med` / `near-low` / `partial`) + score,
 - a **span witness** — the exact duplicated line range in each file (local alignment),
@@ -52,16 +55,20 @@ and the maintainer's call (see [design](design.md)). Consequences:
 
 ## Measurement
 
-Quality is measured against a frozen, **LLM-built golden set** (no human in the loop;
+Quality is measured against frozen, **LLM-built golden sets** (no human in the loop;
 3 heterogeneous judges, majority vote, self-calibrated on construction-truth anchors) — see
-[`bench/markdown/`](../bench/markdown/README.md):
+[`bench/markdown/`](../bench/markdown/README.md). The detector engine is exercised directly through
+the `nose-markdown` dev example (the user surface is `nose query`):
 
 ```
-nose markdown bench/markdown/corpus --eval bench/markdown/golden.v1.json
+cargo run -p nose-markdown --example mddup -- bench/markdown/corpus --eval bench/markdown/golden.v1.json
+cargo run -p nose-markdown --example mddup -- bench/markdown/corpus-docs --eval bench/markdown/golden.docs.v1.json
 ```
 
-Headline (golden v1): panel Fleiss κ 0.70, anchor self-calibration 1.0; detector **PR-AUC 0.995**,
-ROC-AUC 0.992, recall@P95 0.96, recall@P99 0.93, candidate-recall 1.0; byte-identical across runs.
+Headline (golden v1, code-of-conduct corpus): panel Fleiss κ 0.70, anchor self-calibration 1.0;
+detector **PR-AUC 0.995**, ROC-AUC 0.992, recall@P95 0.96, recall@P99 0.93, candidate-recall 1.0.
+Multi-genre golden (docs v1, 5 genres): κ 0.71; **PR-AUC 0.944**, ROC-AUC 0.970, recall@P95 0.74,
+candidate-recall 1.0. Byte-identical across runs.
 
 ## Related
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,6 +38,7 @@ from-source `./target/release/nose`.
 | Ask what an installed binary supports | `nose capabilities` |
 | Check a local semantic-pack manifest | `nose semantic-pack check <file-or-dir>` |
 | Inspect lowering coverage for a language | `nose stats <paths...>` |
+| Find near-duplicate Markdown **prose** | `nose query <path>` — see [markdown-duplication](markdown-duplication.md) |
 | Debug why two snippets do or do not converge | `nose il <file> --normalized` |
 | One-shot ranked report (**deprecated**) | `nose scan <paths...>` — prefer `nose query --format markdown` |
 


### PR DESCRIPTION
## Summary

Releases **v0.13.0** and converges the Markdown near-duplicate detector into `nose query` as a domain, per **capabilities over features** (duplication has one entry point — markdown is surfaced exactly like the CSS/HTML declarative track, not as a separate command).

### What changed
- **Converge `nose markdown` → `nose query` domain.** Removes the standalone `Cmd::Markdown`. `nose query` now discovers `.md`/`.markdown` (respecting `.gitignore` + `exclude` globs) and reports:
  - a **"markdown near-duplicates"** section in the human dashboard, and
  - a top-level **`markdown`** array under `--format json` (additive; query-JSON v2 unchanged).
  - Dev golden-build/eval tooling (`--dump-pairs`/`--eval`) moves to the `nose-markdown` **`mddup` example**.
  - The empty-corpus warning is now **markdown-aware** — a docs-only tree with real near-dups is not reported as "no supported source files found".
- **Docs fixed** to reference `nose query` instead of the removed command: `docs/markdown-duplication.md`, `docs/languages.md`, `docs/home.md`, `docs/usage.md`, `README.md`, `bench/markdown/README.md`.
- **CHANGELOG finalized** as `[0.13.0]`, adding previously-missing entries: Swift language frontend (#442), Type-4 coverage floor ≥50%, `structural_fold` integer-head soundness gate (#434), Swift implicit-member lowering fix (#452/#455).
- **Version bump** 0.12.0 → 0.13.0 (workspace + 7 internal dep pins + Cargo.lock).

> Note: `nose markdown` was introduced (#444) and converged into `nose query` **before** this release, so users never saw a separate command — the changelog describes markdown as a `nose query` domain from the start.

### Verification
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc` — all clean.
- Full workspace test suite green (incl. 32 `nose-markdown` tests).
- `awiki lint --root docs` clean (connected graph, 0 orphans, full content coverage).
- Manual: `nose query` on mixed code+markdown trees shows both surfaces; `--format json` carries the `markdown` key (schema_version 2); markdown output byte-identical across runs.

### Detector quality (unchanged)
- golden v1 (CoC): PR-AUC 0.995 / R@P95 0.96 / candidate-recall 1.0
- golden docs v1 (5 genres): PR-AUC 0.944 / R@P95 0.74 / candidate-recall 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)